### PR TITLE
fix(torghut): preserve portfolio runtime closure params

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
   imagePullPolicy: IfNotPresent
-  restartNonce: 6
+  restartNonce: 7
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -57,6 +57,12 @@ def _string(value: Any) -> str:
     return str(value or "").strip()
 
 
+def _mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[Any, Any], value).items()}
+
+
 def _boolish(value: Any) -> bool:
     if isinstance(value, bool):
         return value
@@ -65,6 +71,32 @@ def _boolish(value: Any) -> bool:
 
 def _scorecard(bundle: CandidateEvidenceBundle) -> Mapping[str, Any]:
     return bundle.objective_scorecard
+
+
+def _scorecard_runtime_params(bundle: CandidateEvidenceBundle) -> Mapping[str, Any]:
+    return _mapping(_scorecard(bundle).get("runtime_params"))
+
+
+def _scorecard_universe_symbols(bundle: CandidateEvidenceBundle) -> list[str]:
+    raw_symbols = _scorecard(bundle).get("universe_symbols")
+    if not isinstance(raw_symbols, Sequence) or isinstance(raw_symbols, str):
+        return []
+    return [
+        symbol
+        for symbol in (
+            _string(item).upper() for item in cast(Sequence[Any], raw_symbols)
+        )
+        if symbol
+    ]
+
+
+def _scorecard_signal(bundle: CandidateEvidenceBundle) -> str:
+    params = _scorecard_runtime_params(bundle)
+    signal = _string(params.get("signal_motif"))
+    if signal:
+        return signal
+    signal_key = _string(_scorecard(bundle).get("signal_key"))
+    return signal_key.split("|", 1)[0] if signal_key else ""
 
 
 def _net_per_day(bundle: CandidateEvidenceBundle) -> Decimal:
@@ -931,6 +963,9 @@ def optimize_portfolio_candidate(
                 "runtime_family": _string(_scorecard(bundle).get("runtime_family")),
                 "runtime_strategy_name": f"{base_runtime_strategy_name}-sleeve-{sleeve_index}",
                 "weight": str(weight),
+                "signal": _scorecard_signal(bundle),
+                "params": dict(_scorecard_runtime_params(bundle)),
+                "universe_symbols": _scorecard_universe_symbols(bundle),
                 "expected_net_pnl_per_day": str(_net_per_day(bundle) * weight),
                 "source_expected_net_pnl_per_day": str(_net_per_day(bundle)),
                 "risk_contribution": str(_max_drawdown(bundle) * weight),

--- a/services/torghut/app/trading/discovery/runtime_closure.py
+++ b/services/torghut/app/trading/discovery/runtime_closure.py
@@ -164,7 +164,38 @@ _MICROBAR_PORTFOLIO_SIGNAL_SETTINGS: dict[str, dict[str, str]] = {
         "rank_feature": "cross_section_prev_day_open45_return_rank",
         "selection_mode": "continuation",
     },
+    "overnight_gap_reversal": {
+        "rank_feature": "cross_section_prev_session_close_rank",
+        "selection_mode": "reversal",
+    },
+    "opening_window_prev_close_reversal": {
+        "rank_feature": "cross_section_opening_window_return_from_prev_close_rank",
+        "selection_mode": "reversal",
+    },
+    "intraday_tug_of_war_reversal": {
+        "rank_feature": "cross_section_prev_session_close_rank",
+        "selection_mode": "reversal",
+    },
 }
+
+_MICROBAR_PORTFOLIO_RUNTIME_PARAM_KEYS: tuple[str, ...] = (
+    "entry_window_minutes",
+    "gate_feature",
+    "gate_min",
+    "gate_max",
+    "max_pair_legs",
+    "entry_cooldown_seconds",
+    "long_stop_loss_bps",
+    "short_stop_loss_bps",
+    "long_trailing_stop_activation_profit_bps",
+    "long_trailing_stop_drawdown_bps",
+    "short_trailing_stop_activation_profit_bps",
+    "short_trailing_stop_drawdown_bps",
+    "max_hold_seconds",
+    "max_session_negative_exit_bps",
+    "max_stop_loss_exits_per_session",
+    "stop_loss_lockout_seconds",
+)
 
 _PORTFOLIO_POLICY_REF_PREFIX = "torghut.autoresearch.portfolio"
 
