### PR TITLE
chore(jangar): promote image 5de6d046

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/jangar
-  tag: codex-goal-alpaca-0ab3f5a38
-  digest: sha256:de68b60586750a1e7798ba216decd48e66f32b876b5df1b4a4f64ecd7f62bc45
+  tag: 5de6d046
+  digest: sha256:aed09ee8295c1e7b9c84042228b79a174e2286b586bbba6fd599f913ee9f07bb
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,25 +11,25 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: codex-goal-alpaca-0ab3f5a38
-    digest: sha256:be9462bc32d45ab2e035ce2e2bfe6372fd44d1826a5d7d30f388ef5fe3f5aa1a
+    tag: 5de6d046
+    digest: sha256:b5188e6237d70f9e28514ea1b1a13d4a321e6f56eef30d76ea0f7a6501cfbedc
   env:
     vars:
       JANGAR_CONTROL_PLANE_CACHE_ENABLED: "true"
       JANGAR_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       JANGAR_TORGHUT_STATUS_TIMEOUT_MS: "12000"
-      JANGAR_SOURCE_HEAD_SHA: ea0f7a1d3d41adacf18185a26a3bafc72f7ba355
-      JANGAR_GITOPS_REVISION: ea0f7a1d3d41adacf18185a26a3bafc72f7ba355
-      JANGAR_SOURCE_CI_RUN_ID: "25981198000"
+      JANGAR_SOURCE_HEAD_SHA: 5de6d046508c62cb025dc08338f9efc8b81b5c60
+      JANGAR_GITOPS_REVISION: 5de6d046508c62cb025dc08338f9efc8b81b5c60
+      JANGAR_SOURCE_CI_RUN_ID: "26001743500"
       JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:6d372f58f7115b395ec40f7dba35b8c1bddb41875c6be9bd0cf7350eb6744f6d
-      JANGAR_SERVING_BUILD_COMMIT: ea0f7a1d3d41adacf18185a26a3bafc72f7ba355
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:6d372f58f7115b395ec40f7dba35b8c1bddb41875c6be9bd0cf7350eb6744f6d
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:b5188e6237d70f9e28514ea1b1a13d4a321e6f56eef30d76ea0f7a6501cfbedc
+      JANGAR_SERVING_BUILD_COMMIT: 5de6d046508c62cb025dc08338f9efc8b81b5c60
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:b5188e6237d70f9e28514ea1b1a13d4a321e6f56eef30d76ea0f7a6501cfbedc
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/jangar
-    tag: codex-goal-alpaca-0ab3f5a38
-    digest: sha256:de68b60586750a1e7798ba216decd48e66f32b876b5df1b4a4f64ecd7f62bc45
+    tag: 5de6d046
+    digest: sha256:aed09ee8295c1e7b9c84042228b79a174e2286b586bbba6fd599f913ee9f07bb
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-17T04:22:56Z
+    deploy.knative.dev/rollout: 2026-05-17T20:24:38Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:ea0f7a1d@sha256:71fe9ceae23b187fe3f1dfec034687dd86d4acf7dc6ec586102565b95bd49683
+              value: registry.ide-newton.ts.net/lab/jangar:5de6d046@sha256:aed09ee8295c1e7b9c84042228b79a174e2286b586bbba6fd599f913ee9f07bb
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: ea0f7a1d3d41adacf18185a26a3bafc72f7ba355
+              value: 5de6d046508c62cb025dc08338f9efc8b81b5c60
             - name: JANGAR_GITOPS_REVISION
-              value: ea0f7a1d3d41adacf18185a26a3bafc72f7ba355
+              value: 5de6d046508c62cb025dc08338f9efc8b81b5c60
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "25981198000"
+              value: "26001743500"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:6d372f58f7115b395ec40f7dba35b8c1bddb41875c6be9bd0cf7350eb6744f6d
+              value: sha256:b5188e6237d70f9e28514ea1b1a13d4a321e6f56eef30d76ea0f7a6501cfbedc
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: ea0f7a1d3d41adacf18185a26a3bafc72f7ba355
+              value: 5de6d046508c62cb025dc08338f9efc8b81b5c60
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:6d372f58f7115b395ec40f7dba35b8c1bddb41875c6be9bd0cf7350eb6744f6d
+              value: sha256:b5188e6237d70f9e28514ea1b1a13d4a321e6f56eef30d76ea0f7a6501cfbedc
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: ea0f7a1d
-    digest: sha256:71fe9ceae23b187fe3f1dfec034687dd86d4acf7dc6ec586102565b95bd49683
+    newTag: 5de6d046
+    digest: sha256:aed09ee8295c1e7b9c84042228b79a174e2286b586bbba6fd599f913ee9f07bb


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `5de6d046508c62cb025dc08338f9efc8b81b5c60`
- Image tag: `5de6d046`
- Image digest: `sha256:aed09ee8295c1e7b9c84042228b79a174e2286b586bbba6fd599f913ee9f07bb`
- Source CI run: `26001743500`
- Control-plane serving digest: `sha256:b5188e6237d70f9e28514ea1b1a13d4a321e6f56eef30d76ea0f7a6501cfbedc`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates