### PR TITLE
fix(agents): spawn codex by absolute runner path

### DIFF
--- a/.github/workflows/agents-build-push.yml
+++ b/.github/workflows/agents-build-push.yml
@@ -56,10 +56,11 @@ jobs:
       - name: Build and push Agents images
         env:
           AGENTS_APPLY: 'false'
-          AGENTS_BUILD_RUNNER: 'false'
+          AGENTS_BUILD_RUNNER: 'true'
           AGENTS_DOCKERFILE: services/agents/Dockerfile
           AGENTS_IMAGE_TAG: ${{ steps.meta.outputs.tag }}
           AGENTS_IMAGE_PLATFORMS: linux/arm64
+          AGENTS_RUNNER_BUILD_CACHE_REF: registry.ide-newton.ts.net/lab/agents-codex-runner:buildcache
           AGENTS_BUILD_CACHE_MODE: max
           AGENTS_BUILD_NODE_OPTIONS: --max-old-space-size=4096
           AGENTS_BUILD_SOURCEMAP: '0'
@@ -67,7 +68,7 @@ jobs:
           AGENTS_BUILD_LOG_LEVEL: warn
           DOCKER_BUILD_PROVENANCE: max
           DOCKER_BUILD_SBOM: 'true'
-        run: bun run agents:deploy -- --no-apply --skip-runner
+        run: bun run agents:deploy -- --no-apply
 
       - name: Upload rendered Agents values
         uses: actions/upload-artifact@v6

--- a/packages/scripts/src/agents/__tests__/deploy-service.test.ts
+++ b/packages/scripts/src/agents/__tests__/deploy-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -38,6 +38,30 @@ describe('agents deploy-service helpers', () => {
         platforms: ['linux/arm64'],
       },
     ])
