### PR TITLE
fix(torghut-options): rotate ta transactional client

### DIFF
--- a/argocd/applications/torghut-options/ta/configmap.yaml
+++ b/argocd/applications/torghut-options/ta/configmap.yaml
@@ -28,7 +28,7 @@ data:
   TA_SIGNALS_TOPIC: "torghut.options.ta.contract-features.v1"
   TA_STATUS_TOPIC: "torghut.options.ta.status.v1"
   TA_GROUP_ID: "torghut-options-ta-2026-03-08"
-  TA_CLIENT_ID: "torghut-options-ta"
+  TA_CLIENT_ID: "torghut-options-ta-r8"
   TA_AUTO_OFFSET_RESET: "earliest"
   TA_CHECKPOINT_DIR: "s3a://flink-checkpoints/torghut/options-technical-analysis"
   TA_SAVEPOINT_DIR: "s3a://flink-checkpoints/torghut/options-technical-analysis/savepoints"

--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
   imagePullPolicy: IfNotPresent
-  restartNonce: 7
+  restartNonce: 8
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   flinkConfiguration:

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -10,6 +10,14 @@ const agentsCiClusterRbac = readFileSync(
   new URL('../../../../../argocd/applications/agents-ci/runner-rbac-cluster.yaml', import.meta.url),
   'utf8',
 )
+const optionsTaConfigmap = readFileSync(
+  new URL('../../../../../argocd/applications/torghut-options/ta/configmap.yaml', import.meta.url),
+  'utf8',
+)
+const optionsTaFlinkDeployment = readFileSync(
+  new URL('../../../../../argocd/applications/torghut-options/ta/flinkdeployment.yaml', import.meta.url),
+  'utf8',
+)
 
 describe('torghut post-deploy verifier workflow', () => {
   it('does not skip Knative Service readiness when the runner lacks RBAC', () => {
@@ -50,5 +58,13 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(agentsCiClusterRbac).toContain('agents-ci-runner-argocd-application-refresh')
     expect(agentsCiClusterRbac).toContain('argoproj.io')
     expect(agentsCiClusterRbac).toContain('patch')
+  })
+
+  it('rotates the options TA Kafka transactional client prefix with the restart nonce', () => {
+    expect(optionsTaFlinkDeployment).toContain('restartNonce: 8')
+    expect(optionsTaConfigmap).toContain('TA_KAFKA_TRANSACTION_TIMEOUT_MS: "120000"')
+    expect(optionsTaConfigmap).toContain('TA_CLIENT_ID: "torghut-options-ta-r8"')
+    expect(optionsTaConfigmap).toContain('TA_GROUP_ID: "torghut-options-ta-2026-03-08"')
+    expect(optionsTaFlinkDeployment).toContain('value: EXACTLY_ONCE')
   })
 })


### PR DESCRIPTION
## Summary

- Rotates the options TA Kafka transactional client prefix to `torghut-options-ta-r8`.
- Bumps `torghut-options-ta` `restartNonce` to restart the Flink job through GitOps while preserving `EXACTLY_ONCE`.
- Adds a workflow contract test tying the transactional client prefix to the restart nonce and preserving the consumer group.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bun run lint:argocd`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `git diff --check`
- Live inspection before the change: `torghut-options-ta` Flink REST reported the job globally `RUNNING`, but downstream sink vertices stayed `INITIALIZING` and checkpoints failed because required tasks were not running.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
