### PR TITLE
fix(torghut): prefer oracle-ready portfolio fallbacks

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -44,6 +44,10 @@ _FAMILY_RUNTIME = {
         "breakout_continuation_consistent",
         "breakout-continuation-long-v1",
     ),
+    "opening_drive_leader_reclaim_v1": (
+        "breakout_continuation_consistent",
+        "breakout-continuation-long-v1",
+    ),
     "intraday_tsmom_v2": ("intraday_tsmom_consistent", "intraday-tsmom-profit-v3"),
     "late_day_continuation_v1": (
         "late_day_continuation_consistent",
@@ -60,6 +64,7 @@ _FAMILY_TIEBREAK = {
     for index, family_template_id in enumerate(
         (
             "microstructure_continuation_matched_filter_v1",
+            "opening_drive_leader_reclaim_v1",
             "microbar_cross_sectional_pairs_v1",
             "intraday_tsmom_v2",
             "momentum_pullback_v1",
@@ -77,6 +82,7 @@ _PORTFOLIO_TARGET_NET_PNL_PER_DAY = Decimal("500")
 _PORTFOLIO_SLEEVE_FAMILY_TARGET = len(_FAMILY_RUNTIME)
 _PORTFOLIO_SLEEVE_FAMILY_ORDER = (
     "microstructure_continuation_matched_filter_v1",
+    "opening_drive_leader_reclaim_v1",
     "microbar_cross_sectional_pairs_v1",
     "intraday_tsmom_v2",
     "momentum_pullback_v1",
@@ -375,6 +381,76 @@ _FAMILY_EXECUTION_PROFILES: dict[str, tuple[dict[str, Any], ...]] = {
                 "long_stop_loss_bps": "10",
                 "long_trailing_stop_activation_profit_bps": "10",
                 "long_trailing_stop_drawdown_bps": "4",
+            },
+        },
+    ),
+    "opening_drive_leader_reclaim_v1": (
+        {
+            "universe_symbols": list(_PORTFOLIO_COVERAGE_UNIVERSE_PROFILE),
+            "max_position_pct_equity": "6.0",
+            "max_notional_per_trade": "189540",
+            "params": {
+                "min_cross_section_continuation_rank": "0.58",
+                "min_cross_section_opening_window_return_rank": "0.54",
+                "max_gross_exposure_pct_equity": "6.0",
+                "entry_notional_max_multiplier": "1.00",
+                "max_entries_per_session": "2",
+                "entry_cooldown_seconds": "600",
+                "leader_reclaim_start_minutes_since_open": "20",
+                "leader_reclaim_min_recent_imbalance_pressure": "0.06",
+                "leader_reclaim_min_recent_microprice_bias_bps": "0.12",
+                "leader_reclaim_min_recent_above_opening_window_close_ratio": "0.54",
+                "leader_reclaim_min_recent_above_vwap_w5m_ratio": "0.52",
+                "max_session_negative_exit_bps": "6",
+                "long_stop_loss_bps": "8",
+                "long_trailing_stop_activation_profit_bps": "6",
+                "long_trailing_stop_drawdown_bps": "3",
+            },
+        },
+        {
+            "universe_symbols": list(
+                _PORTFOLIO_AI_ACCELERATOR_COVERAGE_UNIVERSE_PROFILE
+            ),
+            "max_position_pct_equity": "5.0",
+            "max_notional_per_trade": "157950",
+            "params": {
+                "min_cross_section_continuation_rank": "0.64",
+                "min_cross_section_opening_window_return_rank": "0.60",
+                "max_gross_exposure_pct_equity": "5.0",
+                "entry_notional_max_multiplier": "0.90",
+                "max_entries_per_session": "2",
+                "entry_cooldown_seconds": "900",
+                "leader_reclaim_start_minutes_since_open": "30",
+                "leader_reclaim_min_recent_imbalance_pressure": "0.08",
+                "leader_reclaim_min_recent_microprice_bias_bps": "0.16",
+                "leader_reclaim_min_recent_above_opening_window_close_ratio": "0.58",
+                "leader_reclaim_min_recent_above_vwap_w5m_ratio": "0.56",
+                "max_session_negative_exit_bps": "5",
+                "long_stop_loss_bps": "7",
+                "long_trailing_stop_activation_profit_bps": "6",
+                "long_trailing_stop_drawdown_bps": "3",
+            },
+        },
+        {
+            "universe_symbols": list(_PORTFOLIO_PLATFORM_COVERAGE_UNIVERSE_PROFILE),
+            "max_position_pct_equity": "4.0",
+            "max_notional_per_trade": "126360",
+            "params": {
+                "min_cross_section_continuation_rank": "0.52",
+                "min_cross_section_opening_window_return_rank": "0.48",
+                "max_gross_exposure_pct_equity": "4.0",
+                "entry_notional_max_multiplier": "0.80",
+                "max_entries_per_session": "3",
+                "entry_cooldown_seconds": "600",
+                "leader_reclaim_start_minutes_since_open": "15",
+                "leader_reclaim_min_recent_imbalance_pressure": "0.04",
+                "leader_reclaim_min_recent_microprice_bias_bps": "0.08",
+                "leader_reclaim_min_recent_above_opening_window_close_ratio": "0.50",
+                "leader_reclaim_min_recent_above_vwap_w5m_ratio": "0.48",
+                "max_session_negative_exit_bps": "4",
+                "long_stop_loss_bps": "6",
+                "long_trailing_stop_activation_profit_bps": "5",
+                "long_trailing_stop_drawdown_bps": "2",
             },
         },
     ),
@@ -1237,6 +1313,76 @@ _PORTFOLIO_ORACLE_COVERAGE_EXECUTION_PROFILES: dict[str, tuple[dict[str, Any], .
                 "leader_reclaim_min_recent_microprice_bias_bps": "0.04",
                 "leader_reclaim_min_recent_above_opening_window_close_ratio": "0.48",
                 "leader_reclaim_min_recent_above_vwap_w5m_ratio": "0.48",
+                "max_session_negative_exit_bps": "3",
+                "long_stop_loss_bps": "4",
+                "long_trailing_stop_activation_profit_bps": "4",
+                "long_trailing_stop_drawdown_bps": "2",
+            },
+        },
+    ),
+    "opening_drive_leader_reclaim_v1": (
+        {
+            "universe_symbols": list(_PORTFOLIO_COVERAGE_UNIVERSE_PROFILE),
+            "max_position_pct_equity": "3.0",
+            "max_notional_per_trade": "94770",
+            "params": {
+                "min_cross_section_continuation_rank": "0.48",
+                "min_cross_section_opening_window_return_rank": "0.44",
+                "max_gross_exposure_pct_equity": "4.0",
+                "entry_notional_max_multiplier": "0.70",
+                "max_entries_per_session": "4",
+                "entry_cooldown_seconds": "300",
+                "leader_reclaim_start_minutes_since_open": "15",
+                "leader_reclaim_min_recent_imbalance_pressure": "0.03",
+                "leader_reclaim_min_recent_microprice_bias_bps": "0.06",
+                "leader_reclaim_min_recent_above_opening_window_close_ratio": "0.48",
+                "leader_reclaim_min_recent_above_vwap_w5m_ratio": "0.46",
+                "max_session_negative_exit_bps": "3",
+                "long_stop_loss_bps": "5",
+                "long_trailing_stop_activation_profit_bps": "4",
+                "long_trailing_stop_drawdown_bps": "2",
+            },
+        },
+        {
+            "universe_symbols": list(
+                _PORTFOLIO_AI_ACCELERATOR_COVERAGE_UNIVERSE_PROFILE
+            ),
+            "max_position_pct_equity": "2.5",
+            "max_notional_per_trade": "78975",
+            "params": {
+                "min_cross_section_continuation_rank": "0.56",
+                "min_cross_section_opening_window_return_rank": "0.52",
+                "max_gross_exposure_pct_equity": "4.0",
+                "entry_notional_max_multiplier": "0.60",
+                "max_entries_per_session": "3",
+                "entry_cooldown_seconds": "600",
+                "leader_reclaim_start_minutes_since_open": "25",
+                "leader_reclaim_min_recent_imbalance_pressure": "0.05",
+                "leader_reclaim_min_recent_microprice_bias_bps": "0.10",
+                "leader_reclaim_min_recent_above_opening_window_close_ratio": "0.54",
+                "leader_reclaim_min_recent_above_vwap_w5m_ratio": "0.52",
+                "max_session_negative_exit_bps": "3",
+                "long_stop_loss_bps": "5",
+                "long_trailing_stop_activation_profit_bps": "5",
+                "long_trailing_stop_drawdown_bps": "2",
+            },
+        },
+        {
+            "universe_symbols": list(_PORTFOLIO_PLATFORM_COVERAGE_UNIVERSE_PROFILE),
+            "max_position_pct_equity": "2.0",
+            "max_notional_per_trade": "63180",
+            "params": {
+                "min_cross_section_continuation_rank": "0.42",
+                "min_cross_section_opening_window_return_rank": "0.38",
+                "max_gross_exposure_pct_equity": "3.0",
+                "entry_notional_max_multiplier": "0.50",
+                "max_entries_per_session": "4",
+                "entry_cooldown_seconds": "600",
+                "leader_reclaim_start_minutes_since_open": "15",
+                "leader_reclaim_min_recent_imbalance_pressure": "0.02",
+                "leader_reclaim_min_recent_microprice_bias_bps": "0.04",
+                "leader_reclaim_min_recent_above_opening_window_close_ratio": "0.46",
+                "leader_reclaim_min_recent_above_vwap_w5m_ratio": "0.44",
                 "max_session_negative_exit_bps": "3",
                 "long_stop_loss_bps": "4",
                 "long_trailing_stop_activation_profit_bps": "4",
@@ -2280,9 +2426,11 @@ def _family_scores_for_hypothesis(
     if has_any(("volatility", "regime", "stress window", "nearly unstable")):
         bump("intraday_tsmom_v2", 4, "volatility_or_regime_state")
         bump("momentum_pullback_v1", 2, "volatility_or_regime_state")
+        bump("opening_drive_leader_reclaim_v1", 2, "volatility_or_regime_state")
     if has_any(("momentum", "trend", "pullback", "trend persistence")):
         bump("momentum_pullback_v1", 5, "momentum_or_pullback")
         bump("intraday_tsmom_v2", 4, "momentum_or_pullback")
+        bump("opening_drive_leader_reclaim_v1", 3, "momentum_or_pullback")
     if has_any(
         (
             "weighted microprice",
@@ -2337,6 +2485,25 @@ def _family_scores_for_hypothesis(
             2,
             "continuation_or_reclaim",
         )
+    if has_any(
+        (
+            "first half-hour",
+            "first half hour",
+            "first 30",
+            "morning momentum",
+            "opening drive",
+            "opening-drive",
+            "opening window",
+            "open window",
+            "leader reclaim",
+            "macro announcement",
+            "announcement",
+            "information discreteness",
+        )
+    ):
+        bump("opening_drive_leader_reclaim_v1", 7, "morning_or_announcement_momentum")
+        bump("late_day_continuation_v1", 3, "morning_or_announcement_momentum")
+        bump("intraday_tsmom_v2", 2, "morning_or_announcement_momentum")
     if has_any(("washout", "reversal", "rebound", "mean reversion", "dislocation")):
         bump("washout_rebound_v2", 5, "reversal_or_rebound")
         bump("mean_reversion_rebound_v1", 5, "reversal_or_rebound")

--- a/services/torghut/app/trading/discovery/mlx_training_data.py
+++ b/services/torghut/app/trading/discovery/mlx_training_data.py
@@ -316,10 +316,11 @@ def _family_code(family_template_id: str) -> float:
         "mean_reversion_rebound_v1": 4.0,
         "microbar_cross_sectional_pairs_v1": 5.0,
         "microstructure_continuation_matched_filter_v1": 6.0,
-        "intraday_tsmom_v2": 7.0,
-        "late_day_continuation_v1": 8.0,
-        "end_of_day_reversal_v1": 9.0,
-        "mean_reversion_exhaustion_short_v1": 10.0,
+        "opening_drive_leader_reclaim_v1": 7.0,
+        "intraday_tsmom_v2": 8.0,
+        "late_day_continuation_v1": 9.0,
+        "end_of_day_reversal_v1": 10.0,
+        "mean_reversion_exhaustion_short_v1": 11.0,
     }
     return families.get(family_template_id, 0.0)
 

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -526,6 +526,7 @@ def _portfolio_scorecard(
         "target_met": net_per_day >= target_net_pnl_per_day,
         "active_day_ratio": str(active_day_ratio),
         "positive_day_ratio": str(positive_day_ratio),
+        "min_daily_net_pnl": str(min_day),
         "worst_day_loss": str(worst_day_loss),
         "max_drawdown": str(_max_drawdown_from_daily(daily_net)),
         "max_gross_exposure_pct_equity": str(
@@ -597,6 +598,17 @@ def _scorecard_decimal(scorecard: Mapping[str, Any], field: str) -> Decimal:
     return _decimal(scorecard.get(field))
 
 
+def _oracle_blocker_count(scorecard: Mapping[str, Any]) -> Decimal:
+    oracle = scorecard.get("profit_target_oracle")
+    if not isinstance(oracle, Mapping):
+        return Decimal("0")
+    oracle_mapping = cast(Mapping[Any, Any], oracle)
+    blockers = oracle_mapping.get("blockers")
+    if isinstance(blockers, Sequence) and not isinstance(blockers, str):
+        return Decimal(len(cast(Sequence[Any], blockers)))
+    return Decimal("0")
+
+
 def _portfolio_selection_key(
     *,
     selected: Sequence[CandidateEvidenceBundle],
@@ -604,10 +616,14 @@ def _portfolio_selection_key(
 ) -> tuple[Decimal, ...]:
     return (
         Decimal(1 if bool(scorecard.get("oracle_passed")) else 0),
+        -_oracle_blocker_count(scorecard),
         Decimal(1 if bool(scorecard.get("target_met")) else 0),
-        _scorecard_decimal(scorecard, "net_pnl_per_day"),
         _scorecard_decimal(scorecard, "active_day_ratio"),
         _scorecard_decimal(scorecard, "positive_day_ratio"),
+        _scorecard_decimal(scorecard, "min_daily_net_pnl"),
+        _scorecard_decimal(scorecard, "net_pnl_per_day"),
+        -_scorecard_decimal(scorecard, "missing_sleeve_daily_net_count"),
+        _scorecard_decimal(scorecard, "avg_filled_notional_per_day"),
         -_scorecard_decimal(scorecard, "best_day_share"),
         -_scorecard_decimal(scorecard, "max_single_symbol_contribution_share"),
         -_scorecard_decimal(scorecard, "max_cluster_contribution_share"),
@@ -621,43 +637,27 @@ def _portfolio_selection_key(
     )
 
 
-def _partial_selection_key(
-    selected: Sequence[CandidateEvidenceBundle],
-) -> tuple[Decimal, ...]:
-    if not selected:
-        return (
-            Decimal("0"),
-            Decimal("0"),
-            Decimal("0"),
-            Decimal("0"),
-            Decimal("0"),
-            Decimal("0"),
-            Decimal("0"),
-            Decimal("0"),
-            Decimal("0"),
-            Decimal("0"),
-            Decimal("0"),
-            Decimal("0"),
-            Decimal("0"),
-            Decimal("0"),
-            Decimal("0"),
-        )
+def _empty_selection_key() -> tuple[Decimal, ...]:
     return (
         Decimal("0"),
         Decimal("0"),
-        sum((_net_per_day(bundle) for bundle in selected), Decimal("0")),
-        _mean([_active_ratio(bundle) for bundle in selected]),
-        _mean([_positive_ratio(bundle) for bundle in selected]),
-        -max((_best_day_share(bundle) for bundle in selected), default=Decimal("0")),
-        -_max_share(_symbol_contribution_shares(selected)),
-        -_max_share(_cluster_contribution_shares(selected)),
-        -_portfolio_max_gross_exposure_pct_equity(selected),
-        _portfolio_min_cash(selected),
-        Decimal(-_portfolio_negative_cash_observation_count(selected)),
-        -max((_worst_day_loss(bundle) for bundle in selected), default=Decimal("0")),
-        -max((_max_drawdown(bundle) for bundle in selected), default=Decimal("0")),
-        Decimal(len(selected)),
-        sum((_sleeve_score(bundle) for bundle in selected), Decimal("0")),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("0"),
     )
 
 
@@ -738,13 +738,13 @@ def _select_portfolio_bundles(
 
     def state_sort_key(state: tuple[int, ...]) -> tuple[tuple[Decimal, ...], str]:
         selected = _selected_from_state(ordered, state)
-        if len(state) >= requested_portfolio_size_min:
+        if not selected:
+            quality_key = _empty_selection_key()
+        else:
             quality_key = _portfolio_selection_key(
                 selected=selected,
                 scorecard=state_scorecard(state),
             )
-        else:
-            quality_key = _partial_selection_key(selected)
         return (quality_key, "|".join(bundle.candidate_id for bundle in selected))
 
     beam: list[tuple[int, ...]] = [()]

--- a/services/torghut/app/trading/discovery/whitepaper_candidate_compiler.py
+++ b/services/torghut/app/trading/discovery/whitepaper_candidate_compiler.py
@@ -24,6 +24,7 @@ EXECUTABLE_FAMILY_IDS = {
     "mean_reversion_exhaustion_short_v1",
     "microbar_cross_sectional_pairs_v1",
     "microstructure_continuation_matched_filter_v1",
+    "opening_drive_leader_reclaim_v1",
     "intraday_tsmom_v2",
     "late_day_continuation_v1",
     "end_of_day_reversal_v1",

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -2375,6 +2375,7 @@ def _pre_replay_candidate_score(spec: CandidateSpec) -> Decimal:
     family_score = {
         "microbar_cross_sectional_pairs_v1": Decimal("70"),
         "microstructure_continuation_matched_filter_v1": Decimal("65"),
+        "opening_drive_leader_reclaim_v1": Decimal("63"),
         "momentum_pullback_v1": Decimal("60"),
         "washout_rebound_v2": Decimal("55"),
         "breakout_reclaim_v2": Decimal("50"),
@@ -3509,6 +3510,7 @@ def _synthetic_net_for_spec(spec: CandidateSpec, *, rank: int) -> Decimal:
     family_bonus = {
         "microbar_cross_sectional_pairs_v1": Decimal("215"),
         "microstructure_continuation_matched_filter_v1": Decimal("190"),
+        "opening_drive_leader_reclaim_v1": Decimal("185"),
         "momentum_pullback_v1": Decimal("175"),
         "washout_rebound_v2": Decimal("165"),
         "breakout_reclaim_v2": Decimal("155"),

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -132,6 +132,41 @@ class TestCandidateSpecs(TestCase):
         reloaded = candidate_spec_from_payload(first[0].to_payload())
         self.assertEqual(reloaded.candidate_spec_id, first[0].candidate_spec_id)
 
+    def test_morning_momentum_claim_selects_opening_drive_family(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-morning-momentum",
+            claims=[
+                {
+                    "claim_id": "claim-first-half-hour",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": (
+                        "First half-hour return and opening drive leader reclaim "
+                        "predict intraday momentum when information is discrete."
+                    ),
+                    "confidence": "0.83",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+
+        opening_specs = [
+            spec
+            for spec in specs
+            if spec.family_template_id == "opening_drive_leader_reclaim_v1"
+        ]
+        self.assertTrue(opening_specs)
+        self.assertEqual(
+            opening_specs[0].runtime_strategy_name,
+            "breakout-continuation-long-v1",
+        )
+        self.assertIn(
+            "morning_or_announcement_momentum",
+            opening_specs[0].feature_contract["family_selection"]["reasons"],
+        )
+
     def test_unpinned_hypotheses_expand_all_family_execution_profiles(self) -> None:
         cards = build_hypothesis_cards(
             source_run_id="paper-profile-breadth",

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -1000,6 +1000,118 @@ class TestPortfolioOptimizer(TestCase):
         )
         self.assertGreater(portfolio.optimizer_report["finalist_state_count"], 1)
 
+    def test_optimizer_prefers_fewer_oracle_blockers_over_average_only(
+        self,
+    ) -> None:
+        def bundle(
+            *,
+            candidate_id: str,
+            net_pnl_per_day: str,
+            symbol: str,
+            cluster: str,
+            daily_net: tuple[str, str, str, str, str],
+        ) -> CandidateEvidenceBundle:
+            return evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"spec-{candidate_id}",
+                candidate={
+                    "candidate_id": candidate_id,
+                    "runtime_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "family_template_id": "microbar_cross_sectional_pairs_v1",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": net_pnl_per_day,
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "best_day_share": "0.2",
+                        "avg_filled_notional_per_day": "350000",
+                        "regime_slice_pass_rate": "0.55",
+                        "posterior_edge_lower": "0.01",
+                        "shadow_parity_status": "within_budget",
+                        "correlation_cluster": cluster,
+                        "symbol_contribution_shares": {symbol: "1.0"},
+                        **_executable_scorecard_fields(candidate_id),
+                    },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": daily_net[0],
+                            "2026-02-24": daily_net[1],
+                            "2026-02-25": daily_net[2],
+                            "2026-02-26": daily_net[3],
+                            "2026-02-27": daily_net[4],
+                        },
+                        "daily_filled_notional": {
+                            "2026-02-23": "350000",
+                            "2026-02-24": "350000",
+                            "2026-02-25": "350000",
+                            "2026-02-26": "350000",
+                            "2026-02-27": "350000",
+                        },
+                    },
+                },
+                dataset_snapshot_id="snapshot-oracle-aware-fallback",
+                result_path=f"/tmp/{candidate_id}.json",
+            )
+
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=[
+                bundle(
+                    candidate_id="cand-sparse-intc",
+                    net_pnl_per_day="540",
+                    symbol="INTC",
+                    cluster="sparse-intc",
+                    daily_net=("2700", "0", "0", "0", "0"),
+                ),
+                bundle(
+                    candidate_id="cand-steady-aapl",
+                    net_pnl_per_day="480",
+                    symbol="AAPL",
+                    cluster="steady-aapl",
+                    daily_net=("480", "480", "480", "480", "480"),
+                ),
+                bundle(
+                    candidate_id="cand-steady-amzn",
+                    net_pnl_per_day="480",
+                    symbol="AMZN",
+                    cluster="steady-amzn",
+                    daily_net=("480", "480", "480", "480", "480"),
+                ),
+                bundle(
+                    candidate_id="cand-steady-googl",
+                    net_pnl_per_day="480",
+                    symbol="GOOGL",
+                    cluster="steady-googl",
+                    daily_net=("480", "480", "480", "480", "480"),
+                ),
+            ],
+            target_net_pnl_per_day=Decimal("500"),
+            portfolio_size_min=3,
+            portfolio_size_max=3,
+        )
+
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        self.assertCountEqual(
+            portfolio.source_candidate_ids,
+            ("cand-steady-aapl", "cand-steady-amzn", "cand-steady-googl"),
+        )
+        self.assertFalse(portfolio.objective_scorecard["oracle_passed"])
+        self.assertEqual(
+            portfolio.objective_scorecard["min_daily_net_pnl"],
+            "480.0000000000000000000000000",
+        )
+        self.assertLessEqual(
+            Decimal(
+                portfolio.objective_scorecard["max_single_symbol_contribution_share"]
+            ),
+            Decimal("0.35"),
+        )
+        self.assertEqual(
+            portfolio.objective_scorecard["profit_target_oracle"]["blockers"],
+            ["portfolio_post_cost_net_pnl_per_day_failed"],
+        )
+
     def test_optimizer_rejects_correlated_sleeves_before_minimum_size(
         self,
     ) -> None:

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -28,6 +28,20 @@ def _executable_scorecard_fields(index: int | str = 0) -> dict[str, object]:
 
 
 class TestPortfolioOptimizer(TestCase):
+    def test_oracle_blocker_count_treats_malformed_payloads_as_unblocked(
+        self,
+    ) -> None:
+        self.assertEqual(
+            portfolio_optimizer_module._oracle_blocker_count({}),
+            Decimal("0"),
+        )
+        self.assertEqual(
+            portfolio_optimizer_module._oracle_blocker_count(
+                {"profit_target_oracle": {"blockers": "missing_daily_net"}}
+            ),
+            Decimal("0"),
+        )
+
     def test_capital_safety_rejection_reasons_block_minimums(self) -> None:
         def bundle(
             candidate_id: str,


### PR DESCRIPTION
## Summary

- Makes portfolio fallback scoring oracle-aware when no candidate fully passes yet.
- Adds minimum daily net PnL to portfolio scorecards for optimizer selection diagnostics.
- Enables the existing opening-drive leader-reclaim family as an executable autoresearch sleeve, with morning/opening-window execution profiles.
- Adds regression coverage for sparse high-average portfolios, malformed oracle blocker payloads, and morning momentum family selection.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py`
- `uv run --frozen pytest tests/test_candidate_specs.py tests/test_whitepaper_candidate_compiler.py tests/test_whitepaper_autoresearch_artifacts.py -q`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py tests/test_profit_target_oracle.py tests/test_run_whitepaper_autoresearch_profit_target.py -k "portfolio or optimizer or profit_target" -q`
- `uv run --frozen coverage erase && uv run --frozen coverage run -m pytest tests/test_portfolio_optimizer.py tests/test_candidate_specs.py -q && uv run --frozen coverage xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen ruff format --check app/trading/discovery/portfolio_optimizer.py app/trading/discovery/candidate_specs.py app/trading/discovery/whitepaper_candidate_compiler.py app/trading/discovery/mlx_training_data.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_portfolio_optimizer.py tests/test_candidate_specs.py`
- `uv run --frozen ruff check app/trading/discovery/portfolio_optimizer.py app/trading/discovery/candidate_specs.py app/trading/discovery/whitepaper_candidate_compiler.py app/trading/discovery/mlx_training_data.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_portfolio_optimizer.py tests/test_candidate_specs.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
