### PR TITLE
feat(torghut): add cuda ranker lane

### DIFF
--- a/argocd/applications/torghut-cuda-ranker/cloud-init-network-secret.yaml
+++ b/argocd/applications/torghut-cuda-ranker/cloud-init-network-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: torghut-cuda-ranker-cloud-init-network
+type: Opaque
+stringData:
+  networkData: |-
+    version: 1
+    config:
+      - type: physical
+        name: enp1s0
+        subnets:
+          - type: dhcp
+  networkdata: |-
+    version: 1
+    config:
+      - type: physical
+        name: enp1s0
+        subnets:
+          - type: dhcp

--- a/argocd/applications/torghut-cuda-ranker/cloud-init-secret.yaml
+++ b/argocd/applications/torghut-cuda-ranker/cloud-init-secret.yaml
@@ -1,0 +1,179 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: torghut-cuda-ranker-cloud-init
+type: Opaque
+stringData:
+  userdata: |-
+    #cloud-config
+    preserve_hostname: false
+    hostname: torghut-cuda-ranker
+    manage_etc_hosts: true
+    package_update: true
+    package_upgrade: false
+    disk_setup:
+      /dev/vdb:
+        table_type: gpt
+        layout: true
+        overwrite: false
+    fs_setup:
+      - device: /dev/vdb1
+        filesystem: ext4
+        overwrite: false
+    mounts:
+      - ["/dev/vdb1", "/var/lib/torghut-cuda-ranker", "ext4", "defaults,nofail", "0", "2"]
+    packages:
+      - openssh-server
+      - ca-certificates
+      - curl
+      - git
+      - jq
+      - gnupg
+      - python3
+      - python3-venv
+      - build-essential
+      - pkg-config
+    write_files:
+      - path: /etc/netplan/99-torghut-cuda-ranker.yaml
+        owner: root:root
+        permissions: '0600'
+        content: |-
+          network:
+            version: 2
+            renderer: networkd
+            ethernets:
+              primary:
+                match:
+                  name: 'en*'
+                dhcp4: true
+                dhcp6: false
+      - path: /var/lib/cloud/scripts/per-boot/10-netplan-apply
+        owner: root:root
+        permissions: '0755'
+        content: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+          netplan generate || true
+          netplan apply || true
+      - path: /usr/local/sbin/torghut-cuda-ranker-prepare-storage
+        owner: root:root
+        permissions: '0755'
+        content: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          install -d -m 0755 /var/lib/torghut-cuda-ranker
+          if [ ! -b /dev/vdb ]; then
+            exit 0
+          fi
+
+          if [ ! -b /dev/vdb1 ]; then
+            if [ -n "$(wipefs -n /dev/vdb | tail -n +2)" ]; then
+              echo "/dev/vdb has filesystem signatures but no /dev/vdb1; refusing to repartition" >&2
+              exit 1
+            fi
+            parted -s /dev/vdb mklabel gpt mkpart primary ext4 1MiB 100%
+            partprobe /dev/vdb || true
+            for _ in $(seq 1 20); do
+              [ -b /dev/vdb1 ] && break
+              sleep 1
+            done
+          fi
+
+          if [ ! -b /dev/vdb1 ]; then
+            echo "/dev/vdb1 was not created" >&2
+            exit 1
+          fi
+
+          if ! blkid /dev/vdb1 >/dev/null 2>&1; then
+            mkfs.ext4 -F /dev/vdb1
+          fi
+
+          if ! findmnt -rn /var/lib/torghut-cuda-ranker >/dev/null 2>&1; then
+            mount /var/lib/torghut-cuda-ranker || mount /dev/vdb1 /var/lib/torghut-cuda-ranker
+          fi
+          chown -R ubuntu:ubuntu /var/lib/torghut-cuda-ranker || true
+      - path: /etc/systemd/system/torghut-cuda-ranker-storage.service
+        owner: root:root
+        permissions: '0644'
+        content: |-
+          [Unit]
+          Description=Prepare Torghut CUDA ranker storage
+          After=local-fs.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/sbin/torghut-cuda-ranker-prepare-storage
+          RemainAfterExit=yes
+
+          [Install]
+          WantedBy=multi-user.target
+      - path: /usr/local/sbin/torghut-cuda-ranker-verify
+        owner: root:root
+        permissions: '0755'
+        content: |-
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          nvidia-smi -L
+          python3 - <<'PY'
+          import json
+          import subprocess
+
+          payload = subprocess.check_output(
+              [
+                  "nvidia-smi",
+                  "--query-gpu=name,memory.total,driver_version",
+                  "--format=csv,noheader,nounits",
+              ],
+              text=True,
+          ).strip()
+          print(json.dumps({"cuda_ranker_gpu": payload}, sort_keys=True))
+          PY
+      - path: /etc/systemd/system/torghut-cuda-ranker-verify.service
+        owner: root:root
+        permissions: '0644'
+        content: |-
+          [Unit]
+          Description=Verify Torghut CUDA ranker GPU passthrough
+          After=network-online.target torghut-cuda-ranker-storage.service
+          Requires=torghut-cuda-ranker-storage.service
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/sbin/torghut-cuda-ranker-verify
+          RemainAfterExit=yes
+
+          [Install]
+          WantedBy=multi-user.target
+    users:
+      - name: ubuntu
+        groups: [sudo]
+        shell: /bin/bash
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        ssh_authorized_keys:
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOE//lpGZI2015yMUjHwhWJjgarTLIsqQBIFXlAanPvS
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDVYPSSdt6tjSWRooRm7nUDS73CebsP92G6GjFa9X+zy
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAzVze3nx4QPa6t9Wvp5FLrcAlM7BDLUmxf049N4HC6d
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDW2gOD2bqZxDwKEsfZM+ggSBV+DlTrUxMQY8JxDMVgG
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAlmf/vteEu7gLBfxyEUjVtQiZ2LCqU6zo+6+G5gmaaa
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEht47QYSXM1n78ww4Aw9jHS50FR9IpQlQGU8emLg1ed
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB9gANXCk/KnE27qvzZk9pGSc1wIzSUewHhqZQXwFJs+
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINXAA7B1vTdTvaMTUcDJTD96v1oiNZx6XI+amVwPXPzy
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOco184B4eZEOoLP5ehTK9cgsJgbelKWUxXuO3+S38U/
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII0/89LwFLAM6tu2gtbwVDrQwFhPiW55RciZo0RUVMrF
+          - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH77X+Ekaz8sSLPImUYO8VYhgDDcb+DXkqU26UZ2PaAP
+          - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMqGcgm6U9z2d9kH5SNjm4wZumlbMxndFi40iNEhI2OKvfSoE4OQJQ8j5KCiu6GrcE2biJcqP1dkMCaJ8xcaYA8= sshid.io/gregkonush
+    ssh_pwauth: false
+    disable_root: true
+    runcmd:
+      - [ bash, -lc, 'systemctl enable --now ssh' ]
+      - [ bash, -lc, 'netplan generate && netplan apply || true' ]
+      - [ bash, -lc, 'apt-get update' ]
+      - [ bash, -lc, 'DEBIAN_FRONTEND=noninteractive apt-get install -y ubuntu-drivers-common' ]
+      - [ bash, -lc, 'installed=0; for pkg in nvidia-driver-590 nvidia-driver-580 nvidia-driver-570 nvidia-driver-550 nvidia-driver-535; do if apt-cache show $pkg >/dev/null 2>&1; then if DEBIAN_FRONTEND=noninteractive apt-get install -y $pkg; then installed=1; break; fi; fi; done; if [ $installed -ne 1 ]; then echo "failed to install any nvidia-driver package" >&2; exit 1; fi' ]
+      - [ bash, -lc, 'modprobe nvidia || true; modprobe nvidia_uvm || true' ]
+      - [ bash, -lc, 'for i in $(seq 1 90); do if nvidia-smi -L; then break; fi; sleep 2; done; nvidia-smi -L' ]
+      - [ bash, -lc, 'curl -LsSf https://astral.sh/uv/install.sh | sh' ]
+      - [ bash, -lc, 'systemctl enable --now torghut-cuda-ranker-storage.service' ]
+      - [ bash, -lc, 'systemctl enable --now torghut-cuda-ranker-verify.service' ]

