### PR TITLE
refactor(agents): move run read handlers

### DIFF
--- a/services/agents/src/server/v1/run-read.test.ts
+++ b/services/agents/src/server/v1/run-read.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { RESOURCE_MAP, type KubernetesClient } from '../kube-types'
+
+import {
+  getAgentRunHandler,
+  getRunHandler,
+  type AgentRunDetailsUpdate,
+  type RunLookupRecord,
+  type RunReadApiStore,
+} from './run-read'
+
+const now = new Date('2026-05-18T12:00:00.000Z')
+
+const createKubeMock = (resource: Record<string, unknown> | null): KubernetesClient => ({
+  apply: vi.fn(async (input) => input),
+  applyManifest: vi.fn(async () => ({})),
+  applyStatus: vi.fn(async (input) => input),
+  createManifest: vi.fn(async () => ({})),
+  delete: vi.fn(async () => ({})),
+  patch: vi.fn(async (_resource, _name, _namespace, patch) => patch),
+  get: vi.fn(async () => resource),
+  list: vi.fn(async () => ({ items: [] })),
+  listEvents: vi.fn(async () => ({ items: [] })),
+  logs: vi.fn(async () => ''),
+})
+
+const createStoreMock = (overrides: Partial<RunReadApiStore>): RunReadApiStore => ({
+  ready: Promise.resolve(),
+  close: vi.fn(async () => {}),
+  getAgentRunById: vi.fn(async () => null),
+  updateAgentRunDetails: vi.fn(async (input: AgentRunDetailsUpdate) => ({
+    id: input.id,
+    agentName: 'demo-agent',
+    deliveryId: 'delivery-1',
+    provider: 'job',
+    status: input.status,
+    externalRunId: input.externalRunId ?? null,
+    payload: input.payload ?? {},
+    createdAt: now,
+    updatedAt: now,
+  })),
+  getRunById: vi.fn(async () => null),
+  updateOrchestrationRunDetails: vi.fn(async (input: AgentRunDetailsUpdate) => ({
+    id: input.id,
+    orchestrationName: 'demo-orchestration',
+    deliveryId: 'delivery-1',
+    provider: 'workflow',
+    status: input.status,
+    externalRunId: input.externalRunId ?? null,
+    payload: input.payload ?? {},
+    createdAt: now,
+    updatedAt: now,
+  })),
+  ...overrides,
+})
+
+describe('run read v1 API', () => {
+  it('refreshes an AgentRun status from the Kubernetes resource', async () => {
+    const resource = {
+      apiVersion: 'agents.proompteng.ai/v1alpha1',
+      kind: 'AgentRun',
+      metadata: { name: 'agent-run-1', namespace: 'agents' },
+      status: { phase: 'Succeeded' },
+    }
+    const store = createStoreMock({
+      getAgentRunById: vi.fn(async () => ({
+        id: 'record-1',
+        agentName: 'demo-agent',
+        deliveryId: 'delivery-1',
+        provider: 'job',
+        status: 'Running',
+        externalRunId: 'agent-run-1',
+        payload: { request: { namespace: 'agents' } },
+        createdAt: now,
+        updatedAt: now,
+      })),
+    })
+    const kube = createKubeMock(resource)
+
+    const response = await getAgentRunHandler('record-1', new Request('http://agents.local/v1/agent-runs/record-1'), {
+      storeFactory: () => store,
+      kubeClient: kube,
+    })
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { agentRun?: { status?: string }; resource?: Record<string, unknown> }
+    expect(body.agentRun?.status).toBe('Succeeded')
+    expect(body.resource).toEqual(resource)
+    expect(kube.get).toHaveBeenCalledWith(RESOURCE_MAP.AgentRun, 'agent-run-1', 'agents')
+    expect(store.updateAgentRunDetails).toHaveBeenCalledWith({
+      id: 'record-1',
+      status: 'Succeeded',
+      externalRunId: 'agent-run-1',
+      payload: { request: { namespace: 'agents' }, resource },
+    })
+    expect(store.close).toHaveBeenCalled()
+  })
+
+  it('refreshes an OrchestrationRun status from the generic run lookup endpoint', async () => {
+    const resource = {
+      apiVersion: 'orchestration.proompteng.ai/v1alpha1',
+      kind: 'OrchestrationRun',
+      metadata: { name: 'orchestration-run-1', namespace: 'agents' },
+      status: { phase: 'Failed' },
+    }
+    const run: RunLookupRecord = {
+      kind: 'orchestration',
+      record: {
+        id: 'orchestration-record-1',
+        orchestrationName: 'demo-orchestration',
+        deliveryId: 'delivery-1',
+        provider: 'workflow',
+        status: 'Running',
+        externalRunId: 'orchestration-run-1',
+        payload: { resource: { metadata: { namespace: 'agents' } } },
+        createdAt: now,
+        updatedAt: now,
+      },
+    }
+    const store = createStoreMock({ getRunById: vi.fn(async () => run) })
+    const kube = createKubeMock(resource)
+
+    const response = await getRunHandler(
+      'orchestration-record-1',
+      new Request('http://agents.local/v1/runs/record-1'),
+      {
+        storeFactory: () => store,
+        kubeClient: kube,
+      },
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      kind?: string
+      run?: { status?: string }
+      resource?: Record<string, unknown>
+    }
+    expect(body.kind).toBe('orchestration')
+    expect(body.run?.status).toBe('Failed')
+    expect(body.resource).toEqual(resource)
+    expect(kube.get).toHaveBeenCalledWith(RESOURCE_MAP.OrchestrationRun, 'orchestration-run-1', 'agents')
+    expect(store.updateOrchestrationRunDetails).toHaveBeenCalledWith({
+      id: 'orchestration-record-1',
+      status: 'Failed',
+      externalRunId: 'orchestration-run-1',
+      payload: { resource },
+    })
+    expect(store.close).toHaveBeenCalled()
+  })
+
+  it('returns not found when a run record does not exist', async () => {
+    const store = createStoreMock({})
+
+    const response = await getRunHandler('missing-run', new Request('http://agents.local/v1/runs/missing-run'), {
+      storeFactory: () => store,
+      kubeClient: createKubeMock(null),
+    })
+
+    expect(response.status).toBe(404)
+    const body = (await response.json()) as { error?: string }
+    expect(body.error).toBe('Run not found')
+    expect(store.close).toHaveBeenCalled()
+  })
+})

--- a/services/agents/src/server/v1/run-read.ts
+++ b/services/agents/src/server/v1/run-read.ts
@@ -1,0 +1,146 @@
+import { errorResponse, okResponse } from '../http'
+import { createKubernetesClient, type KubernetesClient, RESOURCE_MAP } from '../kube-types'
+import { asRecord, asString, normalizeNamespace, readNested } from '../primitives'
+
+import { type AgentRunRecord } from './agent-runs'
+
+type Timestamp = string | Date
+
+export type OrchestrationRunRecord = {
+  id: string
+  orchestrationName: string
+  deliveryId: string
+  provider: string
+  status: string
+  externalRunId: string | null
+  payload: Record<string, unknown>
+  createdAt?: Timestamp
+  updatedAt?: Timestamp
+}
+
+export type AgentRunDetailsUpdate = {
+  id: string
+  status: string
+  externalRunId?: string | null
+  payload?: Record<string, unknown>
+}
+
+export type RunLookupRecord = {
+  kind: 'agent' | 'orchestration'
+  record: AgentRunRecord | OrchestrationRunRecord
+}
+
+export type RunReadApiStore = {
+  ready: Promise<unknown>
+  close: () => Promise<unknown>
+  getAgentRunById: (id: string) => Promise<AgentRunRecord | null>
+  updateAgentRunDetails: (input: AgentRunDetailsUpdate) => Promise<AgentRunRecord | null>
+  getRunById: (id: string) => Promise<RunLookupRecord | null>
+  updateOrchestrationRunDetails: (input: AgentRunDetailsUpdate) => Promise<OrchestrationRunRecord | null>
+}
+
+export type RunReadApiDependencies = {
+  storeFactory: () => RunReadApiStore
+  kubeClient?: KubernetesClient
+  kubeClientFactory?: () => KubernetesClient
+  defaultNamespace?: string
+}
+
+const extractStatusPhase = (resource: Record<string, unknown>) => {
+  const status = asRecord(resource.status)
+  return asString(status?.phase)
+}
+
+const responseStatusForError = (message: string) => (message.includes('DATABASE_URL') ? 503 : 500)
+
+const resolveResourceNamespace = (payload: Record<string, unknown>, fallbackNamespace: string) =>
+  asString(readNested(payload, ['resource', 'metadata', 'namespace'])) ??
+  asString(readNested(payload, ['request', 'namespace'])) ??
+  fallbackNamespace
+
+const getKubeClient = (deps: Pick<RunReadApiDependencies, 'kubeClient' | 'kubeClientFactory'>) =>
+  deps.kubeClient ?? deps.kubeClientFactory?.() ?? createKubernetesClient()
+
+export const getAgentRunHandler = async (id: string, request: Request, deps: RunReadApiDependencies) => {
+  const url = new URL(request.url)
+  const namespace = normalizeNamespace(url.searchParams.get('namespace'), deps.defaultNamespace)
+  const store = deps.storeFactory()
+  try {
+    await store.ready
+    const record = await store.getAgentRunById(id)
+    if (!record) return errorResponse('AgentRun not found', 404)
+
+    const resourceNamespace = resolveResourceNamespace(record.payload, namespace)
+    const kube = getKubeClient(deps)
+    const resource = record.externalRunId
+      ? await kube.get(RESOURCE_MAP.AgentRun, record.externalRunId, resourceNamespace)
+      : null
+    if (resource) {
+      const phase = extractStatusPhase(resource)
+      if (phase && phase !== record.status) {
+        await store.updateAgentRunDetails({
+          id: record.id,
+          status: phase,
+          externalRunId: record.externalRunId,
+          payload: { ...record.payload, resource },
+        })
+        record.status = phase
+      }
+    }
+
+    return okResponse({ ok: true, agentRun: record, resource })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return errorResponse(message, responseStatusForError(message))
+  } finally {
+    await store.close()
+  }
+}
+
+export const getRunHandler = async (id: string, request: Request, deps: RunReadApiDependencies) => {
+  const url = new URL(request.url)
+  const namespace = normalizeNamespace(url.searchParams.get('namespace'), deps.defaultNamespace)
+  const store = deps.storeFactory()
+  try {
+    await store.ready
+    const run = await store.getRunById(id)
+    if (!run) return errorResponse('Run not found', 404)
+
+    const kube = getKubeClient(deps)
+    let resource: Record<string, unknown> | null = null
+    if (run.record.externalRunId) {
+      const resourceNamespace = resolveResourceNamespace(run.record.payload, namespace)
+      const resourceName = run.record.externalRunId
+      const resourceType = run.kind === 'agent' ? RESOURCE_MAP.AgentRun : RESOURCE_MAP.OrchestrationRun
+      resource = await kube.get(resourceType, resourceName, resourceNamespace)
+      if (resource) {
+        const phase = extractStatusPhase(resource)
+        if (phase && phase !== run.record.status) {
+          if (run.kind === 'agent') {
+            await store.updateAgentRunDetails({
+              id: run.record.id,
+              status: phase,
+              externalRunId: run.record.externalRunId,
+              payload: { ...run.record.payload, resource },
+            })
+          } else {
+            await store.updateOrchestrationRunDetails({
+              id: run.record.id,
+              status: phase,
+              externalRunId: run.record.externalRunId,
+              payload: { ...run.record.payload, resource },
+            })
+          }
+          run.record.status = phase
+        }
+      }
+    }
+
+    return okResponse({ ok: true, kind: run.kind, run: run.record, resource })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return errorResponse(message, responseStatusForError(message))
+  } finally {
+    await store.close()
+  }
+}

