### PR TITLE
fix(temporal-bun-sdk): stop queued tasks on shutdown

### DIFF
--- a/packages/temporal-bun-sdk/src/worker/concurrency.ts
+++ b/packages/temporal-bun-sdk/src/worker/concurrency.ts
@@ -136,6 +136,10 @@ export const makeWorkerScheduler = (options: WorkerSchedulerOptions): Effect.Eff
       Effect.gen(function* () {
         while (true) {
           const task = yield* Queue.take(queue)
+          const running = yield* Ref.get(runningRef)
+          if (!running) {
+            break
+          }
           yield* Ref.update(activeRef, (count) => count + 1)
           const execute = Effect.scoped(
             TSemaphore.withPermitScoped(semaphore).pipe(
@@ -155,6 +159,10 @@ export const makeWorkerScheduler = (options: WorkerSchedulerOptions): Effect.Eff
 
     const enqueueWorkflow: WorkerScheduler['enqueueWorkflow'] = (task) =>
       Effect.gen(function* () {
+        const running = yield* Ref.get(runningRef)
+        if (!running) {
+          yield* Effect.fail(new Error('Workflow scheduler is no longer accepting tasks'))
+        }
         const offered = yield* workflowQueue.offer(task)
         if (!offered) {
           yield* Effect.fail(new Error('Workflow scheduler is no longer accepting tasks'))
@@ -163,6 +171,10 @@ export const makeWorkerScheduler = (options: WorkerSchedulerOptions): Effect.Eff
 
     const enqueueActivity: WorkerScheduler['enqueueActivity'] = (task) =>
       Effect.gen(function* () {
+        const running = yield* Ref.get(runningRef)
+        if (!running) {
+          yield* Effect.fail(new Error('Activity scheduler is no longer accepting tasks'))
+        }
         const offered = yield* activityQueue.offer(task)
         if (!offered) {
           yield* Effect.fail(new Error('Activity scheduler is no longer accepting tasks'))

--- a/packages/temporal-bun-sdk/tests/worker.scheduler.test.ts
+++ b/packages/temporal-bun-sdk/tests/worker.scheduler.test.ts
@@ -21,6 +21,26 @@ const workflowEnvelope = (
     }),
 })
 
+const activityEnvelope = (
+  start: Deferred.Deferred<void>,
+  complete: Deferred.Deferred<void>,
+  release?: Deferred.Deferred<void>,
+) => ({
+  taskToken: new Uint8Array([2]),
+  args: [],
+  handler: async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* Deferred.succeed(start, undefined)
+        if (release) {
+          yield* Deferred.await(release)
+        }
+        yield* Deferred.succeed(complete, undefined)
+      }),
+    )
+  },
+})
+
 test('workflow scheduler enforces concurrency limits', async () => {
   await Effect.runPromise(
     Effect.gen(function* () {
@@ -94,6 +114,76 @@ test('stop waits for in-flight workflow tasks to finish', async () => {
       const isCompleted = yield* Deferred.isDone(completed)
       yield* Effect.sync(() => {
         expect(isCompleted).toBeTrue()
+      })
+    }),
+  )
+})
+
+test('stop skips queued workflow tasks that have not started', async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const scheduler = yield* makeWorkerScheduler({ workflowConcurrency: 1, activityConcurrency: 1 })
+      const firstStarted = yield* Deferred.make<void>()
+      const firstCompleted = yield* Deferred.make<void>()
+      const releaseFirst = yield* Deferred.make<void>()
+      const secondStarted = yield* Deferred.make<void>()
+
+      yield* scheduler.start
+      yield* scheduler.enqueueWorkflow(workflowEnvelope(firstStarted, firstCompleted, releaseFirst))
+      yield* scheduler.enqueueWorkflow(workflowEnvelope(secondStarted, yield* Deferred.make<void>()))
+
+      yield* Deferred.await(firstStarted)
+
+      const stopFiber = yield* Effect.fork(scheduler.stop)
+      yield* Effect.sleep('20 millis')
+
+      const secondStartedBeforeRelease = yield* Deferred.isDone(secondStarted)
+      yield* Effect.sync(() => {
+        expect(secondStartedBeforeRelease).toBeFalse()
+      })
+
+      yield* Deferred.succeed(releaseFirst, undefined)
+      yield* Deferred.await(firstCompleted)
+      yield* Fiber.await(stopFiber)
+
+      const secondStartedAfterStop = yield* Deferred.isDone(secondStarted)
+      yield* Effect.sync(() => {
+        expect(secondStartedAfterStop).toBeFalse()
+      })
+    }),
+  )
+})
+
+test('stop skips queued activity tasks that have not started', async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const scheduler = yield* makeWorkerScheduler({ workflowConcurrency: 1, activityConcurrency: 1 })
+      const firstStarted = yield* Deferred.make<void>()
+      const firstCompleted = yield* Deferred.make<void>()
+      const releaseFirst = yield* Deferred.make<void>()
+      const secondStarted = yield* Deferred.make<void>()
+
+      yield* scheduler.start
+      yield* scheduler.enqueueActivity(activityEnvelope(firstStarted, firstCompleted, releaseFirst))
+      yield* scheduler.enqueueActivity(activityEnvelope(secondStarted, yield* Deferred.make<void>()))
+
+      yield* Deferred.await(firstStarted)
+
+      const stopFiber = yield* Effect.fork(scheduler.stop)
+      yield* Effect.sleep('20 millis')
+
+      const secondStartedBeforeRelease = yield* Deferred.isDone(secondStarted)
+      yield* Effect.sync(() => {
+        expect(secondStartedBeforeRelease).toBeFalse()
+      })
+
+      yield* Deferred.succeed(releaseFirst, undefined)
+      yield* Deferred.await(firstCompleted)
+      yield* Fiber.await(stopFiber)
+
+      const secondStartedAfterStop = yield* Deferred.isDone(secondStarted)
+      yield* Effect.sync(() => {
+        expect(secondStartedAfterStop).toBeFalse()
       })
     }),
   )


