### PR TITLE
fix(torghut): keep replay evidence after persistence retries

### DIFF
--- a/services/torghut/scripts/run_strategy_factory_v2.py
+++ b/services/torghut/scripts/run_strategy_factory_v2.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal, ROUND_CEILING
@@ -14,6 +15,7 @@ from typing import Any, Mapping, Sequence, cast
 
 import yaml
 from sqlalchemy import delete, select
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.db import SessionLocal
 from app.models import VNextExperimentRun, VNextExperimentSpec
@@ -463,7 +465,7 @@ def _load_source_experiment_specs(
         return list(rows)
 
 
-def _persist_result(
+def _persist_result_once(
     *,
     runner_run_id: str,
     experiment: CompiledExperimentSweep,
@@ -558,6 +560,40 @@ def _persist_result(
         session.commit()
 
 
+def _persist_result(
+    *,
+    runner_run_id: str,
+    experiment: CompiledExperimentSweep,
+    result_payload: Mapping[str, Any],
+    compiled_sweep_path: Path,
+    result_path: Path,
+    max_attempts: int = 3,
+) -> dict[str, Any]:
+    bounded_attempts = max(1, int(max_attempts))
+    last_error: SQLAlchemyError | None = None
+    for attempt in range(1, bounded_attempts + 1):
+        try:
+            _persist_result_once(
+                runner_run_id=runner_run_id,
+                experiment=experiment,
+                result_payload=result_payload,
+                compiled_sweep_path=compiled_sweep_path,
+                result_path=result_path,
+            )
+            return {"status": "persisted", "attempt": attempt}
+        except SQLAlchemyError as exc:
+            last_error = exc
+            if attempt >= bounded_attempts:
+                break
+            time.sleep(min(2.0, 0.25 * attempt))
+    return {
+        "status": "failed",
+        "attempts": bounded_attempts,
+        "error_type": type(last_error).__name__ if last_error is not None else "",
+        "error": str(last_error) if last_error is not None else "",
+    }
+
+
 def run_strategy_factory_v2(args: argparse.Namespace) -> dict[str, Any]:
     return run_strategy_factory_v2_from_specs(args)
 
@@ -585,6 +621,7 @@ def run_strategy_factory_v2_from_specs(
         f"strategy-factory-v2-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}"
     )
     results: list[dict[str, Any]] = []
+    persistence_failures: list[dict[str, Any]] = []
     max_total_candidates_to_evaluate = max(
         0, int(getattr(args, "max_total_candidates_to_evaluate", 0) or 0)
     )
@@ -638,14 +675,26 @@ def run_strategy_factory_v2_from_specs(
             json.dumps(frontier_payload, indent=2, sort_keys=True),
             encoding="utf-8",
         )
+        persistence_status: Mapping[str, Any] | None = None
         if args.persist_results:
-            _persist_result(
+            persistence_status = _persist_result(
                 runner_run_id=runner_run_id,
                 experiment=compiled,
                 result_payload=frontier_payload,
                 compiled_sweep_path=compiled_sweep_path,
                 result_path=result_path,
             )
+            if persistence_status.get("status") != "persisted":
+                persistence_failures.append(
+                    {
+                        "experiment_id": compiled.experiment_id,
+                        "candidate_spec_id": _mapping(
+                            compiled.experiment_payload.get("candidate_spec")
+                        ).get("candidate_spec_id")
+                        or compiled.experiment_id,
+                        **dict(persistence_status),
+                    }
+                )
         top_candidates = cast(list[dict[str, Any]], frontier_payload.get("top") or [])
         top_candidate_id = (
             str(top_candidates[0].get("candidate_id") or "").strip()
@@ -691,6 +740,9 @@ def run_strategy_factory_v2_from_specs(
                     else ""
                 ),
                 "promotion_readiness": promotion_readiness,
+                "persistence_status": dict(persistence_status)
+                if persistence_status is not None
+                else None,
             }
         )
         if (
@@ -704,12 +756,15 @@ def run_strategy_factory_v2_from_specs(
         "status": (
             "total_candidate_budget_exhausted"
             if total_candidate_budget_exhausted
+            else "ok_with_persistence_warnings"
+            if persistence_failures
             else "ok"
         ),
         "runner_run_id": runner_run_id,
         "count": len(results),
         "max_total_candidates_to_evaluate": max_total_candidates_to_evaluate,
-        "persisted": bool(args.persist_results),
+        "persisted": bool(args.persist_results) and not persistence_failures,
+        "persistence_failures": persistence_failures,
         "total_candidate_count": total_candidate_count,
         "experiments": results,
     }

--- a/services/torghut/tests/test_run_strategy_factory_v2.py
+++ b/services/torghut/tests/test_run_strategy_factory_v2.py
@@ -12,10 +12,12 @@ from unittest.mock import patch
 
 import yaml
 from sqlalchemy import create_engine, select
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
 import scripts.run_strategy_factory_v2 as runner
 from app.models import Base, VNextExperimentRun, VNextExperimentSpec
+from app.trading.discovery.family_templates import FamilyTemplate
 
 
 class TestRunStrategyFactoryV2(TestCase):
@@ -127,6 +129,29 @@ class TestRunStrategyFactoryV2(TestCase):
             encoding="utf-8",
         )
         return seed_dir
+
+    def _family_template_fixture(self) -> FamilyTemplate:
+        return FamilyTemplate(
+            family_id="breakout_reclaim_v2",
+            economic_mechanism="Breakout reclaim.",
+            supported_markets=("us_equities_intraday",),
+            required_features=("quote_quality",),
+            allowed_normalizations=("price_scaled",),
+            entry_motifs=("breakout_reclaim",),
+            exit_motifs=("trailing_stop",),
+            risk_controls=("stop_loss",),
+            activity_model={},
+            liquidity_assumptions={},
+            regime_activation_rules=(),
+            day_veto_rules=(),
+            default_hard_vetoes={},
+            default_selection_objectives={},
+            runtime_harness={
+                "family": "breakout_continuation_consistent",
+                "strategy_name": "breakout-continuation-long-v1",
+                "disable_other_strategies": True,
+            },
+        )
 
     def _args(
         self,
@@ -621,6 +646,110 @@ class TestRunStrategyFactoryV2(TestCase):
                     )
                 ).scalar_one()
                 self.assertEqual(run_row.experiment_id, "exp-breakout-2")
+
+    def test_persist_result_retries_transient_sqlalchemy_failure(self) -> None:
+        transient_error = OperationalError(
+            "insert into vnext_experiment_specs",
+            {},
+            Exception("server closed the connection unexpectedly"),
+        )
+
+        with (
+            patch.object(
+                runner,
+                "_persist_result_once",
+                side_effect=[transient_error, None],
+            ) as mock_persist_once,
+            patch("scripts.run_strategy_factory_v2.time.sleep") as mock_sleep,
+        ):
+            result = runner._persist_result(
+                runner_run_id="strategy-factory-v2-retry",
+                experiment=runner.CompiledExperimentSweep(
+                    source_run_id="paper-run-1",
+                    experiment_id="exp-breakout-1",
+                    family_template=self._family_template_fixture(),
+                    experiment_payload={"family_template_id": "breakout_reclaim_v2"},
+                    sweep_config={},
+                ),
+                result_payload={"top": []},
+                compiled_sweep_path=Path("compiled-sweep.yaml"),
+                result_path=Path("result.json"),
+            )
+
+        self.assertEqual(result, {"status": "persisted", "attempt": 2})
+        self.assertEqual(mock_persist_once.call_count, 2)
+        mock_sleep.assert_called_once()
+
+    def test_run_strategy_factory_v2_reports_persistence_warning_without_dropping_replay(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = self._write_strategy_configmap(root)
+            family_template_dir = self._write_family_template(root)
+            seed_sweep_dir = self._write_seed_sweep(root)
+            output_dir = root / "artifacts"
+            output_dir.mkdir()
+
+            experiment_row = VNextExperimentSpec(
+                run_id="paper-run-1",
+                candidate_id=None,
+                experiment_id="exp-breakout-1",
+                payload_json={"family_template_id": "breakout_reclaim_v2"},
+            )
+            fake_payload = {
+                "dataset_snapshot_receipt": {"snapshot_id": "snap-1"},
+                "top": [
+                    {
+                        "candidate_id": "cand-1",
+                        "full_window": {"net_per_day": "321.5"},
+                    }
+                ],
+            }
+            persistence_failure = {
+                "status": "failed",
+                "attempts": 3,
+                "error_type": "OperationalError",
+                "error": "server closed the connection unexpectedly",
+            }
+
+            with (
+                patch(
+                    "scripts.run_strategy_factory_v2.SessionLocal",
+                    side_effect=lambda: Session(self.engine),
+                ),
+                patch(
+                    "scripts.run_strategy_factory_v2._load_source_experiment_specs",
+                    return_value=[experiment_row],
+                ),
+                patch(
+                    "scripts.run_strategy_factory_v2.run_consistent_profitability_frontier",
+                    return_value=fake_payload,
+                ),
+                patch(
+                    "scripts.run_strategy_factory_v2._persist_result",
+                    return_value=persistence_failure,
+                ),
+            ):
+                result = runner.run_strategy_factory_v2(
+                    self._args(
+                        output_dir=output_dir,
+                        strategy_configmap=strategy_configmap,
+                        family_template_dir=family_template_dir,
+                        seed_sweep_dir=seed_sweep_dir,
+                    )
+                )
+
+        self.assertEqual(result["status"], "ok_with_persistence_warnings")
+        self.assertFalse(result["persisted"])
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["experiments"][0]["top_candidate_id"], "cand-1")
+        self.assertEqual(
+            result["experiments"][0]["persistence_status"], persistence_failure
+        )
+        self.assertEqual(
+            result["persistence_failures"][0]["candidate_spec_id"], "exp-breakout-1"
+        )
 
     def test_run_strategy_factory_v2_respects_global_candidate_budget(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Retries transient SQLAlchemy persistence failures when storing strategy-factory replay results.
- Keeps completed frontier replay artifacts in the factory response when persistence still fails, instead of aborting the replay and losing evidence for selected specs.
- Adds explicit persistence warning fields and regression tests for retry and non-dropping behavior.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_run_strategy_factory_v2.py -q`
- `cd services/torghut && uv run --frozen ruff format scripts/run_strategy_factory_v2.py tests/test_run_strategy_factory_v2.py --check && uv run --frozen ruff check scripts/run_strategy_factory_v2.py tests/test_run_strategy_factory_v2.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest tests/test_portfolio_optimizer.py tests/test_candidate_specs.py tests/test_profit_target_oracle.py tests/test_run_strategy_factory_v2.py -q`
- `cd services/torghut && uv run --frozen coverage erase && uv run --frozen coverage run -m pytest tests/test_portfolio_optimizer.py tests/test_candidate_specs.py tests/test_profit_target_oracle.py tests/test_run_strategy_factory_v2.py -q && uv run --frozen coverage xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `cd services/torghut && uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k "real_replay or replay" -q`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
