### PR TITLE
fix(agents): drop provider challenge suffixes

### DIFF
--- a/argocd/applications/agents/codex-spark-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-agentprovider.yaml
@@ -215,13 +215,8 @@ spec:
             if match:
               prefix = strip_short_tags(line[: match.start()]).rstrip()
               suffix = line[match.end() :]
-              end = HTML_END_PATTERN.search(suffix)
-              if end:
-                suffix = strip_short_tags(suffix[end.end() :]).strip()
-              else:
-                suffix = ""
-                suppressing_html = True
-              parts = [part for part in (prefix, SUPPRESSED_PROVIDER_HTML, suffix) if part]
+              suppressing_html = HTML_END_PATTERN.search(suffix) is None
+              parts = [part for part in (prefix, SUPPRESSED_PROVIDER_HTML) if part]
               print(" ".join(parts), flush=True)
               continue
 

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -424,6 +424,7 @@ describe('scheduled AgentRun templates', () => {
         '<span id="challenge-error-text"',
         'data-cf-error="403">Enable JavaScript and cookies to continue</span>',
         '<body><svg width="41" height="41" viewBox="0 0 41 41"><path d="M37.5324 16.8707"/></svg></body></html>',
+        '<script>(function(){window._cf_chl_opt={cRay:"9fc9c7b1bfd6fdda",fa:"/backend-api/plugins/featured?platform=codex&__cf_chl_tk=token"}})();</script>',
         'Turn failed -> Quota exceeded. Check your plan and billing details.',
       ].join('\n'),
       encoding: 'utf8',
@@ -438,6 +439,9 @@ describe('scheduled AgentRun templates', () => {
     expect(result.stdout).not.toContain('<span')
     expect(result.stdout).not.toContain('viewBox')
     expect(result.stdout).not.toContain('challenge-error-text')
+    expect(result.stdout).not.toContain('window._cf_chl_opt')
+    expect(result.stdout).not.toContain('__cf_chl')
+    expect(result.stdout).not.toContain('backend-api/plugins/featured?platform=codex')
     expect(result.stdout).not.toMatch(/<[A-Za-z]/)
   })
 


### PR DESCRIPTION
## Summary

- Drop same-line provider challenge suffixes after the sanitizer emits the suppressed-provider marker.
- Add regression coverage for Cloudflare JavaScript challenge tokens such as `window._cf_chl_opt` and `__cf_chl`.
- Keep Codex runner logs readable while preserving the actionable quota/auth failure lines.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `kubectl apply --dry-run=client -f argocd/applications/agents/codex-spark-agentprovider.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-drop-provider-suffix-render.yaml && wc -l /tmp/agents-drop-provider-suffix-render.yaml`
- `git diff --check -- argocd/applications/agents/codex-spark-agentprovider.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
