### PR TITLE
fix(torghut): import paper runtime windows from sim db

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -40,6 +40,7 @@ spec:
                     --runtime-window-strategy-name intraday-tsmom-profit-v3 \
                     --runtime-window-account-label TORGHUT_SIM \
                     --runtime-window-observed-stage paper \
+                    --runtime-window-source-dsn-env SIM_DB_DSN \
                     --runtime-window-dataset-snapshot-ref portfolio-profit-autoresearch-500-v1 \
                     --runtime-window-source-manifest-ref config/trading/hypotheses/h-tsmom-01.json \
                     --json
@@ -49,6 +50,28 @@ spec:
                     secretKeyRef:
                       name: torghut-db-app
                       key: uri
+                - name: TORGHUT_SIM_DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: host
+                - name: TORGHUT_SIM_DB_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: port
+                - name: TORGHUT_SIM_DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: username
+                - name: TORGHUT_SIM_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: password
+                - name: SIM_DB_DSN
+                  value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
                   value: sha256:7b416d274f66c879b72f550c43d8d5a905e2a6d0c8bdbc76fd124507533b1dcd
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -139,6 +139,21 @@ def _load_torghut_strategy_catalog() -> list[dict[str, object]]:
     ]
 
 
+def _load_cronjob_container(
+    relative_path: str,
+) -> tuple[Mapping[str, object], Mapping[str, object]]:
+    manifest = _load_yaml_mapping(relative_path)
+    spec = cast(Mapping[str, object], manifest.get("spec", {}))
+    job_template = cast(Mapping[str, object], spec.get("jobTemplate", {}))
+    job_spec = cast(Mapping[str, object], job_template.get("spec", {}))
+    template = cast(Mapping[str, object], job_spec.get("template", {}))
+    pod_spec = cast(Mapping[str, object], template.get("spec", {}))
+    containers = cast(list[Mapping[str, object]], pod_spec.get("containers", []))
+    if not containers:
+        raise AssertionError(f"{relative_path} missing job container")
+    return spec, containers[0]
+
+
 def _csv_symbols(value: object) -> list[str]:
     return [
         symbol.strip().upper()
@@ -705,6 +720,49 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--batch-size 250", args)
         self.assertIn("--max-batches 1", args)
         self.assertIn("--apply", args)
+
+    def test_empirical_promotion_renewal_imports_paper_windows_from_sim_db(
+        self,
+    ) -> None:
+        spec, container = _load_cronjob_container(
+            "argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml"
+        )
+
+        self.assertEqual(spec.get("schedule"), "23 8,20 * * *")
+        env = {
+            item.get("name"): item
+            for item in cast(list[Mapping[str, object]], container.get("env", []))
+        }
+        db_dsn = cast(Mapping[str, object], env["DB_DSN"])
+        db_value_from = cast(Mapping[str, object], db_dsn.get("valueFrom", {}))
+        self.assertEqual(
+            db_value_from.get("secretKeyRef"),
+            {"name": "torghut-db-app", "key": "uri"},
+        )
+        self.assertEqual(
+            env["SIM_DB_DSN"].get("value"),
+            "postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@"
+            "$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default",
+        )
+        for name, key in {
+            "TORGHUT_SIM_DB_HOST": "host",
+            "TORGHUT_SIM_DB_PORT": "port",
+            "TORGHUT_SIM_DB_USER": "username",
+            "TORGHUT_SIM_DB_PASSWORD": "password",
+        }.items():
+            value_from = cast(Mapping[str, object], env[name].get("valueFrom", {}))
+            self.assertEqual(
+                value_from.get("secretKeyRef"),
+                {"name": "torghut-db-app", "key": key},
+            )
+
+        args = "\n".join(str(item) for item in container.get("args", []))
+        self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
+        self.assertIn("--runtime-window-hypothesis-id H-TSMOM-01", args)
+        self.assertIn("--runtime-window-account-label TORGHUT_SIM", args)
+        self.assertIn("--runtime-window-observed-stage paper", args)
+        self.assertIn("--runtime-window-source-dsn-env SIM_DB_DSN", args)
+        self.assertNotIn("--runtime-window-source-dsn-env DB_DSN", args)
 
     def test_migration_job_prepares_sim_database_before_sim_upgrade(self) -> None:
         manifest = _load_yaml_mapping(

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -397,7 +397,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             runtime_window_candidate_id="",
             runtime_window_observed_stage="paper",
             runtime_window_strategy_family="intraday_tsmom_consistent",
-            runtime_window_source_dsn_env="DB_DSN",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
             runtime_window_strategy_name="intraday-tsmom-profit-v3",
             runtime_window_account_label="TORGHUT_SIM",
             runtime_window_start="2026-05-18T13:30:00Z",
@@ -433,6 +433,8 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertIn("--candidate-id", command)
         self.assertIn("spec-83161ae16d17828eabcc58cc", command)
         self.assertNotIn("stale-empirical-candidate", command)
+        self.assertIn("--source-dsn-env", command)
+        self.assertIn("SIM_DB_DSN", command)
         self.assertIn("--dataset-snapshot-ref", command)
         self.assertIn("portfolio-profit-autoresearch-500-v1", command)
         self.assertNotIn("stale-empirical-dataset", command)


### PR DESCRIPTION
## Summary

- Point the H-TSMOM paper runtime-window import at the Torghut sim database via `SIM_DB_DSN` while keeping `DB_DSN` as the governance-write database.
- Add sim database secret wiring to the empirical promotion renewal CronJob so paper decisions/executions from `torghut_sim_default` can become promotion evidence.
- Add regression coverage for the renewal command and GitOps manifest contract.

## Related Issues

None

## Testing

- `uv run --frozen ruff format services/torghut/tests/test_live_config_manifest_contract.py services/torghut/tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen ruff check services/torghut/tests/test_live_config_manifest_contract.py services/torghut/tests/test_run_empirical_promotion_jobs.py`
- `bun run lint:argocd`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
