### PR TITLE
chore(jangar): promote image 8f244fa8

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-18T10:01:00Z
+    deploy.knative.dev/rollout: 2026-05-18T10:49:58Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:2f9c9552@sha256:d9f31232955a0bf8ae109d5bbe3baa916a9ca9ee156f54eaa9ae3cf9855f417f
+              value: registry.ide-newton.ts.net/lab/jangar:8f244fa8@sha256:453e2ab4ae6d57f9120e504293ee9bc559085a8319951ed7854140484339cc9e
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 2f9c95526ea0549fb9f690f51732caab158075e0
+              value: 8f244fa8eb8237994febbb5923d69cfc440b0d44
             - name: JANGAR_GITOPS_REVISION
-              value: 2f9c95526ea0549fb9f690f51732caab158075e0
+              value: 8f244fa8eb8237994febbb5923d69cfc440b0d44
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26026598045"
+              value: "26028749841"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:56c66c6d740ef0c73d01735c53b8bd7e334e606dab8b047e72db9996a192796e
+              value: sha256:7a3cb34f968ac01d5af283af6e641ed507f509e10e9782e72d5f5a220702a46d
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 2f9c95526ea0549fb9f690f51732caab158075e0
+              value: 8f244fa8eb8237994febbb5923d69cfc440b0d44
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:56c66c6d740ef0c73d01735c53b8bd7e334e606dab8b047e72db9996a192796e
+              value: sha256:7a3cb34f968ac01d5af283af6e641ed507f509e10e9782e72d5f5a220702a46d
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 2f9c9552
-    digest: sha256:d9f31232955a0bf8ae109d5bbe3baa916a9ca9ee156f54eaa9ae3cf9855f417f
+    newTag: 8f244fa8
+    digest: sha256:453e2ab4ae6d57f9120e504293ee9bc559085a8319951ed7854140484339cc9e


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `8f244fa8eb8237994febbb5923d69cfc440b0d44`
- Image tag: `8f244fa8`
- Image digest: `sha256:453e2ab4ae6d57f9120e504293ee9bc559085a8319951ed7854140484339cc9e`
- Source CI run: `26028749841`
- Control-plane serving digest: `sha256:7a3cb34f968ac01d5af283af6e641ed507f509e10e9782e72d5f5a220702a46d`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates