### PR TITLE
chore(torghut): promote image e4cb1512

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-95-ga63995fa3
+              value: v0.571.1-98-ge4cb15125
             - name: TORGHUT_OPTIONS_COMMIT
-              value: a63995fa363221a036c6ba966d02c4cdc4107140
+              value: e4cb15125d02798792c8485a9dadef4f1b22e909
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-95-ga63995fa3
+              value: v0.571.1-98-ge4cb15125
             - name: TORGHUT_OPTIONS_COMMIT
-              value: a63995fa363221a036c6ba966d02c4cdc4107140
+              value: e4cb15125d02798792c8485a9dadef4f1b22e909
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -73,7 +73,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+                  value: sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-18T12:27:24Z"
+        client.knative.dev/updateTimestamp: "2026-05-18T12:48:24Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
           ports:
             - name: http1
               containerPort: 8181
@@ -497,11 +497,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-95-ga63995fa3
+              value: v0.571.1-98-ge4cb15125
             - name: TORGHUT_COMMIT
-              value: a63995fa363221a036c6ba966d02c4cdc4107140
+              value: e4cb15125d02798792c8485a9dadef4f1b22e909
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+              value: sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-18T12:27:24Z"
+        client.knative.dev/updateTimestamp: "2026-05-18T12:48:24Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
           ports:
             - name: http1
               containerPort: 8181
@@ -318,11 +318,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-95-ga63995fa3
+              value: v0.571.1-98-ge4cb15125
             - name: TORGHUT_COMMIT
-              value: a63995fa363221a036c6ba966d02c4cdc4107140
+              value: e4cb15125d02798792c8485a9dadef4f1b22e909
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+              value: sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -111,7 +111,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:93d0115fefc0f3aa47ec273d612c3f21b94beeb914eaf531549d9a5c76e3ce96
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `e4cb15125d02798792c8485a9dadef4f1b22e909`
- Image tag: `e4cb1512`
- Image digest: `sha256:51732f4cfb4e73e1479e6a7e5505853701eda56d5f66a1bd86e46d0e3aec5e20`