+  })
+
+  it('treats local Codex auth as optional for runner image builds', () => {
+    const previousHome = process.env.HOME
+    const dir = mkdtempSync(join(tmpdir(), 'agents-codex-auth-'))
+    try {
+      process.env.HOME = dir
+      expect(__private.resolveCodexAuthPath()).toBeUndefined()
+
+      const authDir = join(dir, '.codex')
+      const authPath = join(authDir, 'auth.json')
+      mkdirSync(authDir, { recursive: true })
+      writeFileSync(authPath, '{}\n')
+
+      expect(__private.resolveCodexAuthPath()).toBe(authPath)
+      expect(__private.resolveCodexAuthPath(authPath)).toBe(authPath)
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = previousHome
+      }
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 
   it('drops Argo CD hook resources from direct kubectl apply manifests', () => {

--- a/packages/scripts/src/agents/deploy-service.ts
+++ b/packages/scripts/src/agents/deploy-service.ts
@@ -39,7 +39,7 @@ type Options = {
   controlPlaneRepository: string
   runnerRepository: string
   runnerDockerfile: string
-  codexAuthPath: string
+  codexAuthPath?: string
   tag: string
   platforms: string[]
   buildRunner: boolean
@@ -103,6 +103,19 @@ const parsePlatforms = (value: string | undefined): string[] | undefined => {
     .map((platform) => platform.trim())
     .filter(Boolean)
   return platforms.length > 0 ? platforms : undefined
+}
+
+const resolveCodexAuthPath = (explicitPath?: string): string | undefined => {
+  if (explicitPath) {
+    const resolved = resolve(explicitPath)
+    if (!existsSync(resolved)) {
+      fatal(`Codex auth not found at explicit path ${resolved}.`)
+    }
+    return resolved
+  }
+
+  const defaultPath = resolve(process.env.HOME ?? '', '.codex/auth.json')
+  return existsSync(defaultPath) ? defaultPath : undefined
 }
 
 const parseArgs = (argv: string[]): Partial<Options> => {
@@ -226,8 +239,7 @@ const resolveOptions = (): Options => {
     'lab/agents-codex-runner'
   const runnerDockerfile =
     args.runnerDockerfile ?? process.env.AGENTS_RUNNER_DOCKERFILE ?? 'services/agents/Dockerfile.codex-runner'
-  const codexAuthPath =
-    args.codexAuthPath ?? process.env.CODEX_AUTH_PATH ?? resolve(process.env.HOME ?? '', '.codex/auth.json')
+  const codexAuthPath = resolveCodexAuthPath(args.codexAuthPath ?? process.env.CODEX_AUTH_PATH)
   const tag =
     args.tag ??
     process.env.AGENTS_IMAGE_TAG ??
@@ -608,8 +620,8 @@ const main = async () => {
   }
   const runnerPin = options.buildRunner ? undefined : readRunnerImagePin(options.valuesPath)
   if (options.buildRunner) {
-    if (!existsSync(options.codexAuthPath)) {
-      fatal(`Codex auth not found at ${options.codexAuthPath}; cannot build agents-codex-runner image.`)
+    if (!options.codexAuthPath) {
+      console.warn('Codex auth not found at ~/.codex/auth.json; runner image will rely on runtime codex-auth mount.')
     }
     await buildAndPushDockerImage({
       registry: options.registry,
@@ -674,6 +686,7 @@ export const __private = {
   parseArgs,
   parseBoolean,
   resolveOptions,
+  resolveCodexAuthPath,
   filterDirectApplyManifests,
   isArgoHookManifest,
   renderAndApply,

--- a/services/agents/Dockerfile.codex-runner
+++ b/services/agents/Dockerfile.codex-runner
@@ -14,6 +14,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     WORKSPACE=/workspace \
     WORKTREE=/workspace/lab \
     GIT_TERMINAL_PROMPT=0 \
+    AGENTS_CODEX_BINARY=/usr/local/bin/codex \
+    CODEX_BINARY=/usr/local/bin/codex \
     BUN_INSTALL=/usr/local \
     BUN_INSTALL_CACHE_DIR=/opt/bun/install/cache \
     BUN_INSTALL_CACHE_SEED_DIR=/opt/bun/install/cache
@@ -40,14 +42,16 @@ RUN set -eux; \
     && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g "@openai/codex@${CODEX_VERSION}" node-gyp \
+    && ln -sf /usr/local/bin/codex /usr/bin/codex \
     && npm cache clean --force \
     && test -x /usr/local/bin/codex \
+    && test -x /usr/bin/codex \
     && test -x /usr/local/bin/node-gyp
 
 RUN mkdir -p "$WORKSPACE" /root/.codex "$BUN_INSTALL_CACHE_DIR"
 
 RUN --mount=type=secret,id=codexauth,target=/tmp/codex_auth.json \
-    cp /tmp/codex_auth.json /root/.codex/auth.json \
+    if [ -s /tmp/codex_auth.json ]; then cp /tmp/codex_auth.json /root/.codex/auth.json; else printf '{}\n' > /root/.codex/auth.json; fi \
     && printf '%s\n' "${CODEX_AUTH_CHECKSUM}" > /root/.codex/auth.checksum
 
 COPY services/agents/scripts/codex-config-container.toml /root/.codex/config.toml

--- a/services/agents/src/runner/codex-app-server.test.ts
+++ b/services/agents/src/runner/codex-app-server.test.ts
@@ -5,7 +5,12 @@ import { tmpdir } from 'node:os'
 import type { CodexAppServerOptions, CodexAppServerTurnOptions, StreamDelta, Turn } from '@proompteng/codex'
 import { describe, expect, it } from 'vitest'
 
-import { runCodexAppServerAdapter, type CodexAppServerRunnerClient } from './codex-app-server'
+import {
+  DEFAULT_CODEX_BINARY_PATH,
+  resolveCodexBinaryPath,
+  runCodexAppServerAdapter,
+  type CodexAppServerRunnerClient,
+} from './codex-app-server'
 
 const makeStream = async function* (): AsyncGenerator<StreamDelta, Turn | null, void> {
   yield { type: 'message', delta: 'done' }
@@ -13,6 +18,15 @@ const makeStream = async function* (): AsyncGenerator<StreamDelta, Turn | null, 
 }
 
 describe('codex app-server runner adapter', () => {
+  it('uses an absolute Codex binary path by default for Bun child-process spawning', () => {
+    expect(resolveCodexBinaryPath({}, {})).toBe(DEFAULT_CODEX_BINARY_PATH)
+    expect(resolveCodexBinaryPath({}, { AGENTS_CODEX_BINARY: '/custom/agents-codex' })).toBe('/custom/agents-codex')
+    expect(resolveCodexBinaryPath({}, { CODEX_BINARY: '/custom/codex' })).toBe('/custom/codex')
+    expect(resolveCodexBinaryPath({ binaryPath: '/adapter/codex' }, { AGENTS_CODEX_BINARY: '/env/codex' })).toBe(
+      '/adapter/codex',
+    )
+  })
+
   it('maps run.json and runner adapter config into a Codex app-server turn', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'agents-codex-runner-'))
     const runPath = join(dir, 'run.json')
@@ -71,6 +85,7 @@ describe('codex app-server runner adapter', () => {
 
     expect(exitCode).toBe(0)
     expect(createdClients[0]).toMatchObject({
+      binaryPath: DEFAULT_CODEX_BINARY_PATH,
       defaultModel: 'gpt-5.5',
       defaultEffort: 'high',
       sandbox: 'danger-full-access',

--- a/services/agents/src/runner/codex-app-server.ts
+++ b/services/agents/src/runner/codex-app-server.ts
@@ -24,6 +24,8 @@ import {
 
 type AgentRunPayload = Record<string, unknown>
 
+export const DEFAULT_CODEX_BINARY_PATH = '/usr/local/bin/codex'
+
 export type CodexAppServerRunnerStatus = {
   provider: string
   adapter: 'codex-app-server'
@@ -93,6 +95,18 @@ const loadRunPayload = async (spec: AgentRunnerSpec): Promise<AgentRunPayload> =
 const nonEmptyString = (value: unknown): string | null => {
   const text = asString(value)?.trim()
   return text ? text : null
+}
+
+export const resolveCodexBinaryPath = (
+  adapter: CodexAppServerAdapterConfig,
+  env: Record<string, string | undefined> = process.env,
+): string => {
+  return (
+    nonEmptyString(adapter.binaryPath) ??
+    nonEmptyString(env.AGENTS_CODEX_BINARY) ??
+    nonEmptyString(env.CODEX_BINARY) ??
+    DEFAULT_CODEX_BINARY_PATH
+  )
 }
 
 const renderOptionalTemplate = (
@@ -221,7 +235,7 @@ export const runCodexAppServerAdapter = async (
   let errorMessage: string | undefined
 
   const clientOptions: CodexAppServerOptions = {
-    binaryPath: adapter.binaryPath,
+    binaryPath: resolveCodexBinaryPath(adapter),
     cliConfigOverrides: adapter.cliConfigOverrides,
     cwd: adapter.cwd,
     sandbox: adapter.sandbox,


### PR DESCRIPTION
## Summary

- Fixes the Agents Codex app-server runner to spawn Codex through an absolute `/usr/local/bin/codex` path, avoiding Bun child-process PATH lookup failures.
- Sets canonical `AGENTS_CODEX_BINARY` and `CODEX_BINARY` in the runner image and adds `/usr/bin/codex` compatibility symlink.
- Allows CI to build and publish the runner image without baking local Codex auth into the image; runtime auth remains mounted from `codex-auth`.
- Updates the Agents build workflow to publish the runner image instead of preserving the stale runner pin.

## Related Issues

None

## Testing

- `bun test services/agents/src/runner/codex-app-server.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts`
- `bunx oxfmt --check services/agents/src/runner/codex-app-server.ts services/agents/src/runner/codex-app-server.test.ts packages/scripts/src/agents/deploy-service.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts`
- `bun run --cwd services/agents tsc`
- `bun run --cwd services/agents test`
- `bun run --cwd services/agents lint`
- `scripts/agents/guard-extraction-boundaries.sh`
- `docker build -f services/agents/Dockerfile.codex-runner -t agents-codex-runner-binary-smoke:local .`
- `docker run --rm agents-codex-runner-binary-smoke:local sh -lc 'echo AGENTS_CODEX_BINARY=$AGENTS_CODEX_BINARY; echo CODEX_BINARY=$CODEX_BINARY; command -v codex; ls -l /usr/local/bin/codex /usr/bin/codex; codex --version'`
- `docker run --rm agents-codex-runner-binary-smoke:local bun -e "const m = await import('/app/services/agents/src/runner/codex-app-server.ts'); console.log(m.resolveCodexBinaryPath({})); const { spawn } = await import('node:child_process'); const child = spawn(m.resolveCodexBinaryPath({}), ['--version'], { stdio: 'inherit' }); child.on('exit', (code) => process.exit(code ?? 1));"`
- `bunx tsc --noEmit -p packages/scripts/tsconfig.json` fails on existing unrelated strictness errors in `packages/scripts/src/agents/setup-kubeconfig.ts`, `packages/scripts/src/jangar/**`, `packages/scripts/src/registry/prune-images.ts`, and other scripts.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
