### PR TITLE
chore(torghut): promote image 4e5fe3b4

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.0-71-gb9db29ad1
+              value: v0.571.0-77-g4e5fe3b49
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b9db29ad19258d616a092e258e60a8c6c7674da1
+              value: 4e5fe3b4910e4b557c8d3aea97d6edc9bcb4e0f2
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.0-71-gb9db29ad1
+              value: v0.571.0-77-g4e5fe3b49
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b9db29ad19258d616a092e258e60a8c6c7674da1
+              value: 4e5fe3b4910e4b557c8d3aea97d6edc9bcb4e0f2
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-16T23:44:29Z"
+        client.knative.dev/updateTimestamp: "2026-05-17T00:49:27Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
           ports:
             - name: http1
               containerPort: 8181
@@ -495,11 +495,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.0-71-gb9db29ad1
+              value: v0.571.0-77-g4e5fe3b49
             - name: TORGHUT_COMMIT
-              value: b9db29ad19258d616a092e258e60a8c6c7674da1
+              value: 4e5fe3b4910e4b557c8d3aea97d6edc9bcb4e0f2
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+              value: sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-16T23:44:29Z"
+        client.knative.dev/updateTimestamp: "2026-05-17T00:49:27Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
           ports:
             - name: http1
               containerPort: 8181
@@ -316,11 +316,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.0-71-gb9db29ad1
+              value: v0.571.0-77-g4e5fe3b49
             - name: TORGHUT_COMMIT
-              value: b9db29ad19258d616a092e258e60a8c6c7674da1
+              value: 4e5fe3b4910e4b557c8d3aea97d6edc9bcb4e0f2
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+              value: sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47e3a8c36d4ca13c1d2800af26d76e4a9539a6380a29e351ce96493517324565
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `4e5fe3b4910e4b557c8d3aea97d6edc9bcb4e0f2`
- Image tag: `4e5fe3b4`
- Image digest: `sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58`