### PR TITLE
perf(torghut): add feedback-block replay reaudits

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -37,11 +37,13 @@ spec:
       - name: targetNetPnlPerDay
         value: '500'
       - name: maxCandidates
-        value: '420'
+        value: '640'
       - name: topK
-        value: '192'
+        value: '256'
       - name: explorationSlots
-        value: '228'
+        value: '256'
+      - name: feedbackBlockReauditSlots
+        value: '128'
       - name: portfolioSizeMin
         value: '3'
       - name: portfolioSizeMax
@@ -49,7 +51,7 @@ spec:
       - name: maxFrontierCandidatesPerSpec
         value: '4'
       - name: maxTotalFrontierCandidates
-        value: '420'
+        value: '640'
       - name: realReplayTimeoutSeconds
         value: '14400'
       - name: realReplayShardSize
@@ -57,7 +59,7 @@ spec:
       - name: realReplayShardTimeoutSeconds
         value: '1800'
       - name: realReplayShardWorkers
-        value: '48'
+        value: '64'
       - name: prefetchFullWindowRows
         value: 'true'
       - name: allowStaleTape
@@ -86,6 +88,7 @@ spec:
           - name: maxCandidates
           - name: topK
           - name: explorationSlots
+          - name: feedbackBlockReauditSlots
           - name: portfolioSizeMin
           - name: portfolioSizeMax
           - name: maxFrontierCandidatesPerSpec
@@ -164,6 +167,7 @@ spec:
               --max-candidates "{{inputs.parameters.maxCandidates}}"
               --top-k "{{inputs.parameters.topK}}"
               --exploration-slots "{{inputs.parameters.explorationSlots}}"
+              --feedback-block-reaudit-slots "{{inputs.parameters.feedbackBlockReauditSlots}}"
               --portfolio-size-min "{{inputs.parameters.portfolioSizeMin}}"
               --portfolio-size-max "{{inputs.parameters.portfolioSizeMax}}"
               --replay-mode real

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -99,8 +99,8 @@ describe('Torghut manifest scheduling', () => {
     const requests = getAtPath(resources, ['requests'])
     const limits = getAtPath(resources, ['limits'])
 
-    expect(requests.memory).toBe('8Gi')
-    expect(limits.memory).toBe('16Gi')
+    expect(requests.memory).toBe('32Gi')
+    expect(limits.memory).toBe('160Gi')
     expect(container.volumeMounts).toContainEqual(
       expect.objectContaining({
         mountPath: '/etc/torghut',
@@ -118,9 +118,11 @@ describe('Torghut manifest scheduling', () => {
     expect(JSON.stringify(template)).toContain('--real-replay-shard-size')
     expect(JSON.stringify(template)).toContain('--real-replay-shard-timeout-seconds')
     expect(JSON.stringify(template)).toContain('--real-replay-shard-workers')
-    expect(parameterValue(manifest, 'maxCandidates')).toBe('136')
-    expect(parameterValue(manifest, 'topK')).toBe('72')
-    expect(parameterValue(manifest, 'explorationSlots')).toBe('64')
+    expect(JSON.stringify(template)).toContain('--feedback-block-reaudit-slots')
+    expect(parameterValue(manifest, 'maxCandidates')).toBe('640')
+    expect(parameterValue(manifest, 'topK')).toBe('256')
+    expect(parameterValue(manifest, 'explorationSlots')).toBe('256')
+    expect(parameterValue(manifest, 'feedbackBlockReauditSlots')).toBe('128')
     expect(parameterValue(manifest, 'portfolioSizeMin')).toBe('3')
   })
 
@@ -128,11 +130,11 @@ describe('Torghut manifest scheduling', () => {
     const manifest = parseManifest('argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml')
     const template = getAtPath(manifest, ['spec', 'templates', 0])
 
-    expect(parameterValue(manifest, 'maxFrontierCandidatesPerSpec')).toBe('2')
-    expect(parameterValue(manifest, 'maxTotalFrontierCandidates')).toBe('128')
-    expect(parameterValue(manifest, 'realReplayTimeoutSeconds')).toBe('10000')
+    expect(parameterValue(manifest, 'maxFrontierCandidatesPerSpec')).toBe('4')
+    expect(parameterValue(manifest, 'maxTotalFrontierCandidates')).toBe('640')
+    expect(parameterValue(manifest, 'realReplayTimeoutSeconds')).toBe('14400')
     expect(parameterValue(manifest, 'realReplayShardSize')).toBe('1')
-    expect(parameterValue(manifest, 'realReplayShardWorkers')).toBe('6')
+    expect(parameterValue(manifest, 'realReplayShardWorkers')).toBe('64')
     expect(template.activeDeadlineSeconds).toBe(21600)
   })
 })

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -173,6 +173,16 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--max-candidates", type=int, default=64)
     parser.add_argument("--top-k", type=int, default=16)
     parser.add_argument("--exploration-slots", type=int, default=8)
+    parser.add_argument(
+        "--feedback-block-reaudit-slots",
+        type=int,
+        default=0,
+        help=(
+            "Bounded slots for replaying candidates blocked only by prior "
+            "feedback. These are diagnostic re-audits; capital blocks and final "
+            "promotion/oracle gates still apply."
+        ),
+    )
     parser.add_argument("--portfolio-size-min", type=int, default=2)
     parser.add_argument("--portfolio-size-max", type=int, default=8)
     parser.add_argument("--replay-mode", choices=("synthetic", "real"), default="real")
@@ -2139,6 +2149,9 @@ def _profitability_next_epoch_plan(
         "--max-candidates": str(max(64, _int_arg(args, "max_candidates", 64))),
         "--top-k": str(max(16, _int_arg(args, "top_k", 16))),
         "--exploration-slots": str(max(8, _int_arg(args, "exploration_slots", 8))),
+        "--feedback-block-reaudit-slots": str(
+            max(0, _int_arg(args, "feedback_block_reaudit_slots", 0))
+        ),
         "--portfolio-size-min": str(max(2, _int_arg(args, "portfolio_size_min", 2))),
         "--portfolio-size-max": str(max(8, _int_arg(args, "portfolio_size_max", 8))),
         "--max-frontier-candidates-per-spec": str(
@@ -2202,6 +2215,7 @@ def _profitability_next_epoch_plan(
         "--max-candidates",
         "--top-k",
         "--exploration-slots",
+        "--feedback-block-reaudit-slots",
         "--portfolio-size-min",
         "--portfolio-size-max",
         "--max-total-frontier-candidates",
@@ -3201,6 +3215,7 @@ def _select_candidate_specs_for_replay(
     exploration_slots: int,
     max_candidates: int,
     portfolio_size_min: int,
+    feedback_block_reaudit_slots: int = 0,
 ) -> tuple[list[CandidateSpec], dict[str, Any]]:
     if not specs:
         return [], {
@@ -3350,6 +3365,13 @@ def _select_candidate_specs_for_replay(
         if block_reason_by_spec.get(spec.candidate_spec_id)
         == "pre_replay_mlx_synthetic_nonpositive_expected_value"
     ]
+    feedback_block_reaudit_candidates = [
+        spec
+        for spec in ordered_unique
+        if is_feedback_block_reason(
+            block_reason_by_spec.get(spec.candidate_spec_id, "")
+        )
+    ]
     rank_position_by_spec = {
         spec.candidate_spec_id: index for index, spec in enumerate(ordered, start=1)
     }
@@ -3357,9 +3379,16 @@ def _select_candidate_specs_for_replay(
         requested_exploration_slots,
         len(synthetic_prior_probe_candidates),
     )
+    requested_feedback_block_reaudit_slots = max(0, int(feedback_block_reaudit_slots))
+    feedback_block_reaudit_capacity = min(
+        requested_feedback_block_reaudit_slots,
+        len(feedback_block_reaudit_candidates),
+    )
     replay_budget = min(
         replay_budget,
-        len(ordered_eligible) + synthetic_prior_probe_capacity,
+        len(ordered_eligible)
+        + synthetic_prior_probe_capacity
+        + feedback_block_reaudit_capacity,
     )
     exploitation_count = min(max(0, int(top_k)), replay_budget, len(ordered_eligible))
 
@@ -3463,6 +3492,23 @@ def _select_candidate_specs_for_replay(
         count=synthetic_prior_probe_exploration_count,
         selected_so_far=[*exploitation, *exploration],
     )
+    feedback_block_reaudit_count = min(
+        requested_feedback_block_reaudit_slots,
+        replay_budget
+        - len(exploitation)
+        - len(exploration)
+        - len(synthetic_prior_probe_exploration),
+        len(feedback_block_reaudit_candidates),
+    )
+    feedback_block_reaudit = take_diverse(
+        feedback_block_reaudit_candidates,
+        count=feedback_block_reaudit_count,
+        selected_so_far=[
+            *exploitation,
+            *exploration,
+            *synthetic_prior_probe_exploration,
+        ],
+    )
     if len(exploitation) + len(exploration) < replay_budget:
         selected_ids = {
             item.candidate_spec_id
@@ -3470,6 +3516,7 @@ def _select_candidate_specs_for_replay(
                 *exploitation,
                 *exploration,
                 *synthetic_prior_probe_exploration,
+                *feedback_block_reaudit,
             )
         }
         backfill_candidates = [
@@ -3482,11 +3529,13 @@ def _select_candidate_specs_for_replay(
             count=replay_budget
             - len(exploitation)
             - len(exploration)
-            - len(synthetic_prior_probe_exploration),
+            - len(synthetic_prior_probe_exploration)
+            - len(feedback_block_reaudit),
             selected_so_far=[
                 *exploitation,
                 *exploration,
                 *synthetic_prior_probe_exploration,
+                *feedback_block_reaudit,
             ],
         )
     else:
@@ -3501,18 +3550,25 @@ def _select_candidate_specs_for_replay(
         }
     )
     selected_reason.update(
+        {
+            item.candidate_spec_id: "feedback_block_reaudit"
+            for item in feedback_block_reaudit
+        }
+    )
+    selected_reason.update(
         {item.candidate_spec_id: "budget_backfill" for item in backfill}
     )
     selected = [
         *exploitation,
         *exploration,
         *synthetic_prior_probe_exploration,
+        *feedback_block_reaudit,
         *backfill,
     ]
     selected_ids = {item.candidate_spec_id for item in selected}
-    synthetic_prior_probe_selected_ids = {
+    selected_pre_replay_blocked_ids = {
         item.candidate_spec_id for item in synthetic_prior_probe_exploration
-    }
+    } | {item.candidate_spec_id for item in feedback_block_reaudit}
     replay_order_by_spec = {
         item.candidate_spec_id: index for index, item in enumerate(selected, start=1)
     }
@@ -3629,6 +3685,9 @@ def _select_candidate_specs_for_replay(
             "exploration_slots_requested": requested_exploration_slots,
             "exploration_slots_effective": effective_exploration_slots,
             "exploration_slots": effective_exploration_slots,
+            "feedback_block_reaudit_slots_requested": requested_feedback_block_reaudit_slots,
+            "feedback_block_reaudit_slots_effective": feedback_block_reaudit_capacity,
+            "feedback_block_reaudit_selected_count": len(feedback_block_reaudit),
             "portfolio_size_min": max(1, int(portfolio_size_min)),
             "selected_count": len(selected),
             "compiled_candidate_count": len(specs),
@@ -3655,9 +3714,9 @@ def _select_candidate_specs_for_replay(
             "pre_replay_blocked_candidate_count": sum(
                 1
                 for candidate_spec_id in block_reason_by_spec
-                if candidate_spec_id not in synthetic_prior_probe_selected_ids
+                if candidate_spec_id not in selected_pre_replay_blocked_ids
             ),
-            "replay_order_policy": "quality_gated_diversity_pick_order_with_synthetic_prior_probe",
+            "replay_order_policy": "quality_gated_diversity_pick_order_with_synthetic_prior_probe_and_feedback_reaudit",
             "capital_feasible_candidate_count": sum(
                 1
                 for features in capital_features_by_spec.values()
@@ -4981,6 +5040,9 @@ def run_whitepaper_autoresearch_profit_target(
         proposal_rows=pre_replay_proposal_rows,
         top_k=int(args.top_k),
         exploration_slots=int(args.exploration_slots),
+        feedback_block_reaudit_slots=int(
+            getattr(args, "feedback_block_reaudit_slots", 0) or 0
+        ),
         max_candidates=int(args.max_candidates),
         portfolio_size_min=int(args.portfolio_size_min),
     )
@@ -5429,6 +5491,9 @@ def run_whitepaper_autoresearch_profit_target(
             "max_candidates": int(args.max_candidates),
             "top_k": int(args.top_k),
             "exploration_slots": int(args.exploration_slots),
+            "feedback_block_reaudit_slots": int(
+                getattr(args, "feedback_block_reaudit_slots", 0) or 0
+            ),
             "replay_candidate_spec_count": len(replay_candidate_specs),
             "replay_incomplete": replay_result.incomplete,
             "replay_failure_reasons": replay_failure_reasons,

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -94,6 +94,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             max_candidates=8,
             top_k=4,
             exploration_slots=2,
+            feedback_block_reaudit_slots=0,
             portfolio_size_min=2,
             portfolio_size_max=4,
             replay_mode="synthetic",
@@ -305,11 +306,12 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             'if [ -n "{{inputs.parameters.expectedLastTradingDay}}" ]; then',
             template,
         )
-        self.assertIn("name: maxCandidates\n        value: '420'", template)
-        self.assertIn("name: topK\n        value: '192'", template)
-        self.assertIn("name: explorationSlots\n        value: '228'", template)
+        self.assertIn("name: maxCandidates\n        value: '640'", template)
+        self.assertIn("name: topK\n        value: '256'", template)
+        self.assertIn("name: explorationSlots\n        value: '256'", template)
+        self.assertIn("name: feedbackBlockReauditSlots\n        value: '128'", template)
         self.assertIn(
-            "name: maxTotalFrontierCandidates\n        value: '420'", template
+            "name: maxTotalFrontierCandidates\n        value: '640'", template
         )
         self.assertIn(
             "name: realReplayTimeoutSeconds\n        value: '14400'", template
@@ -317,7 +319,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn(
             "name: realReplayShardTimeoutSeconds\n        value: '1800'", template
         )
-        self.assertIn("name: realReplayShardWorkers\n        value: '48'", template)
+        self.assertIn("name: realReplayShardWorkers\n        value: '64'", template)
+        self.assertIn("--feedback-block-reaudit-slots", template)
         self.assertIn(
             "--program config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml",
             template,
@@ -1126,6 +1129,76 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             selection["rows"][0]["selection_reason"],
             "pre_replay_mlx_family_feedback_blocked",
+        )
+
+    def test_candidate_selection_can_reaudit_feedback_blocked_candidates(
+        self,
+    ) -> None:
+        source_spec = self._candidate_spec("spec-reaudit-source")
+        blocked_spec = self._candidate_spec(
+            "spec-reaudit-blocked",
+            entry_minute_after_open="60",
+        )
+        capital_unsafe_spec = replace(
+            self._candidate_spec(
+                "spec-reaudit-capital-unsafe",
+                family_template_id="breakout_reclaim_v2",
+            ),
+            strategy_overrides={
+                **self._candidate_spec(
+                    "spec-reaudit-capital-unsafe",
+                    family_template_id="breakout_reclaim_v2",
+                ).strategy_overrides,
+                "max_notional_per_trade": "157950",
+                "max_position_pct_equity": "4",
+            },
+        )
+        feedback_bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id=source_spec.candidate_spec_id,
+            candidate={
+                "candidate_id": "cand-reaudit-source",
+                "family_template_id": source_spec.family_template_id,
+                "runtime_family": source_spec.runtime_family,
+                "runtime_strategy_name": source_spec.runtime_strategy_name,
+                "objective_scorecard": {
+                    "net_pnl_per_day": "-250",
+                    "active_day_ratio": "1",
+                    "positive_day_ratio": "0",
+                    "negative_day_count": 4,
+                    "daily_net": {"2026-05-01": "-250"},
+                },
+            },
+            dataset_snapshot_id="snap-reaudit-feedback",
+            result_path="feedback://reaudit",
+        )
+
+        _model, rows = runner._pre_replay_proposal_model_and_rows(
+            specs=(blocked_spec, capital_unsafe_spec),
+            feedback_evidence_bundles=(feedback_bundle,),
+        )
+
+        selected, selection = runner._select_candidate_specs_for_replay(
+            specs=(blocked_spec, capital_unsafe_spec),
+            proposal_rows=rows,
+            top_k=1,
+            exploration_slots=0,
+            feedback_block_reaudit_slots=1,
+            max_candidates=2,
+            portfolio_size_min=1,
+        )
+        row_by_spec = {row["candidate_spec_id"]: row for row in selection["rows"]}
+
+        self.assertEqual(selected, [blocked_spec])
+        self.assertEqual(selection["budget"]["selected_count"], 1)
+        self.assertEqual(
+            selection["budget"]["feedback_block_reaudit_selected_count"], 1
+        )
+        self.assertEqual(
+            row_by_spec[blocked_spec.candidate_spec_id]["selection_reason"],
+            "feedback_block_reaudit",
+        )
+        self.assertFalse(
+            row_by_spec[capital_unsafe_spec.candidate_spec_id]["selected_for_replay"]
         )
 
     def test_candidate_selection_keeps_positive_blocked_feedback_repair_candidates(


### PR DESCRIPTION
## Summary

- Adds a bounded `--feedback-block-reaudit-slots` lane so whitepaper autoresearch can spend spare replay capacity on previously feedback-blocked candidates without weakening capital, risk, or promotion gates.
- Marks re-audited candidates as `feedback_block_reaudit` and records explicit budget counters in the candidate-selection manifest.
- Scales the Torghut whitepaper autoresearch WorkflowTemplate to 640 max replay candidates, 256 top/exploration slots, 128 feedback-block re-audit slots, and 64 shard workers.
- Updates manifest and selector tests for the widened production envelope.

## Related Issues

None

## Testing

- `uv run --frozen ruff check services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff format --check services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'reaudit or workflow_template or seed_recent_whitepapers_honors_top_k_and_exploration_budget or feedback'`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