### PR DESCRIPTION
## Summary

- Stops the Temporal Bun SDK scheduler from accepting new workflow or activity tasks after shutdown starts.
- Prevents queued workflow/activity tasks from being started during worker restart, while still allowing in-flight tasks to drain.
- Adds regression coverage for queued workflow and activity tasks during scheduler shutdown.

## Related Issues

None

## Testing

- `bun test packages/temporal-bun-sdk/tests/worker.scheduler.test.ts`
- `bun run --cwd packages/temporal-bun-sdk build`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint:type`
- `bun test tests/packaging/manifest-packaging.test.ts`
- `TEMPORAL_LOAD_TEST_WORKFLOWS=300 TEMPORAL_LOAD_TEST_WORKFLOW_CONCURRENCY=50 TEMPORAL_LOAD_TEST_ACTIVITY_CONCURRENCY=80 TEMPORAL_LOAD_TEST_RESTART_AFTER_SUBMIT=true TEMPORAL_LOAD_TEST_RESTART_DELAY_MS=250 TEMPORAL_LOAD_TEST_UPDATE_RATIO=0.2 TEMPORAL_LOAD_TEST_TIMEOUT_MS=300000 TEMPORAL_WORKER_LOAD_ARTIFACTS_DIR=/tmp/temporal-bun-sdk-local-restart-after bun run --cwd packages/temporal-bun-sdk test:load`
- `TEMPORAL_LOAD_TEST_WORKFLOWS=1000 TEMPORAL_LOAD_TEST_WORKFLOW_CONCURRENCY=50 TEMPORAL_LOAD_TEST_ACTIVITY_CONCURRENCY=80 TEMPORAL_LOAD_TEST_RESTART_AFTER_SUBMIT=true TEMPORAL_LOAD_TEST_RESTART_DELAY_MS=250 TEMPORAL_LOAD_TEST_UPDATE_RATIO=0.2 TEMPORAL_LOAD_TEST_TIMEOUT_MS=420000 TEMPORAL_WORKER_LOAD_ARTIFACTS_DIR=/tmp/temporal-bun-sdk-local-restart-after-1000 bun run --cwd packages/temporal-bun-sdk test:load`
- `TEMPORAL_REQUIRE_DEFAULT_CHOICE=1 bun run --cwd packages/temporal-bun-sdk verify:default-choice` failed locally because immutable GitHub Actions provenance and CI evidence artifacts are intentionally absent outside the release workflow.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
