### PR TITLE
chore(agents): promote agents gitops images

### DIFF
--- a/.github/workflows/jangar-release.yml
+++ b/.github/workflows/jangar-release.yml
@@ -182,8 +182,7 @@ jobs:
             --manifest-image-digest "${JANGAR_MANIFEST_IMAGE_DIGEST}" \
             --serving-build-commit "${JANGAR_SERVING_BUILD_COMMIT}" \
             --serving-image-digest "${JANGAR_SERVING_IMAGE_DIGEST}" \
-            --rollout-timestamp "${TIMESTAMP}" \
-            --agents-values-path "argocd/applications/agents/values.yaml"
+            --rollout-timestamp "${TIMESTAMP}"
 
       - name: Check for manifest changes
         if: steps.meta.outputs.promote == 'true'
@@ -193,8 +192,7 @@ jobs:
           set -euo pipefail
           if git diff --quiet -- \
             argocd/applications/jangar/kustomization.yaml \
-            argocd/applications/jangar/deployment.yaml \
-            argocd/applications/agents/values.yaml; then
+            argocd/applications/jangar/deployment.yaml; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -213,10 +211,9 @@ jobs:
           add-paths: |
             argocd/applications/jangar/kustomization.yaml
             argocd/applications/jangar/deployment.yaml
-            argocd/applications/agents/values.yaml
           body: |
             ## Summary
-            Promote Jangar image into GitOps manifests, including the Agents namespace release.
+            Promote Jangar image into GitOps manifests.
 
             - Source commit: `${{ steps.meta.outputs.source_sha }}`
             - Image tag: `${{ steps.meta.outputs.tag }}`
@@ -224,7 +221,6 @@ jobs:
             - Source CI run: `${{ github.run_id }}`
             - Control-plane serving digest: `${{ steps.control_plane_digest.outputs.digest }}`
             - Updated API rollout annotation
-            - Updated `argocd/applications/agents/values.yaml` for automated sync to namespace `agents`
             - Published source-serving proof env for revenue repair custody gates
 
       - name: No manifest changes detected

--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
-  repository: registry.ide-newton.ts.net/lab/jangar
-  tag: e69f6e09
-  digest: sha256:ca638ebb92ee2cfb6eb21c03af4cc27437f56d9cd4f73379abd3ba5027e895e1
+  repository: registry.ide-newton.ts.net/lab/agents-controller
+  tag: fdceeaac
+  digest: sha256:7b33d7ac135c3760f95c56bef82753baf5f45dea4c84333f252313fa7a5ccb29
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -10,33 +10,26 @@ nodeSelector:
   kubernetes.io/arch: arm64
 controlPlane:
   image:
-    repository: registry.ide-newton.ts.net/lab/jangar-control-plane
-    tag: e69f6e09
-    digest: sha256:316d16751a7a8bd75c428c36ab01585603da11546050f497de91891b4e55bbc6
+    repository: registry.ide-newton.ts.net/lab/agents-control-plane
+    tag: fdceeaac
+    digest: sha256:ed6b8f7d948981983966c8e3ab037ab43d9dcbfaf455e11e3cbbd733bae77e1f
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
       AGENTS_TORGHUT_STATUS_TIMEOUT_MS: "12000"
-      AGENTS_SOURCE_HEAD_SHA: ea0f7a1d3d41adacf18185a26a3bafc72f7ba355
-      AGENTS_GITOPS_REVISION: ea0f7a1d3d41adacf18185a26a3bafc72f7ba355
-      AGENTS_SOURCE_CI_RUN_ID: "25981198000"
+      AGENTS_SOURCE_HEAD_SHA: fdceeaac3c94e7d102f1b4b3f84c6884b3b1f60d
+      AGENTS_GITOPS_REVISION: fdceeaac3c94e7d102f1b4b3f84c6884b3b1f60d
+      AGENTS_SOURCE_CI_RUN_ID: "26005264540"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:6d372f58f7115b395ec40f7dba35b8c1bddb41875c6be9bd0cf7350eb6744f6d
-      AGENTS_SERVING_BUILD_COMMIT: ea0f7a1d3d41adacf18185a26a3bafc72f7ba355
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:6d372f58f7115b395ec40f7dba35b8c1bddb41875c6be9bd0cf7350eb6744f6d
-      JANGAR_SOURCE_HEAD_SHA: e69f6e096ae349e8be465c4f975db1a748898208
-      JANGAR_GITOPS_REVISION: e69f6e096ae349e8be465c4f975db1a748898208
-      JANGAR_SOURCE_CI_RUN_ID: "26005025998"
-      JANGAR_SOURCE_CI_CONCLUSION: success
-      JANGAR_MANIFEST_IMAGE_DIGEST: sha256:316d16751a7a8bd75c428c36ab01585603da11546050f497de91891b4e55bbc6
-      JANGAR_SERVING_BUILD_COMMIT: e69f6e096ae349e8be465c4f975db1a748898208
-      JANGAR_SERVING_IMAGE_DIGEST: sha256:316d16751a7a8bd75c428c36ab01585603da11546050f497de91891b4e55bbc6
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:ed6b8f7d948981983966c8e3ab037ab43d9dcbfaf455e11e3cbbd733bae77e1f
+      AGENTS_SERVING_BUILD_COMMIT: fdceeaac3c94e7d102f1b4b3f84c6884b3b1f60d
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:ed6b8f7d948981983966c8e3ab037ab43d9dcbfaf455e11e3cbbd733bae77e1f
 runner:
   image:
-    repository: registry.ide-newton.ts.net/lab/jangar
-    tag: e69f6e09
-    digest: sha256:ca638ebb92ee2cfb6eb21c03af4cc27437f56d9cd4f73379abd3ba5027e895e1
+    repository: registry.ide-newton.ts.net/lab/agents-codex-runner
+    tag: fdceeaac
+    digest: sha256:94dd5154dd73494e6eafef6fda6d7d04bb2e666e1784875265dea4d800f56b8f
 argocdHooks:
   enabled: true
   image:
@@ -91,8 +84,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: ea0f7a1d
-    digest: sha256:6d372f58f7115b395ec40f7dba35b8c1bddb41875c6be9bd0cf7350eb6744f6d
+    tag: fdceeaac
+    digest: sha256:7b33d7ac135c3760f95c56bef82753baf5f45dea4c84333f252313fa7a5ccb29
   autoscaling:
     enabled: false
   env:

--- a/packages/scripts/src/agents/__tests__/deploy-service.test.ts
+++ b/packages/scripts/src/agents/__tests__/deploy-service.test.ts
@@ -84,6 +84,11 @@ controlPlane:
     repository: old/control-plane
     tag: old
     digest: sha256:old-control-plane
+controllers:
+  image:
+    repository: old/controllers-override
+    tag: old
+    digest: sha256:old-controllers-override
 runner:
   image:
     repository: old/runner
@@ -107,8 +112,10 @@ runner:
 
     const updated = readFileSync(valuesPath, 'utf8')
     expect(updated).toContain('repository: registry.example/lab/agents-controller')
+    expect(updated).not.toContain('old/controllers-override')
     expect(updated).toContain('repository: registry.example/lab/agents-control-plane')
     expect(updated).toContain('repository: registry.example/lab/agents-codex-runner')
+    expect(updated).toContain('digest: sha256:controller')
     expect(updated).toContain('digest: sha256:runner')
 
     rmSync(dir, { recursive: true, force: true })

--- a/packages/scripts/src/agents/deploy-service.ts
+++ b/packages/scripts/src/agents/deploy-service.ts
@@ -359,6 +359,12 @@ const updateValuesFile = (
   doc.image.tag = tag
   doc.image.digest = digest
 
+  doc.controllers ??= {}
+  doc.controllers.image ??= {}
+  doc.controllers.image.repository = imageRepository
+  doc.controllers.image.tag = tag
+  doc.controllers.image.digest = digest
+
   doc.controlPlane ??= {}
   doc.controlPlane.image ??= {}
   doc.controlPlane.image.repository = controlPlaneImageRepository


### PR DESCRIPTION
## Summary

- Promote the Agents GitOps values to Agents-owned controller, control-plane, and Codex runner image repositories with immutable digests.
- Stop the Jangar release workflow from writing `argocd/applications/agents/values.yaml` during Jangar promotions.
- Update the Agents deploy helper so existing `controllers.image` overrides are pinned with the same controller image as top-level chart defaults.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun test packages/scripts/src/jangar/__tests__/update-manifests.test.ts packages/scripts/src/jangar/__tests__/resolve-release-metadata.test.ts packages/scripts/src/jangar/__tests__/release-contract.test.ts`
- `scripts/agents/guard-extraction-boundaries.sh`
- `git diff --check`
- `bunx oxfmt --check packages/scripts/src/agents/deploy-service.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts`
- `scripts/agents/validate-agents.sh`
- `mise exec helm@3 -- kubectl kustomize --enable-helm argocd/applications/agents > /tmp/agents-render.yaml && rg -n 'registry\\.ide-newton\\.ts\\.net/lab/jangar|jangar-db-app|JANGAR_|/app/services/jangar|codex-implement' /tmp/agents-render.yaml || true`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
