### PR TITLE
fix(agents): clear recovered swarm pause status

### DIFF
--- a/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
+++ b/services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts
@@ -2172,6 +2172,10 @@ describe('supporting primitives controller', () => {
     const conditions = Array.isArray(status.conditions) ? status.conditions : []
     const ready = conditions.find((condition) => condition.type === 'Ready')
     const degraded = conditions.find((condition) => condition.type === 'Degraded')
+    const requirements = (status.requirements ?? {}) as Record<string, unknown>
+    expect(requirements.paused).toBe(false)
+    expect(requirements.pauseReason).toBe('')
+    expect(requirements.pauseMessage).toBe('')
     expect(ready).toMatchObject({ status: 'True', reason: 'Active', message: 'swarm active' })
     expect(degraded).toMatchObject({
       status: 'False',

--- a/services/jangar/src/server/supporting-primitives-controller.ts
+++ b/services/jangar/src/server/supporting-primitives-controller.ts
@@ -2611,8 +2611,8 @@ const reconcileSwarm = async (
       paused: requirementStats.paused,
       admission: admissionStatusForStage(requirementAdmission),
       ...(requirementStageClearance ? { stageClearance: stageClearanceStatusForStage(requirementStageClearance) } : {}),
-      ...(requirementStats.pauseReason ? { pauseReason: requirementStats.pauseReason } : {}),
-      ...(requirementStats.pauseMessage ? { pauseMessage: requirementStats.pauseMessage } : {}),
+      pauseReason: requirementStats.pauseReason ?? '',
+      pauseMessage: requirementStats.pauseMessage ?? '',
       error: requirementTemplateError ?? '',
     },
   }


### PR DESCRIPTION
## Summary

- Clears recovered Swarm requirement pause fields instead of preserving stale degraded text through server-side apply.
- Adds regression coverage that healthy Swarm reconciliation emits `paused=false` with empty `pauseReason` and `pauseMessage`.
- Keeps existing AgentRun ingestion degradation behavior unchanged while making recovered status truthful.

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/supporting-primitives-controller.test.ts`
- `bunx oxfmt --check services/jangar/src/server/supporting-primitives-controller.ts services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts`
- `git diff --check -- services/jangar/src/server/supporting-primitives-controller.ts services/jangar/src/server/__tests__/supporting-primitives-controller.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
