### PR TITLE
fix(torghut): align portfolio profit harness

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -166,7 +166,7 @@ spec:
               --portfolio-size-min "{{inputs.parameters.portfolioSizeMin}}"
               --portfolio-size-max "{{inputs.parameters.portfolioSizeMax}}"
               --replay-mode real
-              --program config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml
+              --program config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
               --strategy-configmap /etc/torghut/strategies.yaml
               --clickhouse-http-url "${TA_CLICKHOUSE_URL}"
               --clickhouse-username "${TA_CLICKHOUSE_USERNAME}"
@@ -183,10 +183,6 @@ spec:
               --real-replay-shard-workers "{{inputs.parameters.realReplayShardWorkers}}"
               --train-days 6
               --holdout-days 3
-              --min-active-day-ratio 1
-              --min-positive-day-ratio 1
-              --min-daily-net-pnl "{{inputs.parameters.targetNetPnlPerDay}}"
-              --require-no-flat-days
             )
 
             if [ "{{inputs.parameters.seedRecentWhitepapers}}" = "true" ]; then

--- a/docs/torghut/design-system/v6/214-torghut-current-whitepaper-to-profitable-strategy-workflow-2026-05-16.md
+++ b/docs/torghut/design-system/v6/214-torghut-current-whitepaper-to-profitable-strategy-workflow-2026-05-16.md
@@ -1,0 +1,323 @@
+# 214. Torghut Current Whitepaper to Profitable Strategy Workflow (2026-05-16)
+
+This is the current operating workflow for turning a research paper into a Torghut strategy or
+portfolio sleeve that can eventually trade. It is intentionally stricter than "find a high backtest":
+the only acceptable output is a replayed, post-cost, capital-feasible portfolio candidate with runtime
+closure, paper or shadow evidence, and promotion receipts. MLX can accelerate search, but it cannot
+approve promotion or bypass replay.
+
+Current status: the workflow exists, but the latest live epochs still did not find a valid portfolio
+candidate. The current fix is to align the harness with the real objective: portfolio-level average
+`$500/day` post-cost net PnL with bounded drawdown, not "every day must be profitable" and not a
+single sleeve that prints `$500` daily.
+
+## End-to-End Flow
+
+```mermaid
+flowchart TD
+  Paper["Whitepaper or research note"] --> Ingest["Whitepaper ingest and versioning"]
+  Ingest --> Claims["Claim compiler\nmechanism, signal, data, risk, validation"]
+  Claims --> Cards["Hypothesis cards\nbounded, falsifiable, feature-linked"]
+  Cards --> Factory["Candidate compiler / strategy factory\nchecked runtime family ids only"]
+  Factory --> Specs["CandidateSpec ledger\nfamily, universe, features, risk, execution profile"]
+
+  Specs --> Snapshot["Immutable epoch snapshot\nspecs, prior evidence, feature contracts"]
+  Snapshot --> MLX["MLX proposal ranker\nranking only, no promotion authority"]
+  MLX --> Budget["Replay budget selector\ntop-K plus exploration plus backfill"]
+  Specs --> Budget
+
+  Budget --> Replay["Runtime replay\nscheduler-v3 / real replay mode"]
+  Replay --> Evidence["CandidateEvidenceBundle\npost-cost PnL, notional, cash, drawdown, blockers"]
+  Evidence --> Optimizer["Portfolio optimizer\nsleeve weights, correlation, exposure, concentration"]
+  Optimizer --> Portfolio["PortfolioCandidateSpec\nportfolio objective scorecard"]
+
+  Portfolio --> Oracle{"Profit target oracle"}
+  Oracle -->|"fail"| LedgerFail["Persist failure table\nfalse positives, blockers, next epoch plan"]
+  LedgerFail --> Train["Train next proposal model\nrank-bucket lift and replay feedback"]
+  Train --> MLX
+
+  Oracle -->|"pass"| Closure["Runtime closure\nconfig, replay plan, parity plan, approval prerequisites"]
+  Closure --> Shadow{"Paper/shadow gate"}
+  Shadow -->|"fail"| LedgerFail
+  Shadow -->|"pass"| Promotion["Promotion readiness receipt\nno MLX-only promotion"]
+  Promotion --> LiveSleeve["Live strategy / sleeve candidate\neligible for controlled rollout"]
+```
+
+## Promotion State Machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> ResearchOnly
+  ResearchOnly: paper parsed\nclaims compiled\ncandidate specs generated
+  ResearchOnly --> ReplayEligible: bounded CandidateSpec\nknown runtime family\nfeature contract present
+  ReplayEligible --> ReplayFailed: replay missing, stale, synthetic-only,\nor objective blockers
+  ReplayFailed --> ResearchOnly: feedback enters next epoch
+
+  ReplayEligible --> PortfolioCandidate: real replay evidence exists\npost-cost metrics computed
+  PortfolioCandidate --> OracleFailed: target, drawdown, cash,\nexposure, notional, concentration,\nor activity gates fail
+  OracleFailed --> ResearchOnly: failure is persisted as training signal
+
+  PortfolioCandidate --> RuntimeClosure: portfolio oracle passes
+  RuntimeClosure --> ClosureBlocked: runtime strategy missing,\nparity missing, approval missing,\nor shadow evidence missing
+  ClosureBlocked --> ResearchOnly: closure blockers drive repair work
+
+  RuntimeClosure --> ShadowReady: checked runtime family\nconfig materialized\nparity plan available
+  ShadowReady --> PaperShadow: zero/live-safe paper or shadow run
+  PaperShadow --> PromotionBlocked: paper/shadow evidence fails\nor ledger proof incomplete
+  PromotionBlocked --> ResearchOnly
+
+  PaperShadow --> PromotionEligible: paper/shadow evidence passes\nledger proof complete\ncapital gates pass
+  PromotionEligible --> LiveControlled: controlled rollout enabled
+  LiveControlled --> [*]
+```
+
+## Operator Sequence
+
+```mermaid
+sequenceDiagram
+  participant Operator
+  participant Workflow as Argo WorkflowTemplate
+  participant Runner as run_whitepaper_autoresearch_profit_target.py
+  participant DB as Torghut Postgres
+  participant MLX as MLX ranker
+  participant Replay as Runtime replay
+  participant Oracle as Profit target oracle
+  participant Closure as Runtime closure
+  participant Scheduler as Scheduler / live sleeve
+
+  Operator->>Workflow: submit targetNetPnlPerDay=500 and research program
+  Workflow->>Runner: run epoch with real replay and persistence
+  Runner->>DB: load whitepaper claims and prior epoch evidence
+  Runner->>Runner: compile hypothesis cards into CandidateSpec rows
+  Runner->>MLX: score candidates from immutable snapshot
+  MLX-->>Runner: ranked proposal list, model metadata, diagnostics
+  Runner->>Replay: replay selected CandidateSpecs
+  Replay-->>Runner: evidence bundles with post-cost metrics
+  Runner->>Oracle: evaluate sleeve and portfolio candidates
+  Oracle-->>Runner: pass/fail scorecard and blockers
+  Runner->>DB: persist epoch, specs, proposal scores, evidence, portfolios
+
+  alt no portfolio candidate passes
+    Runner-->>Operator: no_profit_target_candidate with blocker tables
+    Runner->>DB: next epoch plan and false-positive feedback
+  else portfolio candidate passes
+    Runner->>Closure: materialize runtime closure artifacts
+    Closure->>DB: persist proof receipt and promotion prerequisites
+    Closure->>Scheduler: candidate remains blocked until parity and shadow proof
+    Scheduler-->>Operator: promotion eligible only after runtime and ledger gates pass
+  end
+```
+
+## Workflow Stages
+
+### 1. Whitepaper ingestion
+
+Whitepapers are input material, not authority. The system records the paper source, version, claims,
+and relations. The useful output is a typed claim graph: signal mechanism, data requirements, market
+condition, validation requirement, and failure modes.
+
+Primary surfaces:
+
+- `services/torghut/app/whitepapers/workflow.py`
+- `services/torghut/app/whitepapers/claim_compiler.py`
+- `services/torghut/scripts/compile_whitepaper_claims.py`
+
+### 2. Hypothesis cards
+
+Claims become bounded hypothesis cards. A card must say what market behavior is being tested, what
+features it needs, which runtime family can express it, and what would falsify it. A vague paper
+summary is not allowed to become a live sleeve.
+
+Primary surfaces:
+
+- `services/torghut/app/trading/discovery/hypothesis_cards.py`
+- `services/torghut/app/trading/discovery/whitepaper_candidate_compiler.py`
+
+### 3. Candidate specs
+
+Hypothesis cards compile into `CandidateSpec` objects. This is the first hard anti-cheat boundary.
+Specs must map to checked-in runtime family ids and bounded parameters. The workflow should not
+generate arbitrary live code and then call it a strategy.
+
+A candidate spec carries:
+
+- family id and template id
+- universe and symbol filters
+- feature requirements
+- risk profile
+- execution profile
+- objective policy
+- provenance back to paper claims and epoch inputs
+
+Primary surfaces:
+
+- `services/torghut/app/trading/discovery/candidate_specs.py`
+- `services/torghut/app/trading/discovery/family_templates.py`
+- `services/torghut/app/trading/strategy_specs.py`
+
+### 4. MLX proposal ranking
+
+MLX is used to spend replay budget better. It can rank, cluster, or learn proposal priors over prior
+candidate outcomes. It does not approve anything. It does not replace replay. It does not write live
+runtime configuration.
+
+The accepted MLX contract is:
+
+- input is an immutable epoch snapshot
+- output is proposal scores and diagnostics
+- authority is limited to replay selection
+- replay outcomes become the training labels for the next epoch
+
+Primary surfaces:
+
+- `services/torghut/app/trading/discovery/mlx_snapshot.py`
+- `services/torghut/app/trading/discovery/mlx_features.py`
+- `services/torghut/app/trading/discovery/mlx_proposal_models.py`
+- `services/torghut/scripts/train_mlx_autoresearch_ranker.py`
+
+### 5. Replay and evidence bundles
+
+Selected candidates run through replay. For promotion-relevant evidence, synthetic replay is not
+enough. The replay must produce post-cost metrics with enough data quality to support the objective.
+
+The evidence bundle must include:
+
+- post-cost net PnL
+- active-day and positive-day ratios
+- daily notional
+- cash and gross exposure
+- drawdown and worst-day loss
+- concentration and best-day share
+- executable replay status
+- blockers when any gate fails
+
+Primary surfaces:
+
+- `services/torghut/app/trading/discovery/evidence_bundles.py`
+- `services/torghut/app/trading/discovery/autoresearch.py`
+- `services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py`
+
+### 6. Portfolio optimization
+
+The target is portfolio-level profitability. A single sleeve does not need to be profitable every day,
+and a down day is allowed if portfolio-level loss, drawdown, cash, exposure, concentration, and
+notional gates remain inside policy.
+
+The current `$500/day` program should be interpreted as:
+
+- target average post-cost net PnL per active day: `500`
+- bounded daily loss floor, not no-loss days
+- bounded maximum drawdown
+- nonnegative cash
+- gross exposure at or below policy
+- enough daily notional to make the result executable
+- enough active and positive days to avoid one lucky spike
+- no best-day concentration masquerading as durable edge
+
+Primary surfaces:
+
+- `services/torghut/app/trading/discovery/portfolio_optimizer.py`
+- `services/torghut/app/trading/discovery/portfolio_candidates.py`
+- `services/torghut/app/trading/discovery/profit_target_oracle.py`
+- `services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml`
+
+### 7. Profit target oracle
+
+The oracle turns metrics into a hard pass/fail scorecard. It is not trying to make the run look good.
+It is there to prevent false positives from becoming capital decisions.
+
+Typical rejection reasons include:
+
+- portfolio net PnL below target
+- cash below zero
+- gross exposure above limit
+- drawdown too large
+- worst day too large
+- best-day share too concentrated
+- active-day ratio too low
+- positive-day ratio too low
+- daily notional too low
+- executable replay missing
+- runtime closure proof missing
+
+### 8. Runtime closure
+
+Passing replay is still not live readiness. Runtime closure proves the portfolio can be represented
+by actual runtime configuration and scheduler behavior.
+
+Runtime closure must produce:
+
+- candidate runtime config or configmap
+- sleeve materialization plan
+- replay plan and parity expectations
+- approval prerequisites
+- shadow or paper-run prerequisites
+- proof receipt
+- promotion blockers when any artifact is missing
+
+Primary surfaces:
+
+- `services/torghut/app/trading/discovery/runtime_closure.py`
+- `services/torghut/app/trading/discovery/promotion_contract.py`
+- `services/torghut/app/trading/scheduler/runtime.py`
+- `services/torghut/app/trading/research_sleeves.py`
+
+### 9. Paper, shadow, and live promotion
+
+The candidate remains blocked until scheduler parity, approval policy, and paper or shadow evidence
+pass. Only then can it become a live sleeve candidate. The live sleeve is still controlled rollout,
+not a blanket permission to spend capital.
+
+Promotion authority must come from:
+
+- replay evidence
+- portfolio oracle pass
+- runtime closure pass
+- scheduler parity pass
+- paper or shadow pass
+- ledger proof and freshness
+- capital and risk gates
+
+## What Is Not Allowed
+
+- No generated free-form live strategy code.
+- No synthetic replay as production proof.
+- No MLX-only promotion.
+- No target leakage from future evidence into candidate construction.
+- No hardcoded pass for a `$500` target.
+- No "strict every day profitable" harness when the objective is portfolio-level profitability.
+- No ignoring cash, exposure, notional, or drawdown to make PnL look good.
+- No claiming live profitability from service readiness alone.
+
+## Current Operator Commands
+
+Typical local verification before promoting changes to this workflow:
+
+```bash
+cd services/torghut
+uv sync --frozen --extra dev
+uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_strategy_autoresearch.py tests/test_profit_target_oracle.py
+uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_strategy_autoresearch.py tests/test_profit_target_oracle.py -q
+uv run --frozen pyright --project pyrightconfig.json
+uv run --frozen pyright --project pyrightconfig.alpha.json
+uv run --frozen pyright --project pyrightconfig.scripts.json
+```
+
+Typical live evidence checks:
+
+```bash
+kubectl -n torghut get ksvc torghut torghut-sim
+kubectl -n torghut get workflowtemplate torghut-whitepaper-autoresearch-profit-target -o yaml
+kubectl cnpg psql -n torghut torghut-db -- -c "select run_id, status, target_net_pnl_per_day, runtime_closure_status, promotion_status from autoresearch_epochs order by created_at desc limit 10;"
+```
+
+Service readiness is only a prerequisite. Profitability requires the epoch tables and proof receipts
+to show a passing portfolio candidate and promotion-ready runtime evidence.
+
+## Short Version
+
+Whitepaper claims propose hypotheses. Hypotheses compile into checked strategy specs. MLX ranks the
+specs to allocate replay budget. Runtime replay produces evidence. The portfolio optimizer combines
+sleeves. The oracle rejects anything that fails post-cost PnL, drawdown, cash, exposure, notional, or
+concentration gates. Runtime closure proves the candidate can actually run. Paper or shadow evidence
+proves it behaves outside offline replay. Only then can a sleeve become live-eligible.

--- a/docs/torghut/design-system/v6/index.md
+++ b/docs/torghut/design-system/v6/index.md
@@ -1167,3 +1167,8 @@ This pack is positioned as the next architecture layer above:
   and Torghut remains zero-notional. It makes each market-context, empirical, route/TCA, promotion-table, and quant
   pipeline repair cite an expected unblock value, freshness SLO, Jangar packet ref, and zero-notional guardrail before
   the repair can spend launch capacity.
+- `214-torghut-current-whitepaper-to-profitable-strategy-workflow-2026-05-16.md` is the current operator-facing
+  workflow from whitepaper to live-eligible sleeve. It consolidates the active process into Mermaid diagrams and a
+  stage-by-stage writeup: claims, hypothesis cards, checked `CandidateSpec`s, MLX ranking-only proposal authority,
+  real replay evidence, portfolio optimization, profit oracle gates, runtime closure, paper/shadow proof, and live
+  promotion constraints.

--- a/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
@@ -1,9 +1,10 @@
 schema_version: torghut.strategy-autoresearch.v1
-program_id: strict_daily_profit_autoresearch_500_v1
+program_id: portfolio_profit_autoresearch_500_v1
 description: >
-  Strict outer loop for a $500/day post-cost net profit target. This profile keeps
-  the objective explicitly daily, not cumulative, and uses runtime-closure gates before
-  any promotion beyond research-candidate artifacts.
+  Portfolio outer loop for a $500/day post-cost net profit target. This profile keeps
+  the objective explicitly daily, not cumulative, allows ordinary down days, and uses
+  worst-day, drawdown, cash, exposure, replay, and runtime-closure gates before any
+  promotion beyond research-candidate artifacts.
 snapshot_policy:
   bar_interval: PT1S
   feature_set_id: torghut.mlx-autoresearch.v1
@@ -44,14 +45,14 @@ ledger_policy:
   append_only: true
 objective:
   target_net_pnl_per_day: '500'
-  min_daily_net_pnl: '500'
-  min_active_day_ratio: '1.0'
-  min_positive_day_ratio: '1.0'
+  min_daily_net_pnl: '-350'
+  min_active_day_ratio: '0.90'
+  min_positive_day_ratio: '0.60'
   min_daily_notional: '300000'
-  max_best_day_share: '0.30'
-  max_worst_day_loss: '0'
+  max_best_day_share: '0.25'
+  max_worst_day_loss: '350'
   max_drawdown: '900'
-  require_every_day_active: true
+  require_every_day_active: false
   min_regime_slice_pass_rate: '0.45'
   max_gross_exposure_pct_equity: '1.0'
   min_cash: '0'

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -86,8 +86,8 @@ import scripts.run_strategy_factory_v2 as strategy_factory_runner
 
 _DEFAULT_CHIP_UNIVERSE_CSV = ",".join(LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE)
 _DEFAULT_DAILY_PROFIT_TARGET = "500"
-_DEFAULT_STRICT_DAILY_PROFIT_PROGRAM = Path(
-    "config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml"
+_DEFAULT_PORTFOLIO_PROFIT_PROGRAM = Path(
+    "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
 )
 _DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC = 8
 _MAX_PERSISTED_FEEDBACK_EVIDENCE_BUNDLES = 512
@@ -171,7 +171,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--program",
         type=Path,
-        default=_DEFAULT_STRICT_DAILY_PROFIT_PROGRAM,
+        default=_DEFAULT_PORTFOLIO_PROFIT_PROGRAM,
     )
     parser.add_argument(
         "--strategy-configmap",
@@ -299,7 +299,7 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--min-active-day-ratio", default="0.90")
     parser.add_argument("--min-positive-day-ratio", default="0.60")
-    parser.add_argument("--min-daily-net-pnl", default="0")
+    parser.add_argument("--min-daily-net-pnl", default=None)
     parser.add_argument("--max-worst-day-loss", default="350")
     parser.add_argument("--max-drawdown", default="900")
     parser.add_argument("--max-best-day-share", default="0.25")
@@ -2084,6 +2084,17 @@ def _flag_int(value: Any) -> int | None:
         return None
 
 
+def _decimal_arg_or_default(
+    args: argparse.Namespace,
+    name: str,
+    default: Decimal,
+) -> Decimal:
+    raw_value = getattr(args, name, None)
+    if raw_value is None or _string(raw_value) == "":
+        return default
+    return _decimal(raw_value, default=str(default))
+
+
 def _profitability_next_epoch_plan(
     *,
     args: argparse.Namespace,
@@ -2092,9 +2103,7 @@ def _profitability_next_epoch_plan(
 ) -> dict[str, Any]:
     flags: dict[str, str] = {
         "--target-net-pnl-per-day": str(target),
-        "--program": str(
-            getattr(args, "program", _DEFAULT_STRICT_DAILY_PROFIT_PROGRAM)
-        ),
+        "--program": str(getattr(args, "program", _DEFAULT_PORTFOLIO_PROFIT_PROGRAM)),
         "--replay-mode": "real",
         "--max-candidates": str(max(64, _int_arg(args, "max_candidates", 64))),
         "--top-k": str(max(16, _int_arg(args, "top_k", 16))),
@@ -2287,7 +2296,7 @@ def _profitability_search_goal(
         "candidate_framework": {
             "program_id": program.program_id,
             "program_path": str(
-                getattr(args, "program", _DEFAULT_STRICT_DAILY_PROFIT_PROGRAM)
+                getattr(args, "program", _DEFAULT_PORTFOLIO_PROFIT_PROGRAM)
             ),
             "replay_mode": replay_mode,
             "source_count": len(sources),
@@ -4659,7 +4668,11 @@ def run_whitepaper_autoresearch_profit_target(
             ),
             "min_daily_net_pnl": str(
                 max(
-                    _decimal(getattr(args, "min_daily_net_pnl", "0")),
+                    _decimal_arg_or_default(
+                        args,
+                        "min_daily_net_pnl",
+                        objective.min_daily_net_pnl,
+                    ),
                     objective.min_daily_net_pnl,
                 )
             ),

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -97,7 +97,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             portfolio_size_max=4,
             replay_mode="synthetic",
             program=Path(
-                "config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml"
+                "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
             ),
             strategy_configmap=Path(
                 "argocd/applications/torghut/strategy-configmap.yaml"
@@ -127,6 +127,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             expected_last_trading_day="",
             allow_stale_tape=False,
             prefetch_full_window_rows=False,
+            min_daily_net_pnl=None,
             persist_results=False,
         )
 
@@ -212,9 +213,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             args.program,
             Path(
-                "config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml"
+                "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
             ),
         )
+        self.assertIsNone(args.min_daily_net_pnl)
         self.assertEqual(args.symbols.split(","), _CHIP_UNIVERSE)
         self.assertEqual(args.feedback_evidence_jsonl, [])
 
@@ -265,6 +267,14 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertIn(
             "name: realReplayShardTimeoutSeconds\n        value: '1800'", template
+        )
+        self.assertIn(
+            "--program config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml",
+            template,
+        )
+        self.assertNotIn("--require-no-flat-days", template)
+        self.assertNotIn(
+            '--min-daily-net-pnl "{{inputs.parameters.targetNetPnlPerDay}}"', template
         )
         self.assertIn("activeDeadlineSeconds: 21600", template)
         self.assertIn("name: allowStaleTape\n        value: 'false'", template)
@@ -1779,9 +1789,13 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "portfolio_post_cost_net_pnl_per_day_failed",
                 payload["profit_target_oracle"]["blockers"],
             )
-            self.assertIn(
+            self.assertNotIn(
                 "min_daily_net_pnl_failed",
                 payload["profit_target_oracle"]["blockers"],
+            )
+            self.assertEqual(
+                payload["profit_target_oracle_policy"]["min_daily_net_pnl"],
+                "-350",
             )
             self.assertIn(
                 "executable_replay_passed_failed",
@@ -1819,7 +1833,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         with TemporaryDirectory() as tmpdir:
             args = self._args(Path(tmpdir) / "epoch")
             args.program = Path(
-                "config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml"
+                "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
             )
             program = runner._load_epoch_program(args)
             sources = runner._program_whitepaper_sources(program)
@@ -1846,7 +1860,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         with TemporaryDirectory() as tmpdir:
             args = self._args(Path(tmpdir) / "epoch")
             args.program = Path(
-                "config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml"
+                "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
             )
             program = runner._load_epoch_program(args)
 
@@ -1899,7 +1913,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         with TemporaryDirectory() as tmpdir:
             args = self._args(Path(tmpdir) / "epoch")
             args.program = Path(
-                "config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml"
+                "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
             )
             args.replay_mode = "real"
             program = runner._load_epoch_program(args)
@@ -2247,6 +2261,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             ]
 
         self.assertEqual(payload["status"], "no_profit_target_candidate")
+        self.assertEqual(
+            payload["profit_target_oracle_policy"]["min_daily_net_pnl"], "-350"
+        )
         self.assertEqual(selection["budget"]["exploration_slots_requested"], 1)
         self.assertGreaterEqual(selection["budget"]["exploration_slots_effective"], 1)
         self.assertEqual(selection["budget"]["selected_count"], 3)
@@ -3472,6 +3489,15 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(parsed.real_replay_shard_timeout_seconds, 0)
         self.assertEqual(parsed.real_replay_shard_workers, 1)
         self.assertFalse(parsed.persist_results)
+
+    def test_decimal_arg_or_default_uses_explicit_cli_override(self) -> None:
+        value = runner._decimal_arg_or_default(
+            Namespace(min_daily_net_pnl="-125.50"),
+            "min_daily_net_pnl",
+            Decimal("-350"),
+        )
+
+        self.assertEqual(value, Decimal("-125.50"))
 
     def test_clickhouse_password_env_resolution_keeps_secret_out_of_argv(
         self,

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -401,11 +401,11 @@ class TestStrategyAutoresearch(TestCase):
             )
         )
 
-    def test_checked_in_500_daily_profit_program_enforces_cash_capital_realism(
+    def test_checked_in_500_portfolio_profit_program_allows_bounded_down_days(
         self,
     ) -> None:
         program_path = Path(
-            "config/trading/research-programs/strict-daily-profit-autoresearch-500-v1.yaml"
+            "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
         )
 
         program = load_strategy_autoresearch_program(
@@ -413,7 +413,14 @@ class TestStrategyAutoresearch(TestCase):
             family_dir=Path("config/trading/families"),
         )
 
+        self.assertEqual(program.program_id, "portfolio_profit_autoresearch_500_v1")
         self.assertEqual(program.objective.target_net_pnl_per_day, Decimal("500"))
+        self.assertEqual(program.objective.min_daily_net_pnl, Decimal("-350"))
+        self.assertEqual(program.objective.min_active_day_ratio, Decimal("0.90"))
+        self.assertEqual(program.objective.min_positive_day_ratio, Decimal("0.60"))
+        self.assertEqual(program.objective.max_worst_day_loss, Decimal("350"))
+        self.assertEqual(program.objective.max_drawdown, Decimal("900"))
+        self.assertFalse(program.objective.require_every_day_active)
         self.assertEqual(
             program.objective.max_gross_exposure_pct_equity, Decimal("1.0")
         )


### PR DESCRIPTION
## Summary

- Renames the `$500` Torghut autoresearch program from strict daily profit to portfolio profit semantics.
- Allows bounded ordinary down days via `min_daily_net_pnl=-350`, active ratio `0.90`, positive ratio `0.60`, while keeping drawdown, worst-day, cash, exposure, notional, concentration, replay, and shadow gates intact.
- Updates the Argo workflow to stop passing `--require-no-flat-days` and the target as `--min-daily-net-pnl`, so cluster runs use the program policy instead of the old impossible daily gate.
- Updates runner/default tests to prove the new default program and oracle policy are used.
- Adds the current whitepaper-to-live-sleeve workflow writeup with Mermaid diagrams for claims, MLX ranking, replay, portfolio optimization, runtime closure, and promotion gates.
- Adds changed-line coverage for the explicit CLI override path that protects the program policy fallback.

## Related Issues

None

## Testing

- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_strategy_autoresearch.py tests/test_portfolio_optimizer.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_strategy_autoresearch.py tests/test_profit_target_oracle.py -q`
- `uv run --frozen coverage run -m pytest tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_strategy_autoresearch.py tests/test_profit_target_oracle.py -q`
- Generated `coverage.xml` from that partial local coverage run; the partial-suite global total is below the repo-wide threshold, so only changed-line coverage was evaluated locally.
- `GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` (`7/7` changed source lines covered)
- `bunx oxfmt --check docs/torghut/design-system/v6/214-torghut-current-whitepaper-to-profitable-strategy-workflow-2026-05-16.md docs/torghut/design-system/v6/index.md`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
