### PR TITLE
fix(infra): relieve talos local disk pressure

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -33,7 +33,7 @@ spec:
             type: "kubernetes"
             kubernetesModeWorkVolumeClaim:
               accessModes: ["ReadWriteOnce"]
-              storageClassName: "local-path"
+              storageClassName: "rook-ceph-block"
               resources:
                 requests:
                   storage: 20Gi
@@ -142,7 +142,7 @@ spec:
                     volumeClaimTemplate:
                       spec:
                         accessModes: ["ReadWriteOnce"]
-                        storageClassName: "local-path"
+                        storageClassName: "rook-ceph-block"
                         resources:
                           requests:
                             storage: 20Gi

--- a/argocd/applications/argocd/kustomization.yaml
+++ b/argocd/applications/argocd/kustomization.yaml
@@ -33,6 +33,10 @@ patches:
       kind: Deployment
       name: argocd-repo-server
   - path: overlays/argocd-image-updater-config.yaml
+  - path: overlays/argocd-image-updater-deployment.yaml
+    target:
+      kind: Deployment
+      name: argocd-image-updater-controller
   - path: overlays/argocd-server-deployment.yaml
     target:
       kind: Deployment

--- a/argocd/applications/argocd/overlays/argocd-image-updater-config.yaml
+++ b/argocd/applications/argocd/overlays/argocd-image-updater-config.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   git.email: noreply@proompteng.ai
   git.user: Proompt Eng
-  log.level: debug
+  log.level: info
   registries.conf: |
     registries:
     - name: registry

--- a/argocd/applications/argocd/overlays/argocd-image-updater-deployment.yaml
+++ b/argocd/applications/argocd/overlays/argocd-image-updater-deployment.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-image-updater-controller
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: argocd-image-updater-controller
+          args:
+            - --metrics-bind-address=:8443
+            - run
+            - --leader-election=false
+            - --max-concurrent-apps=2

--- a/argocd/applications/forgejo-runners/statefulset-forgejo-runners-amd64.yaml
+++ b/argocd/applications/forgejo-runners/statefulset-forgejo-runners-amd64.yaml
@@ -104,9 +104,11 @@ spec:
             requests:
               cpu: 500m
               memory: 1Gi
+              ephemeral-storage: 2Gi
             limits:
               cpu: '2'
               memory: 4Gi
+              ephemeral-storage: 4Gi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -131,9 +133,11 @@ spec:
             requests:
               cpu: 500m
               memory: 1Gi
+              ephemeral-storage: 8Gi
             limits:
               cpu: '3'
               memory: 6Gi
+              ephemeral-storage: 20Gi
           volumeMounts:
             - name: dind-sock
               mountPath: /var/run
@@ -149,7 +153,8 @@ spec:
         - name: dind-sock
           emptyDir: {}
         - name: docker-graph
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 20Gi
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/argocd/applications/forgejo-runners/statefulset-forgejo-runners-arm64.yaml
+++ b/argocd/applications/forgejo-runners/statefulset-forgejo-runners-arm64.yaml
@@ -104,9 +104,11 @@ spec:
             requests:
               cpu: 500m
               memory: 1Gi
+              ephemeral-storage: 2Gi
             limits:
               cpu: '2'
               memory: 4Gi
+              ephemeral-storage: 4Gi
           volumeMounts:
             - name: config
               mountPath: /config
@@ -131,9 +133,11 @@ spec:
             requests:
               cpu: 500m
               memory: 1Gi
+              ephemeral-storage: 8Gi
             limits:
               cpu: '3'
               memory: 6Gi
+              ephemeral-storage: 20Gi
           volumeMounts:
             - name: dind-sock
               mountPath: /var/run
@@ -149,7 +153,8 @@ spec:
         - name: dind-sock
           emptyDir: {}
         - name: docker-graph
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 20Gi
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/argocd/applications/openclaw/datavolume-rootdisk-rbd.yaml
+++ b/argocd/applications/openclaw/datavolume-rootdisk-rbd.yaml
@@ -1,0 +1,18 @@
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: openclaw-rootdisk-rbd
+  namespace: openclaw
+spec:
+  source:
+    pvc:
+      namespace: openclaw
+      name: openclaw-rootdisk
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 80Gi
+    storageClassName: rook-ceph-block
+    volumeMode: Filesystem

--- a/argocd/applications/openclaw/kustomization.yaml
+++ b/argocd/applications/openclaw/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: openclaw
 resources:
   - cloud-init-secret.yaml
+  - datavolume-rootdisk-rbd.yaml
   - virtualmachine.yaml
   - service-ssh.yaml
   - openclaw-vm-rbac.yaml

--- a/argocd/applications/openclaw/virtualmachine.yaml
+++ b/argocd/applications/openclaw/virtualmachine.yaml
@@ -9,21 +9,6 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   running: true
-  dataVolumeTemplates:
-    - metadata:
-        name: openclaw-rootdisk
-        creationTimestamp: null
-      spec:
-        source:
-          http:
-            url: https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img
-        pvc:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 80Gi
-          storageClassName: local-path
   template:
     metadata:
       labels:
@@ -69,7 +54,7 @@ spec:
       volumes:
         - name: rootdisk
           dataVolume:
-            name: openclaw-rootdisk
+            name: openclaw-rootdisk-rbd
         - name: cloudinitdisk
           cloudInitNoCloud:
             secretRef:


### PR DESCRIPTION
## Summary

- Move OpenClaw root disk desired state from local-path to the cloned rook-ceph-block DataVolume.
- Add bounded ephemeral-storage requests/limits for Forgejo runners and cap the dind Docker graph emptyDir at 20Gi.
- Move ARC runner work PVCs to rook-ceph-block and reduce Argo CD Image Updater leader-election churn with a single replica, info logs, and limited concurrency.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/forgejo-runners >/tmp/forgejo-runners-render.yaml`
- `kubectl apply --dry-run=server -f /tmp/forgejo-runners-render.yaml`
- `kubectl apply --dry-run=server -f argocd/applications/arc/application.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/openclaw >/tmp/openclaw-render.yaml`
- `kubectl apply --dry-run=server -f /tmp/openclaw-render.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/argocd >/tmp/argocd-render.yaml`
- Live validation: OpenClaw cloned to `openclaw-rootdisk-rbd`, booted successfully from the rook-ceph-block PVC, and the old local-path PVC/PV was removed.
- Live validation: Forgejo runner StatefulSets rolled out and expose the new ephemeral-storage requests/limits and Docker graph size limit.
- Live validation: Argo CD Image Updater rolled out with one ready pod and processed both ImageUpdater CRs with zero errors.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
