### PR TITLE
fix(temporal-bun-sdk): decouple release soak from publish

### DIFF
--- a/.github/workflows/temporal-bun-sdk-nightly.yml
+++ b/.github/workflows/temporal-bun-sdk-nightly.yml
@@ -136,6 +136,18 @@ jobs:
             echo "activity_concurrency=${activity_concurrency}"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Run Temporal Bun SDK tests
+        run: |
+          cd packages/temporal-bun-sdk
+          TEMPORAL_TEST_SERVER=1 bun test --timeout=30000 --max-concurrency=1
+
+      - name: Verify replay corpus
+        run: bun run --filter @proompteng/temporal-bun-sdk verify:replay-corpus
+
+      - name: Run worker load suite
+        run: |
+          TEMPORAL_TEST_SERVER=1 bun run --filter @proompteng/temporal-bun-sdk test:load
+
       - name: Run long soak
         run: |
           bun run --filter @proompteng/temporal-bun-sdk test:soak -- \
@@ -164,6 +176,12 @@ jobs:
         with:
           name: temporal-bun-sdk-long-soak-${{ steps.soak.outputs.mode || 'nightly' }}
           path: |
+            packages/temporal-bun-sdk/.artifacts/async-fuzz/report.json
+            packages/temporal-bun-sdk/.artifacts/replay-corpus/report.json
+            packages/temporal-bun-sdk/.artifacts/worker-load/report.json
+            packages/temporal-bun-sdk/.artifacts/worker-load/metrics.jsonl
+            packages/temporal-bun-sdk/.artifacts/worker-load/memory.jsonl
+            packages/temporal-bun-sdk/.artifacts/worker-load/temporal-cli.log
             packages/temporal-bun-sdk/.artifacts/worker-soak/report.json
             packages/temporal-bun-sdk/.artifacts/worker-soak/memory.jsonl
             packages/temporal-bun-sdk/.artifacts/worker-soak/iteration-*/report.json

--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -9,12 +9,14 @@ on:
       - 'packages/temporal-bun-sdk-example/**'
       - 'apps/docs/content/docs/temporal-bun-sdk*.mdx'
       - '.github/workflows/temporal-bun-sdk.yml'
+      - '.github/workflows/temporal-bun-sdk-nightly.yml'
   pull_request:
     paths:
       - 'packages/temporal-bun-sdk/**'
       - 'packages/temporal-bun-sdk-example/**'
       - 'apps/docs/content/docs/temporal-bun-sdk*.mdx'
       - '.github/workflows/temporal-bun-sdk.yml'
+      - '.github/workflows/temporal-bun-sdk-nightly.yml'
   workflow_dispatch:
     inputs:
       npm_tag:
@@ -34,6 +36,11 @@ on:
         options:
           - prepare
           - publish
+      release_soak_run_id:
+        description: 'Required for publish: successful Temporal Bun SDK Long Soak release-mode workflow run id'
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -146,26 +153,14 @@ jobs:
           TEMPORAL_TEST_SERVER=1 bun run --filter @proompteng/temporal-bun-sdk test:load
 
       - name: Run worker soak smoke
-        if: github.event_name != 'workflow_dispatch' || github.event.inputs.release_mode != 'publish'
         run: |
           TEMPORAL_TEST_SERVER=1 bun run --filter @proompteng/temporal-bun-sdk test:soak -- \
             --duration 1000 \
-            --iterations 4 \
-            --workflows 16 \
-            --workflow-concurrency 4 \
-            --activity-concurrency 6 \
-            --failure-modes "${TEMPORAL_SOAK_FAILURE_MODES}"
-
-      - name: Run worker release soak gate
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'publish'
-        run: |
-          TEMPORAL_TEST_SERVER=1 bun run --filter @proompteng/temporal-bun-sdk test:soak -- \
-            --duration 21600000 \
-            --iterations 12 \
-            --workflows 1000 \
-            --workflow-concurrency 50 \
-            --activity-concurrency 80 \
-            --failure-modes "${TEMPORAL_SOAK_FAILURE_MODES}"
+            --iterations 1 \
+            --workflows 4 \
+            --workflow-concurrency 2 \
+            --activity-concurrency 2 \
+            --failure-modes baseline
 
       - name: Verify Temporal Bun SDK load cleanup
         run: bun packages/temporal-bun-sdk/scripts/cleanup-integration-workflows.ts --verify
@@ -264,6 +259,7 @@ jobs:
     needs: test
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'publish' && github.ref == 'refs/heads/main'
     permissions:
+      actions: read
       contents: read
       id-token: write
       issues: write
@@ -300,6 +296,7 @@ jobs:
           version_value=$(node -p "require('./packages/temporal-bun-sdk/package.json').version")
           npm_tag_input="${{ github.event.inputs.npm_tag || 'latest' }}"
           dry_run_input="${{ github.event.inputs.dry_run || 'false' }}"
+          release_soak_run_id="${{ github.event.inputs.release_soak_run_id || '' }}"
 
           case "$dry_run_input" in
             true|True|TRUE) dry_run_value=true ;;
@@ -309,11 +306,20 @@ jobs:
               exit 1
               ;;
           esac
+          if [[ -z "$release_soak_run_id" ]]; then
+            echo 'release_soak_run_id is required for publish; run Temporal Bun SDK Long Soak with mode=release first.' >&2
+            exit 1
+          fi
+          if [[ ! "$release_soak_run_id" =~ ^[0-9]+$ ]]; then
+            echo 'release_soak_run_id must be a numeric GitHub Actions run id.' >&2
+            exit 1
+          fi
 
           {
             echo "version=$version_value"
             echo "npm_tag=$npm_tag_input"
             echo "dry_run=$dry_run_value"
+            echo "release_soak_run_id=$release_soak_run_id"
           } >> "$GITHUB_OUTPUT"
 
       - name: Confirm package version
@@ -335,11 +341,20 @@ jobs:
           name: production-readiness-artifacts
           path: packages/temporal-bun-sdk
 
+      - name: Download release soak evidence
+        uses: actions/download-artifact@v5
+        with:
+          name: temporal-bun-sdk-long-soak-release
+          run-id: ${{ steps.release_meta.outputs.release_soak_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: packages/temporal-bun-sdk
+
       - name: Verify production package boundary
         env:
           TEMPORAL_BUN_EVIDENCE_PURPOSE: publish
           TEMPORAL_BUN_NPM_TAG: ${{ steps.release_meta.outputs.npm_tag }}
           TEMPORAL_BUN_DRY_RUN: ${{ steps.release_meta.outputs.dry_run }}
+          TEMPORAL_BUN_RELEASE_SOAK_RUN_ID: ${{ steps.release_meta.outputs.release_soak_run_id }}
         run: bun run --filter @proompteng/temporal-bun-sdk verify:production
 
       - name: Verify default-choice readiness
@@ -347,6 +362,7 @@ jobs:
           TEMPORAL_BUN_EVIDENCE_PURPOSE: publish
           TEMPORAL_BUN_NPM_TAG: ${{ steps.release_meta.outputs.npm_tag }}
           TEMPORAL_BUN_DRY_RUN: ${{ steps.release_meta.outputs.dry_run }}
+          TEMPORAL_BUN_RELEASE_SOAK_RUN_ID: ${{ steps.release_meta.outputs.release_soak_run_id }}
         run: bun run --filter @proompteng/temporal-bun-sdk verify:default-choice
 
       - name: Verify packed readiness artifacts
@@ -360,6 +376,7 @@ jobs:
           TEMPORAL_BUN_EVIDENCE_PURPOSE: publish
           TEMPORAL_BUN_NPM_TAG: ${{ steps.release_meta.outputs.npm_tag }}
           TEMPORAL_BUN_DRY_RUN: ${{ steps.release_meta.outputs.dry_run }}
+          TEMPORAL_BUN_RELEASE_SOAK_RUN_ID: ${{ steps.release_meta.outputs.release_soak_run_id }}
           TEMPORAL_REQUIRE_DEFAULT_CHOICE: '1'
           NPM_DIST_TAG: ${{ steps.release_meta.outputs.npm_tag }}
           DRY_RUN: ${{ steps.release_meta.outputs.dry_run }}

--- a/packages/temporal-bun-sdk/scripts/collect-production-evidence.ts
+++ b/packages/temporal-bun-sdk/scripts/collect-production-evidence.ts
@@ -150,6 +150,11 @@ type ReleaseProvenanceEvidence = {
     readonly distTag: string | null
     readonly dryRun: string | null
   }
+  readonly releaseSoak: {
+    readonly runId: string | null
+    readonly runUrl: string | null
+    readonly artifactName: string
+  }
   readonly artifactBundles: readonly {
     readonly name: string
     readonly runUrl: string | null
@@ -251,6 +256,24 @@ type SoakReport = {
   readonly passed?: boolean
   readonly durationMs?: number
   readonly elapsedMs?: number
+  readonly provenance?: {
+    readonly package?: {
+      readonly name?: string | null
+      readonly version?: string | null
+    }
+    readonly git?: {
+      readonly sha?: string | null
+      readonly branch?: string | null
+    }
+    readonly githubActions?: {
+      readonly present?: boolean
+      readonly repository?: string | null
+      readonly workflow?: string | null
+      readonly runId?: string | null
+      readonly runAttempt?: string | null
+      readonly sha?: string | null
+    }
+  }
   readonly failureModeCoverage?: Record<string, number>
   readonly failureModeEvidence?: Record<string, Record<string, number>>
   readonly memorySummary?: SoakMemorySummary
@@ -927,6 +950,60 @@ const validateReleaseSoakLoadEvidence = (report: SoakReport | null): LoadEvidenc
   }
 }
 
+const validateSoakProvenance = (
+  report: SoakReport | null,
+  packageJson: PackageJson,
+  localGitSha: string | null,
+): GateStatus => {
+  if (!report) {
+    return buildGate(false, 'missing release-soak report')
+  }
+
+  const missing: string[] = []
+  const provenance = report.provenance
+  if (!provenance) {
+    missing.push('soak report provenance missing')
+  }
+
+  const packageName = provenance?.package?.name ?? null
+  const packageVersion = provenance?.package?.version ?? null
+  const gitSha = provenance?.git?.sha ?? null
+  const githubSha = provenance?.githubActions?.sha ?? null
+  const githubRunId = provenance?.githubActions?.runId ?? null
+  const expectedReleaseSoakRunId = process.env.TEMPORAL_BUN_RELEASE_SOAK_RUN_ID?.trim() || null
+
+  if (packageName !== packageJson.name) {
+    missing.push(`soak package name ${packageName ?? 'missing'} does not match ${packageJson.name ?? 'missing'}`)
+  }
+  if (packageVersion !== packageJson.version) {
+    missing.push(
+      `soak package version ${packageVersion ?? 'missing'} does not match ${packageJson.version ?? 'missing'}`,
+    )
+  }
+  if (!gitSha) {
+    missing.push('soak git SHA missing')
+  } else if (localGitSha && gitSha !== localGitSha) {
+    missing.push(`soak git SHA ${gitSha} does not match local git SHA ${localGitSha}`)
+  }
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    if (!githubSha) {
+      missing.push('soak GitHub Actions SHA missing')
+    } else if (localGitSha && githubSha !== localGitSha) {
+      missing.push(`soak GitHub Actions SHA ${githubSha} does not match local git SHA ${localGitSha}`)
+    }
+    if (expectedReleaseSoakRunId && githubRunId !== expectedReleaseSoakRunId) {
+      missing.push(`soak GitHub Actions run id ${githubRunId ?? 'missing'} does not match ${expectedReleaseSoakRunId}`)
+    }
+  }
+
+  return buildGate(
+    missing.length === 0,
+    missing.length === 0
+      ? `package=${packageName}@${packageVersion}; gitSha=${gitSha}; githubSha=${githubSha ?? 'none'}; runId=${githubRunId ?? 'none'}`
+      : `missing=${missing.join(' | ')}`,
+  )
+}
+
 const collectProductionUsageEvidence = async (): Promise<ProductionUsageEvidence> => {
   const services: ProductionUsageServiceEvidence[] = []
 
@@ -986,6 +1063,9 @@ const requiredCiCommands = [
   'TEMPORAL_TEST_SERVER=1 bun run --filter @proompteng/temporal-bun-sdk test:load',
   'TEMPORAL_TEST_SERVER=1 bun run --filter @proompteng/temporal-bun-sdk test:soak',
   'TEMPORAL_BUN_EVIDENCE_PURPOSE',
+  'release_soak_run_id',
+  'temporal-bun-sdk-long-soak-release',
+  'TEMPORAL_BUN_RELEASE_SOAK_RUN_ID',
   'bun run --filter @proompteng/temporal-bun-sdk verify:production',
   'bun run --filter @proompteng/temporal-bun-sdk verify:default-choice',
   'bun run --filter @proompteng/temporal-bun-sdk verify:packed-readiness',
@@ -1000,12 +1080,18 @@ const requiredLongSoakWorkflowFragments = [
   "TEMPORAL_TEST_SERVER: '1'",
   'TEMPORAL_ADDRESS: temporal-grpc:7233',
   'TEMPORAL_SOAK_FAILURE_MODES: baseline,worker-restart,sticky-cache-churn,update-rejection-termination,activity-cancellation',
+  'TEMPORAL_TEST_SERVER=1 bun test --timeout=30000 --max-concurrency=1',
+  'bun run --filter @proompteng/temporal-bun-sdk verify:replay-corpus',
+  'TEMPORAL_TEST_SERVER=1 bun run --filter @proompteng/temporal-bun-sdk test:load',
   'bun run --filter @proompteng/temporal-bun-sdk test:soak',
   '--duration "${{ steps.soak.outputs.duration }}"',
   '--iterations "${{ steps.soak.outputs.iterations }}"',
   '--failure-modes "${TEMPORAL_SOAK_FAILURE_MODES}"',
   'bun run --filter @proompteng/temporal-bun-sdk verify:default-choice',
   'TEMPORAL_BUN_EVIDENCE_PURPOSE: release-soak',
+  'packages/temporal-bun-sdk/.artifacts/async-fuzz/report.json',
+  'packages/temporal-bun-sdk/.artifacts/replay-corpus/report.json',
+  'packages/temporal-bun-sdk/.artifacts/worker-load/report.json',
   'packages/temporal-bun-sdk/.artifacts/worker-soak/memory.jsonl',
   'packages/temporal-bun-sdk/dist/release-provenance.json',
   'actions/upload-artifact@v5',
@@ -1077,7 +1163,11 @@ const collectReleaseProvenanceEvidence = async (
   const purpose = process.env.TEMPORAL_BUN_EVIDENCE_PURPOSE?.trim() || null
   const npmDistTag = process.env.TEMPORAL_BUN_NPM_TAG?.trim() || null
   const npmDryRun = process.env.TEMPORAL_BUN_DRY_RUN?.trim() || null
+  const releaseSoakRunId =
+    process.env.TEMPORAL_BUN_RELEASE_SOAK_RUN_ID?.trim() || (purpose === 'release-soak' ? runId : null)
   const runUrl = serverUrl && repository && runId ? `${serverUrl}/${repository}/actions/runs/${runId}` : null
+  const releaseSoakRunUrl =
+    serverUrl && repository && releaseSoakRunId ? `${serverUrl}/${repository}/actions/runs/${releaseSoakRunId}` : null
   const evidenceArtifacts = await Promise.all(artifactPaths.map((artifactPath) => hashArtifact(artifactPath)))
   const missing: string[] = []
 
@@ -1127,6 +1217,11 @@ const collectReleaseProvenanceEvidence = async (
     if (!npmDryRun) {
       missing.push('TEMPORAL_BUN_DRY_RUN missing for publish provenance')
     }
+    if (!releaseSoakRunId) {
+      missing.push('TEMPORAL_BUN_RELEASE_SOAK_RUN_ID missing for publish provenance')
+    } else if (!/^[0-9]+$/.test(releaseSoakRunId)) {
+      missing.push(`TEMPORAL_BUN_RELEASE_SOAK_RUN_ID=${releaseSoakRunId} is not a numeric GitHub Actions run id`)
+    }
   }
   for (const artifact of evidenceArtifacts) {
     if (!artifact.present || !artifact.sha256 || artifact.sizeBytes === null) {
@@ -1164,9 +1259,15 @@ const collectReleaseProvenanceEvidence = async (
       distTag: npmDistTag,
       dryRun: npmDryRun,
     },
+    releaseSoak: {
+      runId: releaseSoakRunId,
+      runUrl: releaseSoakRunUrl,
+      artifactName: 'temporal-bun-sdk-long-soak-release',
+    },
     artifactBundles: [
       { name: 'worker-load-artifacts', runUrl },
       { name: 'production-readiness-artifacts', runUrl },
+      { name: 'temporal-bun-sdk-long-soak-release', runUrl: releaseSoakRunUrl },
     ],
     evidenceArtifacts,
     readinessArtifactTargets: [
@@ -1327,6 +1428,7 @@ const main = async () => {
   const soakMemoryReady = soakMemorySampleCount > 0 && soakMemorySummary?.withinSlopeLimit !== false
   const missingSoakFailureModes = requiredSoakFailureModes.filter((mode) => (soakFailureModeCoverage[mode] ?? 0) <= 0)
   const soakPassed = soakReport?.passed === true && soakIterationsPassed
+  const soakProvenance = validateSoakProvenance(soakReport, packageJson, localGitSha)
   const docsHash = await hashDocs()
   const productionUsage = await collectProductionUsageEvidence()
   const adoptionSurface = collectAdoptionSurfaceEvidence(packageJson)
@@ -1383,6 +1485,7 @@ const main = async () => {
         soakIterationCount >= minimumSoakIterations &&
         soakElapsedMs >= minimumSoakDurationMs &&
         soakMemoryReady &&
+        soakProvenance.passed &&
         missingSoakFailureModes.length === 0 &&
         missingSoakFailureEvidence.length === 0,
       soakReport
@@ -1393,7 +1496,7 @@ const main = async () => {
             `rssSlopeMbPerHour=${soakMemorySummary?.rssSlopeMbPerHour?.toFixed(2) ?? 'unknown'}; ` +
             `slopeAssessment=${soakMemorySummary?.slopeAssessment ?? 'unknown'}; ` +
             `memorySlopeLimitMbPerHour=${soakMemorySummary?.slopeLimitMbPerHour ?? 'unknown'}; ` +
-            `path=${relative(packageRoot, soakReportPath)}`
+            `path=${relative(packageRoot, soakReportPath)}; provenance=${soakProvenance.detail}`
         : 'missing',
     ),
     ciWorkflowCoverage: await validateCiWorkflowCoverage(),

--- a/packages/temporal-bun-sdk/scripts/run-worker-soak.ts
+++ b/packages/temporal-bun-sdk/scripts/run-worker-soak.ts
@@ -4,6 +4,8 @@ import { parseArgs } from 'node:util'
 import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
+const packageRoot = join(import.meta.dir, '..')
+
 const failureModes = [
   'baseline',
   'worker-restart',
@@ -50,12 +52,14 @@ const minimumIterations = Math.max(
 )
 const startedAt = Date.now()
 const deadline = startedAt + durationMs
-const artifactsDir = process.env.TEMPORAL_SOAK_ARTIFACTS_DIR ?? join(process.cwd(), '.artifacts', 'worker-soak')
+const artifactsDir = process.env.TEMPORAL_SOAK_ARTIFACTS_DIR ?? join(packageRoot, '.artifacts', 'worker-soak')
 const requestedFailureModes = parseFailureModes(
   String(argv.values['failure-modes'] ?? process.env.TEMPORAL_SOAK_FAILURE_MODES ?? 'baseline'),
 )
 const iterations: SoakIteration[] = []
 const memorySamplesPath = join(artifactsDir, 'memory.jsonl')
+const packageJsonPath = join(packageRoot, 'package.json')
+const packageJson = await readOptionalJson<PackageJson>(packageJsonPath)
 
 const applyOverride = (name: string, value: string | boolean | undefined) => {
   if (value !== undefined) {
@@ -82,7 +86,7 @@ while (Date.now() < deadline || iteration < minimumIterations) {
   const memoryBefore = await memoryRecorder.sample('before-iteration', { iteration, mode })
 
   const child = Bun.spawn(['bun', 'scripts/run-worker-load.ts'], {
-    cwd: process.cwd(),
+    cwd: packageRoot,
     stdout: 'inherit',
     stderr: 'inherit',
     env: {
@@ -134,6 +138,24 @@ const report = {
     arch: process.arch,
     temporalAddress: process.env.TEMPORAL_ADDRESS ?? '127.0.0.1:7233',
     temporalNamespace: process.env.TEMPORAL_NAMESPACE ?? 'default',
+  },
+  provenance: {
+    package: {
+      name: packageJson?.name ?? null,
+      version: packageJson?.version ?? null,
+    },
+    git: {
+      sha: await safeGitOutput(['rev-parse', 'HEAD']),
+      branch: await safeGitOutput(['rev-parse', '--abbrev-ref', 'HEAD']),
+    },
+    githubActions: {
+      present: process.env.GITHUB_ACTIONS === 'true',
+      repository: process.env.GITHUB_REPOSITORY ?? null,
+      workflow: process.env.GITHUB_WORKFLOW ?? null,
+      runId: process.env.GITHUB_RUN_ID ?? null,
+      runAttempt: process.env.GITHUB_RUN_ATTEMPT ?? null,
+      sha: process.env.GITHUB_SHA ?? null,
+    },
   },
   passed: iterations.length > 0 && iterations.every((entry) => entry.exitCode === 0),
   iterations,
@@ -230,6 +252,11 @@ type FailureInjectionReport = {
     readonly runId?: string
     readonly status?: string
   }[]
+}
+
+type PackageJson = {
+  readonly name?: string
+  readonly version?: string
 }
 
 type MemorySample = {
@@ -346,6 +373,20 @@ async function readOptionalJson<T>(path: string): Promise<T | null> {
   } catch {
     return null
   }
+}
+
+async function safeGitOutput(args: readonly string[]): Promise<string | null> {
+  const child = Bun.spawn(['git', ...args], {
+    cwd: packageRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [exitCode, stdout] = await Promise.all([child.exited, new Response(child.stdout).text()])
+  if (exitCode !== 0) {
+    return null
+  }
+  const trimmed = stdout.trim()
+  return trimmed.length > 0 ? trimmed : null
 }
 
 function summarizeLoadReport(report: WorkerLoadReport | null): LoadReportSummary | null {

--- a/packages/temporal-bun-sdk/tests/packaging/manifest-packaging.test.ts
+++ b/packages/temporal-bun-sdk/tests/packaging/manifest-packaging.test.ts
@@ -227,6 +227,7 @@ describe('temporal-bun-sdk packaging manifest', () => {
         git?: { localSha?: string | null; githubSha?: string | null; shaMatchesGithub?: boolean }
         githubActions?: { present?: boolean; runUrl?: string | null; runId?: string | null }
         npm?: { distTag?: string | null; dryRun?: string | null }
+        releaseSoak?: { runId?: string | null; runUrl?: string | null; artifactName?: string }
         artifactBundles?: Array<{ name?: string; runUrl?: string | null }>
         evidenceArtifacts?: Array<{ path?: string; present?: boolean; sizeBytes?: number | null; sha256?: string | null }>
         readinessArtifactTargets?: string[]
@@ -370,6 +371,12 @@ describe('temporal-bun-sdk packaging manifest', () => {
     )
     expect(productionEvidence.releaseProvenance?.artifactBundles?.map((artifact) => artifact.name)).toContain(
       'production-readiness-artifacts',
+    )
+    expect(productionEvidence.releaseProvenance?.artifactBundles?.map((artifact) => artifact.name)).toContain(
+      'temporal-bun-sdk-long-soak-release',
+    )
+    expect(productionEvidence.releaseProvenance?.releaseSoak?.artifactName).toBe(
+      'temporal-bun-sdk-long-soak-release',
     )
     expect(releaseProvenance.releaseProvenanceManifest).toBe('dist/release-provenance.json')
     expect(releaseProvenance.readinessArtifacts?.map((artifact) => artifact.path).sort()).toEqual([


### PR DESCRIPTION
## Summary

- Require publish-mode Temporal Bun SDK releases to provide a prior release-mode long-soak GitHub Actions run id instead of running the six-hour soak inline.
- Make the long-soak workflow artifact self-contained by including replay corpus, async-fuzz, worker-load, worker-soak, and readiness evidence.
- Add package/version/git/GitHub run provenance to worker-soak reports and verify it before default-choice readiness can pass.

## Related Issues

None

## Testing

- `bunx oxfmt --check packages/temporal-bun-sdk/scripts/run-worker-soak.ts packages/temporal-bun-sdk/scripts/collect-production-evidence.ts packages/temporal-bun-sdk/tests/packaging/manifest-packaging.test.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/temporal-bun-sdk.yml"); YAML.load_file(".github/workflows/temporal-bun-sdk-nightly.yml"); puts "ok"'`
- `bun test packages/temporal-bun-sdk/tests/packaging/manifest-packaging.test.ts --timeout=30000`
- `bun run --filter @proompteng/temporal-bun-sdk build`
- `bun run --filter @proompteng/temporal-bun-sdk verify:production`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint`
- `bun run --cwd packages/temporal-bun-sdk lint:oxlint:type`

## Breaking Changes

Publish-mode workflow dispatch now requires a successful `Temporal Bun SDK Long Soak` release-mode run id in `release_soak_run_id`.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