--- a/argocd/applications/torghut-cuda-ranker/kustomization.yaml
+++ b/argocd/applications/torghut-cuda-ranker/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: torghut-cuda-ranker
+resources:
+  - cloud-init-secret.yaml
+  - cloud-init-network-secret.yaml
+  - pvc.yaml
+  - virtualmachine.yaml
+  - service.yaml

--- a/argocd/applications/torghut-cuda-ranker/pvc.yaml
+++ b/argocd/applications/torghut-cuda-ranker/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: torghut-cuda-ranker-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 120Gi

--- a/argocd/applications/torghut-cuda-ranker/service.yaml
+++ b/argocd/applications/torghut-cuda-ranker/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: torghut-cuda-ranker
+  labels:
+    app.kubernetes.io/name: torghut-cuda-ranker
+spec:
+  type: ClusterIP
+  selector:
+    kubevirt.io/domain: torghut-cuda-ranker
+  ports:
+    - name: ssh
+      port: 22
+      protocol: TCP
+      targetPort: 22

--- a/argocd/applications/torghut-cuda-ranker/virtualmachine.yaml
+++ b/argocd/applications/torghut-cuda-ranker/virtualmachine.yaml
@@ -1,0 +1,86 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: torghut-cuda-ranker
+  labels:
+    app.kubernetes.io/name: torghut-cuda-ranker
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  running: false
+  dataVolumeTemplates:
+    - metadata:
+        name: torghut-cuda-ranker-rootdisk
+        creationTimestamp: null
+      spec:
+        source:
+          http:
+            url: https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img
+        pvc:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 80Gi
+          storageClassName: local-path
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: torghut-cuda-ranker
+        app.kubernetes.io/name: torghut-cuda-ranker
+      annotations:
+        kubevirt.io/pci-interface-slot-count: "9"
+        kubevirt.io/pci-topology-version: v2
+      creationTimestamp: null
+    spec:
+      architecture: arm64
+      nodeSelector:
+        kubernetes.io/hostname: talos-192-168-1-85
+      domain:
+        cpu:
+          cores: 12
+        firmware:
+          uuid: 6a372f76-38dd-4ef5-b6d0-5512d466d1cf
+          serial: 7be1eea5-4b21-45d1-94f8-c722cb981751
+        machine:
+          type: virt
+        resources:
+          requests:
+            memory: 48Gi
+        devices:
+          gpus:
+            - name: gpu0
+              deviceName: nvidia.com/GA102_GEFORCE_RTX_3090
+          disks:
+            - name: rootdisk
+              disk:
+                bus: virtio
+              bootOrder: 1
+            - name: datadisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              masquerade: {}
+              macAddress: "02:00:00:00:00:71"
+              ports:
+                - port: 22
+      networks:
+        - name: default
+          pod: {}
+      volumes:
+        - name: rootdisk
+          dataVolume:
+            name: torghut-cuda-ranker-rootdisk
+        - name: datadisk
+          persistentVolumeClaim:
+            claimName: torghut-cuda-ranker-data
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: torghut-cuda-ranker-cloud-init
+            networkDataSecretRef:
+              name: torghut-cuda-ranker-cloud-init-network

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -132,6 +132,19 @@ spec:
                     pod-security.kubernetes.io/enforce: privileged
                     pod-security.kubernetes.io/audit: privileged
                     pod-security.kubernetes.io/warn: privileged
