### PR TITLE
fix(agents): keep hf handoff subject for status

### DIFF
--- a/argocd/applications/agents/hf-team-agentprovider.yaml
+++ b/argocd/applications/agents/hf-team-agentprovider.yaml
@@ -525,7 +525,8 @@ spec:
             "content": content,
           }
           status_path.write_text(json.dumps(handoff, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-          publish_handoff(handoff_subject(payload, swarm_name, role, run_name), handoff)
+          subject = handoff_subject(payload, swarm_name, role, run_name)
+          publish_handoff(subject, handoff)
 
           print("SWARM_HF_RESULT_BEGIN")
           print(content)

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -440,7 +440,9 @@ describe('scheduled AgentRun templates', () => {
     )
     expect(content).toContain('\"handoff_quality\": quality')
     expect(content).toContain('\"exact_next_action\": exact_next_action')
-    expect(content).toContain('publish_handoff(handoff_subject(payload, swarm_name, role, run_name), handoff)')
+    expect(content).toContain('subject = handoff_subject(payload, swarm_name, role, run_name)')
+    expect(content).toContain('publish_handoff(subject, handoff)')
+    expect(content).toContain('\"subject\": subject')
     expect(content).not.toContain('publish_handoff(f"swarm.')
   })
 


### PR DESCRIPTION
## Summary

- Keeps the computed HF swarm handoff subject in a local variable before publishing.
- Reuses that same subject in the worker success JSON so HF runs do not crash after a successful NATS publish.
- Adds smoke-test coverage for the subject assignment, publish call, and status output contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `kubectl apply --dry-run=client -f argocd/applications/agents/hf-team-agentprovider.yaml`
- `git diff --check -- argocd/applications/agents/hf-team-agentprovider.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
