### PR TITLE
fix(saigak): sync kubevirt vm defaults

### DIFF
--- a/argocd/applications/saigak/virtualmachine.yaml
+++ b/argocd/applications/saigak/virtualmachine.yaml
@@ -28,6 +28,9 @@ spec:
       labels:
         kubevirt.io/domain: saigak
         app.kubernetes.io/name: saigak
+      annotations:
+        kubevirt.io/pci-interface-slot-count: "9"
+        kubevirt.io/pci-topology-version: v2
       creationTimestamp: null
     spec:
       architecture: arm64


### PR DESCRIPTION
## Summary

- Add the stable KubeVirt-injected PCI topology annotations to the Saigak VM template.
- Remove the remaining Saigak Argo CD drift after the model provisioning repair.
- Keep the running VM spec aligned with live KubeVirt defaults without changing resources, disks, GPU assignment, or boot behavior.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/saigak >/tmp/saigak-rendered.yaml && kubectl apply --dry-run=server -f /tmp/saigak-rendered.yaml`
- `git diff --check`
- `kubectl kustomize argocd/applications/saigak >/tmp/saigak-rendered.yaml && kubectl apply -f /tmp/saigak-rendered.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
