### PR TITLE
fix(torghut): allow paper route probes for short candidates

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -596,7 +596,9 @@ class SimpleTradingPipeline(TradingPipeline):
             return None
         if not settings.trading_simple_submit_enabled:
             return None
-        if decision.action != "buy":
+        if decision.action == "sell" and not settings.trading_allow_shorts:
+            return None
+        if decision.action not in {"buy", "sell"}:
             return None
         cap = _optional_decimal(settings.trading_simple_paper_route_probe_max_notional)
         if cap is None or cap <= 0:
@@ -622,6 +624,7 @@ class SimpleTradingPipeline(TradingPipeline):
             "mode": "paper_route_acquisition",
             "max_notional": str(cap),
             "symbol": symbol,
+            "side": decision.action,
             "blocking_reasons": sorted(blocking_reasons),
             "route_repair_symbols": sorted(repair_symbols),
         }

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -2465,12 +2465,22 @@ class TestTradingPipeline(TestCase):
 
         config.settings.trading_simple_submit_enabled = True
         sell_decision = decision.model_copy(update={"action": "sell"})
+        config.settings.trading_allow_shorts = False
         self.assertIsNone(
             pipeline._paper_route_probe_context(
                 proof_floor=proof_floor,
                 decision=sell_decision,
             )
         )
+        config.settings.trading_allow_shorts = True
+        sell_probe_context = pipeline._paper_route_probe_context(
+            proof_floor=proof_floor,
+            decision=sell_decision,
+        )
+        self.assertIsNotNone(sell_probe_context)
+        assert sell_probe_context is not None
+        self.assertEqual(sell_probe_context.get("side"), "sell")
+        self.assertEqual(sell_probe_context.get("mode"), "paper_route_acquisition")
 
         config.settings.trading_simple_paper_route_probe_max_notional = 0.0
         self.assertIsNone(


### PR DESCRIPTION
## Summary

- Allows bounded paper route-acquisition probes for `sell` decisions when shorting is explicitly enabled.
- Keeps live mode unchanged and keeps paper probes blocked when `TRADING_ALLOW_SHORTS=false`.
- Records the probe side in `paper_route_probe` metadata so short-side route/TCA evidence is auditable.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_route_probe_context or bounded_paper_route_probe_for_tca_repair'`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `git diff --check`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_route_probe'`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
