### PR TITLE
chore(jangar): promote image a41f71a1

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-18T04:07:47Z
+    deploy.knative.dev/rollout: 2026-05-18T05:50:41Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:cff8aea8@sha256:767431f2de8d96970f7a718558db82671d52824dc58130752a06e56b0c5eef46
+              value: registry.ide-newton.ts.net/lab/jangar:a41f71a1@sha256:1fab1a5b2491ee8393914eccd24e7e05608d460049c1fa795df31c101579cd7f
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: cff8aea82cc8211225272f89adc2ad4aa00bcaaa
+              value: a41f71a1af081e21dd45c08da747adb27dbe0318
             - name: JANGAR_GITOPS_REVISION
-              value: cff8aea82cc8211225272f89adc2ad4aa00bcaaa
+              value: a41f71a1af081e21dd45c08da747adb27dbe0318
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26012940416"
+              value: "26015998361"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:38e41af34f73d57b304864740c272ffc256215ac86754e56447f0539a7b4cf48
+              value: sha256:f04fb06ecf4e10cef5ebb3db08557d23b9d4a4c6cb05a39ed1505179372f1338
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: cff8aea82cc8211225272f89adc2ad4aa00bcaaa
+              value: a41f71a1af081e21dd45c08da747adb27dbe0318
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:38e41af34f73d57b304864740c272ffc256215ac86754e56447f0539a7b4cf48
+              value: sha256:f04fb06ecf4e10cef5ebb3db08557d23b9d4a4c6cb05a39ed1505179372f1338
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: cff8aea8
-    digest: sha256:767431f2de8d96970f7a718558db82671d52824dc58130752a06e56b0c5eef46
+    newTag: a41f71a1
+    digest: sha256:1fab1a5b2491ee8393914eccd24e7e05608d460049c1fa795df31c101579cd7f


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `a41f71a1af081e21dd45c08da747adb27dbe0318`
- Image tag: `a41f71a1`
- Image digest: `sha256:1fab1a5b2491ee8393914eccd24e7e05608d460049c1fa795df31c101579cd7f`
- Source CI run: `26015998361`
- Control-plane serving digest: `sha256:f04fb06ecf4e10cef5ebb3db08557d23b9d4a4c6cb05a39ed1505179372f1338`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates