### PR TITLE
fix(torghut): block terminal risk feedback before replay

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -2613,6 +2613,18 @@ def _feedback_risk_profile_has_penalty(scorecard: Mapping[str, Any]) -> bool:
     return False
 
 
+def _feedback_risk_profile_has_terminal_block(scorecard: Mapping[str, Any]) -> bool:
+    if not _feedback_risk_profile_has_penalty(scorecard):
+        return False
+    if _feedback_has_nonpositive_expected_value(scorecard):
+        return True
+    if _decimal(scorecard.get("max_gross_exposure_pct_equity")) > Decimal("1.0"):
+        return True
+    if _decimal(scorecard.get("min_cash")) < Decimal("0"):
+        return True
+    return _decimal(scorecard.get("negative_cash_observation_count")) > Decimal("0")
+
+
 def _feedback_is_blocked(scorecard: Mapping[str, Any]) -> bool:
     if _feedback_scorecard_has_hard_veto(scorecard):
         return True
@@ -2977,6 +2989,8 @@ def _pre_replay_proposal_model_and_rows(
             and bundle is not None
             and _feedback_risk_profile_has_penalty(bundle.objective_scorecard)
         ):
+            if _feedback_risk_profile_has_terminal_block(bundle.objective_scorecard):
+                return "pre_replay_mlx_risk_profile_feedback_blocked"
             return "pre_replay_mlx_risk_profile_feedback_penalized"
         if (
             source == "feedback_family_replay"
@@ -3007,6 +3021,12 @@ def _pre_replay_proposal_model_and_rows(
             source == "feedback_shape_prior"
             and bundle is not None
             and _feedback_family_prior_has_hard_block(bundle.objective_scorecard)
+        ):
+            return min(-1_000_000.0, target_by_spec.get(candidate_spec_id, raw_score))
+        if (
+            source == "feedback_risk_profile_prior"
+            and bundle is not None
+            and _feedback_risk_profile_has_terminal_block(bundle.objective_scorecard)
         ):
             return min(-1_000_000.0, target_by_spec.get(candidate_spec_id, raw_score))
         if (
@@ -3151,6 +3171,7 @@ def _select_candidate_specs_for_replay(
         "pre_replay_mlx_feedback_blocked",
         "pre_replay_mlx_signature_feedback_blocked",
         "pre_replay_mlx_shape_feedback_blocked",
+        "pre_replay_mlx_risk_profile_feedback_blocked",
         "pre_replay_mlx_family_feedback_blocked",
     }
 

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -1313,6 +1313,115 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "synthetic_prior",
         )
 
+    def test_candidate_selection_blocks_terminal_risk_profile_feedback(self) -> None:
+        failed_spec = self._candidate_spec("spec-risk-terminal-source")
+        matching_risk_probe = replace(
+            failed_spec,
+            candidate_spec_id="spec-risk-terminal-probe",
+            hypothesis_id="hyp-spec-risk-terminal-probe",
+            hard_vetoes={"required_min_daily_notional": "450000"},
+            strategy_overrides={
+                **failed_spec.strategy_overrides,
+                "params": {
+                    **cast(dict[str, Any], failed_spec.strategy_overrides["params"]),
+                    "entry_minute_after_open": "90",
+                },
+            },
+        )
+        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id=failed_spec.candidate_spec_id,
+            candidate=runner._candidate_payload_with_feedback_metadata(
+                spec=failed_spec,
+                candidate={
+                    "candidate_id": "cand-terminal-risk-feedback",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "-72.11",
+                        "active_day_ratio": "0.8",
+                        "positive_day_ratio": "0",
+                        "negative_day_count": 4,
+                        "best_day_share": "1",
+                        "daily_net": {
+                            "2026-05-04": "-287.72",
+                            "2026-05-05": "-22.05",
+                            "2026-05-06": "-13.51",
+                            "2026-05-07": "-37.30",
+                            "2026-05-12": "0",
+                        },
+                    },
+                },
+            ),
+            dataset_snapshot_id="snap-terminal-risk-feedback",
+            result_path="feedback://terminal-risk",
+        )
+
+        model, rows = runner._pre_replay_proposal_model_and_rows(
+            specs=(matching_risk_probe,),
+            feedback_evidence_bundles=(feedback_bundle,),
+        )
+
+        self.assertEqual(model["feedback_risk_profile_matched_spec_count"], 1)
+        self.assertEqual(rows[0]["training_source"], "feedback_risk_profile_prior")
+        self.assertEqual(
+            rows[0]["selection_reason"],
+            "pre_replay_mlx_risk_profile_feedback_blocked",
+        )
+        self.assertLessEqual(
+            Decimal(str(rows[0]["proposal_score"])), Decimal("-999999")
+        )
+
+        selected, selection = runner._select_candidate_specs_for_replay(
+            specs=(matching_risk_probe,),
+            proposal_rows=rows,
+            top_k=1,
+            exploration_slots=0,
+            max_candidates=1,
+            portfolio_size_min=1,
+        )
+
+        self.assertEqual(selected, [])
+        self.assertEqual(selection["budget"]["selected_count"], 0)
+        self.assertEqual(selection["budget"]["eligible_candidate_count"], 0)
+        self.assertEqual(
+            selection["budget"]["pre_replay_feedback_blocked_candidate_count"], 1
+        )
+
+    def test_terminal_risk_profile_block_covers_capital_paths(self) -> None:
+        self.assertFalse(runner._feedback_risk_profile_has_terminal_block({}))
+
+        penalty_scorecard = {
+            "profit_target_oracle": {
+                "blockers": ["max_single_day_contribution_share_failed"]
+            },
+            "net_pnl_per_day": "250",
+            "active_day_ratio": "1",
+            "positive_day_ratio": "1",
+            "best_day_share": "0.25",
+        }
+        self.assertTrue(
+            runner._feedback_risk_profile_has_terminal_block(
+                {
+                    **penalty_scorecard,
+                    "max_gross_exposure_pct_equity": "1.01",
+                }
+            )
+        )
+        self.assertTrue(
+            runner._feedback_risk_profile_has_terminal_block(
+                {
+                    **penalty_scorecard,
+                    "min_cash": "-0.01",
+                }
+            )
+        )
+        self.assertTrue(
+            runner._feedback_risk_profile_has_terminal_block(
+                {
+                    **penalty_scorecard,
+                    "negative_cash_observation_count": "1",
+                }
+            )
+        )
+
     def test_feedback_shape_prior_penalizes_cash_blocks_without_family_veto(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Blocks terminal risk-profile feedback before replay selection when prior matching evidence has nonpositive daily net PnL or capital-safety violations.
- Keeps positive-but-concentrated risk-profile feedback as a repair candidate by leaving it penalized rather than fully blocked.
- Adds a regression test covering the failed epoch pattern where nonpositive risk-profile evidence should not consume another real-replay slot.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q -k 'risk_profile or feedback_shape or candidate_selection_blocks_terminal'`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
