### PR TITLE
fix(agents): strip partial html from swarm logs

### DIFF
--- a/argocd/applications/agents/codex-spark-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-agentprovider.yaml
@@ -187,14 +187,16 @@ spec:
 
         SUPPRESSED_PROVIDER_HTML = "[suppressed provider HTML response body]"
         HTML_START_PATTERN = re.compile(
-          r"<!doctype|<html\b|<head\b|<body\b|<style\b|<script\b|<svg\b|<path\b|viewBox=|challenge-error-text",
+          r"<!doctype|<html\b|<head\b|<body\b|<style\b|<script\b|<svg\b|<path\b|<meta\b|<link\b|<div\b|<span\b|viewBox=|challenge-error-text",
           re.IGNORECASE,
         )
-        HTML_END_PATTERN = re.compile(r"</html>|</body>|</style>|</script>|</svg>", re.IGNORECASE)
+        HTML_END_PATTERN = re.compile(r"</html>|</head>|</body>|</style>|</script>|</svg>|</div>|</span>", re.IGNORECASE)
         TAG_PATTERN = re.compile(r"<[^>\n]{1,400}>")
+        DANGLING_TAG_FRAGMENT_PATTERN = re.compile(r"<[^>\n]*$")
 
         def strip_short_tags(text: str) -> str:
-          return TAG_PATTERN.sub("", text)
+          without_tags = TAG_PATTERN.sub("", text)
+          return DANGLING_TAG_FRAGMENT_PATTERN.sub("", without_tags)
 
         def main() -> int:
           suppressing_html = False
@@ -280,7 +282,10 @@ spec:
           return default
 
         SUPPRESSED_PROVIDER_HTML = "[suppressed provider HTML response body]"
-        HTML_DOCUMENT_FRAGMENT = re.compile(r"(?:<!doctype|<html\b|<head\b|<body\b|<style\b|<script\b|<svg\b|<path\b)", re.IGNORECASE)
+        HTML_DOCUMENT_FRAGMENT = re.compile(
+          r"(?:<!doctype|<html\b|<head\b|<body\b|<style\b|<script\b|<svg\b|<path\b|<meta\b|<link\b|<div\b|<span\b|viewBox=|challenge-error-text)",
+          re.IGNORECASE,
+        )
 
         def summarize_text(value: str, max_chars: int = 600) -> str:
           text = value.strip()
@@ -300,7 +305,12 @@ spec:
             sanitized = re.sub(r"\s*<style[\s\S]*$", f" {SUPPRESSED_PROVIDER_HTML}", sanitized, flags=re.IGNORECASE)
             sanitized = re.sub(r"\s*<script[\s\S]*$", f" {SUPPRESSED_PROVIDER_HTML}", sanitized, flags=re.IGNORECASE)
             sanitized = re.sub(r"\s*<svg[\s\S]*$", f" {SUPPRESSED_PROVIDER_HTML}", sanitized, flags=re.IGNORECASE)
+            sanitized = re.sub(r"\s*<meta[\s\S]*$", f" {SUPPRESSED_PROVIDER_HTML}", sanitized, flags=re.IGNORECASE)
+            sanitized = re.sub(r"\s*<link[\s\S]*$", f" {SUPPRESSED_PROVIDER_HTML}", sanitized, flags=re.IGNORECASE)
+            sanitized = re.sub(r"\s*<div[\s\S]*$", f" {SUPPRESSED_PROVIDER_HTML}", sanitized, flags=re.IGNORECASE)
+            sanitized = re.sub(r"\s*<span[\s\S]*$", f" {SUPPRESSED_PROVIDER_HTML}", sanitized, flags=re.IGNORECASE)
           sanitized = re.sub(r"<[^>\n]{1,500}>", " ", sanitized)
