### PR TITLE
chore(agents): bump chart version for split publish

### DIFF
--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/proompteng/charts/tree/main/charts/agents
 type: application
 kubeVersion: '>=1.25.0-0'
-version: 0.9.16
+version: 0.9.17
 appVersion: '0.9.0'
 icon: https://avatars.githubusercontent.com/u/234536857
 keywords:


### PR DESCRIPTION
## Summary

- Bumps the Agents Helm chart version from `0.9.16` to `0.9.17`.
- Unblocks `agents-sync`, which failed because `0.9.16` already exists in GHCR with different chart contents after PR #6901.
- Keeps the fix scoped to chart release metadata only.

## Related Issues

None

## Testing

- `scripts/agents/validate-agents.sh`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
