### PR TITLE
chore(jangar): promote image eee03be9

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 7662e41d
-  digest: sha256:2d9d11eeea8124c7c36a437c2b5acfea7c4466ee5ed100e91f377c6e3089a57a
+  tag: eee03be9
+  digest: sha256:b7f7b128bd31b39e421702f24af2cf69e9903b583bcdaf9cf3e947b39f94d34a
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 7662e41d
-    digest: sha256:3a9b259403cbc4c2a3c72d86bfcd0f383e4a734f10ac0ac163e0cf2a9c843010
+    tag: eee03be9
+    digest: sha256:890d44fa3701b5ca5246fa2ea8aa4ae9435fb03814cb8c1e82f6071b1165228a
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "12000"
-      JANGAR_SOURCE_HEAD_SHA: 7662e41d7b05ac4b5230fbb63e39c93c164de6e4
-      JANGAR_GITOPS_REVISION: 7662e41d7b05ac4b5230fbb63e39c93c164de6e4
-      JANGAR_SOURCE_CI_RUN_ID: "25956674709"
+      JANGAR_SOURCE_HEAD_SHA: eee03be9b111cd1d63ac3d60e868013460564092
+      JANGAR_GITOPS_REVISION: eee03be9b111cd1d63ac3d60e868013460564092
+      JANGAR_SOURCE_CI_RUN_ID: "25958996541"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:3a9b259403cbc4c2a3c72d86bfcd0f383e4a734f10ac0ac163e0cf2a9c843010
-      JANGAR_SERVING_BUILD_COMMIT: 7662e41d7b05ac4b5230fbb63e39c93c164de6e4
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:3a9b259403cbc4c2a3c72d86bfcd0f383e4a734f10ac0ac163e0cf2a9c843010
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:890d44fa3701b5ca5246fa2ea8aa4ae9435fb03814cb8c1e82f6071b1165228a
+      JANGAR_SERVING_BUILD_COMMIT: eee03be9b111cd1d63ac3d60e868013460564092
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:890d44fa3701b5ca5246fa2ea8aa4ae9435fb03814cb8c1e82f6071b1165228a
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 7662e41d
-    digest: sha256:2d9d11eeea8124c7c36a437c2b5acfea7c4466ee5ed100e91f377c6e3089a57a
+    tag: eee03be9
+    digest: sha256:b7f7b128bd31b39e421702f24af2cf69e9903b583bcdaf9cf3e947b39f94d34a
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-16T07:55:23Z
+    deploy.knative.dev/rollout: 2026-05-16T09:58:15Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:7662e41d@sha256:2d9d11eeea8124c7c36a437c2b5acfea7c4466ee5ed100e91f377c6e3089a57a
+              value: registry.ide-newton.ts.net/lab/jangar:eee03be9@sha256:b7f7b128bd31b39e421702f24af2cf69e9903b583bcdaf9cf3e947b39f94d34a
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 7662e41d7b05ac4b5230fbb63e39c93c164de6e4
+              value: eee03be9b111cd1d63ac3d60e868013460564092
             - name: JANGAR_GITOPS_REVISION
-              value: 7662e41d7b05ac4b5230fbb63e39c93c164de6e4
+              value: eee03be9b111cd1d63ac3d60e868013460564092
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25956674709"
+              value: "25958996541"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:3a9b259403cbc4c2a3c72d86bfcd0f383e4a734f10ac0ac163e0cf2a9c843010
+              value: sha256:890d44fa3701b5ca5246fa2ea8aa4ae9435fb03814cb8c1e82f6071b1165228a
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 7662e41d7b05ac4b5230fbb63e39c93c164de6e4
+              value: eee03be9b111cd1d63ac3d60e868013460564092
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:3a9b259403cbc4c2a3c72d86bfcd0f383e4a734f10ac0ac163e0cf2a9c843010
+              value: sha256:890d44fa3701b5ca5246fa2ea8aa4ae9435fb03814cb8c1e82f6071b1165228a
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 7662e41d
-    digest: sha256:2d9d11eeea8124c7c36a437c2b5acfea7c4466ee5ed100e91f377c6e3089a57a
+    newTag: eee03be9
+    digest: sha256:b7f7b128bd31b39e421702f24af2cf69e9903b583bcdaf9cf3e947b39f94d34a


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `eee03be9b111cd1d63ac3d60e868013460564092`
- Image tag: `eee03be9`
- Image digest: `sha256:b7f7b128bd31b39e421702f24af2cf69e9903b583bcdaf9cf3e947b39f94d34a`
- Source CI run: `25958996541`
- Control-plane serving digest: `sha256:890d44fa3701b5ca5246fa2ea8aa4ae9435fb03814cb8c1e82f6071b1165228a`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates