### PR TITLE
ci(temporal-bun-sdk): make publish idempotent

### DIFF
--- a/.github/workflows/temporal-bun-sdk.yml
+++ b/.github/workflows/temporal-bun-sdk.yml
@@ -337,6 +337,12 @@ jobs:
           DRY_RUN: ${{ steps.release_meta.outputs.dry_run }}
         run: |
           set -euo pipefail
+          spec="@proompteng/temporal-bun-sdk@${{ steps.release_meta.outputs.version }}"
+          if [[ "${DRY_RUN}" != "true" ]] && npm view "$spec" version --json >/dev/null 2>&1; then
+            echo "$spec is already published; skipping npm publish and verifying the published artifact next."
+            exit 0
+          fi
+
           if [[ "${DRY_RUN}" == "true" ]]; then
             echo 'Running npm publish in dry-run mode'
             npm publish --tag "$NPM_DIST_TAG" --access public --provenance --dry-run
@@ -350,11 +356,11 @@ jobs:
         run: |
           set -euo pipefail
           spec="@proompteng/temporal-bun-sdk@${{ steps.release_meta.outputs.version }}"
-          for attempt in {1..10}; do
+          for attempt in {1..40}; do
             if bun run verify:packed-readiness --npm "$spec"; then
               exit 0
             fi
-            echo "Published package not verifiable yet for $spec; retry ${attempt}/10"
+            echo "Published package not verifiable yet for $spec; retry ${attempt}/40"
             sleep 15
           done
           bun run verify:packed-readiness --npm "$spec"


### PR DESCRIPTION
## Summary

- Makes the Temporal Bun SDK publish job idempotent when the exact npm package version already exists.
- Keeps the published-artifact verifier running after a skipped republish, so reruns can close post-publish verification.
- Extends the npm registry verification window from 10 retries to 40 retries to tolerate registry replication after a real publish.

## Related Issues

None

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/temporal-bun-sdk.yml"); puts "workflow yaml ok"'`
- `actionlint .github/workflows/temporal-bun-sdk.yml` (reports existing custom `arc-arm64` runner labels only)
- `bun run verify:packed-readiness --npm @proompteng/temporal-bun-sdk@0.11.0`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
