### PR TITLE
chore(jangar): promote image e69f6e09

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
-  repository: registry.ide-newton.ts.net/lab/agents-control-plane
-  tag: ea0f7a1d
-  digest: sha256:71fe9ceae23b187fe3f1dfec034687dd86d4acf7dc6ec586102565b95bd49683
+  repository: registry.ide-newton.ts.net/lab/jangar
+  tag: e69f6e09
+  digest: sha256:ca638ebb92ee2cfb6eb21c03af4cc27437f56d9cd4f73379abd3ba5027e895e1
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -10,9 +10,9 @@ nodeSelector:
   kubernetes.io/arch: arm64
 controlPlane:
   image:
-    repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: ea0f7a1d
-    digest: sha256:6d372f58f7115b395ec40f7dba35b8c1bddb41875c6be9bd0cf7350eb6744f6d
+    repository: registry.ide-newton.ts.net/lab/jangar-control-plane
+    tag: e69f6e09
+    digest: sha256:316d16751a7a8bd75c428c36ab01585603da11546050f497de91891b4e55bbc6
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
@@ -25,11 +25,18 @@ controlPlane:
       AGENTS_MANIFEST_IMAGE_DIGEST: sha256:6d372f58f7115b395ec40f7dba35b8c1bddb41875c6be9bd0cf7350eb6744f6d
       AGENTS_SERVING_BUILD_COMMIT: ea0f7a1d3d41adacf18185a26a3bafc72f7ba355
       AGENTS_SERVING_IMAGE_DIGEST: sha256:6d372f58f7115b395ec40f7dba35b8c1bddb41875c6be9bd0cf7350eb6744f6d
+      JANGAR_SOURCE_HEAD_SHA: e69f6e096ae349e8be465c4f975db1a748898208
+      JANGAR_GITOPS_REVISION: e69f6e096ae349e8be465c4f975db1a748898208
+      JANGAR_SOURCE_CI_RUN_ID: "26005025998"
+      JANGAR_SOURCE_CI_CONCLUSION: success
+      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:316d16751a7a8bd75c428c36ab01585603da11546050f497de91891b4e55bbc6
+      JANGAR_SERVING_BUILD_COMMIT: e69f6e096ae349e8be465c4f975db1a748898208
+      JANGAR_SERVING_IMAGE_DIGEST: sha256:316d16751a7a8bd75c428c36ab01585603da11546050f497de91891b4e55bbc6
 runner:
   image:
-    repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: ea0f7a1d
-    digest: sha256:71fe9ceae23b187fe3f1dfec034687dd86d4acf7dc6ec586102565b95bd49683
+    repository: registry.ide-newton.ts.net/lab/jangar
+    tag: e69f6e09
+    digest: sha256:ca638ebb92ee2cfb6eb21c03af4cc27437f56d9cd4f73379abd3ba5027e895e1
 argocdHooks:
   enabled: true
   image:

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-17T20:24:38Z
+    deploy.knative.dev/rollout: 2026-05-17T22:55:40Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:5de6d046@sha256:aed09ee8295c1e7b9c84042228b79a174e2286b586bbba6fd599f913ee9f07bb
+              value: registry.ide-newton.ts.net/lab/jangar:e69f6e09@sha256:ca638ebb92ee2cfb6eb21c03af4cc27437f56d9cd4f73379abd3ba5027e895e1
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 5de6d046508c62cb025dc08338f9efc8b81b5c60
+              value: e69f6e096ae349e8be465c4f975db1a748898208
             - name: JANGAR_GITOPS_REVISION
-              value: 5de6d046508c62cb025dc08338f9efc8b81b5c60
+              value: e69f6e096ae349e8be465c4f975db1a748898208
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26001743500"
+              value: "26005025998"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:b5188e6237d70f9e28514ea1b1a13d4a321e6f56eef30d76ea0f7a6501cfbedc
+              value: sha256:316d16751a7a8bd75c428c36ab01585603da11546050f497de91891b4e55bbc6
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 5de6d046508c62cb025dc08338f9efc8b81b5c60
+              value: e69f6e096ae349e8be465c4f975db1a748898208
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:b5188e6237d70f9e28514ea1b1a13d4a321e6f56eef30d76ea0f7a6501cfbedc
+              value: sha256:316d16751a7a8bd75c428c36ab01585603da11546050f497de91891b4e55bbc6
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 5de6d046
-    digest: sha256:aed09ee8295c1e7b9c84042228b79a174e2286b586bbba6fd599f913ee9f07bb
+    newTag: e69f6e09
+    digest: sha256:ca638ebb92ee2cfb6eb21c03af4cc27437f56d9cd4f73379abd3ba5027e895e1


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests, including the Agents namespace release.

- Source commit: `e69f6e096ae349e8be465c4f975db1a748898208`
- Image tag: `e69f6e09`
- Image digest: `sha256:ca638ebb92ee2cfb6eb21c03af4cc27437f56d9cd4f73379abd3ba5027e895e1`
- Source CI run: `26005025998`
- Control-plane serving digest: `sha256:316d16751a7a8bd75c428c36ab01585603da11546050f497de91891b4e55bbc6`
- Updated API rollout annotation
- Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
- Published source-serving proof env for revenue repair custody gates