### PR TITLE
fix(agents): remove domain env from agents runtime

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -16,8 +16,6 @@ controlPlane:
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
-      AGENTS_TORGHUT_STATUS_URL: http://torghut.torghut.svc.cluster.local/trading/consumer-evidence
-      AGENTS_TORGHUT_STATUS_TIMEOUT_MS: "12000"
       AGENTS_SOURCE_HEAD_SHA: fdceeaac3c94e7d102f1b4b3f84c6884b3b1f60d
       AGENTS_GITOPS_REVISION: fdceeaac3c94e7d102f1b4b3f84c6884b3b1f60d
       AGENTS_SOURCE_CI_RUN_ID: "26005264540"
@@ -93,9 +91,6 @@ controllers:
       AGENTS_AGENT_RUNNER_NATS_AUTH_SECRET_NAME: nats-agents-credentials
       AGENTS_AGENT_RUNNER_NATS_AUTH_USERNAME_KEY: username
       AGENTS_AGENT_RUNNER_NATS_AUTH_PASSWORD_KEY: password
-      AGENTS_WHITEPAPER_FINALIZE_ENABLED: "true"
-      AGENTS_WHITEPAPER_FINALIZE_BASE_URL: http://torghut.torghut.svc.cluster.local
-      AGENTS_WHITEPAPER_FINALIZE_USE_SERVICE_ACCOUNT_TOKEN: "true"
       AGENTS_MATERIAL_REENTRY_REQUIREMENT_SIGNALS: "false"
       AGENTS_SCHEDULE_RUNNER_ADMISSION_STATUS_URL: http://agents.agents.svc.cluster.local/api/agents/control-plane/status?view=schedule-runner
       AGENTS_SCHEDULE_RUNNER_ADMISSION_STATUS_TIMEOUT_MS: "30000"

--- a/scripts/agents/guard-extraction-boundaries.sh
+++ b/scripts/agents/guard-extraction-boundaries.sh
@@ -31,6 +31,6 @@ trap cleanup EXIT
 helm template agents "${CHART_DIR}" --namespace agents > "${rendered_chart}"
 kubectl kustomize "${ARGO_DIR}" --enable-helm > "${rendered_argo}"
 
-rendered_forbidden='JANGAR_|jangar-db-app|/etc/jangar|lab/jangar|/app/services/jangar|services/jangar|codex-implement'
+rendered_forbidden='JANGAR_|jangar-db-app|/etc/jangar|lab/jangar|/app/services/jangar|services/jangar|codex-implement|AGENTS_TORGHUT_STATUS_|AGENTS_WHITEPAPER_FINALIZE_'
 fail_if_matches "rendered Helm chart must use Agents-owned images, env, DB secret, and runner paths" "${rendered_forbidden}" "${rendered_chart}"
 fail_if_matches "rendered Agents GitOps app must use Agents-owned images, env, DB secret, and runner paths" "${rendered_forbidden}" "${rendered_argo}"


### PR DESCRIPTION
## Summary

- Remove Torghut status env from the Agents control-plane deployment values.
- Remove whitepaper finalize env from the Agents controller deployment values.
- Extend the Agents extraction boundary guard to reject those domain env names in rendered Helm/GitOps output.

## Related Issues

None

## Testing

- `scripts/agents/guard-extraction-boundaries.sh`
- `scripts/agents/validate-agents.sh`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `kubectl kustomize argocd/applications/agents --enable-helm` with a grep check for absent `AGENTS_TORGHUT_STATUS_*` and `AGENTS_WHITEPAPER_FINALIZE_*`
- `kubectl -n agents get deploy agents agents-controllers -o custom-columns=NAME:.metadata.name,READY:.status.readyReplicas,AVAILABLE:.status.availableReplicas,DESIRED:.spec.replicas --no-headers`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
