### PR TITLE
fix(argocd): disable inngest and khoshut

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -380,7 +380,7 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "4"
                 automation: auto
-                enabled: "true"
+                enabled: "false"
               - name: airbyte
                 path: argocd/applications/airbyte
                 namespace: airbyte

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -175,7 +175,7 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
                 automation: auto
-                enabled: "true"
+                enabled: "false"
               - name: galette
                 path: argocd/applications/galette
                 namespace: galette


### PR DESCRIPTION
## Summary

- Disable the platform ApplicationSet entry for `inngest`.
- Disable the product ApplicationSet entry for `khoshut`.
- Keep the application manifests in Git while stopping ApplicationSet generation so Argo can prune the live Applications through GitOps.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=server -f argocd/applicationsets/platform.yaml -f argocd/applicationsets/product.yaml`
- `bun run lint:argocd`

## Breaking Changes

Disables the live `inngest` and `khoshut` Argo CD Applications and their managed workloads after the GitOps reconciliation reaches `main`.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
