### PR TITLE
fix(torghut): block overgross autoresearch replay candidates

### DIFF
--- a/docs/torghut/design-system/v6/214-torghut-current-whitepaper-to-profitable-strategy-workflow-2026-05-16.md
+++ b/docs/torghut/design-system/v6/214-torghut-current-whitepaper-to-profitable-strategy-workflow-2026-05-16.md
@@ -16,31 +16,31 @@ single sleeve that prints `$500` daily.
 ```mermaid
 flowchart TD
   Paper["Whitepaper or research note"] --> Ingest["Whitepaper ingest and versioning"]
-  Ingest --> Claims["Claim compiler: mechanism, signal, data, risk, validation"]
-  Claims --> Cards["Hypothesis cards: bounded, falsifiable, feature-linked"]
-  Cards --> Factory["Candidate compiler: checked runtime family ids only"]
-  Factory --> Specs["CandidateSpec ledger: family, universe, features, risk, execution"]
+  Ingest --> Claims["Claim compiler<br/>mechanism, signal, data,<br/>risk, validation"]
+  Claims --> Cards["Hypothesis cards<br/>bounded, falsifiable,<br/>feature-linked"]
+  Cards --> Factory["Candidate compiler<br/>checked runtime family ids only"]
+  Factory --> Specs["CandidateSpec ledger<br/>family, universe, features,<br/>risk, execution"]
 
-  Specs --> Snapshot["Immutable epoch snapshot: specs, evidence, feature contracts"]
-  Snapshot --> MLX["MLX proposal ranker: ranking only, no promotion authority"]
-  MLX --> Budget["Replay budget selector: top-K, exploration, backfill"]
+  Specs --> Snapshot["Immutable epoch snapshot<br/>specs, evidence,<br/>feature contracts"]
+  Snapshot --> MLX["MLX proposal ranker<br/>ranking only,<br/>no promotion authority"]
+  MLX --> Budget["Replay budget selector<br/>top-K, exploration,<br/>backfill"]
   Specs --> Budget
 
-  Budget --> Replay["Runtime replay: scheduler-v3 real replay mode"]
-  Replay --> Evidence["CandidateEvidenceBundle: PnL, notional, cash, drawdown, blockers"]
-  Evidence --> Optimizer["Portfolio optimizer: weights, correlation, exposure, concentration"]
-  Optimizer --> Portfolio["PortfolioCandidateSpec: portfolio objective scorecard"]
+  Budget --> Replay["Runtime replay<br/>scheduler-v3 real replay mode"]
+  Replay --> Evidence["CandidateEvidenceBundle<br/>PnL, notional, cash,<br/>drawdown, blockers"]
+  Evidence --> Optimizer["Portfolio optimizer<br/>weights, correlation,<br/>exposure, concentration"]
+  Optimizer --> Portfolio["PortfolioCandidateSpec<br/>portfolio objective scorecard"]
 
   Portfolio --> Oracle{"Profit target oracle"}
-  Oracle -->|"fail"| LedgerFail["Persist failure table: false positives, blockers, next plan"]
-  LedgerFail --> Train["Train next proposal model: rank-bucket lift and replay feedback"]
+  Oracle -->|"fail"| LedgerFail["Persist failure table<br/>false positives, blockers,<br/>next plan"]
+  LedgerFail --> Train["Train next proposal model<br/>rank-bucket lift and<br/>replay feedback"]
   Train --> MLX
 
-  Oracle -->|"pass"| Closure["Runtime closure: config, replay plan, parity plan, approvals"]
+  Oracle -->|"pass"| Closure["Runtime closure<br/>config, replay plan,<br/>parity plan, approvals"]
   Closure --> Shadow{"Paper/shadow gate"}
   Shadow -->|"fail"| LedgerFail
-  Shadow -->|"pass"| Promotion["Promotion readiness receipt: no MLX-only promotion"]
-  Promotion --> LiveSleeve["Live strategy / sleeve candidate: controlled rollout eligible"]
+  Shadow -->|"pass"| Promotion["Promotion readiness receipt<br/>no MLX-only promotion"]
+  Promotion --> LiveSleeve["Live strategy / sleeve candidate<br/>controlled rollout eligible"]
 ```
 
 ## Promotion State Machine

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -3174,6 +3174,7 @@ def _select_candidate_specs_for_replay(
         "pre_replay_mlx_risk_profile_feedback_blocked",
         "pre_replay_mlx_family_feedback_blocked",
     }
