### PR TITLE
chore(jangar): promote image 52d3424c

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 966a6a57
-  digest: sha256:d5ac66038d6e9890eee25dea82470ffb5dacabe43ce388289405e6beb8cf5516
+  tag: 52d3424c
+  digest: sha256:9e5127ba48fd1403d868b44d87c152e2c7afec369780cf9586a8eab33f41dd2e
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 966a6a57
-    digest: sha256:fada3cd1142d181dd8168e06f8ed7e0182e2ab1f57a434b66548754dc305d332
+    tag: 52d3424c
+    digest: sha256:ee23b0676da57dfea531604eb8140571f9f515e8032fef6120a38fb707f26638
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "12000"
-      JANGAR_SOURCE_HEAD_SHA: 966a6a574e3abfd702c899dd6f0053237126dc04
-      JANGAR_GITOPS_REVISION: 966a6a574e3abfd702c899dd6f0053237126dc04
-      JANGAR_SOURCE_CI_RUN_ID: "25976648014"
+      JANGAR_SOURCE_HEAD_SHA: 52d3424c7a383096422114824f39c1d2b9efe19a
+      JANGAR_GITOPS_REVISION: 52d3424c7a383096422114824f39c1d2b9efe19a
+      JANGAR_SOURCE_CI_RUN_ID: "25977969267"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:fada3cd1142d181dd8168e06f8ed7e0182e2ab1f57a434b66548754dc305d332
-      JANGAR_SERVING_BUILD_COMMIT: 966a6a574e3abfd702c899dd6f0053237126dc04
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:fada3cd1142d181dd8168e06f8ed7e0182e2ab1f57a434b66548754dc305d332
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:ee23b0676da57dfea531604eb8140571f9f515e8032fef6120a38fb707f26638
+      JANGAR_SERVING_BUILD_COMMIT: 52d3424c7a383096422114824f39c1d2b9efe19a
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:ee23b0676da57dfea531604eb8140571f9f515e8032fef6120a38fb707f26638
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 966a6a57
-    digest: sha256:d5ac66038d6e9890eee25dea82470ffb5dacabe43ce388289405e6beb8cf5516
+    tag: 52d3424c
+    digest: sha256:9e5127ba48fd1403d868b44d87c152e2c7afec369780cf9586a8eab33f41dd2e
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-17T00:18:00Z
+    deploy.knative.dev/rollout: 2026-05-17T01:28:41Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:966a6a57@sha256:d5ac66038d6e9890eee25dea82470ffb5dacabe43ce388289405e6beb8cf5516
+              value: registry.ide-newton.ts.net/lab/jangar:52d3424c@sha256:9e5127ba48fd1403d868b44d87c152e2c7afec369780cf9586a8eab33f41dd2e
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 966a6a574e3abfd702c899dd6f0053237126dc04
+              value: 52d3424c7a383096422114824f39c1d2b9efe19a
             - name: JANGAR_GITOPS_REVISION
-              value: 966a6a574e3abfd702c899dd6f0053237126dc04
+              value: 52d3424c7a383096422114824f39c1d2b9efe19a
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25976648014"
+              value: "25977969267"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:fada3cd1142d181dd8168e06f8ed7e0182e2ab1f57a434b66548754dc305d332
+              value: sha256:ee23b0676da57dfea531604eb8140571f9f515e8032fef6120a38fb707f26638
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 966a6a574e3abfd702c899dd6f0053237126dc04
+              value: 52d3424c7a383096422114824f39c1d2b9efe19a
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:fada3cd1142d181dd8168e06f8ed7e0182e2ab1f57a434b66548754dc305d332
+              value: sha256:ee23b0676da57dfea531604eb8140571f9f515e8032fef6120a38fb707f26638
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 966a6a57
-    digest: sha256:d5ac66038d6e9890eee25dea82470ffb5dacabe43ce388289405e6beb8cf5516
+    newTag: 52d3424c
+    digest: sha256:9e5127ba48fd1403d868b44d87c152e2c7afec369780cf9586a8eab33f41dd2e


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `52d3424c7a383096422114824f39c1d2b9efe19a`
- Image tag: `52d3424c`
- Image digest: `sha256:9e5127ba48fd1403d868b44d87c152e2c7afec369780cf9586a8eab33f41dd2e`
- Source CI run: `25977969267`
- Control-plane serving digest: `sha256:ee23b0676da57dfea531604eb8140571f9f515e8032fef6120a38fb707f26638`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates