### PR TITLE
chore(torghut): promote image a7a3f87f

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-72-gd266982a6
+              value: v0.571.1-80-ga7a3f87fc
             - name: TORGHUT_OPTIONS_COMMIT
-              value: d266982a6729d01f382118732237bcc0deae12e5
+              value: a7a3f87fc226cfdbc931591dc850885603e72b5c
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-72-gd266982a6
+              value: v0.571.1-80-ga7a3f87fc
             - name: TORGHUT_OPTIONS_COMMIT
-              value: d266982a6729d01f382118732237bcc0deae12e5
+              value: a7a3f87fc226cfdbc931591dc850885603e72b5c
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-18T07:53:56Z"
+        client.knative.dev/updateTimestamp: "2026-05-18T09:15:32Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
           ports:
             - name: http1
               containerPort: 8181
@@ -497,11 +497,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-72-gd266982a6
+              value: v0.571.1-80-ga7a3f87fc
             - name: TORGHUT_COMMIT
-              value: d266982a6729d01f382118732237bcc0deae12e5
+              value: a7a3f87fc226cfdbc931591dc850885603e72b5c
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+              value: sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-18T07:53:56Z"
+        client.knative.dev/updateTimestamp: "2026-05-18T09:15:32Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
           ports:
             - name: http1
               containerPort: 8181
@@ -318,11 +318,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-72-gd266982a6
+              value: v0.571.1-80-ga7a3f87fc
             - name: TORGHUT_COMMIT
-              value: d266982a6729d01f382118732237bcc0deae12e5
+              value: a7a3f87fc226cfdbc931591dc850885603e72b5c
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+              value: sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -111,7 +111,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:a1401e1fcedfef12e3e2bc503d007b4457857009b2072d70cfbc8147ddbf2bc4
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `a7a3f87fc226cfdbc931591dc850885603e72b5c`
- Image tag: `a7a3f87f`
- Image digest: `sha256:68a9cbbbe2fb37bb2b63c96ae33c280b60dc4e7917d104088c66edba9cacd0a0`