### PR TITLE
feat(torghut): add notional throughput frontier profiles

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -2518,6 +2518,114 @@ def _turnover_coverage_feedback_escape_profile(
     )
 
 
+def _notional_throughput_feedback_escape_profile(
+    profile: Mapping[str, Any],
+) -> dict[str, Any]:
+    next_profile = json.loads(json.dumps(profile))
+    params = _mapping(next_profile.get("params"))
+    current_entries = _int_profile_param(params, "max_entries_per_session", default=4)
+    params["max_entries_per_session"] = str(max(8, min(12, current_entries + 6)))
+    params["max_concurrent_positions"] = str(
+        max(1, min(2, _profile_rank_count_floor(next_profile)))
+    )
+    if "max_pair_legs" in params:
+        params["max_pair_legs"] = str(
+            max(1, min(2, _int_profile_param(params, "max_pair_legs", default=2)))
+        )
+    if "top_n" in params:
+        params["top_n"] = str(
+            max(1, min(2, _int_profile_param(params, "top_n", default=2)))
+        )
+    current_cooldown = _int_profile_param(params, "entry_cooldown_seconds", default=300)
+    params["entry_cooldown_seconds"] = str(max(90, min(300, current_cooldown)))
+    current_hold_seconds = _int_profile_param(params, "max_hold_seconds", default=900)
+    params["max_hold_seconds"] = str(max(300, min(1200, current_hold_seconds)))
+    params["long_stop_loss_bps"] = str(
+        min(5, max(3, _int_profile_param(params, "long_stop_loss_bps", default=4)))
+    )
+    params["short_stop_loss_bps"] = str(
+        min(5, max(3, _int_profile_param(params, "short_stop_loss_bps", default=4)))
+    )
+    params["max_session_negative_exit_bps"] = str(
+        min(
+            4,
+            max(
+                2,
+                _int_profile_param(params, "max_session_negative_exit_bps", default=3),
+            ),
+        )
+    )
+    threshold_steps = (
+        (
+            "min_cross_section_continuation_rank",
+            Decimal("-0.08"),
+            Decimal("0.35"),
+            Decimal("0.90"),
+        ),
+        (
+            "min_cross_section_opening_window_return_rank",
+            Decimal("-0.08"),
+            Decimal("0.30"),
+            Decimal("0.90"),
+        ),
+        (
+            "min_cross_section_reversal_rank",
+            Decimal("-0.08"),
+            Decimal("0.50"),
+            Decimal("0.90"),
+        ),
+        (
+            "max_cross_section_continuation_rank",
+            Decimal("0.08"),
+            Decimal("0.25"),
+            Decimal("0.75"),
+        ),
+        (
+            "leader_reclaim_min_recent_imbalance_pressure",
+            Decimal("-0.03"),
+            Decimal("-0.05"),
+            Decimal("0.40"),
+        ),
+        (
+            "leader_reclaim_min_recent_microprice_bias_bps",
+            Decimal("-0.08"),
+            Decimal("-0.20"),
+            Decimal("0.60"),
+        ),
+        (
+            "min_recent_imbalance_pressure",
+            Decimal("-0.03"),
+            Decimal("-0.10"),
+            Decimal("0.40"),
+        ),
+        (
+            "min_recent_microprice_bias_bps",
+            Decimal("-0.08"),
+            Decimal("-0.30"),
+            Decimal("0.60"),
+        ),
+        ("min_imbalance_pressure", Decimal("-0.03"), Decimal("-0.12"), Decimal("0.40")),
+    )
+    for key, delta, lower, upper in threshold_steps:
+        if key not in params:
+            continue
+        params[key] = _clamped_profile_decimal(
+            params=params,
+            key=key,
+            default=Decimal(str(params[key])),
+            delta=delta,
+            lower=lower,
+            upper=upper,
+            places=Decimal("0.01"),
+        )
+    next_profile["params"] = params
+    return _cash_constrain_profile(
+        next_profile,
+        capital_profile="feedback_notional_throughput_cash_constrained_1x",
+        label="notional_throughput_feedback_escape",
+    )
+
+
 def _portfolio_feedback_escape_execution_profiles(
     profiles: Sequence[Mapping[str, Any]],
 ) -> tuple[dict[str, Any], ...]:
@@ -2528,6 +2636,7 @@ def _portfolio_feedback_escape_execution_profiles(
             _daily_coverage_feedback_escape_profile(profile),
             _consistency_guard_feedback_escape_profile(profile),
             _turnover_coverage_feedback_escape_profile(profile),
+            _notional_throughput_feedback_escape_profile(profile),
         ):
             key = _stable_hash(next_profile)
             if key in seen:

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -560,6 +560,7 @@ class TestCandidateSpecs(TestCase):
                 "daily_coverage_feedback_escape",
                 "consistency_guard_feedback_escape",
                 "turnover_coverage_feedback_escape",
+                "notional_throughput_feedback_escape",
             ],
         )
         self.assertEqual(

--- a/services/torghut/tests/test_whitepaper_candidate_compiler.py
+++ b/services/torghut/tests/test_whitepaper_candidate_compiler.py
@@ -112,6 +112,72 @@ class TestWhitepaperCandidateCompiler(TestCase):
             "microstructure_continuation_matched_filter_v1",
         )
 
+    def test_portfolio_target_includes_notional_throughput_feedback_escape(
+        self,
+    ) -> None:
+        compilation = compile_claim_payloads_to_whitepaper_experiments(
+            run_id="paper-run-notional-throughput",
+            claims=[
+                {
+                    "claim_id": "claim-flow-throughput",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": (
+                        "Scale-invariant order-flow and intraday transition regimes "
+                        "support diversified high-turnover microstructure sleeves."
+                    ),
+                    "required_features": [
+                        "order_flow_imbalance",
+                        "cross_section_rank",
+                        "quote_quality",
+                    ],
+                    "confidence": "0.78",
+                }
+            ],
+            target_net_pnl_per_day=Decimal("500"),
+            family_template_dir=Path("config/trading/families"),
+            seed_sweep_dir=Path("config/trading"),
+        )
+
+        throughput_specs = [
+            spec
+            for spec in compilation.executable_specs
+            if spec.strategy_overrides["params"].get("feedback_remediation_profile")
+            == "notional_throughput_feedback_escape"
+        ]
+
+        self.assertEqual(
+            {spec.family_template_id for spec in throughput_specs},
+            _PORTFOLIO_TARGET_FAMILIES,
+        )
+        self.assertTrue(
+            all(
+                spec.strategy_overrides["params"]["capital_profile"]
+                == "feedback_notional_throughput_cash_constrained_1x"
+                for spec in throughput_specs
+            )
+        )
+        self.assertTrue(
+            all(
+                int(spec.strategy_overrides["params"]["max_entries_per_session"]) >= 8
+                for spec in throughput_specs
+            )
+        )
+        self.assertTrue(
+            all(
+                Decimal(str(spec.strategy_overrides["max_notional_per_trade"]))
+                <= Decimal("30000")
+                for spec in throughput_specs
+            )
+        )
+        self.assertTrue(
+            all(
+                spec.hard_vetoes["required_min_daily_notional"] == "300000"
+                and spec.hard_vetoes["required_min_active_day_ratio"] == "0.90"
+                and spec.hard_vetoes["required_max_best_day_share"] == "0.25"
+                for spec in throughput_specs
+            )
+        )
+
     def test_missing_family_template_blocks_execution(self) -> None:
         cards = build_hypothesis_cards(
             source_run_id="paper-run-2",


### PR DESCRIPTION
## Summary

- Adds a notional-throughput feedback escape profile to the Torghut whitepaper candidate compiler.
- Keeps the hard promotion gates intact while generating cash-constrained high-turnover candidates for the current active-day, notional, and best-day concentration failure mode.
- Adds compiler coverage proving every portfolio target family receives notional-throughput candidates at the $500/day target.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/discovery/candidate_specs.py tests/test_whitepaper_candidate_compiler.py`
- `uv run --frozen ruff check app/trading/discovery/candidate_specs.py tests/test_whitepaper_candidate_compiler.py`
- `uv run --frozen pytest tests/test_whitepaper_candidate_compiler.py -k 'notional_throughput_feedback_escape or claim_payloads_compile_to_whitepaper'`
- `uv run --frozen pytest tests/test_whitepaper_candidate_compiler.py`
- `uv run --frozen pytest tests/test_candidate_specs.py -k 'feedback_escape_profiles_dedupe_and_fallback_invalid_params or portfolio_target'`
- `uv run --frozen pytest tests/test_candidate_specs.py tests/test_whitepaper_candidate_compiler.py`
- `uv run --frozen python` compile smoke confirming 504 executable $500 portfolio specs and 84 notional-throughput candidates
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
