### PR TITLE
fix(temporal-bun-sdk): extend transient rpc retry window

### DIFF
--- a/packages/temporal-bun-sdk/scripts/cleanup-integration-workflows.ts
+++ b/packages/temporal-bun-sdk/scripts/cleanup-integration-workflows.ts
@@ -128,7 +128,7 @@ async function terminate(query: string, workflowType: string, listOutput: string
     ])
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
-    if (!isRetryableTemporalCliError(message)) {
+    if (!shouldFallbackToIndividualTermination(message)) {
       throw error
     }
 
@@ -372,6 +372,16 @@ export function isRetryableTemporalCliError(output: string): boolean {
   return /namespace rate limit exceeded|context deadline exceeded|transport: error while dialing|unavailable|not enough hosts to serve the request|please retry|temporarily unavailable|workflow is busy/i.test(
     output,
   )
+}
+
+export function isTemporalBatchCapacityError(output: string): boolean {
+  return /failed starting batch operation:.*max concurrent batch operations is reached|max concurrent batch operations is reached/i.test(
+    output,
+  )
+}
+
+export function shouldFallbackToIndividualTermination(output: string): boolean {
+  return isRetryableTemporalCliError(output) || isTemporalBatchCapacityError(output)
 }
 
 export function isWorkflowAlreadyCompleted(output: string): boolean {

--- a/packages/temporal-bun-sdk/src/client/retries.ts
+++ b/packages/temporal-bun-sdk/src/client/retries.ts
@@ -23,7 +23,7 @@ const DEFAULT_RETRYABLE_CODES: number[] = [
 ]
 
 export const defaultRetryPolicy: TemporalRpcRetryPolicy = {
-  maxAttempts: 16,
+  maxAttempts: 32,
   initialDelayMs: 200,
   maxDelayMs: 10_000,
   backoffCoefficient: 2,

--- a/packages/temporal-bun-sdk/tests/client/ops-client.test.ts
+++ b/packages/temporal-bun-sdk/tests/client/ops-client.test.ts
@@ -154,6 +154,53 @@ test('startWorkflow retries server-hinted unknown errors with the same request i
   }
 })
 
+test('startWorkflow survives extended shard-unavailable retries with the same request id', async () => {
+  const config = await loadTemporalConfig()
+  type WorkflowServiceClient = ReturnType<typeof createClient<typeof WorkflowService>>
+  const calls = new Map<string, CallRecord[]>()
+  let attempts = 0
+
+  const workflowService = {
+    startWorkflowExecution: async (request, options) => {
+      attempts += 1
+      recordCall(calls, 'startWorkflowExecution', request, options)
+      if (attempts < 24) {
+        throw new ConnectError('[unavailable] shard status unknown', Code.Unavailable)
+      }
+      return { runId: 'run-shard-retry', started: true }
+    },
+  } as unknown as WorkflowServiceClient
+
+  const { client } = await createTemporalClient({ config, workflowService })
+  const callOptions = temporalCallOptions({
+    retryPolicy: {
+      initialDelayMs: 1,
+      maxDelayMs: 1,
+      jitterFactor: 0,
+    },
+  })
+
+  try {
+    const result = await client.startWorkflow(
+      {
+        workflowId: 'start-retry-shard-unavailable',
+        workflowType: 'testWorkflow',
+      },
+      callOptions,
+    )
+
+    const entries = calls.get('startWorkflowExecution') ?? []
+    expect(result.runId).toBe('run-shard-retry')
+    expect(entries).toHaveLength(24)
+    expect(entries[0]?.request.requestId).toMatch(uuidRegex)
+    for (const entry of entries) {
+      expect(entry.request.requestId).toBe(entries[0]?.request.requestId)
+    }
+  } finally {
+    await client.shutdown()
+  }
+})
+
 test('startWorkflow recovers already-started errors for the same request id', async () => {
   const config = await loadTemporalConfig()
   type WorkflowServiceClient = ReturnType<typeof createClient<typeof WorkflowService>>

--- a/packages/temporal-bun-sdk/tests/client/retries.test.ts
+++ b/packages/temporal-bun-sdk/tests/client/retries.test.ts
@@ -8,7 +8,7 @@ const run = <A>(effect: Effect.Effect<A, unknown, never>) => Effect.runPromise(e
 
 describe('Temporal RPC retries', () => {
   test('default policy survives short Temporal frontend disruption windows', () => {
-    expect(defaultRetryPolicy.maxAttempts).toBeGreaterThanOrEqual(16)
+    expect(defaultRetryPolicy.maxAttempts).toBeGreaterThanOrEqual(32)
     expect(defaultRetryPolicy.initialDelayMs).toBeLessThanOrEqual(250)
     expect(defaultRetryPolicy.maxDelayMs).toBeGreaterThanOrEqual(10_000)
     expect(defaultRetryPolicy.retryableStatusCodes).toEqual(
@@ -40,6 +40,32 @@ describe('Temporal RPC retries', () => {
 
     expect(result).toBe('ok')
     expect(attempts).toBe(3)
+  })
+
+  test('retries Temporal shard-unavailable windows without special-casing the message', async () => {
+    let attempts = 0
+    const effect = Effect.tryPromise({
+      try: async () => {
+        attempts += 1
+        if (attempts < 24) {
+          throw new ConnectError('[unavailable] shard status unknown', Code.Unavailable)
+        }
+        return 'ok'
+      },
+      catch: (error) => error,
+    })
+
+    const result = await run(
+      withTemporalRetry(effect, {
+        ...defaultRetryPolicy,
+        initialDelayMs: 1,
+        maxDelayMs: 1,
+        jitterFactor: 0,
+      }),
+    )
+
+    expect(result).toBe('ok')
+    expect(attempts).toBe(24)
   })
 
   test('retries Temporal server unknown errors when the message says to retry', async () => {

--- a/packages/temporal-bun-sdk/tests/scripts/cleanup-integration-workflows.test.ts
+++ b/packages/temporal-bun-sdk/tests/scripts/cleanup-integration-workflows.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 
 import {
+  isTemporalBatchCapacityError,
   isRetryableTemporalCliError,
   isWorkflowAlreadyCompleted,
   onlyAlreadyResolvedWorkflowsRemainVisible,
   parseWorkflowIdsFromListOutput,
+  shouldFallbackToIndividualTermination,
   verifyOnlyStaleVisibility,
   waitForNoRunningWorkflowCount,
   waitForNoRunningWorkflows,
@@ -18,8 +20,17 @@ describe('cleanup integration workflow retries', () => {
     expect(isRetryableTemporalCliError('Error: failed to describe batch job: Workflow is busy.')).toBe(true)
   })
 
+  test('falls back to individual termination when Temporal batch capacity is saturated', () => {
+    const output = 'Error: failed starting batch operation: Max concurrent batch operations is reached'
+
+    expect(isTemporalBatchCapacityError(output)).toBe(true)
+    expect(isRetryableTemporalCliError(output)).toBe(false)
+    expect(shouldFallbackToIndividualTermination(output)).toBe(true)
+  })
+
   test('does not retry validation failures', () => {
     expect(isRetryableTemporalCliError('Error: invalid search attribute query syntax')).toBe(false)
+    expect(shouldFallbackToIndividualTermination('Error: invalid search attribute query syntax')).toBe(false)
   })
 
   test('treats already completed or missing workflow termination as cleanup success', () => {


### PR DESCRIPTION
## Summary

- Extends the default Temporal RPC retry attempt budget so transient `Unavailable` windows can recover during heavy workflow starts.
- Adds regression coverage for `[unavailable] shard status unknown` retry recovery.
- Makes integration cleanup fall back to individual termination when Temporal batch capacity is saturated by stale workflows.

## Related Issues

None

## Testing

- `bun test packages/temporal-bun-sdk/tests/client/retries.test.ts`
- `bun test packages/temporal-bun-sdk/tests/client/ops-client.test.ts`
- `bun test packages/temporal-bun-sdk/tests/scripts/cleanup-integration-workflows.test.ts`
- `bun test packages/temporal-bun-sdk/tests/client/retries.test.ts packages/temporal-bun-sdk/tests/client/ops-client.test.ts packages/temporal-bun-sdk/tests/scripts/cleanup-integration-workflows.test.ts`
- `bun run --cwd packages/temporal-bun-sdk build`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint:type`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
