### PR TITLE
refactor(torghut): share alpha repair read-model helpers

### DIFF
--- a/services/torghut/app/trading/alpha_evidence_foundry.py
+++ b/services/torghut/app/trading/alpha_evidence_foundry.py
@@ -2,11 +2,22 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Any, cast
+from typing import Any
+
+from .read_model_utils import (
+    as_int as _int,
+    as_mapping as _mapping,
+    as_sequence as _sequence,
+    as_text as _text,
+    first_mapping as _top_queue_item,
+    is_alpha_readiness_repair as _is_alpha_repair,
+    routeable_candidate_count as _routeable_candidate_count,
+    stable_hash24 as _stable_hash,
+    unique_text_list as _string_list,
+    zero_notional_or_stale_evidence_rate as _zero_notional_or_stale_evidence_rate,
+)
 
 ALPHA_EVIDENCE_FOUNDRY_SCHEMA_VERSION = "torghut.alpha-evidence-foundry.v1"
 ALPHA_EVIDENCE_FOUNDRY_REF_SCHEMA_VERSION = "torghut.alpha-evidence-foundry-ref.v1"
@@ -47,97 +58,6 @@ _TCA_BLOCKERS = {
     "active_session_execution_samples_stale",
     "execution_tca_expected_shortfall_samples_missing_non_promoting",
 }
