### PR TITLE
fix(torghut): replay feedback candidates before synthetic probes

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -3459,6 +3459,17 @@ def _select_candidate_specs_for_replay(
             pool.remove(best)
         return picked
 
+    def interleave_replay_segments(
+        *segments: Sequence[CandidateSpec],
+    ) -> list[CandidateSpec]:
+        interleaved: list[CandidateSpec] = []
+        max_length = max((len(segment) for segment in segments), default=0)
+        for index in range(max_length):
+            for segment in segments:
+                if index < len(segment):
+                    interleaved.append(segment[index])
+        return interleaved
+
     exploitation = take_diverse(
         ordered_eligible,
         count=exploitation_count,
@@ -3561,8 +3572,10 @@ def _select_candidate_specs_for_replay(
     selected = [
         *exploitation,
         *exploration,
-        *synthetic_prior_probe_exploration,
-        *feedback_block_reaudit,
+        *interleave_replay_segments(
+            feedback_block_reaudit,
+            synthetic_prior_probe_exploration,
+        ),
         *backfill,
     ]
     selected_ids = {item.candidate_spec_id for item in selected}

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -1201,6 +1201,57 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             row_by_spec[capital_unsafe_spec.candidate_spec_id]["selected_for_replay"]
         )
 
+    def test_candidate_selection_replays_feedback_reaudit_before_synthetic_probe(
+        self,
+    ) -> None:
+        feedback_spec = self._candidate_spec("spec-feedback-first")
+        synthetic_probe_spec = self._candidate_spec(
+            "spec-synthetic-probe",
+            family_template_id="mean_reversion_rebound_v1",
+            entry_minute_after_open="75",
+        )
+
+        selected, selection = runner._select_candidate_specs_for_replay(
+            specs=(synthetic_probe_spec, feedback_spec),
+            proposal_rows=[
+                {
+                    "candidate_spec_id": synthetic_probe_spec.candidate_spec_id,
+                    "rank": 1,
+                    "proposal_score": -12.5,
+                    "selection_reason": "pre_replay_mlx_rank",
+                    "training_source": "synthetic_prior",
+                    "feedback_evidence_context_count": 1,
+                },
+                {
+                    "candidate_spec_id": feedback_spec.candidate_spec_id,
+                    "rank": 2,
+                    "proposal_score": -1_000_000,
+                    "selection_reason": "pre_replay_mlx_feedback_blocked",
+                    "training_source": "feedback_real_replay",
+                },
+            ],
+            top_k=1,
+            exploration_slots=1,
+            feedback_block_reaudit_slots=1,
+            max_candidates=2,
+            portfolio_size_min=1,
+        )
+        row_by_spec = {row["candidate_spec_id"]: row for row in selection["rows"]}
+
+        self.assertEqual(selected, [feedback_spec, synthetic_probe_spec])
+        self.assertEqual(
+            row_by_spec[feedback_spec.candidate_spec_id]["selection_reason"],
+            "feedback_block_reaudit",
+        )
+        self.assertEqual(
+            row_by_spec[synthetic_probe_spec.candidate_spec_id]["selection_reason"],
+            "synthetic_prior_exploration",
+        )
+        self.assertEqual(row_by_spec[feedback_spec.candidate_spec_id]["replay_order"], 1)
+        self.assertEqual(
+            row_by_spec[synthetic_probe_spec.candidate_spec_id]["replay_order"], 2
+        )
+
     def test_candidate_selection_keeps_positive_blocked_feedback_repair_candidates(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Reorders whitepaper autoresearch replay selection so feedback-blocked candidates selected for reaudit are replayed before synthetic-prior probe candidates.
- Keeps exploitation and eligible exploration first, then interleaves feedback reaudits with synthetic probes instead of placing all synthetic probes ahead of feedback repair work.
- Adds a regression test covering replay order and selection reasons for feedback reaudits versus synthetic-prior probes.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'feedback_reaudit_before_synthetic_probe or can_reaudit_feedback_blocked_candidates or uses_exploration_for_synthetic_nonpositive_prior'`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `git diff --check`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
