### PR TITLE
fix(agents): redact provider html in swarm handoffs

### DIFF
--- a/argocd/applications/agents/codex-spark-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-agentprovider.yaml
@@ -212,6 +212,7 @@ spec:
         #!/usr/bin/env python3
         import json
         import os
+        import re
         import subprocess
         import sys
         import urllib.error
@@ -228,6 +229,47 @@ spec:
           if isinstance(value, (int, float, bool)):
             return str(value)
           return default
+
+        SUPPRESSED_PROVIDER_HTML = "[suppressed provider HTML response body]"
+        HTML_DOCUMENT_FRAGMENT = re.compile(r"(?:<!doctype|<html\b|<head\b|<body\b|<style\b|<script\b|<svg\b|<path\b)", re.IGNORECASE)
+
+        def summarize_text(value: str, max_chars: int = 600) -> str:
+          text = value.strip()
+          if len(text) <= max_chars:
+            return text
+          return f"{text[:max_chars]}..."
+
+        def sanitize_human_facing_log_text(value: str, max_chars: int = 1000) -> str:
+          sanitized = value.replace("\r", "").strip()
+          if not sanitized:
+            return ""
+          if HTML_DOCUMENT_FRAGMENT.search(sanitized):
+            sanitized = re.sub(r"\s*<!doctype[\s\S]*$", f" {SUPPRESSED_PROVIDER_HTML}", sanitized, flags=re.IGNORECASE)
+            sanitized = re.sub(r"\s*<html[\s\S]*$", f" {SUPPRESSED_PROVIDER_HTML}", sanitized, flags=re.IGNORECASE)
+            sanitized = re.sub(r"\s*<head[\s\S]*$", f" {SUPPRESSED_PROVIDER_HTML}", sanitized, flags=re.IGNORECASE)
+            sanitized = re.sub(r"\s*<body[\s\S]*$", f" {SUPPRESSED_PROVIDER_HTML}", sanitized, flags=re.IGNORECASE)
+            sanitized = re.sub(r"\s*<style[\s\S]*$", f" {SUPPRESSED_PROVIDER_HTML}", sanitized, flags=re.IGNORECASE)
+            sanitized = re.sub(r"\s*<script[\s\S]*$", f" {SUPPRESSED_PROVIDER_HTML}", sanitized, flags=re.IGNORECASE)
+            sanitized = re.sub(r"\s*<svg[\s\S]*$", f" {SUPPRESSED_PROVIDER_HTML}", sanitized, flags=re.IGNORECASE)
+          sanitized = re.sub(r"<[^>\n]{1,500}>", " ", sanitized)
+          sanitized = re.sub(r"\s+", " ", sanitized).strip()
+          return summarize_text(sanitized or SUPPRESSED_PROVIDER_HTML, max_chars)
+
+        def summarize_failure_tail(log_text: str) -> str:
+          lines: list[str] = []
+          for line in log_text.splitlines():
+            sanitized = sanitize_human_facing_log_text(line, 600)
+            if not sanitized:
+              continue
+            lowered = sanitized.lower()
+            if any(marker in lowered for marker in ("quota exceeded", "codex exited", "stream error", "turn failed", "failed to warm featured plugin", "forbidden", "denied", "timeout", "exception", "traceback", "panic", "suppressed provider html")):
+              lines.append(sanitized)
+          if not lines and log_text.strip():
+            lines.append(sanitize_human_facing_log_text(log_text, 1000))
+          if not lines:
+            return "No primary provider failure log was captured."
+          compact = "\n".join(dict.fromkeys(lines))
+          return compact[-1500:]
 
         def read_field(payload: dict, key: str, default: str = "") -> str:
           value = as_text(payload.get(key))
@@ -543,6 +585,7 @@ spec:
           business_metric = read_field(payload, "swarmBusinessMetric", "unavailable")
           evidence_url = read_field(payload, "swarmBusinessEvidenceUrl", "")
           failure_tail = log_path.read_text(encoding="utf-8", errors="replace")[-4000:] if log_path.exists() else ""
+          failure_summary = summarize_failure_tail(failure_tail)
           upstream = resolve_auto_upstream(payload, swarm_name, stage, role, run_name)
 
           print("SWARM_CODEX_HF_FALLBACK_UPSTREAM_BEGIN")
@@ -577,8 +620,8 @@ spec:
                 f"Business metric: {business_metric}",
                 f"Business evidence URL: {evidence_url}",
                 "",
-                "Primary Codex failure tail:",
-                failure_tail,
+                "Primary Codex failure summary:",
+                failure_summary,
                 "",
                 "The wrapper will render authoritative upstream run and stage facts.",
                 "Do not mention upstream run or upstream stage. Return 2-4 concise bullets with only additional teammate observations.",
@@ -611,7 +654,8 @@ spec:
             "role": role,
             "identity": identity,
             "model": model,
-            "primary_failure_tail": failure_tail,
+            "primary_failure_tail": failure_summary,
+            "primary_failure_summary": failure_summary,
             "upstream_read": summarize_upstream(upstream),
             "model_note": model_note,
             "content": content,

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -377,16 +377,21 @@ describe('scheduled AgentRun templates', () => {
     expect(objectAt(envTemplate, 'AGENT_RUN_NAME')).toBe('{{agentRun.name}}')
     expect(objectAt(envTemplate, 'AGENT_RUN_NAMESPACE')).toBe('{{agentRun.namespace}}')
     expect(content).toContain('def summarize_upstream(upstream: str) -> str:')
+    expect(content).toContain('def summarize_failure_tail(log_text: str) -> str:')
     expect(content).toContain(
       'def handoff_subject(payload: dict, swarm_name: str, role: str, run_name: str, suffix: str = "") -> str:',
     )
     expect(content).toContain('def render_fallback_result(')
     expect(content).toContain('Auto-discovered upstream run:')
     expect(content).toContain('The wrapper will render authoritative upstream run and stage facts.')
+    expect(content).toContain('Primary Codex failure summary:')
+    expect(content).toContain('"primary_failure_tail": failure_summary')
+    expect(content).toContain('"primary_failure_summary": failure_summary')
     expect(content).toContain('\"upstream_read\": summarize_upstream(upstream)')
     expect(content).toContain(
       'publish_handoff(handoff_subject(payload, swarm_name, role, run_name, "fallback"), handoff)',
     )
+    expect(content).not.toContain('Primary Codex failure tail:')
     expect(content).not.toContain('publish_handoff(f"swarm.')
   })
 

--- a/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
+++ b/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
@@ -921,6 +921,60 @@ describe('runCodexImplementation', () => {
     })
   }, 40_000)
 
