### PR TITLE
chore(torghut): promote image 06a5b8e8

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-57-g161633c7a
+              value: v0.571.1-60-g06a5b8e87
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 161633c7acf6f16c2156ba18acbadb29e0fb747e
+              value: 06a5b8e87c5425c79ee833fd863c93cc2cbbfd23
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-57-g161633c7a
+              value: v0.571.1-60-g06a5b8e87
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 161633c7acf6f16c2156ba18acbadb29e0fb747e
+              value: 06a5b8e87c5425c79ee833fd863c93cc2cbbfd23
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-18T04:28:30Z"
+        client.knative.dev/updateTimestamp: "2026-05-18T05:40:00Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
           ports:
             - name: http1
               containerPort: 8181
@@ -497,11 +497,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-57-g161633c7a
+              value: v0.571.1-60-g06a5b8e87
             - name: TORGHUT_COMMIT
-              value: 161633c7acf6f16c2156ba18acbadb29e0fb747e
+              value: 06a5b8e87c5425c79ee833fd863c93cc2cbbfd23
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+              value: sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-18T04:28:30Z"
+        client.knative.dev/updateTimestamp: "2026-05-18T05:40:00Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
           ports:
             - name: http1
               containerPort: 8181
@@ -318,11 +318,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-57-g161633c7a
+              value: v0.571.1-60-g06a5b8e87
             - name: TORGHUT_COMMIT
-              value: 161633c7acf6f16c2156ba18acbadb29e0fb747e
+              value: 06a5b8e87c5425c79ee833fd863c93cc2cbbfd23
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+              value: sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -111,7 +111,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a0318c0a4701aa779f65e1b194baae47318a4a2ae3d5032c055b5f9634745929
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `06a5b8e87c5425c79ee833fd863c93cc2cbbfd23`
- Image tag: `06a5b8e8`
- Image digest: `sha256:1b418c8f8dd75c7e72d1cd7b926ca028c3cfb10231402dcc62ede7470b142375`