### PR TITLE
fix(agents): retry transient image push failures

### DIFF
--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -312,7 +312,7 @@ describe('scheduled AgentRun templates', () => {
     expect(timeoutMs).toBeGreaterThanOrEqual(10_000)
   })
 
-  it('disable retention so schedules can always resolve their template targets', () => {
+  it('keeps scheduled template retention aligned with the swarm brownout window', () => {
     const manifestPaths = [
       'argocd/applications/agents/swarm-agentrun-templates.yaml',
       'argocd/applications/agents/swarm-instances.yaml',
@@ -346,7 +346,7 @@ describe('scheduled AgentRun templates', () => {
     expect([...scheduledTemplateNames].sort()).toEqual([...agentRunTemplates.keys()].sort())
     for (const name of scheduledTemplateNames) {
       const template = agentRunTemplates.get(name)
-      expect(objectAt(objectAt(template, 'spec'), 'ttlSecondsAfterFinished')).toBe(0)
+      expect(objectAt(objectAt(template, 'spec'), 'ttlSecondsAfterFinished')).toBe(21_600)
       expect(objectAt(objectAt(objectAt(template, 'metadata'), 'annotations'), 'agents.proompteng.ai/template')).toBe(
         'true',
       )

--- a/packages/scripts/src/shared/__tests__/docker.test.ts
+++ b/packages/scripts/src/shared/__tests__/docker.test.ts
@@ -9,9 +9,13 @@ afterEach(() => {
   __private.setSpawnSync()
   Bun.spawn = originalSpawn
   Bun.which = originalWhich
+  delete process.env.DOCKER_COMMAND_RETRY_ATTEMPTS
+  delete process.env.DOCKER_COMMAND_RETRY_DELAY_SECONDS
   delete process.env.DOCKER_BUILD_PROVENANCE
   delete process.env.DOCKER_BUILD_SBOM
 })
+
+const streamFromText = (text: string) => new Response(text).body!
 
 describe('inspectImageDigest', () => {
   it('prefers the locally cached repo digest when available', () => {
@@ -110,5 +114,49 @@ describe('resolveBuildAttestations', () => {
     expect(commands[0].slice(0, 4)).toEqual(['docker', 'buildx', 'build', '--push'])
     expect(commands[0]).toContain('--attest')
     expect(commands[0]).toContain('type=provenance,mode=max')
+  })
+
+  it('retries transient registry upload failures from buildx push', async () => {
+    const commands: string[][] = []
+
+    process.env.DOCKER_COMMAND_RETRY_ATTEMPTS = '2'
+    process.env.DOCKER_COMMAND_RETRY_DELAY_SECONDS = '1'
+    Bun.which = ((binary: string) => (binary === 'docker' ? '/usr/bin/docker' : null)) as typeof Bun.which
+    Bun.spawn = ((command: Parameters<typeof Bun.spawn>[0], _options: Parameters<typeof Bun.spawn>[1]) => {
+      commands.push(typeof command === 'string' ? [command] : [...command])
+      const failedAttempt = commands.length === 1
+      return {
+        exited: Promise.resolve(failedAttempt ? 1 : 0),
+        stdout: streamFromText(''),
+        stderr: streamFromText(failedAttempt ? 'unknown: invalid content range' : ''),
+      } as ReturnType<typeof Bun.spawn>
+    }) as typeof Bun.spawn
+    __private.setSpawnSync(((command: Parameters<typeof Bun.spawnSync>[0]) => {
+      const joined = typeof command === 'string' ? command : command.join(' ')
+      if (joined === 'docker buildx version') {
+        return { exitCode: 0, stdout: new Uint8Array(), stderr: new Uint8Array() } as ReturnType<typeof Bun.spawnSync>
+      }
+      if (joined === 'docker buildx inspect') {
+        return {
+          exitCode: 0,
+          stdout: Buffer.from('Driver: docker-container\n'),
+          stderr: new Uint8Array(),
+        } as ReturnType<typeof Bun.spawnSync>
+      }
+      return { exitCode: 1, stdout: new Uint8Array(), stderr: new Uint8Array() } as ReturnType<typeof Bun.spawnSync>
+    }) as typeof Bun.spawnSync)
+
+    await buildAndPushDockerImage({
+      registry: 'registry.example',
+      repository: 'lab/agents-control-plane',
+      tag: 'test',
+      context: '.',
+      dockerfile: 'Dockerfile',
+      cacheRef: 'registry.example/lab/agents-control-plane:buildcache',
+    })
+
+    expect(commands).toHaveLength(2)
+    expect(commands[0].slice(0, 4)).toEqual(['docker', 'buildx', 'build', '--push'])
+    expect(commands[1].slice(0, 4)).toEqual(['docker', 'buildx', 'build', '--push'])
   })
 })

--- a/packages/scripts/src/shared/docker.ts
+++ b/packages/scripts/src/shared/docker.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, relative, resolve } from 'node:path'
 
-import { ensureCli, repoRoot, run } from './cli'
+import { ensureCli, repoRoot } from './cli'
 
 export type DockerCacheMode = 'max' | 'min'
 
@@ -45,6 +45,17 @@ type SpawnSync = typeof Bun.spawnSync
 
 let spawnSyncImpl: SpawnSync = Bun.spawnSync
 
+class DockerCommandError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: number,
+    readonly output: string,
+  ) {
+    super(message)
+    this.name = 'DockerCommandError'
+  }
+}
+
 const isTruthyEnv = (value: string | undefined): boolean => {
   if (!value) return false
   const normalized = value.trim().toLowerCase()
@@ -57,6 +68,92 @@ const normalizeCacheMode = (value: string | undefined): DockerCacheMode => {
   if (!value) return 'max'
   const normalized = value.trim().toLowerCase()
   return normalized === 'min' ? 'min' : 'max'
+}
+
+const parsePositiveInteger = (value: string | undefined, fallback: number): number => {
+  if (!value) return fallback
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const trimTail = (value: string, maxLength = 12_000): string =>
+  value.length > maxLength ? value.slice(value.length - maxLength) : value
+
+const pipeCommandOutput = async (
+  stream: ReadableStream<Uint8Array> | null | undefined,
+  writer: NodeJS.WriteStream,
+): Promise<string> => {
+  if (!stream) return ''
+
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let tail = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    writer.write(value)
+    tail = trimTail(tail + decoder.decode(value, { stream: true }))
+  }
+  tail = trimTail(tail + decoder.decode())
+  return tail
+}
+
+const isRetryableDockerCommandError = (error: unknown): error is DockerCommandError => {
+  if (!(error instanceof DockerCommandError)) return false
+  return /invalid content range|unexpected eof|connection reset by peer|use of closed network connection|i\/o timeout|context deadline exceeded|tls handshake timeout|502 bad gateway|503 service unavailable|504 gateway timeout|blob upload unknown/i.test(
+    error.output,
+  )
+}
+
+const runDockerCommand = async (
+  args: string[],
+  options: { cwd: string; env: Record<string, string> },
+): Promise<void> => {
+  console.log(`$ docker ${args.join(' ')}`.trim())
+  const subprocess = Bun.spawn(['docker', ...args], {
+    cwd: options.cwd,
+    env: options.env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const [exitCode, stdoutTail, stderrTail] = await Promise.all([
+    subprocess.exited,
+    pipeCommandOutput(subprocess.stdout, process.stdout),
+    pipeCommandOutput(subprocess.stderr, process.stderr),
+  ])
+  if (exitCode !== 0) {
+    const output = trimTail(`${stdoutTail}\n${stderrTail}`.trim())
+    throw new DockerCommandError(`Command failed (${exitCode}): docker ${args.join(' ')}`, exitCode, output)
+  }
+}
+
+const runDockerCommandWithRetry = async (
+  args: string[],
+  options: { cwd: string; env: Record<string, string> },
+): Promise<void> => {
+  const attempts = parsePositiveInteger(process.env.DOCKER_COMMAND_RETRY_ATTEMPTS, 3)
+  const baseDelaySeconds = parsePositiveInteger(process.env.DOCKER_COMMAND_RETRY_DELAY_SECONDS, 15)
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      await runDockerCommand(args, options)
+      return
+    } catch (error) {
+      if (attempt >= attempts || !isRetryableDockerCommandError(error)) {
+        throw error
+      }
+      const delaySeconds = baseDelaySeconds * attempt
+      console.warn(
+        `Docker command failed with a retryable registry/upload error; retrying attempt ${
+          attempt + 1
+        }/${attempts} in ${delaySeconds}s.`,
+      )
+      await sleep(delaySeconds * 1000)
+    }
+  }
 }
 
 const normalizeAttestation = (kind: 'provenance' | 'sbom', value: string | undefined): string | undefined => {
@@ -181,7 +278,7 @@ export const buildAndPushDockerImage = async (options: DockerBuildOptions): Prom
       args.push('--build-arg', `${key}=${value}`)
     }
     args.push(options.context)
-    await run('docker', args, { cwd, env: dockerEnv })
+    await runDockerCommandWithRetry(args, { cwd, env: dockerEnv })
   } else {
     const args = ['build', '-f', options.dockerfile, '-t', image]
     if (options.target) args.push('--target', options.target)
@@ -199,8 +296,8 @@ export const buildAndPushDockerImage = async (options: DockerBuildOptions): Prom
       args.push('--build-arg', `${key}=${value}`)
     }
     args.push(options.context)
-    await run('docker', args, { cwd, env: dockerEnv })
-    await run('docker', ['push', image], { cwd, env: dockerEnv })
+    await runDockerCommandWithRetry(args, { cwd, env: dockerEnv })
+    await runDockerCommandWithRetry(['push', image], { cwd, env: dockerEnv })
   }
 
   return { ...options, image }
@@ -325,7 +422,7 @@ export const buildAndPushDockerImages = async (options: DockerBakeOptions): Prom
     }
     bakeArgs.push('--push', '--file', bakeFile, ...targets.map((target) => target.name))
 
-    await run('docker', bakeArgs, {
+    await runDockerCommandWithRetry(bakeArgs, {
       cwd,
       env: dockerEnv,
     })
@@ -504,5 +601,6 @@ export const __private = {
   inspectLocalImageDigest,
   inspectRemoteImageDigest,
   getRepositoryFromReference,
+  isRetryableDockerCommandError,
   setSpawnSync,
 }


### PR DESCRIPTION
## Summary

- Add bounded retries for Docker build/push commands when registry uploads fail with transient errors such as `invalid content range`.
- Stream Docker output while retaining enough failure text to classify retryable registry/upload failures.
- Cover the Agents control-plane push failure mode with a regression test that retries after `unknown: invalid content range`.
- Update the Agents scheduled-template smoke guard for the new 6-hour swarm brownout retention window merged in #6938.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts packages/scripts/src/agents/__tests__/resolve-published-agents-images.test.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/jangar/__tests__/release-contract.test.ts packages/scripts/src/shared/__tests__/docker.test.ts`
- `bunx oxfmt --check packages/scripts/src/shared/docker.ts packages/scripts/src/shared/__tests__/docker.test.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/shared/docker.ts packages/scripts/src/shared/__tests__/docker.test.ts`
- `bun run --cwd packages/scripts lint:oxlint:type` exits 0 with existing warnings only.
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