+          sanitized = re.sub(r"<[^>\n]*$", " ", sanitized)
           sanitized = re.sub(r"\s+", " ", sanitized).strip()
           return summarize_text(sanitized or SUPPRESSED_PROVIDER_HTML, max_chars)
 

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -421,6 +421,8 @@ describe('scheduled AgentRun templates', () => {
         'Running Codex implementation for proompteng/lab#swarm-jangar-control-plane',
         'Failure reason: codex exited with status 1: failed to warm featured plugin ids cache error=remote plugin sync request failed with status 403 Forbidden: <html>',
         '<head><style global>body{font-family:Arial}.challenge-error-text{display:block}</style></head>',
+        '<span id="challenge-error-text"',
+        'data-cf-error="403">Enable JavaScript and cookies to continue</span>',
         '<body><svg width="41" height="41" viewBox="0 0 41 41"><path d="M37.5324 16.8707"/></svg></body></html>',
         'Turn failed -> Quota exceeded. Check your plan and billing details.',
       ].join('\n'),
@@ -433,8 +435,10 @@ describe('scheduled AgentRun templates', () => {
     expect(result.stdout).toContain('Quota exceeded')
     expect(result.stdout).not.toContain('<html')
     expect(result.stdout).not.toContain('<style')
+    expect(result.stdout).not.toContain('<span')
     expect(result.stdout).not.toContain('viewBox')
     expect(result.stdout).not.toContain('challenge-error-text')
+    expect(result.stdout).not.toMatch(/<[A-Za-z]/)
   })
 
   it('classifies current Codex quota logs as HF fallback eligible', () => {

--- a/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
+++ b/services/jangar/scripts/codex/__tests__/codex-implement.test.ts
@@ -962,8 +962,10 @@ describe('runCodexImplementation', () => {
     expect(handoffContent).toContain('[suppressed provider HTML response body]')
     expect(handoffContent).not.toContain('<html')
     expect(handoffContent).not.toContain('<style')
+    expect(handoffContent).not.toContain('<span')
     expect(handoffContent).not.toContain('viewBox')
     expect(handoffAttrs).not.toContain('<html')
+    expect(handoffAttrs).not.toContain('<span')
     expect(handoffAttrs).not.toContain('viewBox')
 
     const runGaps = findCapturedNatsPublish(captured, 'run-gaps')
@@ -972,6 +974,7 @@ describe('runCodexImplementation', () => {
     const runGapContent = contentFromCapturedNatsPublish(runGaps)
     expect(runGapContent).toContain('[suppressed provider HTML response body]')
     expect(runGapContent).not.toContain('<html')
+    expect(runGapContent).not.toContain('<span')
     expect(runGapContent).not.toContain('viewBox')
   }, 40_000)
 

--- a/services/jangar/scripts/codex/codex-implement.ts
+++ b/services/jangar/scripts/codex/codex-implement.ts
@@ -289,7 +289,8 @@ const summarizeText = (value: string | undefined, max = 260) => {
 }
 
 const SUPPRESSED_PROVIDER_HTML = '[suppressed provider HTML response body]'
-const HTML_DOCUMENT_FRAGMENT = /(?:<!doctype|<html\b|<head\b|<body\b|<style\b|<script\b|<svg\b|<path\b)/i
+const HTML_DOCUMENT_FRAGMENT =
+  /(?:<!doctype|<html\b|<head\b|<body\b|<style\b|<script\b|<svg\b|<path\b|<meta\b|<link\b|<div\b|<span\b|viewBox=|challenge-error-text)/i
 
 const sanitizeHumanFacingLogText = (value: string | null | undefined, max = 600) => {
   if (!value) return ''
@@ -306,10 +307,15 @@ const sanitizeHumanFacingLogText = (value: string | null | undefined, max = 600)
       .replace(/\s*<style[\s\S]*$/i, ` ${SUPPRESSED_PROVIDER_HTML}`)
       .replace(/\s*<script[\s\S]*$/i, ` ${SUPPRESSED_PROVIDER_HTML}`)
       .replace(/\s*<svg[\s\S]*$/i, ` ${SUPPRESSED_PROVIDER_HTML}`)
+      .replace(/\s*<meta[\s\S]*$/i, ` ${SUPPRESSED_PROVIDER_HTML}`)
+      .replace(/\s*<link[\s\S]*$/i, ` ${SUPPRESSED_PROVIDER_HTML}`)
+      .replace(/\s*<div[\s\S]*$/i, ` ${SUPPRESSED_PROVIDER_HTML}`)
+      .replace(/\s*<span[\s\S]*$/i, ` ${SUPPRESSED_PROVIDER_HTML}`)
   }
 
   sanitized = sanitized
     .replace(/<[^>\n]{1,500}>/g, ' ')
+    .replace(/<[^>\n]*$/g, ' ')
     .replace(/\s+/g, ' ')
     .trim()
 


### PR DESCRIPTION
## Summary

- Strip dangling partial HTML tags from Codex runner logs before they become swarm evidence.
- Expand provider-response redaction to common Cloudflare challenge tags such as span, div, meta, and link.
- Add regressions for split partial challenge tags in both deployed provider log filtering and Jangar handoff sanitization.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `cd services/jangar && bunx vitest run --config vitest.config.ts scripts/codex/__tests__/codex-implement.test.ts -t 'suppresses provider HTML dumps in failed swarm handoff messages'`
- `cd services/jangar && bunx vitest run --config vitest.config.ts scripts/codex/__tests__/codex-implement.test.ts`
- `bunx oxfmt --check services/jangar/scripts/codex/codex-implement.ts services/jangar/scripts/codex/__tests__/codex-implement.test.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `kubectl apply --dry-run=client -f argocd/applications/agents/codex-spark-agentprovider.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-strip-partial-tags-render.yaml && wc -l /tmp/agents-strip-partial-tags-render.yaml`
- `git diff --check -- argocd/applications/agents/codex-spark-agentprovider.yaml services/jangar/scripts/codex/codex-implement.ts services/jangar/scripts/codex/__tests__/codex-implement.test.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
