### PR TITLE
feat(torghut): add researched reversal breakout surfaces

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -386,7 +386,7 @@ jobs:
   pytest-autoresearch-runner:
     name: Pytest autoresearch runner ${{ matrix.slice }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     needs:
       - changes
     if: ${{ needs.changes.outputs.service == 'true' }}

--- a/services/torghut/app/trading/discovery/autoresearch.py
+++ b/services/torghut/app/trading/discovery/autoresearch.py
@@ -122,6 +122,12 @@ class StrategyObjective:
     min_daily_net_pnl: Decimal = Decimal('0')
     max_gross_exposure_pct_equity: Decimal = Decimal('999999999')
     min_cash: Decimal = Decimal('-999999999')
+    default_start_equity: Decimal = Decimal('31590.02')
+    max_worst_day_loss_pct_equity: Decimal = Decimal('0.05')
+    max_drawdown_pct_equity: Decimal = Decimal('0.10')
+    extended_max_worst_day_loss_pct_equity: Decimal = Decimal('0.10')
+    extended_max_drawdown_pct_equity: Decimal = Decimal('0.20')
+    min_total_net_pnl_to_drawdown_ratio: Decimal = Decimal('1.50')
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -138,6 +144,12 @@ class StrategyObjective:
             'stop_when_objective_met': self.stop_when_objective_met,
             'max_gross_exposure_pct_equity': str(self.max_gross_exposure_pct_equity),
             'min_cash': str(self.min_cash),
+            'default_start_equity': str(self.default_start_equity),
+            'max_worst_day_loss_pct_equity': str(self.max_worst_day_loss_pct_equity),
+            'max_drawdown_pct_equity': str(self.max_drawdown_pct_equity),
+            'extended_max_worst_day_loss_pct_equity': str(self.extended_max_worst_day_loss_pct_equity),
+            'extended_max_drawdown_pct_equity': str(self.extended_max_drawdown_pct_equity),
+            'min_total_net_pnl_to_drawdown_ratio': str(self.min_total_net_pnl_to_drawdown_ratio),
         }
 
 
@@ -471,6 +483,30 @@ def load_strategy_autoresearch_program(
             objective_payload.get('min_cash'),
             default='-999999999',
         ),
