### PR TITLE
chore(torghut): promote image b82fc54c

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-9-gb761f2659
+              value: v0.571.1-17-gb82fc54c1
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b761f26591022eea821b65ccefea093714c4d9d8
+              value: b82fc54c102c27fc3e45e2088b0bdfbc94ad287e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-9-gb761f2659
+              value: v0.571.1-17-gb82fc54c1
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b761f26591022eea821b65ccefea093714c4d9d8
+              value: b82fc54c102c27fc3e45e2088b0bdfbc94ad287e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-17T03:31:05Z"
+        client.knative.dev/updateTimestamp: "2026-05-17T04:40:45Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
           ports:
             - name: http1
               containerPort: 8181
@@ -495,11 +495,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-9-gb761f2659
+              value: v0.571.1-17-gb82fc54c1
             - name: TORGHUT_COMMIT
-              value: b761f26591022eea821b65ccefea093714c4d9d8
+              value: b82fc54c102c27fc3e45e2088b0bdfbc94ad287e
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+              value: sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-17T03:31:05Z"
+        client.knative.dev/updateTimestamp: "2026-05-17T04:40:45Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
           ports:
             - name: http1
               containerPort: 8181
@@ -316,11 +316,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-9-gb761f2659
+              value: v0.571.1-17-gb82fc54c1
             - name: TORGHUT_COMMIT
-              value: b761f26591022eea821b65ccefea093714c4d9d8
+              value: b82fc54c102c27fc3e45e2088b0bdfbc94ad287e
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+              value: sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -98,7 +98,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:4faa60242582f487da654878e02bcc91c9a3e53fe6d7a17e151cb7da6bdbe1c0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `b82fc54c102c27fc3e45e2088b0bdfbc94ad287e`
- Image tag: `b82fc54c`
- Image digest: `sha256:d7f35f45820fb206156d43991ae4d7e42e6c2394358def4fce6668290c147932`