### PR TITLE
fix(registry): force replace deployment during sync

### DIFF
--- a/argocd/applications/registry/deployment.yaml
+++ b/argocd/applications/registry/deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
   name: registry
   namespace: registry
 spec:


### PR DESCRIPTION
## Summary

- Add `argocd.argoproj.io/sync-options: Replace=true` to the registry Deployment.
- Prevent Argo CD server-side apply from merging incompatible `emptyDir` and PVC volume sources after emergency drift.
- Keep registry data on the existing `registry-data` PVC while allowing GitOps to repair future live drift.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/registry | sed -n '/kind: Deployment/,/---/p'`
- Verified live registry app recovered before this PR: `kubectl get app -n argocd registry` reported `Synced` and `Healthy`.
- Verified live registry service before this PR: in-cluster `curl http://registry/v2/` returned `{}`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
