### PR TITLE
fix(torghut): prefer profit target in portfolio diagnostics

### DIFF
--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -616,8 +616,8 @@ def _portfolio_selection_key(
 ) -> tuple[Decimal, ...]:
     return (
         Decimal(1 if bool(scorecard.get("oracle_passed")) else 0),
-        -_oracle_blocker_count(scorecard),
         Decimal(1 if bool(scorecard.get("target_met")) else 0),
+        -_oracle_blocker_count(scorecard),
         _scorecard_decimal(scorecard, "active_day_ratio"),
         _scorecard_decimal(scorecard, "positive_day_ratio"),
         _scorecard_decimal(scorecard, "min_daily_net_pnl"),

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -1014,7 +1014,7 @@ class TestPortfolioOptimizer(TestCase):
         )
         self.assertGreater(portfolio.optimizer_report["finalist_state_count"], 1)
 
-    def test_optimizer_prefers_fewer_oracle_blockers_over_average_only(
+    def test_optimizer_prefers_target_met_before_fewer_oracle_blockers(
         self,
     ) -> None:
         def bundle(
@@ -1106,24 +1106,25 @@ class TestPortfolioOptimizer(TestCase):
 
         self.assertIsNotNone(portfolio)
         assert portfolio is not None
-        self.assertCountEqual(
-            portfolio.source_candidate_ids,
-            ("cand-steady-aapl", "cand-steady-amzn", "cand-steady-googl"),
-        )
+        self.assertIn("cand-sparse-intc", portfolio.source_candidate_ids)
+        self.assertEqual(len(portfolio.source_candidate_ids), 3)
         self.assertFalse(portfolio.objective_scorecard["oracle_passed"])
+        self.assertTrue(portfolio.objective_scorecard["target_met"])
         self.assertEqual(
             portfolio.objective_scorecard["min_daily_net_pnl"],
-            "480.0000000000000000000000000",
+            "320.0000000000000000000000000",
         )
-        self.assertLessEqual(
-            Decimal(
-                portfolio.objective_scorecard["max_single_symbol_contribution_share"]
-            ),
-            Decimal("0.35"),
+        self.assertGreater(
+            Decimal(portfolio.objective_scorecard["max_single_day_contribution_share"]),
+            Decimal("0.25"),
         )
         self.assertEqual(
             portfolio.objective_scorecard["profit_target_oracle"]["blockers"],
-            ["portfolio_post_cost_net_pnl_per_day_failed"],
+            [
+                "best_day_share_failed",
+                "max_single_day_contribution_share_failed",
+                "max_single_symbol_contribution_share_failed",
+            ],
         )
 
     def test_optimizer_rejects_correlated_sleeves_before_minimum_size(


### PR DESCRIPTION
## Summary

- Prefer target-met failed portfolios over lower-profit failed portfolios when no candidate passes the profit oracle.
- Keep oracle-passed portfolios as the top priority; this does not relax profit, risk, shadow, or executable replay gates.
- Update the optimizer regression test so failed-run diagnostics preserve profit-target evidence instead of burying it behind fewer blocker counts.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_portfolio_optimizer.py::TestPortfolioOptimizer::test_optimizer_prefers_target_met_before_fewer_oracle_blockers -q`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py tests/test_candidate_specs.py tests/test_profit_target_oracle.py tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen ruff format app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py --check && uv run --frozen ruff check app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py --cov=app.trading.discovery.portfolio_optimizer --cov-report=xml:coverage.xml --cov-fail-under=0 -q && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
