### PR TITLE
fix(temporal-bun-sdk): suppress transient final shutdown outage

### DIFF
--- a/packages/temporal-bun-sdk/tests/integration/load/runner.test.ts
+++ b/packages/temporal-bun-sdk/tests/integration/load/runner.test.ts
@@ -155,13 +155,19 @@ test('worker load failure cleanup terminates only non-terminal submitted workflo
   expect(events.map((event) => event.status).sort()).toEqual(['terminated', 'terminated'])
 })
 
-test('worker load failure cleanup reports already-completed and failed terminations', async () => {
+test('worker load failure cleanup reports already-completed, transient, and failed terminations', async () => {
   type CleanupClient = Parameters<typeof __workerLoadTestHooks.cleanupSubmittedWorkflows>[0]
   const client = {
     workflow: {
       terminate: async (handle: { workflowId: string }) => {
         if (handle.workflowId === 'already-completed') {
           throw new ConnectError('workflow execution already completed', Code.NotFound)
+        }
+        if (handle.workflowId === 'transient') {
+          throw {
+            _tag: 'UnknownException',
+            cause: new ConnectError('[unavailable] Not enough hosts to serve the request', Code.Unavailable),
+          }
         }
         throw new Error('backend unavailable')
       },
@@ -172,6 +178,7 @@ test('worker load failure cleanup reports already-completed and failed terminati
     client,
     [
       { workflowId: 'already-completed', runId: 'run-already-completed' },
+      { workflowId: 'transient', runId: 'run-transient' },
       { workflowId: 'failed', runId: 'run-failed' },
     ],
     [],
@@ -182,5 +189,6 @@ test('worker load failure cleanup reports already-completed and failed terminati
   expect(events.map((event) => [event.workflowId, event.status]).sort()).toEqual([
     ['already-completed', 'already-completed'],
     ['failed', 'failed'],
+    ['transient', 'transient-cleanup-failed'],
   ])
 })

--- a/packages/temporal-bun-sdk/tests/integration/load/runner.ts
+++ b/packages/temporal-bun-sdk/tests/integration/load/runner.ts
@@ -65,7 +65,7 @@ type WorkflowCleanupEvent = {
   readonly runId: string
   readonly requestedAt: string
   readonly completedAt: string
-  readonly status: 'terminated' | 'already-completed' | 'failed'
+  readonly status: 'terminated' | 'already-completed' | 'transient-cleanup-failed' | 'failed'
   readonly reason: string
   readonly error?: string
 }
@@ -156,7 +156,10 @@ export const runWorkerLoad = async (options: WorkerLoadRunnerOptions): Promise<W
   const shutdownRuntime = async (
     current: ManagedWorkerRuntime,
     reason: string,
-    options: { readonly suppressRunFailure?: boolean } = {},
+    options: {
+      readonly suppressRunFailure?: boolean
+      readonly suppressTransientRunFailure?: boolean
+    } = {},
   ): Promise<SerializedError | undefined> => {
     await memoryRecorder.sample('before-runtime-shutdown', { generation: current.generation, reason })
     await current.runtime.shutdown()
@@ -164,9 +167,16 @@ export const runWorkerLoad = async (options: WorkerLoadRunnerOptions): Promise<W
     try {
       await current.runPromise
     } catch (error) {
-      runFailure = serializeError(error)
-      if (!options.suppressRunFailure) {
+      if (options.suppressTransientRunFailure && isTransientTemporalUnavailableFailure(error)) {
+        await memoryRecorder.sample('runtime-shutdown-transient-failure', {
+          generation: current.generation,
+          reason,
+          error: formatErrorMessage(error),
+        })
+      } else if (!options.suppressRunFailure) {
         throw error
+      } else {
+        runFailure = serializeError(error)
       }
     }
     await memoryRecorder.sample('after-runtime-shutdown', { generation: current.generation, reason })
@@ -275,6 +285,7 @@ export const runWorkerLoad = async (options: WorkerLoadRunnerOptions): Promise<W
           attempted: cleanupEvents.length,
           terminated: cleanupEvents.filter((event) => event.status === 'terminated').length,
           alreadyCompleted: cleanupEvents.filter((event) => event.status === 'already-completed').length,
+          transientCleanupFailed: cleanupEvents.filter((event) => event.status === 'transient-cleanup-failed').length,
           failed: cleanupEvents.filter((event) => event.status === 'failed').length,
         })
       }
@@ -285,6 +296,7 @@ export const runWorkerLoad = async (options: WorkerLoadRunnerOptions): Promise<W
     if (managedRuntime) {
       const shutdownFailure = await shutdownRuntime(managedRuntime, 'final', {
         suppressRunFailure: completionFailure !== undefined,
+        suppressTransientRunFailure: true,
       })
       if (shutdownFailure && !completionFailure) {
         completionFailure = shutdownFailure
@@ -381,6 +393,9 @@ export const runWorkerLoad = async (options: WorkerLoadRunnerOptions): Promise<W
           failureCleanupAttemptCount: workflowCleanupEvents.length,
           failureCleanupTerminatedCount: workflowCleanupEvents.filter((event) => event.status === 'terminated').length,
           failureCleanupAlreadyCompletedCount: workflowCleanupEvents.filter((event) => event.status === 'already-completed').length,
+          failureCleanupTransientCleanupFailureCount: workflowCleanupEvents.filter(
+            (event) => event.status === 'transient-cleanup-failed',
+          ).length,
           failureCleanupFailedCount: workflowCleanupEvents.filter((event) => event.status === 'failed').length,
           workflowCleanupEvents,
         },
@@ -693,6 +708,9 @@ const isWorkflowAlreadyCompletedForTermination = (error: unknown): boolean =>
   })
 
 const isTransientWorkflowTerminationCleanupFailure = (error: unknown): boolean =>
+  isTransientTemporalUnavailableFailure(error)
+
+const isTransientTemporalUnavailableFailure = (error: unknown): boolean =>
   unwrapErrorChain(error).some((candidate) => {
     let message: string
     if (candidate instanceof Error) {
@@ -794,6 +812,16 @@ const cleanupSubmittedWorkflows = async (
               requestedAt,
               completedAt: new Date().toISOString(),
               status: 'already-completed',
+              reason,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          } else if (isTransientWorkflowTerminationCleanupFailure(error)) {
+            events.push({
+              workflowId: handle.workflowId,
+              runId: handle.runId,
+              requestedAt,
+              completedAt: new Date().toISOString(),
+              status: 'transient-cleanup-failed',
               reason,
               error: error instanceof Error ? error.message : String(error),
             })


### PR DESCRIPTION
## Summary

- Suppress final worker-shutdown `Unavailable` transients after load workflows have already completed.
- Classify transient cleanup termination failures separately from real cleanup failures in worker-load reports.
- Add regression coverage for `Not enough hosts to serve the request` cleanup failures wrapped by Effect.

## Related Issues

None

## Testing

- `bun test packages/temporal-bun-sdk/tests/integration/load/runner.test.ts`
- `bun test packages/temporal-bun-sdk/tests/packaging/manifest-packaging.test.ts`
- `bun run --cwd packages/temporal-bun-sdk build`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint:type`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
