### PR TITLE
fix(torghut): verify options rollouts after degraded argo health

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -175,6 +175,10 @@ jobs:
                   echo "Torghut Argo health is Degraded after sync; continuing to runtime safety checks"
                   break
                 fi
+                if [ "${app}" = 'torghut-options' ] && [ "${HEALTH_STATUS}" = 'Degraded' ] && [ "${OPERATION_PHASE}" = 'Succeeded' ]; then
+                  echo "Torghut options Argo health is Degraded after sync; continuing to explicit workload rollout checks"
+                  break
+                fi
               fi
 
               if [ "${attempt}" -eq 90 ]; then
@@ -187,6 +191,9 @@ jobs:
           done
 
           kubectl rollout status deployment/torghut-ws -n torghut --timeout=10m
+          kubectl rollout status deployment/torghut-options-catalog -n torghut --timeout=10m
+          kubectl rollout status deployment/torghut-options-enricher -n torghut --timeout=10m
+          kubectl rollout status deployment/torghut-ws-options -n torghut --timeout=10m
 
           set +e
           KNSVC_READY="$(kubectl get ksvc torghut -n torghut -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2> /tmp/torghut-ksvc-ready.err)"

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -36,6 +36,16 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).toContain('[ "${OPERATION_PHASE}" = \'Succeeded\' ]')
   })
 
+  it('continues past degraded Torghut options Argo health only with explicit workload rollout checks', () => {
+    expect(workflow).toContain(
+      'Torghut options Argo health is Degraded after sync; continuing to explicit workload rollout checks',
+    )
+    expect(workflow).toContain('[ "${app}" = \'torghut-options\' ]')
+    expect(workflow).toContain('kubectl rollout status deployment/torghut-options-catalog -n torghut --timeout=10m')
+    expect(workflow).toContain('kubectl rollout status deployment/torghut-options-enricher -n torghut --timeout=10m')
+    expect(workflow).toContain('kubectl rollout status deployment/torghut-ws-options -n torghut --timeout=10m')
+  })
+
   it('delegates readyz acceptance to the revenue repair evidence validator', () => {
     expect(workflow).toContain('TORGHUT_READYZ_HTTP_STATUS')
     expect(workflow).toContain('TORGHUT_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-readyz.json"')


### PR DESCRIPTION
## Summary

- Allow Torghut post-deploy verification to continue when `torghut-options` is synced to the expected revision but Argo reports Degraded health with no failed workload evidence.
- Add explicit rollout checks for `torghut-options-catalog`, `torghut-options-enricher`, and `torghut-ws-options` before runtime endpoint checks.
- Cover the options degraded-health path in the post-deploy workflow regression test.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts .github/workflows/torghut-post-deploy-verify.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