+  it('suppresses provider HTML dumps in failed swarm handoff messages', async () => {
+    const capturePath = await installNatsPublishCapture(workdir, 'nats-publish-sanitized-failed-handoff.jsonl')
+    runCodexSessionMock.mockRejectedValueOnce(
+      new Error(
+        'codex exited with status 1: failed to warm featured plugin ids cache error=remote plugin sync request to https://chatgpt.com/backend-api/plugins/featured failed with status 403 Forbidden: <html><head><meta name="viewport" content="width=device-width"><style global>body{font-family:Arial}.container{display:flex}</style></head><body><div class="container"><svg width="41" height="41" viewBox="0 0 41 41"><path d="M37.5324 16.8707C37.9808 15.5241"/></svg><noscript>Enable JavaScript and cookies to continue</noscript></div></body></html>',
+      ),
+    )
+
+    const payload = {
+      prompt: 'Implementation prompt',
+      repository: 'owner/repo',
+      issueNumber: 42,
+      base: 'main',
+      head: 'codex/issue-42',
+      issueTitle: 'Title',
+      objective: 'validate readable cross-swarm failure handoff',
+      swarmRequirementChannel: 'workflow.general.requirement',
+      swarmRequirementId: '00gc1i45',
+      swarmRequirementSignal: 'torghut-to-jangar-e2e-1772433239',
+      swarmRequirementSource: 'torghut-quant',
+      swarmRequirementTarget: 'jangar-control-plane',
+      swarmRequirementDescription: 'Post-merge validation with noisy provider failure.',
+      swarmAgentWorkerId: 'worker-0027ilba',
+      swarmAgentIdentity: 'vw-jangar-control-plane-implement-worker-0027ilba',
+      swarmAgentRole: 'implement',
+    }
+    await writeFile(eventPath, JSON.stringify(payload))
+
+    await expect(runCodexImplementation(eventPath)).rejects.toThrow('codex exited with status 1')
+
+    const captured = await readCapturedNatsPublishes(capturePath)
+    const handoff = findCapturedNatsPublish(captured, 'swarm-handoff')
+    expect(handoff).toBeDefined()
+    if (!handoff) throw new Error('Expected a failed swarm-handoff publish call')
+    const handoffContent = contentFromCapturedNatsPublish(handoff)
+    const handoffAttrs = JSON.stringify(attrsFromCapturedNatsPublish(handoff))
+
+    expect(handoffContent).toContain('I am blocked on implementation for owner/repo#42.')
+    expect(handoffContent).toContain('[suppressed provider HTML response body]')
+    expect(handoffContent).not.toContain('<html')
+    expect(handoffContent).not.toContain('<style')
+    expect(handoffContent).not.toContain('viewBox')
+    expect(handoffAttrs).not.toContain('<html')
+    expect(handoffAttrs).not.toContain('viewBox')
+
+    const runGaps = findCapturedNatsPublish(captured, 'run-gaps')
+    expect(runGaps).toBeDefined()
+    if (!runGaps) throw new Error('Expected a failed run-gaps publish call')
+    const runGapContent = contentFromCapturedNatsPublish(runGaps)
+    expect(runGapContent).toContain('[suppressed provider HTML response body]')
+    expect(runGapContent).not.toContain('<html')
+    expect(runGapContent).not.toContain('viewBox')
+  }, 40_000)
+
   it('accepts worker identity metadata from parameters map', async () => {
     const payload = {
       prompt: 'Implementation prompt',

--- a/services/jangar/scripts/codex/codex-implement.ts
+++ b/services/jangar/scripts/codex/codex-implement.ts
@@ -288,6 +288,38 @@ const summarizeText = (value: string | undefined, max = 260) => {
   return `${trimmed.slice(0, max)}…`
 }
 
+const SUPPRESSED_PROVIDER_HTML = '[suppressed provider HTML response body]'
+const HTML_DOCUMENT_FRAGMENT = /(?:<!doctype|<html\b|<head\b|<body\b|<style\b|<script\b|<svg\b|<path\b)/i
+
+const sanitizeHumanFacingLogText = (value: string | null | undefined, max = 600) => {
+  if (!value) return ''
+
+  let sanitized = value.replace(/\r/g, '').trim()
+  if (!sanitized) return ''
+
+  if (HTML_DOCUMENT_FRAGMENT.test(sanitized)) {
+    sanitized = sanitized
+      .replace(/\s*<!doctype[\s\S]*$/i, ` ${SUPPRESSED_PROVIDER_HTML}`)
+      .replace(/\s*<html[\s\S]*$/i, ` ${SUPPRESSED_PROVIDER_HTML}`)
+      .replace(/\s*<head[\s\S]*$/i, ` ${SUPPRESSED_PROVIDER_HTML}`)
+      .replace(/\s*<body[\s\S]*$/i, ` ${SUPPRESSED_PROVIDER_HTML}`)
+      .replace(/\s*<style[\s\S]*$/i, ` ${SUPPRESSED_PROVIDER_HTML}`)
+      .replace(/\s*<script[\s\S]*$/i, ` ${SUPPRESSED_PROVIDER_HTML}`)
+      .replace(/\s*<svg[\s\S]*$/i, ` ${SUPPRESSED_PROVIDER_HTML}`)
+  }
+
+  sanitized = sanitized
+    .replace(/<[^>\n]{1,500}>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (!sanitized) return SUPPRESSED_PROVIDER_HTML
+  return summarizeText(sanitized, max)
+}
+
+const sanitizeHumanFacingList = (items: string[] | undefined, max = 260) =>
+  (items ?? []).map((item) => sanitizeHumanFacingLogText(item, max)).filter((item) => item.length > 0)
+
 const truncatePromptSegment = (value: string, maxChars: number) => {
   const normalized = value.trim()
   if (normalized.length <= maxChars) {
@@ -349,17 +381,20 @@ const buildOwnerUpdateMessage = ({
   prUrl?: string | null
 }) => {
   const completed = decision === 'completed'
+  const safeRunSummary = sanitizeHumanFacingLogText(runSummary, 220)
+  const safeTests = sanitizeHumanFacingList(tests)
+  const safeGaps = sanitizeHumanFacingList(gaps)
   const lines = [
     completed
       ? `I finished ${stage} for ${repository}#${issueNumber}.`
       : `I am blocked on ${stage} for ${repository}#${issueNumber}.`,
     requirementMetadata.objective ? `Objective: ${summarizeText(requirementMetadata.objective, 200)}.` : '',
-    runSummary ? `Summary: ${summarizeText(runSummary, 220)}.` : '',
+    safeRunSummary ? `Summary: ${safeRunSummary}.` : '',
     prUrl ? `PR: ${prUrl}.` : '',
-    tests && tests.length > 0
-      ? `Validation results: ${tests.join('; ')}.`
+    safeTests.length > 0
+      ? `Validation results: ${safeTests.join('; ')}.`
       : 'Validation results: no explicit test list in the final run output.',
-    gaps && gaps.length > 0 ? `Key risks: ${gaps.join('; ')}.` : 'Key risks: none identified.',
+    safeGaps.length > 0 ? `Key risks: ${safeGaps.join('; ')}.` : 'Key risks: none identified.',
     requirementMetadata.acceptance && requirementMetadata.acceptance.length > 0
       ? `Acceptance criteria: ${requirementMetadata.acceptance.join('; ')}.`
       : '',
@@ -392,6 +427,9 @@ const buildReleaseNote = ({
   gaps?: string[]
   prUrl?: string | null
 }) => {
+  const safeRunSummary = sanitizeHumanFacingLogText(runSummary, 220)
+  const safeTests = sanitizeHumanFacingList(tests)
+  const safeGaps = sanitizeHumanFacingList(gaps)
   const requirementProvenance = [
     requirementMetadata.id ? `ID ${requirementMetadata.id}` : '',
     requirementMetadata.signal ? `signal ${requirementMetadata.signal}` : '',
@@ -404,7 +442,7 @@ const buildReleaseNote = ({
   const whatShipped = [
     `${stage} is ${decision === 'completed' ? 'complete' : 'blocked'}`,
     requirementMetadata.objective ? `Objective: ${summarizeText(requirementMetadata.objective, 200)}` : '',
-    runSummary ? `Summary: ${summarizeText(runSummary, 220)}` : '',
+    safeRunSummary ? `Summary: ${safeRunSummary}` : '',
   ]
     .filter((entry) => entry.length > 0)
     .join(' ')
@@ -414,10 +452,10 @@ const buildReleaseNote = ({
     requirementProvenance ? `Requirement provenance: ${requirementProvenance}.` : '',
     `What shipped: ${whatShipped}.`,
     prUrl ? `PR: ${prUrl}.` : '',
-    tests && tests.length > 0
-      ? `Validation results: ${tests.join('; ')}.`
+    safeTests.length > 0
+      ? `Validation results: ${safeTests.join('; ')}.`
       : 'Validation results: no explicit test list in the final run output.',
-    gaps && gaps.length > 0 ? `Key risks: ${gaps.join('; ')}.` : 'Key risks: none identified.',
+    safeGaps.length > 0 ? `Key risks: ${safeGaps.join('; ')}.` : 'Key risks: none identified.',
     `Rollback path: ${buildRollbackPath({ decision, repository, issueNumber, stage, requirementMetadata, prUrl })}.`,
     `Owner-facing status: ${resolveOwnerFacingStatus(decision)}.`,
     requirementMetadata.acceptance && requirementMetadata.acceptance.length > 0
@@ -1147,15 +1185,15 @@ const collectLogExcerpts = async (
 const normalizeFailureReason = (error: unknown) => {
   if (!error) return null
   if (error instanceof Error) {
-    return error.message.trim() || error.name || 'unknown error'
+    return sanitizeHumanFacingLogText(error.message, 1000) || error.name || 'unknown error'
   }
   if (typeof error === 'string') {
-    return error.trim() || null
+    return sanitizeHumanFacingLogText(error, 1000) || null
   }
   try {
-    return JSON.stringify(error)
+    return sanitizeHumanFacingLogText(JSON.stringify(error), 1000)
   } catch {
-    return String(error)
+    return sanitizeHumanFacingLogText(String(error), 1000)
   }
 }
 
@@ -1171,7 +1209,7 @@ const firstActionableLogLine = (logs: CodexNotifyLogExcerpt) => {
     const actionable = [...lines]
       .reverse()
       .find((line) => /\b(error|failed|failure|forbidden|denied|timeout|exception|traceback|panic)\b/i.test(line))
-    if (actionable) return actionable
+    if (actionable) return sanitizeHumanFacingLogText(actionable)
   }
   return null
 }
@@ -1191,9 +1229,10 @@ const buildFailureDiagnostics = ({
   runtimeLogPath: string
   statusPath: string
 }) => {
+  const safeGaps = sanitizeHumanFacingList(gaps, 600)
   if (gaps.length > 0) {
     return {
-      gaps,
+      gaps: safeGaps,
       failureReason: normalizeFailureReason(error),
       logLine: firstActionableLogLine(logs),
     }


### PR DESCRIPTION
## Summary

- Redacts provider/plugin HTML dumps before failed Codex swarm handoffs are published to NATS.
- Changes the Codex HF fallback script to send a concise primary failure summary to the fallback model and handoff payload instead of the raw runner tail.
- Adds regression coverage for the Cloudflare/plugin-cache failure shape that previously leaked raw HTML into teammate-facing messages.

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts scripts/codex/__tests__/codex-implement.test.ts -t 'suppresses provider HTML dumps in failed swarm handoff messages'`
- `bunx vitest run --config vitest.config.ts scripts/codex/__tests__/codex-implement.test.ts`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `kubectl apply --dry-run=client -f argocd/applications/agents/codex-spark-agentprovider.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-readable-handoffs-render.yaml && wc -l /tmp/agents-readable-handoffs-render.yaml`
- `bunx oxfmt --check services/jangar/scripts/codex/codex-implement.ts services/jangar/scripts/codex/__tests__/codex-implement.test.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check -- argocd/applications/agents/codex-spark-agentprovider.yaml services/jangar/scripts/codex/codex-implement.ts services/jangar/scripts/codex/__tests__/codex-implement.test.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A. This is a publisher sanitation fix covered by regression tests.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
