### PR TITLE
fix(agents): preserve terminal agentrun status across hash changes

### DIFF
--- a/services/jangar/src/server/__tests__/agents-controller.test.ts
+++ b/services/jangar/src/server/__tests__/agents-controller.test.ts
@@ -1545,6 +1545,44 @@ describe('agents controller reconcileAgentRun', () => {
     }
   }, 15_000)
 
+  it('does not fail terminal AgentRuns when an older stored immutable spec hash differs', async () => {
+    const previousEnforcement = process.env.JANGAR_AGENTRUN_IMMUTABILITY_ENFORCED
+    process.env.JANGAR_AGENTRUN_IMMUTABILITY_ENFORCED = 'true'
+    try {
+      const kube = buildKube()
+      const terminalRun = buildAgentRun({
+        status: {
+          phase: 'Succeeded',
+          finishedAt: new Date().toISOString(),
+          specHash: 'legacy-hash-from-older-controller',
+          conditions: [
+            { type: 'Accepted', status: 'True', reason: 'Submitted' },
+            { type: 'Succeeded', status: 'True', reason: 'Completed' },
+          ],
+        },
+      })
+
+      await __test.reconcileAgentRun(
+        kube as never,
+        terminalRun,
+        'agents',
+        [],
+        [],
+        defaultConcurrency,
+        buildInFlight(),
+        0,
+      )
+
+      expect(kube.applyStatus).not.toHaveBeenCalled()
+    } finally {
+      if (previousEnforcement === undefined) {
+        delete process.env.JANGAR_AGENTRUN_IMMUTABILITY_ENFORCED
+      } else {
+        process.env.JANGAR_AGENTRUN_IMMUTABILITY_ENFORCED = previousEnforcement
+      }
+    }
+  })
+
   it('blocks AgentRun when repository concurrency limit is reached', async () => {
     const kube = buildKube()
 

--- a/services/jangar/src/server/agents-controller/agent-run-reconciler.ts
+++ b/services/jangar/src/server/agents-controller/agent-run-reconciler.ts
@@ -195,7 +195,7 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
     const acceptedLocked = acceptedCondition?.status === 'True' || phase !== 'Pending'
     const templateMode = isAgentRunTemplate(metadata)
 
-    if (!templateMode && acceptedLocked) {
+    if (!templateMode && acceptedLocked && phase !== 'Succeeded' && phase !== 'Failed' && phase !== 'Cancelled') {
       const currentHash = hashAgentRunImmutableSpec(agentRun)
       if (storedSpecHash && storedSpecHash !== currentHash) {
         const message = `immutable AgentRun spec fields changed after acceptance (expected ${storedSpecHash}, got ${currentHash})`


### PR DESCRIPTION
## Summary

- Preserve already terminal AgentRuns when their stored immutable spec hash differs from the current controller hash calculation.
- Keep immutability enforcement active for accepted, non-terminal AgentRuns so active spec drift still fails loudly.
- Add a regression test for a succeeded AgentRun with a legacy stored spec hash.

## Related Issues

None

## Testing

- `cd services/jangar && bunx vitest run --config vitest.config.ts src/server/__tests__/agents-controller.test.ts src/server/__tests__/supporting-primitives-controller.test.ts`
- `bunx oxfmt --check services/jangar/src/server/__tests__/agents-controller.test.ts services/jangar/src/server/agents-controller/agent-run-reconciler.ts`
- `bun run --cwd services/jangar docs:inventory:write`
- `bun run --cwd services/jangar docs:inventory:check`
- `bun run --cwd services/jangar check:module-sizes`
- `bunx oxfmt --check services/jangar packages/scripts/src/jangar argocd/applications/jangar`
- `git diff --check -- services/jangar/src/server/agents-controller/agent-run-reconciler.ts services/jangar/src/server/__tests__/agents-controller.test.ts docs/jangar/architecture-inventory.md`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
