### PR TITLE
chore(jangar): promote image b000ceeb

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: 2d581433
-  digest: sha256:903eb724880a624f1de7573ba1fbd63f9aab05efbd327c232ae4980ed3db11d8
+  tag: b000ceeb
+  digest: sha256:e6b6b860b7b7aec0b768e989f0c300ede05d0427a5499fa75cba22ecea07355b
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: 2d581433
-    digest: sha256:047aa1a6295ccc0682326d0e41e83ec2e8c01e919e6abba728054c41447da788
+    tag: b000ceeb
+    digest: sha256:dde577d0ddc5ca608a5633930a226dc7df782b6603fe57cbd8c3ce7022cb771f
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "12000"
-      JANGAR_SOURCE_HEAD_SHA: 2d58143370a01c931788a6bc91bf5aef5399cec3
-      JANGAR_GITOPS_REVISION: 2d58143370a01c931788a6bc91bf5aef5399cec3
-      JANGAR_SOURCE_CI_RUN_ID: "25979495834"
+      JANGAR_SOURCE_HEAD_SHA: b000ceeb9ea2880252e97cbc32d27cd59f591f57
+      JANGAR_GITOPS_REVISION: b000ceeb9ea2880252e97cbc32d27cd59f591f57
+      JANGAR_SOURCE_CI_RUN_ID: "25980795914"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:047aa1a6295ccc0682326d0e41e83ec2e8c01e919e6abba728054c41447da788
-      JANGAR_SERVING_BUILD_COMMIT: 2d58143370a01c931788a6bc91bf5aef5399cec3
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:047aa1a6295ccc0682326d0e41e83ec2e8c01e919e6abba728054c41447da788
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:dde577d0ddc5ca608a5633930a226dc7df782b6603fe57cbd8c3ce7022cb771f
+      JANGAR_SERVING_BUILD_COMMIT: b000ceeb9ea2880252e97cbc32d27cd59f591f57
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:dde577d0ddc5ca608a5633930a226dc7df782b6603fe57cbd8c3ce7022cb771f
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: 2d581433
-    digest: sha256:903eb724880a624f1de7573ba1fbd63f9aab05efbd327c232ae4980ed3db11d8
+    tag: b000ceeb
+    digest: sha256:e6b6b860b7b7aec0b768e989f0c300ede05d0427a5499fa75cba22ecea07355b
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-17T02:49:30Z
+    deploy.knative.dev/rollout: 2026-05-17T04:02:36Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:2d581433@sha256:903eb724880a624f1de7573ba1fbd63f9aab05efbd327c232ae4980ed3db11d8
+              value: registry.ide-newton.ts.net/lab/jangar:b000ceeb@sha256:e6b6b860b7b7aec0b768e989f0c300ede05d0427a5499fa75cba22ecea07355b
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 2d58143370a01c931788a6bc91bf5aef5399cec3
+              value: b000ceeb9ea2880252e97cbc32d27cd59f591f57
             - name: JANGAR_GITOPS_REVISION
-              value: 2d58143370a01c931788a6bc91bf5aef5399cec3
+              value: b000ceeb9ea2880252e97cbc32d27cd59f591f57
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25979495834"
+              value: "25980795914"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:047aa1a6295ccc0682326d0e41e83ec2e8c01e919e6abba728054c41447da788
+              value: sha256:dde577d0ddc5ca608a5633930a226dc7df782b6603fe57cbd8c3ce7022cb771f
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 2d58143370a01c931788a6bc91bf5aef5399cec3
+              value: b000ceeb9ea2880252e97cbc32d27cd59f591f57
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:047aa1a6295ccc0682326d0e41e83ec2e8c01e919e6abba728054c41447da788
+              value: sha256:dde577d0ddc5ca608a5633930a226dc7df782b6603fe57cbd8c3ce7022cb771f
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 2d581433
-    digest: sha256:903eb724880a624f1de7573ba1fbd63f9aab05efbd327c232ae4980ed3db11d8
+    newTag: b000ceeb
+    digest: sha256:e6b6b860b7b7aec0b768e989f0c300ede05d0427a5499fa75cba22ecea07355b


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `b000ceeb9ea2880252e97cbc32d27cd59f591f57`
- Image tag: `b000ceeb`
- Image digest: `sha256:e6b6b860b7b7aec0b768e989f0c300ede05d0427a5499fa75cba22ecea07355b`
- Source CI run: `25980795914`
- Control-plane serving digest: `sha256:dde577d0ddc5ca608a5633930a226dc7df782b6603fe57cbd8c3ce7022cb771f`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates