### PR TITLE
refactor(agents): own health readiness contracts

### DIFF
--- a/services/agents/package.json
+++ b/services/agents/package.json
@@ -6,6 +6,7 @@
   "exports": {
     "./server/controller-startup-retry": "./src/server/controller-startup-retry.ts",
     "./server/env-compat": "./src/server/env-compat.ts",
+    "./server/health": "./src/server/health.ts",
     "./server/http": "./src/server/http.ts",
     "./server/http-runtime": "./src/server/http-runtime.ts",
     "./server/kube-gateway": "./src/server/kube-gateway.ts",
@@ -13,6 +14,7 @@
     "./server/kubernetes-bun-transport": "./src/server/kubernetes-bun-transport.ts",
     "./server/primitives": "./src/server/primitives.ts",
     "./server/primitives-policy": "./src/server/primitives-policy.ts",
+    "./server/ready": "./src/server/ready.ts",
     "./server/runtime-identity": "./src/server/runtime-identity.ts",
     "./server/agents-controller/agent-run-reconciler": "./src/server/agents-controller/agent-run-reconciler.ts",
     "./server/agents-controller/mutable-state": "./src/server/agents-controller/mutable-state.ts",

--- a/services/agents/src/server/health.test.ts
+++ b/services/agents/src/server/health.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildAgentsHealthResponse } from './health'
+
+const readJson = async (response: Response) => (await response.json()) as Record<string, unknown>
+
+describe('buildAgentsHealthResponse', () => {
+  it('returns ok when the agents controller is disabled', async () => {
+    const response = buildAgentsHealthResponse({
+      service: 'agents',
+      agentsController: { enabled: false, crdsReady: null },
+    })
+
+    expect(response.status).toBe(200)
+    expect(await readJson(response)).toMatchObject({
+      status: 'ok',
+      service: 'agents',
+      agentsController: { enabled: false, crdsReady: null },
+    })
+  })
+
+  it('returns degraded when an enabled controller has failed CRD readiness', async () => {
+    const response = buildAgentsHealthResponse({
+      service: 'agents',
+      agentsController: { enabled: true, crdsReady: false },
+    })
+
+    expect(response.status).toBe(503)
+    expect(await readJson(response)).toMatchObject({
+      status: 'degraded',
+      service: 'agents',
+    })
+  })
+})