@@ -699,15 +730,36 @@ def _materialized_microbar_portfolio_runtime_strategies(
     candidate_id = _string(best_candidate.get("candidate_id")) or "runtime-closure"
     strategies: list[dict[str, Any]] = []
     for sleeve_index, sleeve in enumerate(sleeves, start=1):
-        signal = _string(sleeve.get("signal"))
+        sleeve_params = _mapping(sleeve.get("params"))
+        signal = _string(sleeve.get("signal")) or _string(
+            sleeve_params.get("signal_motif")
+        )
         signal_settings = _MICROBAR_PORTFOLIO_SIGNAL_SETTINGS.get(signal)
         if signal_settings is None:
             raise ValueError(
                 f"runtime_closure_microbar_portfolio_signal_unsupported:{signal}"
             )
-        entry_minute = max(0, _int(sleeve.get("entry_minute_after_open")))
-        exit_text = _string(sleeve.get("exit_minute_after_open")) or "close"
-        top_n = max(1, _int(sleeve.get("top_n")))
+        entry_minute = max(
+            0,
+            _int(
+                sleeve.get("entry_minute_after_open")
+                or sleeve_params.get("entry_minute_after_open")
+            ),
+        )
+        exit_text = (
+            _string(sleeve.get("exit_minute_after_open"))
+            or _string(sleeve_params.get("exit_minute_after_open"))
+            or "close"
+        )
+        top_n = max(1, _int(sleeve.get("top_n") or sleeve_params.get("top_n")))
+        sleeve_symbols = [
+            symbol
+            for symbol in (
+                _string(item).upper()
+                for item in cast(Sequence[Any], sleeve.get("universe_symbols") or [])
+            )
+            if symbol
+        ] or list(symbols)
         weight = _decimal(sleeve.get("weight"), default="1")
         if weight <= 0:
             weight = Decimal("1")
@@ -740,20 +792,27 @@ def _materialized_microbar_portfolio_runtime_strategies(
                     "enabled": True,
                     "base_timeframe": "1Sec",
                     "universe_type": strategy_type,
-                    "universe_symbols": list(symbols),
+                    "universe_symbols": list(sleeve_symbols),
                     "max_notional_per_trade": _decimal_string(max_notional_per_trade),
                     "max_position_pct_equity": _decimal_string(max_position_pct_equity),
                     "params": {
                         "entry_minute_after_open": str(entry_minute),
                         "exit_minute_after_open": exit_text,
                         "signal_motif": signal,
-                        "rank_feature": signal_settings["rank_feature"],
-                        "selection_mode": signal_settings["selection_mode"],
+                        "rank_feature": _string(sleeve_params.get("rank_feature"))
+                        or signal_settings["rank_feature"],
+                        "selection_mode": _string(sleeve_params.get("selection_mode"))
+                        or signal_settings["selection_mode"],
                         "top_n": str(top_n),
-                        "universe_size": str(len(symbols)),
+                        "universe_size": str(len(sleeve_symbols)),
                         "max_concurrent_positions": str(top_n),
                         "max_entries_per_session": str(top_n),
                         "position_isolation_mode": "per_strategy",
+                        **{
+                            key: _string(sleeve_params.get(key))
+                            for key in _MICROBAR_PORTFOLIO_RUNTIME_PARAM_KEYS
+                            if _string(sleeve_params.get(key))
+                        },
                     },
                 }
             )

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -2522,6 +2522,14 @@ def _candidate_spec_feedback_shape_key(spec: CandidateSpec) -> str:
 
 def _candidate_spec_feedback_metadata(spec: CandidateSpec) -> dict[str, Any]:
     execution_profile = _candidate_spec_execution_profile(spec)
+    params = _mapping(spec.strategy_overrides.get("params"))
+    universe_symbols = [
+        _string(symbol).upper()
+        for symbol in cast(
+            Sequence[Any], spec.strategy_overrides.get("universe_symbols") or []
+        )
+        if _string(symbol)
+    ]
     return {
         "family_template_id": spec.family_template_id,
         "runtime_family": spec.runtime_family,
@@ -2533,6 +2541,8 @@ def _candidate_spec_feedback_metadata(spec: CandidateSpec) -> dict[str, Any]:
         "feedback_shape_key": _candidate_spec_feedback_shape_key(spec),
         "universe_key": _candidate_spec_universe_key(spec),
         "signal_key": _candidate_spec_signal_key(spec),
+        "runtime_params": dict(params),
+        "universe_symbols": universe_symbols,
     }
 
 

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -200,6 +200,95 @@ class TestPortfolioOptimizer(TestCase):
         self.assertTrue(portfolio.objective_scorecard["target_met"])
         self.assertTrue(portfolio.objective_scorecard["oracle_passed"])
 
