### PR TITLE
chore(agents): disable torghut quant swarm schedules

### DIFF
--- a/argocd/applications/agents/swarm-instances.yaml
+++ b/argocd/applications/agents/swarm-instances.yaml
@@ -204,18 +204,22 @@ spec:
     freezeDuration: 60m
   execution:
     discover:
+      enabled: false
       targetRef:
         kind: AgentRun
         name: torghut-swarm-discover-template
     plan:
+      enabled: false
       targetRef:
         kind: AgentRun
         name: torghut-swarm-plan-template
     implement:
+      enabled: false
       targetRef:
         kind: AgentRun
         name: torghut-swarm-implement-template
     verify:
+      enabled: false
       targetRef:
         kind: AgentRun
         name: torghut-swarm-verify-template


### PR DESCRIPTION
## Summary

- Disable the Torghut quant swarm discover, plan, implement, and verify schedules in GitOps.
- Preserve the existing target templates so the stages can be re-enabled intentionally after cluster runner pressure is cleared.
- Match the emergency runtime throttle applied in the `agents` namespace to stop new Torghut quant swarm jobs from being created.

## Related Issues

None

## Testing

- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