+    capital_block_reason = "pre_replay_capital_budget_blocked"
 
     def proposal_score(candidate_spec_id: str) -> Decimal:
         return _decimal(
@@ -3197,11 +3198,28 @@ def _select_candidate_specs_for_replay(
         except (TypeError, ValueError):
             return 0
 
+    def capital_blocked(spec: CandidateSpec) -> bool:
+        features = capital_features_by_spec.get(spec.candidate_spec_id, {})
+        oracle_policy = _mapping(
+            spec.promotion_contract.get("profit_target_oracle_policy")
+        )
+        max_gross_exposure = _decimal(
+            oracle_policy.get("max_gross_exposure_pct_equity"), default="1.0"
+        )
+        return (
+            _decimal(features.get("capital_feasible_flag")) < Decimal("1")
+            or _decimal(features.get("capital_budget_overage_ratio")) > Decimal("0")
+            or _decimal(features.get("estimated_max_gross_exposure_pct_equity"))
+            > max_gross_exposure
+        )
+
     def pre_replay_block_reason(spec: CandidateSpec) -> str:
         proposal = proposal_by_spec.get(spec.candidate_spec_id, {})
         selection_reason = _string(proposal.get("selection_reason"))
         if selection_reason in feedback_block_reasons:
             return selection_reason
+        if capital_blocked(spec):
+            return capital_block_reason
         score = proposal_score(spec.candidate_spec_id)
         if proposal.get("proposal_score") is not None and score <= Decimal("-999999"):
             return "pre_replay_mlx_feedback_blocked"
@@ -3528,6 +3546,11 @@ def _select_candidate_specs_for_replay(
                 1
                 for reason in block_reason_by_spec.values()
                 if reason == "pre_replay_mlx_synthetic_nonpositive_expected_value"
+            ),
+            "pre_replay_capital_blocked_candidate_count": sum(
+                1
+                for reason in block_reason_by_spec.values()
+                if reason == capital_block_reason
             ),
             "pre_replay_blocked_candidate_count": len(block_reason_by_spec),
             "replay_order_policy": "quality_gated_diversity_pick_order",

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -1137,6 +1137,66 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "exploitation",
         )
 
+    def test_candidate_selection_blocks_capital_infeasible_replay_candidates(
+        self,
+    ) -> None:
+        base_unsafe_spec = self._candidate_spec("spec-unsafe-capital")
+        unsafe_spec = replace(
+            base_unsafe_spec,
+            strategy_overrides={
+                **base_unsafe_spec.strategy_overrides,
+                "max_notional_per_trade": "157950",
+                "max_position_pct_equity": "8.0",
+            },
+            promotion_contract={
+                "profit_target_oracle_policy": {"max_gross_exposure_pct_equity": "1.0"}
+            },
+        )
+        safe_spec = self._candidate_spec("spec-safe-capital")
+        proposal_rows = [
+            {
+                "candidate_spec_id": unsafe_spec.candidate_spec_id,
+                "proposal_score": 1000,
+                "rank": 1,
+                "selection_reason": "pre_replay_mlx_rank",
+                "training_source": "synthetic_prior",
+            },
+            {
+                "candidate_spec_id": safe_spec.candidate_spec_id,
+                "proposal_score": 10,
+                "rank": 2,
+                "selection_reason": "pre_replay_mlx_rank",
+                "training_source": "synthetic_prior",
+            },
+        ]
+
+        selected, selection = runner._select_candidate_specs_for_replay(
+            specs=(unsafe_spec, safe_spec),
+            proposal_rows=proposal_rows,
+            top_k=1,
+            exploration_slots=0,
+            max_candidates=1,
+            portfolio_size_min=1,
+        )
+
+        self.assertEqual(selected, [safe_spec])
+        row_by_spec = {row["candidate_spec_id"]: row for row in selection["rows"]}
+        self.assertEqual(
+            row_by_spec[unsafe_spec.candidate_spec_id]["selection_reason"],
+            "pre_replay_capital_budget_blocked",
+        )
+        self.assertFalse(
+            row_by_spec[unsafe_spec.candidate_spec_id]["selected_for_replay"]
+        )
+        self.assertEqual(
+            selection["budget"]["pre_replay_capital_blocked_candidate_count"], 1
+        )
+        self.assertTrue(
+            row_by_spec[safe_spec.candidate_spec_id]["capital_budget"][
+                "capital_feasible"
+            ]
+        )
+
     def test_candidate_selection_keeps_positive_signature_feedback_repair_candidates(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Blocks capital-infeasible autoresearch candidates before they can consume real replay budget.
- Adds `pre_replay_capital_budget_blocked` accounting to the candidate-selection manifest for auditability.
- Adds a regression test where a high-scoring overgross candidate is skipped in favor of a lower-scoring capital-feasible candidate.
- Updates the current whitepaper-to-live workflow diagram to use Mermaid-compatible HTML line break tags instead of renderer-visible escaped newline artifacts.

## Related Issues

None

## Testing

- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q -k 'capital_infeasible or honors_top_k or terminal_risk_profile'`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Live workflow `torghut-whitepaper-autoresearch-profit-target-xw2s8` on image digest `sha256:f8d1badf74043ce546a683a956119cb5b41e5fa7a9664c77047d189fb43c2b58` failed honestly with `status=no_profit_target_candidate` and `status_reason=portfolio_optimizer_produced_no_candidate`; it selected 11 replay candidates and produced no promotable portfolio.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
