### PR TITLE
fix(temporal-bun-sdk): extend default rpc retry budget

### DIFF
--- a/packages/temporal-bun-sdk/scripts/cleanup-integration-workflows.ts
+++ b/packages/temporal-bun-sdk/scripts/cleanup-integration-workflows.ts
@@ -35,6 +35,7 @@ const maxAttempts = normalizePositiveInteger(process.env.TEMPORAL_CLEANUP_MAX_AT
 const retryDelayMs = normalizePositiveInteger(process.env.TEMPORAL_CLEANUP_RETRY_MS, 1_000)
 
 async function main(): Promise<void> {
+  let foundVisibleWorkflows = false
   let leaked = false
 
   for (const workflowType of workflowTypes) {
@@ -44,16 +45,22 @@ async function main(): Promise<void> {
       continue
     }
 
-    leaked = true
+    foundVisibleWorkflows = true
     console.warn(`[temporal-bun-sdk] ${workflowType} has ${before} running workflow(s)`)
     const listOutput = await list(query, before)
 
     if (mode === 'terminate') {
       await terminate(query, workflowType, listOutput)
-      const after = await count(query)
-      if (after > 0) {
-        throw new Error(`${workflowType} still has ${after} running workflow(s) after cleanup`)
+      const onlyStaleVisibilityRemains = await terminateRemainingWorkflows(query, workflowType)
+      if (!onlyStaleVisibilityRemains) {
+        await waitForNoRunningWorkflows(query, workflowType)
       }
+      continue
+    }
+
+    const onlyStaleVisibilityRemains = await verifyOnlyStaleVisibility(query, workflowType, listOutput)
+    if (!onlyStaleVisibilityRemains) {
+      leaked = true
     }
   }
 
@@ -61,7 +68,7 @@ async function main(): Promise<void> {
     throw new Error('Temporal Bun SDK integration workflows leaked after test cleanup')
   }
 
-  if (!leaked) {
+  if (!foundVisibleWorkflows) {
     console.info('[temporal-bun-sdk] no running integration workflow leaks found')
   }
 }
@@ -125,7 +132,7 @@ async function terminate(query: string, workflowType: string, listOutput: string
       throw error
     }
 
-    await terminateIndividually(workflowType, listOutput)
+    await terminateIndividually(workflowType, listOutput, 'Temporal batch termination is unavailable')
     return
   }
 
@@ -135,28 +142,146 @@ async function terminate(query: string, workflowType: string, listOutput: string
   }
 }
 
-async function terminateIndividually(workflowType: string, listOutput: string): Promise<void> {
+type IndividualTerminationResult = {
+  readonly alreadyResolvedWorkflowIds: readonly string[]
+  readonly terminatedWorkflowIds: readonly string[]
+}
+
+async function terminateIndividually(
+  workflowType: string,
+  listOutput: string,
+  context: string,
+): Promise<IndividualTerminationResult> {
   const workflowIds = parseWorkflowIdsFromListOutput(listOutput, workflowType)
   if (workflowIds.length === 0) {
     throw new Error(`Unable to parse ${workflowType} workflow IDs from Temporal list output:\n${listOutput}`)
   }
+  const alreadyResolvedWorkflowIds: string[] = []
+  const terminatedWorkflowIds: string[] = []
 
   console.warn(
-    `[temporal-bun-sdk] Temporal batch termination is unavailable; terminating ${workflowIds.length} ${workflowType} workflow(s) individually`,
+    `[temporal-bun-sdk] ${context}; terminating ${workflowIds.length} ${workflowType} workflow(s) individually`,
   )
 
   for (const workflowId of workflowIds) {
-    await temporalCli([
-      'workflow',
-      'terminate',
-      '--namespace',
-      namespace,
-      '--workflow-id',
-      workflowId,
-      '--reason',
-      reason,
-    ])
+    try {
+      await temporalCli([
+        'workflow',
+        'terminate',
+        '--namespace',
+        namespace,
+        '--workflow-id',
+        workflowId,
+        '--reason',
+        reason,
+      ])
+      terminatedWorkflowIds.push(workflowId)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      if (!isWorkflowAlreadyCompleted(message)) {
+        throw error
+      }
+      alreadyResolvedWorkflowIds.push(workflowId)
+      console.warn(`[temporal-bun-sdk] ${workflowId} completed before individual cleanup could terminate it`)
+    }
   }
+
+  return { alreadyResolvedWorkflowIds, terminatedWorkflowIds }
+}
+
+async function terminateRemainingWorkflows(query: string, workflowType: string): Promise<boolean> {
+  const after = await waitForNoRunningWorkflowCount(query)
+  if (after === 0) {
+    return false
+  }
+
+  console.warn(
+    `[temporal-bun-sdk] ${workflowType} still has ${after} running workflow(s) after batch cleanup; retrying individually`,
+  )
+  const listOutput = await list(query, after)
+  const result = await terminateIndividually(
+    workflowType,
+    listOutput,
+    'remaining workflows are still visible after batch cleanup',
+  )
+  if (result.alreadyResolvedWorkflowIds.length === 0) {
+    return false
+  }
+
+  const remainingAfterIndividual = await waitForNoRunningWorkflowCount(query)
+  if (remainingAfterIndividual === 0) {
+    return false
+  }
+
+  const remainingListOutput = await list(query, remainingAfterIndividual)
+  const onlyStaleVisibilityRemains = onlyAlreadyResolvedWorkflowsRemainVisible(
+    remainingListOutput,
+    workflowType,
+    result.alreadyResolvedWorkflowIds,
+  )
+  if (!onlyStaleVisibilityRemains) {
+    return false
+  }
+
+  console.warn(
+    `[temporal-bun-sdk] ${workflowType} has ${remainingAfterIndividual} stale visibility record(s) for workflow(s) already reported terminal or missing`,
+  )
+  return true
+}
+
+type VerifyOnlyStaleVisibilityOptions = {
+  readonly terminateVisibleWorkflows?: (
+    workflowType: string,
+    listOutput: string,
+    context: string,
+  ) => Promise<IndividualTerminationResult>
+  readonly waitForNoRunningCount?: (query: string) => Promise<number>
+  readonly listRunning?: (query: string, limit?: number) => Promise<string>
+}
+
+export async function verifyOnlyStaleVisibility(
+  query: string,
+  workflowType: string,
+  listOutput: string,
+  options: VerifyOnlyStaleVisibilityOptions = {},
+): Promise<boolean> {
+  const terminateVisibleWorkflows = options.terminateVisibleWorkflows ?? terminateIndividually
+  const waitForNoRunningCount = options.waitForNoRunningCount ?? waitForNoRunningWorkflowCount
+  const listRunning = options.listRunning ?? list
+
+  const result = await terminateVisibleWorkflows(
+    workflowType,
+    listOutput,
+    'verify detected running workflows after test cleanup',
+  )
+  if (result.terminatedWorkflowIds.length > 0) {
+    console.error(
+      `[temporal-bun-sdk] ${workflowType} leaked ${result.terminatedWorkflowIds.length} workflow(s) that required termination during verification`,
+    )
+    return false
+  }
+
+  if (result.alreadyResolvedWorkflowIds.length === 0) {
+    return false
+  }
+
+  const remaining = await waitForNoRunningCount(query)
+  if (remaining === 0) {
+    return true
+  }
+
+  const remainingListOutput = await listRunning(query, remaining)
+  const onlyStaleVisibilityRemains = onlyAlreadyResolvedWorkflowsRemainVisible(
+    remainingListOutput,
+    workflowType,
+    result.alreadyResolvedWorkflowIds,
+  )
+  if (onlyStaleVisibilityRemains) {
+    console.warn(
+      `[temporal-bun-sdk] ${workflowType} has ${remaining} stale visibility record(s) during verification for workflow(s) already reported terminal or missing`,
+    )
+  }
+  return onlyStaleVisibilityRemains
 }
 
 async function waitForBatch(jobId: string): Promise<void> {
@@ -172,6 +297,48 @@ async function waitForBatch(jobId: string): Promise<void> {
     await Bun.sleep(retryDelayMs * attempt)
   }
   throw new Error(`Timed out waiting for Temporal batch ${jobId} to complete`)
+}
+
+type WaitForNoRunningWorkflowsOptions = {
+  readonly countRunning?: (query: string) => Promise<number>
+  readonly sleep?: (ms: number) => Promise<void>
+  readonly maxAttempts?: number
+  readonly retryDelayMs?: number
+}
+
+export async function waitForNoRunningWorkflowCount(
+  query: string,
+  options: WaitForNoRunningWorkflowsOptions = {},
+): Promise<number> {
+  const countRunning = options.countRunning ?? count
+  const sleep = options.sleep ?? Bun.sleep
+  const attempts = options.maxAttempts ?? maxAttempts
+  const delayMs = options.retryDelayMs ?? retryDelayMs
+  let after = 0
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    after = await countRunning(query)
+    if (after === 0) {
+      return 0
+    }
+    if (attempt < attempts) {
+      await sleep(delayMs * attempt)
+    }
+  }
+
+  return after
+}
+
+export async function waitForNoRunningWorkflows(
+  query: string,
+  workflowType: string,
+  options: WaitForNoRunningWorkflowsOptions = {},
+): Promise<void> {
+  const after = await waitForNoRunningWorkflowCount(query, options)
+  if (after === 0) {
+    return
+  }
+  throw new Error(`${workflowType} still has ${after} running workflow(s) after cleanup`)
 }
 
 async function temporalCli(args: readonly string[]): Promise<{ stdout: string; stderr: string }> {
@@ -202,9 +369,26 @@ async function temporalCli(args: readonly string[]): Promise<{ stdout: string; s
 }
 
 export function isRetryableTemporalCliError(output: string): boolean {
-  return /namespace rate limit exceeded|context deadline exceeded|transport: error while dialing|unavailable|not enough hosts to serve the request|please retry|temporarily unavailable/i.test(
+  return /namespace rate limit exceeded|context deadline exceeded|transport: error while dialing|unavailable|not enough hosts to serve the request|please retry|temporarily unavailable|workflow is busy/i.test(
     output,
   )
+}
+
+export function isWorkflowAlreadyCompleted(output: string): boolean {
+  return /workflow execution already completed|workflow not found for ID/i.test(output)
+}
+
+export function onlyAlreadyResolvedWorkflowsRemainVisible(
+  output: string,
+  workflowType: string,
+  alreadyResolvedWorkflowIds: readonly string[],
+): boolean {
+  const workflowIds = parseWorkflowIdsFromListOutput(output, workflowType)
+  if (workflowIds.length === 0) {
+    return false
+  }
+  const alreadyResolved = new Set(alreadyResolvedWorkflowIds)
+  return workflowIds.every((workflowId) => alreadyResolved.has(workflowId))
 }
 
 export function parseWorkflowIdsFromListOutput(output: string, workflowType: string): string[] {

--- a/packages/temporal-bun-sdk/src/client/retries.ts
+++ b/packages/temporal-bun-sdk/src/client/retries.ts
@@ -23,9 +23,9 @@ const DEFAULT_RETRYABLE_CODES: number[] = [
 ]
 
 export const defaultRetryPolicy: TemporalRpcRetryPolicy = {
-  maxAttempts: 8,
+  maxAttempts: 16,
   initialDelayMs: 200,
-  maxDelayMs: 5_000,
+  maxDelayMs: 10_000,
   backoffCoefficient: 2,
   jitterFactor: 0.2,
   retryableStatusCodes: [...DEFAULT_RETRYABLE_CODES],
@@ -44,6 +44,9 @@ const clampJitter = (factor: number): number => {
 const unwrapRetryError = (error: unknown): unknown => {
   if (error && typeof error === 'object') {
     const candidate = error as { _tag?: string; cause?: unknown; error?: unknown }
+    if (error instanceof Error && error.name === 'TemporalTlsHandshakeError') {
+      return error
+    }
     // Effect.tryPromise failures arrive as UnknownException; surface the underlying cause when present.
     if (candidate._tag === 'UnknownException') {
       return candidate.cause ?? candidate.error ?? error
@@ -75,6 +78,9 @@ const shouldRetryError = (policy: TemporalRpcRetryPolicy) => {
     // Treat generic errors as transient for interceptor-driven retries; bounded by maxAttempts.
     if (underlying instanceof Error) {
       if (underlying.name === 'AbortError') {
+        return false
+      }
+      if (underlying.name === 'TemporalTlsHandshakeError') {
         return false
       }
       return true

--- a/packages/temporal-bun-sdk/tests/client/retries.test.ts
+++ b/packages/temporal-bun-sdk/tests/client/retries.test.ts
@@ -7,6 +7,15 @@ import { withTemporalRetry, defaultRetryPolicy } from '../../src/client/retries'
 const run = <A>(effect: Effect.Effect<A, unknown, never>) => Effect.runPromise(effect)
 
 describe('Temporal RPC retries', () => {
+  test('default policy survives short Temporal frontend disruption windows', () => {
+    expect(defaultRetryPolicy.maxAttempts).toBeGreaterThanOrEqual(16)
+    expect(defaultRetryPolicy.initialDelayMs).toBeLessThanOrEqual(250)
+    expect(defaultRetryPolicy.maxDelayMs).toBeGreaterThanOrEqual(10_000)
+    expect(defaultRetryPolicy.retryableStatusCodes).toEqual(
+      expect.arrayContaining([Code.Unavailable, Code.ResourceExhausted, Code.DeadlineExceeded, Code.Internal]),
+    )
+  })
+
   test('retries retryable ConnectError codes until success', async () => {
     let attempts = 0
     const effect = Effect.tryPromise({
@@ -98,6 +107,29 @@ describe('Temporal RPC retries', () => {
         }),
       ),
     ).rejects.toThrow('fatal')
+    expect(attempts).toBe(1)
+  })
+
+  test('does not retry TLS handshake errors', async () => {
+    let attempts = 0
+    const effect = Effect.tryPromise({
+      try: async () => {
+        attempts += 1
+        const error = new Error('Temporal TLS handshake failed')
+        error.name = 'TemporalTlsHandshakeError'
+        throw error
+      },
+      catch: (error) => error,
+    })
+
+    await expect(
+      run(
+        withTemporalRetry(effect, {
+          ...defaultRetryPolicy,
+          maxAttempts: 5,
+        }),
+      ),
+    ).rejects.toThrow('Temporal TLS handshake failed')
     expect(attempts).toBe(1)
   })
 })

--- a/packages/temporal-bun-sdk/tests/scripts/cleanup-integration-workflows.test.ts
+++ b/packages/temporal-bun-sdk/tests/scripts/cleanup-integration-workflows.test.ts
@@ -1,16 +1,31 @@
 import { describe, expect, test } from 'bun:test'
 
-import { isRetryableTemporalCliError, parseWorkflowIdsFromListOutput } from '../../scripts/cleanup-integration-workflows'
+import {
+  isRetryableTemporalCliError,
+  isWorkflowAlreadyCompleted,
+  onlyAlreadyResolvedWorkflowsRemainVisible,
+  parseWorkflowIdsFromListOutput,
+  verifyOnlyStaleVisibility,
+  waitForNoRunningWorkflowCount,
+  waitForNoRunningWorkflows,
+} from '../../scripts/cleanup-integration-workflows'
 
 describe('cleanup integration workflow retries', () => {
   test('retries transient Temporal batch-start placement failures', () => {
     expect(isRetryableTemporalCliError('Error: failed starting batch operation: Not enough hosts to serve the request')).toBe(
       true,
     )
+    expect(isRetryableTemporalCliError('Error: failed to describe batch job: Workflow is busy.')).toBe(true)
   })
 
   test('does not retry validation failures', () => {
     expect(isRetryableTemporalCliError('Error: invalid search attribute query syntax')).toBe(false)
+  })
+
+  test('treats already completed or missing workflow termination as cleanup success', () => {
+    expect(isWorkflowAlreadyCompleted('Error: failed to terminate workflow: workflow execution already completed')).toBe(true)
+    expect(isWorkflowAlreadyCompleted('Error: failed to terminate workflow: workflow not found for ID: worker-load')).toBe(true)
+    expect(isWorkflowAlreadyCompleted('Error: failed to terminate workflow: permission denied')).toBe(false)
   })
 
   test('parses workflow ids from Temporal list table output', () => {
@@ -25,5 +40,97 @@ Status                         WorkflowId                                 Type  
       'worker-load-cpu-26-4a42c7d7-53a0-49a1-bcb5-2cb1f8b644f6',
       'worker-load-cpu-25-8d2e17a2-d6d9-4a8b-93d5-736e551710d8',
     ])
+  })
+
+  test('detects stale visibility rows for already resolved workflows', () => {
+    const output = `
+Status                         WorkflowId                                 Type             StartTime
+  Running  worker-load-update-304-0a9e4910-6ffe-40cd-8194-bca78b94aec1  workerLoadUpdateWorkflow  28 minutes ago
+`
+
+    expect(
+      onlyAlreadyResolvedWorkflowsRemainVisible(output, 'workerLoadUpdateWorkflow', [
+        'worker-load-update-304-0a9e4910-6ffe-40cd-8194-bca78b94aec1',
+      ]),
+    ).toBe(true)
+    expect(onlyAlreadyResolvedWorkflowsRemainVisible(output, 'workerLoadUpdateWorkflow', ['other-id'])).toBe(false)
+  })
+
+  test('waits for terminated workflows to disappear from visibility', async () => {
+    const counts = [3, 2, 0]
+    const delays: number[] = []
+
+    await waitForNoRunningWorkflows('WorkflowType="workerLoadActivityWorkflow"', 'workerLoadActivityWorkflow', {
+      countRunning: async () => counts.shift() ?? 0,
+      sleep: async (delayMs) => {
+        delays.push(delayMs)
+      },
+      maxAttempts: 5,
+      retryDelayMs: 10,
+    })
+
+    expect(delays).toEqual([10, 20])
+  })
+
+  test('fails when terminated workflows remain visible after retries', async () => {
+    await expect(
+      waitForNoRunningWorkflows('WorkflowType="workerLoadActivityWorkflow"', 'workerLoadActivityWorkflow', {
+        countRunning: async () => 1,
+        sleep: async () => {},
+        maxAttempts: 2,
+        retryDelayMs: 1,
+      }),
+    ).rejects.toThrow('workerLoadActivityWorkflow still has 1 running workflow(s) after cleanup')
+  })
+
+  test('returns remaining workflow count for fallback cleanup', async () => {
+    const remaining = await waitForNoRunningWorkflowCount('WorkflowType="workerLoadUpdateWorkflow"', {
+      countRunning: async () => 2,
+      sleep: async () => {},
+      maxAttempts: 3,
+      retryDelayMs: 1,
+    })
+
+    expect(remaining).toBe(2)
+  })
+
+  test('verify mode accepts stale visibility for already resolved workflows', async () => {
+    const workflowId = 'worker-load-update-304-0a9e4910-6ffe-40cd-8194-bca78b94aec1'
+    const output = `
+Status                         WorkflowId                                 Type             StartTime
+  Running  ${workflowId}  workerLoadUpdateWorkflow  1 hour ago
+`
+
+    const result = await verifyOnlyStaleVisibility(
+      'WorkflowType="workerLoadUpdateWorkflow"',
+      'workerLoadUpdateWorkflow',
+      output,
+      {
+        terminateVisibleWorkflows: async () => ({
+          alreadyResolvedWorkflowIds: [workflowId],
+          terminatedWorkflowIds: [],
+        }),
+        waitForNoRunningCount: async () => 1,
+        listRunning: async () => output,
+      },
+    )
+
+    expect(result).toBe(true)
+  })
+
+  test('verify mode fails when a visible workflow required termination', async () => {
+    const result = await verifyOnlyStaleVisibility(
+      'WorkflowType="workerLoadUpdateWorkflow"',
+      'workerLoadUpdateWorkflow',
+      'Running  worker-load-update-1  workerLoadUpdateWorkflow  1 minute ago',
+      {
+        terminateVisibleWorkflows: async () => ({
+          alreadyResolvedWorkflowIds: [],
+          terminatedWorkflowIds: ['worker-load-update-1'],
+        }),
+      },
+    )
+
+    expect(result).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- Extends the default Temporal RPC retry budget from 8 to 16 attempts.
- Raises the default retry delay cap from 5s to 10s so client calls survive short Temporal frontend/service placement disruptions.
- Adds a regression assertion for the default retry profile and retryable status-code coverage.
- Makes pre-test Temporal cleanup wait for terminated workflows to disappear, retry any remaining visible workflows individually, and ignore only already-terminal or visibility-stale records for the same workflow IDs.
- Makes post-test cleanup verification classify already-terminal visibility rows without masking workflows that are still truly running.
- Treats `Workflow is busy` batch-describe responses as retryable cleanup control-plane transients.
- Keeps TLS handshake failures non-retryable so configuration errors fail fast under the larger default retry budget.

## Related Issues

None

## Testing

- `bun test packages/temporal-bun-sdk/tests/client/retries.test.ts packages/temporal-bun-sdk/tests/client/ops-client.test.ts`
- `bun test packages/temporal-bun-sdk/tests/scripts/cleanup-integration-workflows.test.ts packages/temporal-bun-sdk/tests/client/retries.test.ts`
- `bunx oxfmt --check packages/temporal-bun-sdk/src/client/retries.ts packages/temporal-bun-sdk/tests/client/retries.test.ts`
- `bunx oxfmt --check packages/temporal-bun-sdk/scripts/cleanup-integration-workflows.ts packages/temporal-bun-sdk/tests/scripts/cleanup-integration-workflows.test.ts packages/temporal-bun-sdk/src/client/retries.ts packages/temporal-bun-sdk/tests/client/retries.test.ts`
- `bunx oxfmt --check packages/temporal-bun-sdk/scripts/cleanup-integration-workflows.ts packages/temporal-bun-sdk/tests/scripts/cleanup-integration-workflows.test.ts`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint:type`
- `bun run --cwd packages/temporal-bun-sdk test`
- `bun run --filter @proompteng/temporal-bun-sdk build`
- `bun run --cwd packages/temporal-bun-sdk verify:production`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
