### PR TITLE
fix(saigak): restore qwen model provisioning

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -395,7 +395,7 @@ spec:
             - name: DOCKER_ENABLED
               value: "1"
             - name: OPENAI_API_BASE_URL
-              value: http://saigak.saigak.svc.cluster.local:11435/v1
+              value: http://saigak.saigak.svc.cluster.local:11434/v1
             - name: OPENAI_EMBEDDING_API_BASE_URL
               value: http://saigak.saigak.svc.cluster.local:11435/v1
             - name: OPENAI_EMBEDDING_MODEL

--- a/argocd/applications/saigak/cloud-init-secret.yaml
+++ b/argocd/applications/saigak/cloud-init-secret.yaml
@@ -170,6 +170,37 @@ stringData:
           set -euo pipefail
           netplan generate || true
           netplan apply || true
+      - path: /usr/local/sbin/saigak-provision-ollama-models
+        owner: root:root
+        permissions: '0755'
+        content: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          export HOME=/home/ubuntu
+          export OLLAMA_HOST=127.0.0.1:11434
+
+          ollama pull qwen3:30b-a3b
+          ollama create qwen3-main-saigak:30b-a3b -f /etc/saigak/qwen3-main-30b-a3b.modelfile
+          ollama show qwen3-main-saigak:30b-a3b >/dev/null
+
+          ollama pull qwen3-embedding:8b
+          ollama create qwen3-embedding-saigak:8b -f /etc/saigak/qwen3-embedding-8b.modelfile
+          ollama show qwen3-embedding-saigak:8b >/dev/null
+
+          for model in \
+            qwen3-coder-saigak:30b-a3b-q4_K_M \
+            qwen3-coder-saigak:30b \
+            qwen3-embedding-saigak:0.6b \
+            qwen3-coder:30b \
+            qwen3-coder:30b-a3b-q4_K_M \
+            qwen3-embedding:0.6b \
+            qwen3:30b-a3b \
+            qwen3-embedding:8b; do
+            if ollama list | awk '{print $1}' | grep -Fxq "$model"; then
+              ollama rm "$model"
+            fi
+          done
     users:
       - name: ubuntu
         groups: [sudo]
@@ -206,13 +237,7 @@ stringData:
       - [ bash, -lc, 'systemctl enable --now ollama' ]
       - [ bash, -lc, 'sleep 2' ]
       - [ bash, -lc, 'curl -fsS http://127.0.0.1:11434/api/version' ]
-      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama pull qwen3:30b-a3b' ]
-      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama create qwen3-main-saigak:30b-a3b -f /etc/saigak/qwen3-main-30b-a3b.modelfile' ]
-      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama show qwen3-main-saigak:30b-a3b >/dev/null' ]
-      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama pull qwen3-embedding:8b' ]
-      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama create qwen3-embedding-saigak:8b -f /etc/saigak/qwen3-embedding-8b.modelfile' ]
-      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; ollama show qwen3-embedding-saigak:8b >/dev/null' ]
-      - [ bash, -lc, 'export HOME=/home/ubuntu OLLAMA_HOST=127.0.0.1:11434; for model in qwen3-coder-saigak:30b-a3b-q4_K_M qwen3-coder-saigak:30b qwen3-embedding-saigak:0.6b qwen3-coder:30b qwen3-coder:30b-a3b-q4_K_M qwen3-embedding:0.6b qwen3:30b-a3b qwen3-embedding:8b; do ollama list | awk '\''{print $1}'\'' | grep -Fxq \"$model\" && ollama rm \"$model\" || true; done' ]
+      - [ bash, -lc, 'saigak-provision-ollama-models' ]
       - [ bash, -lc, 'systemctl enable --now ollama-embed' ]
       - [ bash, -lc, 'sleep 2' ]
       - [ bash, -lc, 'curl -fsS http://127.0.0.1:11435/api/version' ]


### PR DESCRIPTION
## Summary

- Fix Saigak cloud-init model provisioning by moving the brittle inline Ollama commands into a root-owned provisioning script.
- Restore creation of both `qwen3-main-saigak:30b-a3b` and `qwen3-embedding-saigak:8b` during VM boot.
- Point Jangar's generic OpenAI-compatible base URL at Saigak's main Ollama port while leaving embeddings on the dedicated embedding port.

## Related Issues

None

## Testing

- `ruby -ryaml -e 'outer = YAML.load_file("argocd/applications/saigak/cloud-init-secret.yaml"); YAML.safe_load(outer.fetch("stringData").fetch("userdata")); puts "saigak cloud-config yaml ok"'`
- `kubectl kustomize argocd/applications/saigak >/tmp/saigak-rendered.yaml && kubectl apply --dry-run=server -f /tmp/saigak-rendered.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/jangar >/tmp/jangar-rendered.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/jangar/deployment.yaml`
- `git diff --check`
- Live repaired Saigak VM and verified `qwen3-main-saigak:30b-a3b` on GPU, `qwen3-embedding-saigak:8b` on the CPU embedding service, and Jangar memory save/retrieve.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
