### PR TITLE
fix(torghut): use manifest promotion thresholds

### DIFF
--- a/docs/torghut/design-system/v6/29-completion-matrix-2026-03-07.yaml
+++ b/docs/torghut/design-system/v6/29-completion-matrix-2026-03-07.yaml
@@ -170,7 +170,9 @@ gates:
   - gate_id: paper_gate_satisfied
     requirement_summary: Paper promotion must be backed by calibrated replay evidence and full benchmark coverage.
     source_design_doc_section: Promotion and Capital Stages
-    acceptance_rule: historical_market_replay plus calibrated maturity, at least 500 simulated decisions, 100 percent benchmark-family coverage, and a defined fill-price error budget are all required.
+    acceptance_rule: historical_market_replay plus calibrated maturity, policy-declared simulated-decision depth, 100 percent benchmark-family coverage, and a defined fill-price error budget are all required.
+    policy_parameters:
+      min_simulated_decisions: 500
     required_artifacts:
       - completion-trace.json
       - gates/benchmark-parity-report-v1.json
@@ -184,7 +186,7 @@ gates:
     required_cluster_resources:
       - torghut
     blocking_conditions:
-      - fewer than 500 simulated decisions are proven
+      - fewer than the policy-declared minimum simulated decisions are proven
       - benchmark-family coverage is incomplete
       - fill-price error budget is not explicitly recorded
     evidence_freshness_rule:
@@ -198,7 +200,10 @@ gates:
   - gate_id: live_canary_observed
     requirement_summary: Live canary needs observed paper-runtime evidence across enough sessions.
     source_design_doc_section: Promotion and Capital Stages
-    acceptance_rule: paper_runtime_observed, empirically_validated maturity, at least 40 market-session samples, shadow/live alignment >= 95 percent, and slippage within budget.
+    acceptance_rule: paper_runtime_observed, empirically_validated maturity, hypothesis-manifest live-canary sample depth, shadow/live alignment >= 95 percent, and slippage within budget.
+    policy_parameters:
+      threshold_source: hypothesis_manifest.min_sample_count_for_live_canary
+      fallback_min_market_session_samples: 40
     required_artifacts:
       - completion-trace.json
     required_db_queries:
@@ -221,7 +226,10 @@ gates:
   - gate_id: live_scale_observed
     requirement_summary: Scaled live requires sustained observed runtime proof across multiple sessions.
     source_design_doc_section: Promotion and Capital Stages
-    acceptance_rule: live_runtime_observed, empirically_validated maturity, at least 120 market-session samples across at least 10 sessions, positive rolling post-cost expectancy, stable slippage, and no continuity or drift failure.
+    acceptance_rule: live_runtime_observed, empirically_validated maturity, hypothesis-manifest scale-up sample depth across at least 10 sessions, positive rolling post-cost expectancy, stable slippage, and no continuity or drift failure.
+    policy_parameters:
+      threshold_source: hypothesis_manifest.min_sample_count_for_scale_up
+      fallback_min_market_session_samples: 120
     required_artifacts:
       - completion-trace.json
     required_db_queries:

--- a/services/torghut/app/trading/completion.py
+++ b/services/torghut/app/trading/completion.py
@@ -18,6 +18,7 @@ from ..models import (
     VNextEmpiricalJobRun,
 )
 from .empirical_jobs import EMPIRICAL_JOB_TYPES, build_empirical_jobs_status
+from .hypotheses import HypothesisManifest, load_hypothesis_registry
 
 
 def _runtime_matrix_path() -> Path:
@@ -109,6 +110,69 @@ def _safe_float(value: Any, *, default: float = 0.0) -> float:
             except ValueError:
                 return default
     return default
