### PR TITLE
fix(torghut): bound options freshness route queries

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -5005,38 +5005,20 @@ def _load_options_catalog_freshness_summary(
     )
     try:
         session.execute(text("SET LOCAL statement_timeout = 500"))
-        row = (
-            session.execute(
-                text(
-                    """
-SELECT
-  COUNT(*) FILTER (WHERE status = 'active') AS active_contracts,
-  MAX(last_seen_ts) FILTER (WHERE status = 'active') AS newest_last_seen_ts,
-  COUNT(*) FILTER (WHERE status = 'active' AND provider_updated_ts IS NULL) AS missing_provider_updated_ts_count,
-  MAX(provider_updated_ts) FILTER (WHERE status = 'active') AS newest_provider_updated_ts,
-  COUNT(*) FILTER (WHERE status = 'active' AND close_price IS NULL) AS missing_close_price_count,
-  COUNT(*) FILTER (WHERE status = 'active' AND COALESCE(open_interest, 0) <= 0) AS zero_open_interest_count
-FROM torghut_options_contract_catalog
-"""
-                )
-            )
-            .mappings()
-            .one()
-        )
-        scoped_rows = []
         if scoped_symbols:
             scoped_query = text(
                 """
 SELECT
   underlying_symbol,
-  COUNT(*) FILTER (WHERE status = 'active') AS active_contracts,
-  MAX(last_seen_ts) FILTER (WHERE status = 'active') AS newest_last_seen_ts,
-  COUNT(*) FILTER (WHERE status = 'active' AND provider_updated_ts IS NULL) AS missing_provider_updated_ts_count,
-  MAX(provider_updated_ts) FILTER (WHERE status = 'active') AS newest_provider_updated_ts,
-  COUNT(*) FILTER (WHERE status = 'active' AND close_price IS NULL) AS missing_close_price_count,
-  COUNT(*) FILTER (WHERE status = 'active' AND COALESCE(open_interest, 0) <= 0) AS zero_open_interest_count
+  COUNT(*) AS active_contracts,
+  MAX(last_seen_ts) AS newest_last_seen_ts,
+  COUNT(*) FILTER (WHERE provider_updated_ts IS NULL) AS missing_provider_updated_ts_count,
+  MAX(provider_updated_ts) AS newest_provider_updated_ts,
+  COUNT(*) FILTER (WHERE close_price IS NULL) AS missing_close_price_count,
+  COUNT(*) FILTER (WHERE COALESCE(open_interest, 0) <= 0) AS zero_open_interest_count
 FROM torghut_options_contract_catalog
 WHERE underlying_symbol IN :route_symbols
+  AND status = 'active'
 GROUP BY underlying_symbol
 """
             ).bindparams(bindparam("route_symbols", expanding=True))
@@ -5046,6 +5028,80 @@ GROUP BY underlying_symbol
                     {"route_symbols": scoped_symbols},
                 ).mappings()
             )
+            active_contracts = sum(
+                int(row["active_contracts"] or 0) for row in scoped_rows
+            )
+            newest_last_seen_values = [
+                value
+                for value in (
+                    _ensure_utc_datetime(
+                        cast(datetime | None, row["newest_last_seen_ts"])
+                    )
+                    for row in scoped_rows
+                )
+                if value is not None
+            ]
+            newest_last_seen_ts = (
+                max(newest_last_seen_values) if newest_last_seen_values else None
+            )
+            missing_provider_updated_ts_count = sum(
+                int(row["missing_provider_updated_ts_count"] or 0)
+                for row in scoped_rows
+            )
+            newest_provider_updated_values = [
+                value
+                for value in (
+                    _ensure_utc_datetime(
+                        cast(datetime | None, row["newest_provider_updated_ts"])
+                    )
+                    for row in scoped_rows
+                )
+                if value is not None
+            ]
+            newest_provider_updated_ts = (
+                max(newest_provider_updated_values)
+                if newest_provider_updated_values
+                else None
+            )
+            missing_close_price_count = sum(
+                int(row["missing_close_price_count"] or 0) for row in scoped_rows
+            )
+            zero_open_interest_count = sum(
+                int(row["zero_open_interest_count"] or 0) for row in scoped_rows
+            )
+        else:
+            row = (
+                session.execute(
+                    text(
+                        """
+SELECT
+  COUNT(*) AS active_contracts,
+  MAX(last_seen_ts) AS newest_last_seen_ts,
+  COUNT(*) FILTER (WHERE provider_updated_ts IS NULL) AS missing_provider_updated_ts_count,
+  MAX(provider_updated_ts) AS newest_provider_updated_ts,
+  COUNT(*) FILTER (WHERE close_price IS NULL) AS missing_close_price_count,
+  COUNT(*) FILTER (WHERE COALESCE(open_interest, 0) <= 0) AS zero_open_interest_count
+FROM torghut_options_contract_catalog
+WHERE status = 'active'
+"""
+                    )
+                )
+                .mappings()
+                .one()
+            )
+            scoped_rows = []
+            active_contracts = int(row["active_contracts"] or 0)
+            newest_last_seen_ts = _ensure_utc_datetime(
+                cast(datetime | None, row["newest_last_seen_ts"])
+            )
+            missing_provider_updated_ts_count = int(
+                row["missing_provider_updated_ts_count"] or 0
+            )
+            newest_provider_updated_ts = _ensure_utc_datetime(
+                cast(datetime | None, row["newest_provider_updated_ts"])
+            )
+            missing_close_price_count = int(row["missing_close_price_count"] or 0)
+            zero_open_interest_count = int(row["zero_open_interest_count"] or 0)
     except SQLAlchemyError as exc:
         logger.warning("Options catalog freshness summary unavailable: %s", exc)
         return {
@@ -5053,10 +5109,6 @@ GROUP BY underlying_symbol
             "reason_codes": ["options_catalog_freshness_summary_unavailable"],
         }
 
-    active_contracts = int(row["active_contracts"] or 0)
-    missing_provider_updated_ts_count = int(
-        row["missing_provider_updated_ts_count"] or 0
-    )
     route_symbol_freshness = {
         str(scoped_row["underlying_symbol"]).strip().upper(): {
             "status": "current"
@@ -5088,18 +5140,15 @@ GROUP BY underlying_symbol
     }
     return {
         "status": "current" if active_contracts > 0 else "missing",
+        "scope": "route_symbols" if scoped_symbols else "global",
         "active_contracts": active_contracts,
-        "newest_last_seen_ts": _ensure_utc_datetime(
-            cast(datetime | None, row["newest_last_seen_ts"])
-        ),
+        "newest_last_seen_ts": newest_last_seen_ts,
         "missing_provider_updated_ts_count": missing_provider_updated_ts_count,
         "provider_updated_ts_present": missing_provider_updated_ts_count == 0
-        and row["newest_provider_updated_ts"] is not None,
-        "newest_provider_updated_ts": _ensure_utc_datetime(
-            cast(datetime | None, row["newest_provider_updated_ts"])
-        ),
-        "missing_close_price_count": int(row["missing_close_price_count"] or 0),
-        "zero_open_interest_count": int(row["zero_open_interest_count"] or 0),
+        and newest_provider_updated_ts is not None,
+        "newest_provider_updated_ts": newest_provider_updated_ts,
+        "missing_close_price_count": missing_close_price_count,
+        "zero_open_interest_count": zero_open_interest_count,
         "route_symbols": list(scoped_symbols),
         "route_symbol_freshness": route_symbol_freshness,
     }

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -426,6 +426,7 @@ class TestTradingApi(TestCase):
             route_symbols=[" aapl ", "MSFT", "AAPL", ""],
         )
 
+        self.assertEqual(payload["scope"], "route_symbols")
         self.assertEqual(payload["route_symbols"], ["AAPL", "MSFT"])
         self.assertEqual(payload["active_contracts"], 6)
         route_scope = payload["route_symbol_freshness"]
@@ -435,8 +436,38 @@ class TestTradingApi(TestCase):
         self.assertFalse(route_scope["MSFT"]["provider_updated_ts_present"])
         self.assertEqual(route_scope["MSFT"]["missing_close_price_count"], 1)
         self.assertEqual(
-            fake_session.calls[2][1],
+            fake_session.calls[1][1],
             {"route_symbols": ("AAPL", "MSFT")},
+        )
+        self.assertIn("WHERE underlying_symbol IN", fake_session.calls[1][0])
+        self.assertIn("AND status = 'active'", fake_session.calls[1][0])
+        self.assertEqual(
+            sum(
+                "FROM torghut_options_contract_catalog" in sql
+                for sql, _params in fake_session.calls
+            ),
+            1,
+        )
+
+    def test_options_catalog_freshness_summary_uses_global_scan_without_route_scope(
+        self,
+    ) -> None:
+        fake_session = _OptionsFreshnessSession()
+
+        payload = _load_options_catalog_freshness_summary(
+            fake_session,  # type: ignore[arg-type]
+        )
+
+        self.assertEqual(payload["scope"], "global")
+        self.assertEqual(payload["active_contracts"], 6)
+        self.assertEqual(payload["route_symbols"], [])
+        self.assertIn("WHERE status = 'active'", fake_session.calls[1][0])
+        self.assertEqual(
+            sum(
+                "FROM torghut_options_contract_catalog" in sql
+                for sql, _params in fake_session.calls
+            ),
+            1,
         )
 
     def test_route_image_proof_summary_preserves_route_workload_status(self) -> None:


### PR DESCRIPTION
## Summary

- Use route-scoped options catalog freshness queries when route symbols are available.
- Derive aggregate freshness from the bounded symbol result instead of scanning the full options catalog first.
- Add regression coverage proving route-scoped calls issue one catalog query and no global scan.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/main.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `uv run --frozen pytest tests/test_trading_api.py -k 'options_catalog_freshness_summary'`
- `uv run --frozen pytest tests/test_trading_api.py tests/test_route_evidence_clearinghouse.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
