### PR TITLE
chore(jangar): promote image 8e8507cd

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-18T08:35:39Z
+    deploy.knative.dev/rollout: 2026-05-18T09:19:20Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:cf19c4ff@sha256:bb1e52b7e54b07b9b9fbf736cc511e0cc114c5dfebae1814fabf6a22f8e8aa29
+              value: registry.ide-newton.ts.net/lab/jangar:8e8507cd@sha256:130da83fb5c5e735797395f7cb89b29d100091b6f49e99d18d0a7178011a0b02
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: cf19c4ff6cf3ffd8c358811291bed0ee1dc2aad5
+              value: 8e8507cdacc83fadac5d61d31c135b9133ebfcc3
             - name: JANGAR_GITOPS_REVISION
-              value: cf19c4ff6cf3ffd8c358811291bed0ee1dc2aad5
+              value: 8e8507cdacc83fadac5d61d31c135b9133ebfcc3
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26022499444"
+              value: "26024561875"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:9df6b9e56ca8335e84ed86f6c8b85462b316384d25c316cf0b0244de4a68ee76
+              value: sha256:435797966b4933fac785d8a108f5c94b80167fb3b00c58ad056ecbd7f6228809
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: cf19c4ff6cf3ffd8c358811291bed0ee1dc2aad5
+              value: 8e8507cdacc83fadac5d61d31c135b9133ebfcc3
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:9df6b9e56ca8335e84ed86f6c8b85462b316384d25c316cf0b0244de4a68ee76
+              value: sha256:435797966b4933fac785d8a108f5c94b80167fb3b00c58ad056ecbd7f6228809
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: cf19c4ff
-    digest: sha256:bb1e52b7e54b07b9b9fbf736cc511e0cc114c5dfebae1814fabf6a22f8e8aa29
+    newTag: 8e8507cd
+    digest: sha256:130da83fb5c5e735797395f7cb89b29d100091b6f49e99d18d0a7178011a0b02


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `8e8507cdacc83fadac5d61d31c135b9133ebfcc3`
- Image tag: `8e8507cd`
- Image digest: `sha256:130da83fb5c5e735797395f7cb89b29d100091b6f49e99d18d0a7178011a0b02`
- Source CI run: `26024561875`
- Control-plane serving digest: `sha256:435797966b4933fac785d8a108f5c94b80167fb3b00c58ad056ecbd7f6228809`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates