### PR TITLE
perf(torghut): scale whitepaper autoresearch replay

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -37,27 +37,27 @@ spec:
       - name: targetNetPnlPerDay
         value: '500'
       - name: maxCandidates
-        value: '136'
+        value: '240'
       - name: topK
-        value: '72'
+        value: '128'
       - name: explorationSlots
-        value: '64'
+        value: '112'
       - name: portfolioSizeMin
         value: '3'
       - name: portfolioSizeMax
         value: '8'
       - name: maxFrontierCandidatesPerSpec
-        value: '2'
+        value: '3'
       - name: maxTotalFrontierCandidates
-        value: '128'
+        value: '240'
       - name: realReplayTimeoutSeconds
-        value: '10000'
+        value: '14400'
       - name: realReplayShardSize
         value: '1'
       - name: realReplayShardTimeoutSeconds
         value: '1800'
       - name: realReplayShardWorkers
-        value: '6'
+        value: '24'
       - name: prefetchFullWindowRows
         value: 'true'
       - name: allowStaleTape
@@ -135,11 +135,11 @@ spec:
             readOnly: true
         resources:
           requests:
-            cpu: 1
-            memory: 8Gi
+            cpu: 16
+            memory: 32Gi
           limits:
-            cpu: 4
-            memory: 16Gi
+            cpu: 32
+            memory: 96Gi
         args:
           - |
             set -euo pipefail


### PR DESCRIPTION
## Summary

- Scales the Torghut whitepaper autoresearch workflow defaults from the narrow 4-CPU replay lane to a 32-CPU replay lane.
- Raises default candidate, ranking, exploration, and frontier budgets so the larger pod can search and replay more strategies per run.
- Keeps the same profit target, real replay mode, stale-tape rejection, and persistence gates; this changes throughput, not proof semantics.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check`
- Live verification: patched `torghut-whitepaper-autoresearch-profit-target` in namespace `torghut`, then submitted `torghut-whitepaper-autoresearch-profit-target-btzjl` and confirmed its main container requests `16` CPU / `32Gi` and limits `32` CPU / `96Gi`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
