### PR TITLE
fix(agents): sanitize codex swarm runner logs

### DIFF
--- a/argocd/applications/agents/codex-spark-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-agentprovider.yaml
@@ -53,7 +53,7 @@ spec:
           "binary": "/bin/bash",
           "argsTemplate": [
             "-lc",
-            "set -o pipefail; EVENT_FILE=$(mktemp /tmp/codex-event.XXXXXX.json) && cp \"$1\" \"$EVENT_FILE\" && python3 /root/.codex/ensure-market-context-issue-number.py \"$EVENT_FILE\" && mkdir -p /workspace/.agent && LOG_PATH=/workspace/.agent/runner.log && /usr/local/bin/codex-implement \"$EVENT_FILE\" 2>&1 | tee \"$LOG_PATH\"; status=${PIPESTATUS[0]}; if [ \"$status\" -eq 0 ]; then exit 0; fi; if python3 /root/.codex/should-hf-swarm-fallback.py \"$LOG_PATH\"; then exec python3 /root/.codex/swarm-hf-codex-fallback.py \"$EVENT_FILE\" \"$LOG_PATH\"; fi; exit \"$status\"",
+            "set -o pipefail; EVENT_FILE=$(mktemp /tmp/codex-event.XXXXXX.json) && cp \"$1\" \"$EVENT_FILE\" && python3 /root/.codex/ensure-market-context-issue-number.py \"$EVENT_FILE\" && mkdir -p /workspace/.agent && LOG_PATH=/workspace/.agent/runner.log && /usr/local/bin/codex-implement \"$EVENT_FILE\" 2>&1 | python3 /root/.codex/sanitize-codex-log.py | tee \"$LOG_PATH\"; status=${PIPESTATUS[0]}; if [ \"$status\" -eq 0 ]; then exit 0; fi; if python3 /root/.codex/should-hf-swarm-fallback.py \"$LOG_PATH\"; then exec python3 /root/.codex/swarm-hf-codex-fallback.py \"$EVENT_FILE\" \"$LOG_PATH\"; fi; exit \"$status\"",
             "--",
             "{{payloads.eventFilePath}}"
           ],
@@ -178,6 +178,55 @@ spec:
           return 0
 
         if __name__ == '__main__':
+          raise SystemExit(main())
+    - path: /root/.codex/sanitize-codex-log.py
+      content: |-
+        #!/usr/bin/env python3
+        import re
+        import sys
+
+        SUPPRESSED_PROVIDER_HTML = "[suppressed provider HTML response body]"
+        HTML_START_PATTERN = re.compile(
+          r"<!doctype|<html\b|<head\b|<body\b|<style\b|<script\b|<svg\b|<path\b|viewBox=|challenge-error-text",
+          re.IGNORECASE,
+        )
+        HTML_END_PATTERN = re.compile(r"</html>|</body>|</style>|</script>|</svg>", re.IGNORECASE)
+        TAG_PATTERN = re.compile(r"<[^>\n]{1,400}>")
+
+        def strip_short_tags(text: str) -> str:
+          return TAG_PATTERN.sub("", text)
+
+        def main() -> int:
+          suppressing_html = False
+          for raw_line in sys.stdin:
+            line = raw_line.rstrip("\n")
+            if suppressing_html:
+              end = HTML_END_PATTERN.search(line)
+              if not end:
+                continue
+              line = line[end.end() :]
+              suppressing_html = False
+              if not line.strip():
+                continue
+
+            match = HTML_START_PATTERN.search(line)
+            if match:
+              prefix = strip_short_tags(line[: match.start()]).rstrip()
+              suffix = line[match.end() :]
+              end = HTML_END_PATTERN.search(suffix)
+              if end:
+                suffix = strip_short_tags(suffix[end.end() :]).strip()
+              else:
+                suffix = ""
+                suppressing_html = True
+              parts = [part for part in (prefix, SUPPRESSED_PROVIDER_HTML, suffix) if part]
+              print(" ".join(parts), flush=True)
+              continue
+
+            print(strip_short_tags(line), flush=True)
+          return 0
+
+        if __name__ == "__main__":
           raise SystemExit(main())
     - path: /root/.codex/should-hf-swarm-fallback.py
       content: |-
@@ -342,7 +391,7 @@ spec:
             end = log_text.find(end_marker)
             if start >= 0 and end > start:
               return log_text[start + len(start_marker) : end].strip()
-          return log_text.strip()[-4000:]
+          return summarize_failure_tail(log_text)
 
         def read_pod_log(namespace: str, job_name: str) -> str:
           from urllib.parse import quote
@@ -480,9 +529,13 @@ spec:
           run = ""
           stage = ""
           for line in upstream.splitlines():
-            if line.startswith("Auto-discovered upstream run:"):
+            if not line.strip() and (run or stage):
+              break
+            if line.startswith("## ") and (run or stage):
+              break
+            if line.startswith("Auto-discovered upstream run:") and not run:
               run = line.split(":", 1)[1].strip()
