### PR TITLE
ci(agents): publish extracted runtime images

### DIFF
--- a/.github/workflows/agents-build-push.yml
+++ b/.github/workflows/agents-build-push.yml
@@ -1,0 +1,78 @@
+name: agents-build-push
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/agents/**'
+      - 'packages/codex/**'
+      - 'packages/cx-tools/**'
+      - 'packages/otel/**'
+      - 'packages/scripts/src/agents/**'
+      - 'packages/scripts/src/jangar/**'
+      - 'packages/scripts/src/shared/**'
+      - 'packages/temporal-bun-sdk/**'
+      - 'services/agents/**'
+      - 'services/jangar/**'
+      - 'skills/**'
+      - 'package.json'
+      - 'bun.lock'
+      - '.github/workflows/agents-build-push.yml'
+      - '.github/workflows/agents-release.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: agents-build-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: arc-arm64
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          cache-binary: false
+
+      - name: Resolve image tag
+        id: meta
+        run: echo "tag=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts --filter @proompteng/jangar
+
+      - name: Build and push Agents images
+        env:
+          AGENTS_APPLY: 'false'
+          AGENTS_BUILD_RUNNER: 'false'
+          AGENTS_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
+          AGENTS_IMAGE_PLATFORMS: linux/arm64
+          JANGAR_BUILD_CACHE_MODE: max
+          JANGAR_BUILD_NODE_OPTIONS: --max-old-space-size=4096
+          JANGAR_BUILD_SOURCEMAP: '0'
+          JANGAR_BUILD_CI: 'true'
+          JANGAR_BUILD_LOG_LEVEL: warn
+          DOCKER_BUILD_PROVENANCE: max
+          DOCKER_BUILD_SBOM: 'true'
+        run: bun run agents:deploy -- --no-apply --skip-runner
+
+      - name: Upload rendered Agents values
+        uses: actions/upload-artifact@v6
+        with:
+          name: agents-values
+          path: argocd/applications/agents/values.yaml
+          if-no-files-found: error
+          retention-days: 3

--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -25,8 +25,10 @@ on:
       - 'services/jangar/**'
       - 'scripts/agents/**'
       - 'scripts/download_crd_schema.py'
+      - '.github/workflows/agents-build-push.yml'
       - '.github/workflows/agents-ci.yml'
-      - '.github/workflows/jangar-build-push.yaml'
+      - '.github/workflows/agents-deploy-automerge.yml'
+      - '.github/workflows/agents-release.yml'
   push:
     branches:
       - main
@@ -49,8 +51,10 @@ on:
       - 'services/jangar/**'
       - 'scripts/agents/**'
       - 'scripts/download_crd_schema.py'
+      - '.github/workflows/agents-build-push.yml'
       - '.github/workflows/agents-ci.yml'
-      - '.github/workflows/jangar-build-push.yaml'
+      - '.github/workflows/agents-deploy-automerge.yml'
+      - '.github/workflows/agents-release.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/agents-deploy-automerge.yml
+++ b/.github/workflows/agents-deploy-automerge.yml
@@ -1,0 +1,38 @@
+name: agents-deploy-automerge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  enable:
+    if: >-
+      ${{
+        startsWith(github.event.pull_request.head.ref, 'codex/agents-release-') &&
+        github.event.pull_request.base.ref == 'main' &&
+        github.event.pull_request.draft == false
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Enable squash auto-merge
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          AUTO_MERGE_ENABLED="$(gh pr view "${PR_NUMBER}" -R "${REPO}" --json autoMergeRequest --jq '.autoMergeRequest != null')"
+          if [ "${AUTO_MERGE_ENABLED}" = "true" ]; then
+            echo "Auto-merge already enabled for PR #${PR_NUMBER}"
+            exit 0
+          fi
+
+          gh pr merge "${PR_NUMBER}" -R "${REPO}" --auto --squash

--- a/.github/workflows/agents-release.yml
+++ b/.github/workflows/agents-release.yml
@@ -1,0 +1,106 @@
+name: agents-release
+
+on:
+  workflow_run:
+    workflows:
+      - agents-build-push
+    types:
+      - completed
+
+concurrency:
+  group: agents-release-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  promote:
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main'
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve promotion metadata
+        id: meta
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          CURRENT_MAIN="$(git rev-parse origin/main)"
+          TAG="${SOURCE_SHA:0:8}"
+          if [ "${SOURCE_SHA}" = "${CURRENT_MAIN}" ]; then
+            PROMOTE=true
+          else
+            PROMOTE=false
+          fi
+          {
+            echo "promote=${PROMOTE}"
+            echo "source_sha=${SOURCE_SHA}"
+            echo "tag=${TAG}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Download Agents values artifact
+        if: steps.meta.outputs.promote == 'true'
+        uses: actions/download-artifact@v7
+        with:
+          name: agents-values
+          path: .artifacts/agents
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stage Agents values
+        if: steps.meta.outputs.promote == 'true'
+        shell: bash
+        run: cp .artifacts/agents/values.yaml argocd/applications/agents/values.yaml
+
+      - name: Check for manifest changes
+        if: steps.meta.outputs.promote == 'true'
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- argocd/applications/agents/values.yaml; then
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Create deploy pull request
+        if: steps.meta.outputs.promote == 'true' && steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.AGENTS_SPLIT_TOKEN || secrets.GITHUB_TOKEN }}
+          branch: codex/agents-release-${{ steps.meta.outputs.tag }}
+          base: main
+          title: 'chore(agents): promote images ${{ steps.meta.outputs.tag }}'
+          commit-message: 'chore(agents): promote images ${{ steps.meta.outputs.tag }}'
+          delete-branch: true
+          add-paths: argocd/applications/agents/values.yaml
+          body: |
+            ## Summary
+            Promote Agents controller and control-plane images into GitOps manifests.
+
+            - Source commit: `${{ steps.meta.outputs.source_sha }}`
+            - Image tag: `${{ steps.meta.outputs.tag }}`
+            - Source CI run: `${{ github.event.workflow_run.id }}`
+            - Runner image pin preserved
+
+      - name: No manifest changes detected
+        if: steps.meta.outputs.promote == 'true' && steps.changes.outputs.changed != 'true'
+        run: echo 'No Agents manifest changes detected.'
+
+      - name: Promotion skipped
+        if: steps.meta.outputs.promote != 'true'
+        run: echo 'Skipping stale agents-build-push workflow_run promotion because source SHA is not current main.'

--- a/packages/scripts/src/agents/__tests__/deploy-service.test.ts
+++ b/packages/scripts/src/agents/__tests__/deploy-service.test.ts
@@ -6,6 +6,13 @@ import { join } from 'node:path'
 import { __private } from '../deploy-service'
 
 describe('agents deploy-service helpers', () => {
+  it('parses runner and apply rollout flags', () => {
+    expect(__private.parseArgs(['--skip-runner', '--no-apply'])).toMatchObject({
+      buildRunner: false,
+      apply: false,
+    })
+  })
+
   it('drops Argo CD hook resources from direct kubectl apply manifests', () => {
     const rendered = `apiVersion: v1
 kind: ConfigMap
@@ -108,6 +115,15 @@ runner:
       'registry.example/lab/agents-codex-runner',
       'abc123',
       'sha256:runner',
+      {
+        sourceHeadSha: 'abcdef1234567890',
+        gitopsRevision: 'abcdef1234567890',
+        sourceCiRunId: '12345',
+        sourceCiConclusion: 'success',
+        manifestImageDigest: 'sha256:control-plane',
+        servingBuildCommit: 'abcdef1234567890',
+        servingImageDigest: 'sha256:control-plane',
+      },
     )
 
     const updated = readFileSync(valuesPath, 'utf8')
@@ -117,6 +133,9 @@ runner:
     expect(updated).toContain('repository: registry.example/lab/agents-codex-runner')
     expect(updated).toContain('digest: sha256:controller')
     expect(updated).toContain('digest: sha256:runner')
+    expect(updated).toContain('AGENTS_SOURCE_HEAD_SHA: abcdef1234567890')
+    expect(updated).toContain('AGENTS_SOURCE_CI_RUN_ID: "12345"')
+    expect(updated).toContain('AGENTS_SERVING_IMAGE_DIGEST: sha256:control-plane')
 
     rmSync(dir, { recursive: true, force: true })
   })

--- a/packages/scripts/src/agents/deploy-service.ts
+++ b/packages/scripts/src/agents/deploy-service.ts
@@ -42,7 +42,24 @@ type Options = {
   codexAuthPath: string
   tag: string
   platforms: string[]
+  buildRunner: boolean
   apply: boolean
+}
+
+type ImagePin = {
+  repository: string
+  tag: string
+  digest: string
+}
+
+type ReleaseMetadata = {
+  sourceHeadSha?: string
+  gitopsRevision?: string
+  sourceCiRunId?: string
+  sourceCiConclusion?: string
+  manifestImageDigest?: string
+  servingBuildCommit?: string
+  servingImageDigest?: string
 }
 
 type DatabaseSecretRequirement = {
@@ -154,6 +171,10 @@ const parseArgs = (argv: string[]): Partial<Options> => {
     }
     if (arg === '--no-apply') {
       options.apply = false
+      continue
+    }
+    if (arg === '--skip-runner') {
+      options.buildRunner = false
     }
   }
   return options
@@ -211,6 +232,7 @@ const resolveOptions = (): Options => {
     codexAuthPath,
     tag,
     platforms,
+    buildRunner: args.buildRunner ?? parseBoolean(process.env.AGENTS_BUILD_RUNNER, true),
     apply: args.apply ?? parseBoolean(process.env.AGENTS_APPLY, true),
   }
 }
@@ -350,6 +372,7 @@ const updateValuesFile = (
   runnerImageRepository: string,
   runnerTag: string,
   runnerDigest: string,
+  releaseMetadata?: ReleaseMetadata,
 ) => {
   const raw = readFileSync(valuesPath, 'utf8')
   const doc = YAML.parse(raw) ?? {}
@@ -377,10 +400,37 @@ const updateValuesFile = (
   doc.runner.image.tag = runnerTag
   doc.runner.image.digest = runnerDigest
 
+  if (releaseMetadata) {
+    doc.controlPlane.env ??= {}
+    doc.controlPlane.env.vars ??= {}
+    const vars = doc.controlPlane.env.vars as Record<string, string>
+    if (releaseMetadata.sourceHeadSha) vars.AGENTS_SOURCE_HEAD_SHA = releaseMetadata.sourceHeadSha
+    if (releaseMetadata.gitopsRevision) vars.AGENTS_GITOPS_REVISION = releaseMetadata.gitopsRevision
+    if (releaseMetadata.sourceCiRunId) vars.AGENTS_SOURCE_CI_RUN_ID = releaseMetadata.sourceCiRunId
+    if (releaseMetadata.sourceCiConclusion) vars.AGENTS_SOURCE_CI_CONCLUSION = releaseMetadata.sourceCiConclusion
+    if (releaseMetadata.manifestImageDigest) vars.AGENTS_MANIFEST_IMAGE_DIGEST = releaseMetadata.manifestImageDigest
+    if (releaseMetadata.servingBuildCommit) vars.AGENTS_SERVING_BUILD_COMMIT = releaseMetadata.servingBuildCommit
+    if (releaseMetadata.servingImageDigest) vars.AGENTS_SERVING_IMAGE_DIGEST = releaseMetadata.servingImageDigest
+  }
+
   writeFileSync(valuesPath, YAML.stringify(doc, { lineWidth: 120 }))
   console.log(
     `Updated ${valuesPath} with ${imageRepository}:${tag}@${digest}, ${controlPlaneImageRepository}:${controlPlaneTag}@${controlPlaneDigest}, and ${runnerImageRepository}:${runnerTag}@${runnerDigest}`,
   )
+}
+
+const readRunnerImagePin = (valuesPath: string): ImagePin => {
+  const values = YAML.parse(readFileSync(valuesPath, 'utf8')) ?? {}
+  const runnerImage = values.runner?.image
+  const repository = typeof runnerImage?.repository === 'string' ? runnerImage.repository : ''
+  const tag = typeof runnerImage?.tag === 'string' ? runnerImage.tag : ''
+  const digest = typeof runnerImage?.digest === 'string' ? runnerImage.digest : ''
+  if (!repository || !tag || !digest) {
+    fatal(
+      `Runner image pin missing from ${valuesPath}; cannot preserve runner image without repository, tag, and digest.`,
+    )
+  }
+  return { repository, tag, digest }
 }
 
 const resolveDatabaseSecretRequirement = (
@@ -548,19 +598,23 @@ const main = async () => {
     target: 'control-plane',
     platforms: options.platforms,
   })
-  if (!existsSync(options.codexAuthPath)) {
-    fatal(`Codex auth not found at ${options.codexAuthPath}; cannot build agents-codex-runner image.`)
+  const runnerPin = options.buildRunner ? undefined : readRunnerImagePin(options.valuesPath)
+  if (options.buildRunner) {
+    if (!existsSync(options.codexAuthPath)) {
+      fatal(`Codex auth not found at ${options.codexAuthPath}; cannot build agents-codex-runner image.`)
+    }
+    await buildAndPushDockerImage({
+      registry: options.registry,
+      repository: options.runnerRepository,
+      tag: options.tag,
+      context: repoRoot,
+      dockerfile: options.runnerDockerfile,
+      codexAuthPath: options.codexAuthPath,
+      cacheRef:
+        process.env.AGENTS_RUNNER_BUILD_CACHE_REF ?? `${options.registry}/${options.runnerRepository}:buildcache`,
+      platforms: options.platforms,
+    })
   }
-  await buildAndPushDockerImage({
-    registry: options.registry,
-    repository: options.runnerRepository,
-    tag: options.tag,
-    context: repoRoot,
-    dockerfile: options.runnerDockerfile,
-    codexAuthPath: options.codexAuthPath,
-    cacheRef: process.env.AGENTS_RUNNER_BUILD_CACHE_REF ?? `${options.registry}/${options.runnerRepository}:buildcache`,
-    platforms: options.platforms,
-  })
 
   const repoDigest = inspectImageDigest(image)
   const digest = repoDigest.includes('@') ? repoDigest.split('@')[1] : repoDigest
@@ -569,8 +623,11 @@ const main = async () => {
   const controlPlaneDigest = controlPlaneRepoDigest.includes('@')
     ? controlPlaneRepoDigest.split('@')[1]
     : controlPlaneRepoDigest
-  const runnerRepoDigest = inspectImageDigest(runnerImage)
-  const runnerDigest = runnerRepoDigest.includes('@') ? runnerRepoDigest.split('@')[1] : runnerRepoDigest
+  const runnerRepoDigest = options.buildRunner ? inspectImageDigest(runnerImage) : runnerPin?.digest
+  const runnerDigest = runnerRepoDigest?.includes('@') ? runnerRepoDigest.split('@')[1] : runnerRepoDigest
+  if (!runnerDigest) {
+    fatal('Agents runner digest is empty.')
+  }
 
   updateValuesFile(
     options.valuesPath,
@@ -580,9 +637,18 @@ const main = async () => {
     controlPlaneImageName,
     options.tag,
     controlPlaneDigest,
-    runnerImageName,
-    options.tag,
+    runnerPin?.repository ?? runnerImageName,
+    runnerPin?.tag ?? options.tag,
     runnerDigest,
+    {
+      sourceHeadSha: execGit(['rev-parse', 'HEAD']),
+      gitopsRevision: execGit(['rev-parse', 'HEAD']),
+      sourceCiRunId: process.env.GITHUB_RUN_ID,
+      sourceCiConclusion: process.env.AGENTS_SOURCE_CI_CONCLUSION ?? 'success',
+      manifestImageDigest: controlPlaneDigest,
+      servingBuildCommit: execGit(['rev-parse', 'HEAD']),
+      servingImageDigest: controlPlaneDigest,
+    },
   )
 
   if (options.apply) {
@@ -604,6 +670,7 @@ export const __private = {
   isArgoHookManifest,
   renderAndApply,
   updateValuesFile,
+  readRunnerImagePin,
   resolveDatabaseSecretRequirement,
   buildDatabaseSecretAliasManifest,
 }


### PR DESCRIPTION
## Summary

- Add an Agents build-push workflow that publishes `lab/agents-controller` and `lab/agents-control-plane` images on relevant `main` changes.
- Add an Agents release workflow that promotes the rendered `argocd/applications/agents/values.yaml` image pins through a GitOps PR.
- Add an Agents release auto-merge workflow matching the existing Jangar release branch flow.
- Extend `agents:deploy` with a `--skip-runner` path so CI can preserve the existing Codex runner pin without requiring Codex auth.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts packages/scripts/src/agents/__tests__/resolve-published-agents-images.test.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts packages/scripts/src/shared/__tests__/docker.test.ts`
- `bunx oxfmt --check packages/scripts/src/agents/deploy-service.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts .github/workflows/agents-build-push.yml .github/workflows/agents-release.yml .github/workflows/agents-deploy-automerge.yml .github/workflows/agents-ci.yml`
- `actionlint -ignore 'label "arc-arm64" is unknown' .github/workflows/agents-build-push.yml .github/workflows/agents-release.yml .github/workflows/agents-deploy-automerge.yml .github/workflows/agents-ci.yml`
- `git diff --check`
- `bun run --cwd packages/scripts lint:oxlint:type` exits 0 with existing warnings only.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
