### PR TITLE
fix(agents): build controller from slim runtime target

### DIFF
--- a/packages/scripts/src/agents/__tests__/deploy-service.test.ts
+++ b/packages/scripts/src/agents/__tests__/deploy-service.test.ts
@@ -13,6 +13,33 @@ describe('agents deploy-service helpers', () => {
     })
   })
 
+  it('builds controller and control-plane images from the narrow control-plane Docker target', () => {
+    expect(
+      __private.buildAgentsServiceImagePlans({
+        registry: 'registry.example',
+        repository: 'lab/agents-controller',
+        controlPlaneRepository: 'lab/agents-control-plane',
+        tag: 'abc1234',
+        platforms: ['linux/arm64'],
+      }),
+    ).toEqual([
+      {
+        registry: 'registry.example',
+        repository: 'lab/agents-controller',
+        tag: 'abc1234',
+        target: 'control-plane',
+        platforms: ['linux/arm64'],
+      },
+      {
+        registry: 'registry.example',
+        repository: 'lab/agents-control-plane',
+        tag: 'abc1234',
+        target: 'control-plane',
+        platforms: ['linux/arm64'],
+      },
+    ])
+  })
+
   it('drops Argo CD hook resources from direct kubectl apply manifests', () => {
     const rendered = `apiVersion: v1
 kind: ConfigMap

--- a/packages/scripts/src/agents/deploy-service.ts
+++ b/packages/scripts/src/agents/deploy-service.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import process from 'node:process'
 import YAML from 'yaml'
-import { buildImage } from '../jangar/build-image'
+import { buildImage, type BuildImageOptions } from '../jangar/build-image'
 import { ensureCli, fatal, repoRoot, run } from '../shared/cli'
 import { buildAndPushDockerImage, inspectImageDigest } from '../shared/docker'
 import { execGit } from '../shared/git'
@@ -66,6 +66,27 @@ type DatabaseSecretRequirement = {
   namespace: string
   name: string
 }
+
+const CONTROL_PLANE_DOCKER_TARGET = 'control-plane'
+
+const buildAgentsServiceImagePlans = (
+  options: Pick<Options, 'registry' | 'repository' | 'controlPlaneRepository' | 'tag' | 'platforms'>,
+): BuildImageOptions[] => [
+  {
+    registry: options.registry,
+    repository: options.repository,
+    tag: options.tag,
+    target: CONTROL_PLANE_DOCKER_TARGET,
+    platforms: options.platforms,
+  },
+  {
+    registry: options.registry,
+    repository: options.controlPlaneRepository,
+    tag: options.tag,
+    target: CONTROL_PLANE_DOCKER_TARGET,
+    platforms: options.platforms,
+  },
+]
 
 const parseBoolean = (value: string | undefined, fallback: boolean): boolean => {
   if (value === undefined) return fallback
@@ -550,10 +571,7 @@ const filterDirectApplyManifests = (rendered: string): string => {
 const renderAndApply = async (kustomizePath: string) => {
   ensureCli('kubectl')
   const { helmDir, helmBinary, cleanup } = writeHelmShim()
-  const kubectl = Bun.which('kubectl')
-  if (!kubectl) {
-    fatal('Missing kubectl: install kubectl to render kustomize manifests')
-  }
+  const kubectl = Bun.which('kubectl') ?? fatal('Missing kubectl: install kubectl to render kustomize manifests')
   const renderEnv = { PATH: `${helmDir}:${process.env.PATH ?? ''}`, HELM_BIN: helmBinary }
   const rendered = await capture([kubectl, 'kustomize', kustomizePath, '--enable-helm'], renderEnv)
   const tmpDir = mkdtempSync(`${tmpdir()}/agents-render-`)
@@ -585,19 +603,9 @@ const main = async () => {
   const runnerImageName = `${options.registry}/${options.runnerRepository}`
   const runnerImage = `${runnerImageName}:${options.tag}`
 
-  await buildImage({
-    registry: options.registry,
-    repository: options.repository,
-    tag: options.tag,
-    platforms: options.platforms,
-  })
-  await buildImage({
-    registry: options.registry,
-    repository: options.controlPlaneRepository,
-    tag: options.tag,
-    target: 'control-plane',
-    platforms: options.platforms,
-  })
+  for (const imagePlan of buildAgentsServiceImagePlans(options)) {
+    await buildImage(imagePlan)
+  }
   const runnerPin = options.buildRunner ? undefined : readRunnerImagePin(options.valuesPath)
   if (options.buildRunner) {
     if (!existsSync(options.codexAuthPath)) {
@@ -624,10 +632,9 @@ const main = async () => {
     ? controlPlaneRepoDigest.split('@')[1]
     : controlPlaneRepoDigest
   const runnerRepoDigest = options.buildRunner ? inspectImageDigest(runnerImage) : runnerPin?.digest
-  const runnerDigest = runnerRepoDigest?.includes('@') ? runnerRepoDigest.split('@')[1] : runnerRepoDigest
-  if (!runnerDigest) {
+  const runnerDigest =
+    (runnerRepoDigest?.includes('@') ? runnerRepoDigest.split('@')[1] : runnerRepoDigest) ??
     fatal('Agents runner digest is empty.')
-  }
 
   updateValuesFile(
     options.valuesPath,
@@ -663,6 +670,7 @@ if (import.meta.main) {
 }
 
 export const __private = {
+  buildAgentsServiceImagePlans,
   parseArgs,
   parseBoolean,
   resolveOptions,


### PR DESCRIPTION
## Summary

- Changes the Agents deploy script so `agents-controller` builds from the existing `control-plane` Docker target instead of the final Jangar runtime stage.
- Keeps `agents-control-plane` on the same narrow target, so controller/control-plane publish behavior is explicit and consistent.
- Adds a regression test for the controller/control-plane build plan.
- Avoids shipping Codex CLI, OpenVSCode, skills, and legacy `codex-implement` tooling in the controller image path.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/deploy-service.test.ts`
- `bunx oxfmt --check packages/scripts/src/agents/deploy-service.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts`
- `git diff --check`
- `bun run --cwd packages/scripts lint:oxlint:type`
- `bunx tsc --noEmit -p packages/scripts/tsconfig.json 2>&1 | rg "packages/scripts/src/agents/deploy-service.ts"` confirmed no deploy-service type errors; the full package script still has pre-existing unrelated type errors in other script modules.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
