### PR TITLE
fix(torghut): report replayable autoresearch surface honestly

### DIFF
--- a/docs/torghut/design-system/v6/214-torghut-current-whitepaper-to-profitable-strategy-workflow-2026-05-16.md
+++ b/docs/torghut/design-system/v6/214-torghut-current-whitepaper-to-profitable-strategy-workflow-2026-05-16.md
@@ -16,31 +16,31 @@ single sleeve that prints `$500` daily.
 ```mermaid
 flowchart TD
   Paper["Whitepaper or research note"] --> Ingest["Whitepaper ingest and versioning"]
-  Ingest --> Claims["Claim compiler<br/>mechanism, signal, data,<br/>risk, validation"]
-  Claims --> Cards["Hypothesis cards<br/>bounded, falsifiable,<br/>feature-linked"]
-  Cards --> Factory["Candidate compiler<br/>checked runtime family ids only"]
-  Factory --> Specs["CandidateSpec ledger<br/>family, universe, features,<br/>risk, execution"]
+  Ingest --> Claims["Claim compiler: mechanism, signal, data, risk, validation"]
+  Claims --> Cards["Hypothesis cards: bounded, falsifiable, feature-linked"]
+  Cards --> Factory["Candidate compiler: checked runtime family ids only"]
+  Factory --> Specs["CandidateSpec ledger: family, universe, features, risk, execution"]
 
-  Specs --> Snapshot["Immutable epoch snapshot<br/>specs, evidence,<br/>feature contracts"]
-  Snapshot --> MLX["MLX proposal ranker<br/>ranking only,<br/>no promotion authority"]
-  MLX --> Budget["Replay budget selector<br/>top-K, exploration,<br/>backfill"]
+  Specs --> Snapshot["Immutable epoch snapshot: specs, evidence, feature contracts"]
+  Snapshot --> MLX["MLX proposal ranker: ranking only, no promotion authority"]
+  MLX --> Budget["Replay budget selector: top-K, exploration, backfill"]
   Specs --> Budget
 
-  Budget --> Replay["Runtime replay<br/>scheduler-v3 real replay mode"]
-  Replay --> Evidence["CandidateEvidenceBundle<br/>PnL, notional, cash,<br/>drawdown, blockers"]
-  Evidence --> Optimizer["Portfolio optimizer<br/>weights, correlation,<br/>exposure, concentration"]
-  Optimizer --> Portfolio["PortfolioCandidateSpec<br/>portfolio objective scorecard"]
+  Budget --> Replay["Runtime replay: scheduler-v3 real replay mode"]
+  Replay --> Evidence["CandidateEvidenceBundle: PnL, notional, cash, drawdown, blockers"]
+  Evidence --> Optimizer["Portfolio optimizer: weights, correlation, exposure, concentration"]
+  Optimizer --> Portfolio["PortfolioCandidateSpec: portfolio objective scorecard"]
 
   Portfolio --> Oracle{"Profit target oracle"}
-  Oracle -->|"fail"| LedgerFail["Persist failure table<br/>false positives, blockers,<br/>next plan"]
-  LedgerFail --> Train["Train next proposal model<br/>rank-bucket lift and<br/>replay feedback"]
+  Oracle -->|"fail"| LedgerFail["Persist failure table: false positives, blockers, next plan"]
+  LedgerFail --> Train["Train next proposal model: rank-bucket lift and replay feedback"]
   Train --> MLX
 
-  Oracle -->|"pass"| Closure["Runtime closure<br/>config, replay plan,<br/>parity plan, approvals"]
+  Oracle -->|"pass"| Closure["Runtime closure: config, replay plan, parity plan, approvals"]
   Closure --> Shadow{"Paper/shadow gate"}
   Shadow -->|"fail"| LedgerFail
-  Shadow -->|"pass"| Promotion["Promotion readiness receipt<br/>no MLX-only promotion"]
-  Promotion --> LiveSleeve["Live strategy / sleeve candidate<br/>controlled rollout eligible"]
+  Shadow -->|"pass"| Promotion["Promotion readiness receipt: no MLX-only promotion"]
+  Promotion --> LiveSleeve["Live strategy / sleeve candidate: controlled rollout eligible"]
 ```
 
 ## Promotion State Machine

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -1457,6 +1457,9 @@ def _best_false_negative_table(
             or candidate_spec_id in evidence_by_spec
             or _string(selection.get("selection_reason"))
             == "duplicate_execution_signature"
+            or _selection_reason_blocks_replay(
+                _string(selection.get("selection_reason"))
+            )
         ):
             continue
         pre_replay = pre_replay_by_spec.get(candidate_spec_id, {})
@@ -1563,6 +1566,16 @@ def _candidate_search_remediation(
         + observed_selection_budget["exploration_slots"]
         >= unique_execution_signature_count
     )
+    replayable_candidate_surface_exhausted = (
+        observed_selection_budget["eligible_candidate_count"] > 0
+        and observed_selection_budget["selected_count"]
+        >= observed_selection_budget["eligible_candidate_count"]
+        and observed_selection_budget["max_candidates"]
+        >= observed_selection_budget["eligible_candidate_count"]
+        and observed_selection_budget["top_k"]
+        + observed_selection_budget["exploration_slots"]
+        >= observed_selection_budget["eligible_candidate_count"]
+    )
     next_actions: list[dict[str, Any]] = []
     if (
         observed_selection_budget["selected_count"] <= 0
@@ -1616,6 +1629,7 @@ def _candidate_search_remediation(
             "failure_reason_counts": dict(sorted(failure_counts.items())),
             "partial_scorecards": partial_scorecards,
             "candidate_surface_exhausted": candidate_surface_exhausted,
+            "replayable_candidate_surface_exhausted": replayable_candidate_surface_exhausted,
             "observed_selection_budget": observed_selection_budget,
             "next_actions": next_actions,
         }
@@ -1705,7 +1719,7 @@ def _candidate_search_remediation(
             "positive_day_ratio_below_oracle",
         )
     ):
-        if candidate_surface_exhausted:
+        if candidate_surface_exhausted or replayable_candidate_surface_exhausted:
             selected_families = sorted(
                 {
                     _string(row.get("family_template_id"))
@@ -1718,8 +1732,16 @@ def _candidate_search_remediation(
                     "priority": 4,
                     "action": "expand_execution_profile_surface",
                     "reason": (
-                        "candidate selection replayed every unique execution signature; "
-                        "max-candidates, top-k, and exploration-slots are no longer binding"
+                        (
+                            "candidate selection replayed every currently eligible execution signature; "
+                            "pre-replay feedback, capital, or expected-value gates blocked the rest"
+                        )
+                        if replayable_candidate_surface_exhausted
+                        and not candidate_surface_exhausted
+                        else (
+                            "candidate selection replayed every unique execution signature; "
+                            "max-candidates, top-k, and exploration-slots are no longer binding"
+                        )
                     ),
                     "observed_selection_budget": observed_selection_budget,
                     "target_family_template_ids": selected_families,
@@ -1817,6 +1839,7 @@ def _candidate_search_remediation(
         "failure_reason_counts": dict(sorted(failure_counts.items())),
         "partial_scorecards": partial_scorecards,
         "candidate_surface_exhausted": candidate_surface_exhausted,
+        "replayable_candidate_surface_exhausted": replayable_candidate_surface_exhausted,
         "observed_selection_budget": observed_selection_budget,
         "next_actions": next_actions,
     }
@@ -3138,6 +3161,28 @@ def _candidate_spec_execution_signature(spec: CandidateSpec) -> str:
     )
 
 
+_PRE_REPLAY_FEEDBACK_BLOCK_REASONS = frozenset(
+    {
+        "pre_replay_mlx_feedback_blocked",
+        "pre_replay_mlx_signature_feedback_blocked",
+        "pre_replay_mlx_shape_feedback_blocked",
+        "pre_replay_mlx_risk_profile_feedback_blocked",
+        "pre_replay_mlx_family_feedback_blocked",
+    }
+)
+_PRE_REPLAY_SELECTION_BLOCK_REASONS = frozenset(
+    {
+        *_PRE_REPLAY_FEEDBACK_BLOCK_REASONS,
+        "pre_replay_capital_budget_blocked",
+        "pre_replay_mlx_synthetic_nonpositive_expected_value",
+    }
+)
+
+
+def _selection_reason_blocks_replay(reason: str) -> bool:
+    return reason in _PRE_REPLAY_SELECTION_BLOCK_REASONS
+
+
 def _select_candidate_specs_for_replay(
     *,
     specs: Sequence[CandidateSpec],
@@ -3166,13 +3211,6 @@ def _select_candidate_specs_for_replay(
         _string(row.get("candidate_spec_id")): row
         for row in _list_of_mappings(list(proposal_rows))
         if _string(row.get("candidate_spec_id"))
-    }
-    feedback_block_reasons = {
-        "pre_replay_mlx_feedback_blocked",
-        "pre_replay_mlx_signature_feedback_blocked",
-        "pre_replay_mlx_shape_feedback_blocked",
-        "pre_replay_mlx_risk_profile_feedback_blocked",
-        "pre_replay_mlx_family_feedback_blocked",
     }
     capital_block_reason = "pre_replay_capital_budget_blocked"
 
@@ -3216,7 +3254,7 @@ def _select_candidate_specs_for_replay(
     def pre_replay_block_reason(spec: CandidateSpec) -> str:
         proposal = proposal_by_spec.get(spec.candidate_spec_id, {})
         selection_reason = _string(proposal.get("selection_reason"))
-        if selection_reason in feedback_block_reasons:
+        if selection_reason in _PRE_REPLAY_FEEDBACK_BLOCK_REASONS:
             return selection_reason
         if capital_blocked(spec):
             return capital_block_reason
@@ -3234,7 +3272,7 @@ def _select_candidate_specs_for_replay(
 
     def is_feedback_block_reason(reason: str) -> bool:
         return (
-            reason in feedback_block_reasons
+            reason in _PRE_REPLAY_FEEDBACK_BLOCK_REASONS
             or reason == "pre_replay_mlx_feedback_blocked"
         )
 

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -2473,6 +2473,55 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             {"pre_replay_mlx_rank"},
         )
 
+    def test_best_false_negative_table_excludes_pre_replay_blocked_specs(self) -> None:
+        table = runner._best_false_negative_table(
+            candidate_selection={
+                "rows": [
+                    {
+                        "candidate_spec_id": "spec-feedback-blocked",
+                        "rank": 1,
+                        "selected_for_replay": False,
+                        "selection_reason": "pre_replay_mlx_feedback_blocked",
+                    },
+                    {
+                        "candidate_spec_id": "spec-capital-blocked",
+                        "rank": 2,
+                        "selected_for_replay": False,
+                        "selection_reason": "pre_replay_capital_budget_blocked",
+                    },
+                    {
+                        "candidate_spec_id": "spec-negative-prior",
+                        "rank": 3,
+                        "selected_for_replay": False,
+                        "selection_reason": "pre_replay_mlx_synthetic_nonpositive_expected_value",
+                    },
+                    {
+                        "candidate_spec_id": "spec-duplicate",
+                        "rank": 4,
+                        "selected_for_replay": False,
+                        "selection_reason": "duplicate_execution_signature",
+                    },
+                    {
+                        "candidate_spec_id": "spec-clean-budget-miss",
+                        "rank": 5,
+                        "selected_for_replay": False,
+                        "selection_reason": "not_selected_budget",
+                    },
+                ]
+            },
+            pre_replay_proposal_rows=[
+                {
+                    "candidate_spec_id": "spec-clean-budget-miss",
+                    "proposal_score": 25,
+                }
+            ],
+            evidence_bundles=(),
+        )
+
+        self.assertEqual(len(table), 1)
+        self.assertEqual(table[0]["candidate_spec_id"], "spec-clean-budget-miss")
+        self.assertEqual(table[0]["reason"], "not_replayed_budget")
+
     def test_seed_recent_whitepapers_diversifies_exploitation_slots(self) -> None:
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
@@ -3116,6 +3165,71 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             ],
         )
         self.assertNotIn("recommended_flags", surface_action)
+        self.assertFalse(
+            [
+                action
+                for action in remediation["next_actions"]
+                if action["action"] == "increase_breadth_and_portfolio_diversity"
+            ]
+        )
+
+    def test_remediation_recommends_surface_mutation_when_only_eligible_specs_replayed(
+        self,
+    ) -> None:
+        selected_rows = [
+            {
+                "candidate_spec_id": "spec-eligible",
+                "family_template_id": "end_of_day_reversal_v1",
+                "selected_for_replay": True,
+            }
+        ]
+        remediation = runner._candidate_search_remediation(
+            failure_reason="portfolio_optimizer_produced_no_candidate",
+            candidate_selection={
+                "budget": {
+                    "compiled_candidate_count": 2250,
+                    "unique_execution_signature_count": 375,
+                    "eligible_candidate_count": 1,
+                    "selected_count": 1,
+                    "pre_replay_feedback_blocked_candidate_count": 179,
+                    "pre_replay_nonpositive_synthetic_candidate_count": 185,
+                    "pre_replay_blocked_candidate_count": 364,
+                    "max_candidates": 264,
+                    "top_k": 136,
+                    "exploration_slots_effective": 128,
+                },
+                "rows": selected_rows,
+            },
+            evidence_bundles=(),
+            false_positive_table=(
+                {
+                    "candidate_spec_id": "spec-eligible",
+                    "evidence_status": "replayed",
+                    "failure_reasons": [
+                        "active_day_ratio_below_oracle",
+                        "positive_day_ratio_below_oracle",
+                        "non_positive_net_pnl_per_day",
+                    ],
+                },
+            ),
+            best_false_negative_table=(),
+            replay_timeout_seconds=7200,
+            max_frontier_candidates_per_spec=2,
+            current_top_k=136,
+            current_exploration_slots=128,
+            current_portfolio_size_min=3,
+            current_max_candidates=264,
+            current_max_total_frontier_candidates=128,
+        )
+
+        self.assertFalse(remediation["candidate_surface_exhausted"])
+        self.assertTrue(remediation["replayable_candidate_surface_exhausted"])
+        surface_action = remediation["next_actions"][0]
+        self.assertEqual(surface_action["action"], "expand_execution_profile_surface")
+        self.assertIn("currently eligible", surface_action["reason"])
+        self.assertEqual(
+            surface_action["target_family_template_ids"], ["end_of_day_reversal_v1"]
+        )
         self.assertFalse(
             [
                 action


### PR DESCRIPTION
## Summary

- Stop reporting pre-replay blocked specs as budget-missed false negatives.
- Add replayable-surface exhaustion detection when feedback, capital, or expected-value gates block the rest of the compiled surface.
- Keep the Torghut workflow diagram labels single-line so Mermaid renderers do not display newline artifacts.

## Related Issues

None

## Testing

- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q -k 'false_negative_table_excludes or only_eligible_specs_replayed or candidate_selection_blocks_capital_infeasible'`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `mmdc -i /tmp/torghut-workflow.mmd -o /tmp/torghut-workflow.svg`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
