### PR TITLE
fix(torghut): prefer promotion-ready portfolio candidates

### DIFF
--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -685,10 +685,12 @@ def _portfolio_selection_key(
     selected: Sequence[CandidateEvidenceBundle],
     scorecard: Mapping[str, Any],
 ) -> tuple[Decimal, ...]:
+    # Once no portfolio fully passes the oracle, the next best promotion target is
+    # the one with the smallest repair surface, not the one with the largest raw PnL.
     return (
         Decimal(1 if bool(scorecard.get("oracle_passed")) else 0),
-        Decimal(1 if bool(scorecard.get("target_met")) else 0),
         -_oracle_blocker_count(scorecard),
+        Decimal(1 if bool(scorecard.get("target_met")) else 0),
         _scorecard_decimal(scorecard, "active_day_ratio"),
         _scorecard_decimal(scorecard, "positive_day_ratio"),
         _scorecard_decimal(scorecard, "min_daily_net_pnl"),
@@ -1010,7 +1012,8 @@ def optimize_portfolio_candidate(
         "max_single_symbol_contribution_share": objective_scorecard.get(
             "max_single_symbol_contribution_share"
         ),
-        "method": "deterministic_beam_oracle_search_v1",
+        "method": "deterministic_beam_promotion_ready_search_v2",
+        "selection_priority": "oracle_passed_then_blocker_minimized_then_target_met",
         **search_report,
         "target_met": bool(objective_scorecard["target_met"]),
         "oracle_passed": bool(objective_scorecard["oracle_passed"]),

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -1192,11 +1192,15 @@ class TestPortfolioOptimizer(TestCase):
         )
         self.assertEqual(
             portfolio.optimizer_report["method"],
-            "deterministic_beam_oracle_search_v1",
+            "deterministic_beam_promotion_ready_search_v2",
+        )
+        self.assertEqual(
+            portfolio.optimizer_report["selection_priority"],
+            "oracle_passed_then_blocker_minimized_then_target_met",
         )
         self.assertGreater(portfolio.optimizer_report["finalist_state_count"], 1)
 
-    def test_optimizer_prefers_target_met_before_fewer_oracle_blockers(
+    def test_optimizer_prefers_nearest_promotion_candidate_over_raw_target_met(
         self,
     ) -> None:
         def bundle(
@@ -1288,24 +1292,25 @@ class TestPortfolioOptimizer(TestCase):
 
         self.assertIsNotNone(portfolio)
         assert portfolio is not None
-        self.assertIn("cand-sparse-intc", portfolio.source_candidate_ids)
-        self.assertEqual(len(portfolio.source_candidate_ids), 3)
+        self.assertNotIn("cand-sparse-intc", portfolio.source_candidate_ids)
+        self.assertCountEqual(
+            portfolio.source_candidate_ids,
+            ("cand-steady-aapl", "cand-steady-amzn", "cand-steady-googl"),
+        )
         self.assertFalse(portfolio.objective_scorecard["oracle_passed"])
-        self.assertTrue(portfolio.objective_scorecard["target_met"])
+        self.assertFalse(portfolio.objective_scorecard["target_met"])
         self.assertEqual(
             portfolio.objective_scorecard["min_daily_net_pnl"],
-            "320.0000000000000000000000000",
+            "480.0000000000000000000000000",
         )
-        self.assertGreater(
+        self.assertLessEqual(
             Decimal(portfolio.objective_scorecard["max_single_day_contribution_share"]),
             Decimal("0.25"),
         )
         self.assertEqual(
             portfolio.objective_scorecard["profit_target_oracle"]["blockers"],
             [
-                "best_day_share_failed",
-                "max_single_day_contribution_share_failed",
-                "max_single_symbol_contribution_share_failed",
+                "portfolio_post_cost_net_pnl_per_day_failed",
             ],
         )
 


### PR DESCRIPTION
## Summary

- Prefer portfolio candidates with fewer promotion-oracle blockers before raw target-met status when no candidate fully passes the oracle.
- Rename the optimizer report method and selection priority so the promotion-readiness ordering is explicit.
- Add regression coverage that prevents a sparse, concentrated raw-PnL candidate from beating a steadier near-target repair candidate.

## Related Issues

None

## Testing

- `uv run --frozen ruff format --check app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen ruff check app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen coverage run -m pytest tests/test_portfolio_optimizer.py -q`
- `uv run --frozen coverage xml --fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