+
+
+def _gate_policy_parameters(gate_definition: Mapping[str, Any] | None) -> dict[str, Any]:
+    if gate_definition is None:
+        return {}
+    return _as_dict(gate_definition.get('policy_parameters'))
+
+
+def _policy_int(
+    policy_parameters: Mapping[str, Any],
+    key: str,
+    *,
+    default: int,
+) -> int:
+    value = _safe_int(policy_parameters.get(key), default=default)
+    return value if value > 0 else default
+
+
+def _load_hypothesis_manifests_by_id() -> dict[str, HypothesisManifest]:
+    try:
+        registry = load_hypothesis_registry(raise_on_error=True)
+    except Exception:
+        return {}
+    return {item.hypothesis_id: item for item in registry.items}
+
+
+def _candidate_hypothesis_manifests(
+    *,
+    candidate_id: str | None,
+    rows: Sequence[StrategyHypothesisMetricWindow] = (),
+) -> list[HypothesisManifest]:
+    manifests_by_id = _load_hypothesis_manifests_by_id()
+    selected: dict[str, HypothesisManifest] = {}
+    for row in rows:
+        manifest = manifests_by_id.get(row.hypothesis_id)
+        if manifest is not None:
+            selected[manifest.hypothesis_id] = manifest
+    if candidate_id:
+        for manifest in manifests_by_id.values():
+            if manifest.candidate_id == candidate_id:
+                selected[manifest.hypothesis_id] = manifest
+    return list(selected.values())
+
+
+def _manifest_runtime_session_threshold(
+    *,
+    candidate_id: str | None,
+    rows: Sequence[StrategyHypothesisMetricWindow],
+    policy_parameters: Mapping[str, Any],
+    fallback_key: str,
+    default: int,
+    manifest_attr: str,
+) -> int:
+    threshold = _policy_int(policy_parameters, fallback_key, default=default)
+    manifests = _candidate_hypothesis_manifests(candidate_id=candidate_id, rows=rows)
+    manifest_thresholds = [
+        int(value)
+        for manifest in manifests
+        if (value := getattr(manifest, manifest_attr, None)) is not None
+    ]
+    if manifest_thresholds:
+        threshold = max(threshold, max(manifest_thresholds))
+    return threshold
 
 
 def _load_yaml_mapping(path: Path) -> dict[str, Any]:
@@ -517,6 +581,7 @@ def _evaluate_paper_gate(
     empirical_gate: Mapping[str, Any],
     full_day_row: VNextCompletionGateResult | None,
     empirical_rows: Mapping[str, VNextEmpiricalJobRun],
+    gate_definition: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     if empirical_gate.get('status') != TRACE_STATUS_SATISFIED:
         return {
@@ -560,7 +625,12 @@ def _evaluate_paper_gate(
     gate_result = _as_dict(full_day_details.get('gate_result'))
     acceptance = _as_dict(gate_result.get('acceptance_snapshot'))
     trade_decisions = _safe_int(acceptance.get('trade_decisions'))
-    if trade_decisions < 500:
+    min_simulated_decisions = _policy_int(
+        _gate_policy_parameters(gate_definition),
+        'min_simulated_decisions',
+        default=500,
+    )
+    if trade_decisions < min_simulated_decisions:
         return {
             'status': TRACE_STATUS_BLOCKED,
             'blocked_reason': 'insufficient_simulated_decisions',
@@ -632,6 +702,7 @@ def _evaluate_live_canary_gate(
     *,
     paper_gate: Mapping[str, Any],
     paper_rows: Sequence[StrategyHypothesisMetricWindow],
+    gate_definition: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     if paper_gate.get('status') != TRACE_STATUS_SATISFIED:
         return {
@@ -651,7 +722,15 @@ def _evaluate_live_canary_gate(
         and (_as_text(row.evidence_maturity) == 'empirically_validated')
     ]
     summary = _window_gate_summary(qualifying)
-    if summary['market_session_count'] < 40:
+    min_market_session_samples = _manifest_runtime_session_threshold(
+        candidate_id=candidate_id,
+        rows=qualifying,
+        policy_parameters=_gate_policy_parameters(gate_definition),
+        fallback_key='fallback_min_market_session_samples',
+        default=40,
+        manifest_attr='min_sample_count_for_live_canary',
+    )
+    if summary['market_session_count'] < min_market_session_samples:
         blocked_reason = 'insufficient_paper_runtime_sessions'
     elif summary['decision_alignment_ratio'] < 0.95:
         blocked_reason = 'shadow_live_alignment_below_threshold'
@@ -680,6 +759,7 @@ def _evaluate_live_scale_gate(
     *,
     canary_gate: Mapping[str, Any],
     live_rows: Sequence[StrategyHypothesisMetricWindow],
+    gate_definition: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     if canary_gate.get('status') != TRACE_STATUS_SATISFIED:
         return {
@@ -699,7 +779,15 @@ def _evaluate_live_scale_gate(
         and (_as_text(row.evidence_maturity) == 'empirically_validated')
     ]
     summary = _window_gate_summary(qualifying)
-    if summary['market_session_count'] < 120:
+    min_market_session_samples = _manifest_runtime_session_threshold(
+        candidate_id=candidate_id,
+        rows=qualifying,
+        policy_parameters=_gate_policy_parameters(gate_definition),
+        fallback_key='fallback_min_market_session_samples',
+        default=120,
+        manifest_attr='min_sample_count_for_scale_up',
+    )
+    if summary['market_session_count'] < min_market_session_samples:
         blocked_reason = 'insufficient_live_runtime_sessions'
     elif summary['window_count'] < 10:
         blocked_reason = 'insufficient_live_runtime_windows'
@@ -830,6 +918,7 @@ def build_doc29_completion_status(
                 empirical_gate=gate_status_map.get(DOC29_EMPIRICAL_JOBS_GATE) or derived_empirical,
                 full_day_row=lineage_rows.get(DOC29_SIMULATION_FULL_DAY_GATE),
                 empirical_rows=empirical_rows,
+                gate_definition=gate_definition,
             )
             freshness_state = 'fresh' if paper['status'] == TRACE_STATUS_SATISFIED else 'blocked'
             gate_status_map[gate_id] = {
@@ -857,10 +946,12 @@ def build_doc29_completion_status(
                 ),
                 full_day_row=lineage_rows.get(DOC29_SIMULATION_FULL_DAY_GATE),
                 empirical_rows=empirical_rows,
+                gate_definition=gate_definition_by_id.get(DOC29_PAPER_GATE),
             )
             canary = _evaluate_live_canary_gate(
                 paper_gate=derived_paper,
                 paper_rows=paper_windows,
+                gate_definition=gate_definition,
             )
             gate_status_map[gate_id] = {
                 **gate_definition,
@@ -889,12 +980,15 @@ def build_doc29_completion_status(
                     ),
                     full_day_row=lineage_rows.get(DOC29_SIMULATION_FULL_DAY_GATE),
                     empirical_rows=empirical_rows,
+                    gate_definition=gate_definition_by_id.get(DOC29_PAPER_GATE),
                 ),
                 paper_rows=paper_windows,
+                gate_definition=gate_definition_by_id.get(DOC29_LIVE_CANARY_GATE),
             )
             scale = _evaluate_live_scale_gate(
                 canary_gate=derived_canary,
                 live_rows=live_windows,
+                gate_definition=gate_definition,
             )
             gate_status_map[gate_id] = {
                 **gate_definition,

--- a/services/torghut/config/completion/doc29-completion-matrix.yaml
+++ b/services/torghut/config/completion/doc29-completion-matrix.yaml
@@ -170,7 +170,9 @@ gates:
   - gate_id: paper_gate_satisfied
     requirement_summary: Paper promotion must be backed by calibrated replay evidence and full benchmark coverage.
     source_design_doc_section: Promotion and Capital Stages
-    acceptance_rule: historical_market_replay plus calibrated maturity, at least 500 simulated decisions, 100 percent benchmark-family coverage, and a defined fill-price error budget are all required.
+    acceptance_rule: historical_market_replay plus calibrated maturity, policy-declared simulated-decision depth, 100 percent benchmark-family coverage, and a defined fill-price error budget are all required.
+    policy_parameters:
+      min_simulated_decisions: 500
     required_artifacts:
       - completion-trace.json
       - gates/benchmark-parity-report-v1.json
@@ -184,7 +186,7 @@ gates:
     required_cluster_resources:
       - torghut
     blocking_conditions:
-      - fewer than 500 simulated decisions are proven
+      - fewer than the policy-declared minimum simulated decisions are proven
       - benchmark-family coverage is incomplete
       - fill-price error budget is not explicitly recorded
     evidence_freshness_rule:
@@ -198,7 +200,10 @@ gates:
   - gate_id: live_canary_observed
     requirement_summary: Live canary needs observed paper-runtime evidence across enough sessions.
     source_design_doc_section: Promotion and Capital Stages
-    acceptance_rule: paper_runtime_observed, empirically_validated maturity, at least 40 market-session samples, shadow/live alignment >= 95 percent, and slippage within budget.
+    acceptance_rule: paper_runtime_observed, empirically_validated maturity, hypothesis-manifest live-canary sample depth, shadow/live alignment >= 95 percent, and slippage within budget.
+    policy_parameters:
+      threshold_source: hypothesis_manifest.min_sample_count_for_live_canary
+      fallback_min_market_session_samples: 40
     required_artifacts:
       - completion-trace.json
     required_db_queries:
@@ -221,7 +226,10 @@ gates:
   - gate_id: live_scale_observed
     requirement_summary: Scaled live requires sustained observed runtime proof across multiple sessions.
     source_design_doc_section: Promotion and Capital Stages
-    acceptance_rule: live_runtime_observed, empirically_validated maturity, at least 120 market-session samples across at least 10 sessions, positive rolling post-cost expectancy, stable slippage, and no continuity or drift failure.
+    acceptance_rule: live_runtime_observed, empirically_validated maturity, hypothesis-manifest scale-up sample depth across at least 10 sessions, positive rolling post-cost expectancy, stable slippage, and no continuity or drift failure.
+    policy_parameters:
+      threshold_source: hypothesis_manifest.min_sample_count_for_scale_up
+      fallback_min_market_session_samples: 120
     required_artifacts:
       - completion-trace.json
     required_db_queries:

--- a/services/torghut/tests/test_completion_trace.py
+++ b/services/torghut/tests/test_completion_trace.py
@@ -632,6 +632,105 @@ class TestCompletionTrace(TestCase):
         self.assertEqual(canary_gate['status'], 'blocked')
         self.assertEqual(canary_gate['blocked_reason'], 'insufficient_paper_runtime_sessions')
 
+    def test_doc29_completion_status_uses_manifest_canary_threshold(self) -> None:
+        candidate_id = 'chip-paper-microbar-composite@execution-proof'
+        dataset_snapshot_ref = 'torghut-chip-full-day-20260505-4c330ce9-r1'
+        trace = build_completion_trace(
+            doc_id='doc29',
+            gate_ids_attempted=[DOC29_SIMULATION_FULL_DAY_GATE],
+            run_id='sim-2026-05-06-full-day',
+            dataset_snapshot_ref=dataset_snapshot_ref,
+            candidate_id=candidate_id,
+            workflow_name='torghut-historical-simulation',
+            analysis_run_names=[],
+            artifact_refs=['s3://artifacts/run-full-lifecycle-manifest.json'],
+            db_row_refs={},
+            status_snapshot={},
+            result_by_gate={
+                DOC29_SIMULATION_FULL_DAY_GATE: {
+                    'status': TRACE_STATUS_SATISFIED,
+                    'artifact_ref': 's3://artifacts/run-full-lifecycle-manifest.json',
+                    'acceptance_snapshot': {
+                        'trade_decisions': 640,
+                        'executions': 320,
+                        'execution_tca_metrics': 320,
+                        'execution_order_events': 320,
+                        'coverage_ratio': 0.99,
+                        'fill_price_error_budget_status': 'within_budget',
+                    },
+                }
+            },
+            blocked_reasons={},
+            git_revision='abc123',
+            image_digest='sha256:test',
+        )
+        paper_window_time = datetime.now(timezone.utc) - timedelta(minutes=5)
+        with self.session_local() as session:
+            persist_completion_trace(session=session, trace_payload=trace)
+            for job_type in (
+                'benchmark_parity',
+                'foundation_router_parity',
+                'janus_event_car',
+                'janus_hgrm_reward',
+            ):
+                session.add(
+                    VNextEmpiricalJobRun(
+                        run_id='empirical-1',
+                        candidate_id=candidate_id,
+                        job_name=job_type,
+                        job_type=job_type,
+                        job_run_id=f'job-{job_type}',
+                        status='completed',
+                        authority='empirical',
+                        promotion_authority_eligible=True,
+                        dataset_snapshot_ref=dataset_snapshot_ref,
+                        artifact_refs=[f's3://artifacts/{job_type}.json'],
+                        payload_json=_truthful_empirical_payload(
+                            job_run_id=f'job-{job_type}',
+                            dataset_snapshot_ref=dataset_snapshot_ref,
+                        ),
+                    )
+                )
+            session.add(
+                StrategyHypothesisMetricWindow(
+                    run_id='paper-h-micro-50',
+                    candidate_id=candidate_id,
+                    hypothesis_id='H-MICRO-01',
+                    observed_stage='paper',
+                    window_started_at=paper_window_time,
+                    window_ended_at=paper_window_time,
+                    market_session_count=50,
+                    decision_count=50,
+                    trade_count=49,
+                    order_count=49,
+                    evidence_provenance='paper_runtime_observed',
+                    evidence_maturity='empirically_validated',
+                    decision_alignment_ratio='0.98',
+                    avg_abs_slippage_bps='4.2',
+                    slippage_budget_bps='8.0',
+                    post_cost_expectancy_bps='10.5',
+                    continuity_ok=True,
+                    drift_ok=True,
+                    dependency_quorum_decision='allow',
+                    capital_stage='shadow',
+                    payload_json={},
+                )
+            )
+            session.commit()
+
+            status = build_doc29_completion_status(
+                session=session,
+                stale_after_seconds=86400,
+                current_git_revision='abc123',
+                current_image_digest='sha256:test',
+            )
+
+        paper_gate = next(item for item in status['gates'] if item['gate_id'] == DOC29_PAPER_GATE)
+        canary_gate = next(item for item in status['gates'] if item['gate_id'] == DOC29_LIVE_CANARY_GATE)
+        self.assertEqual(paper_gate['status'], 'satisfied')
+        self.assertEqual(canary_gate['status'], 'blocked')
+        self.assertEqual(canary_gate['blocked_reason'], 'insufficient_paper_runtime_sessions')
+
     def test_doc29_completion_status_blocks_stale_live_windows(self) -> None:
         trace = build_completion_trace(
             doc_id='doc29',


### PR DESCRIPTION
## Summary

- Moves doc29 completion gate sample-depth policy into the completion matrix instead of opaque code literals.
- Uses each Torghut hypothesis manifest to derive paper-canary and live-scale runtime sample thresholds.
- Adds a regression proving `H-MICRO-01` stays blocked at 50 paper runtime samples because its manifest requires 60.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_completion_trace.py -k 'manifest_canary_threshold or runtime_and_doc_completion_matrices_match or scopes_live_canary_windows_to_paper_candidate'`
- `uv run --frozen ruff check app/trading/completion.py tests/test_completion_trace.py`
- `uv run --frozen pytest tests/test_completion_trace.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
