### PR TITLE
fix(torghut-options): restart failed ta flink job

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
   imagePullPolicy: IfNotPresent
-  restartNonce: 5
+  restartNonce: 6
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:


### PR DESCRIPTION
## Summary

- Bumps the GitOps `restartNonce` for `torghut-options-ta` from `5` to `6`.
- Recovers the failed options Flink job that exhausted fixed-delay retries after a Kafka partition position lookup timeout.
- Keeps the existing image, Flink job config, and upgrade mode unchanged.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut-options >/tmp/torghut-options-kustomize.yaml && rg -n 'name: torghut-options-ta|restartNonce:' /tmp/torghut-options-kustomize.yaml`
- `kubectl get flinkdeployment -n torghut torghut-options-ta -o yaml | sed -n '1,220p'`
- `kubectl logs -n torghut deploy/torghut-options-ta --tail=160`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
