### PR TITLE
fix(torghut): import pairs runtime renewal windows

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -34,6 +34,8 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref intraday_tsmom_v2@research \
                     --runtime-window-import \
+                    --runtime-window-target hypothesis_id=H-TSMOM-01,candidate_id=spec-83161ae16d17828eabcc58cc,strategy_family=intraday_tsmom_consistent,strategy_name=intraday-tsmom-profit-v3,source_manifest_ref=config/trading/hypotheses/h-tsmom-01.json \
+                    --runtime-window-target hypothesis_id=H-PAIRS-01,candidate_id=spec-d74b07b2aaab8d0cfa8a4c38,strategy_family=microbar_cross_sectional_pairs,strategy_name=microbar-cross-sectional-pairs-v1,source_manifest_ref=config/trading/hypotheses/h-pairs-01.json \
                     --runtime-window-hypothesis-id H-TSMOM-01 \
                     --runtime-window-candidate-id spec-83161ae16d17828eabcc58cc \
                     --runtime-window-strategy-family intraday_tsmom_consistent \

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import sys
+from dataclasses import dataclass
 from datetime import datetime, time, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -48,6 +49,17 @@ def _parse_args() -> argparse.Namespace:
         "--run-id-prefix", default="sim-2026-05-05-chip-4c330ce9-r1-renew"
     )
     parser.add_argument("--runtime-window-import", action="store_true")
+    parser.add_argument(
+        "--runtime-window-target",
+        action="append",
+        default=[],
+        help=(
+            "Repeatable comma-separated key=value runtime import target. "
+            "Supported keys: hypothesis_id,candidate_id,strategy_family,"
+            "strategy_name,account_label,observed_stage,source_dsn_env,"
+            "dataset_snapshot_ref,source_manifest_ref,source_kind."
+        ),
+    )
     parser.add_argument("--runtime-window-hypothesis-id", default="H-TSMOM-01")
     parser.add_argument("--runtime-window-candidate-id", default="")
     parser.add_argument(
@@ -128,6 +140,98 @@ def _read_runtime_window_manifest(ref: str) -> dict[str, Any]:
     except Exception:
         return {}
     return _as_dict(payload)
+
+
+@dataclass(frozen=True)
+class RuntimeWindowImportTarget:
+    hypothesis_id: str
+    candidate_id: str
+    observed_stage: str
+    strategy_family: str
+    source_dsn_env: str
+    strategy_name: str
+    account_label: str
+    dataset_snapshot_ref: str
+    source_manifest_ref: str
+    source_kind: str
+
+
+def _parse_runtime_window_target_spec(spec: str) -> dict[str, str]:
+    text = spec.strip()
+    if not text:
+        return {}
+    if text.startswith("{"):
+        payload = json.loads(text)
+        if not isinstance(payload, Mapping):
+            raise RuntimeError("runtime_window_target_json_not_mapping")
+        return {
+            str(key).replace("-", "_"): str(value)
+            for key, value in payload.items()
+            if value is not None
+        }
+    parsed: dict[str, str] = {}
+    for part in text.split(","):
+        item = part.strip()
+        if not item:
+            continue
+        if "=" not in item:
+            raise RuntimeError(f"runtime_window_target_invalid:{item}")
+        key, value = item.split("=", 1)
+        normalized_key = key.strip().replace("-", "_")
+        normalized_value = value.strip()
+        if not normalized_key or not normalized_value:
+            raise RuntimeError(f"runtime_window_target_invalid:{item}")
+        parsed[normalized_key] = normalized_value
+    return parsed
+
+
+def _runtime_window_targets(
+    args: argparse.Namespace,
+) -> list[RuntimeWindowImportTarget]:
+    specs = [str(item) for item in getattr(args, "runtime_window_target", []) or []]
+    if not specs:
+        specs = [""]
+    targets: list[RuntimeWindowImportTarget] = []
+    for spec in specs:
+        payload = _parse_runtime_window_target_spec(spec)
+
+        def value(key: str, legacy_name: str) -> str:
+            return str(payload.get(key) or getattr(args, legacy_name, "") or "").strip()
+
+        hypothesis_id = value("hypothesis_id", "runtime_window_hypothesis_id")
+        strategy_family = value("strategy_family", "runtime_window_strategy_family")
+        strategy_name = value("strategy_name", "runtime_window_strategy_name")
+        if not hypothesis_id:
+            raise RuntimeError("runtime_window_target_hypothesis_id_missing")
+        if not strategy_family:
+            raise RuntimeError("runtime_window_target_strategy_family_missing")
+        if not strategy_name:
+            raise RuntimeError("runtime_window_target_strategy_name_missing")
+        targets.append(
+            RuntimeWindowImportTarget(
+                hypothesis_id=hypothesis_id,
+                candidate_id=value("candidate_id", "runtime_window_candidate_id"),
+                observed_stage=value("observed_stage", "runtime_window_observed_stage")
+                or "paper",
+                strategy_family=strategy_family,
+                source_dsn_env=value("source_dsn_env", "runtime_window_source_dsn_env")
+                or "DB_DSN",
+                strategy_name=strategy_name,
+                account_label=value("account_label", "runtime_window_account_label")
+                or "TORGHUT_SIM",
+                dataset_snapshot_ref=value(
+                    "dataset_snapshot_ref",
+                    "runtime_window_dataset_snapshot_ref",
+                ),
+                source_manifest_ref=value(
+                    "source_manifest_ref",
+                    "runtime_window_source_manifest_ref",
+                ),
+                source_kind=value("source_kind", "runtime_window_source_kind")
+                or "paper_runtime_observed",
+            )
+        )
+    return targets
 
 
 def _latest_completed_regular_session(now: datetime) -> tuple[datetime, datetime]:
@@ -286,17 +390,47 @@ def _run_runtime_window_import(
 ) -> dict[str, Any] | None:
     if not bool(getattr(args, "runtime_window_import", False)):
         return None
-    runtime_manifest = _read_runtime_window_manifest(
-        str(getattr(args, "runtime_window_source_manifest_ref", "") or "")
-    )
+    window_start, window_end = _runtime_window_bounds(args, now)
+    imports: list[dict[str, Any]] = []
+    for target in _runtime_window_targets(args):
+        imports.append(
+            _run_runtime_window_import_target(
+                args=args,
+                target=target,
+                manifest=manifest,
+                run_id=run_id,
+                manifest_path=manifest_path,
+                window_start=window_start,
+                window_end=window_end,
+            )
+        )
+    if len(imports) == 1:
+        return imports[0]
+    return {
+        "status": "ok",
+        "target_count": len(imports),
+        "imports": imports,
+    }
+
+
+def _run_runtime_window_import_target(
+    *,
+    args: argparse.Namespace,
+    target: RuntimeWindowImportTarget,
+    manifest: Mapping[str, Any],
+    run_id: str,
+    manifest_path: Path,
+    window_start: datetime,
+    window_end: datetime,
+) -> dict[str, Any]:
+    runtime_manifest = _read_runtime_window_manifest(target.source_manifest_ref)
     candidate_id = (
-        _as_text(getattr(args, "runtime_window_candidate_id", ""))
+        _as_text(target.candidate_id)
         or _as_text(runtime_manifest.get("candidate_id"))
         or _as_text(manifest.get("candidate_id"))
     )
     if candidate_id is None:
         raise RuntimeError("runtime_window_candidate_id_missing")
-    window_start, window_end = _runtime_window_bounds(args, now)
     command = [
         sys.executable,
         "scripts/import_hypothesis_runtime_windows.py",
@@ -305,17 +439,17 @@ def _run_runtime_window_import(
         "--candidate-id",
         candidate_id,
         "--hypothesis-id",
-        args.runtime_window_hypothesis_id,
+        target.hypothesis_id,
         "--observed-stage",
-        args.runtime_window_observed_stage,
+        target.observed_stage,
         "--strategy-family",
-        args.runtime_window_strategy_family,
+        target.strategy_family,
         "--source-dsn-env",
-        args.runtime_window_source_dsn_env,
+        target.source_dsn_env,
         "--strategy-name",
-        args.runtime_window_strategy_name,
+        target.strategy_name,
         "--account-label",
-        args.runtime_window_account_label,
+        target.account_label,
         "--window-start",
         _utc_iso(window_start),
         "--window-end",
@@ -325,9 +459,9 @@ def _run_runtime_window_import(
         "--sample-minutes",
         str(args.runtime_window_sample_minutes),
         "--source-manifest-ref",
-        args.runtime_window_source_manifest_ref,
+        target.source_manifest_ref,
         "--source-kind",
-        args.runtime_window_source_kind,
+        target.source_kind,
         "--artifact-ref",
         str(manifest_path),
         "--dependency-quorum-decision",
@@ -339,7 +473,7 @@ def _run_runtime_window_import(
         "--json",
     ]
     dataset_snapshot_ref = (
-        _as_text(getattr(args, "runtime_window_dataset_snapshot_ref", ""))
+        _as_text(target.dataset_snapshot_ref)
         or _as_text(runtime_manifest.get("dataset_snapshot_ref"))
         or _as_text(manifest.get("dataset_snapshot_ref"))
     )
@@ -352,9 +486,9 @@ def _run_runtime_window_import(
         "command": " ".join(command[:2] + ["..."]),
         "window_start": _utc_iso(window_start),
         "window_end": _utc_iso(window_end),
-        "hypothesis_id": args.runtime_window_hypothesis_id,
-        "strategy_name": args.runtime_window_strategy_name,
-        "account_label": args.runtime_window_account_label,
+        "hypothesis_id": target.hypothesis_id,
+        "strategy_name": target.strategy_name,
+        "account_label": target.account_label,
         "summary": payload,
     }
 

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -759,6 +759,22 @@ class TestLiveConfigManifestContract(TestCase):
         args = "\n".join(str(item) for item in container.get("args", []))
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn("--runtime-window-hypothesis-id H-TSMOM-01", args)
+        self.assertIn(
+            "--runtime-window-target hypothesis_id=H-TSMOM-01,"
+            "candidate_id=spec-83161ae16d17828eabcc58cc,"
+            "strategy_family=intraday_tsmom_consistent,"
+            "strategy_name=intraday-tsmom-profit-v3,"
+            "source_manifest_ref=config/trading/hypotheses/h-tsmom-01.json",
+            args,
+        )
+        self.assertIn(
+            "--runtime-window-target hypothesis_id=H-PAIRS-01,"
+            "candidate_id=spec-d74b07b2aaab8d0cfa8a4c38,"
+            "strategy_family=microbar_cross_sectional_pairs,"
+            "strategy_name=microbar-cross-sectional-pairs-v1,"
+            "source_manifest_ref=config/trading/hypotheses/h-pairs-01.json",
+            args,
+        )
         self.assertIn("--runtime-window-account-label TORGHUT_SIM", args)
         self.assertIn("--runtime-window-observed-stage paper", args)
         self.assertIn("--runtime-window-source-dsn-env SIM_DB_DSN", args)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -334,6 +334,13 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                 "intraday-tsmom-profit-v3",
                 "--runtime-window-dataset-snapshot-ref",
                 "portfolio-profit-autoresearch-500-v1",
+                "--runtime-window-target",
+                (
+                    "hypothesis_id=H-PAIRS-01,candidate_id=spec-d74b07b2aaab8d0cfa8a4c38,"
+                    "strategy_family=microbar_cross_sectional_pairs,"
+                    "strategy_name=microbar-cross-sectional-pairs-v1,"
+                    "source_manifest_ref=config/trading/hypotheses/h-pairs-01.json"
+                ),
                 "--json",
             ],
         ):
@@ -355,7 +362,74 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             args.runtime_window_dataset_snapshot_ref,
             "portfolio-profit-autoresearch-500-v1",
         )
+        self.assertEqual(len(args.runtime_window_target), 1)
+        self.assertIn("H-PAIRS-01", args.runtime_window_target[0])
         self.assertTrue(args.json)
+
+    def test_runtime_window_target_accepts_json_payload(self) -> None:
+        args = SimpleNamespace(
+            runtime_window_target=[
+                json.dumps(
+                    {
+                        "hypothesis-id": "H-PAIRS-01",
+                        "candidate_id": "spec-d74b07b2aaab8d0cfa8a4c38",
+                        "strategy_family": "microbar_cross_sectional_pairs",
+                        "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                        "optional_null": None,
+                    }
+                )
+            ],
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="portfolio-profit-autoresearch-500-v1",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        targets = renewal._runtime_window_targets(args)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].hypothesis_id, "H-PAIRS-01")
+        self.assertEqual(targets[0].strategy_family, "microbar_cross_sectional_pairs")
+        self.assertEqual(
+            targets[0].source_manifest_ref,
+            "config/trading/hypotheses/h-pairs-01.json",
+        )
+
+    def test_runtime_window_target_rejects_invalid_specs(self) -> None:
+        invalid_specs = [
+            "{}",
+            "hypothesis_id=H-PAIRS-01,strategy_name=pairs",
+            "hypothesis_id=H-PAIRS-01,strategy_family=pairs",
+            "hypothesis_id=H-PAIRS-01,bad-token",
+            "hypothesis_id=H-PAIRS-01,strategy_family=,strategy_name=pairs",
+            "[1, 2, 3]",
+        ]
+        args = SimpleNamespace(
+            runtime_window_target=[],
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="portfolio-profit-autoresearch-500-v1",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        for spec in invalid_specs:
+            with self.subTest(spec=spec):
+                args.runtime_window_target = [spec]
+                with self.assertRaises(RuntimeError):
+                    renewal._runtime_window_targets(args)
 
     def test_latest_completed_regular_session_uses_prior_session_before_close(
         self,
@@ -438,6 +512,91 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertIn("--dataset-snapshot-ref", command)
         self.assertIn("portfolio-profit-autoresearch-500-v1", command)
         self.assertNotIn("stale-empirical-dataset", command)
+
+    def test_runtime_window_import_runs_multiple_observed_paper_imports(self) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        tsmom_path = self.tmp_dir / "h-tsmom-01.json"
+        tsmom_path.write_text(
+            json.dumps(
+                {
+                    "candidate_id": "spec-83161ae16d17828eabcc58cc",
+                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                }
+            ),
+            encoding="utf-8",
+        )
+        pairs_path = self.tmp_dir / "h-pairs-01.json"
+        pairs_path.write_text(
+            json.dumps(
+                {
+                    "candidate_id": "spec-d74b07b2aaab8d0cfa8a4c38",
+                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                }
+            ),
+            encoding="utf-8",
+        )
+        completed = SimpleNamespace(
+            stdout=json.dumps({"inserted_windows": 1, "promotion_decision": "blocked"})
+        )
+        args = SimpleNamespace(
+            runtime_window_import=True,
+            runtime_window_target=[
+                (
+                    "hypothesis_id=H-TSMOM-01,candidate_id=spec-83161ae16d17828eabcc58cc,"
+                    f"strategy_family=intraday_tsmom_consistent,strategy_name=intraday-tsmom-profit-v3,"
+                    f"source_manifest_ref={tsmom_path}"
+                ),
+                (
+                    "hypothesis_id=H-PAIRS-01,candidate_id=spec-d74b07b2aaab8d0cfa8a4c38,"
+                    f"strategy_family=microbar_cross_sectional_pairs,"
+                    f"strategy_name=microbar-cross-sectional-pairs-v1,"
+                    f"source_manifest_ref={pairs_path}"
+                ),
+            ],
+            runtime_window_hypothesis_id="H-TSMOM-01",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="intraday_tsmom_consistent",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="intraday-tsmom-profit-v3",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_start="2026-05-18T13:30:00Z",
+            runtime_window_end="2026-05-18T20:00:00Z",
+            runtime_window_dataset_snapshot_ref="portfolio-profit-autoresearch-500-v1",
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_source_manifest_ref=str(tsmom_path),
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with patch.object(
+            renewal.subprocess, "run", return_value=completed
+        ) as run_mock:
+            payload = renewal._run_runtime_window_import(
+                args=args,
+                manifest={
+                    "candidate_id": "stale-empirical-candidate",
+                    "dataset_snapshot_ref": "stale-empirical-dataset",
+                },
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                now=datetime(2026, 5, 18, 21, 23, tzinfo=timezone.utc),
+            )
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertEqual(payload["target_count"], 2)
+        self.assertEqual(
+            [item["hypothesis_id"] for item in payload["imports"]],
+            ["H-TSMOM-01", "H-PAIRS-01"],
+        )
+        commands = [call.args[0] for call in run_mock.call_args_list]
+        self.assertEqual(len(commands), 2)
+        joined = "\n".join(" ".join(command) for command in commands)
+        self.assertIn("spec-83161ae16d17828eabcc58cc", joined)
+        self.assertIn("spec-d74b07b2aaab8d0cfa8a4c38", joined)
+        self.assertIn("microbar-cross-sectional-pairs-v1", joined)
 
     def test_main_writes_manifest_and_runs_empirical_promotion_job(self) -> None:
         created_at = datetime(2026, 5, 18, 8, 13, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary

- Adds repeatable `--runtime-window-target` support to the empirical promotion renewal script while preserving the existing single-target flags.
- Wires the Torghut empirical renewal CronJob to import paper runtime windows for both `H-TSMOM-01` and `H-PAIRS-01` from the sim DB.
- Extends renewal-script and live-manifest tests so the pairs lane cannot silently lose runtime lineage again.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen python -m py_compile scripts/renew_latest_empirical_promotion_jobs.py`
- `uv run --frozen python -m pytest tests/test_run_empirical_promotion_jobs.py -k 'runtime_window_import or parse_args_accepts_strategy_and_json_flag' -q`
- `uv run --frozen python -m pytest tests/test_live_config_manifest_contract.py -k 'empirical_promotion_renewal_imports_paper_windows_from_sim_db' -q`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