--- a/services/jangar/src/routes/v1/agent-runs/$id.ts
+++ b/services/jangar/src/routes/v1/agent-runs/$id.ts
@@ -1,6 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { asRecord, asString, errorResponse, normalizeNamespace, okResponse, readNested } from '~/server/primitives-http'
-import { createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
+import {
+  getAgentRunHandler as getAgentsServiceAgentRunHandler,
+  type RunReadApiDependencies,
+  type RunReadApiStore,
+} from '@proompteng/agents/server/v1/run-read'
+import { createKubernetesClient } from '~/server/primitives-kube'
 import { createPrimitivesStore } from '~/server/primitives-store'
 
 export const Route = createFileRoute('/v1/agent-runs/$id')({
@@ -11,54 +15,16 @@ export const Route = createFileRoute('/v1/agent-runs/$id')({
   },
 })
 
-const extractStatusPhase = (resource: Record<string, unknown>) => {
-  const status = asRecord(resource.status)
-  return asString(status?.phase)
-}
+type JangarRunReadApiDependencies = Partial<RunReadApiDependencies>
 
-export const getAgentRunHandler = async (
-  id: string,
-  request: Request,
-  deps: {
-    storeFactory?: typeof createPrimitivesStore
-    kubeClient?: ReturnType<typeof createKubernetesClient>
-  } = {},
-) => {
-  const url = new URL(request.url)
-  const namespace = normalizeNamespace(url.searchParams.get('namespace'))
-  const store = (deps.storeFactory ?? createPrimitivesStore)()
-  try {
-    await store.ready
-    const record = await store.getAgentRunById(id)
-    if (!record) return errorResponse('AgentRun not found', 404)
+const createJangarPrimitivesStore = (): RunReadApiStore => createPrimitivesStore()
 
-    const resourceNamespace =
-      asString(readNested(record.payload, ['resource', 'metadata', 'namespace'])) ??
-      asString(readNested(record.payload, ['request', 'namespace'])) ??
-      namespace
+const buildRunReadApiDependencies = (deps: JangarRunReadApiDependencies = {}): RunReadApiDependencies => ({
+  storeFactory: deps.storeFactory ?? createJangarPrimitivesStore,
+  kubeClient: deps.kubeClient,
+  kubeClientFactory: deps.kubeClientFactory ?? createKubernetesClient,
+  defaultNamespace: deps.defaultNamespace,
+})
 
-    const kube = deps.kubeClient ?? createKubernetesClient()
-    const resource = record.externalRunId
-      ? await kube.get(RESOURCE_MAP.AgentRun, record.externalRunId, resourceNamespace)
-      : null
-    if (resource) {
-      const phase = extractStatusPhase(resource)
-      if (phase && phase !== record.status) {
-        await store.updateAgentRunDetails({
-          id: record.id,
-          status: phase,
-          externalRunId: record.externalRunId,
-          payload: { ...record.payload, resource },
-        })
-        record.status = phase
-      }
-    }
-
-    return okResponse({ ok: true, agentRun: record, resource })
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    return errorResponse(message, message.includes('DATABASE_URL') ? 503 : 500)
-  } finally {
-    await store.close()
-  }
-}
+export const getAgentRunHandler = async (id: string, request: Request, deps: JangarRunReadApiDependencies = {}) =>
+  getAgentsServiceAgentRunHandler(id, request, buildRunReadApiDependencies(deps))

--- a/services/jangar/src/routes/v1/runs/$id.ts
+++ b/services/jangar/src/routes/v1/runs/$id.ts
@@ -1,6 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { asRecord, asString, errorResponse, normalizeNamespace, okResponse, readNested } from '~/server/primitives-http'
-import { createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
+import {
+  getRunHandler as getAgentsServiceRunHandler,
+  type RunReadApiDependencies,
+  type RunReadApiStore,
+} from '@proompteng/agents/server/v1/run-read'
+import { createKubernetesClient } from '~/server/primitives-kube'
 import { createPrimitivesStore } from '~/server/primitives-store'
 
 export const Route = createFileRoute('/v1/runs/$id')({
@@ -11,65 +15,16 @@ export const Route = createFileRoute('/v1/runs/$id')({
   },
 })
 
-const extractStatusPhase = (resource: Record<string, unknown>) => {
-  const status = asRecord(resource.status)
-  return asString(status?.phase)
-}
+type JangarRunReadApiDependencies = Partial<RunReadApiDependencies>
 
-export const getRunHandler = async (
-  id: string,
-  request: Request,
-  deps: {
-    storeFactory?: typeof createPrimitivesStore
-    kubeClient?: ReturnType<typeof createKubernetesClient>
-  } = {},
-) => {
-  const url = new URL(request.url)
-  const namespace = normalizeNamespace(url.searchParams.get('namespace'))
-  const store = (deps.storeFactory ?? createPrimitivesStore)()
-  try {
-    await store.ready
-    const run = await store.getRunById(id)
-    if (!run) return errorResponse('Run not found', 404)
+const createJangarPrimitivesStore = (): RunReadApiStore => createPrimitivesStore()
 
-    const kube = deps.kubeClient ?? createKubernetesClient()
-    let resource: Record<string, unknown> | null = null
-    if (run.record.externalRunId) {
-      const resourceNamespace =
-        asString(readNested(run.record.payload, ['resource', 'metadata', 'namespace'])) ??
-        asString(readNested(run.record.payload, ['request', 'namespace'])) ??
-        namespace
-      const resourceName = run.record.externalRunId
-      const resourceType = run.kind === 'agent' ? RESOURCE_MAP.AgentRun : RESOURCE_MAP.OrchestrationRun
-      resource = await kube.get(resourceType, resourceName, resourceNamespace)
-      if (resource) {
-        const phase = extractStatusPhase(resource)
-        if (phase && phase !== run.record.status) {
-          if (run.kind === 'agent') {
-            await store.updateAgentRunDetails({
-              id: run.record.id,
-              status: phase,
-              externalRunId: run.record.externalRunId,
-              payload: { ...run.record.payload, resource },
-            })
-          } else {
-            await store.updateOrchestrationRunDetails({
-              id: run.record.id,
-              status: phase,
-              externalRunId: run.record.externalRunId,
-              payload: { ...run.record.payload, resource },
-            })
-          }
-          run.record.status = phase
-        }
-      }
-    }
+const buildRunReadApiDependencies = (deps: JangarRunReadApiDependencies = {}): RunReadApiDependencies => ({
+  storeFactory: deps.storeFactory ?? createJangarPrimitivesStore,
+  kubeClient: deps.kubeClient,
+  kubeClientFactory: deps.kubeClientFactory ?? createKubernetesClient,
+  defaultNamespace: deps.defaultNamespace,
+})
 
-    return okResponse({ ok: true, kind: run.kind, run: run.record, resource })
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    return errorResponse(message, message.includes('DATABASE_URL') ? 503 : 500)
-  } finally {
-    await store.close()
-  }
-}
+export const getRunHandler = async (id: string, request: Request, deps: JangarRunReadApiDependencies = {}) =>
+  getAgentsServiceRunHandler(id, request, buildRunReadApiDependencies(deps))


### PR DESCRIPTION
## Summary

- Moves the AgentRun-by-id and generic run read/status handlers into `@proompteng/agents`.
- Leaves the Jangar route files as adapters that inject the existing primitives store and Kubernetes client.
- Adds Agents unit coverage for AgentRun status refresh, OrchestrationRun status refresh, and missing run handling.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test`
- `bun run --cwd services/agents tsc`
- `bun run --cwd services/jangar tsc`
- `bun run --cwd services/jangar test -- src/server/__tests__/primitives-endpoints.test.ts`
- `bun run --cwd services/agents lint`
- `bun run --cwd services/jangar lint`
- `bunx oxfmt --check services/agents/src/server/v1/run-read.ts services/agents/src/server/v1/run-read.test.ts services/jangar/src/routes/v1/agent-runs/'$id'.ts services/jangar/src/routes/v1/runs/'$id'.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