+              - name: torghut-cuda-ranker
+                path: argocd/applications/torghut-cuda-ranker
+                namespace: torghut-cuda-ranker
+                annotations:
+                  argocd.argoproj.io/sync-wave: "2"
+                automation: manual
+                # Keep disabled until the 3090 is intentionally moved away from saigak.
+                enabled: "false"
+                managedNamespaceMetadata:
+                  labels:
+                    pod-security.kubernetes.io/enforce: privileged
+                    pod-security.kubernetes.io/audit: privileged
+                    pod-security.kubernetes.io/warn: privileged
               - name: openclaw
                 path: argocd/applications/openclaw
                 namespace: openclaw
@@ -727,6 +740,15 @@ spec:
           group: kubevirt.io
           namespace: saigak
           name: saigak
+          jqPathExpressions:
+            - .metadata.annotations
+            - .metadata.finalizers
+            - .spec.dataVolumeTemplates[].metadata.creationTimestamp
+            - .spec.template.metadata.creationTimestamp
+        - kind: VirtualMachine
+          group: kubevirt.io
+          namespace: torghut-cuda-ranker
+          name: torghut-cuda-ranker
           jqPathExpressions:
             - .metadata.annotations
             - .metadata.finalizers

--- a/docs/torghut/cuda-ranker-pod.md
+++ b/docs/torghut/cuda-ranker-pod.md
@@ -1,0 +1,45 @@
+# Torghut CUDA Ranker Pod Notes
+
+The cluster 3090 is not available to the regular Torghut service pod as a normal
+CUDA container device. The GPU node is ARM Talos, the NVIDIA host driver/toolkit
+path is disabled, and KubeVirt exposes the GPU as PCI passthrough:
+
+- resource: `nvidia.com/GA102_GEFORCE_RTX_3090`
+- current consumer pattern: `argocd/applications/saigak/virtualmachine.yaml`
+- KubeVirt setup: `argocd/applications/kubevirt/kustomization.yaml`
+- GPU operator mode: `argocd/applications/nvidia-gpu-operator/values.yaml`
+- Torghut CUDA lane: `argocd/applications/torghut-cuda-ranker/`
+
+A CUDA-backed Torghut ranker therefore needs a separate KubeVirt VM/pod lane,
+not a flag on the current autoresearch container. The VM must request the same
+GPU resource under `spec.template.spec.domain.devices.gpus`, boot an ARM64 image
+with NVIDIA guest drivers, and expose a narrow ranker API or artifact exchange
+that the whitepaper autoresearch workflow can call before replay selection.
+
+`argocd/applications/torghut-cuda-ranker` defines that separate lane. It is a
+KubeVirt `VirtualMachine` that will create a `virt-launcher` pod with:
+
+- `architecture: arm64`
+- node pin: `talos-192-168-1-85`
+- GPU device: `nvidia.com/GA102_GEFORCE_RTX_3090`
+- 12 vCPU cores, 48 GiB memory, and a local-path data disk
+- guest boot verification through `nvidia-smi`
+
+When enabled and started, KubeVirt will create a dedicated
+`virt-launcher-torghut-cuda-ranker-*` pod, which is the actual Kubernetes pod
+that owns the GPU device. The `platform` ApplicationSet keeps the app disabled
+and the VM manifest keeps `spec.running: false`. Do not enable or start it while
+`saigak` owns the only `nvidia.com/GA102_GEFORCE_RTX_3090` device. A second GPU
+consumer will remain pending, or it will force an operational decision to stop
+or migrate `saigak`.
+
+Activation requires both changes:
+
+1. Set the `torghut-cuda-ranker` ApplicationSet entry to `enabled: "true"`.
+2. Set `argocd/applications/torghut-cuda-ranker/virtualmachine.yaml` to
+   `spec.running: true`.
+
+The current production authority stays unchanged: scheduler-v3 real replay,
+post-cost ledgers, hard vetoes, portfolio oracle, runtime closure, and shadow or
+paper evidence decide promotion. GPU ranking can only propose candidates; it
+must not bypass replay or risk gates.

--- a/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
@@ -151,6 +151,39 @@ research_sources:
       - claim_id: macro_information_momentum
         summary: Intraday momentum is stronger around macro-announcement information windows.
         implication: Treat late-day continuation as regime conditional and require non-announcement held-out validation.
+  - source_id: intraday_residual_reversal_2024
+    title: 'Intraday Residual Reversal in the U.S. Stock Market'
+    url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4731947
+    published_at: '2024-02-19'
+    claims:
+      - claim_id: residual_noise_reversal
+        summary: Factor-unexplained intraday price moves can reverse as transitory liquidity pressure unwinds.
+        implication: Add residual-style cross-sectional reversal sleeves that fade short-horizon losers/winners after costs.
+      - claim_id: liquidity_provision_profit_source
+        summary: The claimed return source is liquidity provision to transitory stock-return components.
+        implication: Keep cost, notional, spread, active-day, and best-day concentration gates intact before promotion.
+  - source_id: intraday_return_autocorrelation_term_structure_2025
+    title: 'The Term Structure of Intraday Return Autocorrelations'
+    url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5227714
+    published_at: '2025-04-23'
+    claims:
+      - claim_id: horizon_specific_reversal
+        summary: Intraday autocorrelation direction depends on horizon, with reversals stronger around 15-minute horizons.
+        implication: Sweep short, horizon-specific reversal entries instead of pooling open, mid-day, and close effects.
+      - claim_id: subminute_large_stock_continuation
+        summary: Sub-minute continuations can appear in larger stocks, market stress, and the first half-hour.
+        implication: Keep continuation and reversal sleeves separated by horizon and require holdout proof for each sleeve.
+  - source_id: intraday_cross_section_patterns_2010
+    title: 'Intraday Patterns in the Cross-section of Stock Returns'
+    url: https://arxiv.org/abs/1005.3535
+    published_at: '2010-05-19'
+    claims:
+      - claim_id: same_interval_daily_periodicity
+        summary: Cross-sectional returns can continue at half-hour intervals matching prior trading-day timing.
+        implication: Test interval-specific cross-sectional sleeves with timing controls instead of broad all-day ranks.
+      - claim_id: subhour_liquidity_reversal
+        summary: Short-term reversals can be driven by temporary liquidity imbalances lasting less than an hour.
+        implication: Add sub-hour reversal sleeves with strict turnover, cost, and drawdown evidence.
 families:
   - family_template_id: microstructure_continuation_matched_filter_v1
     seed_sweep_config: ../profitability-frontier-strict-daily-microstructure.yaml