+    def test_portfolio_sleeves_preserve_runtime_params_for_closure(self) -> None:
+        def bundle(candidate_id: str, symbol: str) -> CandidateEvidenceBundle:
+            return evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"spec-{candidate_id}",
+                candidate={
+                    "candidate_id": candidate_id,
+                    "runtime_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "family_template_id": "microbar_cross_sectional_pairs_v1",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "300",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "max_gross_exposure_pct_equity": "0.5",
+                        "min_cash": "5000",
+                        "negative_cash_observation_count": 0,
+                        "best_day_share": "0.2",
+                        "avg_filled_notional_per_day": "150000",
+                        "regime_slice_pass_rate": "0.55",
+                        "posterior_edge_lower": "0.01",
+                        "shadow_parity_status": "within_budget",
+                        "correlation_cluster": candidate_id,
+                        "symbol_contribution_shares": {symbol: "1.0"},
+                        "runtime_params": {
+                            "entry_minute_after_open": "35",
+                            "entry_window_minutes": "25",
+                            "exit_minute_after_open": "180",
+                            "signal_motif": "opening_window_prev_close_reversal",
+                            "rank_feature": (
+                                "cross_section_opening_window_return_from_prev_close_rank"
+                            ),
+                            "selection_mode": "reversal",
+                            "top_n": "2",
+                            "gate_feature": (
+                                "cross_section_positive_opening_window_return_from_prev_close_ratio"
+                            ),
+                            "gate_min": "0.20",
+                            "gate_max": "0.85",
+                        },
+                        "universe_symbols": ["NVDA", "AVGO", "AMD"],
+                        **_executable_scorecard_fields(candidate_id),
+                    },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": "300",
+                            "2026-02-24": "300",
+                            "2026-02-25": "300",
+                            "2026-02-26": "300",
+                            "2026-02-27": "300",
+                        },
+                        "daily_filled_notional": {
+                            "2026-02-23": "150000",
+                            "2026-02-24": "150000",
+                            "2026-02-25": "150000",
+                            "2026-02-26": "150000",
+                            "2026-02-27": "150000",
+                        },
+                    },
+                },
+                dataset_snapshot_id="snapshot-runtime-param-carry",
+                result_path=f"/tmp/{candidate_id}.json",
+            )
+
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=[
+                bundle("cand-prevclose-a", "NVDA"),
+                bundle("cand-prevclose-b", "AVGO"),
+            ],
+            target_net_pnl_per_day=Decimal("500"),
+            oracle_policy=ProfitTargetOraclePolicy(
+                max_cluster_contribution_share=Decimal("0.50"),
+                max_single_symbol_contribution_share=Decimal("0.50"),
+            ),
+            portfolio_size_min=2,
+            portfolio_size_max=2,
+        )
+
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        first_sleeve = portfolio.sleeves[0]
+        self.assertEqual(first_sleeve["signal"], "opening_window_prev_close_reversal")
+        self.assertEqual(
+            first_sleeve["params"]["gate_feature"],
+            "cross_section_positive_opening_window_return_from_prev_close_ratio",
+        )
+        self.assertEqual(first_sleeve["universe_symbols"], ["NVDA", "AVGO", "AMD"])
+
     def test_portfolio_candidate_round_trips_from_optimizer_payload(self) -> None:
         daily_profiles = [
             ("610", "620", "630", "640", "650"),

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -197,6 +197,52 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             promotion_contract={},
         )
 
+    def test_candidate_feedback_metadata_preserves_runtime_params_for_closure(
+        self,
+    ) -> None:
+        spec = replace(
+            self._candidate_spec("spec-prevclose-runtime"),
+            strategy_overrides={
+                "max_notional_per_trade": "7500",
+                "max_position_pct_equity": "0.25",
+                "params": {
+                    "entry_minute_after_open": "35",
+                    "entry_window_minutes": "25",
+                    "exit_minute_after_open": "180",
+                    "signal_motif": "opening_window_prev_close_reversal",
+                    "rank_feature": "cross_section_opening_window_return_from_prev_close_rank",
+                    "selection_mode": "reversal",
+                    "top_n": "2",
+                    "gate_feature": "cross_section_positive_opening_window_return_from_prev_close_ratio",
+                    "gate_min": "0.20",
+                    "gate_max": "0.85",
+                    "long_stop_loss_bps": "5",
+                    "long_trailing_stop_activation_profit_bps": "5",
+                    "long_trailing_stop_drawdown_bps": "2",
+                },
+                "universe_symbols": ["NVDA", "AVGO", "AMD"],
+            },
+        )
+
+        candidate = runner._candidate_payload_with_feedback_metadata(
+            spec=spec,
+            candidate={
+                "candidate_id": "candidate-prevclose",
+                "objective_scorecard": {"net_pnl_per_day": "401.8"},
+            },
+        )
+
+        scorecard = candidate["objective_scorecard"]
+        self.assertEqual(
+            scorecard["runtime_params"]["signal_motif"],
+            "opening_window_prev_close_reversal",
+        )
+        self.assertEqual(
+            scorecard["runtime_params"]["gate_feature"],
+            "cross_section_positive_opening_window_return_from_prev_close_ratio",
+        )
+        self.assertEqual(scorecard["universe_symbols"], ["NVDA", "AVGO", "AMD"])
+
     def test_parse_args_defaults_to_500_daily_profit_program(self) -> None:
         with TemporaryDirectory() as tmpdir:
             with patch.object(

--- a/services/torghut/tests/test_runtime_closure.py
+++ b/services/torghut/tests/test_runtime_closure.py
@@ -635,6 +635,80 @@ data:
                 gate_report["vnext"]["portfolio_promotion"]["missing_policy_refs"], []
             )
 
+    def test_microbar_portfolio_closure_preserves_prevclose_runtime_params(
+        self,
+    ) -> None:
+        context = RuntimeClosureExecutionContext(
+            strategy_configmap_path=Path("/tmp/unused.yaml"),
+            clickhouse_http_url="http://example.invalid:8123",
+            clickhouse_username="torghut",
+            clickhouse_password="secret",
+            start_equity=Decimal("31590.02"),
+            chunk_minutes=10,
+            symbols=("NVDA", "AVGO", "AMD"),
+        )
+        best_candidate = {
+            "candidate_id": "cand-prevclose",
+            "family": "microbar_cross_sectional_pairs",
+            "family_template_id": "microbar_cross_sectional_pairs_v1",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "replay_config": {
+                "backend": "microbar_daily_portfolio",
+                "portfolio": {
+                    "base_per_leg_notional": "30000",
+                    "symbols": ["NVDA", "AVGO", "AMD"],
+                    "sleeves": [
+                        {
+                            "signal": "opening_window_prev_close_reversal",
+                            "weight": "1",
+                            "params": {
+                                "entry_minute_after_open": "35",
+                                "entry_window_minutes": "25",
+                                "exit_minute_after_open": "180",
+                                "signal_motif": "opening_window_prev_close_reversal",
+                                "rank_feature": (
+                                    "cross_section_opening_window_return_from_prev_close_rank"
+                                ),
+                                "selection_mode": "reversal",
+                                "top_n": "2",
+                                "gate_feature": (
+                                    "cross_section_positive_opening_window_return_from_prev_close_ratio"
+                                ),
+                                "gate_min": "0.20",
+                                "gate_max": "0.85",
+                                "long_stop_loss_bps": "5",
+                                "long_trailing_stop_activation_profit_bps": "5",
+                                "long_trailing_stop_drawdown_bps": "2",
+                                "max_session_negative_exit_bps": "3",
+                            },
+                            "universe_symbols": ["NVDA", "AVGO", "AMD"],
+                        }
+                    ],
+                },
+            },
+        }
+
+        strategies = (
+            runtime_closure._materialized_microbar_portfolio_runtime_strategies(
+                best_candidate=best_candidate,
+                execution_context=context,
+            )
+        )
+
+        self.assertEqual(len(strategies), 2)
+        long_params = strategies[0]["params"]
+        self.assertEqual(
+            long_params["rank_feature"],
+            "cross_section_opening_window_return_from_prev_close_rank",
+        )
+        self.assertEqual(
+            long_params["gate_feature"],
+            "cross_section_positive_opening_window_return_from_prev_close_ratio",
+        )
+        self.assertEqual(long_params["entry_window_minutes"], "25")
+        self.assertEqual(long_params["long_stop_loss_bps"], "5")
+        self.assertEqual(strategies[0]["universe_symbols"], ["NVDA", "AVGO", "AMD"])
+
     def test_materialize_candidate_configmap_supports_generic_portfolio_candidates(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Preserve candidate runtime params and universe symbols in whitepaper autoresearch scorecards so replay evidence can flow into portfolio sleeves.
- Carry those params through the portfolio optimizer sleeve payload instead of losing signal/risk settings before runtime closure.
- Teach runtime closure the prev-close microbar motifs and pass through gated entry/risk controls when materializing long/short sleeve strategies.
- Bump the GitOps restart nonce for the failed options TA FlinkDeployment so the post-deploy gate can recover from the `InvalidProducerEpochException` failure without weakening exactly-once delivery semantics.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/run_whitepaper_autoresearch_profit_target.py app/trading/discovery/portfolio_optimizer.py app/trading/discovery/runtime_closure.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_runtime_closure.py tests/test_portfolio_optimizer.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py app/trading/discovery/portfolio_optimizer.py app/trading/discovery/runtime_closure.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_runtime_closure.py tests/test_portfolio_optimizer.py`
- `uv run --frozen pytest tests/test_runtime_closure.py::TestRuntimeClosure::test_microbar_portfolio_closure_preserves_prevclose_runtime_params tests/test_portfolio_optimizer.py::TestPortfolioOptimizer::test_portfolio_sleeves_preserve_runtime_params_for_closure tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_candidate_feedback_metadata_preserves_runtime_params_for_closure`
- `uv run --frozen pytest tests/test_runtime_closure.py tests/test_portfolio_optimizer.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k "candidate_feedback_metadata_preserves_runtime_params_for_closure or candidate_selection or portfolio"`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
