### PR TITLE
fix(torghut): close superseded rollback prs

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -237,6 +237,35 @@ jobs:
           export TORGHUT_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-readyz.json"
           bun run packages/scripts/src/torghut/post-deploy-evidence.ts
 
+      - name: Close superseded Torghut rollback pull requests
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          VERIFIED_SHA: ${{ github.sha }}
+          VERIFIED_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t rollback_pr_numbers < <(
+            gh pr list -R "${GH_REPO}" --state open --base main --limit 200 \
+              --json number,title,headRefName \
+              --jq ".[] | select(.headRefName | startswith(\"codex/torghut-rollback-\")) | select(.title | startswith(\"revert(torghut): rollback failed promotion \")) | .number"
+          )
+
+          if [ "${#rollback_pr_numbers[@]}" -eq 0 ]; then
+            echo "No superseded Torghut rollback pull requests to close"
+            exit 0
+          fi
+
+          for pr_number in "${rollback_pr_numbers[@]}"; do
+            printf -v comment "Closing this superseded automatic Torghut rollback PR because a newer torghut-post-deploy-verify run succeeded on %s.\n\nSuccessful run: %s\n" \
+              "${VERIFIED_SHA}" \
+              "${VERIFIED_RUN_URL}"
+            gh pr close "${pr_number}" -R "${GH_REPO}" --delete-branch --comment "${comment}"
+          done
+
       - name: Prepare rollback manifests
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: rollback

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -67,4 +67,12 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(optionsTaConfigmap).toContain('TA_GROUP_ID: "torghut-options-ta-2026-03-08"')
     expect(optionsTaFlinkDeployment).toContain('value: EXACTLY_ONCE')
   })
+
+  it('closes superseded automatic rollback pull requests after successful verification', () => {
+    expect(workflow).toContain('Close superseded Torghut rollback pull requests')
+    expect(workflow).toContain("success() && github.event_name == 'push' && github.ref == 'refs/heads/main'")
+    expect(workflow).toContain('codex/torghut-rollback-')
+    expect(workflow).toContain('revert(torghut): rollback failed promotion ')
+    expect(workflow).toContain('gh pr close "${pr_number}" -R "${GH_REPO}" --delete-branch --comment "${comment}"')
+  })
 })


### PR DESCRIPTION
## Summary

- Adds a success-path cleanup step to `torghut-post-deploy-verify` that closes superseded automatic Torghut rollback PRs after a newer main-branch verification succeeds.
- Scopes cleanup to open `codex/torghut-rollback-*` PRs against `main` with the generated `revert(torghut): rollback failed promotion` title prefix.
- Adds a workflow contract test so rollback cleanup behavior is covered alongside the existing post-deploy verifier guards.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `actionlint -color -ignore 'label "arc-arm64" is unknown' .github/workflows/torghut-post-deploy-verify.yml`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/torghut-post-deploy-verify.yml"); puts "yaml-ok"'`
- `git diff --check`
- Manual GitHub cleanup: closed PRs `#6883`, `#6878`, `#6874`, `#6868`, `#6854`, `#6846`, and `#6840` after successful verification run `25981988723`.
- Manual live check: `kubectl get application torghut torghut-options -n argocd` showed both `Synced/Healthy`; `kubectl get flinkdeployment -n torghut` showed `torghut-options-ta`, `torghut-ta`, and `torghut-ta-sim` `RUNNING/STABLE`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
