### PR TITLE
fix(torghut): throttle whitepaper autoresearch workflows

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -9,6 +9,16 @@ metadata:
     app.kubernetes.io/part-of: lab
 spec:
   serviceAccountName: torghut-runtime
+  parallelism: 1
+  synchronization:
+    mutexes:
+      - name: torghut-whitepaper-autoresearch-profit-target
+  ttlStrategy:
+    secondsAfterSuccess: 86400
+    secondsAfterFailure: 172800
+    secondsAfterCompletion: 172800
+  podGC:
+    strategy: OnPodCompletion
   entrypoint: run
   arguments:
     parameters:
@@ -37,29 +47,29 @@ spec:
       - name: targetNetPnlPerDay
         value: '500'
       - name: maxCandidates
-        value: '640'
-      - name: topK
-        value: '256'
-      - name: explorationSlots
-        value: '256'
-      - name: feedbackBlockReauditSlots
         value: '128'
+      - name: topK
+        value: '64'
+      - name: explorationSlots
+        value: '48'
+      - name: feedbackBlockReauditSlots
+        value: '32'
       - name: portfolioSizeMin
         value: '3'
       - name: portfolioSizeMax
         value: '12'
       - name: maxFrontierCandidatesPerSpec
-        value: '4'
+        value: '2'
       - name: maxTotalFrontierCandidates
-        value: '640'
+        value: '128'
       - name: realReplayTimeoutSeconds
-        value: '14400'
+        value: '7200'
       - name: realReplayShardSize
         value: '1'
       - name: realReplayShardTimeoutSeconds
-        value: '1800'
+        value: '900'
       - name: realReplayShardWorkers
-        value: '64'
+        value: '4'
       - name: prefetchFullWindowRows
         value: 'true'
       - name: allowStaleTape
@@ -70,7 +80,7 @@ spec:
     - name: run
       nodeSelector:
         kubernetes.io/arch: arm64
-      activeDeadlineSeconds: 21600
+      activeDeadlineSeconds: 9000
       inputs:
         parameters:
           - name: runId
@@ -138,11 +148,11 @@ spec:
             readOnly: true
         resources:
           requests:
-            cpu: 16
-            memory: 32Gi
+            cpu: 4
+            memory: 12Gi
           limits:
-            cpu: 64
-            memory: 160Gi
+            cpu: 8
+            memory: 32Gi
         args:
           - |
             set -euo pipefail

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -306,20 +306,31 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             'if [ -n "{{inputs.parameters.expectedLastTradingDay}}" ]; then',
             template,
         )
-        self.assertIn("name: maxCandidates\n        value: '640'", template)
-        self.assertIn("name: topK\n        value: '256'", template)
-        self.assertIn("name: explorationSlots\n        value: '256'", template)
-        self.assertIn("name: feedbackBlockReauditSlots\n        value: '128'", template)
+        self.assertIn("parallelism: 1", template)
+        self.assertIn("name: torghut-whitepaper-autoresearch-profit-target", template)
+        self.assertIn("podGC:\n    strategy: OnPodCompletion", template)
+        self.assertIn("secondsAfterCompletion: 172800", template)
+        self.assertIn("name: maxCandidates\n        value: '128'", template)
+        self.assertIn("name: topK\n        value: '64'", template)
+        self.assertIn("name: explorationSlots\n        value: '48'", template)
+        self.assertIn("name: feedbackBlockReauditSlots\n        value: '32'", template)
         self.assertIn(
-            "name: maxTotalFrontierCandidates\n        value: '640'", template
+            "name: maxFrontierCandidatesPerSpec\n        value: '2'", template
         )
         self.assertIn(
-            "name: realReplayTimeoutSeconds\n        value: '14400'", template
+            "name: maxTotalFrontierCandidates\n        value: '128'", template
         )
         self.assertIn(
-            "name: realReplayShardTimeoutSeconds\n        value: '1800'", template
+            "name: realReplayTimeoutSeconds\n        value: '7200'", template
         )
-        self.assertIn("name: realReplayShardWorkers\n        value: '64'", template)
+        self.assertIn(
+            "name: realReplayShardTimeoutSeconds\n        value: '900'", template
+        )
+        self.assertIn("name: realReplayShardWorkers\n        value: '4'", template)
+        self.assertIn("cpu: 4", template)
+        self.assertIn("memory: 12Gi", template)
+        self.assertIn("cpu: 8", template)
+        self.assertIn("memory: 32Gi", template)
         self.assertIn("--feedback-block-reaudit-slots", template)
         self.assertIn(
             "--program config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml",
@@ -329,7 +340,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertNotIn(
             '--min-daily-net-pnl "{{inputs.parameters.targetNetPnlPerDay}}"', template
         )
-        self.assertIn("activeDeadlineSeconds: 21600", template)
+        self.assertIn("activeDeadlineSeconds: 9000", template)
         self.assertIn("name: allowStaleTape\n        value: 'false'", template)
         self.assertNotIn("value: '2026-04-24'", template)
         self.assertNotIn("value: '2026-05-01'", template)


### PR DESCRIPTION
## Summary

- Serializes Torghut whitepaper autoresearch runs with WorkflowTemplate `parallelism: 1` and an Argo mutex.
- Reduces default replay pressure from 64 workers to 4, caps candidate fanout, and lowers CPU/memory requests and limits.
- Adds TTL and pod GC for submitted runs, and updates the contract test so these overload controls do not regress silently.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k workflow_template_surfaces_feedback_and_fails_closed_on_stale_tape`
- `python -c "from pathlib import Path; import yaml; p=Path('argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml'); obj=yaml.safe_load(p.read_text()); print(obj['kind'], obj['metadata']['name'], obj['spec']['parallelism'])"`
- `kubectl kustomize argocd/applications/torghut >/tmp/torghut-kustomize.yaml && rg -n "torghut-whitepaper-autoresearch-profit-target|parallelism: 1|realReplayShardWorkers|value: '4'|OnPodCompletion|activeDeadlineSeconds: 9000" /tmp/torghut-kustomize.yaml`
- `uv run --frozen ruff check tests/test_run_whitepaper_autoresearch_profit_target.py`
- `git diff --check`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