@@ -210,6 +243,96 @@ families:
       max_notional_per_trade:
         mode: explicit_values
         values: ['7500', '15000', '22500', '30000']
+  - family_template_id: microbar_cross_sectional_pairs_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-microbar-eod-loser-reversal.yaml
+    max_iterations: 2
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: false
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    parameter_mutations:
+      entry_minute_after_open:
+        mode: numeric_step
+        deltas: ['-15', '0', '15']
+        minimum: '330'
+        maximum: '390'
+      exit_minute_after_open:
+        mode: numeric_step
+        deltas: ['-15', '0', '15']
+        minimum: '360'
+        maximum: '390'
+      top_n:
+        mode: explicit_values
+        values: ['1', '2', '3']
+    strategy_override_mutations:
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['7500', '15000', '22500', '30000']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['0.25', '0.50', '0.75', '1.0']
+  - family_template_id: microbar_cross_sectional_pairs_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-microbar-vwap-reversal.yaml
+    max_iterations: 2
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: false
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    parameter_mutations:
+      entry_minute_after_open:
+        mode: numeric_step
+        deltas: ['-30', '0', '30']
+        minimum: '120'
+        maximum: '240'
+      exit_minute_after_open:
+        mode: numeric_step
+        deltas: ['-30', '0', '30']
+        minimum: '150'
+        maximum: '300'
+      top_n:
+        mode: explicit_values
+        values: ['1', '2', '3']
+    strategy_override_mutations:
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['7500', '15000', '22500', '30000']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['0.25', '0.50', '0.75', '1.0']
+  - family_template_id: microbar_cross_sectional_pairs_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-microbar-prev-day-open60-short-top1.yaml
+    max_iterations: 2
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: false
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    parameter_mutations:
+      entry_minute_after_open:
+        mode: numeric_step
+        deltas: ['0', '15', '30']
+        minimum: '0'
+        maximum: '60'
+      exit_minute_after_open:
+        mode: numeric_step
+        deltas: ['-15', '0', '15']
+        minimum: '30'
+        maximum: '90'
+      top_n:
+        mode: explicit_values
+        values: ['1', '2']
+    strategy_override_mutations:
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['7500', '15000', '22500', '30000']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['0.25', '0.50', '0.75', '1.0']
   - family_template_id: intraday_tsmom_v2
     seed_sweep_config: ../profitability-frontier-strict-daily-tsmom.yaml
     max_iterations: 2

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -426,6 +426,42 @@ class TestStrategyAutoresearch(TestCase):
         )
         self.assertEqual(program.objective.min_cash, Decimal("0"))
 
