### PR TITLE
fix(saigak): ignore kubevirt managed vm drift

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -723,6 +723,15 @@ spec:
             - .spec.template.spec.architecture
             - .spec.template.spec.domain.firmware
             - .spec.template.spec.domain.machine
+        - kind: VirtualMachine
+          group: kubevirt.io
+          namespace: saigak
+          name: saigak
+          jqPathExpressions:
+            - .metadata.annotations
+            - .metadata.finalizers
+            - .spec.dataVolumeTemplates[].metadata.creationTimestamp
+            - .spec.template.metadata.creationTimestamp
         - kind: ClusterPolicy
           group: nvidia.com
           name: cluster-policy


### PR DESCRIPTION
## Summary

- Add Saigak to the existing ApplicationSet KubeVirt VM ignore rules.
- Ignore only KubeVirt-managed metadata/default timestamp fields for the Saigak VM.
- Let the Saigak Argo CD application settle after the model provisioning repair.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=server -f argocd/applicationsets/platform.yaml`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