-
-
-def _text(value: object, default: str = "") -> str:
-    if value is None:
-        return default
-    normalized = str(value).strip()
-    return normalized or default
-
-
-def _int(value: object, default: int = 0) -> int:
-    if isinstance(value, bool):
-        return int(value)
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return int(value)
-    if isinstance(value, str) and value.strip():
-        try:
-            return int(float(value.strip()))
-        except ValueError:
-            return default
-    return default
-
-
-def _mapping(value: object) -> Mapping[str, Any]:
-    if isinstance(value, Mapping):
-        return cast(Mapping[str, Any], value)
-    return {}
-
-
-def _sequence(value: object) -> Sequence[object]:
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return cast(Sequence[object], value)
-    return ()
-
-
-def _string_list(value: object) -> list[str]:
-    items: list[str] = []
-    seen: set[str] = set()
-    for item in _sequence(value):
-        normalized = _text(item)
-        if not normalized or normalized in seen:
-            continue
-        seen.add(normalized)
-        items.append(normalized)
-    return items
-
-
-def _stable_hash(prefix: str, payload: Mapping[str, object]) -> str:
-    encoded = json.dumps(
-        {"prefix": prefix, **dict(payload)},
-        sort_keys=True,
-        separators=(",", ":"),
-        default=str,
-    ).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()[:24]
-
-
-def _top_queue_item(repair_queue: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
-    for item in repair_queue:
-        payload = _mapping(item)
-        if payload:
-            return payload
-    return {}
-
-
-def _is_alpha_repair(item: Mapping[str, Any]) -> bool:
-    return (
-        _text(item.get("code")) == "repair_alpha_readiness"
-        or _text(item.get("reason")) == "alpha_readiness_not_promotion_eligible"
-    )
-
-
-def _routeable_candidate_count(evidence: Mapping[str, Any]) -> int:
-    repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
-    routeability_acceptance = _mapping(evidence.get("routeability_acceptance"))
-    route_clearinghouse = _mapping(evidence.get("route_evidence_clearinghouse"))
-    return max(
-        _int(repair_bid_settlement.get("routeable_candidate_count")),
-        _int(routeability_acceptance.get("accepted_routeable_candidate_count")),
-        _int(route_clearinghouse.get("accepted_routeable_candidate_count")),
-    )
-
-
-def _zero_notional_or_stale_evidence_rate(evidence: Mapping[str, Any]) -> object:
-    routeability_acceptance = _mapping(evidence.get("routeability_acceptance"))
-    route_clearinghouse = _mapping(evidence.get("route_evidence_clearinghouse"))
-    return routeability_acceptance.get(
-        "zero_notional_or_stale_evidence_rate",
-        route_clearinghouse.get("zero_notional_or_stale_evidence_rate", 1),
-    )
 
 
 def _source_ref(

--- a/services/torghut/app/trading/alpha_readiness_settlement_conveyor.py
+++ b/services/torghut/app/trading/alpha_readiness_settlement_conveyor.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Any, cast
+from typing import Any
+
+from .read_model_utils import (
+    append_unique_text as _append_unique,
+    as_int as _int,
+    as_mapping as _mapping,
+    as_sequence as _sequence,
+    as_text as _text,
+    first_mapping as _top_queue_item,
+    is_alpha_readiness_repair as _is_alpha_repair,
+    routeable_candidate_count as _routeable_candidate_count,
+    stable_hash24 as _stable_hash,
+    unique_text_list as _string_list,
+    zero_notional_or_stale_evidence_rate as _zero_notional_or_stale_evidence_rate,
+)
 
 ALPHA_READINESS_SETTLEMENT_CONVEYOR_SCHEMA_VERSION = (
     "torghut.alpha-readiness-settlement-conveyor.v1"
@@ -62,114 +74,6 @@ _SCHEMA_LINEAGE_BLOCKERS = {
     "required_feature_set_unavailable",
 }
 _REJECTION_DRAG_BLOCKERS = {"rejection_drag_high", "rejection_drag_unmeasured"}
-
-
-def _text(value: object, default: str = "") -> str:
-    if value is None:
-        return default
-    normalized = str(value).strip()
-    return normalized or default
-
-
-def _int(value: object, default: int = 0) -> int:
-    if isinstance(value, bool):
-        return int(value)
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return int(value)
-    if isinstance(value, str) and value.strip():
-        try:
-            return int(float(value.strip()))
-        except ValueError:
-            return default
-    return default
-
-
-def _mapping(value: object) -> Mapping[str, Any]:
-    if isinstance(value, Mapping):
-        return cast(Mapping[str, Any], value)
-    return {}
-
-
-def _sequence(value: object) -> Sequence[object]:
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return cast(Sequence[object], value)
-    return ()
-
-
-def _string_list(value: object) -> list[str]:
-    items: list[str] = []
-    seen: set[str] = set()
-    for item in _sequence(value):
-        normalized = _text(item)
-        if not normalized or normalized in seen:
-            continue
-        seen.add(normalized)
-        items.append(normalized)
-    return items
-
-
-def _append_unique(items: list[str], *values: object) -> list[str]:
-    seen = set(items)
-    for value in values:
-        if isinstance(value, Sequence) and not isinstance(
-            value, (str, bytes, bytearray)
-        ):
-            candidates = _string_list(cast(Sequence[object], value))
-        else:
-            candidates = [_text(value)]
-        for candidate in candidates:
-            if not candidate or candidate in seen:
-                continue
-            seen.add(candidate)
-            items.append(candidate)
-    return items
-
-
-def _stable_hash(prefix: str, payload: Mapping[str, object]) -> str:
-    encoded = json.dumps(
-        {"prefix": prefix, **dict(payload)},
-        sort_keys=True,
-        separators=(",", ":"),
-        default=str,
-    ).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()[:24]
-
-
-def _top_queue_item(repair_queue: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
-    for item in repair_queue:
-        payload = _mapping(item)
-        if payload:
-            return payload
-    return {}
-
-
-def _is_alpha_repair(item: Mapping[str, Any]) -> bool:
-    return (
-        _text(item.get("code")) == "repair_alpha_readiness"
-        or _text(item.get("reason")) == "alpha_readiness_not_promotion_eligible"
-    )
-
-
-def _routeable_candidate_count(evidence: Mapping[str, Any]) -> int:
-    repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
-    routeability_acceptance = _mapping(evidence.get("routeability_acceptance"))
-    route_clearinghouse = _mapping(evidence.get("route_evidence_clearinghouse"))
-    return max(
-        _int(repair_bid_settlement.get("routeable_candidate_count")),
-        _int(routeability_acceptance.get("accepted_routeable_candidate_count")),
-        _int(route_clearinghouse.get("accepted_routeable_candidate_count")),
-    )
-
-
-def _zero_notional_or_stale_evidence_rate(evidence: Mapping[str, Any]) -> object:
-    routeability_acceptance = _mapping(evidence.get("routeability_acceptance"))
-    route_clearinghouse = _mapping(evidence.get("route_evidence_clearinghouse"))
-    return routeability_acceptance.get(
-        "zero_notional_or_stale_evidence_rate",
-        route_clearinghouse.get("zero_notional_or_stale_evidence_rate", 1),
-    )
 
 
 def _source_commit(

--- a/services/torghut/app/trading/alpha_repair_closure_board.py
+++ b/services/torghut/app/trading/alpha_repair_closure_board.py
@@ -2,11 +2,22 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Any, cast
+from typing import Any
+
+from .read_model_utils import (
+    as_bool as _bool,
+    as_int as _int,
+    as_mapping as _mapping,
+    as_sequence as _sequence,
+    as_text as _text,
+    first_mapping as _top_queue_item,
+    is_alpha_readiness_repair as _is_alpha_repair,
+    routeable_candidate_count as _routeable_candidate_count,
+    stable_hash24 as _stable_hash,
+    unique_text_list as _string_list,
+)
 
 ALPHA_REPAIR_CLOSURE_BOARD_SCHEMA_VERSION = "torghut.alpha-repair-closure-board.v1"
 ALPHA_REPAIR_CLOSURE_BOARD_REF_SCHEMA_VERSION = (
@@ -52,64 +63,6 @@ _NO_DELTA_RELEASE_CONDITIONS = [
 ]
 
 
-def _text(value: object, default: str = "") -> str:
-    if value is None:
-        return default
-    normalized = str(value).strip()
-    return normalized or default
-
-
-def _bool(value: object, default: bool = False) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in {"1", "true", "yes", "on", "allow", "allowed", "ok"}:
-            return True
-        if normalized in {"0", "false", "no", "off", "deny", "blocked", "hold"}:
-            return False
-    return default
-
-
-def _int(value: object, default: int = 0) -> int:
-    if isinstance(value, bool):
-        return int(value)
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return int(value)
-    if isinstance(value, str) and value.strip():
-        try:
-            return int(float(value.strip()))
-        except ValueError:
-            return default
-    return default
-
-
-def _mapping(value: object) -> Mapping[str, Any]:
-    if isinstance(value, Mapping):
-        return cast(Mapping[str, Any], value)
-    return {}
-
-
-def _sequence(value: object) -> Sequence[object]:
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return cast(Sequence[object], value)
-    return []
-
-
-def _string_list(value: object) -> list[str]:
-    items: list[str] = []
-    seen: set[str] = set()
-    for item in _sequence(value):
-        normalized = _text(item)
-        if not normalized or normalized in seen:
-            continue
-        seen.add(normalized)
-        items.append(normalized)
-    return items
-
-
 def _append_unique(items: list[str], *values: object) -> list[str]:
     seen = set(items)
     for value in values:
@@ -119,42 +72,6 @@ def _append_unique(items: list[str], *values: object) -> list[str]:
             seen.add(candidate)
             items.append(candidate)
     return items
-
-
-def _stable_hash(prefix: str, payload: Mapping[str, object]) -> str:
-    encoded = json.dumps(
-        {"prefix": prefix, **dict(payload)},
-        sort_keys=True,
-        separators=(",", ":"),
-        default=str,
-    ).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()[:24]
-
-
-def _top_queue_item(repair_queue: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
-    for item in repair_queue:
-        payload = _mapping(item)
-        if payload:
-            return payload
-    return {}
-
-
-def _is_alpha_repair(item: Mapping[str, Any]) -> bool:
-    return (
-        _text(item.get("code")) == "repair_alpha_readiness"
-        or _text(item.get("reason")) == "alpha_readiness_not_promotion_eligible"
-    )
-
-
-def _routeable_candidate_count(evidence: Mapping[str, Any]) -> int:
-    repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
-    routeability_acceptance = _mapping(evidence.get("routeability_acceptance"))
-    route_clearinghouse = _mapping(evidence.get("route_evidence_clearinghouse"))
-    return max(
-        _int(repair_bid_settlement.get("routeable_candidate_count")),
-        _int(routeability_acceptance.get("accepted_routeable_candidate_count")),
-        _int(route_clearinghouse.get("accepted_routeable_candidate_count")),
-    )
 
 
 def _account_window(

--- a/services/torghut/app/trading/alpha_repair_dividend_ledger.py
+++ b/services/torghut/app/trading/alpha_repair_dividend_ledger.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Any, cast
+from typing import Any
+
+from .read_model_utils import (
+    append_unique_text as _append_unique,
+    as_int as _int,
+    as_mapping as _mapping,
+    as_sequence as _sequence,
+    as_text as _text,
+    first_mapping as _top_queue_item,
+    is_alpha_readiness_repair as _is_alpha_repair,
+    parse_datetime_utc as _parse_datetime,
+    routeable_candidate_count as _routeable_candidate_count,
+    stable_hash24 as _stable_hash,
+    unique_text_list as _string_list,
+)
 
 ALPHA_REPAIR_DIVIDEND_LEDGER_SCHEMA_VERSION = "torghut.alpha-repair-dividend-ledger.v1"
 ALPHA_REPAIR_DIVIDEND_LEDGER_REF_SCHEMA_VERSION = (
@@ -34,119 +46,6 @@ _NO_DELTA_RELEASE_CONDITIONS = [
     "blocker_set_changes",
     "required_receipt_changes",
 ]
-
-
-def _mapping(value: object) -> Mapping[str, Any]:
-    if isinstance(value, Mapping):
-        return cast(Mapping[str, Any], value)
-    return {}
-
-
-def _sequence(value: object) -> Sequence[object]:
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return cast(Sequence[object], value)
-    return ()
-
-
-def _text(value: object, default: str = "") -> str:
-    if value is None:
-        return default
-    normalized = str(value).strip()
-    return normalized or default
-
-
-def _int(value: object, default: int = 0) -> int:
-    if isinstance(value, bool):
-        return int(value)
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return int(value)
-    if isinstance(value, str) and value.strip():
-        try:
-            return int(float(value.strip()))
-        except ValueError:
-            return default
-    return default
-
-
-def _string_list(value: object) -> list[str]:
-    result: list[str] = []
-    seen: set[str] = set()
-    for item in _sequence(value):
-        normalized = _text(item)
-        if not normalized or normalized in seen:
-            continue
-        seen.add(normalized)
-        result.append(normalized)
-    return result
-
-
-def _append_unique(items: list[str], *values: object) -> list[str]:
-    seen = set(items)
-    for value in values:
-        if isinstance(value, Sequence) and not isinstance(
-            value, (str, bytes, bytearray)
-        ):
-            candidates = _string_list(cast(Sequence[object], value))
-        else:
-            candidates = [_text(value)]
-        for candidate in candidates:
-            if not candidate or candidate in seen:
-                continue
-            seen.add(candidate)
-            items.append(candidate)
-    return items
-
-
-def _stable_hash(prefix: str, payload: Mapping[str, object]) -> str:
-    encoded = json.dumps(
-        {"prefix": prefix, **dict(payload)},
-        sort_keys=True,
-        separators=(",", ":"),
-        default=str,
-    ).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()[:24]
-
-
-def _parse_datetime(value: object) -> datetime | None:
-    raw = _text(value)
-    if not raw:
-        return None
-    normalized = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return None
-    return parsed.astimezone(timezone.utc)
-
-
-def _top_queue_item(repair_queue: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
-    for item in repair_queue:
-        payload = _mapping(item)
-        if payload:
-            return payload
-    return {}
-
-
-def _is_alpha_repair(item: Mapping[str, Any]) -> bool:
-    return (
-        _text(item.get("code")) == "repair_alpha_readiness"
-        or _text(item.get("reason")) == "alpha_readiness_not_promotion_eligible"
-    )
-
-
-def _routeable_candidate_count(evidence: Mapping[str, Any]) -> int:
-    repair_bid_settlement = _mapping(evidence.get("repair_bid_settlement"))
-    routeability_acceptance = _mapping(evidence.get("routeability_acceptance"))
-    route_clearinghouse = _mapping(evidence.get("route_evidence_clearinghouse"))
-    return max(
-        _int(repair_bid_settlement.get("routeable_candidate_count")),
-        _int(routeability_acceptance.get("accepted_routeable_candidate_count")),
-        _int(route_clearinghouse.get("accepted_routeable_candidate_count")),
-    )
 
 
 def _source_revenue_repair_ref(

--- a/services/torghut/app/trading/no_delta_repair_reentry_auction.py
+++ b/services/torghut/app/trading/no_delta_repair_reentry_auction.py
@@ -2,11 +2,22 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Any, cast
+from typing import Any
+
+from .read_model_utils import (
+    append_unique_text as _append_unique,
+    as_int as _int,
+    as_mapping as _mapping,
+    as_sequence as _sequence,
+    as_text as _text,
+    first_mapping as _top_queue_item,
+    is_alpha_readiness_repair as _is_alpha_repair,
+    parse_datetime_utc as _parse_datetime,
+    stable_hash24 as _stable_hash,
+    unique_text_list as _string_list,
+)
 
 NO_DELTA_REPAIR_REENTRY_AUCTION_SCHEMA_VERSION = (
     "torghut.no-delta-repair-reentry-auction.v1"
@@ -94,108 +105,6 @@ _TCA_BLOCKERS = {
     "execution_tca_symbol_missing",
     "tca_evidence_stale",
 }
-
-
-def _mapping(value: object) -> Mapping[str, Any]:
-    if isinstance(value, Mapping):
-        return cast(Mapping[str, Any], value)
-    return {}
-
-
-def _sequence(value: object) -> Sequence[object]:
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return cast(Sequence[object], value)
-    return ()
-
-
-def _text(value: object, default: str = "") -> str:
-    if value is None:
-        return default
-    normalized = str(value).strip()
-    return normalized or default
-
-
-def _int(value: object, default: int = 0) -> int:
-    if isinstance(value, bool):
-        return int(value)
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return int(value)
-    if isinstance(value, str) and value.strip():
-        try:
-            return int(float(value.strip()))
-        except ValueError:
-            return default
-    return default
-
-
-def _string_list(value: object) -> list[str]:
-    result: list[str] = []
-    seen: set[str] = set()
-    for item in _sequence(value):
-        normalized = _text(item)
-        if not normalized or normalized in seen:
-            continue
-        seen.add(normalized)
-        result.append(normalized)
-    return result
-
-
-def _append_unique(items: list[str], *values: object) -> list[str]:
-    seen = set(items)
-    for value in values:
-        if isinstance(value, Sequence) and not isinstance(
-            value, (str, bytes, bytearray)
-        ):
-            candidates = _string_list(cast(Sequence[object], value))
-        else:
-            candidates = [_text(value)]
-        for candidate in candidates:
-            if not candidate or candidate in seen:
-                continue
-            seen.add(candidate)
-            items.append(candidate)
-    return items
-
-
-def _stable_hash(prefix: str, payload: Mapping[str, object]) -> str:
-    encoded = json.dumps(
-        {"prefix": prefix, **dict(payload)},
-        sort_keys=True,
-        separators=(",", ":"),
-        default=str,
-    ).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()[:24]
-
-
-def _parse_datetime(value: object) -> datetime | None:
-    raw = _text(value)
-    if not raw:
-        return None
-    normalized = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return None
-    return parsed.astimezone(timezone.utc)
-
-
-def _top_queue_item(repair_queue: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
-    for item in repair_queue:
-        payload = _mapping(item)
-        if payload:
-            return payload
-    return {}
-
-
-def _is_alpha_repair(item: Mapping[str, Any]) -> bool:
-    return (
-        _text(item.get("code")) == "repair_alpha_readiness"
-        or _text(item.get("reason")) == "alpha_readiness_not_promotion_eligible"
-    )
 
 
 def _zero_notional(value: object) -> bool:

--- a/services/torghut/app/trading/read_model_utils.py
+++ b/services/torghut/app/trading/read_model_utils.py
@@ -1,0 +1,160 @@
+"""Shared helpers for Torghut additive read-model payload builders."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any, cast
+
+
+def as_mapping(value: object) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value)
+    return {}
+
+
+def as_sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return ()
+
+
+def as_text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    normalized = str(value).strip()
+    return normalized or default
+
+
+def as_int(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(float(value.strip()))
+        except ValueError:
+            return default
+    return default
+
+
+def as_bool(value: object, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on", "allow", "allowed", "ok"}:
+            return True
+        if normalized in {"0", "false", "no", "off", "deny", "blocked", "hold"}:
+            return False
+    return default
+
+
+def unique_text_list(value: object) -> list[str]:
+    items: list[str] = []
+    seen: set[str] = set()
+    for item in as_sequence(value):
+        normalized = as_text(item)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        items.append(normalized)
+    return items
+
+
+def append_unique_text(items: list[str], *values: object) -> list[str]:
+    seen = set(items)
+    for value in values:
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            candidates = unique_text_list(cast(Sequence[object], value))
+        else:
+            candidates = [as_text(value)]
+        for candidate in candidates:
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            items.append(candidate)
+    return items
+
+
+def stable_hash24(prefix: str, payload: Mapping[str, object]) -> str:
+    encoded = json.dumps(
+        {"prefix": prefix, **dict(payload)},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:24]
+
+
+def parse_datetime_utc(value: object) -> datetime | None:
+    raw = as_text(value)
+    if not raw:
+        return None
+    normalized = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def first_mapping(values: Sequence[object]) -> Mapping[str, Any]:
+    for item in values:
+        payload = as_mapping(item)
+        if payload:
+            return payload
+    return {}
+
+
+def is_alpha_readiness_repair(item: Mapping[str, Any]) -> bool:
+    return (
+        as_text(item.get("code")) == "repair_alpha_readiness"
+        or as_text(item.get("reason")) == "alpha_readiness_not_promotion_eligible"
+    )
+
+
+def routeable_candidate_count(evidence: Mapping[str, Any]) -> int:
+    repair_bid_settlement = as_mapping(evidence.get("repair_bid_settlement"))
+    routeability_acceptance = as_mapping(evidence.get("routeability_acceptance"))
+    route_clearinghouse = as_mapping(evidence.get("route_evidence_clearinghouse"))
+    return max(
+        as_int(repair_bid_settlement.get("routeable_candidate_count")),
+        as_int(routeability_acceptance.get("accepted_routeable_candidate_count")),
+        as_int(route_clearinghouse.get("accepted_routeable_candidate_count")),
+    )
+
+
+def zero_notional_or_stale_evidence_rate(evidence: Mapping[str, Any]) -> object:
+    routeability_acceptance = as_mapping(evidence.get("routeability_acceptance"))
+    route_clearinghouse = as_mapping(evidence.get("route_evidence_clearinghouse"))
+    return routeability_acceptance.get(
+        "zero_notional_or_stale_evidence_rate",
+        route_clearinghouse.get("zero_notional_or_stale_evidence_rate", 1),
+    )
+
+
+__all__ = [
+    "append_unique_text",
+    "as_bool",
+    "as_int",
+    "as_mapping",
+    "as_sequence",
+    "as_text",
+    "first_mapping",
+    "is_alpha_readiness_repair",
+    "parse_datetime_utc",
+    "routeable_candidate_count",
+    "stable_hash24",
+    "unique_text_list",
+    "zero_notional_or_stale_evidence_rate",
+]

--- a/services/torghut/tests/test_read_model_utils.py
+++ b/services/torghut/tests/test_read_model_utils.py
@@ -1,0 +1,73 @@
+from datetime import timezone
+
+from app.trading.read_model_utils import (
+    append_unique_text,
+    as_bool,
+    as_int,
+    as_mapping,
+    as_sequence,
+    as_text,
+    first_mapping,
+    is_alpha_readiness_repair,
+    parse_datetime_utc,
+    routeable_candidate_count,
+    stable_hash24,
+    unique_text_list,
+    zero_notional_or_stale_evidence_rate,
+)
+
+
+def test_coercion_helpers_match_read_model_expectations() -> None:
+    assert as_mapping({"a": 1}) == {"a": 1}
+    assert as_mapping(["a"]) == {}
+    assert as_sequence(["a", "b"]) == ["a", "b"]
+    assert as_sequence("ab") == ()
+    assert as_text("  value  ") == "value"
+    assert as_text(None, default="missing") == "missing"
+    assert as_int("4.9") == 4
+    assert as_int("nope", default=7) == 7
+    assert as_bool("allowed") is True
+    assert as_bool("hold", default=True) is False
+
+
+def test_collection_helpers_dedupe_without_string_splitting() -> None:
+    items = unique_text_list(["a", " b ", "a", "", None, "c"])
+    assert items == ["a", "b", "c"]
+
+    appended = append_unique_text(["a"], ["b", "a"], " c ", "", None)
+    assert appended == ["a", "b", "c"]
+
+
+def test_timestamp_and_hash_helpers_are_stable() -> None:
+    parsed = parse_datetime_utc("2026-05-16T12:30:00Z")
+    assert parsed is not None
+    assert parsed.tzinfo == timezone.utc
+    assert parsed.isoformat() == "2026-05-16T12:30:00+00:00"
+    assert parse_datetime_utc("2026-05-16T12:30:00") is None
+
+    first = stable_hash24("prefix", {"b": 2, "a": 1})
+    second = stable_hash24("prefix", {"a": 1, "b": 2})
+    assert first == second
+    assert len(first) == 24
+
+
+def test_repair_read_model_helpers_extract_shared_contract_fields() -> None:
+    assert first_mapping([{}, {"code": "repair_alpha_readiness"}]) == {
+        "code": "repair_alpha_readiness"
+    }
+    assert is_alpha_readiness_repair({"code": "repair_alpha_readiness"})
+    assert is_alpha_readiness_repair(
+        {"reason": "alpha_readiness_not_promotion_eligible"}
+    )
+    assert not is_alpha_readiness_repair({"code": "repair_market_context"})
+
+    evidence = {
+        "repair_bid_settlement": {"routeable_candidate_count": "2"},
+        "routeability_acceptance": {
+            "accepted_routeable_candidate_count": 5,
+            "zero_notional_or_stale_evidence_rate": "0.25",
+        },
+        "route_evidence_clearinghouse": {"accepted_routeable_candidate_count": 3},
+    }
+    assert routeable_candidate_count(evidence) == 5
+    assert zero_notional_or_stale_evidence_rate(evidence) == "0.25"


### PR DESCRIPTION
## Summary

- Extract shared Torghut read-model coercion, hashing, queue-selection, and routeable-candidate helpers into `app/trading/read_model_utils.py`.
- Rewire the alpha-repair read-model builders to use the shared helpers instead of local duplicated implementations.
- Add focused regression coverage for the shared helpers.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_read_model_utils.py tests/test_alpha_evidence_foundry.py tests/test_alpha_readiness_settlement_conveyor.py tests/test_alpha_repair_closure_board.py tests/test_alpha_repair_dividend_ledger.py tests/test_no_delta_repair_reentry_auction.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/read_model_utils.py app/trading/alpha_repair_dividend_ledger.py app/trading/alpha_evidence_foundry.py app/trading/alpha_readiness_settlement_conveyor.py app/trading/alpha_repair_closure_board.py app/trading/no_delta_repair_reentry_auction.py tests/test_read_model_utils.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `cd services/torghut && uvx --from vulture vulture --config pyproject.toml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
