### PR TITLE
chore(jangar): promote image 7662e41d

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: b35eb9cd
-  digest: sha256:14f358992cf5604add328b2b308a228dc3f3b54ac0b5dffdba3626d1bae2ac61
+  tag: 7662e41d
+  digest: sha256:2d9d11eeea8124c7c36a437c2b5acfea7c4466ee5ed100e91f377c6e3089a57a
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: b35eb9cd
-    digest: sha256:08075a4c9f20cd5e590786937dcda4f8013df7b03f9ed1382d5bec71ac3ede1b
+    tag: 7662e41d
+    digest: sha256:3a9b259403cbc4c2a3c72d86bfcd0f383e4a734f10ac0ac163e0cf2a9c843010
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "12000"
-      JANGAR_SOURCE_HEAD_SHA: b35eb9cda753343351c7b02bb4c98704cb7fd3ef
-      JANGAR_GITOPS_REVISION: b35eb9cda753343351c7b02bb4c98704cb7fd3ef
-      JANGAR_SOURCE_CI_RUN_ID: "25954277300"
+      JANGAR_SOURCE_HEAD_SHA: 7662e41d7b05ac4b5230fbb63e39c93c164de6e4
+      JANGAR_GITOPS_REVISION: 7662e41d7b05ac4b5230fbb63e39c93c164de6e4
+      JANGAR_SOURCE_CI_RUN_ID: "25956674709"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:08075a4c9f20cd5e590786937dcda4f8013df7b03f9ed1382d5bec71ac3ede1b
-      JANGAR_SERVING_BUILD_COMMIT: b35eb9cda753343351c7b02bb4c98704cb7fd3ef
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:08075a4c9f20cd5e590786937dcda4f8013df7b03f9ed1382d5bec71ac3ede1b
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:3a9b259403cbc4c2a3c72d86bfcd0f383e4a734f10ac0ac163e0cf2a9c843010
+      JANGAR_SERVING_BUILD_COMMIT: 7662e41d7b05ac4b5230fbb63e39c93c164de6e4
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:3a9b259403cbc4c2a3c72d86bfcd0f383e4a734f10ac0ac163e0cf2a9c843010
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: b35eb9cd
-    digest: sha256:14f358992cf5604add328b2b308a228dc3f3b54ac0b5dffdba3626d1bae2ac61
+    tag: 7662e41d
+    digest: sha256:2d9d11eeea8124c7c36a437c2b5acfea7c4466ee5ed100e91f377c6e3089a57a
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-16T05:50:55Z
+    deploy.knative.dev/rollout: 2026-05-16T07:55:23Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:b35eb9cd@sha256:14f358992cf5604add328b2b308a228dc3f3b54ac0b5dffdba3626d1bae2ac61
+              value: registry.ide-newton.ts.net/lab/jangar:7662e41d@sha256:2d9d11eeea8124c7c36a437c2b5acfea7c4466ee5ed100e91f377c6e3089a57a
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: b35eb9cda753343351c7b02bb4c98704cb7fd3ef
+              value: 7662e41d7b05ac4b5230fbb63e39c93c164de6e4
             - name: JANGAR_GITOPS_REVISION
-              value: b35eb9cda753343351c7b02bb4c98704cb7fd3ef
+              value: 7662e41d7b05ac4b5230fbb63e39c93c164de6e4
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25954277300"
+              value: "25956674709"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:08075a4c9f20cd5e590786937dcda4f8013df7b03f9ed1382d5bec71ac3ede1b
+              value: sha256:3a9b259403cbc4c2a3c72d86bfcd0f383e4a734f10ac0ac163e0cf2a9c843010
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: b35eb9cda753343351c7b02bb4c98704cb7fd3ef
+              value: 7662e41d7b05ac4b5230fbb63e39c93c164de6e4
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:08075a4c9f20cd5e590786937dcda4f8013df7b03f9ed1382d5bec71ac3ede1b
+              value: sha256:3a9b259403cbc4c2a3c72d86bfcd0f383e4a734f10ac0ac163e0cf2a9c843010
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: b35eb9cd
-    digest: sha256:14f358992cf5604add328b2b308a228dc3f3b54ac0b5dffdba3626d1bae2ac61
+    newTag: 7662e41d
+    digest: sha256:2d9d11eeea8124c7c36a437c2b5acfea7c4466ee5ed100e91f377c6e3089a57a


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `7662e41d7b05ac4b5230fbb63e39c93c164de6e4`
- Image tag: `7662e41d`
- Image digest: `sha256:2d9d11eeea8124c7c36a437c2b5acfea7c4466ee5ed100e91f377c6e3089a57a`
- Source CI run: `25956674709`
- Control-plane serving digest: `sha256:3a9b259403cbc4c2a3c72d86bfcd0f383e4a734f10ac0ac163e0cf2a9c843010`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates