### PR TITLE
fix(registry): expand image storage

### DIFF
--- a/argocd/applications/registry/pvc.yaml
+++ b/argocd/applications/registry/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: rook-ceph-block
   resources:
     requests:
-      storage: 200Gi
+      storage: 500Gi


### PR DESCRIPTION
## Summary

- Expands the GitOps registry PVC request from `200Gi` to `500Gi`.
- Matches the live emergency PVC expansion applied to unblock image pushes after the registry hit 100% disk usage.
- Leaves the existing registry deployment, service, config, and GC CronJob behavior unchanged.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/registry > /tmp/registry-render.yaml`
- `git diff --check`
- Live verification: `kubectl -n registry patch pvc registry-data --type=merge -p '{"spec":{"resources":{"requests":{"storage":"500Gi"}}}}'`
- Live verification: `kubectl -n registry get pvc registry-data -o 'custom-columns=NAME:.metadata.name,REQ:.spec.resources.requests.storage,CAP:.status.capacity.storage,PHASE:.status.phase,CONDS:.status.conditions[*].type'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