-            elif line.startswith("Auto-discovered upstream stage:"):
+            elif line.startswith("Auto-discovered upstream stage:") and not stage:
               stage = line.split(":", 1)[1].strip()
           if run and stage:
             return f"Auto-discovered upstream run: {run}\nAuto-discovered upstream stage: {stage}"

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -366,18 +366,27 @@ describe('scheduled AgentRun templates', () => {
       (inputFile) => objectAt(inputFile, 'path') === '/root/.codex/provider-codex-spark.json',
     )
     const providerCommand = JSON.parse(String(objectAt(providerConfig, 'content'))).argsTemplate[1]
+    const logSanitizer = inputFiles?.find(
+      (inputFile) => objectAt(inputFile, 'path') === '/root/.codex/sanitize-codex-log.py',
+    )
     const fallbackScript = inputFiles?.find(
       (inputFile) => objectAt(inputFile, 'path') === '/root/.codex/swarm-hf-codex-fallback.py',
     )
+    const sanitizerContent = objectAt(logSanitizer, 'content')
     const content = objectAt(fallbackScript, 'content')
 
-    expect(providerCommand).toContain('2>&1 | tee "$LOG_PATH"')
+    expect(providerCommand).toContain('2>&1 | python3 /root/.codex/sanitize-codex-log.py | tee "$LOG_PATH"')
     expect(providerCommand).toContain('status=${PIPESTATUS[0]}')
     expect(providerCommand).not.toContain('> >(tee')
     expect(objectAt(envTemplate, 'AGENT_RUN_NAME')).toBe('{{agentRun.name}}')
     expect(objectAt(envTemplate, 'AGENT_RUN_NAMESPACE')).toBe('{{agentRun.namespace}}')
+    expect(sanitizerContent).toContain('SUPPRESSED_PROVIDER_HTML = "[suppressed provider HTML response body]"')
+    expect(sanitizerContent).toContain('HTML_START_PATTERN = re.compile(')
     expect(content).toContain('def summarize_upstream(upstream: str) -> str:')
     expect(content).toContain('def summarize_failure_tail(log_text: str) -> str:')
+    expect(content).toContain('return summarize_failure_tail(log_text)')
+    expect(content).toContain('if not line.strip() and (run or stage):')
+    expect(content).toContain('if line.startswith("Auto-discovered upstream run:") and not run:')
     expect(content).toContain(
       'def handoff_subject(payload: dict, swarm_name: str, role: str, run_name: str, suffix: str = "") -> str:',
     )
@@ -393,6 +402,39 @@ describe('scheduled AgentRun templates', () => {
     )
     expect(content).not.toContain('Primary Codex failure tail:')
     expect(content).not.toContain('publish_handoff(f"swarm.')
+  })
+
+  it('redacts provider HTML before Codex runner logs become swarm evidence', () => {
+    const manifests = readYamlObjects('argocd/applications/agents/codex-spark-agentprovider.yaml')
+    const provider = manifests.find((manifest) => objectAt(objectAt(manifest, 'metadata'), 'name') === 'codex-spark')
+    const inputFiles = objectAt(objectAt(provider, 'spec'), 'inputFiles') as Record<string, unknown>[] | undefined
+    const logSanitizer = inputFiles?.find(
+      (inputFile) => objectAt(inputFile, 'path') === '/root/.codex/sanitize-codex-log.py',
+    )
+    const tempDir = mkdtempSync(join(tmpdir(), 'codex-log-sanitizer-'))
+    const scriptPath = join(tempDir, 'sanitize-codex-log.py')
+
+    writeFileSync(scriptPath, String(objectAt(logSanitizer, 'content')))
+
+    const result = spawnSync('python3', [scriptPath], {
+      input: [
+        'Running Codex implementation for proompteng/lab#swarm-jangar-control-plane',
+        'Failure reason: codex exited with status 1: failed to warm featured plugin ids cache error=remote plugin sync request failed with status 403 Forbidden: <html>',
+        '<head><style global>body{font-family:Arial}.challenge-error-text{display:block}</style></head>',
+        '<body><svg width="41" height="41" viewBox="0 0 41 41"><path d="M37.5324 16.8707"/></svg></body></html>',
+        'Turn failed -> Quota exceeded. Check your plan and billing details.',
+      ].join('\n'),
+      encoding: 'utf8',
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('failed to warm featured plugin ids cache')
+    expect(result.stdout).toContain('[suppressed provider HTML response body]')
+    expect(result.stdout).toContain('Quota exceeded')
+    expect(result.stdout).not.toContain('<html')
+    expect(result.stdout).not.toContain('<style')
+    expect(result.stdout).not.toContain('viewBox')
+    expect(result.stdout).not.toContain('challenge-error-text')
   })
 
   it('classifies current Codex quota logs as HF fallback eligible', () => {


### PR DESCRIPTION
## Summary

- Filter Codex provider stderr/stdout through a small Python sanitizer before teeing runner logs so Cloudflare/provider HTML never becomes swarm evidence.
- Keep the HF fallback extraction path sanitized when marker extraction fails.
- Preserve immediate upstream run/stage metadata when a fallback handoff contains nested older handoffs.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `kubectl apply --dry-run=client -f argocd/applications/agents/codex-spark-agentprovider.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-clean-logs-render.yaml && wc -l /tmp/agents-clean-logs-render.yaml`
- `git diff --check -- argocd/applications/agents/codex-spark-agentprovider.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
