### PR TITLE
fix(agents): preserve market-context runs on quota exhaustion

### DIFF
--- a/argocd/applications/agents/torghut-market-context-agentprovider.yaml
+++ b/argocd/applications/agents/torghut-market-context-agentprovider.yaml
@@ -245,6 +245,9 @@ spec:
           suffix = '/api/torghut/market-context/ingest'
           if normalized.endswith(suffix):
             return normalized[: -len('/ingest')]
+          base_suffix = '/api/torghut/market-context'
+          if normalized.endswith(base_suffix):
+            return normalized
           return None
 
         def _get_json(url: str, timeout_seconds: int):
@@ -342,6 +345,88 @@ spec:
               return response.getcode() or 200, _parse_json_bytes(response.read())
           except urllib.error.HTTPError as error:
             return error.code, _parse_json_bytes(error.read())
+
+        def _build_capacity_fallback_payload(payload: dict, attempts: list[dict]) -> dict:
+          symbol = _resolve_field(payload, 'symbol') or 'UNKNOWN'
+          domain = _resolve_field(payload, 'domain') or 'news'
+          request_id = _resolve_field(payload, 'requestId') or ''
+          as_of_utc = _resolve_field(payload, 'asOfUtc') or time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
+          provider = 'provider-capacity-fallback'
+          risk_flags = [
+            'provider_capacity_exhausted',
+            'market_context_generation_unavailable',
+            'market_context_partial_no_sources',
+          ]
+          metadata = {
+            'providerAttempts': attempts,
+            'providerChain': [entry.get('provider') for entry in attempts if entry.get('provider')],
+            'activeProvider': provider,
+            'failureCategory': 'provider_capacity_exhausted',
+            'failureMessage': 'all Codex-backed market-context providers exhausted capacity before producing evidence',
+          }
+          if domain == 'fundamentals':
+            context_payload = {
+              'thesis': 'Current fundamentals generation is unavailable because all Codex-backed market-context providers exhausted capacity before producing evidence.',
+              'valuation': {},
+              'growth': {},
+              'profitability': {},
+              'balanceSheet': {},
+              'upcomingCatalysts': [],
+              'providerCapacityExhausted': True,
+            }
+          else:
+            domain = 'news'
+            context_payload = {
+              'summary': 'Current news generation is unavailable because all Codex-backed market-context providers exhausted capacity before producing evidence.',
+              'headlines': [],
+              'eventRisk': 'high',
+              'providerCapacityExhausted': True,
+            }
+          return {
+            'symbol': symbol,
+            'domain': domain,
+            'asOfUtc': as_of_utc,
+            'sourceCount': 0,
+            'qualityScore': 0,
+            'payload': context_payload,
+            'citations': [],
+            'riskFlags': risk_flags,
+            'provider': provider,
+            'runStatus': 'partial',
+            'requestId': request_id,
+            'metadata': metadata,
+          }
+
+        def _should_finalize_capacity_fallback(attempts: list[dict]) -> bool:
+          if not attempts:
+            return False
+          eligible_categories = {'provider_fallback_eligible', 'provider_attempt_timeout', 'provider_circuit_open'}
+          for attempt in attempts:
+            category = str(attempt.get('failureCategory') or '').strip()
+            error = str(attempt.get('error') or '').lower()
+            if category in eligible_categories:
+              return True
+            if any(token in error for token in ('quota', 'usage limit', 'insufficient_quota', 'provider capacity')):
+              return True
+          return False
+
+        def _finalize_capacity_fallback(payload: dict, attempts: list[dict], timeout_seconds: int) -> tuple[bool, str]:
+          callback_url = _resolve_field(payload, 'callbackUrl')
+          runs_base = _resolve_runs_base(callback_url)
+          request_id = _resolve_field(payload, 'requestId')
+          if not runs_base or not request_id:
+            return False, 'capacity fallback missing callbackUrl or requestId'
+          fallback_payload = _build_capacity_fallback_payload(payload, attempts)
+          try:
+            status_code, response_payload = _post_json(f'{runs_base}/runs/finalize', fallback_payload, timeout_seconds)
+          except Exception as error:
+            return False, str(error).strip() or type(error).__name__
+          if 200 <= status_code < 300:
+            if isinstance(response_payload, dict) and response_payload.get('ok') is False:
+              return False, _extract_response_message(response_payload, 'capacity fallback finalize rejected')
+            print('market_context_capacity_fallback_partial_finalized')
+            return True, ''
+          return False, _extract_response_message(response_payload, f'capacity fallback finalize HTTP {status_code}')
 
         def _build_attempt_metadata(
           payload: dict,
@@ -655,6 +740,11 @@ spec:
 
           final_provider = attempts[-1]['provider'] if attempts else 'unknown'
           final_model = attempts[-1]['model'] if attempts else 'unknown'
+          if _should_finalize_capacity_fallback(attempts):
+            finalized, finalize_message = _finalize_capacity_fallback(original_payload, attempts, progress_timeout)
+            if finalized:
+              return 0
+            print(f'market_context_capacity_fallback_failed:{finalize_message}', file=sys.stderr)
           _emit_progress_event(
             original_payload,
             final_provider,

--- a/services/jangar/src/server/__tests__/torghut-market-context-agentprovider-manifest.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-market-context-agentprovider-manifest.test.ts
@@ -289,4 +289,116 @@ assert message == 'Command exited with status 1', message
 
     expect(stderr).toContain('SyntaxError')
   })