--- a/services/agents/src/server/health.ts
+++ b/services/agents/src/server/health.ts
@@ -1,0 +1,38 @@
+import { resolveRuntimeServiceName, type AgentsRuntimeServiceName } from './runtime-identity'
+
+export type AgentsHealthControllerState = {
+  enabled: boolean
+  crdsReady: boolean | null
+}
+
+export type AgentsHealthResponseInput = {
+  agentsController: AgentsHealthControllerState
+  service?: AgentsRuntimeServiceName
+}
+
+export type AgentsHealthHandlerDependencies = {
+  getAgentsControllerHealth: () => AgentsHealthControllerState
+  resolveServiceName?: () => AgentsRuntimeServiceName
+}
+
+export const buildAgentsHealthResponse = (input: AgentsHealthResponseInput) => {
+  const ready = input.agentsController.enabled ? input.agentsController.crdsReady !== false : true
+  const body = JSON.stringify({
+    status: ready ? 'ok' : 'degraded',
+    service: input.service ?? 'agents',
+    agentsController: input.agentsController,
+  })
+  return new Response(body, {
+    status: ready ? 200 : 503,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+export const createAgentsHealthHandler = (deps: AgentsHealthHandlerDependencies) => () =>
+  buildAgentsHealthResponse({
+    agentsController: deps.getAgentsControllerHealth(),
+    service: deps.resolveServiceName?.() ?? resolveRuntimeServiceName(),
+  })

--- a/services/agents/src/server/ready.test.ts
+++ b/services/agents/src/server/ready.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { buildAgentsRuntimeReadyResponse, type AgentsControllerHealthState } from './ready'
+
+const healthyController = (overrides: Partial<AgentsControllerHealthState> = {}): AgentsControllerHealthState => ({
+  enabled: true,
+  started: true,
+  namespaces: ['agents'],
+  crdsReady: true,
+  missingCrds: [],
+  lastCheckedAt: '2026-05-18T00:00:00.000Z',
+  agentRunIngestion: [],
+  ...overrides,
+})
+
+const readJson = async (response: Response) => (await response.json()) as Record<string, unknown>
+
+describe('buildAgentsRuntimeReadyResponse', () => {
+  it('returns the versioned agents readiness contract when controllers and leadership are ready', async () => {
+    const assessAgentRunIngestion = vi.fn(() => ({
+      namespace: 'agents',
+      lastWatchEventAt: '2026-05-18T00:00:00.000Z',
+      lastResyncAt: '2026-05-18T00:00:00.000Z',
+      untouchedRunCount: 0,
+      oldestUntouchedAgeSeconds: null,
+      status: 'healthy' as const,
+      message: 'healthy',
+      dispatchPaused: false,
+    }))
+
+    const response = buildAgentsRuntimeReadyResponse({
+      leaderElection: {
+        required: true,
+        isLeader: true,
+        lastAttemptAt: '2026-05-18T00:00:00.000Z',
+        lastError: null,
+      },
+      agentsController: healthyController(),
+      orchestrationController: healthyController({ enabled: false, started: false, crdsReady: null }),
+      supportingController: healthyController({ enabled: false, started: false, crdsReady: null }),
+      assessAgentRunIngestion,
+    })
+
+    expect(response.status).toBe(200)
+    expect(await readJson(response)).toMatchObject({
+      schemaVersion: 'agents.proompteng.ai/ready/v1',
+      status: 'ok',
+      service: 'agents',
+      httpReady: true,
+      reason_codes: [],
+      namespaces: ['agents'],
+    })
+    expect(assessAgentRunIngestion).toHaveBeenCalledWith('agents', expect.objectContaining({ enabled: true }))
+  })
+
+  it('keeps HTTP ready on a standby replica with healthy leader election', async () => {
+    const response = buildAgentsRuntimeReadyResponse({
+      leaderElection: {
+        required: true,
+        isLeader: false,
+        lastAttemptAt: '2026-05-18T00:00:00.000Z',
+        lastError: null,
+      },
+      agentsController: healthyController({ started: false }),
+      orchestrationController: healthyController({ enabled: false, started: false, crdsReady: null }),
+      supportingController: healthyController({ enabled: false, started: false, crdsReady: null }),
+      assessAgentRunIngestion: vi.fn(),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await readJson(response)).toMatchObject({
+      status: 'ok',
+      httpReady: true,
+    })
+  })
+
+  it('returns a 503 when controller CRDs are missing', async () => {
+    const response = buildAgentsRuntimeReadyResponse({
+      leaderElection: {
+        required: true,
+        isLeader: true,
+        lastAttemptAt: '2026-05-18T00:00:00.000Z',
+        lastError: null,
+      },
+      agentsController: healthyController({
+        crdsReady: false,
+        missingCrds: ['agentruns.agents.proompteng.ai'],
+      }),
+      orchestrationController: healthyController({ enabled: false, started: false, crdsReady: null }),
+      supportingController: healthyController({ enabled: false, started: false, crdsReady: null }),
+      assessAgentRunIngestion: vi.fn(() => ({
+        namespace: 'agents',
+        lastWatchEventAt: null,
+        lastResyncAt: null,
+        untouchedRunCount: 0,
+        oldestUntouchedAgeSeconds: null,
+        status: 'healthy' as const,
+        message: 'healthy',
+        dispatchPaused: false,
+      })),
+    })
+
+    expect(response.status).toBe(503)
+    expect(await readJson(response)).toMatchObject({
+      status: 'degraded',
+      httpReady: false,
+      reason_codes: ['controller_crd_check_failed', 'missing_agents_controller_crd:agentruns.agents.proompteng.ai'],
+    })
+  })
+})

--- a/services/agents/src/server/ready.ts
+++ b/services/agents/src/server/ready.ts
@@ -1,0 +1,147 @@
+export type AgentRunIngestionHealth = {
+  namespace: string
+  lastWatchEventAt: string | null
+  lastResyncAt: string | null
+  untouchedRunCount: number
+  oldestUntouchedAgeSeconds: number | null
+}
+
+export type AgentRunIngestionAssessment = AgentRunIngestionHealth & {
+  status: 'healthy' | 'degraded' | 'unknown'
+  message: string
+  dispatchPaused: boolean
+}
+
+export type AgentsControllerHealthState = {
+  enabled: boolean
+  started: boolean
+  namespaces: string[] | null
+  crdsReady: boolean | null
+  missingCrds: string[]
+  lastCheckedAt: string | null
+  agentRunIngestion?: AgentRunIngestionHealth[]
+}
+
+export type AgentsLeaderElectionStatus = {
+  required: boolean
+  isLeader: boolean
+  lastAttemptAt: string | null
+  lastError: string | null
+}
+
+export type AgentsReadyResponseInput = {
+  leaderElection: AgentsLeaderElectionStatus
+  agentsController: AgentsControllerHealthState
+  orchestrationController: AgentsControllerHealthState
+  supportingController: AgentsControllerHealthState
+  assessAgentRunIngestion: (namespace: string, health: AgentsControllerHealthState) => AgentRunIngestionAssessment
+}
+
+export type AgentsReadyHandlerDependencies = Omit<
+  AgentsReadyResponseInput,
+  'leaderElection' | 'agentsController' | 'orchestrationController' | 'supportingController'
+> & {
+  getLeaderElectionStatus: () => AgentsLeaderElectionStatus
+  getAgentsControllerHealth: () => AgentsControllerHealthState
+  getOrchestrationControllerHealth: () => AgentsControllerHealthState
+  getSupportingControllerHealth: () => AgentsControllerHealthState
+}
+
+export const uniqueStrings = (values: string[]) => [...new Set(values.filter((value) => value.length > 0))]
+
+export const isControllerHealthReady = (health: Pick<AgentsControllerHealthState, 'enabled' | 'crdsReady'>) =>
+  !health.enabled || health.crdsReady !== false
+
+export const isAgentRunIngestionReady = (
+  health: AgentsControllerHealthState,
+  assessAgentRunIngestion: AgentsReadyResponseInput['assessAgentRunIngestion'],
+) => {
+  if (!health.enabled) return true
+  if (!health.started) return false
+  const namespaces = health.namespaces?.length ? health.namespaces : ['agents']
+  return namespaces.every((namespace) => assessAgentRunIngestion(namespace, health).status !== 'degraded')
+}
+
+export const isStandbyLeaderElectionReady = (
+  leaderElection: Pick<AgentsLeaderElectionStatus, 'lastAttemptAt' | 'lastError'>,
+) => leaderElection.lastAttemptAt !== null && leaderElection.lastError === null
+
+export const buildReadinessReasonCodes = (input: {
+  controllersOk: boolean
+  leaderElectionReady: boolean
+  agentsControllerHealthy: boolean
+  memoryProviderReady?: boolean
+  servingPassportReady?: boolean
+  agentsController: Pick<AgentsControllerHealthState, 'crdsReady' | 'missingCrds'>
+  orchestrationController: Pick<AgentsControllerHealthState, 'crdsReady' | 'missingCrds'>
+  supportingController: Pick<AgentsControllerHealthState, 'crdsReady' | 'missingCrds'>
+}) =>
+  uniqueStrings([
+    ...(input.controllersOk ? [] : ['controller_crd_check_failed']),
+    ...(input.leaderElectionReady ? [] : ['leader_election_not_ready']),
+    ...(input.agentsControllerHealthy ? [] : ['agentrun_ingestion_not_ready']),
+    ...(input.memoryProviderReady === false ? ['memory_provider_blocked'] : []),
+    ...(input.servingPassportReady === false ? ['serving_passport_not_ready'] : []),
+    ...(input.agentsController.crdsReady === false
+      ? input.agentsController.missingCrds.map((name) => `missing_agents_controller_crd:${name}`)
+      : []),
+    ...(input.orchestrationController.crdsReady === false
+      ? input.orchestrationController.missingCrds.map((name) => `missing_orchestration_controller_crd:${name}`)
+      : []),
+    ...(input.supportingController.crdsReady === false
+      ? input.supportingController.missingCrds.map((name) => `missing_supporting_controller_crd:${name}`)
+      : []),
+  ])
+
+export const buildAgentsRuntimeReadyResponse = (input: AgentsReadyResponseInput) => {
+  const namespaces = input.agentsController.namespaces?.length ? input.agentsController.namespaces : ['agents']
+  const controllersOk =
+    isControllerHealthReady(input.agentsController) &&
+    isControllerHealthReady(input.orchestrationController) &&
+    isControllerHealthReady(input.supportingController)
+  const activeControllerReplica = !input.leaderElection.required || input.leaderElection.isLeader
+  const leaderElectionReady = activeControllerReplica || isStandbyLeaderElectionReady(input.leaderElection)
+  const agentsControllerHealthy = activeControllerReplica
+    ? isAgentRunIngestionReady(input.agentsController, input.assessAgentRunIngestion)
+    : leaderElectionReady
+  const httpReady = controllersOk && leaderElectionReady
+  const status = httpReady && agentsControllerHealthy ? 'ok' : 'degraded'
+  const reasonCodes = buildReadinessReasonCodes({
+    controllersOk,
+    leaderElectionReady,
+    agentsControllerHealthy,
+    agentsController: input.agentsController,
+    orchestrationController: input.orchestrationController,
+    supportingController: input.supportingController,
+  })
+
+  const body = JSON.stringify({
+    schemaVersion: 'agents.proompteng.ai/ready/v1',
+    status,
+    service: 'agents' as const,
+    httpReady,
+    reason_codes: reasonCodes,
+    namespaces,
+    leaderElection: input.leaderElection,
+    agentsController: input.agentsController,
+    orchestrationController: input.orchestrationController,
+    supportingController: input.supportingController,
+  })
+
+  return new Response(body, {
+    status: httpReady ? 200 : 503,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}
+
+export const createAgentsReadyHandler = (deps: AgentsReadyHandlerDependencies) => () =>
+  buildAgentsRuntimeReadyResponse({
+    leaderElection: deps.getLeaderElectionStatus(),
+    agentsController: deps.getAgentsControllerHealth(),
+    orchestrationController: deps.getOrchestrationControllerHealth(),
+    supportingController: deps.getSupportingControllerHealth(),
+    assessAgentRunIngestion: deps.assessAgentRunIngestion,
+  })

--- a/services/jangar/src/routes/health.tsx
+++ b/services/jangar/src/routes/health.tsx
@@ -1,26 +1,17 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { createAgentsHealthHandler } from '@proompteng/agents/server/health'
 import { resolveRuntimeServiceName } from '@proompteng/agents/server/runtime-identity'
 import { getAgentsControllerHealth } from '~/server/agents-controller'
+
+export const getHealthHandler = createAgentsHealthHandler({
+  getAgentsControllerHealth,
+  resolveServiceName: resolveRuntimeServiceName,
+})
 
 export const Route = createFileRoute('/health')({
   server: {
     handlers: {
-      GET: async () => {
-        const agentsController = getAgentsControllerHealth()
-        const ready = agentsController.enabled ? agentsController.crdsReady !== false : true
-        const body = JSON.stringify({
-          status: ready ? 'ok' : 'degraded',
-          service: resolveRuntimeServiceName(),
-          agentsController,
-        })
-        return new Response(body, {
-          status: ready ? 200 : 503,
-          headers: {
-            'content-type': 'application/json',
-            'content-length': Buffer.byteLength(body).toString(),
-          },
-        })
-      },
+      GET: getHealthHandler,
     },
   },
 })

--- a/services/jangar/src/routes/ready.tsx
+++ b/services/jangar/src/routes/ready.tsx
@@ -1,4 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
+import {
+  buildAgentsRuntimeReadyResponse,
+  isAgentRunIngestionReady,
+  isControllerHealthReady,
+  isStandbyLeaderElectionReady,
+  uniqueStrings,
+} from '@proompteng/agents/server/ready'
 import { isAgentsRuntimeService, resolveRuntimeServiceName } from '@proompteng/agents/server/runtime-identity'
 
 import type {
@@ -43,48 +50,6 @@ import type {
   DatabaseStatus,
 } from '~/server/control-plane-status-types'
 import { getWatchReliabilitySummary } from '~/server/control-plane-watch-reliability'
-
-const isControllerHealthReady = (health: ReturnType<typeof getAgentsControllerHealth>) =>
-  !health.enabled || health.crdsReady !== false
-
-const isAgentRunIngestionReady = (health: ReturnType<typeof getAgentsControllerHealth>) => {
-  if (!health.enabled) return true
-  if (!health.started) return false
-  const namespaces = health.namespaces?.length ? health.namespaces : ['agents']
-  return namespaces.every((namespace) => assessAgentRunIngestion(namespace, health).status !== 'degraded')
-}
-
-const isStandbyLeaderElectionReady = (leaderElection: ReturnType<typeof getLeaderElectionStatus>) =>
-  leaderElection.lastAttemptAt !== null && leaderElection.lastError === null
-
-const buildReadinessReasonCodes = (input: {
-  controllersOk: boolean
-  leaderElectionReady: boolean
-  agentsControllerHealthy: boolean
-  memoryProviderReady?: boolean
-  servingPassportReady?: boolean
-  agentsController: ReturnType<typeof getAgentsControllerHealth>
-  orchestrationController: ReturnType<typeof getOrchestrationControllerHealth>
-  supportingController: ReturnType<typeof getSupportingControllerHealth>
-}) =>
-  uniqueStrings([
-    ...(input.controllersOk ? [] : ['controller_crd_check_failed']),
-    ...(input.leaderElectionReady ? [] : ['leader_election_not_ready']),
-    ...(input.agentsControllerHealthy ? [] : ['agentrun_ingestion_not_ready']),
-    ...(input.memoryProviderReady === false ? ['memory_provider_blocked'] : []),
-    ...(input.servingPassportReady === false ? ['serving_passport_not_ready'] : []),
-    ...(input.agentsController.crdsReady === false
-      ? input.agentsController.missingCrds.map((name) => `missing_agents_controller_crd:${name}`)
-      : []),
-    ...(input.orchestrationController.crdsReady === false
-      ? input.orchestrationController.missingCrds.map((name) => `missing_orchestration_controller_crd:${name}`)
-      : []),
-    ...(input.supportingController.crdsReady === false
-      ? input.supportingController.missingCrds.map((name) => `missing_supporting_controller_crd:${name}`)
-      : []),
-  ])
-
-const uniqueStrings = (values: string[]) => [...new Set(values.filter((value) => value.length > 0))]
 
 const buildReadyControllerReadiness = (
   name: string,
@@ -434,55 +399,6 @@ export const Route = createFileRoute('/ready')({
   },
 })
 
-const buildAgentsRuntimeReadyResponse = (input: {
-  leaderElection: ReturnType<typeof getLeaderElectionStatus>
-  agentsController: ReturnType<typeof getAgentsControllerHealth>
-  orchestrationController: ReturnType<typeof getOrchestrationControllerHealth>
-  supportingController: ReturnType<typeof getSupportingControllerHealth>
-}) => {
-  const namespaces = input.agentsController.namespaces?.length ? input.agentsController.namespaces : ['agents']
-  const controllersOk =
-    isControllerHealthReady(input.agentsController) &&
-    isControllerHealthReady(input.orchestrationController) &&
-    isControllerHealthReady(input.supportingController)
-  const activeControllerReplica = !input.leaderElection.required || input.leaderElection.isLeader
-  const leaderElectionReady = activeControllerReplica || isStandbyLeaderElectionReady(input.leaderElection)
-  const agentsControllerHealthy = activeControllerReplica
-    ? isAgentRunIngestionReady(input.agentsController)
-    : leaderElectionReady
-  const httpReady = controllersOk && leaderElectionReady
-  const status = httpReady && agentsControllerHealthy ? 'ok' : 'degraded'
-  const reasonCodes = buildReadinessReasonCodes({
-    controllersOk,
-    leaderElectionReady,
-    agentsControllerHealthy,
-    agentsController: input.agentsController,
-    orchestrationController: input.orchestrationController,
-    supportingController: input.supportingController,
-  })
-
-  const body = JSON.stringify({
-    schemaVersion: 'agents.proompteng.ai/ready/v1',
-    status,
-    service: 'agents' as const,
-    httpReady,
-    reason_codes: reasonCodes,
-    namespaces,
-    leaderElection: input.leaderElection,
-    agentsController: input.agentsController,
-    orchestrationController: input.orchestrationController,
-    supportingController: input.supportingController,
-  })
-
-  return new Response(body, {
-    status: httpReady ? 200 : 503,
-    headers: {
-      'content-type': 'application/json',
-      'content-length': Buffer.byteLength(body).toString(),
-    },
-  })
-}
-
 export const getReadyHandler = async () => {
   const now = new Date()
   const leaderElection = getLeaderElectionStatus()
@@ -495,6 +411,7 @@ export const getReadyHandler = async () => {
       agentsController,
       orchestrationController,
       supportingController,
+      assessAgentRunIngestion,
     })
   }
   const namespaces = agentsController.namespaces?.length ? agentsController.namespaces : ['agents']
@@ -557,7 +474,7 @@ export const getReadyHandler = async () => {
   const activeControllerReplica = !leaderRequired || leaderElection.isLeader
   const leaderElectionReady = activeControllerReplica || isStandbyLeaderElectionReady(leaderElection)
   const agentsControllerHealthy = activeControllerReplica
-    ? isAgentRunIngestionReady(agentsController)
+    ? isAgentRunIngestionReady(agentsController, assessAgentRunIngestion)
     : leaderElectionReady
   const servingPassportReady =
     servingPassport !== undefined && servingPassport.decision !== 'block' && servingPassport.decision !== 'hold'


### PR DESCRIPTION
## Summary

- Add Agents-owned health and readiness response builders under `services/agents`.
- Export the new server modules from `@proompteng/agents` for runtime consumers.
- Make Jangar health/readiness routes delegate generic Agents runtime behavior to the Agents package while retaining Jangar domain readiness details.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test`
- `bun run --cwd services/agents tsc`
- `bun run --cwd services/agents lint`
- `bun run --cwd services/agents lint:oxlint`
- `bun run --cwd services/agents lint:oxlint:type`
- `bun run --cwd services/agents test -- src/server/health.test.ts src/server/ready.test.ts`
- `bun run --cwd services/jangar test -- src/routes/health.test.tsx src/routes/ready.test.ts`
- `bun run --cwd services/jangar tsc`
- `bun run --cwd services/jangar lint`
- `bun run --cwd services/jangar lint:oxlint`
- `bun run --cwd services/jangar lint:oxlint:type`
- `bun run --cwd services/jangar build:server`
- `scripts/agents/guard-extraction-boundaries.sh`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