+    def test_checked_in_500_portfolio_profit_program_includes_reversal_surfaces(
+        self,
+    ) -> None:
+        program_path = Path(
+            "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
+        )
+
+        program = load_strategy_autoresearch_program(
+            program_path,
+            family_dir=Path("config/trading/families"),
+        )
+
+        source_ids = {source.source_id for source in program.research_sources}
+        self.assertTrue(
+            {
+                "intraday_residual_reversal_2024",
+                "intraday_return_autocorrelation_term_structure_2025",
+                "intraday_cross_section_patterns_2010",
+            }.issubset(source_ids)
+        )
+
+        microbar_seed_names = {
+            plan.seed_sweep_config.name
+            for plan in program.families
+            if plan.family_template.family_id == "microbar_cross_sectional_pairs_v1"
+        }
+        self.assertTrue(
+            {
+                "profitability-frontier-strict-daily-microbar-eod-loser-reversal.yaml",
+                "profitability-frontier-strict-daily-microbar-vwap-reversal.yaml",
+                "profitability-frontier-strict-daily-microbar-prev-day-open60-short-top1.yaml",
+            }.issubset(microbar_seed_names)
+        )
+        self.assertEqual(program.promotion_policy, "research_only")
+        self.assertIn("scheduler_v3_parity_replay", program.parity_requirements)
+
     def test_load_program_rejects_non_mapping_schema_and_missing_families(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Summary

- Adds a disabled-by-default `torghut-cuda-ranker` GitOps app with a separate KubeVirt VM lane for the cluster RTX 3090.
- Documents the CUDA lane activation path and the constraint that Saigak currently owns the only GPU.
- Expands the `$500/day` portfolio autoresearch program with source-backed intraday residual, autocorrelation, and cross-sectional reversal surfaces.
- Adds a regression test that the checked-in `$500/day` program retains the new sources and microbar reversal seed sweeps.

## Related Issues

None

## Testing

- `uv run --frozen ruff format tests/test_strategy_autoresearch.py`
- `kubectl kustomize argocd/applications/torghut-cuda-ranker`
- YAML parse check for `argocd/applicationsets/platform.yaml`, the CUDA ranker manifests, and the `$500/day` autoresearch program.
- `uv run --frozen pytest tests/test_strategy_autoresearch.py -k 'checked_in_500_portfolio_profit_program'`
- `uv run --frozen ruff check tests/test_strategy_autoresearch.py`
- `git diff --check`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. The CUDA ranker ApplicationSet entry is disabled and the VM has `spec.running: false`, so this PR does not allocate the GPU or preempt Saigak.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
