### PR TITLE
chore(jangar): promote image 966a6a57

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: bac82f02
-  digest: sha256:563e77836384358e3dc25ffe12171c86e9b60e3c01b3d38ca816a416f22399ac
+  tag: 966a6a57
+  digest: sha256:d5ac66038d6e9890eee25dea82470ffb5dacabe43ce388289405e6beb8cf5516
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: bac82f02
-    digest: sha256:fa00c4726b55f01289750020b31fe05f50bcdbd243a8c3b048d0323606c47c24
+    tag: 966a6a57
+    digest: sha256:fada3cd1142d181dd8168e06f8ed7e0182e2ab1f57a434b66548754dc305d332
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "12000"
-      JANGAR_SOURCE_HEAD_SHA: bac82f02703102ee1f27706e6b09ce49f75703e9
-      JANGAR_GITOPS_REVISION: bac82f02703102ee1f27706e6b09ce49f75703e9
-      JANGAR_SOURCE_CI_RUN_ID: "25975071243"
+      JANGAR_SOURCE_HEAD_SHA: 966a6a574e3abfd702c899dd6f0053237126dc04
+      JANGAR_GITOPS_REVISION: 966a6a574e3abfd702c899dd6f0053237126dc04
+      JANGAR_SOURCE_CI_RUN_ID: "25976648014"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:fa00c4726b55f01289750020b31fe05f50bcdbd243a8c3b048d0323606c47c24
-      JANGAR_SERVING_BUILD_COMMIT: bac82f02703102ee1f27706e6b09ce49f75703e9
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:fa00c4726b55f01289750020b31fe05f50bcdbd243a8c3b048d0323606c47c24
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:fada3cd1142d181dd8168e06f8ed7e0182e2ab1f57a434b66548754dc305d332
+      JANGAR_SERVING_BUILD_COMMIT: 966a6a574e3abfd702c899dd6f0053237126dc04
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:fada3cd1142d181dd8168e06f8ed7e0182e2ab1f57a434b66548754dc305d332
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: bac82f02
-    digest: sha256:563e77836384358e3dc25ffe12171c86e9b60e3c01b3d38ca816a416f22399ac
+    tag: 966a6a57
+    digest: sha256:d5ac66038d6e9890eee25dea82470ffb5dacabe43ce388289405e6beb8cf5516
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-16T22:51:35Z
+    deploy.knative.dev/rollout: 2026-05-17T00:18:00Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:bac82f02@sha256:563e77836384358e3dc25ffe12171c86e9b60e3c01b3d38ca816a416f22399ac
+              value: registry.ide-newton.ts.net/lab/jangar:966a6a57@sha256:d5ac66038d6e9890eee25dea82470ffb5dacabe43ce388289405e6beb8cf5516
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: bac82f02703102ee1f27706e6b09ce49f75703e9
+              value: 966a6a574e3abfd702c899dd6f0053237126dc04
             - name: JANGAR_GITOPS_REVISION
-              value: bac82f02703102ee1f27706e6b09ce49f75703e9
+              value: 966a6a574e3abfd702c899dd6f0053237126dc04
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25975071243"
+              value: "25976648014"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:fa00c4726b55f01289750020b31fe05f50bcdbd243a8c3b048d0323606c47c24
+              value: sha256:fada3cd1142d181dd8168e06f8ed7e0182e2ab1f57a434b66548754dc305d332
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: bac82f02703102ee1f27706e6b09ce49f75703e9
+              value: 966a6a574e3abfd702c899dd6f0053237126dc04
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:fa00c4726b55f01289750020b31fe05f50bcdbd243a8c3b048d0323606c47c24
+              value: sha256:fada3cd1142d181dd8168e06f8ed7e0182e2ab1f57a434b66548754dc305d332
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: bac82f02
-    digest: sha256:563e77836384358e3dc25ffe12171c86e9b60e3c01b3d38ca816a416f22399ac
+    newTag: 966a6a57
+    digest: sha256:d5ac66038d6e9890eee25dea82470ffb5dacabe43ce388289405e6beb8cf5516


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `966a6a574e3abfd702c899dd6f0053237126dc04`
- Image tag: `966a6a57`
- Image digest: `sha256:d5ac66038d6e9890eee25dea82470ffb5dacabe43ce388289405e6beb8cf5516`
- Source CI run: `25976648014`
- Control-plane serving digest: `sha256:fada3cd1142d181dd8168e06f8ed7e0182e2ab1f57a434b66548754dc305d332`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates