### PR TITLE
fix(torghut): separate turnover from exposure budget

### DIFF
--- a/services/torghut/app/trading/discovery/capital_budget.py
+++ b/services/torghut/app/trading/discovery/capital_budget.py
@@ -29,15 +29,20 @@ def _param_slot(params: Mapping[str, Any], key: str) -> float:
 def estimate_capital_slot_count(
     params: Mapping[str, Any], *, rank_count_floor: int = 1
 ) -> float:
-    """Estimate simultaneous entry slots implied by runtime sleeve controls."""
+    """Estimate simultaneous exposure slots implied by runtime sleeve controls.
+
+    ``max_entries_per_session`` is a turnover cap, not a concurrency cap. Counting
+    it as simultaneous exposure blocks honest high-turnover candidates before
+    replay can prove whether they satisfy daily notional and drawdown gates.
+    """
 
     return max(
         1.0,
         float(max(1, int(rank_count_floor))),
-        _param_slot(params, "max_entries_per_session"),
         _param_slot(params, "max_concurrent_positions"),
         _param_slot(params, "max_pair_legs"),
         _param_slot(params, "top_n"),
+        _param_slot(params, "rank_count"),
     )
 
 

--- a/services/torghut/app/trading/discovery/mlx_features.py
+++ b/services/torghut/app/trading/discovery/mlx_features.py
@@ -129,7 +129,6 @@ def _infer_rank_policy(config: Mapping[str, Any], template: FamilyTemplate) -> s
 
 def _infer_rank_count(config: Mapping[str, Any]) -> int:
     for key in (
-        "max_entries_per_session",
         "max_concurrent_positions",
         "max_pair_legs",
         "top_n",
@@ -141,6 +140,8 @@ def _infer_rank_count(config: Mapping[str, Any]) -> int:
                 return max(1, int(float(str(value))))
             except ValueError:
                 continue
+    if _param_value(config, "max_entries_per_session") is not None:
+        return 1
     universe = _override_value(config, "universe_symbols")
     if isinstance(universe, list):
         universe_values = cast(list[Any], universe)

--- a/services/torghut/app/trading/discovery/mlx_training_data.py
+++ b/services/torghut/app/trading/discovery/mlx_training_data.py
@@ -212,7 +212,6 @@ def _capital_rank_count_floor(
     *, strategy_overrides: Mapping[str, Any], params: Mapping[str, Any]
 ) -> int:
     for key in (
-        "max_entries_per_session",
         "max_concurrent_positions",
         "max_pair_legs",
         "top_n",
@@ -220,6 +219,8 @@ def _capital_rank_count_floor(
     ):
         if _float(params.get(key)) > 0:
             return 1
+    if _float(params.get("max_entries_per_session")) > 0:
+        return 1
     return max(1, len(_sequence_strings(strategy_overrides.get("universe_symbols"))))
 
 

--- a/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
@@ -173,6 +173,28 @@ research_sources:
       - claim_id: subminute_large_stock_continuation
         summary: Sub-minute continuations can appear in larger stocks, market stress, and the first half-hour.
         implication: Keep continuation and reversal sleeves separated by horizon and require holdout proof for each sleeve.
+  - source_id: intraday_time_series_reversal_2025
+    title: 'Intraday Time Series Reversal'
+    url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5807282
+    published_at: '2025-12-13'
+    claims:
+      - claim_id: volatility_conditioned_intraday_reversal
+        summary: Intraday reversal effects can strengthen during high-volatility regimes.
+        implication: Reaudit short-horizon reversal sleeves with explicit volatility and drawdown gates instead of broad all-day pooling.
+      - claim_id: time_series_not_only_cross_section
+        summary: Reversal can be framed as a time-series effect, not only a cross-sectional loser/winner sort.
+        implication: Include recent-window reversal profiles that can trade serially while respecting simultaneous exposure caps.
+  - source_id: overnight_jump_intraday_reversal_2026
+    title: 'Dark Side of the Day: Overnight Price Jumps and Short-Term Return Predictability'
+    url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4335622
+    published_at: '2026-04-27'
+    claims:
+      - claim_id: overnight_jump_reversal
+        summary: Overnight price jumps can negatively predict short-term returns as overreaction unwinds.
+        implication: Reaudit overnight-gap and opening-window reversal sleeves using prior-close features and strict cost controls.
+      - claim_id: transient_active_trading_window
+        summary: The reversal pattern is transient and tied to active trading conditions.
+        implication: Prefer opening-window exits and reject candidates that need stale or late-day-only evidence.
   - source_id: intraday_cross_section_patterns_2010
     title: 'Intraday Patterns in the Cross-section of Stock Returns'
     url: https://arxiv.org/abs/1005.3535
@@ -231,9 +253,9 @@ families:
         maximum: '0.75'
       max_entries_per_session:
         mode: numeric_step
-        deltas: ['-1', '0', '1']
+        deltas: ['-1', '0', '1', '3', '5']
         minimum: '1'
-        maximum: '3'
+        maximum: '8'
       max_gross_exposure_pct_equity:
         mode: explicit_values
         values: ['0.50', '0.75', '1.0']
@@ -266,6 +288,12 @@ families:
       top_n:
         mode: explicit_values
         values: ['1', '2', '3']
+      max_entries_per_session:
+        mode: explicit_values
+        values: ['1', '3', '6', '8']
+      entry_cooldown_seconds:
+        mode: explicit_values
+        values: ['60', '180', '300']
     strategy_override_mutations:
       max_notional_per_trade:
         mode: explicit_values
@@ -296,6 +324,12 @@ families:
       top_n:
         mode: explicit_values
         values: ['1', '2', '3']
+      max_entries_per_session:
+        mode: explicit_values
+        values: ['1', '3', '6', '8']
+      entry_cooldown_seconds:
+        mode: explicit_values
+        values: ['60', '180', '300']
     strategy_override_mutations:
       max_notional_per_trade:
         mode: explicit_values
@@ -326,6 +360,84 @@ families:
       top_n:
         mode: explicit_values
         values: ['1', '2']
+      max_entries_per_session:
+        mode: explicit_values
+        values: ['1', '3', '6', '8']
+      entry_cooldown_seconds:
+        mode: explicit_values
+        values: ['60', '180', '300']
+    strategy_override_mutations:
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['7500', '15000', '22500', '30000']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['0.25', '0.50', '0.75', '1.0']
+  - family_template_id: microbar_cross_sectional_pairs_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-microbar-recent15-reversal-short.yaml
+    max_iterations: 2
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: false
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    parameter_mutations:
+      entry_minute_after_open:
+        mode: numeric_step
+        deltas: ['-15', '0', '15']
+        minimum: '45'
+        maximum: '180'
+      exit_minute_after_open:
+        mode: numeric_step
+        deltas: ['-15', '0', '15']
+        minimum: '75'
+        maximum: '240'
+      top_n:
+        mode: explicit_values
+        values: ['1', '2', '3']
+      max_entries_per_session:
+        mode: explicit_values
+        values: ['1', '3', '6', '8']
+      entry_cooldown_seconds:
+        mode: explicit_values
+        values: ['60', '180', '300']
+    strategy_override_mutations:
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['7500', '15000', '22500', '30000']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['0.25', '0.50', '0.75', '1.0']
+  - family_template_id: microbar_cross_sectional_pairs_v1
+    seed_sweep_config: ../profitability-frontier-strict-daily-microbar-vwap-stretch-reversal-long-top4.yaml
+    max_iterations: 2
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: false
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    parameter_mutations:
+      entry_minute_after_open:
+        mode: numeric_step
+        deltas: ['-30', '0', '30']
+        minimum: '90'
+        maximum: '270'
+      exit_minute_after_open:
+        mode: numeric_step
+        deltas: ['-30', '0', '30']
+        minimum: '150'
+        maximum: '360'
+      top_n:
+        mode: explicit_values
+        values: ['1', '2', '4']
+      max_entries_per_session:
+        mode: explicit_values
+        values: ['1', '3', '6', '8']
+      entry_cooldown_seconds:
+        mode: explicit_values
+        values: ['60', '180', '300']
     strategy_override_mutations:
       max_notional_per_trade:
         mode: explicit_values

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -203,7 +203,7 @@ def _positive_decimal_grid_values(value: Any) -> list[Decimal]:
 
 
 def _max_entry_count(parameters: Mapping[str, Any]) -> int:
-    for key in ("max_entries_per_session", "rank_count"):
+    for key in ("max_concurrent_positions", "max_pair_legs", "top_n", "rank_count"):
         values = _positive_decimal_grid_values(parameters.get(key))
         if values:
             return max(1, int(max(values)))

--- a/services/torghut/tests/test_mlx_autoresearch.py
+++ b/services/torghut/tests/test_mlx_autoresearch.py
@@ -212,6 +212,15 @@ class TestMlxAutoresearch(TestCase):
             ),
             2,
         )
