### PR TITLE
chore(jangar): promote image 86fe37b9

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 6051c7ea
-  digest: sha256:1df8d572e50dd95a90bc4223977bac1abef77ce680a8d5e2109ade711bd951e7
+  tag: 86fe37b9
+  digest: sha256:ef3970a77c4e423d05f5ceb0eadea050e44700c64645afee21e6ec54bae5ac5f
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 6051c7ea
-    digest: sha256:ef4d214a85be7b02c65a2b62dd956858b25f6e6f0a1897cee7a2340fd2234cc9
+    tag: 86fe37b9
+    digest: sha256:109c3ce0eb0dcf8147a04eac3b8d7ffe0cc74f6bca52025627d530c3b8cd2ecb
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "12000"
-      JANGAR_SOURCE_HEAD_SHA: 6051c7eab171cb296446ac71aaadab8ab6d8fb36
-      JANGAR_GITOPS_REVISION: 6051c7eab171cb296446ac71aaadab8ab6d8fb36
-      JANGAR_SOURCE_CI_RUN_ID: "25959905403"
+      JANGAR_SOURCE_HEAD_SHA: 86fe37b9869bf96cf8455e6c2dd09d7e638cb501
+      JANGAR_GITOPS_REVISION: 86fe37b9869bf96cf8455e6c2dd09d7e638cb501
+      JANGAR_SOURCE_CI_RUN_ID: "25961346273"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:ef4d214a85be7b02c65a2b62dd956858b25f6e6f0a1897cee7a2340fd2234cc9
-      JANGAR_SERVING_BUILD_COMMIT: 6051c7eab171cb296446ac71aaadab8ab6d8fb36
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:ef4d214a85be7b02c65a2b62dd956858b25f6e6f0a1897cee7a2340fd2234cc9
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:109c3ce0eb0dcf8147a04eac3b8d7ffe0cc74f6bca52025627d530c3b8cd2ecb
+      JANGAR_SERVING_BUILD_COMMIT: 86fe37b9869bf96cf8455e6c2dd09d7e638cb501
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:109c3ce0eb0dcf8147a04eac3b8d7ffe0cc74f6bca52025627d530c3b8cd2ecb
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 6051c7ea
-    digest: sha256:1df8d572e50dd95a90bc4223977bac1abef77ce680a8d5e2109ade711bd951e7
+    tag: 86fe37b9
+    digest: sha256:ef3970a77c4e423d05f5ceb0eadea050e44700c64645afee21e6ec54bae5ac5f
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-16T10:43:58Z
+    deploy.knative.dev/rollout: 2026-05-16T11:59:50Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:6051c7ea@sha256:1df8d572e50dd95a90bc4223977bac1abef77ce680a8d5e2109ade711bd951e7
+              value: registry.ide-newton.ts.net/lab/jangar:86fe37b9@sha256:ef3970a77c4e423d05f5ceb0eadea050e44700c64645afee21e6ec54bae5ac5f
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 6051c7eab171cb296446ac71aaadab8ab6d8fb36
+              value: 86fe37b9869bf96cf8455e6c2dd09d7e638cb501
             - name: JANGAR_GITOPS_REVISION
-              value: 6051c7eab171cb296446ac71aaadab8ab6d8fb36
+              value: 86fe37b9869bf96cf8455e6c2dd09d7e638cb501
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25959905403"
+              value: "25961346273"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:ef4d214a85be7b02c65a2b62dd956858b25f6e6f0a1897cee7a2340fd2234cc9
+              value: sha256:109c3ce0eb0dcf8147a04eac3b8d7ffe0cc74f6bca52025627d530c3b8cd2ecb
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 6051c7eab171cb296446ac71aaadab8ab6d8fb36
+              value: 86fe37b9869bf96cf8455e6c2dd09d7e638cb501
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:ef4d214a85be7b02c65a2b62dd956858b25f6e6f0a1897cee7a2340fd2234cc9
+              value: sha256:109c3ce0eb0dcf8147a04eac3b8d7ffe0cc74f6bca52025627d530c3b8cd2ecb
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 6051c7ea
-    digest: sha256:1df8d572e50dd95a90bc4223977bac1abef77ce680a8d5e2109ade711bd951e7
+    newTag: 86fe37b9
+    digest: sha256:ef3970a77c4e423d05f5ceb0eadea050e44700c64645afee21e6ec54bae5ac5f


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `86fe37b9869bf96cf8455e6c2dd09d7e638cb501`
- Image tag: `86fe37b9`
- Image digest: `sha256:ef3970a77c4e423d05f5ceb0eadea050e44700c64645afee21e6ec54bae5ac5f`
- Source CI run: `25961346273`
- Control-plane serving digest: `sha256:109c3ce0eb0dcf8147a04eac3b8d7ffe0cc74f6bca52025627d530c3b8cd2ecb`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates