### PR TITLE
fix(temporal-bun-sdk): tolerate transient termination cleanup outage

### DIFF
--- a/packages/temporal-bun-sdk/tests/integration/load/runner.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/load/runner.test.ts
@@ -102,6 +102,11 @@ test('worker load update termination classifies shard-status cleanup transients'
       cause: new ConnectError('[unavailable] shard status unknown', Code.Unavailable),
     }),
   ).toBe(true)
+  expect(
+    __workerLoadTestHooks.isTransientWorkflowTerminationCleanupFailure(
+      new ConnectError('[unavailable] Not enough hosts to serve the request', Code.Unavailable),
+    ),
+  ).toBe(true)
 })
 
 test('worker load update termination keeps non-unavailable cleanup failures fatal', () => {

--- a/packages/temporal-bun-sdk/tests/integration/load/runner.ts
+++ b/packages/temporal-bun-sdk/tests/integration/load/runner.ts
@@ -703,7 +703,7 @@ const isTransientWorkflowTerminationCleanupFailure = (error: unknown): boolean =
       message = String(candidate)
     }
 
-    if (!/shard status unknown|service unavailable|temporarily unavailable/i.test(message)) {
+    if (!/shard status unknown|service unavailable|temporarily unavailable|not enough hosts to serve the request/i.test(message)) {
       return false
     }
     return candidate instanceof ConnectError ? candidate.code === Code.Unavailable : true


### PR DESCRIPTION
## Summary

- Treat Temporal `Code.Unavailable` termination cleanup responses that say `Not enough hosts to serve the request` as transient cleanup failures in the worker-load update cleanup path.
- Preserve fatal handling for non-unavailable termination errors while allowing already-terminal update workflows to continue through completion verification.
- Add a regression assertion for the exact error text observed in failed publish run `25958501223`.

## Related Issues

None

## Testing

- `bun test packages/temporal-bun-sdk/tests/integration/load/runner.test.ts`
- `bun test packages/temporal-bun-sdk/tests/packaging/manifest-packaging.test.ts`
- `bun run --cwd packages/temporal-bun-sdk build`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint` (completed with existing warnings, 0 errors)
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint:type` (completed with existing warnings, 0 errors)
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
