### PR TITLE
chore(symphony): promote image cff8aea8

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-17T22:54:10Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-18T04:01:59Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "e69f6e09"
-    digest: sha256:d1017e7db18ebc1f8b549b2c10eb1a6ad887bace0cd2056f5b743a41dd1d8a0e
+    newTag: "cff8aea8"
+    digest: sha256:587ca5ed07ee3383e64af5be92a4972c2fe4a7f6e12b4bd422897b8438f7ab35

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-17T22:54:10Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-18T04:01:59Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "e69f6e09"
-    digest: sha256:d1017e7db18ebc1f8b549b2c10eb1a6ad887bace0cd2056f5b743a41dd1d8a0e
+    newTag: "cff8aea8"
+    digest: sha256:587ca5ed07ee3383e64af5be92a4972c2fe4a7f6e12b4bd422897b8438f7ab35

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-17T22:54:10Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-18T04:01:59Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "e69f6e09"
-    digest: sha256:d1017e7db18ebc1f8b549b2c10eb1a6ad887bace0cd2056f5b743a41dd1d8a0e
+    newTag: "cff8aea8"
+    digest: sha256:587ca5ed07ee3383e64af5be92a4972c2fe4a7f6e12b4bd422897b8438f7ab35


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `cff8aea82cc8211225272f89adc2ad4aa00bcaaa`
- Image tag: `cff8aea8`
- Image digest: `sha256:587ca5ed07ee3383e64af5be92a4972c2fe4a7f6e12b4bd422897b8438f7ab35`