+        default_start_equity=_coerce_decimal(
+            objective_payload.get('default_start_equity'),
+            default='31590.02',
+        ),
+        max_worst_day_loss_pct_equity=_coerce_decimal(
+            objective_payload.get('max_worst_day_loss_pct_equity'),
+            default='0.05',
+        ),
+        max_drawdown_pct_equity=_coerce_decimal(
+            objective_payload.get('max_drawdown_pct_equity'),
+            default='0.10',
+        ),
+        extended_max_worst_day_loss_pct_equity=_coerce_decimal(
+            objective_payload.get('extended_max_worst_day_loss_pct_equity'),
+            default='0.10',
+        ),
+        extended_max_drawdown_pct_equity=_coerce_decimal(
+            objective_payload.get('extended_max_drawdown_pct_equity'),
+            default='0.20',
+        ),
+        min_total_net_pnl_to_drawdown_ratio=_coerce_decimal(
+            objective_payload.get('min_total_net_pnl_to_drawdown_ratio'),
+            default='1.50',
+        ),
     )
     snapshot_policy_payload = _mapping(payload.get('snapshot_policy'))
     snapshot_policy = SnapshotPolicy(
@@ -662,6 +698,16 @@ def apply_program_objective(
     consistency['min_regime_slice_pass_rate'] = str(objective.min_regime_slice_pass_rate)
     consistency['max_gross_exposure_pct_equity'] = str(objective.max_gross_exposure_pct_equity)
     consistency['min_cash'] = str(objective.min_cash)
+    consistency['default_start_equity'] = str(objective.default_start_equity)
+    consistency['max_worst_day_loss_pct_equity'] = str(objective.max_worst_day_loss_pct_equity)
+    consistency['max_drawdown_pct_equity'] = str(objective.max_drawdown_pct_equity)
+    consistency['extended_max_worst_day_loss_pct_equity'] = str(
+        objective.extended_max_worst_day_loss_pct_equity
+    )
+    consistency['extended_max_drawdown_pct_equity'] = str(objective.extended_max_drawdown_pct_equity)
+    consistency['min_total_net_pnl_to_drawdown_ratio'] = str(
+        objective.min_total_net_pnl_to_drawdown_ratio
+    )
     payload['constraints'] = constraints
     payload['consistency_constraints'] = consistency
     return payload
@@ -798,6 +844,58 @@ def build_mutated_sweep_config(
     return payload, description
 
 
+def _objective_start_equity(
+    scorecard: Mapping[str, Any],
+    full_window: Mapping[str, Any],
+    objective: StrategyObjective,
+) -> Decimal:
+    for payload in (scorecard, full_window):
+        for key in (
+            'start_equity',
+            'account_start_equity',
+            'execution_start_equity',
+            'executable_replay_start_equity',
+            'runtime_start_equity',
+        ):
+            value = _coerce_decimal(payload.get(key), default='0')
+            if value > 0:
+                return value
+    return objective.default_start_equity
+
+
+def _objective_total_net_pnl(
+    *,
+    scorecard: Mapping[str, Any],
+    full_window: Mapping[str, Any],
+    net_pnl_per_day: Decimal,
+    trading_day_count: int,
+) -> Decimal:
+    daily_net_payload = _mapping(full_window.get('daily_net')) or _mapping(scorecard.get('daily_net'))
+    if daily_net_payload:
+        return sum((_coerce_decimal(value, default='0') for value in daily_net_payload.values()), Decimal('0'))
+    return net_pnl_per_day * Decimal(max(1, trading_day_count))
+
+
+def _objective_drawdown_passes(
+    *,
+    observed: Decimal,
+    start_equity: Decimal,
+    normal_pct: Decimal,
+    extended_pct: Decimal,
+    absolute_cap: Decimal,
+    total_net_pnl: Decimal,
+    min_total_net_pnl_to_drawdown_ratio: Decimal,
+) -> bool:
+    normal_limit = max(Decimal('0'), start_equity * normal_pct)
+    percent_limit = max(normal_limit, start_equity * extended_pct)
+    extended_limit = percent_limit if absolute_cap <= 0 else min(absolute_cap, percent_limit)
+    if observed <= normal_limit:
+        return True
+    if observed <= extended_limit and observed > 0:
+        return (total_net_pnl / observed) >= min_total_net_pnl_to_drawdown_ratio
+    return observed <= extended_limit
+
+
 def candidate_meets_objective(
     candidate_payload: Mapping[str, Any],
     *,
@@ -822,6 +920,31 @@ def candidate_meets_objective(
     min_cash = _coerce_decimal(scorecard.get('min_cash') or full_window.get('min_cash'), default='0')
     trading_day_count = int(full_window.get('trading_day_count') or 0)
     active_days = int(full_window.get('active_days') or 0)
+    start_equity = _objective_start_equity(scorecard, full_window, objective)
+    total_net_pnl = _objective_total_net_pnl(
+        scorecard=scorecard,
+        full_window=full_window,
+        net_pnl_per_day=net_pnl_per_day,
+        trading_day_count=trading_day_count,
+    )
+    worst_day_loss_ok = _objective_drawdown_passes(
+        observed=worst_day_loss,
+        start_equity=start_equity,
+        normal_pct=objective.max_worst_day_loss_pct_equity,
+        extended_pct=objective.extended_max_worst_day_loss_pct_equity,
+        absolute_cap=objective.max_worst_day_loss,
+        total_net_pnl=total_net_pnl,
+        min_total_net_pnl_to_drawdown_ratio=objective.min_total_net_pnl_to_drawdown_ratio,
+    )
+    max_drawdown_ok = _objective_drawdown_passes(
+        observed=max_drawdown,
+        start_equity=start_equity,
+        normal_pct=objective.max_drawdown_pct_equity,
+        extended_pct=objective.extended_max_drawdown_pct_equity,
+        absolute_cap=objective.max_drawdown,
+        total_net_pnl=total_net_pnl,
+        min_total_net_pnl_to_drawdown_ratio=objective.min_total_net_pnl_to_drawdown_ratio,
+    )
     if objective.require_every_day_active and trading_day_count > 0 and active_days != trading_day_count:
         return False
     if objective.min_daily_net_pnl > 0:
@@ -842,8 +965,8 @@ def candidate_meets_objective(
             positive_day_ratio >= objective.min_positive_day_ratio,
             avg_daily_notional >= objective.min_daily_notional,
             best_day_share <= objective.max_best_day_share,
-            worst_day_loss <= objective.max_worst_day_loss,
-            max_drawdown <= objective.max_drawdown,
+            worst_day_loss_ok,
+            max_drawdown_ok,
             regime_slice_pass_rate >= objective.min_regime_slice_pass_rate,
             max_gross_exposure_pct_equity <= objective.max_gross_exposure_pct_equity,
             min_cash >= objective.min_cash,

--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -2872,10 +2872,26 @@ def _family_scores_for_hypothesis(
             3,
             "liquidity_response_or_execution_stress",
         )
-    if has_any(("volatility", "regime", "stress window", "nearly unstable")):
+    if has_any(
+        (
+            "volatility",
+            "regime",
+            "latent regime",
+            "regime persistence",
+            "stress window",
+            "nearly unstable",
+            "hidden markov",
+            "hmm",
+        )
+    ):
         bump("intraday_tsmom_v2", 4, "volatility_or_regime_state")
         bump("momentum_pullback_v1", 2, "volatility_or_regime_state")
         bump("opening_drive_leader_reclaim_v1", 2, "volatility_or_regime_state")
+        bump(
+            "microstructure_continuation_matched_filter_v1",
+            2,
+            "volatility_or_regime_state",
+        )
     if has_any(("momentum", "trend", "pullback", "trend persistence")):
         bump("momentum_pullback_v1", 5, "momentum_or_pullback")
         bump("intraday_tsmom_v2", 4, "momentum_or_pullback")
@@ -2902,6 +2918,9 @@ def _family_scores_for_hypothesis(
             "late-session",
             "late session",
             "final half-hour",
+            "end-of-day",
+            "end of day",
+            "eod",
             "closing",
             "into the close",
             "macro announcement",
@@ -2919,6 +2938,11 @@ def _family_scores_for_hypothesis(
         (
             "final 30",
             "final half-hour",
+            "end-of-day reversal",
+            "end of day reversal",
+            "eod reversal",
+            "intraday loser",
+            "intraday losers",
             "late-session loser",
             "late session loser",
             "closing-window",
@@ -2927,7 +2951,18 @@ def _family_scores_for_hypothesis(
         )
     ):
         bump("end_of_day_reversal_v1", 7, "closing_window_reversal")
-    if has_any(("breakout", "continuation", "reclaim", "leader")):
+    if has_any(
+        (
+            "breakout",
+            "continuation",
+            "reclaim",
+            "leader",
+            "opening range breakout",
+            "orb",
+            "stocks in play",
+            "overactive stocks",
+        )
+    ):
         bump("breakout_reclaim_v2", 5, "continuation_or_reclaim")
         bump(
             "microstructure_continuation_matched_filter_v1",
@@ -2942,9 +2977,14 @@ def _family_scores_for_hypothesis(
             "morning momentum",
             "opening drive",
             "opening-drive",
+            "opening range",
+            "opening-range",
+            "opening range breakout",
             "opening window",
             "open window",
             "leader reclaim",
+            "stocks in play",
+            "unusually high daily volume",
             "macro announcement",
             "announcement",
             "information discreteness",

--- a/services/torghut/app/trading/discovery/profit_target_oracle.py
+++ b/services/torghut/app/trading/discovery/profit_target_oracle.py
@@ -14,12 +14,18 @@ PROFIT_TARGET_ORACLE_SCHEMA_VERSION = "torghut.profit-target-oracle.v1"
 class ProfitTargetOraclePolicy:
     min_active_day_ratio: Decimal = Decimal("0.90")
     min_positive_day_ratio: Decimal = Decimal("0.60")
-    min_daily_net_pnl: Decimal = Decimal("-350")
+    min_daily_net_pnl: Decimal = Decimal("-999999999")
     max_best_day_share: Decimal = Decimal("0.25")
     max_cluster_contribution_share: Decimal = Decimal("0.40")
     max_single_symbol_contribution_share: Decimal = Decimal("0.35")
-    max_worst_day_loss: Decimal = Decimal("350")
-    max_drawdown: Decimal = Decimal("900")
+    max_worst_day_loss: Decimal = Decimal("999999999")
+    max_drawdown: Decimal = Decimal("999999999")
+    default_start_equity: Decimal = Decimal("31590.02")
+    max_worst_day_loss_pct_equity: Decimal = Decimal("0.05")
+    max_drawdown_pct_equity: Decimal = Decimal("0.10")
+    extended_max_worst_day_loss_pct_equity: Decimal = Decimal("0.10")
+    extended_max_drawdown_pct_equity: Decimal = Decimal("0.20")
+    min_total_net_pnl_to_drawdown_ratio: Decimal = Decimal("1.50")
     max_gross_exposure_pct_equity: Decimal = Decimal("1.0")
     min_cash: Decimal = Decimal("0")
     max_negative_cash_observation_count: int = 0
@@ -44,6 +50,20 @@ class ProfitTargetOraclePolicy:
             ),
             "max_worst_day_loss": str(self.max_worst_day_loss),
             "max_drawdown": str(self.max_drawdown),
+            "default_start_equity": str(self.default_start_equity),
+            "max_worst_day_loss_pct_equity": str(
+                self.max_worst_day_loss_pct_equity
+            ),
+            "max_drawdown_pct_equity": str(self.max_drawdown_pct_equity),
+            "extended_max_worst_day_loss_pct_equity": str(
+                self.extended_max_worst_day_loss_pct_equity
+            ),
+            "extended_max_drawdown_pct_equity": str(
+                self.extended_max_drawdown_pct_equity
+            ),
+            "min_total_net_pnl_to_drawdown_ratio": str(
+                self.min_total_net_pnl_to_drawdown_ratio
+            ),
             "max_gross_exposure_pct_equity": str(self.max_gross_exposure_pct_equity),
             "min_cash": str(self.min_cash),
             "max_negative_cash_observation_count": self.max_negative_cash_observation_count,
@@ -110,6 +130,75 @@ def _numeric_check(
     }
 
 
+def _start_equity(scorecard: Mapping[str, Any], policy: ProfitTargetOraclePolicy) -> Decimal:
+    for key in (
+        "start_equity",
+        "account_start_equity",
+        "execution_start_equity",
+        "executable_replay_start_equity",
+        "runtime_start_equity",
+    ):
+        value = _decimal(scorecard.get(key))
+        if value > 0:
+            return value
+    return policy.default_start_equity
+
+
+def _total_net_pnl(
+    *,
+    daily_net: Mapping[str, Any] | None,
+    net_pnl_per_day: Decimal,
+    trading_day_count: int,
+) -> Decimal:
+    if daily_net:
+        return sum((_decimal(value) for value in daily_net.values()), Decimal("0"))
+    return net_pnl_per_day * Decimal(max(1, trading_day_count))
+
+
+def _risk_adjusted_drawdown_check(
+    *,
+    metric: str,
+    observed: Decimal,
+    start_equity: Decimal,
+    normal_pct: Decimal,
+    extended_pct: Decimal,
+    total_net_pnl: Decimal,
+    min_total_net_pnl_to_drawdown_ratio: Decimal,
+    absolute_cap: Decimal,
+) -> dict[str, Any]:
+    normal_limit = max(Decimal("0"), start_equity * normal_pct)
+    extended_limit = max(normal_limit, start_equity * extended_pct)
+    absolute_limit = (
+        extended_limit if absolute_cap <= 0 else min(absolute_cap, extended_limit)
+    )
+    ratio = Decimal("999999999") if observed <= 0 else total_net_pnl / observed
+    if observed <= normal_limit:
+        passed = True
+        mode = "normal_pct"
+    elif observed <= absolute_limit and observed > 0:
+        passed = ratio >= min_total_net_pnl_to_drawdown_ratio
+        mode = "return_adjusted"
+    else:
+        passed = observed <= absolute_limit
+        mode = "hard_cap"
+    return {
+        "metric": metric,
+        "observed": str(observed),
+        "operator": "risk_adjusted_lte",
+        "threshold": str(normal_limit),
+        "extended_threshold": str(absolute_limit),
+        "start_equity": str(start_equity),
+        "normal_pct_equity": str(normal_pct),
+        "extended_pct_equity": str(extended_pct),
+        "total_net_pnl_to_drawdown_ratio": str(ratio),
+        "min_total_net_pnl_to_drawdown_ratio": str(
+            min_total_net_pnl_to_drawdown_ratio
+        ),
+        "mode": mode,
+        "passed": passed,
+    }
+
+
 def evaluate_profit_target_oracle(
     scorecard: Mapping[str, Any],
     *,
@@ -129,6 +218,7 @@ def evaluate_profit_target_oracle(
         min_daily_net_pnl = min(_decimal(value) for value in daily_net.values())
         daily_net_observed_day_count = len(daily_net)
     else:
+        daily_net = None
         min_daily_net_pnl = Decimal("0")
         daily_net_observed_day_count = 0
     trading_day_count = _nonnegative_int(
@@ -142,6 +232,12 @@ def evaluate_profit_target_oracle(
         and daily_net_observed_day_count < trading_day_count
     ):
         min_daily_net_pnl = min(min_daily_net_pnl, Decimal("0"))
+    start_equity = _start_equity(scorecard, policy)
+    total_net_pnl = _total_net_pnl(
+        daily_net=daily_net,
+        net_pnl_per_day=net_pnl,
+        trading_day_count=trading_day_count,
+    )
     checks = [
         _numeric_check(
             metric="portfolio_post_cost_net_pnl_per_day",
@@ -212,17 +308,25 @@ def evaluate_profit_target_oracle(
             operator="lte",
             threshold=policy.max_single_symbol_contribution_share,
         ),
-        _numeric_check(
+        _risk_adjusted_drawdown_check(
             metric="worst_day_loss",
             observed=_decimal(scorecard.get("worst_day_loss")),
-            operator="lte",
-            threshold=policy.max_worst_day_loss,
+            start_equity=start_equity,
+            normal_pct=policy.max_worst_day_loss_pct_equity,
+            extended_pct=policy.extended_max_worst_day_loss_pct_equity,
+            total_net_pnl=total_net_pnl,
+            min_total_net_pnl_to_drawdown_ratio=policy.min_total_net_pnl_to_drawdown_ratio,
+            absolute_cap=policy.max_worst_day_loss,
         ),
-        _numeric_check(
+        _risk_adjusted_drawdown_check(
             metric="max_drawdown",
             observed=_decimal(scorecard.get("max_drawdown")),
-            operator="lte",
-            threshold=policy.max_drawdown,
+            start_equity=start_equity,
+            normal_pct=policy.max_drawdown_pct_equity,
+            extended_pct=policy.extended_max_drawdown_pct_equity,
+            total_net_pnl=total_net_pnl,
+            min_total_net_pnl_to_drawdown_ratio=policy.min_total_net_pnl_to_drawdown_ratio,
+            absolute_cap=policy.max_drawdown,
         ),
         _numeric_check(
             metric="max_gross_exposure_pct_equity",

--- a/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
@@ -45,13 +45,19 @@ ledger_policy:
   append_only: true
 objective:
   target_net_pnl_per_day: '500'
-  min_daily_net_pnl: '-350'
+  min_daily_net_pnl: '-999999999'
   min_active_day_ratio: '0.90'
   min_positive_day_ratio: '0.60'
   min_daily_notional: '300000'
   max_best_day_share: '0.25'
-  max_worst_day_loss: '350'
-  max_drawdown: '900'
+  max_worst_day_loss: '999999999'
+  max_drawdown: '999999999'
+  default_start_equity: '31590.02'
+  max_worst_day_loss_pct_equity: '0.05'
+  max_drawdown_pct_equity: '0.10'
+  extended_max_worst_day_loss_pct_equity: '0.10'
+  extended_max_drawdown_pct_equity: '0.20'
+  min_total_net_pnl_to_drawdown_ratio: '1.50'
   require_every_day_active: false
   min_regime_slice_pass_rate: '0.45'
   max_gross_exposure_pct_equity: '1.0'
@@ -151,6 +157,17 @@ research_sources:
       - claim_id: macro_information_momentum
         summary: Intraday momentum is stronger around macro-announcement information windows.
         implication: Treat late-day continuation as regime conditional and require non-announcement held-out validation.
+  - source_id: opening_range_breakout_stocks_in_play_2024
+    title: 'A Profitable Day Trading Strategy For The U.S. Equity Market'
+    url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4729284
+    published_at: '2024-02-19'
+    claims:
+      - claim_id: stocks_in_play_opening_range_breakout
+        summary: A 5-minute opening range breakout applied to stocks with unusually high daily volume can produce systematic intraday momentum candidates.
+        implication: Reaudit opening-drive and breakout-reclaim sleeves with relative-volume, VWAP, and no-overnight-hold controls.
+      - claim_id: orb_risk_controls_required
+        summary: Opening range breakout profits depend on strict intraday risk management rather than raw breakout direction alone.
+        implication: Keep stop-loss, close-flatten, drawdown, concentration, and post-cost replay gates as blockers before promotion.
   - source_id: intraday_residual_reversal_2024
     title: 'Intraday Residual Reversal in the U.S. Stock Market'
     url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4731947
@@ -184,6 +201,17 @@ research_sources:
       - claim_id: time_series_not_only_cross_section
         summary: Reversal can be framed as a time-series effect, not only a cross-sectional loser/winner sort.
         implication: Include recent-window reversal profiles that can trade serially while respecting simultaneous exposure caps.
+  - source_id: end_of_day_reversal_2024
+    title: 'End-of-Day Reversal'
+    url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5039009
+    published_at: '2024-11-29'
+    claims:
+      - claim_id: final_half_hour_loser_reversal
+        summary: Individual-stock intraday losers can reverse in the final 30 minutes of the trading day.
+        implication: Reaudit end-of-day reversal sleeves on late-session losers, but cap best-day and symbol concentration.
+      - claim_id: closing_pressure_unwind
+        summary: The pattern is linked to intraday price pressure unwinding near the close.
+        implication: Keep closing-window entry, short hold, cost, and no-overnight exposure controls explicit.
   - source_id: overnight_jump_intraday_reversal_2026
     title: 'Dark Side of the Day: Overnight Price Jumps and Short-Term Return Predictability'
     url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4335622
@@ -206,6 +234,17 @@ research_sources:
       - claim_id: subhour_liquidity_reversal
         summary: Short-term reversals can be driven by temporary liquidity imbalances lasting less than an hour.
         implication: Add sub-hour reversal sleeves with strict turnover, cost, and drawdown evidence.
+  - source_id: asymmetric_ofi_hmm_regime_2025
+    title: 'Asymmetric Hidden Markov Modeling of Order Flow Imbalances for Microstructure-Aware Market Regime Detection'
+    url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5315733
+    published_at: '2025-06-23'
+    claims:
+      - claim_id: ofi_latent_regime_breakout
+        summary: Hidden Markov regimes from order-flow imbalance can identify breakout and liquidity-dislocation states.
+        implication: Route OFI regime claims into microstructure continuation and opening-drive sleeves with quote-quality gates.
+      - claim_id: asymmetric_liquidity_transition
+        summary: Directional asymmetry and regime persistence matter for intraday liquidity state transitions.
+        implication: Keep continuation and reversal candidates separated by regime and require held-out shadow parity before promotion.
 families:
   - family_template_id: microstructure_continuation_matched_filter_v1
     seed_sweep_config: ../profitability-frontier-strict-daily-microstructure.yaml

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -923,6 +923,53 @@ def _proposal_sort_value(value: Any) -> float:
         return 0.0
 
 
+def _scorecard_start_equity(
+    scorecard: Mapping[str, Any], *, oracle_policy: ProfitTargetOraclePolicy
+) -> Decimal:
+    for key in (
+        "start_equity",
+        "account_start_equity",
+        "execution_start_equity",
+        "executable_replay_start_equity",
+        "runtime_start_equity",
+    ):
+        value = _decimal(scorecard.get(key))
+        if value > 0:
+            return value
+    return oracle_policy.default_start_equity
+
+
+def _scorecard_total_net_pnl(scorecard: Mapping[str, Any]) -> Decimal:
+    daily_net_payload = scorecard.get("daily_net")
+    if isinstance(daily_net_payload, Mapping) and daily_net_payload:
+        return sum(
+            (_decimal(value) for value in daily_net_payload.values()), Decimal("0")
+        )
+    net_pnl_per_day = _decimal(scorecard.get("net_pnl_per_day"))
+    trading_day_count = max(1, int(_decimal(scorecard.get("trading_day_count"))))
+    return net_pnl_per_day * Decimal(trading_day_count)
+
+
+def _risk_adjusted_drawdown_passes(
+    *,
+    observed: Decimal,
+    start_equity: Decimal,
+    normal_pct: Decimal,
+    extended_pct: Decimal,
+    absolute_cap: Decimal,
+    total_net_pnl: Decimal,
+    min_total_net_pnl_to_drawdown_ratio: Decimal,
+) -> bool:
+    normal_limit = max(Decimal("0"), start_equity * normal_pct)
+    percent_limit = max(normal_limit, start_equity * extended_pct)
+    extended_limit = percent_limit if absolute_cap <= 0 else min(absolute_cap, percent_limit)
+    if observed <= normal_limit:
+        return True
+    if observed <= extended_limit and observed > 0:
+        return (total_net_pnl / observed) >= min_total_net_pnl_to_drawdown_ratio
+    return observed <= extended_limit
+
+
 def _oracle_policy_from_args(args: argparse.Namespace) -> ProfitTargetOraclePolicy:
     target_net_pnl_per_day = _decimal(
         getattr(args, "target_net_pnl_per_day", _DEFAULT_DAILY_PROFIT_TARGET),
@@ -934,11 +981,16 @@ def _oracle_policy_from_args(args: argparse.Namespace) -> ProfitTargetOraclePoli
     min_positive_day_ratio = _decimal(
         getattr(args, "min_positive_day_ratio", "0.60"), default="0.60"
     )
-    min_daily_net_pnl = _decimal(getattr(args, "min_daily_net_pnl", "0"), default="0")
-    max_worst_day_loss = _decimal(
-        getattr(args, "max_worst_day_loss", "350"), default="350"
+    min_daily_net_pnl = _decimal(
+        getattr(args, "min_daily_net_pnl", "-999999999"),
+        default="-999999999",
     )
-    max_drawdown = _decimal(getattr(args, "max_drawdown", "900"), default="900")
+    max_worst_day_loss = _decimal(
+        getattr(args, "max_worst_day_loss", "999999999"), default="999999999"
+    )
+    max_drawdown = _decimal(
+        getattr(args, "max_drawdown", "999999999"), default="999999999"
+    )
     if bool(getattr(args, "require_no_flat_days", False)):
         min_active_day_ratio = max(min_active_day_ratio, Decimal("1"))
         min_positive_day_ratio = max(min_positive_day_ratio, Decimal("1"))
@@ -968,6 +1020,9 @@ def _oracle_policy_from_args(args: argparse.Namespace) -> ProfitTargetOraclePoli
         min_regime_slice_pass_rate=_decimal(
             getattr(args, "min_regime_slice_pass_rate", "0.45"), default="0.45"
         ),
+        default_start_equity=_decimal(
+            getattr(args, "start_equity", "31590.02"), default="31590.02"
+        ),
     )
 
 
@@ -987,6 +1042,19 @@ def _candidate_spec_with_oracle_policy(
         "required_max_best_day_share": str(oracle_policy.max_best_day_share),
         "required_max_worst_day_loss": str(oracle_policy.max_worst_day_loss),
         "required_max_drawdown": str(oracle_policy.max_drawdown),
+        "required_max_worst_day_loss_pct_equity": str(
+            oracle_policy.max_worst_day_loss_pct_equity
+        ),
+        "required_max_drawdown_pct_equity": str(oracle_policy.max_drawdown_pct_equity),
+        "required_extended_max_worst_day_loss_pct_equity": str(
+            oracle_policy.extended_max_worst_day_loss_pct_equity
+        ),
+        "required_extended_max_drawdown_pct_equity": str(
+            oracle_policy.extended_max_drawdown_pct_equity
+        ),
+        "required_min_total_net_pnl_to_drawdown_ratio": str(
+            oracle_policy.min_total_net_pnl_to_drawdown_ratio
+        ),
         "required_min_regime_slice_pass_rate": str(
             oracle_policy.min_regime_slice_pass_rate
         ),
@@ -1253,6 +1321,8 @@ def _candidate_quality_gate_failures(
     scorecard: Mapping[str, Any], *, oracle_policy: ProfitTargetOraclePolicy
 ) -> list[str]:
     failures: list[str] = []
+    start_equity = _scorecard_start_equity(scorecard, oracle_policy=oracle_policy)
+    total_net_pnl = _scorecard_total_net_pnl(scorecard)
     if _decimal(scorecard.get("net_pnl_per_day")) <= 0:
         failures.append("non_positive_net_pnl_per_day")
     if _decimal(scorecard.get("active_day_ratio")) < oracle_policy.min_active_day_ratio:
@@ -1267,14 +1337,24 @@ def _candidate_quality_gate_failures(
         > oracle_policy.max_best_day_share
     ):
         failures.append("best_day_share_above_oracle")
-    if (
-        _decimal(scorecard.get("worst_day_loss"), default="999999")
-        > oracle_policy.max_worst_day_loss
+    if not _risk_adjusted_drawdown_passes(
+        observed=_decimal(scorecard.get("worst_day_loss"), default="999999"),
+        start_equity=start_equity,
+        normal_pct=oracle_policy.max_worst_day_loss_pct_equity,
+        extended_pct=oracle_policy.extended_max_worst_day_loss_pct_equity,
+        absolute_cap=oracle_policy.max_worst_day_loss,
+        total_net_pnl=total_net_pnl,
+        min_total_net_pnl_to_drawdown_ratio=oracle_policy.min_total_net_pnl_to_drawdown_ratio,
     ):
         failures.append("worst_day_loss_above_oracle")
-    if (
-        _decimal(scorecard.get("max_drawdown"), default="999999")
-        > oracle_policy.max_drawdown
+    if not _risk_adjusted_drawdown_passes(
+        observed=_decimal(scorecard.get("max_drawdown"), default="999999"),
+        start_equity=start_equity,
+        normal_pct=oracle_policy.max_drawdown_pct_equity,
+        extended_pct=oracle_policy.extended_max_drawdown_pct_equity,
+        absolute_cap=oracle_policy.max_drawdown,
+        total_net_pnl=total_net_pnl,
+        min_total_net_pnl_to_drawdown_ratio=oracle_policy.min_total_net_pnl_to_drawdown_ratio,
     ):
         failures.append("max_drawdown_above_oracle")
     if (

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -167,6 +167,93 @@ class TestCandidateSpecs(TestCase):
             opening_specs[0].feature_contract["family_selection"]["reasons"],
         )
 
+    def test_orb_claim_selects_opening_drive_and_breakout_families(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-orb-stocks-in-play",
+            claims=[
+                {
+                    "claim_id": "claim-orb",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": (
+                        "Stocks in Play with unusually high daily volume can produce "
+                        "opening range breakout continuation after the first five minutes."
+                    ),
+                    "confidence": "0.82",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+        families = {spec.family_template_id for spec in specs}
+
+        self.assertIn("opening_drive_leader_reclaim_v1", families)
+        self.assertIn("breakout_reclaim_v2", families)
+
+    def test_literal_eod_reversal_claim_selects_end_of_day_family(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-eod-reversal",
+            claims=[
+                {
+                    "claim_id": "claim-eod",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": (
+                        "End-of-day reversal in individual intraday losers appears "
+                        "during the final 30 minutes as closing pressure unwinds."
+                    ),
+                    "confidence": "0.80",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+        eod_specs = [
+            spec
+            for spec in specs
+            if spec.family_template_id == "end_of_day_reversal_v1"
+        ]
+
+        self.assertTrue(eod_specs)
+        self.assertIn(
+            "closing_window_reversal",
+            eod_specs[0].feature_contract["family_selection"]["reasons"],
+        )
+
+    def test_hmm_ofi_claim_selects_microstructure_family(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-ofi-hmm",
+            claims=[
+                {
+                    "claim_id": "claim-ofi-hmm",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": (
+                        "A hidden Markov model over order flow imbalance identifies "
+                        "latent regime persistence and liquidity dislocation states."
+                    ),
+                    "confidence": "0.78",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+        microstructure_specs = [
+            spec
+            for spec in specs
+            if spec.family_template_id
+            == "microstructure_continuation_matched_filter_v1"
+        ]
+
+        self.assertTrue(microstructure_specs)
+        self.assertIn(
+            "volatility_or_regime_state",
+            microstructure_specs[0].feature_contract["family_selection"]["reasons"],
+        )
+
     def test_unpinned_hypotheses_expand_all_family_execution_profiles(self) -> None:
         cards = build_hypothesis_cards(
             source_run_id="paper-profile-breadth",

--- a/services/torghut/tests/test_profit_target_oracle.py
+++ b/services/torghut/tests/test_profit_target_oracle.py
@@ -73,7 +73,77 @@ class TestProfitTargetOracle(TestCase):
         )
 
         self.assertTrue(result["passed"])
-        self.assertEqual(result["policy"]["min_daily_net_pnl"], "-350")
+        self.assertEqual(result["policy"]["min_daily_net_pnl"], "-999999999")
+
+    def test_profit_target_oracle_allows_drawdown_when_return_quality_is_strong(
+        self,
+    ) -> None:
+        result = evaluate_profit_target_oracle(
+            {
+                "net_pnl_per_day": "9666.67",
+                "active_day_ratio": "1",
+                "positive_day_ratio": "0.67",
+                "daily_net": {
+                    "2026-04-01": "-3000",
+                    "2026-04-02": "17000",
+                    "2026-04-03": "15000",
+                },
+                "trading_day_count": 3,
+                "start_equity": "31590.02",
+                "best_day_share": "0.24",
+                "max_single_day_contribution_share": "0.24",
+                "max_cluster_contribution_share": "0.34",
+                "max_single_symbol_contribution_share": "0.25",
+                "worst_day_loss": "3000",
+                "max_drawdown": "3000",
+                "avg_filled_notional_per_day": "700000",
+                "regime_slice_pass_rate": "0.55",
+                "posterior_edge_lower": "0.01",
+                "shadow_parity_status": "within_budget",
+                **_executable_scorecard_fields(),
+            },
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertTrue(result["passed"])
+        worst_day_check = next(
+            item for item in result["checks"] if item["metric"] == "worst_day_loss"
+        )
+        self.assertEqual(worst_day_check["mode"], "return_adjusted")
+
+    def test_profit_target_oracle_rejects_drawdown_above_extended_percent_cap(
+        self,
+    ) -> None:
+        result = evaluate_profit_target_oracle(
+            {
+                "net_pnl_per_day": "12000",
+                "active_day_ratio": "1",
+                "positive_day_ratio": "0.67",
+                "daily_net": {
+                    "2026-04-01": "-7000",
+                    "2026-04-02": "22000",
+                    "2026-04-03": "21000",
+                },
+                "trading_day_count": 3,
+                "start_equity": "31590.02",
+                "best_day_share": "0.24",
+                "max_single_day_contribution_share": "0.24",
+                "max_cluster_contribution_share": "0.34",
+                "max_single_symbol_contribution_share": "0.25",
+                "worst_day_loss": "7000",
+                "max_drawdown": "7000",
+                "avg_filled_notional_per_day": "700000",
+                "regime_slice_pass_rate": "0.55",
+                "posterior_edge_lower": "0.01",
+                "shadow_parity_status": "within_budget",
+                **_executable_scorecard_fields(),
+            },
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertFalse(result["passed"])
+        self.assertIn("worst_day_loss_failed", result["blockers"])
+        self.assertIn("max_drawdown_failed", result["blockers"])
 
     def test_profit_target_oracle_can_require_every_day_to_clear_target(self) -> None:
         result = evaluate_profit_target_oracle(

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -2189,7 +2189,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             )
             self.assertEqual(
                 payload["profit_target_oracle_policy"]["min_daily_net_pnl"],
-                "-350",
+                "-999999999",
             )
             self.assertIn(
                 "executable_replay_passed_failed",
@@ -2656,7 +2656,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
 
         self.assertEqual(payload["status"], "no_profit_target_candidate")
         self.assertEqual(
-            payload["profit_target_oracle_policy"]["min_daily_net_pnl"], "-350"
+            payload["profit_target_oracle_policy"]["min_daily_net_pnl"], "-999999999"
         )
         self.assertEqual(selection["budget"]["exploration_slots_requested"], 1)
         self.assertGreaterEqual(selection["budget"]["exploration_slots_effective"], 1)

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -445,11 +445,25 @@ class TestStrategyAutoresearch(TestCase):
 
         self.assertEqual(program.program_id, "portfolio_profit_autoresearch_500_v1")
         self.assertEqual(program.objective.target_net_pnl_per_day, Decimal("500"))
-        self.assertEqual(program.objective.min_daily_net_pnl, Decimal("-350"))
+        self.assertEqual(program.objective.min_daily_net_pnl, Decimal("-999999999"))
         self.assertEqual(program.objective.min_active_day_ratio, Decimal("0.90"))
         self.assertEqual(program.objective.min_positive_day_ratio, Decimal("0.60"))
-        self.assertEqual(program.objective.max_worst_day_loss, Decimal("350"))
-        self.assertEqual(program.objective.max_drawdown, Decimal("900"))
+        self.assertEqual(program.objective.max_worst_day_loss, Decimal("999999999"))
+        self.assertEqual(program.objective.max_drawdown, Decimal("999999999"))
+        self.assertEqual(
+            program.objective.max_worst_day_loss_pct_equity, Decimal("0.05")
+        )
+        self.assertEqual(program.objective.max_drawdown_pct_equity, Decimal("0.10"))
+        self.assertEqual(
+            program.objective.extended_max_worst_day_loss_pct_equity,
+            Decimal("0.10"),
+        )
+        self.assertEqual(
+            program.objective.extended_max_drawdown_pct_equity, Decimal("0.20")
+        )
+        self.assertEqual(
+            program.objective.min_total_net_pnl_to_drawdown_ratio, Decimal("1.50")
+        )
         self.assertFalse(program.objective.require_every_day_active)
         self.assertEqual(
             program.objective.max_gross_exposure_pct_equity, Decimal("1.0")
@@ -474,8 +488,11 @@ class TestStrategyAutoresearch(TestCase):
                 "intraday_residual_reversal_2024",
                 "intraday_return_autocorrelation_term_structure_2025",
                 "intraday_time_series_reversal_2025",
+                "end_of_day_reversal_2024",
                 "overnight_jump_intraday_reversal_2026",
                 "intraday_cross_section_patterns_2010",
+                "asymmetric_ofi_hmm_regime_2025",
+                "opening_range_breakout_stocks_in_play_2024",
             }.issubset(source_ids)
         )
 
@@ -872,6 +889,48 @@ class TestStrategyAutoresearch(TestCase):
         vetoed = dict(candidate)
         vetoed["hard_vetoes"] = ["best_day_share_above_max"]
         self.assertFalse(candidate_meets_objective(vetoed, objective=objective))
+
+    def test_candidate_meets_objective_allows_return_adjusted_drawdown(self) -> None:
+        objective = StrategyObjective(
+            target_net_pnl_per_day=Decimal("500"),
+            min_active_day_ratio=Decimal("0.80"),
+            min_positive_day_ratio=Decimal("0.60"),
+            min_daily_notional=Decimal("300000"),
+            max_best_day_share=Decimal("0.35"),
+            max_worst_day_loss=Decimal("999999999"),
+            max_drawdown=Decimal("999999999"),
+            require_every_day_active=False,
+            min_regime_slice_pass_rate=Decimal("0.40"),
+            stop_when_objective_met=False,
+            max_gross_exposure_pct_equity=Decimal("1.50"),
+            min_cash=Decimal("0"),
+        )
+        candidate = {
+            "hard_vetoes": [],
+            "objective_scorecard": {
+                "net_pnl_per_day": "9666.67",
+                "active_day_ratio": "1",
+                "positive_day_ratio": "0.67",
+                "avg_filled_notional_per_day": "700000",
+                "best_day_share": "0.30",
+                "worst_day_loss": "3000",
+                "max_drawdown": "3000",
+                "regime_slice_pass_rate": "0.45",
+                "max_gross_exposure_pct_equity": "1.25",
+                "min_cash": "2500",
+            },
+            "full_window": {
+                "trading_day_count": 3,
+                "active_days": 3,
+                "daily_net": {
+                    "2026-04-01": "-3000",
+                    "2026-04-02": "17000",
+                    "2026-04-03": "15000",
+                },
+            },
+        }
+
+        self.assertTrue(candidate_meets_objective(candidate, objective=objective))
 
     def test_candidate_meets_objective_requires_daily_minimum_when_configured(
         self,


### PR DESCRIPTION
## Summary

- Adds literal routing from researched ORB/stocks-in-play, end-of-day reversal, and asymmetric OFI/HMM claims into existing executable Torghut candidate families.
- Replaces raw dollar drawdown rejection for the $500/day autoresearch objective with percentage-based, return-adjusted risk gates: 5% normal daily loss, 10% normal drawdown, and 10%/20% extended caps only when total net PnL to drawdown is at least 1.5x.
- Updates the checked-in $500/day research program, oracle policy, runner quality gates, and regression tests so down days are allowed when the total strategy remains strong.
- Raises the Torghut autoresearch runner CI shard timeout to 25 minutes after the unchanged shard tests passed locally but timed out on GitHub Actions; no tests are skipped or weakened.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_candidate_specs.py tests/test_strategy_autoresearch.py tests/test_profit_target_oracle.py tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_candidate_quality_gate_flags_capital_safety_failures tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_runtime_closure_replay_is_disabled_when_candidate_already_failed_oracle tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_runtime_closure_replay_stays_enabled_for_proof_only_oracle_failure tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_runner_parse_args_covers_cli_defaults_and_flags -q`
- `uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report= <slice 13 test ids from tests/test_run_whitepaper_autoresearch_profit_target.py>`
- `uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report= <slice 15 test ids from tests/test_run_whitepaper_autoresearch_profit_target.py>`
- `uv run --frozen ruff check app/trading/discovery/profit_target_oracle.py app/trading/discovery/autoresearch.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_profit_target_oracle.py tests/test_strategy_autoresearch.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
