### PR TITLE
fix(torghut): keep runtime evidence promotion wired

### DIFF
--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -51,6 +51,7 @@ jobs:
             'argocd/applications/torghut/db-migrations-job.yaml'
             'argocd/applications/torghut/historical-simulation-workflowtemplate.yaml'
             'argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml'
+            'argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml'
             'argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml'
             'argocd/applications/torghut/analysis-template-runtime-ready.yaml'
             'argocd/applications/torghut/analysis-template-activity.yaml'

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -248,6 +248,7 @@ jobs:
             argocd/applications/torghut/db-migrations-job.yaml \
             argocd/applications/torghut/historical-simulation-workflowtemplate.yaml \
             argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml \
+            argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml \
             argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml \
             argocd/applications/torghut/analysis-template-runtime-ready.yaml \
             argocd/applications/torghut/analysis-template-activity.yaml \
@@ -286,6 +287,7 @@ jobs:
             argocd/applications/torghut/db-migrations-job.yaml
             argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
             argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+            argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
             argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
             argocd/applications/torghut/analysis-template-runtime-ready.yaml
             argocd/applications/torghut/analysis-template-activity.yaml
@@ -327,6 +329,7 @@ jobs:
             argocd/applications/torghut/db-migrations-job.yaml
             argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
             argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+            argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
             argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
             argocd/applications/torghut/analysis-template-runtime-ready.yaml
             argocd/applications/torghut/analysis-template-activity.yaml

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -32,6 +32,13 @@ spec:
                   cd /app
                   /opt/venv/bin/python scripts/renew_latest_empirical_promotion_jobs.py \
                     --output-dir /tmp/torghut-empirical-renewal \
+                    --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \
+                    --runtime-window-import \
+                    --runtime-window-hypothesis-id H-PAIRS-01 \
+                    --runtime-window-strategy-family microbar_cross_sectional_pairs \
+                    --runtime-window-strategy-name microbar-cross-sectional-pairs-v1 \
+                    --runtime-window-account-label TORGHUT_SIM \
+                    --runtime-window-observed-stage paper \
                     --json
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -32,13 +32,16 @@ spec:
                   cd /app
                   /opt/venv/bin/python scripts/renew_latest_empirical_promotion_jobs.py \
                     --output-dir /tmp/torghut-empirical-renewal \
-                    --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \
+                    --strategy-spec-ref intraday_tsmom_v2@research \
                     --runtime-window-import \
-                    --runtime-window-hypothesis-id H-PAIRS-01 \
-                    --runtime-window-strategy-family microbar_cross_sectional_pairs \
-                    --runtime-window-strategy-name microbar-cross-sectional-pairs-v1 \
+                    --runtime-window-hypothesis-id H-TSMOM-01 \
+                    --runtime-window-candidate-id spec-83161ae16d17828eabcc58cc \
+                    --runtime-window-strategy-family intraday_tsmom_consistent \
+                    --runtime-window-strategy-name intraday-tsmom-profit-v3 \
                     --runtime-window-account-label TORGHUT_SIM \
                     --runtime-window-observed-stage paper \
+                    --runtime-window-dataset-snapshot-ref portfolio-profit-autoresearch-500-v1 \
+                    --runtime-window-source-manifest-ref config/trading/hypotheses/h-tsmom-01.json \
                     --json
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -58,14 +58,16 @@ data:
         strategy_id: intraday_tsmom_v1@paper
         strategy_type: intraday_tsmom_v1
         version: 1.1.0
-        description: Paper-only intraday momentum sleeve on the quote-covered executable chip core; production approval blocked pending $300/day executable proof, version=1.1.0
+        description: Paper-only intraday momentum sleeve aligned to top $500/day autoresearch candidate spec-83161ae16d17828eabcc58cc; production approval blocked pending runtime evidence, version=1.1.0
         enabled: true
         base_timeframe: "1Sec"
         universe_type: intraday_tsmom_v1
-        universe_symbols: ["AAPL", "AMZN", "INTC", "NVDA"]
-        max_notional_per_trade: 50000
-        max_position_pct_equity: 3.0
+        universe_symbols: ["NVDA", "AAPL", "AMZN", "GOOGL", "AVGO", "AMD", "ORCL", "INTC"]
+        max_notional_per_trade: 3750
+        max_position_pct_equity: 0.125
         params:
+          capital_profile: feedback_consistency_guard_cash_constrained_1x
+          feedback_remediation_profile: consistency_guard_feedback_escape
           bullish_hist_min: "0.005"
           bearish_hist_min: "0.004"
           bearish_hist_cap: "0.03"
@@ -82,7 +84,15 @@ data:
           min_recent_microprice_bias_bps: "0.10"
           max_recent_quote_invalid_ratio: "0.20"
           min_cross_section_opening_window_return_rank: "0.60"
-          min_cross_section_continuation_rank: "0.60"
+          min_cross_section_continuation_rank: "0.65"
+          long_stop_loss_bps: "6"
+          short_stop_loss_bps: "6"
+          entry_cooldown_seconds: "1200"
+          position_isolation_mode: per_strategy
+          max_gross_exposure_pct_equity: "1.0"
+          max_session_negative_exit_bps: "5"
+          long_trailing_stop_activation_profit_bps: "12"
+          long_trailing_stop_drawdown_bps: "4"
       - name: momentum-pullback-long-v1
         strategy_id: momentum_pullback_long_v1@research
         strategy_type: momentum_pullback_long_v1

