### PR TITLE
fix(torghut): persist autoresearch run id as epoch id

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -159,6 +159,7 @@ spec:
 
             SCRIPT_ARGS=(
               --output-dir "${OUTPUT_DIR}"
+              --epoch-id "${RUN_ID}"
               --target-net-pnl-per-day "{{inputs.parameters.targetNetPnlPerDay}}"
               --max-candidates "{{inputs.parameters.maxCandidates}}"
               --top-k "{{inputs.parameters.topK}}"

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -140,6 +140,14 @@ def _parse_args() -> argparse.Namespace:
         description="Run whitepaper autoresearch and assemble a portfolio candidate for a profit target.",
     )
     parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--epoch-id",
+        default="",
+        help=(
+            "Optional persisted autoresearch epoch id. Defaults to a generated "
+            "whitepaper-autoresearch id when omitted."
+        ),
+    )
     parser.add_argument("--paper-run-id", action="append", default=[])
     parser.add_argument("--seed-recent-whitepapers", action="store_true")
     parser.add_argument(
@@ -4634,7 +4642,9 @@ def run_whitepaper_autoresearch_profit_target(
             "clickhouse_password": _resolved_clickhouse_password(args),
         }
     )
-    epoch_id = run_id("whitepaper-autoresearch")
+    epoch_id = str(getattr(args, "epoch_id", "") or "").strip() or run_id(
+        "whitepaper-autoresearch"
+    )
     started_at = datetime.now(UTC)
     output_dir = args.output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -85,6 +85,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
     def _args(self, output_dir: Path) -> Namespace:
         return Namespace(
             output_dir=output_dir,
+            epoch_id="",
             paper_run_id=[],
             source_jsonl=[],
             feedback_evidence_jsonl=[],
@@ -210,6 +211,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 args = runner._parse_args()
 
         self.assertEqual(args.target_net_pnl_per_day, "500")
+        self.assertEqual(args.epoch_id, "")
         self.assertEqual(
             args.program,
             Path(
@@ -239,6 +241,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn("TORGHUT_WHITEPAPER_FEEDBACK_EVIDENCE_JSONL_B64", template)
         self.assertIn("TORGHUT_WHITEPAPER_FEEDBACK_EVIDENCE_CONFIGMAP_PATH", template)
         self.assertIn("TORGHUT_WHITEPAPER_SOURCE_JSONL_B64", template)
+        self.assertIn('--epoch-id "${RUN_ID}"', template)
         self.assertIn("name: feedback-evidence", template)
         self.assertNotIn(
             "printf '%s' \"{{inputs.parameters.feedbackEvidenceJsonlB64}}\"",
@@ -1595,10 +1598,11 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
     def test_seed_recent_whitepapers_runs_end_to_end_and_writes_artifacts(self) -> None:
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
-            payload = runner.run_whitepaper_autoresearch_profit_target(
-                self._args(output_dir)
-            )
+            args = self._args(output_dir)
+            args.epoch_id = "whitepaper-autoresearch-test-epoch"
+            payload = runner.run_whitepaper_autoresearch_profit_target(args)
 
+            self.assertEqual(payload["epoch_id"], "whitepaper-autoresearch-test-epoch")
             self.assertEqual(payload["status"], "no_profit_target_candidate")
             self.assertEqual(
                 payload["status_reason"],
@@ -3460,6 +3464,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                     "run_whitepaper_autoresearch_profit_target.py",
                     "--output-dir",
                     str(output_dir),
+                    "--epoch-id",
+                    "whitepaper-autoresearch-cli-epoch",
                     "--seed-recent-whitepapers",
                     "--replay-mode",
                     "synthetic",
@@ -3475,6 +3481,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 parsed = runner._parse_args()
 
         self.assertEqual(parsed.output_dir, output_dir)
+        self.assertEqual(parsed.epoch_id, "whitepaper-autoresearch-cli-epoch")
         self.assertTrue(parsed.seed_recent_whitepapers)
         self.assertEqual(parsed.replay_mode, "synthetic")
         self.assertEqual(parsed.source_jsonl, [source_path])


### PR DESCRIPTION
## Summary

- Adds an explicit `--epoch-id` option to the whitepaper autoresearch runner.
- Passes the Argo `runId` through the WorkflowTemplate as the persisted epoch id.
- Covers the CLI, WorkflowTemplate contract, and end-to-end synthetic runner path.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q -k "parse_args_defaults_to_500_daily_profit_program or workflow_template_surfaces_feedback_and_fails_closed_on_stale_tape or seed_recent_whitepapers_runs_end_to_end_and_writes_artifacts or runner_parse_args_covers_cli_defaults_and_flags"`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
