### PR TITLE
revert(torghut): rollback failed promotion fcfd327acd78eb71669b50e9fbbf6278bbcaf763

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-30-g9815b264c
+              value: v0.571.1-28-g68905b3da
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 9815b264c3a3be6e8663cf12b25709cc13006058
+              value: 68905b3da1b0820acd20495570886d0a0517b8b1
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-30-g9815b264c
+              value: v0.571.1-28-g68905b3da
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 9815b264c3a3be6e8663cf12b25709cc13006058
+              value: 68905b3da1b0820acd20495570886d0a0517b8b1
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-17T21:22:15Z"
+        client.knative.dev/updateTimestamp: "2026-05-17T20:53:00Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
           ports:
             - name: http1
               containerPort: 8181
@@ -495,11 +495,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-30-g9815b264c
+              value: v0.571.1-28-g68905b3da
             - name: TORGHUT_COMMIT
-              value: 9815b264c3a3be6e8663cf12b25709cc13006058
+              value: 68905b3da1b0820acd20495570886d0a0517b8b1
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+              value: sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-17T21:22:15Z"
+        client.knative.dev/updateTimestamp: "2026-05-17T20:53:00Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
           ports:
             - name: http1
               containerPort: 8181
@@ -316,11 +316,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-30-g9815b264c
+              value: v0.571.1-28-g68905b3da
             - name: TORGHUT_COMMIT
-              value: 9815b264c3a3be6e8663cf12b25709cc13006058
+              value: 68905b3da1b0820acd20495570886d0a0517b8b1
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+              value: sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -101,7 +101,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:3a9e07fac52e20e6ccfc26fadaa652757636ae0e5c34e93a8b477290dba1a8c0
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e22d9b72446aa23932e3cb9c7c3cba3769f9a8e38363decbbbb8cb6720e710d9
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `fcfd327acd78eb71669b50e9fbbf6278bbcaf763`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/26003318040`
- Rollback source: `HEAD^` manifests from the failed run checkout