### PR TITLE
refactor(agents): own http runtime scaffold

### DIFF
--- a/services/agents/package.json
+++ b/services/agents/package.json
@@ -7,6 +7,7 @@
     "./server/controller-startup-retry": "./src/server/controller-startup-retry.ts",
     "./server/env-compat": "./src/server/env-compat.ts",
     "./server/http": "./src/server/http.ts",
+    "./server/http-runtime": "./src/server/http-runtime.ts",
     "./server/kube-gateway": "./src/server/kube-gateway.ts",
     "./server/kube-types": "./src/server/kube-types.ts",
     "./server/kubernetes-bun-transport": "./src/server/kubernetes-bun-transport.ts",
@@ -32,7 +33,9 @@
     "@kubernetes/client-node": "^1.4.0",
     "@proompteng/codex": "workspace:*",
     "@proompteng/temporal-bun-sdk": "workspace:*",
+    "crossws": "^0.4.5",
     "effect": "3.21.2",
+    "h3": "2.0.1-rc.22",
     "xstate": "5.31.0"
   },
   "devDependencies": {

--- a/services/agents/src/server/http-runtime.test.ts
+++ b/services/agents/src/server/http-runtime.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('crossws/adapters/bun', () => ({
+  default: vi.fn(() => ({
+    handleUpgrade: vi.fn(async () => null),
+    websocket: {},
+  })),
+}))
+
+import { createAgentsHttpRuntime } from './http-runtime'
+
+const buildRouteRuntime = () =>
+  createAgentsHttpRuntime({
+    routeSources: {
+      './routes/v1/agent-runs/$id.ts': "export const Route = createFileRoute('/v1/agent-runs/$id')({ server: {} })",
+    },
+    routeModules: {
+      './routes/v1/agent-runs/$id.ts': async () => ({
+        Route: {
+          options: {
+            server: {
+              handlers: {
+                GET: ({ params }: { params: Record<string, string> }) =>
+                  new Response(JSON.stringify({ ok: true, id: params.id }), {
+                    headers: { 'content-type': 'application/json' },
+                  }),
+              },
+            },
+          },
+        },
+      }),
+    },
+  })
+
+describe('Agents HTTP runtime', () => {
+  it('registers TanStack-style server route modules with decoded params', async () => {
+    const runtime = await buildRouteRuntime()
+
+    const response = await runtime.handleRequest(new Request('http://agents.local/v1/agent-runs/run%201'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true, id: 'run 1' })
+  })
+
+  it('serves injected Prometheus metrics before route fallback handling', async () => {
+    const runtime = await createAgentsHttpRuntime({
+      routeSources: {},
+      routeModules: {},
+      metrics: {
+        enabled: () => true,
+        path: () => '/metrics',
+        render: vi.fn(async () => ({ ok: true as const, body: 'agents_runtime_up 1\n' })),
+      },
+    })
+
+    const response = await runtime.handleRequest(new Request('http://agents.local/metrics'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/plain')
+    await expect(response.text()).resolves.toBe('agents_runtime_up 1\n')
+  })
+})

--- a/services/agents/src/server/http-runtime.ts
+++ b/services/agents/src/server/http-runtime.ts
@@ -1,0 +1,344 @@
+import { stat } from 'node:fs/promises'
+import { isAbsolute, relative, resolve } from 'node:path'
+
+import wsAdapter from 'crossws/adapters/bun'
+import { createApp, defineEventHandler, getRouterParams, toWebHandler } from 'h3'
+
+export type AgentsServerRouteHandler = (args: {
+  request: Request
+  params: Record<string, string>
+}) => Response | Promise<Response>
+
+export type AgentsServerRouteModule = {
+  Route?: {
+    options?: {
+      server?: {
+        handlers?: Partial<Record<string, AgentsServerRouteHandler>>
+      }
+    }
+  }
+}
+
+export type AgentsServerRouteDefinition = {
+  file: string
+  routePath: string
+  handlers: Partial<Record<string, AgentsServerRouteHandler>>
+}
+
+export type AgentsHttpRuntime = {
+  handleRequest: (request: Request) => Promise<Response>
+  handleUpgrade: (
+    request: Request,
+    server: Bun.Server<unknown>,
+  ) => Promise<{ kind: 'handled' } | { kind: 'response'; response: Response } | { kind: 'skip' }>
+  websocket: Bun.WebSocketHandler<unknown>
+}
+
+export type AgentsHttpRuntimeMetrics = {
+  enabled: () => boolean
+  path: () => string
+  render: () => Promise<{ ok: true; body: string } | { ok: false; message: string }>
+}
+
+export type AgentsHttpRuntimeOptions = {
+  routeModules: Record<string, () => Promise<unknown>>
+  routeSources: Record<string, string>
+  serveClient?: boolean
+  clientOutputDirCandidates?: () => string[]
+  clientMissingMessage?: string
+  metrics?: AgentsHttpRuntimeMetrics
+}
+
+type WebSocketAdapterOptions = NonNullable<Parameters<typeof wsAdapter>[0]>
+type ResolvedWebSocketHooks = NonNullable<WebSocketAdapterOptions['hooks']>
+type WebSocketRouteProbeResponse = Response & { crossws?: ResolvedWebSocketHooks }
+type WebSocketRequest = Request & {
+  context?: Record<string, unknown> & { __agentsResolvedWebSocketHooks?: ResolvedWebSocketHooks }
+}
+
+const serverRoutePattern = /createFileRoute\(\s*(['"`])([^'"`]+)\1\s*\)/
+const serverMethods = ['DELETE', 'GET', 'PATCH', 'POST', 'PUT'] as const
+const defaultClientOutputDirCandidates = () => [resolve(process.cwd(), '.output/public')]
+
+const isWebSocketUpgradeRequest = (request: Request) => request.headers.get('upgrade')?.toLowerCase() === 'websocket'
+
+const getEventRequest = (event: { req: Request }) => event.req
+
+const normalizeRoutePath = (routePath: string) => {
+  if (routePath === '/') return '/'
+
+  const trimmed = routePath.trim()
+  const withoutTrailingSlash = trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed
+  return withoutTrailingSlash.length > 0 ? withoutTrailingSlash : '/'
+}
+
+const toH3RoutePath = (routePath: string) => {
+  const normalized = normalizeRoutePath(routePath)
+  if (normalized === '/') return '/'
+
+  return normalized
+    .split('/')
+    .map((segment) => {
+      if (!segment) return segment
+      if (segment === '$') return '**'
+      if (segment.startsWith('$')) return `:${segment.slice(1)}`
+      return segment
+    })
+    .join('/')
+}
+
+const getRegistrationPaths = (routePath: string) => {
+  const h3RoutePath = toH3RoutePath(routePath)
+  if (h3RoutePath === '/') return ['/']
+  return Array.from(new Set([h3RoutePath, `${h3RoutePath}/`]))
+}
+
+const hasRegularFile = async (path: string) => {
+  try {
+    return (await stat(path)).isFile()
+  } catch {
+    return false
+  }
+}
+
+const isPathInsideDirectory = (rootDir: string, targetPath: string) => {
+  const relativePath = relative(rootDir, targetPath)
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+}
+
+const getFirstPathSegment = (pathname: string) => pathname.split('/').find(Boolean) ?? null
+
+const getServerRouteRoots = (definitions: AgentsServerRouteDefinition[]) =>
+  new Set(
+    definitions
+      .map(({ routePath }) => getFirstPathSegment(normalizeRoutePath(routePath)))
+      .filter((segment): segment is string => segment !== null),
+  )
+
+const shouldServeClientPath = (pathname: string, serverRouteRoots: ReadonlySet<string>) => {
+  const firstSegment = getFirstPathSegment(pathname)
+  return firstSegment === null || !serverRouteRoots.has(firstSegment)
+}
+
+const getResolvedWebSocketHooks = (request: Request) =>
+  (request as WebSocketRequest).context?.__agentsResolvedWebSocketHooks
+
+const storeResolvedWebSocketHooks = (request: Request, hooks: ResolvedWebSocketHooks) => {
+  const websocketRequest = request as WebSocketRequest
+  websocketRequest.context = {
+    ...websocketRequest.context,
+    __agentsResolvedWebSocketHooks: hooks,
+  }
+}
+
+const resolveClientIndexPath = async (getClientOutputDirCandidates: () => string[]) => {
+  for (const clientDir of getClientOutputDirCandidates()) {
+    const indexPath = resolve(clientDir, 'index.html')
+    if (await hasRegularFile(indexPath)) return indexPath
+  }
+
+  return null
+}
+
+const resolveStaticFile = async (pathname: string, getClientOutputDirCandidates: () => string[]) => {
+  let decodedPath: string
+  try {
+    decodedPath = decodeURIComponent(pathname)
+  } catch {
+    return null
+  }
+
+  for (const clientDir of getClientOutputDirCandidates()) {
+    if (decodedPath === '/') {
+      const indexPath = resolve(clientDir, 'index.html')
+      if (await hasRegularFile(indexPath)) return indexPath
+      continue
+    }
+
+    const target = resolve(clientDir, `.${decodedPath}`)
+    if (!isPathInsideDirectory(clientDir, target)) continue
+    if (await hasRegularFile(target)) return target
+  }
+
+  return null
+}
+
+const serveClientResponse = async (
+  request: Request,
+  getClientOutputDirCandidates: () => string[],
+  clientMissingMessage: string,
+) => {
+  const { pathname } = new URL(request.url)
+  const staticFile = await resolveStaticFile(pathname, getClientOutputDirCandidates)
+  if (staticFile) {
+    const file = Bun.file(staticFile)
+    return new Response(file, {
+      headers: file.type ? { 'content-type': file.type } : undefined,
+    })
+  }
+
+  const indexPath = await resolveClientIndexPath(getClientOutputDirCandidates)
+  if (!indexPath) {
+    return new Response(clientMissingMessage, { status: 503 })
+  }
+
+  return new Response(Bun.file(indexPath), {
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+  })
+}
+
+const loadServerRoutes = async (
+  routeModules: AgentsHttpRuntimeOptions['routeModules'],
+  routeSources: AgentsHttpRuntimeOptions['routeSources'],
+): Promise<AgentsServerRouteDefinition[]> => {
+  const definitions: AgentsServerRouteDefinition[] = []
+
+  for (const [file, source] of Object.entries(routeSources)) {
+    if (file.includes('.test.') || file.includes('.spec.')) continue
+    if (!source.includes('server:')) continue
+
+    const load = routeModules[file]
+    if (!load) continue
+
+    const match = serverRoutePattern.exec(source)
+    const routePath = match?.[2]
+    if (!routePath) continue
+
+    const module = (await load()) as AgentsServerRouteModule
+    const handlers = module.Route?.options?.server?.handlers
+    if (!handlers || Object.keys(handlers).length === 0) continue
+
+    definitions.push({
+      file,
+      routePath,
+      handlers,
+    })
+  }
+
+  return definitions
+}
+
+const registerServerRoutes = (app: ReturnType<typeof createApp>, definitions: AgentsServerRouteDefinition[]) => {
+  for (const definition of definitions) {
+    for (const method of serverMethods) {
+      const handler = definition.handlers[method]
+      if (!handler) continue
+
+      const wrappedHandler = defineEventHandler((event) =>
+        handler({
+          request: getEventRequest(event),
+          params: getRouterParams(event, { decode: true }),
+        }),
+      )
+
+      for (const path of getRegistrationPaths(definition.routePath)) {
+        switch (method) {
+          case 'DELETE':
+            app.delete(path, wrappedHandler)
+            break
+          case 'GET':
+            app.get(path, wrappedHandler)
+            break
+          case 'PATCH':
+            app.patch(path, wrappedHandler)
+            break
+          case 'POST':
+            app.post(path, wrappedHandler)
+            break
+          case 'PUT':
+            app.put(path, wrappedHandler)
+            break
+        }
+      }
+    }
+  }
+}
+
+export const createAgentsHttpRuntime = async (options: AgentsHttpRuntimeOptions): Promise<AgentsHttpRuntime> => {
+  const app = createApp()
+  const getClientOutputDirCandidates = options.clientOutputDirCandidates ?? defaultClientOutputDirCandidates
+  const clientMissingMessage =
+    options.clientMissingMessage ?? 'Client build output missing. Run the owning service build before serving client.'
+
+  if (options.metrics) {
+    app.use(
+      defineEventHandler(async (event) => {
+        if (!options.metrics?.enabled()) return
+
+        const request = getEventRequest(event)
+        const url = new URL(request.url)
+        if (url.pathname !== options.metrics.path()) return
+
+        const rendered = await options.metrics.render()
+        if (!rendered.ok) {
+          return new Response(JSON.stringify({ ok: false, message: rendered.message }), {
+            status: 404,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+
+        return new Response(rendered.body, {
+          status: 200,
+          headers: { 'content-type': 'text/plain; version=0.0.4; charset=utf-8' },
+        })
+      }),
+    )
+  }
+
+  const serverRouteDefinitions = await loadServerRoutes(options.routeModules, options.routeSources)
+  const serverRouteRoots = getServerRouteRoots(serverRouteDefinitions)
+  registerServerRoutes(app, serverRouteDefinitions)
+
+  if (options.serveClient === true) {
+    const serveClient = defineEventHandler((event) => {
+      const request = getEventRequest(event)
+      const { pathname } = new URL(request.url)
+      if (!shouldServeClientPath(pathname, serverRouteRoots)) {
+        return new Response('Not Found', { status: 404 })
+      }
+      return serveClientResponse(request, getClientOutputDirCandidates, clientMissingMessage)
+    })
+    app.get('/**', serveClient)
+    app.head('/**', serveClient)
+  }
+
+  const handleRequest = toWebHandler(app)
+  const adapter = wsAdapter({
+    resolve: (request) => getResolvedWebSocketHooks(request) ?? {},
+  })
+
+  return {
+    handleRequest,
+    async handleUpgrade(request, server) {
+      if (!isWebSocketUpgradeRequest(request)) {
+        return { kind: 'skip' }
+      }
+
+      const upgradeProbeResponse = (await handleRequest(request)) as WebSocketRouteProbeResponse
+      const routeHooks = upgradeProbeResponse.crossws
+      if (!routeHooks) {
+        return { kind: 'response', response: upgradeProbeResponse }
+      }
+
+      storeResolvedWebSocketHooks(request, routeHooks)
+
+      const response = await adapter.handleUpgrade(request, server)
+      if (response) {
+        return { kind: 'response', response }
+      }
+
+      return { kind: 'handled' }
+    },
+    websocket: adapter.websocket,
+  }
+}
+
+export const __private = {
+  getRegistrationPaths,
+  getServerRouteRoots,
+  isPathInsideDirectory,
+  loadServerRoutes,
+  normalizeRoutePath,
+  shouldServeClientPath,
+  toH3RoutePath,
+}

--- a/services/jangar/src/server/app.ts
+++ b/services/jangar/src/server/app.ts
@@ -1,44 +1,15 @@
-import { stat } from 'node:fs/promises'
-import { isAbsolute, relative, resolve } from 'node:path'
+import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import wsAdapter from 'crossws/adapters/bun'
-import { createApp, defineEventHandler, getRouterParams, toWebHandler } from 'h3'
+
+import {
+  createAgentsHttpRuntime,
+  type AgentsHttpRuntime,
+  type AgentsHttpRuntimeOptions,
+} from '@proompteng/agents/server/http-runtime'
 
 import { getPrometheusMetricsPath, isPrometheusMetricsEnabled, renderPrometheusMetrics } from './metrics'
 
-type ServerRouteHandler = (args: { request: Request; params: Record<string, string> }) => Response | Promise<Response>
-
-type ServerRouteModule = {
-  Route?: {
-    options?: {
-      server?: {
-        handlers?: Partial<Record<string, ServerRouteHandler>>
-      }
-    }
-  }
-}
-
-type ServerRouteDefinition = {
-  file: string
-  routePath: string
-  handlers: Partial<Record<string, ServerRouteHandler>>
-}
-
-type JangarRuntime = {
-  handleRequest: (request: Request) => Promise<Response>
-  handleUpgrade: (
-    request: Request,
-    server: Bun.Server<unknown>,
-  ) => Promise<{ kind: 'handled' } | { kind: 'response'; response: Response } | { kind: 'skip' }>
-  websocket: Bun.WebSocketHandler<unknown>
-}
-
-type WebSocketAdapterOptions = NonNullable<Parameters<typeof wsAdapter>[0]>
-type ResolvedWebSocketHooks = NonNullable<WebSocketAdapterOptions['hooks']>
-type WebSocketRouteProbeResponse = Response & { crossws?: ResolvedWebSocketHooks }
-type WebSocketRequest = Request & {
-  context?: Record<string, unknown> & { __jangarResolvedWebSocketHooks?: ResolvedWebSocketHooks }
-}
+export type JangarRuntime = AgentsHttpRuntime
 
 const serverRouteModules = import.meta.glob([
   '../routes/api/**/*.{ts,tsx}',
@@ -68,50 +39,6 @@ const serverRouteSources = import.meta.glob(
   },
 ) as Record<string, string>
 
-const serverRoutePattern = /createFileRoute\(\s*(['"`])([^'"`]+)\1\s*\)/
-const serverMethods = ['DELETE', 'GET', 'PATCH', 'POST', 'PUT'] as const
-
-const isWebSocketUpgradeRequest = (request: Request) => request.headers.get('upgrade')?.toLowerCase() === 'websocket'
-
-const getEventRequest = (event: { req: Request }) => event.req
-
-const normalizeRoutePath = (routePath: string) => {
-  if (routePath === '/') return '/'
-
-  const trimmed = routePath.trim()
-  const withoutTrailingSlash = trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed
-  return withoutTrailingSlash.length > 0 ? withoutTrailingSlash : '/'
-}
-
-const toH3RoutePath = (routePath: string) => {
-  const normalized = normalizeRoutePath(routePath)
-  if (normalized === '/') return '/'
-
-  return normalized
-    .split('/')
-    .map((segment) => {
-      if (!segment) return segment
-      if (segment === '$') return '**'
-      if (segment.startsWith('$')) return `:${segment.slice(1)}`
-      return segment
-    })
-    .join('/')
-}
-
-const getRegistrationPaths = (routePath: string) => {
-  const h3RoutePath = toH3RoutePath(routePath)
-  if (h3RoutePath === '/') return ['/']
-  return Array.from(new Set([h3RoutePath, `${h3RoutePath}/`]))
-}
-
-const hasRegularFile = async (path: string) => {
-  try {
-    return (await stat(path)).isFile()
-  } catch {
-    return false
-  }
-}
-
 export const getClientOutputDirCandidates = ({
   cwd = process.cwd(),
   moduleUrl = import.meta.url,
@@ -128,222 +55,16 @@ export const getClientOutputDirCandidates = ({
     ]),
   )
 
-const isPathInsideDirectory = (rootDir: string, targetPath: string) => {
-  const relativePath = relative(rootDir, targetPath)
-  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
-}
-
-const getFirstPathSegment = (pathname: string) => pathname.split('/').find(Boolean) ?? null
-
-const getServerRouteRoots = (definitions: ServerRouteDefinition[]) =>
-  new Set(
-    definitions
-      .map(({ routePath }) => getFirstPathSegment(normalizeRoutePath(routePath)))
-      .filter((segment): segment is string => segment !== null),
-  )
-
-const shouldServeClientPath = (pathname: string, serverRouteRoots: ReadonlySet<string>) => {
-  const firstSegment = getFirstPathSegment(pathname)
-  return firstSegment === null || !serverRouteRoots.has(firstSegment)
-}
-
-const getResolvedWebSocketHooks = (request: Request) =>
-  (request as WebSocketRequest).context?.__jangarResolvedWebSocketHooks
-
-const storeResolvedWebSocketHooks = (request: Request, hooks: ResolvedWebSocketHooks) => {
-  const websocketRequest = request as WebSocketRequest
-  websocketRequest.context = {
-    ...(websocketRequest.context ?? {}),
-    __jangarResolvedWebSocketHooks: hooks,
-  }
-}
-
-const resolveClientIndexPath = async () => {
-  for (const clientDir of getClientOutputDirCandidates()) {
-    const indexPath = resolve(clientDir, 'index.html')
-    if (await hasRegularFile(indexPath)) return indexPath
-  }
-
-  return null
-}
-
-const resolveStaticFile = async (pathname: string) => {
-  let decodedPath: string
-  try {
-    decodedPath = decodeURIComponent(pathname)
-  } catch {
-    return null
-  }
-
-  for (const clientDir of getClientOutputDirCandidates()) {
-    if (decodedPath === '/') {
-      const indexPath = resolve(clientDir, 'index.html')
-      if (await hasRegularFile(indexPath)) return indexPath
-      continue
-    }
-
-    const target = resolve(clientDir, `.${decodedPath}`)
-    if (!isPathInsideDirectory(clientDir, target)) continue
-    if (await hasRegularFile(target)) return target
-  }
-
-  return null
-}
-
-const serveClientResponse = async (request: Request) => {
-  const { pathname } = new URL(request.url)
-  const staticFile = await resolveStaticFile(pathname)
-  if (staticFile) {
-    const file = Bun.file(staticFile)
-    return new Response(file, {
-      headers: file.type ? { 'content-type': file.type } : undefined,
-    })
-  }
-
-  const indexPath = await resolveClientIndexPath()
-  if (!indexPath) {
-    return new Response('Client build output missing. Run `bun run build` for services/jangar.', { status: 503 })
-  }
-
-  return new Response(Bun.file(indexPath), {
-    headers: { 'content-type': 'text/html; charset=utf-8' },
-  })
-}
-
-const loadServerRoutes = async (): Promise<ServerRouteDefinition[]> => {
-  const definitions: ServerRouteDefinition[] = []
-
-  for (const [file, source] of Object.entries(serverRouteSources)) {
-    if (file.includes('.test.') || file.includes('.spec.')) continue
-    if (!source.includes('server:')) continue
-
-    const load = serverRouteModules[file]
-    if (!load) continue
-
-    const match = serverRoutePattern.exec(source)
-    const routePath = match?.[2]
-    if (!routePath) continue
-
-    const module = (await load()) as ServerRouteModule
-    const handlers = module.Route?.options?.server?.handlers
-    if (!handlers || Object.keys(handlers).length === 0) continue
-
-    definitions.push({
-      file,
-      routePath,
-      handlers,
-    })
-  }
-
-  return definitions
-}
-
-const registerServerRoutes = (app: ReturnType<typeof createApp>, definitions: ServerRouteDefinition[]) => {
-  for (const definition of definitions) {
-    for (const method of serverMethods) {
-      const handler = definition.handlers[method]
-      if (!handler) continue
-
-      const wrappedHandler = defineEventHandler((event) =>
-        handler({
-          request: getEventRequest(event),
-          params: getRouterParams(event, { decode: true }),
-        }),
-      )
-
-      for (const path of getRegistrationPaths(definition.routePath)) {
-        switch (method) {
-          case 'DELETE':
-            app.delete(path, wrappedHandler)
-            break
-          case 'GET':
-            app.get(path, wrappedHandler)
-            break
-          case 'PATCH':
-            app.patch(path, wrappedHandler)
-            break
-          case 'POST':
-            app.post(path, wrappedHandler)
-            break
-          case 'PUT':
-            app.put(path, wrappedHandler)
-            break
-        }
-      }
-    }
-  }
-}
-
-export const createJangarRuntime = async (options: { serveClient?: boolean } = {}): Promise<JangarRuntime> => {
-  const app = createApp()
-
-  app.use(
-    defineEventHandler(async (event) => {
-      if (!isPrometheusMetricsEnabled()) return
-
-      const request = getEventRequest(event)
-      const url = new URL(request.url)
-      if (url.pathname !== getPrometheusMetricsPath()) return
-
-      const rendered = await renderPrometheusMetrics()
-      if (!rendered.ok) {
-        return new Response(JSON.stringify({ ok: false, message: rendered.message }), {
-          status: 404,
-          headers: { 'content-type': 'application/json' },
-        })
-      }
-
-      return new Response(rendered.body, {
-        status: 200,
-        headers: { 'content-type': 'text/plain; version=0.0.4; charset=utf-8' },
-      })
-    }),
-  )
-
-  const serverRouteDefinitions = await loadServerRoutes()
-  const serverRouteRoots = getServerRouteRoots(serverRouteDefinitions)
-  registerServerRoutes(app, serverRouteDefinitions)
-
-  if (options.serveClient === true) {
-    const serveClient = defineEventHandler((event) => {
-      const request = getEventRequest(event)
-      const { pathname } = new URL(request.url)
-      if (!shouldServeClientPath(pathname, serverRouteRoots)) {
-        return new Response('Not Found', { status: 404 })
-      }
-      return serveClientResponse(request)
-    })
-    app.get('/**', serveClient)
-    app.head('/**', serveClient)
-  }
-
-  const handleRequest = toWebHandler(app)
-  const adapter = wsAdapter({
-    resolve: (request) => getResolvedWebSocketHooks(request) ?? {},
-  })
-
-  return {
-    handleRequest,
-    async handleUpgrade(request, server) {
-      if (!isWebSocketUpgradeRequest(request)) {
-        return { kind: 'skip' }
-      }
-
-      const upgradeProbeResponse = (await handleRequest(request)) as WebSocketRouteProbeResponse
-      const routeHooks = upgradeProbeResponse.crossws
-      if (!routeHooks) {
-        return { kind: 'response', response: upgradeProbeResponse }
-      }
-
-      storeResolvedWebSocketHooks(request, routeHooks)
-
-      const response = await adapter.handleUpgrade(request, server)
-      if (response) {
-        return { kind: 'response', response }
-      }
-
-      return { kind: 'handled' }
+export const createJangarRuntime = async (options: { serveClient?: boolean } = {}): Promise<JangarRuntime> =>
+  createAgentsHttpRuntime({
+    routeModules: serverRouteModules as AgentsHttpRuntimeOptions['routeModules'],
+    routeSources: serverRouteSources,
+    serveClient: options.serveClient,
+    clientOutputDirCandidates: getClientOutputDirCandidates,
+    clientMissingMessage: 'Client build output missing. Run `bun run build` for services/jangar.',
+    metrics: {
+      enabled: isPrometheusMetricsEnabled,
+      path: getPrometheusMetricsPath,
+      render: renderPrometheusMetrics,
     },
-    websocket: adapter.websocket,
-  }
-}
+  })


### PR DESCRIPTION
## Summary

- Moves the generic HTTP/WebSocket route runtime from Jangar into `@proompteng/agents`.
- Leaves Jangar as the route-glob, client-build, and metrics dependency provider for current behavior.
- Adds Agents unit coverage for runtime route registration, decoded params, and injected metrics serving.

## Related Issues

None

## Testing

- `bun install --frozen-lockfile`
- `bun run --cwd services/agents test`
- `bun run --cwd services/agents tsc`
- `bun run --cwd services/agents lint`
- `bun run --cwd services/agents lint:oxlint`
- `bun run --cwd services/agents lint:oxlint:type` (existing warnings in `primitives-policy.ts`)
- `bun run --cwd services/jangar tsc`
- `bun run --cwd services/jangar lint`
- `bun run --cwd services/jangar lint:oxlint` (existing warnings outside this change)
- `bun run --cwd services/jangar test -- src/server/__tests__/app.test.ts`
- `bun run --cwd services/jangar build:server`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
