### PR TITLE
fix(agents): slim codex runner app-server failures

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -28,8 +28,8 @@ controlPlane:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: fdceeaac
-    digest: sha256:94dd5154dd73494e6eafef6fda6d7d04bb2e666e1784875265dea4d800f56b8f
+    tag: codex-slim-20260518032813
+    digest: sha256:0b00d3c035ebad47982fc5fcfd583f4a23445f5de3afa49940d27389f6199fec
 argocdHooks:
   enabled: true
   image:

--- a/charts/agents/values-prod.yaml
+++ b/charts/agents/values-prod.yaml
@@ -20,8 +20,8 @@ controllers:
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: '8e480ce4'
-    digest: sha256:103cdef8c8d92e3ac6274c67d18312a683c3e71a7270c2d748ed7bfe3108fbba
+    tag: codex-slim-20260518032813
+    digest: sha256:0b00d3c035ebad47982fc5fcfd583f4a23445f5de3afa49940d27389f6199fec
     pullSecrets:
       - registry-cred
 

--- a/packages/codex/src/app-server-client.events.test.ts
+++ b/packages/codex/src/app-server-client.events.test.ts
@@ -52,9 +52,10 @@ const nextMessage = (child: FakeChildProcess) =>
 
 const nextRequest = async (child: FakeChildProcess) => (await nextMessage(child)) as JsonRpcRequest
 
-const respondToInitialize = async (child: FakeChildProcess) => {
+const respondToInitialize = async (child: FakeChildProcess, inspect?: (request: JsonRpcRequest) => void) => {
   const initReq = await nextRequest(child)
   expect(initReq.method).toBe('initialize')
+  inspect?.(initReq)
   writeLine(child, { id: initReq.id, result: {} })
 }
 
@@ -136,6 +137,103 @@ describe('CodexAppServerClient v2 notifications', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it('opts into experimental app-server APIs during initialize', async () => {
+    const { child, client } = setupClient()
+    await respondToInitialize(child, (request) => {
+      expect(request.params).toMatchObject({
+        clientInfo: {
+          name: 'lab',
+          title: 'lab app-server client',
+          version: '0.0.0',
+        },
+        capabilities: {
+          experimentalApi: true,
+        },
+      })
+    })
+    await client.ensureReady()
+    client.stop()
+  })
+
+  it('rejects JSON-RPC error objects with their message instead of Object stringification', async () => {
+    const { child, client } = setupClient()
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    const runPromise = client.runTurnStream('hello', {
+      goal: {
+        objective: 'ship AgentRun goals',
+      },
+    })
+    await respondToThreadStart(child, 'thread-1')
+    const request = await nextRequest(child)
+    expect(request.method).toBe('thread/goal/set')
+    writeLine(child, {
+      id: request.id,
+      error: {
+        code: -32600,
+        message: 'thread/goal/set requires experimentalApi capability',
+      },
+    })
+
+    await expect(runPromise).rejects.toThrow('thread/goal/set requires experimentalApi capability (code -32600)')
+    client.stop()
+  })
+
+  it('fails the active stream when error notifications use the canonical turn id from turn/started', async () => {
+    const { child, client } = setupClient()
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    const runPromise = client.runTurnStream('hello')
+    await respondToThreadStart(child, 'thread-1')
+    await respondToTurnStart(child, 'response-turn-id')
+    const { stream } = await runPromise
+
+    writeLine(child, {
+      method: 'turn/started',
+      params: {
+        threadId: 'thread-1',
+        turn: {
+          id: 'canonical-turn-id',
+          status: 'inProgress',
+          items: [],
+          error: null,
+          startedAt: null,
+          completedAt: null,
+          durationMs: null,
+        },
+      },
+    })
+    writeLine(child, {
+      method: 'error',
+      params: {
+        error: {
+          message: 'Quota exceeded. Check your plan and billing details.',
+          codexErrorInfo: 'usageLimitExceeded',
+          additionalDetails: null,
+        },
+        willRetry: false,
+        threadId: 'thread-1',
+        turnId: 'canonical-turn-id',
+      },
+    })
+
+    await expect(stream.next()).resolves.toMatchObject({
+      value: {
+        type: 'error',
+        error: {
+          error: {
+            message: 'Quota exceeded. Check your plan and billing details.',
+          },
+        },
+      },
+      done: false,
+    })
+    await expect(stream.next()).rejects.toThrow('Quota exceeded. Check your plan and billing details.')
+    client.stop()
   })
 
   it('omits the CLI approval flag for structured rejection policies', async () => {

--- a/packages/codex/src/app-server-client.ts
+++ b/packages/codex/src/app-server-client.ts
@@ -1,6 +1,6 @@
 import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process'
 
-import type { ClientInfo, RequestId } from './app-server'
+import type { ClientInfo, InitializeCapabilities, RequestId } from './app-server'
 import type { ReasoningEffort } from './app-server/ReasoningEffort'
 import type { JsonValue } from './app-server/serde_json/JsonValue'
 import type {
@@ -57,6 +57,7 @@ type JsonRpcRequestMethod =
   | 'turn/interrupt'
 type JsonRpcRequest = { id: RequestId; method: JsonRpcRequestMethod; params: unknown }
 type JsonRpcNotification = { method: string; params?: unknown }
+type JsonRpcErrorObject = { code?: unknown; message?: unknown; data?: unknown }
 
 export type StreamDelta =
   | { type: 'message' | 'reasoning'; delta: string }
@@ -181,6 +182,7 @@ const resolveCliApprovalPolicy = (approval: AskForApproval): string | null =>
   typeof approval === 'string' ? approval : null
 
 const defaultClientInfo: ClientInfo = { name: 'lab', title: 'lab app-server client', version: '0.0.0' }
+const defaultInitializeCapabilities: InitializeCapabilities = { experimentalApi: true }
 const DEFAULT_EFFORT: ReasoningEffort = 'high'
 const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 10_000
 
@@ -208,8 +210,38 @@ const toSandboxPolicy = (mode: SandboxMode): SandboxPolicy => {
   return { type: 'dangerFullAccess' as const }
 }
 
+const jsonRpcErrorToError = (error: unknown): Error => {
+  if (error instanceof Error) return error
+  if (typeof error === 'string') return new Error(error)
+  if (typeof error === 'object' && error !== null) {
+    const rpcError = error as JsonRpcErrorObject
+    const message =
+      typeof rpcError.message === 'string' && rpcError.message.trim()
+        ? rpcError.message
+        : 'codex app-server request failed'
+    const code =
+      typeof rpcError.code === 'number' || typeof rpcError.code === 'string' ? ` (code ${rpcError.code})` : ''
+    const err = new Error(`${message}${code}`)
+    if (rpcError.data !== undefined) {
+      ;(err as Error & { data?: unknown }).data = rpcError.data
+    }
+    return err
+  }
+  return new Error(String(error))
+}
+
+const streamErrorToError = (payload: unknown): Error => {
+  if (payload instanceof Error) return payload
+  if (typeof payload === 'object' && payload !== null) {
+    const params = payload as { error?: unknown; message?: unknown }
+    if (params.error) return jsonRpcErrorToError(params.error)
+    if (typeof params.message === 'string') return new Error(params.message)
+  }
+  return jsonRpcErrorToError(payload)
+}
+
 const createTurnStream = (): TurnStream => {
-  const queue: Array<StreamDelta | { done: true; turn: Turn | null } | { error: unknown }> = []
+  const queue: Array<StreamDelta | { done: true; turn: Turn | null } | { failed: true; error: unknown }> = []
   let resolver: (() => void) | null = null
   let closed = false
   let stream: TurnStream
@@ -238,7 +270,7 @@ const createTurnStream = (): TurnStream => {
   const fail = (error: unknown) => {
     if (closed) return
     closed = true
-    queue.push({ error })
+    queue.push({ failed: true, error })
     wake()
   }
 
@@ -253,7 +285,7 @@ const createTurnStream = (): TurnStream => {
       const next = queue.shift()
       if (!next) continue
 
-      if ('error' in next) {
+      if ('failed' in next) {
         throw next.error
       }
 
@@ -672,7 +704,7 @@ export class CodexAppServerClient {
       for (const line of lines) this.handleLine(line)
     })
 
-    const initializeParams = { clientInfo }
+    const initializeParams = { clientInfo, capabilities: defaultInitializeCapabilities }
     await this.request('initialize', initializeParams)
     this.log('info', 'codex app-server initialized', { clientInfo })
   }
@@ -742,7 +774,7 @@ export class CodexAppServerClient {
     this.pending.delete(message.id)
 
     if (message.error !== undefined) {
-      entry.reject(message.error)
+      entry.reject(jsonRpcErrorToError(message.error))
       this.log('error', 'codex app-server request failed', {
         id: message.id,
         method: entry.method,
@@ -1171,10 +1203,11 @@ export class CodexAppServerClient {
       case 'turn/completed': {
         const params = notification.params as TurnCompletedNotification
         const turnId = this.findTurnId(params) ?? params.turn.id
+        this.reconcileActiveTurnId(turnId)
         const stream = this.turnStreams.get(turnId)
         if (stream) {
           if (params.turn.status === 'failed') {
-            stream.fail(new Error(JSON.stringify(params.turn)))
+            stream.fail(streamErrorToError(params.turn.error ?? params.turn))
           } else {
             stream.complete(params.turn)
           }
@@ -1188,6 +1221,7 @@ export class CodexAppServerClient {
       }
       case 'turn/started': {
         const params = notification.params as { turn: Turn }
+        this.reconcileActiveTurnId(params.turn.id)
         this.log('info', 'turn started', { turnId: params.turn.id })
         break
       }
@@ -1305,10 +1339,12 @@ export class CodexAppServerClient {
       }
       case 'error': {
         const errorPayload = (notification.params as ErrorNotification) ?? { message: 'unknown error' }
+        const notificationTurnId = this.findTurnId(notification.params)
+        if (notificationTurnId) this.reconcileActiveTurnId(notificationTurnId)
         const resolved = this.resolveTurnStream(notification.params)
         if (resolved) {
           resolved.stream.push({ type: 'error', error: errorPayload })
-          this.failTurnStream(resolved.turnId, new Error(JSON.stringify(errorPayload)))
+          this.failTurnStream(resolved.turnId, streamErrorToError(errorPayload))
         } else {
           this.log('info', 'stream error without matching active turn (dropped)', {
             method,
@@ -1388,6 +1424,35 @@ export class CodexAppServerClient {
     const stream = this.turnStreams.get(turnId)
     if (!stream) return null
     return { stream, turnId }
+  }
+
+  private reconcileActiveTurnId(turnId: string): void {
+    if (this.turnStreams.has(turnId)) return
+    const activeTurnIds = Array.from(this.turnStreams.keys())
+    if (activeTurnIds.length !== 1) return
+    const [previousTurnId] = activeTurnIds
+    if (!previousTurnId || previousTurnId === turnId) return
+
+    const stream = this.turnStreams.get(previousTurnId)
+    if (!stream) return
+
+    this.turnStreams.delete(previousTurnId)
+    this.turnStreams.set(turnId, stream)
+
+    const items = this.turnItems.get(previousTurnId)
+    this.turnItems.delete(previousTurnId)
+    if (items) {
+      this.turnItems.set(turnId, items)
+      for (const itemId of items) {
+        this.itemTurnMap.set(itemId, turnId)
+      }
+    }
+
+    if (this.lastActiveTurnId === previousTurnId) {
+      this.lastActiveTurnId = turnId
+    }
+
+    this.log('info', 'reconciled app-server turn id', { previousTurnId, turnId })
   }
 
   private trackItemFromParams(params: unknown): void {

--- a/services/agents/Dockerfile.codex-runner
+++ b/services/agents/Dockerfile.codex-runner
@@ -1,5 +1,11 @@
 # syntax=docker/dockerfile:1.6
-FROM ghcr.io/openai/codex-universal@sha256:956c2e7dd1590fc12763f172579d777464312006b9fa1f6405f5f1b78b8ea2dc
+
+ARG BUN_VERSION=1.3.13
+ARG NODE_VERSION=24.11.1
+
+FROM node:${NODE_VERSION}-bookworm-slim AS node-runtime
+
+FROM oven/bun:${BUN_VERSION}-slim
 
 ARG CODEX_AUTH_CHECKSUM=unspecified
 ARG CODEX_VERSION=0.130.0
@@ -12,21 +18,31 @@ ENV DEBIAN_FRONTEND=noninteractive \
     BUN_INSTALL_CACHE_DIR=/opt/bun/install/cache \
     BUN_INSTALL_CACHE_SEED_DIR=/opt/bun/install/cache
 
-ENV CODEX_ENV_NODE_VERSION=24.11.1 \
-    BUN_VERSION=1.3.13
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
 
-RUN bash -lc 'source /root/.nvm/nvm.sh && nvm install ${CODEX_ENV_NODE_VERSION}'
+RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 RUN set -eux; \
     apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20 \
-    && apt-get install -y -V --no-install-recommends ca-certificates curl git gh jq python3 build-essential pkg-config \
+    && apt-get install -y -V --no-install-recommends \
+      bash \
+      build-essential \
+      ca-certificates \
+      curl \
+      gh \
+      git \
+      jq \
+      openssh-client \
+      pkg-config \
+      python3 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN mise use --global "bun@${BUN_VERSION}" \
-    && mise cache clear \
-    && rm -rf "$HOME/.cache/mise" "$HOME/.local/share/mise/downloads"
-
-RUN bash -lc 'source /root/.nvm/nvm.sh && npm install -g "@openai/codex@${CODEX_VERSION}" node-gyp && ln -sf "$(command -v codex)" /usr/local/bin/codex && ln -sf "$(command -v node)" /usr/local/bin/node && ln -sf "$(command -v npm)" /usr/local/bin/npm && ln -sf "$(command -v node-gyp)" /usr/local/bin/node-gyp'
+RUN npm install -g "@openai/codex@${CODEX_VERSION}" node-gyp \
+    && npm cache clean --force \
+    && test -x /usr/local/bin/codex \
+    && test -x /usr/local/bin/node-gyp
 
 RUN mkdir -p "$WORKSPACE" /root/.codex "$BUN_INSTALL_CACHE_DIR"
 


### PR DESCRIPTION
## Summary

- Replaces the Agents Codex runner image base with a slim Bun/Node image instead of `ghcr.io/openai/codex-universal`.
- Opts the Codex app-server client into experimental APIs so AgentRun goals can be set through `thread/goal/set`.
- Normalizes JSON-RPC and stream errors, reconciles canonical app-server turn ids, and prevents quota/auth failures from being dropped or looped.
- Pins the verified slim runner digest in Agents GitOps/prod values for default AgentRun workload creation.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/codex test -- src/app-server-client.events.test.ts`
- `bun run --filter @proompteng/codex build`
- `bun run --filter @proompteng/agents test -- src/runner/codex-app-server.test.ts src/runner/spec.test.ts`
- `bun run --filter @proompteng/agents tsc`
- `bunx oxfmt --check packages/codex/src/app-server-client.ts packages/codex/src/app-server-client.events.test.ts services/agents/src/runner/codex-app-server.ts services/agents/scripts/codex/agent-runner.ts`
- `mise exec helm@3 -- helm lint charts/agents -f argocd/applications/agents/values.yaml`
- `mise exec helm@3 -- helm template agents charts/agents -n agents -f argocd/applications/agents/values.yaml`
- `docker build --platform linux/arm64 --secret id=codexauth,src=/Users/gregkonush/.codex/auth.json -f services/agents/Dockerfile.codex-runner -t registry.ide-newton.ts.net/lab/agents-codex-runner:codex-slim-20260518032813 .`
- `docker run --rm --platform linux/arm64 registry.ide-newton.ts.net/lab/agents-codex-runner:codex-slim-20260518032813 sh -lc 'bun --version && node --version && npm --version && codex --version && agent-runner 2>&1 | head -1'`
- `docker push registry.ide-newton.ts.net/lab/agents-codex-runner:codex-slim-20260518032813`
- Live canary `agents-harness-canary-20260518033509` in namespace `agents` pinned `registry.ide-newton.ts.net/lab/agents-codex-runner:codex-slim-20260518032813@sha256:0b00d3c035ebad47982fc5fcfd583f4a23445f5de3afa49940d27389f6199fec`; it initialized app-server, set the AgentRun goal, reconciled the canonical turn id, and failed deterministically as `ProviderCapacityExhausted` due Codex quota.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. The GitOps runner image digest changes; existing provider specs and `agent-runner.json` remain compatible.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
