### PR TITLE
fix(torghut): renew empirical promotion evidence

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -1,0 +1,68 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: torghut-empirical-promotion-renewal
+  namespace: torghut
+spec:
+  schedule: "23 8,20 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 900
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 900
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: torghut-runtime
+          nodeSelector:
+            kubernetes.io/arch: arm64
+          containers:
+            - name: renew
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -euo pipefail
+                  cd /app
+                  /opt/venv/bin/python scripts/renew_latest_empirical_promotion_jobs.py \
+                    --output-dir /tmp/torghut-empirical-renewal \
+                    --json
+              env:
+                - name: DB_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: uri
+                - name: TORGHUT_IMAGE_DIGEST
+                  value: sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+                - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
+                  valueFrom:
+                    configMapKeyRef:
+                      name: torghut-empirical-artifacts
+                      key: BUCKET_NAME
+                - name: TORGHUT_EMPIRICAL_CEPH_BUCKET_HOST
+                  valueFrom:
+                    configMapKeyRef:
+                      name: torghut-empirical-artifacts
+                      key: BUCKET_HOST
+                - name: TORGHUT_EMPIRICAL_CEPH_BUCKET_PORT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: torghut-empirical-artifacts
+                      key: BUCKET_PORT
+                - name: TORGHUT_EMPIRICAL_CEPH_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-empirical-artifacts
+                      key: AWS_ACCESS_KEY_ID
+                - name: TORGHUT_EMPIRICAL_CEPH_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-empirical-artifacts
+                      key: AWS_SECRET_ACCESS_KEY

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -32,6 +32,7 @@ resources:
   - whitepaper-semantic-backfill-job.yaml
   - empirical-artifacts-objectbucketclaim.yaml
   - empirical-jobs-backfill-job.yaml
+  - empirical-promotion-renewal-cronjob.yaml
   - empirical-artifacts-retention-cronjob.yaml
   - execution-tca-refresh-cronjob.yaml
   - whitepaper-autoresearch-workflowtemplate.yaml

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -19,6 +19,10 @@ const torghutArm64ImageChecks: ManifestCheck[] = [
   { path: 'argocd/applications/torghut/db-migrations-job.yaml', selectorPath: ['spec', 'template', 'spec'] },
   { path: 'argocd/applications/torghut/empirical-jobs-backfill-job.yaml', selectorPath: ['spec', 'template', 'spec'] },
   {
+    path: 'argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml',
+    selectorPath: ['spec', 'jobTemplate', 'spec', 'template', 'spec'],
+  },
+  {
     path: 'argocd/applications/torghut/analysis-template-runtime-ready.yaml',
     selectorPath: ['spec', 'metrics', 0, 'provider', 'job', 'spec', 'template', 'spec'],
   },

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -19,6 +19,7 @@ const createFixture = () => {
   const analysisTeardownManifestPath = join(dir, 'analysis-template-teardown-clean.yaml')
   const analysisArtifactManifestPath = join(dir, 'analysis-template-artifact-bundle.yaml')
   const empiricalBackfillManifestPath = join(dir, 'empirical-jobs-backfill-job.yaml')
+  const empiricalPromotionRenewalManifestPath = join(dir, 'empirical-promotion-renewal-cronjob.yaml')
   const executionTcaRefreshManifestPath = join(dir, 'execution-tca-refresh-cronjob.yaml')
   const whitepaperSemanticBackfillManifestPath = join(dir, 'whitepaper-semantic-backfill-job.yaml')
   const optionsCatalogManifestPath = join(dir, 'options-catalog-deployment.yaml')
@@ -94,6 +95,7 @@ spec:
     analysisTeardownManifestPath,
     analysisArtifactManifestPath,
     empiricalBackfillManifestPath,
+    empiricalPromotionRenewalManifestPath,
     executionTcaRefreshManifestPath,
     whitepaperSemanticBackfillManifestPath,
   ]) {
@@ -107,6 +109,9 @@ spec:
       containers:
         - name: torghut
           image: registry.ide-newton.ts.net/lab/torghut@sha256:1111111111111111111111111111111111111111111111111111111111111111
+          env:
+            - name: TORGHUT_IMAGE_DIGEST
+              value: sha256:1111111111111111111111111111111111111111111111111111111111111111
 `,
       'utf8',
     )
@@ -144,6 +149,7 @@ spec:
     analysisTeardownManifestPath,
     analysisArtifactManifestPath,
     empiricalBackfillManifestPath,
+    empiricalPromotionRenewalManifestPath,
     executionTcaRefreshManifestPath,
     whitepaperSemanticBackfillManifestPath,
     optionsCatalogManifestPath,
@@ -213,6 +219,7 @@ describe('update-manifests', () => {
       analysisTeardownManifestPath: relative(repoRoot, fixture.analysisTeardownManifestPath),
       analysisArtifactManifestPath: relative(repoRoot, fixture.analysisArtifactManifestPath),
       empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
+      empiricalPromotionRenewalManifestPath: relative(repoRoot, fixture.empiricalPromotionRenewalManifestPath),
       executionTcaRefreshManifestPath: relative(repoRoot, fixture.executionTcaRefreshManifestPath),
       whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
       optionsCatalogManifestPath: relative(repoRoot, fixture.optionsCatalogManifestPath),
@@ -233,6 +240,7 @@ describe('update-manifests', () => {
     const analysisTeardownManifest = readFileSync(fixture.analysisTeardownManifestPath, 'utf8')
     const analysisArtifactManifest = readFileSync(fixture.analysisArtifactManifestPath, 'utf8')
     const empiricalBackfillManifest = readFileSync(fixture.empiricalBackfillManifestPath, 'utf8')
+    const empiricalPromotionRenewalManifest = readFileSync(fixture.empiricalPromotionRenewalManifestPath, 'utf8')
     const executionTcaRefreshManifest = readFileSync(fixture.executionTcaRefreshManifestPath, 'utf8')
     const whitepaperSemanticBackfillManifest = readFileSync(fixture.whitepaperSemanticBackfillManifestPath, 'utf8')
     const optionsCatalogManifest = readFileSync(fixture.optionsCatalogManifestPath, 'utf8')
@@ -266,12 +274,14 @@ describe('update-manifests', () => {
       analysisTeardownManifest,
       analysisArtifactManifest,
       empiricalBackfillManifest,
+      empiricalPromotionRenewalManifest,
       executionTcaRefreshManifest,
       whitepaperSemanticBackfillManifest,
     ]) {
       expect(manifest).toContain(
         'image: registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
       )
+      expect(manifest).toContain('value: sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e')
     }
     for (const manifest of [optionsCatalogManifest, optionsEnricherManifest]) {
       expect(manifest).toContain(
@@ -284,7 +294,7 @@ describe('update-manifests', () => {
     expect(result.imageRef).toBe(
       'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
-    expect(result.changedPaths.length).toBe(15)
+    expect(result.changedPaths.length).toBe(16)
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })
@@ -311,6 +321,7 @@ describe('update-manifests', () => {
       analysisTeardownManifestPath: relative(repoRoot, fixture.analysisTeardownManifestPath),
       analysisArtifactManifestPath: relative(repoRoot, fixture.analysisArtifactManifestPath),
       empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
+      empiricalPromotionRenewalManifestPath: relative(repoRoot, fixture.empiricalPromotionRenewalManifestPath),
       executionTcaRefreshManifestPath: relative(repoRoot, fixture.executionTcaRefreshManifestPath),
       whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
       optionsCatalogManifestPath: relative(repoRoot, fixture.optionsCatalogManifestPath),

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -24,6 +24,8 @@ const defaultAnalysisActivityManifestPath = 'argocd/applications/torghut/analysi
 const defaultAnalysisTeardownManifestPath = 'argocd/applications/torghut/analysis-template-teardown-clean.yaml'
 const defaultAnalysisArtifactManifestPath = 'argocd/applications/torghut/analysis-template-artifact-bundle.yaml'
 const defaultEmpiricalBackfillManifestPath = 'argocd/applications/torghut/empirical-jobs-backfill-job.yaml'
+const defaultEmpiricalPromotionRenewalManifestPath =
+  'argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml'
 const defaultExecutionTcaRefreshManifestPath = 'argocd/applications/torghut/execution-tca-refresh-cronjob.yaml'
 const defaultWhitepaperSemanticBackfillManifestPath =
   'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
@@ -49,6 +51,7 @@ type UpdateManifestsOptions = {
   analysisTeardownManifestPath?: string
   analysisArtifactManifestPath?: string
   empiricalBackfillManifestPath?: string
+  empiricalPromotionRenewalManifestPath?: string
   executionTcaRefreshManifestPath?: string
   whitepaperSemanticBackfillManifestPath?: string
   optionsCatalogManifestPath?: string
@@ -74,6 +77,7 @@ type CliOptions = {
   analysisTeardownManifestPath?: string
   analysisArtifactManifestPath?: string
   empiricalBackfillManifestPath?: string
+  empiricalPromotionRenewalManifestPath?: string
   executionTcaRefreshManifestPath?: string
   whitepaperSemanticBackfillManifestPath?: string
   optionsCatalogManifestPath?: string
@@ -194,7 +198,12 @@ const updateImageOnlyManifest = (options: UpdateManifestsOptions, manifestPathVa
   const source = readFileSync(manifestPath, 'utf8')
   const imageRef = `${options.imageName}@${options.digest}`
 
-  const updated = replaceSingle(source, /(\n\s*image:\s*)([^\n]+)/, `$1${imageRef}`, label)
+  let updated = replaceSingle(source, /(\n\s*image:\s*)([^\n]+)/, `$1${imageRef}`, label)
+  updated = replaceIfPresent(
+    updated,
+    /(- name:\s*TORGHUT_IMAGE_DIGEST\s*\n\s*value:\s*)([^\n]+)/,
+    `$1${options.digest}`,
+  )
 
   if (updated !== source) {
     writeFileSync(manifestPath, updated, 'utf8')
@@ -296,6 +305,11 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     options.empiricalBackfillManifestPath ?? defaultEmpiricalBackfillManifestPath,
     'torghut-empirical-jobs-backfill image reference',
   )
+  const empiricalPromotionRenewal = updateImageOnlyManifest(
+    options,
+    options.empiricalPromotionRenewalManifestPath ?? defaultEmpiricalPromotionRenewalManifestPath,
+    'torghut-empirical-promotion-renewal image reference',
+  )
   const executionTcaRefresh = updateImageOnlyManifest(
     options,
     options.executionTcaRefreshManifestPath ?? defaultExecutionTcaRefreshManifestPath,
@@ -334,6 +348,7 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     analysisTeardown,
     analysisArtifact,
     empiricalBackfill,
+    empiricalPromotionRenewal,
     executionTcaRefresh,
     whitepaperSemanticBackfill,
     optionsCatalog,
@@ -375,6 +390,7 @@ Options:
   --analysis-teardown-manifest-path <path>
   --analysis-artifact-manifest-path <path>
   --empirical-backfill-manifest-path <path>
+  --empirical-promotion-renewal-manifest-path <path>
   --execution-tca-refresh-manifest-path <path>
   --whitepaper-semantic-backfill-manifest-path <path>
   --options-catalog-manifest-path <path>
@@ -450,6 +466,9 @@ Options:
       case '--empirical-backfill-manifest-path':
         options.empiricalBackfillManifestPath = value
         break
+      case '--empirical-promotion-renewal-manifest-path':
+        options.empiricalPromotionRenewalManifestPath = value
+        break
       case '--execution-tca-refresh-manifest-path':
         options.executionTcaRefreshManifestPath = value
         break
@@ -513,6 +532,8 @@ const main = (cliOptions?: CliOptions) => {
       parsed.analysisArtifactManifestPath ?? process.env.TORGHUT_ANALYSIS_ARTIFACT_MANIFEST_PATH,
     empiricalBackfillManifestPath:
       parsed.empiricalBackfillManifestPath ?? process.env.TORGHUT_EMPIRICAL_BACKFILL_MANIFEST_PATH,
+    empiricalPromotionRenewalManifestPath:
+      parsed.empiricalPromotionRenewalManifestPath ?? process.env.TORGHUT_EMPIRICAL_PROMOTION_RENEWAL_MANIFEST_PATH,
     executionTcaRefreshManifestPath:
       parsed.executionTcaRefreshManifestPath ?? process.env.TORGHUT_EXECUTION_TCA_REFRESH_MANIFEST_PATH,
     whitepaperSemanticBackfillManifestPath:

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Renew empirical promotion artifacts from the latest authoritative replay outputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import yaml
+from sqlalchemy import select
+
+from app.db import SessionLocal
+from app.models import VNextEmpiricalJobRun
+from app.trading.empirical_jobs import (
+    EMPIRICAL_JOB_TYPES,
+    empirical_artifact_truthfulness_reasons,
+)
+from app.trading.empirical_manifest import (
+    normalize_empirical_promotion_manifest,
+    validate_empirical_promotion_manifest,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Re-run empirical promotion assembly against the latest authoritative "
+            "replay outputs, preserving source lineage in the renewal manifest."
+        ),
+    )
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument(
+        "--strategy-spec-ref",
+        default="microbar_volume_continuation_long_top2_chip_v1@paper",
+    )
+    parser.add_argument(
+        "--run-id-prefix", default="sim-2026-05-05-chip-4c330ce9-r1-renew"
+    )
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return (
+        {str(key): item for key, item in value.items()}
+        if isinstance(value, Mapping)
+        else {}
+    )
+
+
+def _as_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _runtime_version_ref() -> str:
+    digest = _as_text(os.getenv("TORGHUT_IMAGE_DIGEST")) or _as_text(
+        os.getenv("BUILD_IMAGE_DIGEST")
+    )
+    if digest and digest.startswith("sha256:"):
+        return f"services/torghut@{digest}"
+    return digest or "services/torghut@unknown"
+
+
+def _latest_authoritative_rows(
+    rows: Sequence[VNextEmpiricalJobRun],
+) -> dict[str, VNextEmpiricalJobRun]:
+    latest: dict[str, VNextEmpiricalJobRun] = {}
+    for row in rows:
+        if row.job_type not in EMPIRICAL_JOB_TYPES or row.job_type in latest:
+            continue
+        payload = _as_dict(row.payload_json)
+        truthful_reasons = empirical_artifact_truthfulness_reasons(payload)
+        if (
+            row.status != "completed"
+            or row.authority != "empirical"
+            or not row.promotion_authority_eligible
+            or truthful_reasons
+        ):
+            raise RuntimeError(
+                "latest_empirical_job_not_authoritative:"
+                f"{row.job_type}:{row.status}:{row.authority}:{','.join(truthful_reasons)}"
+            )
+        latest[row.job_type] = row
+        if len(latest) == len(EMPIRICAL_JOB_TYPES):
+            break
+    missing = [job_type for job_type in EMPIRICAL_JOB_TYPES if job_type not in latest]
+    if missing:
+        raise RuntimeError(f"latest_empirical_jobs_missing:{','.join(missing)}")
+    return latest
+
+
+def build_renewal_manifest(
+    *,
+    latest: Mapping[str, VNextEmpiricalJobRun],
+    run_id: str,
+    strategy_spec_ref: str,
+    runtime_version_ref: str,
+) -> dict[str, Any]:
+    benchmark = _as_dict(latest["benchmark_parity"].payload_json)
+    foundation = _as_dict(latest["foundation_router_parity"].payload_json)
+    event = _as_dict(latest["janus_event_car"].payload_json)
+    reward = _as_dict(latest["janus_hgrm_reward"].payload_json)
+    lineage = _as_dict(benchmark.get("lineage"))
+    candidate_id = _as_text(latest["benchmark_parity"].candidate_id)
+    dataset_snapshot_ref = _as_text(latest["benchmark_parity"].dataset_snapshot_ref)
+    if candidate_id is None or dataset_snapshot_ref is None:
+        raise RuntimeError("latest_empirical_job_lineage_missing")
+
+    manifest = normalize_empirical_promotion_manifest(
+        {
+            "schema_version": "torghut-empirical-promotion-manifest-v1",
+            "run_id": run_id,
+            "candidate_id": candidate_id,
+            "baseline_candidate_id": benchmark.get("baseline_candidate_id")
+            or "baseline",
+            "dataset_snapshot_ref": dataset_snapshot_ref,
+            "artifact_prefix": f"empirical/{run_id}",
+            "strategy_spec_ref": strategy_spec_ref,
+            "benchmark_parity": {
+                "benchmark_runs": benchmark.get("benchmark_runs") or [],
+                "scorecards": benchmark.get("scorecards") or {},
+                "degradation_summary": benchmark.get("degradation_summary") or {},
+            },
+            "foundation_router_parity": {
+                "router_policy_version": foundation.get("router_policy_version")
+                or "forecast_router_policy_v1",
+                "adapters": foundation.get("adapters") or [],
+                "slice_metrics": foundation.get("slice_metrics") or {},
+                "calibration_metrics": foundation.get("calibration_metrics") or {},
+                "latency_metrics": foundation.get("latency_metrics") or {},
+                "fallback_metrics": foundation.get("fallback_metrics") or {},
+                "drift_metrics": foundation.get("drift_metrics") or {},
+                "overall_status": foundation.get("overall_status") or "pass",
+            },
+            "janus_event_car": {
+                key: value
+                for key, value in event.items()
+                if key
+                not in {"artifact_authority", "lineage", "promotion_authority_eligible"}
+            },
+            "janus_hgrm_reward": {
+                key: value
+                for key, value in reward.items()
+                if key
+                not in {"artifact_authority", "lineage", "promotion_authority_eligible"}
+            },
+            "model_refs": lineage.get("model_refs")
+            or ["rules/chip-paper-microbar-composite"],
+            "runtime_version_refs": [runtime_version_ref],
+            "authority": {
+                "generated_from_simulation_outputs": True,
+                "source_artifacts": {
+                    "source_empirical_job_run_ids": {
+                        job_type: latest[job_type].job_run_id
+                        for job_type in EMPIRICAL_JOB_TYPES
+                    },
+                    "source_created_at": {
+                        job_type: latest[job_type].created_at.isoformat()
+                        for job_type in EMPIRICAL_JOB_TYPES
+                    },
+                    "renewal_reason": (
+                        "re-run empirical promotion assembly against latest authoritative "
+                        "replay outputs using the deployed runtime image"
+                    ),
+                },
+            },
+            "promotion_authority_eligible": True,
+        }
+    )
+    validation_errors = validate_empirical_promotion_manifest(manifest)
+    if validation_errors:
+        raise RuntimeError(
+            "invalid_renewal_manifest:" + ",".join(sorted(set(validation_errors)))
+        )
+    return manifest
+
+
+def main() -> int:
+    args = _parse_args()
+    now = datetime.now(tz=timezone.utc)
+    run_id = f"{args.run_id_prefix}-{now.strftime('%Y%m%dT%H%M%SZ')}"
+    output_dir = Path(args.output_dir) / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = output_dir / "empirical-promotion-manifest.yaml"
+
+    with SessionLocal() as session:
+        rows = (
+            session.execute(
+                select(VNextEmpiricalJobRun).order_by(
+                    VNextEmpiricalJobRun.created_at.desc()
+                )
+            )
+            .scalars()
+            .all()
+        )
+        manifest = build_renewal_manifest(
+            latest=_latest_authoritative_rows(rows),
+            run_id=run_id,
+            strategy_spec_ref=args.strategy_spec_ref,
+            runtime_version_ref=_runtime_version_ref(),
+        )
+
+    manifest_path.write_text(
+        yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8"
+    )
+    command = [
+        sys.executable,
+        "scripts/run_empirical_promotion_jobs.py",
+        "--manifest",
+        str(manifest_path),
+        "--output-dir",
+        str(output_dir),
+        "--json",
+    ]
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    payload = {
+        "status": "ok",
+        "run_id": run_id,
+        "manifest_path": str(manifest_path),
+        "output_dir": str(output_dir),
+        "empirical_promotion": json.loads(result.stdout),
+    }
+    print(
+        json.dumps(payload, separators=(",", ":"))
+        if args.json
+        else json.dumps(payload, indent=2)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
-from app.trading.empirical_jobs import promote_janus_payload_to_empirical
+from app.trading.empirical_jobs import (
+    build_empirical_benchmark_parity_report,
+    build_empirical_foundation_router_parity_report,
+    promote_janus_payload_to_empirical,
+)
+from scripts import renew_latest_empirical_promotion_jobs as renewal
+from scripts.renew_latest_empirical_promotion_jobs import build_renewal_manifest
 from scripts.run_empirical_promotion_jobs import _build_janus_summary
 
 
@@ -10,90 +22,376 @@ class TestRunEmpiricalPromotionJobs(TestCase):
     def test_build_janus_summary_requires_truthful_child_artifacts(self) -> None:
         event_payload = promote_janus_payload_to_empirical(
             payload={
-                'schema_version': 'janus-event-car-v1',
-                'summary': {'event_count': 3},
-                'manifest_hash': 'event-hash',
+                "schema_version": "janus-event-car-v1",
+                "summary": {"event_count": 3},
+                "manifest_hash": "event-hash",
             },
-            dataset_snapshot_ref='snapshot-1',
-            job_run_id='job-event',
-            runtime_version_refs=['services/torghut@sha256:abc'],
-            model_refs=['models/candidate@sha256:def'],
+            dataset_snapshot_ref="snapshot-1",
+            job_run_id="job-event",
+            runtime_version_refs=["services/torghut@sha256:abc"],
+            model_refs=["models/candidate@sha256:def"],
             promotion_authority_eligible=True,
         )
         reward_payload = promote_janus_payload_to_empirical(
             payload={
-                'schema_version': 'janus-hgrm-reward-v1',
-                'summary': {
-                    'reward_count': 3,
-                    'event_mapped_count': 3,
-                    'direction_gate_pass_ratio': '1',
+                "schema_version": "janus-hgrm-reward-v1",
+                "summary": {
+                    "reward_count": 3,
+                    "event_mapped_count": 3,
+                    "direction_gate_pass_ratio": "1",
                 },
-                'manifest_hash': 'reward-hash',
+                "manifest_hash": "reward-hash",
             },
-            dataset_snapshot_ref='snapshot-1',
-            job_run_id='job-reward',
-            runtime_version_refs=['services/torghut@sha256:abc'],
-            model_refs=['models/candidate@sha256:def'],
+            dataset_snapshot_ref="snapshot-1",
+            job_run_id="job-reward",
+            runtime_version_refs=["services/torghut@sha256:abc"],
+            model_refs=["models/candidate@sha256:def"],
             promotion_authority_eligible=True,
         )
 
         summary = _build_janus_summary(
             event_car_payload=event_payload,
             hgrm_reward_payload=reward_payload,
-            event_car_artifact_ref='s3://artifacts/event.json',
-            hgrm_reward_artifact_ref='s3://artifacts/reward.json',
-            dataset_snapshot_ref='snapshot-1',
-            job_run_id='job-summary',
-            runtime_version_refs=['services/torghut@sha256:abc'],
-            model_refs=['models/candidate@sha256:def'],
+            event_car_artifact_ref="s3://artifacts/event.json",
+            hgrm_reward_artifact_ref="s3://artifacts/reward.json",
+            dataset_snapshot_ref="snapshot-1",
+            job_run_id="job-summary",
+            runtime_version_refs=["services/torghut@sha256:abc"],
+            model_refs=["models/candidate@sha256:def"],
         )
 
-        self.assertTrue(summary['promotion_authority_eligible'])
-        self.assertTrue(summary['artifact_authority']['authoritative'])
-        self.assertEqual(summary['reasons'], [])
-        self.assertEqual(summary['hgrm_reward']['event_mapped_count'], 3)
+        self.assertTrue(summary["promotion_authority_eligible"])
+        self.assertTrue(summary["artifact_authority"]["authoritative"])
+        self.assertEqual(summary["reasons"], [])
+        self.assertEqual(summary["hgrm_reward"]["event_mapped_count"], 3)
 
     def test_build_janus_summary_blocks_non_truthful_child_artifacts(self) -> None:
         event_payload = promote_janus_payload_to_empirical(
             payload={
-                'schema_version': 'janus-event-car-v1',
-                'summary': {'event_count': 3},
-                'manifest_hash': 'event-hash',
+                "schema_version": "janus-event-car-v1",
+                "summary": {"event_count": 3},
+                "manifest_hash": "event-hash",
             },
-            dataset_snapshot_ref='snapshot-1',
-            job_run_id='job-event',
+            dataset_snapshot_ref="snapshot-1",
+            job_run_id="job-event",
             runtime_version_refs=[],
-            model_refs=['models/candidate@sha256:def'],
+            model_refs=["models/candidate@sha256:def"],
             promotion_authority_eligible=True,
         )
         reward_payload = promote_janus_payload_to_empirical(
             payload={
-                'schema_version': 'janus-hgrm-reward-v1',
-                'summary': {
-                    'reward_count': 3,
-                    'event_mapped_count': 3,
-                    'direction_gate_pass_ratio': '1',
+                "schema_version": "janus-hgrm-reward-v1",
+                "summary": {
+                    "reward_count": 3,
+                    "event_mapped_count": 3,
+                    "direction_gate_pass_ratio": "1",
                 },
-                'manifest_hash': 'reward-hash',
+                "manifest_hash": "reward-hash",
             },
-            dataset_snapshot_ref='snapshot-1',
-            job_run_id='job-reward',
-            runtime_version_refs=['services/torghut@sha256:abc'],
-            model_refs=['models/candidate@sha256:def'],
+            dataset_snapshot_ref="snapshot-1",
+            job_run_id="job-reward",
+            runtime_version_refs=["services/torghut@sha256:abc"],
+            model_refs=["models/candidate@sha256:def"],
             promotion_authority_eligible=True,
         )
 
         summary = _build_janus_summary(
             event_car_payload=event_payload,
             hgrm_reward_payload=reward_payload,
-            event_car_artifact_ref='s3://artifacts/event.json',
-            hgrm_reward_artifact_ref='s3://artifacts/reward.json',
-            dataset_snapshot_ref='snapshot-1',
-            job_run_id='job-summary',
-            runtime_version_refs=['services/torghut@sha256:abc'],
-            model_refs=['models/candidate@sha256:def'],
+            event_car_artifact_ref="s3://artifacts/event.json",
+            hgrm_reward_artifact_ref="s3://artifacts/reward.json",
+            dataset_snapshot_ref="snapshot-1",
+            job_run_id="job-summary",
+            runtime_version_refs=["services/torghut@sha256:abc"],
+            model_refs=["models/candidate@sha256:def"],
         )
 
-        self.assertFalse(summary['promotion_authority_eligible'])
-        self.assertFalse(summary['artifact_authority']['authoritative'])
-        self.assertIn('janus_event_car_not_truthful', summary['reasons'])
+        self.assertFalse(summary["promotion_authority_eligible"])
+        self.assertFalse(summary["artifact_authority"]["authoritative"])
+        self.assertIn("janus_event_car_not_truthful", summary["reasons"])
+
+    def test_build_renewal_manifest_preserves_source_job_lineage(self) -> None:
+        created_at = datetime(2026, 5, 18, 8, 13, tzinfo=timezone.utc)
+        benchmark = build_empirical_benchmark_parity_report(
+            candidate_id="chip-paper-microbar-composite@execution-proof",
+            baseline_candidate_id="baseline",
+            benchmark_runs=[
+                {
+                    "schema_version": "benchmark-parity-run-v1",
+                    "dataset_ref": "dataset-1",
+                    "window_ref": "window-1",
+                    "family": family,
+                    "metrics": {},
+                    "slice_metrics": {},
+                    "policy_violations": {"deterministic_gate_compatible": True},
+                    "run_hash": f"hash-{family}",
+                }
+                for family in ("ai-trader", "fev-bench", "gift-eval")
+            ],
+            scorecards={
+                "decision_quality": {"status": "pass", "decision_count": 4},
+                "reasoning_quality": {"status": "pass"},
+                "forecast_quality": {"status": "pass"},
+            },
+            degradation_summary={},
+            dataset_snapshot_ref="snapshot-1",
+            job_run_id="source-benchmark",
+            runtime_version_refs=["services/torghut@sha256:old"],
+            model_refs=["rules/chip-paper-microbar-composite"],
+            now=created_at,
+        )
+        foundation = build_empirical_foundation_router_parity_report(
+            candidate_id="chip-paper-microbar-composite@execution-proof",
+            router_policy_version="forecast_router_policy_v1",
+            adapters=["deterministic", "chronos", "timesfm"],
+            slice_metrics={},
+            calibration_metrics={},
+            latency_metrics={},
+            fallback_metrics={},
+            drift_metrics={},
+            dataset_snapshot_ref="snapshot-1",
+            job_run_id="source-foundation",
+            runtime_version_refs=["services/torghut@sha256:old"],
+            model_refs=["rules/chip-paper-microbar-composite"],
+            now=created_at,
+        )
+        event = promote_janus_payload_to_empirical(
+            payload={"summary": {"event_count": 4}, "manifest_hash": "event-hash"},
+            dataset_snapshot_ref="snapshot-1",
+            job_run_id="source-event",
+            runtime_version_refs=["services/torghut@sha256:old"],
+            model_refs=["rules/chip-paper-microbar-composite"],
+            promotion_authority_eligible=True,
+        )
+        reward = promote_janus_payload_to_empirical(
+            payload={
+                "summary": {"reward_count": 4, "event_mapped_count": 4},
+                "manifest_hash": "reward-hash",
+            },
+            dataset_snapshot_ref="snapshot-1",
+            job_run_id="source-reward",
+            runtime_version_refs=["services/torghut@sha256:old"],
+            model_refs=["rules/chip-paper-microbar-composite"],
+            promotion_authority_eligible=True,
+        )
+
+        def row(
+            job_type: str, payload: dict[str, object], job_run_id: str
+        ) -> SimpleNamespace:
+            return SimpleNamespace(
+                job_type=job_type,
+                status="completed",
+                authority="empirical",
+                promotion_authority_eligible=True,
+                candidate_id="chip-paper-microbar-composite@execution-proof",
+                dataset_snapshot_ref="snapshot-1",
+                job_run_id=job_run_id,
+                created_at=created_at,
+                payload_json=payload,
+            )
+
+        manifest = build_renewal_manifest(
+            latest=cast(
+                Any,
+                {
+                    "benchmark_parity": row(
+                        "benchmark_parity", benchmark, "source-benchmark"
+                    ),
+                    "foundation_router_parity": row(
+                        "foundation_router_parity", foundation, "source-foundation"
+                    ),
+                    "janus_event_car": row("janus_event_car", event, "source-event"),
+                    "janus_hgrm_reward": row(
+                        "janus_hgrm_reward", reward, "source-reward"
+                    ),
+                },
+            ),
+            run_id="renew-1",
+            strategy_spec_ref="microbar_volume_continuation_long_top2_chip_v1@paper",
+            runtime_version_ref="services/torghut@sha256:new",
+        )
+
+        self.assertEqual(manifest["run_id"], "renew-1")
+        self.assertEqual(manifest["dataset_snapshot_ref"], "snapshot-1")
+        self.assertEqual(
+            manifest["runtime_version_refs"], ["services/torghut@sha256:new"]
+        )
+        self.assertEqual(
+            manifest["authority"]["source_artifacts"]["source_empirical_job_run_ids"][
+                "benchmark_parity"
+            ],
+            "source-benchmark",
+        )
+        self.assertTrue(manifest["promotion_authority_eligible"])
+
+    def test_latest_authoritative_rows_rejects_non_empirical_latest_job(self) -> None:
+        created_at = datetime(2026, 5, 18, 8, 13, tzinfo=timezone.utc)
+        rows = [
+            SimpleNamespace(
+                job_type="benchmark_parity",
+                status="degraded",
+                authority="empirical",
+                promotion_authority_eligible=True,
+                payload_json={},
+                created_at=created_at,
+            )
+        ]
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "latest_empirical_job_not_authoritative:benchmark_parity:degraded:empirical",
+        ):
+            renewal._latest_authoritative_rows(cast(Any, rows))
+
+    def test_latest_authoritative_rows_requires_all_job_types(self) -> None:
+        created_at = datetime(2026, 5, 18, 8, 13, tzinfo=timezone.utc)
+        benchmark = build_empirical_benchmark_parity_report(
+            candidate_id="chip-paper-microbar-composite@execution-proof",
+            baseline_candidate_id="baseline",
+            benchmark_runs=[
+                {
+                    "schema_version": "benchmark-parity-run-v1",
+                    "dataset_ref": "dataset-1",
+                    "window_ref": "window-1",
+                    "family": family,
+                    "metrics": {},
+                    "slice_metrics": {},
+                    "policy_violations": {"deterministic_gate_compatible": True},
+                    "run_hash": f"hash-{family}",
+                }
+                for family in ("ai-trader", "fev-bench", "gift-eval")
+            ],
+            scorecards={
+                "decision_quality": {"status": "pass", "decision_count": 4},
+                "reasoning_quality": {"status": "pass"},
+                "forecast_quality": {"status": "pass"},
+            },
+            degradation_summary={},
+            dataset_snapshot_ref="snapshot-1",
+            job_run_id="source-benchmark",
+            runtime_version_refs=["services/torghut@sha256:old"],
+            model_refs=["rules/chip-paper-microbar-composite"],
+            now=created_at,
+        )
+        rows = [
+            SimpleNamespace(
+                job_type="benchmark_parity",
+                status="completed",
+                authority="empirical",
+                promotion_authority_eligible=True,
+                payload_json=benchmark,
+                created_at=created_at,
+            )
+        ]
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "latest_empirical_jobs_missing:foundation_router_parity,janus_event_car,janus_hgrm_reward",
+        ):
+            renewal._latest_authoritative_rows(cast(Any, rows))
+
+    def test_runtime_version_ref_prefers_runtime_digest(self) -> None:
+        with patch.dict(
+            renewal.os.environ,
+            {
+                "TORGHUT_IMAGE_DIGEST": "sha256:new",
+                "BUILD_IMAGE_DIGEST": "sha256:old",
+            },
+            clear=True,
+        ):
+            self.assertEqual(
+                renewal._runtime_version_ref(),
+                "services/torghut@sha256:new",
+            )
+
+    def test_runtime_version_ref_falls_back_to_unknown(self) -> None:
+        with patch.dict(renewal.os.environ, {}, clear=True):
+            self.assertEqual(
+                renewal._runtime_version_ref(),
+                "services/torghut@unknown",
+            )
+
+    def test_parse_args_accepts_strategy_and_json_flag(self) -> None:
+        with patch.object(
+            renewal.sys,
+            "argv",
+            [
+                "renew_latest_empirical_promotion_jobs.py",
+                "--output-dir",
+                "/tmp/out",
+                "--strategy-spec-ref",
+                "strategy@paper",
+                "--run-id-prefix",
+                "renew-prefix",
+                "--json",
+            ],
+        ):
+            args = renewal._parse_args()
+
+        self.assertEqual(args.output_dir, "/tmp/out")
+        self.assertEqual(args.strategy_spec_ref, "strategy@paper")
+        self.assertEqual(args.run_id_prefix, "renew-prefix")
+        self.assertTrue(args.json)
+
+    def test_main_writes_manifest_and_runs_empirical_promotion_job(self) -> None:
+        created_at = datetime(2026, 5, 18, 8, 13, tzinfo=timezone.utc)
+        manifest = {
+            "schema_version": "torghut-empirical-promotion-manifest-v1",
+            "run_id": "renew-prefix-20260518T081300Z",
+            "candidate_id": "candidate-1",
+            "dataset_snapshot_ref": "snapshot-1",
+            "promotion_authority_eligible": True,
+        }
+        session = MagicMock()
+        execute_result = MagicMock()
+        execute_result.scalars.return_value.all.return_value = []
+        session.execute.return_value = execute_result
+        session_context = MagicMock()
+        session_context.__enter__.return_value = session
+        session_context.__exit__.return_value = None
+        completed = SimpleNamespace(stdout=json.dumps({"persisted_jobs": []}))
+
+        with (
+            patch.object(
+                renewal,
+                "_parse_args",
+                return_value=SimpleNamespace(
+                    output_dir=str(self.tmp_dir),
+                    strategy_spec_ref="strategy@paper",
+                    run_id_prefix="renew-prefix",
+                    json=True,
+                ),
+            ),
+            patch.object(renewal, "datetime") as datetime_mock,
+            patch.object(renewal, "SessionLocal", return_value=session_context),
+            patch.object(renewal, "_latest_authoritative_rows", return_value={}),
+            patch.object(renewal, "_runtime_version_ref", return_value="runtime@sha"),
+            patch.object(renewal, "build_renewal_manifest", return_value=manifest),
+            patch.object(renewal.subprocess, "run", return_value=completed) as run_mock,
+            patch("builtins.print") as print_mock,
+        ):
+            datetime_mock.now.return_value = created_at
+            self.assertEqual(renewal.main(), 0)
+
+        manifest_path = (
+            self.tmp_dir
+            / "renew-prefix-20260518T081300Z"
+            / "empirical-promotion-manifest.yaml"
+        )
+        self.assertTrue(manifest_path.exists())
+        run_mock.assert_called_once()
+        command = run_mock.call_args.args[0]
+        self.assertIn("scripts/run_empirical_promotion_jobs.py", command)
+        self.assertIn(str(manifest_path), command)
+        print_mock.assert_called_once()
+
+    def setUp(self) -> None:
+        super().setUp()
+        from tempfile import TemporaryDirectory
+
+        self._tmp_dir_context = TemporaryDirectory()
+        self.tmp_dir = Path(self._tmp_dir_context.name)
+
+    def tearDown(self) -> None:
+        self._tmp_dir_context.cleanup()
+        super().tearDown()


### PR DESCRIPTION
## Summary

- Adds a Torghut empirical promotion renewal script that rebuilds empirical promotion artifacts from the latest authoritative replay outputs and preserves source job lineage.
- Adds a low-frequency GitOps CronJob with `concurrencyPolicy: Forbid` so empirical promotion evidence does not stale out after 24 hours.
- Extends Torghut manifest release tooling and tests so the renewal CronJob image and `TORGHUT_IMAGE_DIGEST` stay pinned to the promoted image.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `cd services/torghut && uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `cd services/torghut && uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q`
- `cd services/torghut && uv sync --frozen --extra dev && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bunx oxfmt --check packages/scripts/src/torghut/update-manifests.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `bun run lint:argocd`
- Live operational check: submitted `torghut-empirical-promotion-fn5ch`; it succeeded and `/trading/empirical-jobs` returned `ready=true`, `status=healthy`, `authority=empirical`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
