### PR TITLE
chore(torghut): promote image 507d1791

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.0-68-g87ba95315
+              value: v0.571.0-72-g507d17915
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 87ba95315b88a59dd593d8418ae0a39a56308433
+              value: 507d17915d9ed73fe9c58f5f5bf0dc7eaf138d16
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.0-68-g87ba95315
+              value: v0.571.0-72-g507d17915
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 87ba95315b88a59dd593d8418ae0a39a56308433
+              value: 507d17915d9ed73fe9c58f5f5bf0dc7eaf138d16
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-16T23:09:35Z"
+        client.knative.dev/updateTimestamp: "2026-05-16T23:57:36Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
           ports:
             - name: http1
               containerPort: 8181
@@ -495,11 +495,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.0-68-g87ba95315
+              value: v0.571.0-72-g507d17915
             - name: TORGHUT_COMMIT
-              value: 87ba95315b88a59dd593d8418ae0a39a56308433
+              value: 507d17915d9ed73fe9c58f5f5bf0dc7eaf138d16
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+              value: sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-16T23:09:35Z"
+        client.knative.dev/updateTimestamp: "2026-05-16T23:57:36Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
           ports:
             - name: http1
               containerPort: 8181
@@ -316,11 +316,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.0-68-g87ba95315
+              value: v0.571.0-72-g507d17915
             - name: TORGHUT_COMMIT
-              value: 87ba95315b88a59dd593d8418ae0a39a56308433
+              value: 507d17915d9ed73fe9c58f5f5bf0dc7eaf138d16
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+              value: sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:58968b13e4ee0dc9fd5462f6bf8832d40fedac2fe15f4b2695420cc2e8b2d7d3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `507d17915d9ed73fe9c58f5f5bf0dc7eaf138d16`
- Image tag: `507d1791`
- Image digest: `sha256:a613ac7678221611daa4ef074d34419e358ec3d54c01fa20ad6d695a7faa0ce1`