### PR TITLE
perf(torghut): widen autoresearch replay exploration

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -37,19 +37,19 @@ spec:
       - name: targetNetPnlPerDay
         value: '500'
       - name: maxCandidates
-        value: '240'
+        value: '420'
       - name: topK
-        value: '128'
+        value: '192'
       - name: explorationSlots
-        value: '112'
+        value: '228'
       - name: portfolioSizeMin
         value: '3'
       - name: portfolioSizeMax
-        value: '8'
+        value: '12'
       - name: maxFrontierCandidatesPerSpec
-        value: '3'
+        value: '4'
       - name: maxTotalFrontierCandidates
-        value: '240'
+        value: '420'
       - name: realReplayTimeoutSeconds
         value: '14400'
       - name: realReplayShardSize
@@ -57,7 +57,7 @@ spec:
       - name: realReplayShardTimeoutSeconds
         value: '1800'
       - name: realReplayShardWorkers
-        value: '24'
+        value: '48'
       - name: prefetchFullWindowRows
         value: 'true'
       - name: allowStaleTape
@@ -138,8 +138,8 @@ spec:
             cpu: 16
             memory: 32Gi
           limits:
-            cpu: 32
-            memory: 96Gi
+            cpu: 64
+            memory: 160Gi
         args:
           - |
             set -euo pipefail

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -3344,10 +3344,23 @@ def _select_candidate_specs_for_replay(
         for spec in ordered_unique
         if spec.candidate_spec_id not in block_reason_by_spec
     ]
+    synthetic_prior_probe_candidates = [
+        spec
+        for spec in ordered_unique
+        if block_reason_by_spec.get(spec.candidate_spec_id)
+        == "pre_replay_mlx_synthetic_nonpositive_expected_value"
+    ]
     rank_position_by_spec = {
         spec.candidate_spec_id: index for index, spec in enumerate(ordered, start=1)
     }
-    replay_budget = min(replay_budget, len(ordered_eligible))
+    synthetic_prior_probe_capacity = min(
+        requested_exploration_slots,
+        len(synthetic_prior_probe_candidates),
+    )
+    replay_budget = min(
+        replay_budget,
+        len(ordered_eligible) + synthetic_prior_probe_capacity,
+    )
     exploitation_count = min(max(0, int(top_k)), replay_budget, len(ordered_eligible))
 
     def spec_source_run_id(spec: CandidateSpec) -> str:
@@ -3440,9 +3453,24 @@ def _select_candidate_specs_for_replay(
         count=exploration_count,
         selected_so_far=exploitation,
     )
+    synthetic_prior_probe_exploration_count = min(
+        max(0, requested_exploration_slots - len(exploration)),
+        replay_budget - len(exploitation) - len(exploration),
+        len(synthetic_prior_probe_candidates),
+    )
+    synthetic_prior_probe_exploration = take_diverse(
+        synthetic_prior_probe_candidates,
+        count=synthetic_prior_probe_exploration_count,
+        selected_so_far=[*exploitation, *exploration],
+    )
     if len(exploitation) + len(exploration) < replay_budget:
         selected_ids = {
-            item.candidate_spec_id for item in (*exploitation, *exploration)
+            item.candidate_spec_id
+            for item in (
+                *exploitation,
+                *exploration,
+                *synthetic_prior_probe_exploration,
+            )
         }
         backfill_candidates = [
             item
@@ -3451,8 +3479,15 @@ def _select_candidate_specs_for_replay(
         ]
         backfill = take_diverse(
             backfill_candidates,
-            count=replay_budget - len(exploitation) - len(exploration),
-            selected_so_far=[*exploitation, *exploration],
+            count=replay_budget
+            - len(exploitation)
+            - len(exploration)
+            - len(synthetic_prior_probe_exploration),
+            selected_so_far=[
+                *exploitation,
+                *exploration,
+                *synthetic_prior_probe_exploration,
+            ],
         )
     else:
         backfill = []
@@ -3460,10 +3495,24 @@ def _select_candidate_specs_for_replay(
         item.candidate_spec_id: "exploitation" for item in exploitation
     } | {item.candidate_spec_id: "exploration" for item in exploration}
     selected_reason.update(
+        {
+            item.candidate_spec_id: "synthetic_prior_exploration"
+            for item in synthetic_prior_probe_exploration
+        }
+    )
+    selected_reason.update(
         {item.candidate_spec_id: "budget_backfill" for item in backfill}
     )
-    selected = [*exploitation, *exploration, *backfill]
+    selected = [
+        *exploitation,
+        *exploration,
+        *synthetic_prior_probe_exploration,
+        *backfill,
+    ]
     selected_ids = {item.candidate_spec_id for item in selected}
+    synthetic_prior_probe_selected_ids = {
+        item.candidate_spec_id for item in synthetic_prior_probe_exploration
+    }
     replay_order_by_spec = {
         item.candidate_spec_id: index for index, item in enumerate(selected, start=1)
     }
@@ -3595,13 +3644,20 @@ def _select_candidate_specs_for_replay(
                 for reason in block_reason_by_spec.values()
                 if reason == "pre_replay_mlx_synthetic_nonpositive_expected_value"
             ),
+            "pre_replay_nonpositive_synthetic_exploration_count": len(
+                synthetic_prior_probe_exploration
+            ),
             "pre_replay_capital_blocked_candidate_count": sum(
                 1
                 for reason in block_reason_by_spec.values()
                 if reason == capital_block_reason
             ),
-            "pre_replay_blocked_candidate_count": len(block_reason_by_spec),
-            "replay_order_policy": "quality_gated_diversity_pick_order",
+            "pre_replay_blocked_candidate_count": sum(
+                1
+                for candidate_spec_id in block_reason_by_spec
+                if candidate_spec_id not in synthetic_prior_probe_selected_ids
+            ),
+            "replay_order_policy": "quality_gated_diversity_pick_order_with_synthetic_prior_probe",
             "capital_feasible_candidate_count": sum(
                 1
                 for features in capital_features_by_spec.values()

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -305,18 +305,19 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             'if [ -n "{{inputs.parameters.expectedLastTradingDay}}" ]; then',
             template,
         )
-        self.assertIn("name: maxCandidates\n        value: '136'", template)
-        self.assertIn("name: topK\n        value: '72'", template)
-        self.assertIn("name: explorationSlots\n        value: '64'", template)
+        self.assertIn("name: maxCandidates\n        value: '420'", template)
+        self.assertIn("name: topK\n        value: '192'", template)
+        self.assertIn("name: explorationSlots\n        value: '228'", template)
         self.assertIn(
-            "name: maxTotalFrontierCandidates\n        value: '128'", template
+            "name: maxTotalFrontierCandidates\n        value: '420'", template
         )
         self.assertIn(
-            "name: realReplayTimeoutSeconds\n        value: '10000'", template
+            "name: realReplayTimeoutSeconds\n        value: '14400'", template
         )
         self.assertIn(
             "name: realReplayShardTimeoutSeconds\n        value: '1800'", template
         )
+        self.assertIn("name: realReplayShardWorkers\n        value: '48'", template)
         self.assertIn(
             "--program config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml",
             template,
@@ -1730,6 +1731,45 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             selection["rows"][0]["selection_reason"],
             "pre_replay_mlx_synthetic_nonpositive_expected_value",
         )
+
+    def test_candidate_selection_uses_exploration_for_synthetic_nonpositive_prior(
+        self,
+    ) -> None:
+        spec = self._candidate_spec("spec-negative-synthetic-prior-probe")
+
+        selected, selection = runner._select_candidate_specs_for_replay(
+            specs=(spec,),
+            proposal_rows=[
+                {
+                    "candidate_spec_id": spec.candidate_spec_id,
+                    "rank": 1,
+                    "proposal_score": -12.5,
+                    "selection_reason": "pre_replay_mlx_rank",
+                    "training_source": "synthetic_prior",
+                    "feedback_evidence_context_count": 1,
+                }
+            ],
+            top_k=1,
+            exploration_slots=1,
+            max_candidates=1,
+            portfolio_size_min=1,
+        )
+
+        self.assertEqual(selected, [spec])
+        self.assertEqual(selection["budget"]["eligible_candidate_count"], 0)
+        self.assertEqual(
+            selection["budget"]["pre_replay_nonpositive_synthetic_candidate_count"], 1
+        )
+        self.assertEqual(
+            selection["budget"]["pre_replay_nonpositive_synthetic_exploration_count"],
+            1,
+        )
+        self.assertEqual(selection["budget"]["pre_replay_blocked_candidate_count"], 0)
+        self.assertEqual(
+            selection["rows"][0]["selection_reason"],
+            "synthetic_prior_exploration",
+        )
+        self.assertTrue(selection["rows"][0]["selected_for_replay"])
 
     def test_candidate_selection_ignores_malformed_feedback_context_for_synthetic_prior(
         self,


### PR DESCRIPTION
## Summary

- Increases the Torghut whitepaper autoresearch workflow defaults to a 420-candidate frontier, 192 top-K, 228 exploration slots, 12-sleeve portfolio cap, 48 replay workers, and a 64 CPU / 160Gi limit.
- Lets explicitly requested exploration slots replay bounded synthetic-prior negative candidates when the ranker is low-value but the candidates are not capital-infeasible or real-feedback hard blocked.
- Adds regression coverage for the synthetic-prior exploration path and updates workflow-template assertions for the larger production lane.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'candidate_selection_blocks_synthetic_nonpositive_expected_value or candidate_selection_uses_exploration_for_synthetic_nonpositive_prior or seed_recent_whitepapers_dedupes_execution_signatures'`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'workflow_template_surfaces_feedback_and_fails_closed_on_stale_tape or candidate_selection_uses_exploration_for_synthetic_nonpositive_prior or candidate_selection_blocks_synthetic_nonpositive_expected_value'`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`
- Replayed the live scaled32 selection manifest locally with the patched selector: selected candidates increased from 7 to 175, including 168 `synthetic_prior_exploration` replays and no capital/feedback hard-block relaxation.

## Screenshots (if applicable)

N/A - backend workflow and selector change.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
