### PR TITLE
chore(agents): align artifacthub chart version

### DIFF
--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-version: 0.9.16
+version: 0.9.17
 name: agents
 displayName: Agents Control Plane (Jangar)
 description: Minimal Agents control plane with CRDs and native workflow runtime.


### PR DESCRIPTION
## Summary

- Aligns `charts/agents/artifacthub-pkg.yml` with the `0.9.17` Agents chart version.
- Fixes the `agents-sync` publish check that rejected mismatched Artifact Hub and Chart.yaml versions.
- Keeps the change limited to chart publishing metadata.

## Related Issues

None

## Testing

- `scripts/agents/validate-agents.sh`
- `AGENTS_CHART_DRY_RUN=true bun packages/scripts/src/agents/publish-chart.ts --chart-dir charts/agents`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
