### PR TITLE
fix(torghut): compose portfolio sleeves by gross budget

### DIFF
--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -23,6 +23,8 @@ MAX_SINGLE_SYMBOL_CONTRIBUTION_SHARE = Decimal("0.35")
 MAX_ALLOWED_PAIRWISE_CORRELATION = Decimal("0.85")
 MAX_PORTFOLIO_GROSS_EXPOSURE_PCT_EQUITY = Decimal("1.0")
 PORTFOLIO_SEARCH_BEAM_WIDTH = 256
+PORTFOLIO_WEIGHTING_EQUAL_COUNT = "equal_count"
+PORTFOLIO_WEIGHTING_GROSS_EXPOSURE_BUDGET = "gross_exposure_budget"
 PORTFOLIO_COMPOSABLE_SINGLE_SLEEVE_VETOES = frozenset(
     {
         "active_day_ratio_below_min",
@@ -242,7 +244,7 @@ def _correlation(left: Mapping[str, Decimal], right: Mapping[str, Decimal]) -> D
 def _portfolio_daily_net(
     selected: Sequence[CandidateEvidenceBundle],
 ) -> dict[str, Decimal]:
-    weights = _equal_weights(selected)
+    weights = _portfolio_weights(selected)
     daily_totals: dict[str, Decimal] = {}
     for bundle, weight in zip(selected, weights, strict=True):
         for day, value in _daily_net(bundle).items():
@@ -253,7 +255,7 @@ def _portfolio_daily_net(
 def _portfolio_daily_filled_notional(
     selected: Sequence[CandidateEvidenceBundle],
 ) -> dict[str, Decimal]:
-    weights = _equal_weights(selected)
+    weights = _portfolio_weights(selected)
     daily_totals: dict[str, Decimal] = {}
     for bundle, weight in zip(selected, weights, strict=True):
         for day, value in _daily_filled_notional(bundle).items():
@@ -324,7 +326,7 @@ def _contribution_shares(values: Mapping[str, Decimal]) -> dict[str, Decimal]:
 def _cluster_contribution_shares(
     selected: Sequence[CandidateEvidenceBundle],
 ) -> dict[str, Decimal]:
-    weights = _equal_weights(selected)
+    weights = _portfolio_weights(selected)
     contributions: dict[str, Decimal] = {}
     for bundle, weight in zip(selected, weights, strict=True):
         cluster = _cluster_id(bundle)
@@ -354,7 +356,7 @@ def _bundle_symbol_shares(bundle: CandidateEvidenceBundle) -> dict[str, Decimal]
 def _symbol_contribution_shares(
     selected: Sequence[CandidateEvidenceBundle],
 ) -> dict[str, Decimal]:
-    weights = _equal_weights(selected)
+    weights = _portfolio_weights(selected)
     contributions: dict[str, Decimal] = {}
     for bundle, weight in zip(selected, weights, strict=True):
         bundle_positive_net = _positive_net_contribution(bundle) * weight
@@ -400,10 +402,41 @@ def _equal_weights(selected: Sequence[CandidateEvidenceBundle]) -> tuple[Decimal
     return tuple(weight for _ in selected)
 
 
+def _gross_exposure_budget_weights(
+    selected: Sequence[CandidateEvidenceBundle],
+) -> tuple[Decimal, ...] | None:
+    exposures = tuple(_max_gross_exposure_pct_equity(bundle) for bundle in selected)
+    if not exposures or any(exposure <= 0 for exposure in exposures):
+        return None
+    total_exposure = sum(exposures, Decimal("0"))
+    if total_exposure <= 0:
+        return None
+    scale = min(
+        Decimal("1"),
+        MAX_PORTFOLIO_GROSS_EXPOSURE_PCT_EQUITY / total_exposure,
+    )
+    return tuple(scale for _ in selected)
+
+
+def _portfolio_weights(
+    selected: Sequence[CandidateEvidenceBundle],
+) -> tuple[Decimal, ...]:
+    gross_budget_weights = _gross_exposure_budget_weights(selected)
+    if gross_budget_weights is not None:
+        return gross_budget_weights
+    return _equal_weights(selected)
+
+
+def _portfolio_weighting_mode(selected: Sequence[CandidateEvidenceBundle]) -> str:
+    if _gross_exposure_budget_weights(selected) is not None:
+        return PORTFOLIO_WEIGHTING_GROSS_EXPOSURE_BUDGET
+    return PORTFOLIO_WEIGHTING_EQUAL_COUNT
+
+
 def _portfolio_max_gross_exposure_pct_equity(
     selected: Sequence[CandidateEvidenceBundle],
 ) -> Decimal:
-    weights = _equal_weights(selected)
+    weights = _portfolio_weights(selected)
     return sum(
         (
             _max_gross_exposure_pct_equity(bundle) * weight
@@ -414,7 +447,7 @@ def _portfolio_max_gross_exposure_pct_equity(
 
 
 def _portfolio_min_cash(selected: Sequence[CandidateEvidenceBundle]) -> Decimal:
-    weights = _equal_weights(selected)
+    weights = _portfolio_weights(selected)
     return sum(
         (
             _min_cash(bundle) * weight
@@ -460,6 +493,7 @@ def _portfolio_scorecard(
     target_net_pnl_per_day: Decimal,
     oracle_policy: ProfitTargetOraclePolicy,
 ) -> dict[str, Any]:
+    weights = _portfolio_weights(selected)
     daily_net = _portfolio_daily_net(selected)
     trading_day_count = _portfolio_trading_day_count(selected, daily_net)
     missing_day_count = max(0, trading_day_count - len(daily_net))
@@ -524,6 +558,11 @@ def _portfolio_scorecard(
         "portfolio_post_cost_net_pnl_per_day": str(net_per_day),
         "target_net_pnl_per_day": str(target_net_pnl_per_day),
         "target_met": net_per_day >= target_net_pnl_per_day,
+        "portfolio_weighting_mode": _portfolio_weighting_mode(selected),
+        "portfolio_sleeve_weights": {
+            bundle.candidate_id: str(weight)
+            for bundle, weight in zip(selected, weights, strict=True)
+        },
         "active_day_ratio": str(active_day_ratio),
         "positive_day_ratio": str(positive_day_ratio),
         "min_daily_net_pnl": str(min_day),

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -107,6 +107,86 @@ class TestPortfolioOptimizer(TestCase):
             portfolio_optimizer_module._candidate_passes_minimums(zero_pnl)
         )
 
+    def test_portfolio_uses_gross_exposure_budget_for_reported_low_gross_sleeves(
+        self,
+    ) -> None:
+        def bundle(
+            candidate_id: str, symbol: str, cluster: str
+        ) -> CandidateEvidenceBundle:
+            return evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"spec-{candidate_id}",
+                candidate={
+                    "candidate_id": candidate_id,
+                    "runtime_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "family_template_id": "microbar_cross_sectional_pairs_v1",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "300",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "max_gross_exposure_pct_equity": "0.5",
+                        "min_cash": "5000",
+                        "negative_cash_observation_count": 0,
+                        "best_day_share": "0.2",
+                        "avg_filled_notional_per_day": "150000",
+                        "regime_slice_pass_rate": "0.55",
+                        "posterior_edge_lower": "0.01",
+                        "shadow_parity_status": "within_budget",
+                        "correlation_cluster": cluster,
+                        "symbol_contribution_shares": {symbol: "1.0"},
+                        **_executable_scorecard_fields(candidate_id),
+                    },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": "300",
+                            "2026-02-24": "300",
+                            "2026-02-25": "300",
+                            "2026-02-26": "300",
+                            "2026-02-27": "300",
+                        },
+                        "daily_filled_notional": {
+                            "2026-02-23": "150000",
+                            "2026-02-24": "150000",
+                            "2026-02-25": "150000",
+                            "2026-02-26": "150000",
+                            "2026-02-27": "150000",
+                        },
+                    },
+                },
+                dataset_snapshot_id="snapshot-gross-budget",
+                result_path=f"/tmp/{candidate_id}.json",
+            )
+
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=[
+                bundle("cand-half-gross-a", "AAPL", "half-gross-a"),
+                bundle("cand-half-gross-b", "AMZN", "half-gross-b"),
+            ],
+            target_net_pnl_per_day=Decimal("500"),
+            oracle_policy=ProfitTargetOraclePolicy(
+                max_cluster_contribution_share=Decimal("0.50"),
+                max_single_symbol_contribution_share=Decimal("0.50"),
+            ),
+            portfolio_size_min=2,
+            portfolio_size_max=2,
+        )
+
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        self.assertEqual(
+            portfolio.objective_scorecard["portfolio_weighting_mode"],
+            "gross_exposure_budget",
+        )
+        self.assertEqual(portfolio.objective_scorecard["net_pnl_per_day"], "600")
+        self.assertEqual(
+            portfolio.objective_scorecard["max_gross_exposure_pct_equity"],
+            "1.0",
+        )
+        self.assertTrue(portfolio.objective_scorecard["target_met"])
+        self.assertTrue(portfolio.objective_scorecard["oracle_passed"])
+
     def test_portfolio_candidate_round_trips_from_optimizer_payload(self) -> None:
         daily_profiles = [
             ("610", "620", "630", "640", "650"),
@@ -841,7 +921,7 @@ class TestPortfolioOptimizer(TestCase):
         )
         self.assertEqual(
             portfolio.objective_scorecard["max_gross_exposure_pct_equity"],
-            "0.2499999999999999999999999999",
+            "0.75",
         )
         self.assertTrue(portfolio.objective_scorecard["oracle_passed"])
 


### PR DESCRIPTION
## Summary

- Compose portfolio sleeve PnL/notional/contribution metrics with a gross-exposure budget when every selected sleeve reports a positive gross exposure footprint.
- Fall back to the previous equal-count weighting when exposure data is missing, avoiding additive scoring without capital evidence.
- Add a regression proving two 50%-gross sleeves can honestly combine to a 100%-gross portfolio target without count-averaging away PnL.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen ruff check app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_strategy_autoresearch.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
