### PR TITLE
chore(jangar): promote image 00dc2eb5

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 24b909b0
-  digest: sha256:763f073c7a512f20e549c71e7149bded7a6c44f9bc6c39387d0e86b7281f91d3
+  tag: 00dc2eb5
+  digest: sha256:1d1afa1937041d0c95a6a10a2c84060a618c8ce35014d17deeb0e3b9d720e954
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 24b909b0
-    digest: sha256:d5994e67c4adace196a5662eccac5c61c5cc0601dbdf1fa88898ff7fda084065
+    tag: 00dc2eb5
+    digest: sha256:adb0d2c0f5473e7957bbe10ed0d8bba53838b91b1bb9810de76a5fdb8fc0edfc
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "12000"
-      JANGAR_SOURCE_HEAD_SHA: 24b909b000d6c5502a9683d733fac93d868b4ea6
-      JANGAR_GITOPS_REVISION: 24b909b000d6c5502a9683d733fac93d868b4ea6
-      JANGAR_SOURCE_CI_RUN_ID: "25969787093"
+      JANGAR_SOURCE_HEAD_SHA: 00dc2eb5130cd3b9976d6ba4d3f70b0862241ce0
+      JANGAR_GITOPS_REVISION: 00dc2eb5130cd3b9976d6ba4d3f70b0862241ce0
+      JANGAR_SOURCE_CI_RUN_ID: "25974087642"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:d5994e67c4adace196a5662eccac5c61c5cc0601dbdf1fa88898ff7fda084065
-      JANGAR_SERVING_BUILD_COMMIT: 24b909b000d6c5502a9683d733fac93d868b4ea6
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:d5994e67c4adace196a5662eccac5c61c5cc0601dbdf1fa88898ff7fda084065
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:adb0d2c0f5473e7957bbe10ed0d8bba53838b91b1bb9810de76a5fdb8fc0edfc
+      JANGAR_SERVING_BUILD_COMMIT: 00dc2eb5130cd3b9976d6ba4d3f70b0862241ce0
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:adb0d2c0f5473e7957bbe10ed0d8bba53838b91b1bb9810de76a5fdb8fc0edfc
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 24b909b0
-    digest: sha256:763f073c7a512f20e549c71e7149bded7a6c44f9bc6c39387d0e86b7281f91d3
+    tag: 00dc2eb5
+    digest: sha256:1d1afa1937041d0c95a6a10a2c84060a618c8ce35014d17deeb0e3b9d720e954
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-16T18:40:31Z
+    deploy.knative.dev/rollout: 2026-05-16T22:02:34Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:24b909b0@sha256:763f073c7a512f20e549c71e7149bded7a6c44f9bc6c39387d0e86b7281f91d3
+              value: registry.ide-newton.ts.net/lab/jangar:00dc2eb5@sha256:1d1afa1937041d0c95a6a10a2c84060a618c8ce35014d17deeb0e3b9d720e954
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 24b909b000d6c5502a9683d733fac93d868b4ea6
+              value: 00dc2eb5130cd3b9976d6ba4d3f70b0862241ce0
             - name: JANGAR_GITOPS_REVISION
-              value: 24b909b000d6c5502a9683d733fac93d868b4ea6
+              value: 00dc2eb5130cd3b9976d6ba4d3f70b0862241ce0
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25969787093"
+              value: "25974087642"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:d5994e67c4adace196a5662eccac5c61c5cc0601dbdf1fa88898ff7fda084065
+              value: sha256:adb0d2c0f5473e7957bbe10ed0d8bba53838b91b1bb9810de76a5fdb8fc0edfc
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 24b909b000d6c5502a9683d733fac93d868b4ea6
+              value: 00dc2eb5130cd3b9976d6ba4d3f70b0862241ce0
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:d5994e67c4adace196a5662eccac5c61c5cc0601dbdf1fa88898ff7fda084065
+              value: sha256:adb0d2c0f5473e7957bbe10ed0d8bba53838b91b1bb9810de76a5fdb8fc0edfc
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 24b909b0
-    digest: sha256:763f073c7a512f20e549c71e7149bded7a6c44f9bc6c39387d0e86b7281f91d3
+    newTag: 00dc2eb5
+    digest: sha256:1d1afa1937041d0c95a6a10a2c84060a618c8ce35014d17deeb0e3b9d720e954


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `00dc2eb5130cd3b9976d6ba4d3f70b0862241ce0`
- Image tag: `00dc2eb5`
- Image digest: `sha256:1d1afa1937041d0c95a6a10a2c84060a618c8ce35014d17deeb0e3b9d720e954`
- Source CI run: `25974087642`
- Control-plane serving digest: `sha256:adb0d2c0f5473e7957bbe10ed0d8bba53838b91b1bb9810de76a5fdb8fc0edfc`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates