### PR TITLE
chore(torghut): promote image 7c62724d

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.0-86-gd6050290f
+              value: v0.571.1-4-g7c62724d2
             - name: TORGHUT_OPTIONS_COMMIT
-              value: d6050290f235aae5683d5249975283a31c515b51
+              value: 7c62724d215cb32edc62edbf794c721aba041653
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.0-86-gd6050290f
+              value: v0.571.1-4-g7c62724d2
             - name: TORGHUT_OPTIONS_COMMIT
-              value: d6050290f235aae5683d5249975283a31c515b51
+              value: 7c62724d215cb32edc62edbf794c721aba041653
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-17T02:12:32Z"
+        client.knative.dev/updateTimestamp: "2026-05-17T02:49:03Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
           ports:
             - name: http1
               containerPort: 8181
@@ -495,11 +495,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.0-86-gd6050290f
+              value: v0.571.1-4-g7c62724d2
             - name: TORGHUT_COMMIT
-              value: d6050290f235aae5683d5249975283a31c515b51
+              value: 7c62724d215cb32edc62edbf794c721aba041653
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+              value: sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-17T02:12:32Z"
+        client.knative.dev/updateTimestamp: "2026-05-17T02:49:03Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
           ports:
             - name: http1
               containerPort: 8181
@@ -316,11 +316,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.0-86-gd6050290f
+              value: v0.571.1-4-g7c62724d2
             - name: TORGHUT_COMMIT
-              value: d6050290f235aae5683d5249975283a31c515b51
+              value: 7c62724d215cb32edc62edbf794c721aba041653
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+              value: sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a57303f079322b12b850a2a76e15964ee3c167b4b9d1a03fe7ebd3dfd4731293
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `7c62724d215cb32edc62edbf794c721aba041653`
- Image tag: `7c62724d`
- Image digest: `sha256:990ae78e15e4582fa50d62f32008554f9bc24815eba37174e7118d598bd939ba`