### PR TITLE
chore(symphony): promote image e69f6e09

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-16T02:40:38Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-17T22:54:10Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "1495ba8b"
-    digest: sha256:8d91887c5740c173b33eade1d8e01e5f210dde82df2d895394ba295da94982eb
+    newTag: "e69f6e09"
+    digest: sha256:d1017e7db18ebc1f8b549b2c10eb1a6ad887bace0cd2056f5b743a41dd1d8a0e

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-16T02:40:38Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-17T22:54:10Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "1495ba8b"
-    digest: sha256:8d91887c5740c173b33eade1d8e01e5f210dde82df2d895394ba295da94982eb
+    newTag: "e69f6e09"
+    digest: sha256:d1017e7db18ebc1f8b549b2c10eb1a6ad887bace0cd2056f5b743a41dd1d8a0e

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-16T02:40:38Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-17T22:54:10Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "1495ba8b"
-    digest: sha256:8d91887c5740c173b33eade1d8e01e5f210dde82df2d895394ba295da94982eb
+    newTag: "e69f6e09"
+    digest: sha256:d1017e7db18ebc1f8b549b2c10eb1a6ad887bace0cd2056f5b743a41dd1d8a0e


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `e69f6e096ae349e8be465c4f975db1a748898208`
- Image tag: `e69f6e09`
- Image digest: `sha256:d1017e7db18ebc1f8b549b2c10eb1a6ad887bace0cd2056f5b743a41dd1d8a0e`