### PR TITLE
chore(torghut): promote image 383f5cd3

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.0-41-gd3042fe1b
+              value: v0.571.0-56-g383f5cd3d
             - name: TORGHUT_OPTIONS_COMMIT
-              value: d3042fe1b49255e874731a84bf61ff648cab9e12
+              value: 383f5cd3d92a65fd9b46d714a772b39e4769a02e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.0-41-gd3042fe1b
+              value: v0.571.0-56-g383f5cd3d
             - name: TORGHUT_OPTIONS_COMMIT
-              value: d3042fe1b49255e874731a84bf61ff648cab9e12
+              value: 383f5cd3d92a65fd9b46d714a772b39e4769a02e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-16T16:11:30Z"
+        client.knative.dev/updateTimestamp: "2026-05-16T21:12:33Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
           ports:
             - name: http1
               containerPort: 8181
@@ -495,11 +495,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.0-41-gd3042fe1b
+              value: v0.571.0-56-g383f5cd3d
             - name: TORGHUT_COMMIT
-              value: d3042fe1b49255e874731a84bf61ff648cab9e12
+              value: 383f5cd3d92a65fd9b46d714a772b39e4769a02e
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+              value: sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-16T16:11:30Z"
+        client.knative.dev/updateTimestamp: "2026-05-16T21:12:33Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
           ports:
             - name: http1
               containerPort: 8181
@@ -316,11 +316,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.0-41-gd3042fe1b
+              value: v0.571.0-56-g383f5cd3d
             - name: TORGHUT_COMMIT
-              value: d3042fe1b49255e874731a84bf61ff648cab9e12
+              value: 383f5cd3d92a65fd9b46d714a772b39e4769a02e
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+              value: sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2d1e75de455e8a7848248fd4bbdc5adc1e87aa62156fdb3e8d8ce36173fad9f9
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `383f5cd3d92a65fd9b46d714a772b39e4769a02e`
- Image tag: `383f5cd3`
- Image digest: `sha256:25d4124f3942257c3049effd0e5abbf43dda5e9917b41c84032869d5a87da061`