### PR TITLE
fix(agents): brownout autonomous swarm schedules

### DIFF
--- a/argocd/applications/agents/swarm-agentrun-templates.yaml
+++ b/argocd/applications/agents/swarm-agentrun-templates.yaml
@@ -14,7 +14,7 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 21600
   workflow:
     steps:
       - name: discover
@@ -76,7 +76,7 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 21600
   workflow:
     steps:
       - name: plan
@@ -138,7 +138,7 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 21600
   workflow:
     steps:
       - name: implement
@@ -210,7 +210,7 @@ spec:
       limits:
         memory: 16Gi
         ephemeral-storage: 16Gi
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 21600
   workflow:
     steps:
       - name: verify
@@ -276,7 +276,7 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 21600
   workflow:
     steps:
       - name: discover
@@ -338,7 +338,7 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 21600
   workflow:
     steps:
       - name: plan
@@ -400,7 +400,7 @@ spec:
     type: workflow
     config:
       serviceAccountName: agents-sa
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 21600
   workflow:
     steps:
       - name: implement
@@ -472,7 +472,7 @@ spec:
       limits:
         memory: 16Gi
         ephemeral-storage: 16Gi
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 21600
   workflow:
     steps:
       - name: verify

--- a/argocd/applications/agents/swarm-instances.yaml
+++ b/argocd/applications/agents/swarm-instances.yaml
@@ -40,10 +40,10 @@ spec:
   mode: lights-out
   timezone: UTC
   cadence:
-    discoverEvery: 1h
-    planEvery: 4h
-    implementEvery: 30m
-    verifyEvery: 1h
+    discoverEvery: 6h
+    planEvery: 24h
+    implementEvery: 6h
+    verifyEvery: 6h
   integrations:
     nats:
       url: nats://nats.nats.svc.cluster.local:4222
@@ -151,10 +151,10 @@ spec:
   mode: lights-out
   timezone: UTC
   cadence:
-    discoverEvery: 1h
-    planEvery: 4h
-    implementEvery: 30m
-    verifyEvery: 1h
+    discoverEvery: 6h
+    planEvery: 24h
+    implementEvery: 6h
+    verifyEvery: 6h
   integrations:
     nats:
       url: nats://nats.nats.svc.cluster.local:4222

--- a/argocd/applications/agents/torghut-market-context-batch.yaml
+++ b/argocd/applications/agents/torghut-market-context-batch.yaml
@@ -187,7 +187,7 @@ spec:
     config:
       serviceAccountName: agents-sa
       priorityClassName: torghut-market-context-low
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 21600
   workload:
     resources:
       requests:
@@ -222,7 +222,7 @@ spec:
     config:
       serviceAccountName: agents-sa
       priorityClassName: torghut-market-context-low
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 21600
   workload:
     resources:
       requests:
@@ -257,7 +257,7 @@ spec:
     config:
       serviceAccountName: agents-sa
       priorityClassName: torghut-market-context-low
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 21600
   workload:
     resources:
       requests:
@@ -292,7 +292,7 @@ spec:
     config:
       serviceAccountName: agents-sa
       priorityClassName: torghut-market-context-low
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 21600
   workload:
     resources:
       requests:


### PR DESCRIPTION
## Summary

- Reduces the `jangar-control-plane` and `torghut-quant` autonomous swarm cadence from hourly/30-minute cycles to a bounded 6-hour/24-hour brownout cadence.
- Sets swarm AgentRun template retention to 6 hours instead of retaining terminal AgentRuns indefinitely.
- Sets Torghut market-context batch AgentRun template retention to 6 hours to prevent failed provider runs from accumulating permanently.

## Related Issues

None

## Testing

- `kubectl apply --dry-run=server -f argocd/applications/agents/swarm-instances.yaml -f argocd/applications/agents/swarm-agentrun-templates.yaml -f argocd/applications/agents/torghut-market-context-batch.yaml`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
