### PR TITLE
chore(torghut): promote image ebc2694c

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-41-g894f8f901
+              value: v0.571.1-45-gebc2694c0
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 894f8f901fac236f6c046ab3ef86d908b8250f5f
+              value: ebc2694c029c66b1099853deb9037a803b0cd5b8
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-41-g894f8f901
+              value: v0.571.1-45-gebc2694c0
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 894f8f901fac236f6c046ab3ef86d908b8250f5f
+              value: ebc2694c029c66b1099853deb9037a803b0cd5b8
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-18T00:18:23Z"
+        client.knative.dev/updateTimestamp: "2026-05-18T02:48:27Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
           ports:
             - name: http1
               containerPort: 8181
@@ -495,11 +495,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-41-g894f8f901
+              value: v0.571.1-45-gebc2694c0
             - name: TORGHUT_COMMIT
-              value: 894f8f901fac236f6c046ab3ef86d908b8250f5f
+              value: ebc2694c029c66b1099853deb9037a803b0cd5b8
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+              value: sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-18T00:18:23Z"
+        client.knative.dev/updateTimestamp: "2026-05-18T02:48:27Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
           ports:
             - name: http1
               containerPort: 8181
@@ -316,11 +316,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-41-g894f8f901
+              value: v0.571.1-45-gebc2694c0
             - name: TORGHUT_COMMIT
-              value: 894f8f901fac236f6c046ab3ef86d908b8250f5f
+              value: ebc2694c029c66b1099853deb9037a803b0cd5b8
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+              value: sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -101,7 +101,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c1904094e551a86945ed81e04bcb599fe7e7c5662791048f987f5b88430d801d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `ebc2694c029c66b1099853deb9037a803b0cd5b8`
- Image tag: `ebc2694c`
- Image digest: `sha256:4b69f745a351cb32793551c27c6ab8fbd4616798fe3fc8187276344e865799f6`