### PR TITLE
fix(torghut): restart degraded ta flink jobs

### DIFF
--- a/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta-sim/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
   imagePullPolicy: IfNotPresent
-  restartNonce: 12
+  restartNonce: 13
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:

--- a/argocd/applications/torghut/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut/ta/flinkdeployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
   imagePullPolicy: IfNotPresent
-  restartNonce: 5
+  restartNonce: 6
   flinkVersion: v2_0
   serviceAccount: torghut-runtime
   logConfiguration:


### PR DESCRIPTION
## Summary

- Bumps `restartNonce` for `FlinkDeployment/torghut-ta` from 5 to 6.
- Bumps `restartNonce` for `FlinkDeployment/torghut-ta-sim` from 12 to 13.
- Uses the documented GitOps recovery path for TA jobs that are degraded after ClickHouse schema initialization failures.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/torghut >/tmp/torghut-render.yaml && rg -n 'kind: FlinkDeployment|name: torghut-ta$|name: torghut-ta-sim$|restartNonce' /tmp/torghut-render.yaml -C 3`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
