### PR TITLE
chore(jangar): promote image 2d581433

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 9d8f7b26
-  digest: sha256:9f8bc855ea096f5ae485d2deb1819c9985c6644700b0232f41cf1edc4f5a0e23
+  tag: 2d581433
+  digest: sha256:903eb724880a624f1de7573ba1fbd63f9aab05efbd327c232ae4980ed3db11d8
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 9d8f7b26
-    digest: sha256:83ffa79ea46b12b7b741489a2058a015811680da3c1835992760a4b7c217ed59
+    tag: 2d581433
+    digest: sha256:047aa1a6295ccc0682326d0e41e83ec2e8c01e919e6abba728054c41447da788
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "12000"
-      JANGAR_SOURCE_HEAD_SHA: 9d8f7b263ca1738b01fbe4e6e9e43edd239f4342
-      JANGAR_GITOPS_REVISION: 9d8f7b263ca1738b01fbe4e6e9e43edd239f4342
-      JANGAR_SOURCE_CI_RUN_ID: "25978718607"
+      JANGAR_SOURCE_HEAD_SHA: 2d58143370a01c931788a6bc91bf5aef5399cec3
+      JANGAR_GITOPS_REVISION: 2d58143370a01c931788a6bc91bf5aef5399cec3
+      JANGAR_SOURCE_CI_RUN_ID: "25979495834"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:83ffa79ea46b12b7b741489a2058a015811680da3c1835992760a4b7c217ed59
-      JANGAR_SERVING_BUILD_COMMIT: 9d8f7b263ca1738b01fbe4e6e9e43edd239f4342
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:83ffa79ea46b12b7b741489a2058a015811680da3c1835992760a4b7c217ed59
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:047aa1a6295ccc0682326d0e41e83ec2e8c01e919e6abba728054c41447da788
+      JANGAR_SERVING_BUILD_COMMIT: 2d58143370a01c931788a6bc91bf5aef5399cec3
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:047aa1a6295ccc0682326d0e41e83ec2e8c01e919e6abba728054c41447da788
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 9d8f7b26
-    digest: sha256:9f8bc855ea096f5ae485d2deb1819c9985c6644700b0232f41cf1edc4f5a0e23
+    tag: 2d581433
+    digest: sha256:903eb724880a624f1de7573ba1fbd63f9aab05efbd327c232ae4980ed3db11d8
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-17T02:10:30Z
+    deploy.knative.dev/rollout: 2026-05-17T02:49:30Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:9d8f7b26@sha256:9f8bc855ea096f5ae485d2deb1819c9985c6644700b0232f41cf1edc4f5a0e23
+              value: registry.ide-newton.ts.net/lab/jangar:2d581433@sha256:903eb724880a624f1de7573ba1fbd63f9aab05efbd327c232ae4980ed3db11d8
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 9d8f7b263ca1738b01fbe4e6e9e43edd239f4342
+              value: 2d58143370a01c931788a6bc91bf5aef5399cec3
             - name: JANGAR_GITOPS_REVISION
-              value: 9d8f7b263ca1738b01fbe4e6e9e43edd239f4342
+              value: 2d58143370a01c931788a6bc91bf5aef5399cec3
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25978718607"
+              value: "25979495834"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:83ffa79ea46b12b7b741489a2058a015811680da3c1835992760a4b7c217ed59
+              value: sha256:047aa1a6295ccc0682326d0e41e83ec2e8c01e919e6abba728054c41447da788
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 9d8f7b263ca1738b01fbe4e6e9e43edd239f4342
+              value: 2d58143370a01c931788a6bc91bf5aef5399cec3
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:83ffa79ea46b12b7b741489a2058a015811680da3c1835992760a4b7c217ed59
+              value: sha256:047aa1a6295ccc0682326d0e41e83ec2e8c01e919e6abba728054c41447da788
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 9d8f7b26
-    digest: sha256:9f8bc855ea096f5ae485d2deb1819c9985c6644700b0232f41cf1edc4f5a0e23
+    newTag: 2d581433
+    digest: sha256:903eb724880a624f1de7573ba1fbd63f9aab05efbd327c232ae4980ed3db11d8


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `2d58143370a01c931788a6bc91bf5aef5399cec3`
- Image tag: `2d581433`
- Image digest: `sha256:903eb724880a624f1de7573ba1fbd63f9aab05efbd327c232ae4980ed3db11d8`
- Source CI run: `25979495834`
- Control-plane serving digest: `sha256:047aa1a6295ccc0682326d0e41e83ec2e8c01e919e6abba728054c41447da788`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates