### PR TITLE
fix(agents): add codex swarm model fallbacks

### DIFF
--- a/argocd/applications/agents/codex-spark-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-agentprovider.yaml
@@ -12,6 +12,8 @@ spec:
     AGENT_RUN_NAMESPACE: "{{agentRun.namespace}}"
     AGENT_PROVIDER_PATH: /root/.codex/provider-codex-spark.json
     CODEX_MODEL: gpt-5.5
+    CODEX_MODEL_FALLBACKS: gpt-5.4,gpt-5.4-mini,gpt-5.3-codex-spark
+    CODEX_MAX_SESSION_ATTEMPTS: "4"
     HF_BASE_URL: https://router.huggingface.co/v1
     HF_MODEL: meta-llama/Llama-3.1-8B-Instruct:novita
   inputFiles:

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -380,6 +380,8 @@ describe('scheduled AgentRun templates', () => {
     expect(providerCommand).not.toContain('> >(tee')
     expect(objectAt(envTemplate, 'AGENT_RUN_NAME')).toBe('{{agentRun.name}}')
     expect(objectAt(envTemplate, 'AGENT_RUN_NAMESPACE')).toBe('{{agentRun.namespace}}')
+    expect(objectAt(envTemplate, 'CODEX_MODEL_FALLBACKS')).toBe('gpt-5.4,gpt-5.4-mini,gpt-5.3-codex-spark')
+    expect(objectAt(envTemplate, 'CODEX_MAX_SESSION_ATTEMPTS')).toBe('4')
     expect(sanitizerContent).toContain('SUPPRESSED_PROVIDER_HTML = "[suppressed provider HTML response body]"')
     expect(sanitizerContent).toContain('HTML_START_PATTERN = re.compile(')
     expect(content).toContain('def summarize_upstream(upstream: str) -> str:')


### PR DESCRIPTION
## Summary

- Add a bounded Codex model fallback chain for codex-spark swarm stages before they drop to HF handoff fallback.
- Increase the Codex session attempt budget so primary plus fallback models can run in one AgentRun.
- Extend the Agents manifest smoke test to assert the fallback chain remains wired.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bunx oxfmt --check argocd/applications/agents/codex-spark-agentprovider.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check -- argocd/applications/agents/codex-spark-agentprovider.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
