### PR TITLE
fix(torghut): make disabled inngest secrets optional

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -372,11 +372,13 @@ spec:
                 secretKeyRef:
                   name: inngest
                   key: INNGEST_EVENT_KEY
+                  optional: true
             - name: INNGEST_SIGNING_KEY
               valueFrom:
                 secretKeyRef:
                   name: inngest
                   key: INNGEST_SIGNING_KEY
+                  optional: true
             - name: WHITEPAPER_INNGEST_EVENT_NAME
               value: torghut/whitepaper.analysis.requested
             - name: WHITEPAPER_INNGEST_FUNCTION_ID

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -265,11 +265,13 @@ spec:
                 secretKeyRef:
                   name: inngest
                   key: INNGEST_EVENT_KEY
+                  optional: true
             - name: INNGEST_SIGNING_KEY
               valueFrom:
                 secretKeyRef:
                   name: inngest
                   key: INNGEST_SIGNING_KEY
+                  optional: true
             - name: WHITEPAPER_INNGEST_EVENT_NAME
               value: torghut/whitepaper.analysis.requested
             - name: WHITEPAPER_INNGEST_FUNCTION_ID


### PR DESCRIPTION
## Summary

- Makes Torghut live and sim Inngest secret references optional in Knative manifests.
- Keeps `WHITEPAPER_INNGEST_ENABLED=false` behavior from blocking pod startup when the Inngest app is disabled.
- Preserves existing Inngest env names so the integration can still use reflected keys when that app is intentionally enabled.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/torghut >/tmp/torghut-render.yaml && rg -n 'name: INNGEST_EVENT_KEY|name: INNGEST_SIGNING_KEY|optional: true|WHITEPAPER_INNGEST_ENABLED' /tmp/torghut-render.yaml -C 3`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