+
+  it('resolves the base market-context callback URL for lifecycle calls', async () => {
+    const manifest = await readFile(
+      resolve(process.cwd(), '..', '..', 'argocd/applications/agents/torghut-market-context-agentprovider.yaml'),
+      'utf8',
+    )
+    const runner = extractInputFileContent(manifest, '/root/.codex/market-context-provider-runner.py')
+    const tempDir = await mkdtemp(resolve(tmpdir(), 'market-context-runner-'))
+    const runnerPath = resolve(tempDir, 'market-context-provider-runner.py')
+    const probePath = resolve(tempDir, 'probe.py')
+    await writeFile(runnerPath, runner)
+    await writeFile(
+      probePath,
+      `
+import importlib.util
+import sys
+from pathlib import Path
+
+runner_path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location('runner', runner_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+base = 'http://jangar.jangar.svc.cluster.local/api/torghut/market-context'
+assert module._resolve_runs_base(base) == base
+assert module._resolve_runs_base(base + '/ingest') == base
+assert module._resolve_runs_base('') is None
+`,
+    )
+
+    await execFileAsync('python3', [probePath, runnerPath], { timeout: 10_000 })
+  })
+
+  it('finalizes a truthful partial payload after provider capacity exhaustion', async () => {
+    const manifest = await readFile(
+      resolve(process.cwd(), '..', '..', 'argocd/applications/agents/torghut-market-context-agentprovider.yaml'),
+      'utf8',
+    )
+    const runner = extractInputFileContent(manifest, '/root/.codex/market-context-provider-runner.py')
+    const tempDir = await mkdtemp(resolve(tmpdir(), 'market-context-runner-'))
+    const runnerPath = resolve(tempDir, 'market-context-provider-runner.py')
+    const eventPath = resolve(tempDir, 'event.json')
+    const probePath = resolve(tempDir, 'probe.py')
+    await writeFile(runnerPath, runner)
+    await writeFile(
+      eventPath,
+      JSON.stringify({
+        parameters: {
+          symbol: 'AMZN',
+          domain: 'news',
+          asOfUtc: '2026-05-17T03:44:17.863Z',
+          callbackUrl: 'http://jangar.jangar.svc.cluster.local/api/torghut/market-context',
+          requestId: 'market-context-news-amzn-test',
+          reason: 'on_demand_stale_snapshot_refresh',
+        },
+      }),
+    )
+    await writeFile(
+      probePath,
+      `
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+runner_path = Path(sys.argv[1])
+event_path = Path(sys.argv[2])
+spec = importlib.util.spec_from_file_location('runner', runner_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+posts = []
+
+def fake_post_json(url, payload, timeout_seconds):
+  posts.append((url, payload))
+  if url.endswith('/runs/finalize'):
+    assert payload['runStatus'] == 'partial'
+    assert payload['qualityScore'] == 0
+    assert payload['sourceCount'] == 0
+    assert payload['citations'] == []
+    assert 'provider_capacity_exhausted' in payload['riskFlags']
+    assert payload['payload']['providerCapacityExhausted'] is True
+    return 200, {'ok': True}
+  return 200, {'ok': True}
+
+def fake_run(*args, **kwargs):
+  return subprocess.CompletedProcess(
+    args=args[0],
+    returncode=1,
+    stdout='',
+    stderr='Turn failed -> Quota exceeded. Check your plan and billing details.\\n',
+  )
+
+module._post_json = fake_post_json
+module.subprocess.run = fake_run
+os.environ['CODEX_MARKET_CONTEXT_PROVIDER_CHAIN'] = 'codex:gpt-5.5,codex-spark:gpt-5.5'
+sys.argv = ['market-context-provider-runner.py', str(event_path)]
+exit_code = module.main()
+assert exit_code == 0, exit_code
+finalize_posts = [entry for entry in posts if entry[0].endswith('/runs/finalize')]
+assert len(finalize_posts) == 1, posts
+`,
+    )
+
+    const { stdout } = await execFileAsync('python3', [probePath, runnerPath, eventPath], { timeout: 10_000 })
+
+    expect(stdout).toContain('market_context_capacity_fallback_partial_finalized')
+  })
 })


### PR DESCRIPTION
## Summary

- Adds a truthful capacity fallback path to the Torghut market-context AgentProvider runner.
- Finalizes provider-quota exhaustion as a `partial` market-context result with zero quality, zero sources, empty citations, and explicit risk flags instead of leaving the AgentRun failed with no lifecycle result.
- Accepts both `/api/torghut/market-context` and `/api/torghut/market-context/ingest` callback URLs when resolving lifecycle endpoints.
- Adds manifest-level tests for callback URL resolution and the capacity-exhaustion fallback finalize path.

## Related Issues

None

## Testing

- `bunx oxfmt --check argocd/applications/agents/torghut-market-context-agentprovider.yaml services/jangar/src/server/__tests__/torghut-market-context-agentprovider-manifest.test.ts`
- `bun run --cwd services/jangar test -- src/server/__tests__/torghut-market-context-agentprovider-manifest.test.ts`
- `bun run --cwd services/jangar test -- src/server/__tests__/torghut-market-context-agents.test.ts`
- `bun run --cwd services/jangar tsc`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
