### PR TITLE
fix(torghut): align portfolio sleeve weights

### DIFF
--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -914,8 +914,9 @@ def optimize_portfolio_candidate(
     )
     max_drawdown = _decimal(objective_scorecard.get("max_drawdown"))
     sleeves: list[Mapping[str, Any]] = []
-    equal_weight = Decimal("1") / Decimal(len(selected))
+    weights = _portfolio_weights(selected)
     for sleeve_index, bundle in enumerate(selected, start=1):
+        weight = weights[sleeve_index - 1]
         base_runtime_strategy_name = (
             _string(_scorecard(bundle).get("runtime_strategy_name"))
             or f"whitepaper-autoresearch-sleeve-{sleeve_index}"
@@ -929,10 +930,10 @@ def optimize_portfolio_candidate(
                 ),
                 "runtime_family": _string(_scorecard(bundle).get("runtime_family")),
                 "runtime_strategy_name": f"{base_runtime_strategy_name}-sleeve-{sleeve_index}",
-                "weight": str(equal_weight),
-                "expected_net_pnl_per_day": str(_net_per_day(bundle) * equal_weight),
+                "weight": str(weight),
+                "expected_net_pnl_per_day": str(_net_per_day(bundle) * weight),
                 "source_expected_net_pnl_per_day": str(_net_per_day(bundle)),
-                "risk_contribution": str(_max_drawdown(bundle) * equal_weight),
+                "risk_contribution": str(_max_drawdown(bundle) * weight),
                 "source_risk_contribution": str(_max_drawdown(bundle)),
                 "correlation_cluster": _string(
                     _scorecard(bundle).get("correlation_cluster")
@@ -988,8 +989,12 @@ def optimize_portfolio_candidate(
         target_net_pnl_per_day=target_net_pnl_per_day,
         sleeves=tuple(sleeves),
         capital_budget={
-            "mode": "equal_weight_initial",
+            "mode": _portfolio_weighting_mode(selected),
             "max_sleeves": portfolio_size_max,
+            "sleeve_weights": {
+                bundle.candidate_id: str(weight)
+                for bundle, weight in zip(selected, weights, strict=True)
+            },
         },
         correlation_budget={
             "mode": "cluster_cap",

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -184,6 +184,19 @@ class TestPortfolioOptimizer(TestCase):
             portfolio.objective_scorecard["max_gross_exposure_pct_equity"],
             "1.0",
         )
+        self.assertEqual(portfolio.capital_budget["mode"], "gross_exposure_budget")
+        self.assertEqual(
+            portfolio.capital_budget["sleeve_weights"],
+            {"cand-half-gross-a": "1", "cand-half-gross-b": "1"},
+        )
+        self.assertEqual(
+            [sleeve["weight"] for sleeve in portfolio.sleeves],
+            ["1", "1"],
+        )
+        self.assertEqual(
+            [sleeve["expected_net_pnl_per_day"] for sleeve in portfolio.sleeves],
+            ["300", "300"],
+        )
         self.assertTrue(portfolio.objective_scorecard["target_met"])
         self.assertTrue(portfolio.objective_scorecard["oracle_passed"])
 


### PR DESCRIPTION
## Summary

- Aligns emitted portfolio sleeve weights with the optimizer's gross-exposure budget weighting.
- Updates sleeve expected PnL and risk contribution to use the same weights used in the portfolio scorecard.
- Records the selected sleeve weights in the portfolio capital budget payload and adds regression coverage.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_portfolio_optimizer.py -q -k 'gross_exposure_budget or round_trips or capital_safety'`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py -q`
- `uv run --frozen ruff check app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen ruff format --check app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