+        self.assertEqual(
+            mlx_features_module._infer_rank_count(
+                {
+                    "parameters": {"max_entries_per_session": ["12"]},
+                    "strategy_overrides": {"universe_symbols": [["NVDA", "AMD"]]},
+                }
+            ),
+            1,
+        )
 
     def test_build_snapshot_manifest_uses_program_snapshot_policy(self) -> None:
         manifest = build_mlx_snapshot_manifest(
@@ -246,6 +255,7 @@ class TestMlxAutoresearch(TestCase):
                     "leader_reclaim_start_minutes_since_open": ["45"],
                     "max_hold_seconds": ["900"],
                     "max_entries_per_session": ["2"],
+                    "top_n": ["2"],
                 },
                 "strategy_overrides": {
                     "max_notional_per_trade": ["315900.20"],

--- a/services/torghut/tests/test_mlx_training_data.py
+++ b/services/torghut/tests/test_mlx_training_data.py
@@ -84,6 +84,45 @@ class TestMlxTrainingData(TestCase):
         self.assertGreater(features["estimated_max_gross_exposure_pct_equity"], 1.0)
         self.assertEqual(features["capital_feasible_flag"], 0.0)
 
+    def test_candidate_capital_features_treat_session_entries_as_turnover(
+        self,
+    ) -> None:
+        spec = CandidateSpec(
+            schema_version="torghut.candidate-spec.v1",
+            candidate_spec_id="spec-turnover-not-concurrency",
+            hypothesis_id="H-TURNOVER",
+            family_template_id="microbar_cross_sectional_pairs_v1",
+            candidate_kind="configuration",
+            runtime_family="microbar_cross_sectional_pairs",
+            runtime_strategy_name="microbar-cross-sectional-pairs-v1",
+            feature_contract={},
+            parameter_space={},
+            strategy_overrides={
+                "max_notional_per_trade": "15000",
+                "max_position_pct_equity": "0.50",
+                "params": {
+                    "max_gross_exposure_pct_equity": "1.0",
+                    "max_entries_per_session": "12",
+                    "max_concurrent_positions": "1",
+                    "top_n": "1",
+                },
+            },
+            objective={},
+            hard_vetoes={},
+            expected_failure_modes=(),
+            promotion_contract={},
+        )
+
+        features = candidate_spec_capital_features(spec)
+
+        self.assertEqual(features["max_entries_per_session"], 12.0)
+        self.assertEqual(features["estimated_capital_slot_count"], 1.0)
+        self.assertLessEqual(
+            features["estimated_max_gross_exposure_pct_equity"],
+            1.0,
+        )
+        self.assertEqual(features["capital_feasible_flag"], 1.0)
+
     def test_candidate_capital_features_infer_uncapped_universe_slots(self) -> None:
         spec = CandidateSpec(
             schema_version="torghut.candidate-spec.v1",

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -85,7 +85,8 @@ class TestStrategyAutoresearch(TestCase):
         limited = runner._apply_objective_capital_limits(
             sweep_config={
                 "parameters": {
-                    "max_entries_per_session": ["2", "3"],
+                    "max_entries_per_session": ["2", "8"],
+                    "top_n": ["3"],
                     "max_gross_exposure_pct_equity": ["10.0"],
                 },
                 "strategy_overrides": {
@@ -106,6 +107,35 @@ class TestStrategyAutoresearch(TestCase):
         self.assertEqual(
             limited["strategy_overrides"]["max_notional_per_trade"], ["10319.4"]
         )
+
+    def test_apply_objective_capital_limits_keeps_turnover_separate_from_exposure(
+        self,
+    ) -> None:
+        limited = runner._apply_objective_capital_limits(
+            sweep_config={
+                "parameters": {
+                    "max_entries_per_session": ["12"],
+                    "max_gross_exposure_pct_equity": ["10.0"],
+                },
+                "strategy_overrides": {
+                    "max_position_pct_equity": ["10.0"],
+                    "max_notional_per_trade": ["315900.20"],
+                },
+            },
+            max_gross_exposure_pct_equity=Decimal("1.0"),
+            start_equity=Decimal("31590.02"),
+        )
+
+        self.assertEqual(
+            limited["parameters"]["max_gross_exposure_pct_equity"], ["0.98"]
+        )
+        self.assertEqual(
+            limited["strategy_overrides"]["max_position_pct_equity"], ["0.98"]
+        )
+        self.assertEqual(
+            limited["strategy_overrides"]["max_notional_per_trade"], ["30958.21"]
+        )
+        self.assertEqual(limited["parameters"]["max_entries_per_session"], ["12"])
 
     def test_runtime_closure_candidate_rejects_failed_or_vetoed_candidates(
         self,
@@ -443,6 +473,8 @@ class TestStrategyAutoresearch(TestCase):
             {
                 "intraday_residual_reversal_2024",
                 "intraday_return_autocorrelation_term_structure_2025",
+                "intraday_time_series_reversal_2025",
+                "overnight_jump_intraday_reversal_2026",
                 "intraday_cross_section_patterns_2010",
             }.issubset(source_ids)
         )
@@ -457,6 +489,8 @@ class TestStrategyAutoresearch(TestCase):
                 "profitability-frontier-strict-daily-microbar-eod-loser-reversal.yaml",
                 "profitability-frontier-strict-daily-microbar-vwap-reversal.yaml",
                 "profitability-frontier-strict-daily-microbar-prev-day-open60-short-top1.yaml",
+                "profitability-frontier-strict-daily-microbar-recent15-reversal-short.yaml",
+                "profitability-frontier-strict-daily-microbar-vwap-stretch-reversal-long-top4.yaml",
             }.issubset(microbar_seed_names)
         )
         self.assertEqual(program.promotion_policy, "research_only")
@@ -1502,6 +1536,7 @@ class TestStrategyAutoresearch(TestCase):
                             "replay_config": {
                                 "params": {
                                     "max_entries_per_session": "1",
+                                    "top_n": "1",
                                     "entry_cooldown_seconds": "600",
                                 },
                                 "strategy_overrides": {
@@ -1538,6 +1573,7 @@ class TestStrategyAutoresearch(TestCase):
                             "replay_config": {
                                 "params": {
                                     "max_entries_per_session": "3",
+                                    "top_n": "2",
                                     "entry_cooldown_seconds": "600",
                                 },
                                 "strategy_overrides": {


### PR DESCRIPTION
## Summary

- Fixes Torghut discovery capital budgeting so max_entries_per_session is treated as serial turnover, not simultaneous exposure.
- Keeps objective capital clamps tied to max_concurrent_positions, max_pair_legs, top_n, and rank_count.
- Expands the $500/day research program with recent reversal research sources and higher-turnover microbar reversal surfaces while preserving gross exposure and drawdown gates.

## Related Issues

None

## Testing

- uv sync --frozen --extra dev
- uv run --frozen ruff format app/trading/discovery/capital_budget.py app/trading/discovery/mlx_training_data.py app/trading/discovery/mlx_features.py scripts/run_strategy_autoresearch_loop.py tests/test_mlx_training_data.py tests/test_mlx_autoresearch.py tests/test_strategy_autoresearch.py
- uv run --frozen ruff check app/trading/discovery/capital_budget.py app/trading/discovery/mlx_training_data.py app/trading/discovery/mlx_features.py scripts/run_strategy_autoresearch_loop.py tests/test_mlx_training_data.py tests/test_mlx_autoresearch.py tests/test_strategy_autoresearch.py tests/test_candidate_specs.py
- uv run --frozen pytest tests/test_mlx_training_data.py -k "capital_features or capital_infeasible"
- uv run --frozen pytest tests/test_mlx_autoresearch.py -k "feature_helpers or descriptor_from_sweep_config"
- uv run --frozen pytest tests/test_strategy_autoresearch.py -k "capital_limits or 500_portfolio_profit_program"
- uv run --frozen pytest tests/test_candidate_specs.py -k "capital_constrained_profiles or feedback_escape_profiles"
- uv run --frozen pyright --project pyrightconfig.scripts.json
- uv run --frozen pyright --project pyrightconfig.json
- uv run --frozen pyright --project pyrightconfig.alpha.json
- python YAML parse of services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or N/A with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