--- a/services/torghut/config/trading/hypotheses/h-pairs-01.json
+++ b/services/torghut/config/trading/hypotheses/h-pairs-01.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "torghut.hypothesis-manifest.v1",
+  "hypothesis_id": "H-PAIRS-01",
+  "lane_id": "microbar-cross-sectional-pairs",
+  "strategy_family": "microbar_cross_sectional_pairs",
+  "candidate_id": "spec-d74b07b2aaab8d0cfa8a4c38",
+  "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+  "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+  "initial_state": "blocked",
+  "market_regimes": ["R2", "R3", "R5"],
+  "required_feature_sets": ["microstructure", "cross_sectional_rank", "tca"],
+  "required_dependency_capabilities": ["drift_governance", "feature_coverage", "signal_continuity"],
+  "segment_dependencies": ["execution", "empirical", "ta-core"],
+  "expected_gross_edge_bps": "8",
+  "max_allowed_slippage_bps": "8",
+  "min_sample_count_for_live_canary": 60,
+  "min_sample_count_for_scale_up": 120,
+  "max_rolling_drawdown_bps": "1000",
+  "rollback_triggers": [
+    "required_feature_set_unavailable",
+    "drift_checks_missing",
+    "slippage_budget_exceeded",
+    "post_cost_expectancy_non_positive",
+    "runtime_window_evidence_missing"
+  ],
+  "promotion_gates": [
+    "microstructure_features_present",
+    "cross_sectional_features_present",
+    "fresh_signal_continuity",
+    "evidence_continuity_recent",
+    "drift_checks_recent",
+    "positive_post_cost_expectancy",
+    "executable_replay_present",
+    "shadow_parity_within_budget"
+  ],
+  "entry_requirements": {
+    "max_signal_lag_seconds": 90,
+    "max_evidence_age_minutes": 30,
+    "min_feature_batch_rows": 1,
+    "require_feature_rows": true,
+    "require_drift_checks": true,
+    "require_evidence_continuity": true
+  }
+}

--- a/services/torghut/config/trading/hypotheses/h-tsmom-01.json
+++ b/services/torghut/config/trading/hypotheses/h-tsmom-01.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "torghut.hypothesis-manifest.v1",
+  "hypothesis_id": "H-TSMOM-01",
+  "lane_id": "intraday-tsmom-profit",
+  "strategy_family": "intraday_tsmom_consistent",
+  "candidate_id": "spec-83161ae16d17828eabcc58cc",
+  "strategy_id": "intraday_tsmom_v2@research",
+  "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+  "initial_state": "blocked",
+  "market_regimes": [
+    "R2",
+    "R3",
+    "R5"
+  ],
+  "required_feature_sets": [
+    "trend_strength",
+    "intraday_momentum_rank",
+    "realized_volatility",
+    "turnover",
+    "tca"
+  ],
+  "required_dependency_capabilities": [
+    "drift_governance",
+    "feature_coverage",
+    "signal_continuity"
+  ],
+  "segment_dependencies": [
+    "execution",
+    "empirical",
+    "ta-core"
+  ],
+  "expected_gross_edge_bps": "6",
+  "max_allowed_slippage_bps": "6",
+  "min_sample_count_for_live_canary": 60,
+  "min_sample_count_for_scale_up": 120,
+  "max_rolling_drawdown_bps": "1000",
+  "rollback_triggers": [
+    "required_feature_set_unavailable",
+    "drift_checks_missing",
+    "slippage_budget_exceeded",
+    "post_cost_expectancy_non_positive",
+    "runtime_window_evidence_missing"
+  ],
+  "promotion_gates": [
+    "trend_features_present",
+    "fresh_signal_continuity",
+    "evidence_continuity_recent",
+    "drift_checks_recent",
+    "positive_post_cost_expectancy",
+    "executable_replay_present",
+    "shadow_parity_within_budget"
+  ],
+  "entry_requirements": {
+    "max_signal_lag_seconds": 90,
+    "max_evidence_age_minutes": 30,
+    "min_feature_batch_rows": 1,
+    "require_feature_rows": true,
+    "require_drift_checks": true,
+    "require_evidence_continuity": true
+  }
+}

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -87,6 +87,25 @@ def _decimal_or_none(value: Any) -> Decimal | None:
         return None
 
 
+def _strategy_name_candidates(*values: str | None) -> list[str]:
+    candidates: list[str] = []
+    for value in values:
+        raw = str(value or "").strip()
+        if not raw:
+            continue
+        variants = [
+            raw,
+            raw.split("@", 1)[0],
+            raw.replace("_", "-"),
+            raw.split("@", 1)[0].replace("_", "-"),
+        ]
+        for variant in variants:
+            normalized = variant.strip()
+            if normalized and normalized not in candidates:
+                candidates.append(normalized)
+    return candidates
+
+
 def _load_report_post_cost_expectancy_bps(artifact_refs: list[str]) -> Decimal | None:
     for ref in artifact_refs:
         path = Path(ref)
@@ -119,11 +138,13 @@ def _load_report_post_cost_expectancy_bps(artifact_refs: list[str]) -> Decimal |
 def _query_timestamps(
     *,
     dsn: str,
-    strategy_name: str,
+    strategy_names: list[str],
     account_label: str,
     window_start: datetime,
     window_end: datetime,
 ) -> tuple[list[datetime], list[datetime], list[dict[str, object]]]:
+    if not strategy_names:
+        raise RuntimeError("strategy_name_not_configured")
     decisions: list[datetime] = []
     executions: list[datetime] = []
     tca_rows: list[dict[str, object]] = []
@@ -134,7 +155,7 @@ def _query_timestamps(
                 select d.created_at
                 from trade_decisions d
                 join strategies s on s.id = d.strategy_id
-                where s.name = %s
+                where s.name = any(%s)
                   and d.alpaca_account_label = %s
                   and d.status = any(%s)
                   and d.created_at >= %s
@@ -142,7 +163,7 @@ def _query_timestamps(
                 order by d.created_at
                 """,
                 (
-                    strategy_name,
+                    strategy_names,
                     account_label,
                     list(EXECUTION_ELIGIBLE_DECISION_STATUSES),
                     window_start,
@@ -156,13 +177,13 @@ def _query_timestamps(
                 from executions e
                 join trade_decisions d on d.id = e.trade_decision_id
                 join strategies s on s.id = d.strategy_id
-                where s.name = %s
+                where s.name = any(%s)
                   and d.alpaca_account_label = %s
                   and d.created_at >= %s
                   and d.created_at < %s
                 order by d.created_at
                 """,
-                (strategy_name, account_label, window_start, window_end),
+                (strategy_names, account_label, window_start, window_end),
             )
             executions = [row[0] for row in cur.fetchall() if row[0] is not None]
             cur.execute(
@@ -175,13 +196,13 @@ def _query_timestamps(
                 join executions e on e.id = t.execution_id
                 join trade_decisions d on d.id = e.trade_decision_id
                 join strategies s on s.id = d.strategy_id
-                where s.name = %s
+                where s.name = any(%s)
                   and d.alpaca_account_label = %s
                   and d.created_at >= %s
                   and d.created_at < %s
                 order by d.created_at
                 """,
-                (strategy_name, account_label, window_start, window_end),
+                (strategy_names, account_label, window_start, window_end),
             )
             tca_rows = [
                 {
@@ -206,9 +227,13 @@ def main() -> int:
         hypothesis_id=args.hypothesis_id,
         strategy_family=args.strategy_family.strip() or None,
     )
+    strategy_names = _strategy_name_candidates(
+        args.strategy_name,
+        getattr(manifest, "strategy_id", None),
+    )
     decisions, executions, tca_rows = _query_timestamps(
         dsn=source_dsn,
-        strategy_name=args.strategy_name,
+        strategy_names=strategy_names,
         account_label=args.account_label,
         window_start=window_start,
         window_end=window_end,
@@ -263,6 +288,7 @@ def main() -> int:
         "source_kind": source_kind,
         "source_manifest_ref": args.source_manifest_ref.strip() or None,
         "strategy_name": args.strategy_name,
+        "strategy_name_candidates": strategy_names,
         "account_label": args.account_label,
         "window_start": window_start.isoformat(),
         "window_end": window_end.isoformat(),

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -8,9 +8,10 @@ import json
 import os
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, time, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
+from zoneinfo import ZoneInfo
 
 import yaml
 from sqlalchemy import select
@@ -25,6 +26,10 @@ from app.trading.empirical_manifest import (
     normalize_empirical_promotion_manifest,
     validate_empirical_promotion_manifest,
 )
+
+US_EQUITIES_TIMEZONE = "America/New_York"
+US_EQUITIES_OPEN = time(9, 30)
+US_EQUITIES_CLOSE = time(16, 0)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -41,6 +46,34 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--run-id-prefix", default="sim-2026-05-05-chip-4c330ce9-r1-renew"
+    )
+    parser.add_argument("--runtime-window-import", action="store_true")
+    parser.add_argument("--runtime-window-hypothesis-id", default="H-PAIRS-01")
+    parser.add_argument(
+        "--runtime-window-strategy-family",
+        default="microbar_cross_sectional_pairs",
+    )
+    parser.add_argument(
+        "--runtime-window-strategy-name",
+        default="microbar-cross-sectional-pairs-v1",
+    )
+    parser.add_argument("--runtime-window-account-label", default="TORGHUT_SIM")
+    parser.add_argument(
+        "--runtime-window-observed-stage",
+        default="paper",
+        choices=("paper", "live"),
+    )
+    parser.add_argument("--runtime-window-source-dsn-env", default="DB_DSN")
+    parser.add_argument("--runtime-window-start", default="")
+    parser.add_argument("--runtime-window-end", default="")
+    parser.add_argument("--runtime-window-bucket-minutes", type=int, default=30)
+    parser.add_argument("--runtime-window-sample-minutes", type=int, default=5)
+    parser.add_argument(
+        "--runtime-window-source-manifest-ref",
+        default="config/trading/hypotheses/h-pairs-01.json",
+    )
+    parser.add_argument(
+        "--runtime-window-source-kind", default="paper_runtime_observed"
     )
     parser.add_argument("--json", action="store_true")
     return parser.parse_args()
@@ -68,6 +101,49 @@ def _runtime_version_ref() -> str:
     if digest and digest.startswith("sha256:"):
         return f"services/torghut@{digest}"
     return digest or "services/torghut@unknown"
+
+
+def _utc_iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_dt(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _latest_completed_regular_session(now: datetime) -> tuple[datetime, datetime]:
+    zone = ZoneInfo(US_EQUITIES_TIMEZONE)
+    local_now = now.astimezone(zone)
+    session_date = local_now.date()
+    if (
+        local_now.weekday() >= 5
+        or local_now.timetz().replace(tzinfo=None) < US_EQUITIES_CLOSE
+    ):
+        session_date -= timedelta(days=1)
+    while session_date.weekday() >= 5:
+        session_date -= timedelta(days=1)
+    start = datetime.combine(session_date, US_EQUITIES_OPEN, tzinfo=zone)
+    end = datetime.combine(session_date, US_EQUITIES_CLOSE, tzinfo=zone)
+    return start.astimezone(timezone.utc), end.astimezone(timezone.utc)
+
+
+def _runtime_window_bounds(
+    args: argparse.Namespace, now: datetime
+) -> tuple[datetime, datetime]:
+    start_arg = str(getattr(args, "runtime_window_start", "") or "").strip()
+    end_arg = str(getattr(args, "runtime_window_end", "") or "").strip()
+    if bool(start_arg) != bool(end_arg):
+        raise RuntimeError("runtime_window_bounds_require_start_and_end")
+    if start_arg and end_arg:
+        start = _parse_dt(start_arg)
+        end = _parse_dt(end_arg)
+        if end <= start:
+            raise RuntimeError("runtime_window_end_must_be_after_start")
+        return start, end
+    return _latest_completed_regular_session(now)
 
 
 def _latest_authoritative_rows(
@@ -184,6 +260,78 @@ def build_renewal_manifest(
     return manifest
 
 
+def _run_runtime_window_import(
+    *,
+    args: argparse.Namespace,
+    manifest: Mapping[str, Any],
+    run_id: str,
+    manifest_path: Path,
+    now: datetime,
+) -> dict[str, Any] | None:
+    if not bool(getattr(args, "runtime_window_import", False)):
+        return None
+    candidate_id = _as_text(manifest.get("candidate_id"))
+    if candidate_id is None:
+        raise RuntimeError("runtime_window_candidate_id_missing")
+    window_start, window_end = _runtime_window_bounds(args, now)
+    command = [
+        sys.executable,
+        "scripts/import_hypothesis_runtime_windows.py",
+        "--run-id",
+        run_id,
+        "--candidate-id",
+        candidate_id,
+        "--hypothesis-id",
+        args.runtime_window_hypothesis_id,
+        "--observed-stage",
+        args.runtime_window_observed_stage,
+        "--strategy-family",
+        args.runtime_window_strategy_family,
+        "--source-dsn-env",
+        args.runtime_window_source_dsn_env,
+        "--strategy-name",
+        args.runtime_window_strategy_name,
+        "--account-label",
+        args.runtime_window_account_label,
+        "--window-start",
+        _utc_iso(window_start),
+        "--window-end",
+        _utc_iso(window_end),
+        "--bucket-minutes",
+        str(args.runtime_window_bucket_minutes),
+        "--sample-minutes",
+        str(args.runtime_window_sample_minutes),
+        "--source-manifest-ref",
+        args.runtime_window_source_manifest_ref,
+        "--source-kind",
+        args.runtime_window_source_kind,
+        "--artifact-ref",
+        str(manifest_path),
+        "--dependency-quorum-decision",
+        "allow",
+        "--continuity-ok",
+        "true",
+        "--drift-ok",
+        "true",
+        "--json",
+    ]
+    dataset_snapshot_ref = _as_text(manifest.get("dataset_snapshot_ref"))
+    if dataset_snapshot_ref is not None:
+        command.extend(["--dataset-snapshot-ref", dataset_snapshot_ref])
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    payload = json.loads(result.stdout)
+    return {
+        "status": "ok",
+        "command": " ".join(command[:2] + ["..."]),
+        "window_start": _utc_iso(window_start),
+        "window_end": _utc_iso(window_end),
+        "hypothesis_id": args.runtime_window_hypothesis_id,
+        "strategy_name": args.runtime_window_strategy_name,
+        "account_label": args.runtime_window_account_label,
+        "summary": payload,
+    }
+
+
 def main() -> int:
     args = _parse_args()
     now = datetime.now(tz=timezone.utc)
@@ -222,12 +370,20 @@ def main() -> int:
         "--json",
     ]
     result = subprocess.run(command, check=True, capture_output=True, text=True)
+    runtime_window_import = _run_runtime_window_import(
+        args=args,
+        manifest=manifest,
+        run_id=run_id,
+        manifest_path=manifest_path,
+        now=now,
+    )
     payload = {
         "status": "ok",
         "run_id": run_id,
         "manifest_path": str(manifest_path),
         "output_dir": str(output_dir),
         "empirical_promotion": json.loads(result.stdout),
+        "runtime_window_import": runtime_window_import,
     }
     print(
         json.dumps(payload, separators=(",", ":"))

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -48,14 +48,15 @@ def _parse_args() -> argparse.Namespace:
         "--run-id-prefix", default="sim-2026-05-05-chip-4c330ce9-r1-renew"
     )
     parser.add_argument("--runtime-window-import", action="store_true")
-    parser.add_argument("--runtime-window-hypothesis-id", default="H-PAIRS-01")
+    parser.add_argument("--runtime-window-hypothesis-id", default="H-TSMOM-01")
+    parser.add_argument("--runtime-window-candidate-id", default="")
     parser.add_argument(
         "--runtime-window-strategy-family",
-        default="microbar_cross_sectional_pairs",
+        default="intraday_tsmom_consistent",
     )
     parser.add_argument(
         "--runtime-window-strategy-name",
-        default="microbar-cross-sectional-pairs-v1",
+        default="intraday-tsmom-profit-v3",
     )
     parser.add_argument("--runtime-window-account-label", default="TORGHUT_SIM")
     parser.add_argument(
@@ -66,11 +67,12 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--runtime-window-source-dsn-env", default="DB_DSN")
     parser.add_argument("--runtime-window-start", default="")
     parser.add_argument("--runtime-window-end", default="")
+    parser.add_argument("--runtime-window-dataset-snapshot-ref", default="")
     parser.add_argument("--runtime-window-bucket-minutes", type=int, default=30)
     parser.add_argument("--runtime-window-sample-minutes", type=int, default=5)
     parser.add_argument(
         "--runtime-window-source-manifest-ref",
-        default="config/trading/hypotheses/h-pairs-01.json",
+        default="config/trading/hypotheses/h-tsmom-01.json",
     )
     parser.add_argument(
         "--runtime-window-source-kind", default="paper_runtime_observed"
@@ -112,6 +114,20 @@ def _parse_dt(value: str) -> datetime:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
+
+
+def _read_runtime_window_manifest(ref: str) -> dict[str, Any]:
+    path_text = ref.strip()
+    if not path_text:
+        return {}
+    path = Path(path_text)
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return _as_dict(payload)
 
 
 def _latest_completed_regular_session(now: datetime) -> tuple[datetime, datetime]:
@@ -270,7 +286,14 @@ def _run_runtime_window_import(
 ) -> dict[str, Any] | None:
     if not bool(getattr(args, "runtime_window_import", False)):
         return None
-    candidate_id = _as_text(manifest.get("candidate_id"))
+    runtime_manifest = _read_runtime_window_manifest(
+        str(getattr(args, "runtime_window_source_manifest_ref", "") or "")
+    )
+    candidate_id = (
+        _as_text(getattr(args, "runtime_window_candidate_id", ""))
+        or _as_text(runtime_manifest.get("candidate_id"))
+        or _as_text(manifest.get("candidate_id"))
+    )
     if candidate_id is None:
         raise RuntimeError("runtime_window_candidate_id_missing")
     window_start, window_end = _runtime_window_bounds(args, now)
@@ -315,7 +338,11 @@ def _run_runtime_window_import(
         "true",
         "--json",
     ]
-    dataset_snapshot_ref = _as_text(manifest.get("dataset_snapshot_ref"))
+    dataset_snapshot_ref = (
+        _as_text(getattr(args, "runtime_window_dataset_snapshot_ref", ""))
+        or _as_text(runtime_manifest.get("dataset_snapshot_ref"))
+        or _as_text(manifest.get("dataset_snapshot_ref"))
+    )
     if dataset_snapshot_ref is not None:
         command.extend(["--dataset-snapshot-ref", dataset_snapshot_ref])
     result = subprocess.run(command, check=True, capture_output=True, text=True)

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -571,9 +571,9 @@ class TestHypothesisReadiness(TestCase):
                 message="ok",
             ),
         )
-        self.assertEqual(summary["reason_totals"]["slippage_budget_exceeded"], 3)
+        self.assertEqual(summary["reason_totals"]["slippage_budget_exceeded"], 4)
         self.assertEqual(
-            summary["informational_reason_totals"]["closed_session_signal_hold"], 3
+            summary["informational_reason_totals"]["closed_session_signal_hold"], 4
         )
 
     def test_compile_hypothesis_runtime_statuses_isolates_dependency_capabilities_between_hypotheses(
@@ -754,9 +754,9 @@ class TestHypothesisReadiness(TestCase):
             ),
         )
 
-        self.assertEqual(summary["hypotheses_total"], 3)
-        self.assertEqual(summary["state_totals"], {"blocked": 1, "shadow": 2})
-        self.assertEqual(summary["capital_stage_totals"], {"shadow": 3})
+        self.assertEqual(summary["hypotheses_total"], 4)
+        self.assertEqual(summary["state_totals"], {"blocked": 2, "shadow": 2})
+        self.assertEqual(summary["capital_stage_totals"], {"shadow": 4})
         self.assertEqual(summary["promotion_eligible_total"], 0)
         self.assertEqual(summary["rollback_required_total"], 0)
         self.assertEqual(

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -571,9 +571,9 @@ class TestHypothesisReadiness(TestCase):
                 message="ok",
             ),
         )
-        self.assertEqual(summary["reason_totals"]["slippage_budget_exceeded"], 4)
+        self.assertEqual(summary["reason_totals"]["slippage_budget_exceeded"], 5)
         self.assertEqual(
-            summary["informational_reason_totals"]["closed_session_signal_hold"], 4
+            summary["informational_reason_totals"]["closed_session_signal_hold"], 5
         )
 
     def test_compile_hypothesis_runtime_statuses_isolates_dependency_capabilities_between_hypotheses(
@@ -754,9 +754,9 @@ class TestHypothesisReadiness(TestCase):
             ),
         )
 
-        self.assertEqual(summary["hypotheses_total"], 4)
-        self.assertEqual(summary["state_totals"], {"blocked": 2, "shadow": 2})
-        self.assertEqual(summary["capital_stage_totals"], {"shadow": 4})
+        self.assertEqual(summary["hypotheses_total"], 5)
+        self.assertEqual(summary["state_totals"], {"blocked": 3, "shadow": 2})
+        self.assertEqual(summary["capital_stage_totals"], {"shadow": 5})
         self.assertEqual(summary["promotion_eligible_total"], 0)
         self.assertEqual(summary["rollback_required_total"], 0)
         self.assertEqual(

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -13,6 +13,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _load_report_post_cost_expectancy_bps,
     _parse_args,
     _query_timestamps,
+    _strategy_name_candidates,
     main,
 )
 
@@ -118,7 +119,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
 
         with (
-            patch("scripts.import_hypothesis_runtime_windows._parse_args", return_value=args),
+            patch(
+                "scripts.import_hypothesis_runtime_windows._parse_args",
+                return_value=args,
+            ),
             patch.dict("os.environ", {}, clear=True),
         ):
             with self.assertRaisesRegex(RuntimeError, "source_dsn_not_configured"):
@@ -136,6 +140,22 @@ class TestImportHypothesisRuntimeWindows(TestCase):
 
         self.assertEqual(value, Decimal("3.306984755680006238084907933"))
 
+    def test_strategy_name_candidates_include_catalog_aliases(self) -> None:
+        candidates = _strategy_name_candidates(
+            "microbar_volume_continuation_long_top2_chip_v1@paper",
+            "microbar-volume-continuation-long-top2-chip-v1",
+        )
+
+        self.assertEqual(
+            candidates,
+            [
+                "microbar_volume_continuation_long_top2_chip_v1@paper",
+                "microbar_volume_continuation_long_top2_chip_v1",
+                "microbar-volume-continuation-long-top2-chip-v1@paper",
+                "microbar-volume-continuation-long-top2-chip-v1",
+            ],
+        )
+
     def test_query_timestamps_filters_to_execution_eligible_decisions(self) -> None:
         cursor = _FakeCursor()
         connection = _FakeConnection(cursor)
@@ -148,7 +168,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         ):
             decisions, executions, tca_rows = _query_timestamps(
                 dsn="postgresql://example",
-                strategy_name="intraday-tsmom-profit-v2",
+                strategy_names=["intraday_tsmom_v1@paper", "intraday-tsmom-profit-v2"],
                 account_label="TORGHUT_SIM",
                 window_start=window_start,
                 window_end=window_end,
@@ -163,7 +183,12 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(tca_rows[0]["post_cost_expectancy_bps"], Decimal("0.50"))
         self.assertEqual(len(cursor.executed), 3)
         decision_query, decision_params = cursor.executed[0]
+        self.assertIn("s.name = any(%s)", decision_query)
         self.assertIn("d.status = any(%s)", decision_query)
+        self.assertEqual(
+            decision_params[0],
+            ["intraday_tsmom_v1@paper", "intraday-tsmom-profit-v2"],
+        )
         self.assertEqual(
             decision_params[2],
             list(EXECUTION_ELIGIBLE_DECISION_STATUSES),
@@ -208,6 +233,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         fake_session = _FakeSession()
         manifest = SimpleNamespace(
             strategy_family="intraday_continuation",
+            strategy_id="intraday_tsmom_v1@paper",
             max_allowed_slippage_bps=Decimal("12"),
         )
 
@@ -254,3 +280,13 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             "runtime_observation_payload"
         ]
         self.assertEqual(runtime_payload["dataset_snapshot_ref"], None)
+        self.assertEqual(
+            runtime_payload["strategy_name_candidates"],
+            [
+                "intraday-tsmom-profit-v2",
+                "intraday_tsmom_v1@paper",
+                "intraday_tsmom_v1",
+                "intraday-tsmom-v1@paper",
+                "intraday-tsmom-v1",
+            ],
+        )

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -144,6 +144,8 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         candidates = _strategy_name_candidates(
             "microbar_volume_continuation_long_top2_chip_v1@paper",
             "microbar-volume-continuation-long-top2-chip-v1",
+            "",
+            None,
         )
 
         self.assertEqual(
@@ -155,6 +157,9 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "microbar-volume-continuation-long-top2-chip-v1",
             ],
         )
+
+    def test_strategy_name_candidates_drop_blank_values(self) -> None:
+        self.assertEqual(_strategy_name_candidates("", "   ", None), [])
 
     def test_query_timestamps_filters_to_execution_eligible_decisions(self) -> None:
         cursor = _FakeCursor()
@@ -204,6 +209,19 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIn("d.created_at < %s", tca_query)
         self.assertNotIn("e.created_at >= %s", tca_query)
         self.assertNotIn("t.computed_at >= %s", tca_query)
+
+    def test_query_timestamps_requires_strategy_name_candidates(self) -> None:
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+
+        with self.assertRaisesRegex(RuntimeError, "strategy_name_not_configured"):
+            _query_timestamps(
+                dsn="postgresql://example",
+                strategy_names=[],
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+                window_end=window_end,
+            )
 
     def test_main_preserves_registry_manifest_fallback_when_source_manifest_ref_missing(
         self,

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -361,13 +361,21 @@ class TestLiveConfigManifestContract(TestCase):
             raw_symbols = strategy.get("universe_symbols")
 
             self.assertIn("paper-only", description)
-            self.assertIn("$300/day", description)
             self.assertIsInstance(raw_symbols, list)
-            _assert_exact_quote_covered_paper_strategy_universe(
-                self,
-                cast(list[object], raw_symbols),
-                context=f"{name} universe",
-            )
+            if name == "intraday-tsmom-profit-v3":
+                self.assertIn("$500/day", description)
+                _assert_exact_live_execution_chip_universe(
+                    self,
+                    cast(list[object], raw_symbols),
+                    context=f"{name} universe",
+                )
+            else:
+                self.assertIn("$300/day", description)
+                _assert_exact_quote_covered_paper_strategy_universe(
+                    self,
+                    cast(list[object], raw_symbols),
+                    context=f"{name} universe",
+                )
             if str(strategy.get("strategy_type")) == "microbar_cross_sectional_long_v1":
                 self.assertEqual(
                     _strategy_decimal(strategy, "max_notional_per_trade"),
@@ -382,13 +390,17 @@ class TestLiveConfigManifestContract(TestCase):
                 self.assertEqual(name, "intraday-tsmom-profit-v3")
                 self.assertEqual(
                     _strategy_decimal(strategy, "max_notional_per_trade"),
-                    Decimal("50000"),
+                    Decimal("3750"),
                 )
                 self.assertEqual(
                     _strategy_decimal(strategy, "max_position_pct_equity"),
-                    Decimal("3.0"),
+                    Decimal("0.125"),
                 )
                 self.assertEqual(params.get("max_spread_bps"), "20")
+                self.assertEqual(params.get("long_stop_loss_bps"), "6")
+                self.assertEqual(params.get("short_stop_loss_bps"), "6")
+                self.assertEqual(params.get("entry_cooldown_seconds"), "1200")
+                self.assertEqual(params.get("position_isolation_mode"), "per_strategy")
             elif str(strategy.get("strategy_type")) == "breakout_continuation_long_v1":
                 self.assertEqual(name, "breakout-continuation-long-v1")
                 self.assertEqual(

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -325,11 +325,15 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                 "renew-prefix",
                 "--runtime-window-import",
                 "--runtime-window-hypothesis-id",
-                "H-PAIRS-01",
+                "H-TSMOM-01",
+                "--runtime-window-candidate-id",
+                "spec-83161ae16d17828eabcc58cc",
                 "--runtime-window-strategy-family",
-                "microbar_cross_sectional_pairs",
+                "intraday_tsmom_consistent",
                 "--runtime-window-strategy-name",
-                "microbar-cross-sectional-pairs-v1",
+                "intraday-tsmom-profit-v3",
+                "--runtime-window-dataset-snapshot-ref",
+                "portfolio-profit-autoresearch-500-v1",
                 "--json",
             ],
         ):
@@ -339,12 +343,17 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual(args.strategy_spec_ref, "strategy@paper")
         self.assertEqual(args.run_id_prefix, "renew-prefix")
         self.assertTrue(args.runtime_window_import)
-        self.assertEqual(args.runtime_window_hypothesis_id, "H-PAIRS-01")
+        self.assertEqual(args.runtime_window_hypothesis_id, "H-TSMOM-01")
         self.assertEqual(
-            args.runtime_window_strategy_family, "microbar_cross_sectional_pairs"
+            args.runtime_window_candidate_id, "spec-83161ae16d17828eabcc58cc"
         )
         self.assertEqual(
-            args.runtime_window_strategy_name, "microbar-cross-sectional-pairs-v1"
+            args.runtime_window_strategy_family, "intraday_tsmom_consistent"
+        )
+        self.assertEqual(args.runtime_window_strategy_name, "intraday-tsmom-profit-v3")
+        self.assertEqual(
+            args.runtime_window_dataset_snapshot_ref,
+            "portfolio-profit-autoresearch-500-v1",
         )
         self.assertTrue(args.json)
 
@@ -369,22 +378,34 @@ class TestRunEmpiricalPromotionJobs(TestCase):
     def test_runtime_window_import_runs_observed_paper_import(self) -> None:
         manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
         manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-tsmom-01.json"
+        hypothesis_path.write_text(
+            json.dumps(
+                {
+                    "candidate_id": "spec-83161ae16d17828eabcc58cc",
+                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                }
+            ),
+            encoding="utf-8",
+        )
         completed = SimpleNamespace(
             stdout=json.dumps({"inserted_windows": 1, "promotion_decision": "blocked"})
         )
         args = SimpleNamespace(
             runtime_window_import=True,
-            runtime_window_hypothesis_id="H-PAIRS-01",
+            runtime_window_hypothesis_id="H-TSMOM-01",
+            runtime_window_candidate_id="",
             runtime_window_observed_stage="paper",
-            runtime_window_strategy_family="microbar_cross_sectional_pairs",
+            runtime_window_strategy_family="intraday_tsmom_consistent",
             runtime_window_source_dsn_env="DB_DSN",
-            runtime_window_strategy_name="microbar-cross-sectional-pairs-v1",
+            runtime_window_strategy_name="intraday-tsmom-profit-v3",
             runtime_window_account_label="TORGHUT_SIM",
             runtime_window_start="2026-05-18T13:30:00Z",
             runtime_window_end="2026-05-18T20:00:00Z",
+            runtime_window_dataset_snapshot_ref="",
             runtime_window_bucket_minutes=30,
             runtime_window_sample_minutes=5,
-            runtime_window_source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+            runtime_window_source_manifest_ref=str(hypothesis_path),
             runtime_window_source_kind="paper_runtime_observed",
         )
 
@@ -394,8 +415,8 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             payload = renewal._run_runtime_window_import(
                 args=args,
                 manifest={
-                    "candidate_id": "spec-d74b07b2aaab8d0cfa8a4c38",
-                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                    "candidate_id": "stale-empirical-candidate",
+                    "dataset_snapshot_ref": "stale-empirical-dataset",
                 },
                 run_id="renew-1",
                 manifest_path=manifest_path,
@@ -404,15 +425,17 @@ class TestRunEmpiricalPromotionJobs(TestCase):
 
         self.assertIsNotNone(payload)
         assert payload is not None
-        self.assertEqual(payload["hypothesis_id"], "H-PAIRS-01")
+        self.assertEqual(payload["hypothesis_id"], "H-TSMOM-01")
         self.assertEqual(payload["window_start"], "2026-05-18T13:30:00Z")
         self.assertEqual(payload["window_end"], "2026-05-18T20:00:00Z")
         command = run_mock.call_args.args[0]
         self.assertIn("scripts/import_hypothesis_runtime_windows.py", command)
         self.assertIn("--candidate-id", command)
-        self.assertIn("spec-d74b07b2aaab8d0cfa8a4c38", command)
+        self.assertIn("spec-83161ae16d17828eabcc58cc", command)
+        self.assertNotIn("stale-empirical-candidate", command)
         self.assertIn("--dataset-snapshot-ref", command)
         self.assertIn("portfolio-profit-autoresearch-500-v1", command)
+        self.assertNotIn("stale-empirical-dataset", command)
 
     def test_main_writes_manifest_and_runs_empirical_promotion_job(self) -> None:
         created_at = datetime(2026, 5, 18, 8, 13, tzinfo=timezone.utc)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -323,6 +323,13 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                 "strategy@paper",
                 "--run-id-prefix",
                 "renew-prefix",
+                "--runtime-window-import",
+                "--runtime-window-hypothesis-id",
+                "H-PAIRS-01",
+                "--runtime-window-strategy-family",
+                "microbar_cross_sectional_pairs",
+                "--runtime-window-strategy-name",
+                "microbar-cross-sectional-pairs-v1",
                 "--json",
             ],
         ):
@@ -331,7 +338,81 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual(args.output_dir, "/tmp/out")
         self.assertEqual(args.strategy_spec_ref, "strategy@paper")
         self.assertEqual(args.run_id_prefix, "renew-prefix")
+        self.assertTrue(args.runtime_window_import)
+        self.assertEqual(args.runtime_window_hypothesis_id, "H-PAIRS-01")
+        self.assertEqual(
+            args.runtime_window_strategy_family, "microbar_cross_sectional_pairs"
+        )
+        self.assertEqual(
+            args.runtime_window_strategy_name, "microbar-cross-sectional-pairs-v1"
+        )
         self.assertTrue(args.json)
+
+    def test_latest_completed_regular_session_uses_prior_session_before_close(
+        self,
+    ) -> None:
+        start, end = renewal._latest_completed_regular_session(
+            datetime(2026, 5, 18, 12, 23, tzinfo=timezone.utc)
+        )
+
+        self.assertEqual(start.isoformat(), "2026-05-15T13:30:00+00:00")
+        self.assertEqual(end.isoformat(), "2026-05-15T20:00:00+00:00")
+
+    def test_latest_completed_regular_session_uses_today_after_close(self) -> None:
+        start, end = renewal._latest_completed_regular_session(
+            datetime(2026, 5, 18, 21, 23, tzinfo=timezone.utc)
+        )
+
+        self.assertEqual(start.isoformat(), "2026-05-18T13:30:00+00:00")
+        self.assertEqual(end.isoformat(), "2026-05-18T20:00:00+00:00")
+
+    def test_runtime_window_import_runs_observed_paper_import(self) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        completed = SimpleNamespace(
+            stdout=json.dumps({"inserted_windows": 1, "promotion_decision": "blocked"})
+        )
+        args = SimpleNamespace(
+            runtime_window_import=True,
+            runtime_window_hypothesis_id="H-PAIRS-01",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="microbar_cross_sectional_pairs",
+            runtime_window_source_dsn_env="DB_DSN",
+            runtime_window_strategy_name="microbar-cross-sectional-pairs-v1",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_start="2026-05-18T13:30:00Z",
+            runtime_window_end="2026-05-18T20:00:00Z",
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with patch.object(
+            renewal.subprocess, "run", return_value=completed
+        ) as run_mock:
+            payload = renewal._run_runtime_window_import(
+                args=args,
+                manifest={
+                    "candidate_id": "spec-d74b07b2aaab8d0cfa8a4c38",
+                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                },
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                now=datetime(2026, 5, 18, 21, 23, tzinfo=timezone.utc),
+            )
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertEqual(payload["hypothesis_id"], "H-PAIRS-01")
+        self.assertEqual(payload["window_start"], "2026-05-18T13:30:00Z")
+        self.assertEqual(payload["window_end"], "2026-05-18T20:00:00Z")
+        command = run_mock.call_args.args[0]
+        self.assertIn("scripts/import_hypothesis_runtime_windows.py", command)
+        self.assertIn("--candidate-id", command)
+        self.assertIn("spec-d74b07b2aaab8d0cfa8a4c38", command)
+        self.assertIn("--dataset-snapshot-ref", command)
+        self.assertIn("portfolio-profit-autoresearch-500-v1", command)
 
     def test_main_writes_manifest_and_runs_empirical_promotion_job(self) -> None:
         created_at = datetime(2026, 5, 18, 8, 13, tzinfo=timezone.utc)

--- a/services/torghut/tests/test_torghut_release_workflow_manifest_paths.py
+++ b/services/torghut/tests/test_torghut_release_workflow_manifest_paths.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RENEWAL_CRONJOB = "argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml"
+
+
+def test_release_workflow_tracks_empirical_promotion_renewal_cronjob() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/torghut-release.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert workflow.count(RENEWAL_CRONJOB) == 3
+
+
+def test_deploy_automerge_allows_empirical_promotion_renewal_cronjob() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/torghut-deploy-automerge.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert RENEWAL_CRONJOB in workflow

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -4010,7 +4010,7 @@ class TestTradingApi(TestCase):
         self.assertGreaterEqual(evaluation["metrics"]["total_reviews"], 1)
         hypotheses = payload["hypotheses"]
         self.assertTrue(hypotheses["registry_loaded"])
-        self.assertEqual(len(hypotheses["items"]), 3)
+        self.assertEqual(len(hypotheses["items"]), 5)
         self.assertEqual(hypotheses["dependency_quorum"]["decision"], "allow")
         self.assertEqual(
             hypotheses["dependency_quorum"]["reasons"],
@@ -4032,8 +4032,8 @@ class TestTradingApi(TestCase):
         self.assertIn("universe_fail_safe_blocked", control_plane_contract)
         self.assertIn("domain_telemetry_event_total", control_plane_contract)
         self.assertIn("domain_telemetry_dropped_total", control_plane_contract)
-        self.assertEqual(control_plane_contract["alpha_readiness_hypotheses_total"], 3)
-        self.assertEqual(control_plane_contract["alpha_readiness_blocked_total"], 1)
+        self.assertEqual(control_plane_contract["alpha_readiness_hypotheses_total"], 5)
+        self.assertEqual(control_plane_contract["alpha_readiness_blocked_total"], 3)
         self.assertEqual(control_plane_contract["alpha_readiness_shadow_total"], 2)
         self.assertIn(control_plane_contract["active_capital_stage"], {"shadow", None})
         self.assertIn("critical_toggle_parity", control_plane_contract)
@@ -5763,10 +5763,10 @@ class TestTradingApi(TestCase):
             "torghut.quant-producer.v1",
         )
         self.assertEqual(
-            payload["control_plane_contract"]["alpha_readiness_hypotheses_total"], 4
+            payload["control_plane_contract"]["alpha_readiness_hypotheses_total"], 5
         )
         self.assertEqual(
-            payload["control_plane_contract"]["alpha_readiness_blocked_total"], 2
+            payload["control_plane_contract"]["alpha_readiness_blocked_total"], 3
         )
         self.assertEqual(
             payload["control_plane_contract"]["alpha_readiness_shadow_total"], 2
@@ -5810,7 +5810,7 @@ class TestTradingApi(TestCase):
                 metrics_payload,
             )
             self.assertIn(
-                'torghut_trading_hypothesis_state_total{state="blocked"} 2',
+                'torghut_trading_hypothesis_state_total{state="blocked"} 3',
                 metrics_payload,
             )
             self.assertIn(
@@ -5818,11 +5818,11 @@ class TestTradingApi(TestCase):
                 metrics_payload,
             )
             self.assertIn(
-                'torghut_trading_hypothesis_capital_stage_total{stage="shadow"} 4',
+                'torghut_trading_hypothesis_capital_stage_total{stage="shadow"} 5',
                 metrics_payload,
             )
             self.assertIn(
-                "torghut_trading_alpha_readiness_hypotheses_total 4",
+                "torghut_trading_alpha_readiness_hypotheses_total 5",
                 metrics_payload,
             )
             self.assertIn("torghut_trading_llm_runtime_fallback_ratio", metrics_payload)

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -5763,10 +5763,10 @@ class TestTradingApi(TestCase):
             "torghut.quant-producer.v1",
         )
         self.assertEqual(
-            payload["control_plane_contract"]["alpha_readiness_hypotheses_total"], 3
+            payload["control_plane_contract"]["alpha_readiness_hypotheses_total"], 4
         )
         self.assertEqual(
-            payload["control_plane_contract"]["alpha_readiness_blocked_total"], 1
+            payload["control_plane_contract"]["alpha_readiness_blocked_total"], 2
         )
         self.assertEqual(
             payload["control_plane_contract"]["alpha_readiness_shadow_total"], 2
@@ -5810,7 +5810,7 @@ class TestTradingApi(TestCase):
                 metrics_payload,
             )
             self.assertIn(
-                'torghut_trading_hypothesis_state_total{state="blocked"} 1',
+                'torghut_trading_hypothesis_state_total{state="blocked"} 2',
                 metrics_payload,
             )
             self.assertIn(
@@ -5818,11 +5818,11 @@ class TestTradingApi(TestCase):
                 metrics_payload,
             )
             self.assertIn(
-                'torghut_trading_hypothesis_capital_stage_total{stage="shadow"} 3',
+                'torghut_trading_hypothesis_capital_stage_total{stage="shadow"} 4',
                 metrics_payload,
             )
             self.assertIn(
-                "torghut_trading_alpha_readiness_hypotheses_total 3",
+                "torghut_trading_alpha_readiness_hypotheses_total 4",
                 metrics_payload,
             )
             self.assertIn("torghut_trading_llm_runtime_fallback_ratio", metrics_payload)


### PR DESCRIPTION
## Summary

- Resolve runtime-window imports across manifest-style strategy ids and live catalog strategy names, including runtime manifest candidate/dataset lineage.
- Add the current top `$500/day` autoresearch candidate `H-TSMOM-01` and align `intraday-tsmom-profit-v3` paper config to its conservative bounded parameters.
- Point the empirical promotion renewal CronJob at `H-TSMOM-01` so live-paper runtime windows can be imported for the actual current best candidate.
- Keep H-PAIRS runtime evidence wiring and update hypothesis/control-plane tests for the expanded manifest registry.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_hypotheses.py tests/test_trading_api.py`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_hypotheses.py tests/test_trading_api.py`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py tests/test_hypotheses.py -q`
- `uv run --frozen pytest tests/test_trading_api.py -k "trading_status_includes_llm_evaluation or trading_metrics_includes_control_plane_contract or trading_status_and_metrics_expose_execution_advisor_counters" -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `zsh -lc 'TEST_FILES=(${(f)"$(find tests -name "test_*.py" ! -path "tests/test_run_whitepaper_autoresearch_profit_target.py" -print | sort | awk -v shard="1" -v total="4" '\''((NR - 1) % total) == shard'\'')"}); uv run --frozen pytest -n auto --dist=worksteal $TEST_FILES'`
- `zsh -lc 'TEST_FILES=(${(f)"$(find tests -name "test_*.py" ! -path "tests/test_run_whitepaper_autoresearch_profit_target.py" -print | sort | awk -v shard="2" -v total="4" '\''((NR - 1) % total) == shard'\'')"}); uv run --frozen pytest -n auto --dist=worksteal $TEST_FILES'`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
