### PR TITLE
fix(torghut): rejudge autoresearch readiness and guard automerge

### DIFF
--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -79,21 +79,29 @@ jobs:
             exit 0
           fi
 
-          has_opt_out_label="$(
+          if ! has_opt_out_label="$(
             gh pr view "${PR_NUMBER}" \
               -R "${GH_REPO}" \
               --json labels \
               --jq 'any(.labels[]?; .name == "do-not-automerge")'
-          )"
+          )"; then
+            echo "reason=labels-api-error" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [ "${has_opt_out_label}" = 'true' ]; then
             echo "reason=opt-out-label-present" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          mapfile -t changed_files < <(
-            gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename'
-          )
+          changed_files_output="$(mktemp)"
+          if ! gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" \
+            --paginate \
+            --jq '.[].filename' > "${changed_files_output}"; then
+            echo "reason=changed-files-api-error" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          mapfile -t changed_files < "${changed_files_output}"
 
           if [ "${#changed_files[@]}" -eq 0 ]; then
             echo "reason=no-files-changed" >> "$GITHUB_OUTPUT"
@@ -112,10 +120,13 @@ jobs:
 
       - name: Eligibility summary
         shell: bash
+        env:
+          ELIGIBLE: ${{ steps.gates.outputs.eligible }}
+          REASON: ${{ steps.gates.outputs.reason }}
         run: |
           set -euo pipefail
-          echo "eligible=${{ steps.gates.outputs.eligible }}"
-          echo "reason=${{ steps.gates.outputs.reason }}"
+          printf 'eligible=%s\n' "${ELIGIBLE}"
+          printf 'reason=%s\n' "${REASON}"
 
       - name: Wait for source commit Torghut CI
         if: steps.gates.outputs.eligible == 'true'

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -35,6 +35,7 @@ from .hypotheses import (
     resolve_hypothesis_dependency_quorum,
     summarize_hypothesis_runtime_statuses,
 )
+from .discovery.profit_target_oracle import evaluate_profit_target_oracle
 from .profit_windows import build_profit_window_contract
 from .profit_leases import build_profit_lease_projection
 from .tca import build_tca_gate_inputs
@@ -75,6 +76,19 @@ _AUTORESEARCH_PORTFOLIO_READY_STATUSES = (
     "accepted",
     "promoted",
 )
+
+
+def _autoresearch_portfolio_current_oracle_passed(
+    row: AutoresearchPortfolioCandidate,
+) -> bool:
+    scorecard = row.objective_scorecard_json
+    if not isinstance(scorecard, Mapping):
+        return False
+    oracle = evaluate_profit_target_oracle(
+        cast(Mapping[str, Any], scorecard),
+        target_net_pnl_per_day=row.target_net_pnl_per_day,
+    )
+    return bool(oracle.get("passed"))
 
 
 def _safe_int(value: object) -> int:
@@ -932,6 +946,21 @@ def _attach_lineage_refs(
 
 
 def _load_profit_promotion_table_counts(session: Session) -> dict[str, int]:
+    portfolio_rows = list(
+        session.execute(select(AutoresearchPortfolioCandidate)).scalars()
+    )
+    current_oracle_ready = 0
+    current_policy_blocked = 0
+    for row in portfolio_rows:
+        current_oracle_passed = _autoresearch_portfolio_current_oracle_passed(row)
+        if (
+            row.status in _AUTORESEARCH_PORTFOLIO_READY_STATUSES
+            and current_oracle_passed
+        ):
+            current_oracle_ready += 1
+        if row.status == "blocked" or not current_oracle_passed:
+            current_policy_blocked += 1
+
     return {
         "research_candidates": int(
             session.execute(select(func.count(ResearchCandidate.id))).scalar_one()
@@ -965,22 +994,8 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, int]:
                 select(func.count(AutoresearchPortfolioCandidate.id))
             ).scalar_one()
         ),
-        "autoresearch_portfolio_ready": int(
-            session.execute(
-                select(func.count(AutoresearchPortfolioCandidate.id)).where(
-                    AutoresearchPortfolioCandidate.status.in_(
-                        _AUTORESEARCH_PORTFOLIO_READY_STATUSES
-                    )
-                )
-            ).scalar_one()
-        ),
-        "autoresearch_portfolio_blocked": int(
-            session.execute(
-                select(func.count(AutoresearchPortfolioCandidate.id)).where(
-                    AutoresearchPortfolioCandidate.status == "blocked"
-                )
-            ).scalar_one()
-        ),
+        "autoresearch_portfolio_ready": current_oracle_ready,
+        "autoresearch_portfolio_blocked": current_policy_blocked,
     }
 
 

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -264,13 +264,74 @@ class TestSubmissionCouncil(TestCase):
                     status="target_met",
                 )
             )
+            session.add(
+                AutoresearchPortfolioCandidate(
+                    portfolio_candidate_id="portfolio-current-ready",
+                    epoch_id="epoch-current",
+                    source_candidate_ids_json=["spec-2"],
+                    target_net_pnl_per_day=Decimal("500"),
+                    objective_scorecard_json={
+                        "net_pnl_per_day": "600",
+                        "trading_day_count": 10,
+                        "daily_net": {
+                            "2026-05-01": "600",
+                            "2026-05-02": "575",
+                            "2026-05-03": "610",
+                            "2026-05-04": "590",
+                            "2026-05-05": "620",
+                            "2026-05-06": "605",
+                            "2026-05-07": "615",
+                            "2026-05-08": "585",
+                            "2026-05-09": "595",
+                            "2026-05-10": "605",
+                        },
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                        "best_day_share": "0.12",
+                        "max_single_day_contribution_share": "0.12",
+                        "max_cluster_contribution_share": "0.20",
+                        "max_single_symbol_contribution_share": "0.20",
+                        "worst_day_loss": "500",
+                        "max_drawdown": "1000",
+                        "max_gross_exposure_pct_equity": "0.5",
+                        "min_cash": "1000",
+                        "negative_cash_observation_count": 0,
+                        "avg_filled_notional_per_day": "300000",
+                        "regime_slice_pass_rate": "0.80",
+                        "posterior_edge_lower": "1",
+                        "shadow_parity_status": "within_budget",
+                        "executable_replay_passed": True,
+                        "executable_replay_artifact_ref": "s3://proof/current-ready.json",
+                        "executable_replay_order_count": 4,
+                        "executable_replay_account_buying_power": "31590",
+                        "executable_replay_max_notional_per_trade": "5000",
+                    },
+                    optimizer_report_json={"method": "current_optimizer"},
+                    payload_json={"portfolio_candidate_id": "portfolio-current-ready"},
+                    status="promotion_ready",
+                )
+            )
+            session.add(
+                AutoresearchPortfolioCandidate(
+                    portfolio_candidate_id="portfolio-invalid-scorecard",
+                    epoch_id="epoch-invalid",
+                    source_candidate_ids_json=["spec-3"],
+                    target_net_pnl_per_day=Decimal("500"),
+                    objective_scorecard_json=["not", "a", "scorecard"],
+                    optimizer_report_json={"method": "bad_writer"},
+                    payload_json={
+                        "portfolio_candidate_id": "portfolio-invalid-scorecard"
+                    },
+                    status="target_met",
+                )
+            )
             session.commit()
 
             counts = _load_profit_promotion_table_counts(session)
 
-        self.assertEqual(counts["autoresearch_portfolio_candidates"], 1)
-        self.assertEqual(counts["autoresearch_portfolio_ready"], 0)
-        self.assertEqual(counts["autoresearch_portfolio_blocked"], 1)
+        self.assertEqual(counts["autoresearch_portfolio_candidates"], 3)
+        self.assertEqual(counts["autoresearch_portfolio_ready"], 1)
+        self.assertEqual(counts["autoresearch_portfolio_blocked"], 2)
 
     def test_profit_lease_projection_uses_runtime_feature_and_persisted_decision_evidence(
         self,

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -219,6 +219,59 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(counts["autoresearch_portfolio_blocked"], 1)
         self.assertEqual(counts["autoresearch_portfolio_ready"], 0)
 
+    def test_load_profit_promotion_counts_rejudges_ready_autoresearch_portfolios(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            session.add(
+                AutoresearchPortfolioCandidate(
+                    portfolio_candidate_id="portfolio-stale-ready",
+                    epoch_id="epoch-stale",
+                    source_candidate_ids_json=["spec-1"],
+                    target_net_pnl_per_day=Decimal("500"),
+                    objective_scorecard_json={
+                        "oracle_passed": True,
+                        "net_pnl_per_day": "9373",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "0.50",
+                        "best_day_share": "1.0",
+                        "max_cluster_contribution_share": "1.0",
+                        "max_single_symbol_contribution_share": "0.90",
+                        "worst_day_loss": "2978",
+                        "max_drawdown": "2978",
+                        "max_gross_exposure_pct_equity": "0.5",
+                        "min_cash": "1000",
+                        "negative_cash_observation_count": 0,
+                        "avg_filled_notional_per_day": "300000",
+                        "regime_slice_pass_rate": "0.5",
+                        "posterior_edge_lower": "1",
+                        "shadow_parity_status": "within_budget",
+                        "executable_replay_passed": True,
+                        "executable_replay_order_count": 1,
+                        "executable_replay_account_buying_power": "31590",
+                        "executable_replay_max_notional_per_trade": "5000",
+                    },
+                    optimizer_report_json={"method": "old_optimizer"},
+                    payload_json={"portfolio_candidate_id": "portfolio-stale-ready"},
+                    status="target_met",
+                )
+            )
+            session.commit()
+
+            counts = _load_profit_promotion_table_counts(session)
+
+        self.assertEqual(counts["autoresearch_portfolio_candidates"], 1)
+        self.assertEqual(counts["autoresearch_portfolio_ready"], 0)
+        self.assertEqual(counts["autoresearch_portfolio_blocked"], 1)
+
     def test_profit_lease_projection_uses_runtime_feature_and_persisted_decision_evidence(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Rejudge persisted autoresearch portfolio readiness with the current profit-target oracle before submission-council counts treat a portfolio as ready.
- Count stale `target_met` portfolios as blocked when current oracle gates fail, preventing old high-PnL candidates from looking promotion-ready after policy changes.
- Harden Torghut release automerge eligibility when GitHub API calls fail under rate limiting, avoiding JSON error text breaking the summary shell step.

## Related Issues

None

## Testing

- `git diff --check`
- `actionlint .github/workflows/torghut-deploy-automerge.yml`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/submission_council.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
