### PR TITLE
fix(agents): block runs during provider capacity outages

### DIFF
--- a/services/agents/src/server/agents-controller/agent-run-reconciler.test.ts
+++ b/services/agents/src/server/agents-controller/agent-run-reconciler.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createAgentRunReconciler, resolveProviderReadinessBlock } from './agent-run-reconciler'
+import { PROVIDER_CAPACITY_EXHAUSTED_REASON } from './provider-capacity'
+import { RESOURCE_MAP } from '../kube-types'
+
+describe('agents controller agent-run reconciler', () => {
+  it('recognizes provider capacity readiness blocks', () => {
+    expect(
+      resolveProviderReadinessBlock({
+        metadata: { name: 'codex-spark' },
+        status: {
+          conditions: [
+            {
+              type: 'Ready',
+              status: 'False',
+              reason: PROVIDER_CAPACITY_EXHAUSTED_REASON,
+              message: 'provider capacity exhausted: Quota exceeded.',
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      reason: PROVIDER_CAPACITY_EXHAUSTED_REASON,
+      message: 'agent provider codex-spark is not ready: provider capacity exhausted: Quota exceeded.',
+    })
+
+    expect(
+      resolveProviderReadinessBlock({
+        metadata: { name: 'codex-spark' },
+        status: { conditions: [{ type: 'Ready', status: 'False', reason: 'MissingBinary' }] },
+      }),
+    ).toBeNull()
+  })
+
+  it('blocks a new AgentRun without submitting a Job when provider capacity is exhausted', async () => {
+    const setStatus = vi.fn(async () => undefined)
+    const submitJobRun = vi.fn()
+    const kube = {
+      patch: vi.fn(async () => ({})),
+      get: vi.fn(async (kind: string) => {
+        if (kind === RESOURCE_MAP.Agent) {
+          return {
+            metadata: { name: 'codex-agent' },
+            spec: { providerRef: { name: 'codex-spark' } },
+          }
+        }
+        if (kind === RESOURCE_MAP.AgentProvider) {
+          return {
+            metadata: { name: 'codex-spark' },
+            status: {
+              conditions: [
+                {
+                  type: 'Ready',
+                  status: 'False',
+                  reason: PROVIDER_CAPACITY_EXHAUSTED_REASON,
+                  message: 'provider capacity exhausted: Quota exceeded.',
+                },
+              ],
+            },
+          }
+        }
+        return null
+      }),
+    }
+    const reconciler = createAgentRunReconciler({
+      setStatus,
+      nowIso: () => '2026-05-18T14:00:00.000Z',
+      isKubeNotFoundError: () => false,
+      resolveJobImage: () => 'registry.example/runner:latest',
+      resolveAgentRunRetentionSeconds: () => 0,
+      getPrimitivesStore: async () => null,
+      getTemporalClient: async () => ({}),
+      reconcileWorkflowRun: vi.fn(),
+      submitJobRun,
+      submitCustomRun: vi.fn(),
+      submitTemporalRun: vi.fn(),
+      reconcileTemporalRun: vi.fn(),
+      buildConditions: () => [],
+      isAgentRunImmutabilityEnforced: () => true,
+      isAgentRunIdempotencyEnabled: () => false,
+      parseQueueLimits: () => ({ perNamespace: 0, perRepo: 0, cluster: 0 }),
+      parseRateLimits: () => ({ perNamespace: 0, perRepo: 0, cluster: 0, windowSeconds: 60 }),
+      getControllerSnapshot: () => null,
+      getControllerRateState: () => ({
+        cluster: { count: 0, resetAt: 0 },
+        perNamespace: new Map(),
+        perRepo: new Map(),
+      }),
+      validateImplementationContract: () => ({ ok: true, requiredKeys: [] }),
+      buildContractStatus: () => undefined,
+      resolveRunnerServiceAccount: () => null,
+      applyJobTtlAfterStatus: vi.fn(),
+      isJobComplete: () => false,
+      isJobFailed: () => false,
+    })
+
+    await reconciler.reconcileAgentRun(
+      kube as never,
+      {
+        metadata: { name: 'run-1', namespace: 'agents', generation: 1 },
+        spec: {
+          agentRef: { name: 'codex-agent' },
+          runtime: { type: 'job' },
+          parameters: {},
+          workload: {},
+        },
+      },
+      'agents',
+      [],
+      [],
+      {
+        perNamespace: 10,
+        perAgent: 10,
+        cluster: 10,
+        repoConcurrency: { enabled: false, defaultLimit: 0, overrides: new Map() },
+      },
+      { total: 0, perAgent: new Map(), perRepository: new Map() },
+      0,
+    )
+
+    expect(submitJobRun).not.toHaveBeenCalled()
+    expect(setStatus).toHaveBeenLastCalledWith(
+      kube,
+      expect.any(Object),
+      expect.objectContaining({
+        phase: 'Pending',
+        reason: PROVIDER_CAPACITY_EXHAUSTED_REASON,
+        message: expect.stringContaining('provider capacity exhausted'),
+      }),
+    )
+  })
+})

--- a/services/agents/src/server/agents-controller/agent-run-reconciler.ts
+++ b/services/agents/src/server/agents-controller/agent-run-reconciler.ts
@@ -8,7 +8,7 @@ import type { AgentsPrimitivesStoreRef } from './mutable-state'
 import { resolveMemory } from './namespace-state'
 import { isAgentRunTemplate, reconcileAgentRunDeletion, reconcileAgentRunTemplate } from './agent-run-template'
 import { normalizeLabelMap, validateAuthSecretPolicy, validateImagePolicy, validateLabelPolicy } from './policy'
-import { extractProviderAwareJobFailure } from './provider-capacity'
+import { extractProviderAwareJobFailure, isNonRetryableProviderFailure } from './provider-capacity'
 import {
   buildQueueCounts,
   type ControllerState,
@@ -138,6 +138,19 @@ type AgentRunReconcilerDependencies = {
       | { scope: 'repo'; repository: string; namespace: string },
   ) => void
   recordAgentRateLimitRejection?: (scope: 'cluster' | 'namespace' | 'repo', attributes: Record<string, string>) => void
+}
+
+export const resolveProviderReadinessBlock = (provider: Record<string, unknown>) => {
+  const conditions = readNested(provider, ['status', 'conditions'])
+  if (!Array.isArray(conditions)) return null
+  const ready = conditions
+    .map((condition) => asRecord(condition))
+    .find((condition) => condition?.type === 'Ready' && condition.status === 'False')
+  const reason = asString(ready?.reason)
+  if (!reason || !isNonRetryableProviderFailure(reason)) return null
+  const providerName = asString(readNested(provider, ['metadata', 'name'])) ?? 'unknown'
+  const message = asString(ready?.message) ?? `agent provider ${providerName} is not ready`
+  return { reason, message: `agent provider ${providerName} is not ready: ${message}` }
 }
 
 export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) => {
@@ -743,6 +756,46 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
         })
         logInvalidSpec('MissingProvider', message)
         await setStatus(kube, agentRun, { observedGeneration, conditions: updated, phase: 'Failed' })
+        return
+      }
+      const providerBlock = resolveProviderReadinessBlock(provider)
+      if (providerBlock) {
+        const updated = upsertCondition(
+          upsertCondition(
+            upsertCondition(conditions, {
+              type: 'Blocked',
+              status: 'True',
+              reason: providerBlock.reason,
+              message: providerBlock.message,
+            }),
+            {
+              type: 'Ready',
+              status: 'False',
+              reason: 'ProviderNotReady',
+              message: providerBlock.message,
+            },
+          ),
+          {
+            type: 'Progressing',
+            status: 'False',
+            reason: providerBlock.reason,
+            message: providerBlock.message,
+          },
+        )
+        await setStatus(kube, agentRun, {
+          observedGeneration,
+          conditions: updated,
+          phase: 'Pending',
+          reason: providerBlock.reason,
+          message: providerBlock.message,
+        })
+        logAgentsControllerWarn('provider_not_ready', {
+          namespace,
+          agentRun: name,
+          provider: providerName,
+          reason: providerBlock.reason,
+          message: providerBlock.message,
+        })
         return
       }
 

--- a/services/agents/src/server/agents-controller/resource-reconcilers.test.ts
+++ b/services/agents/src/server/agents-controller/resource-reconcilers.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { PROVIDER_CAPACITY_EXHAUSTED_REASON } from './provider-capacity'
+import { createResourceReconcilers } from './resource-reconcilers'
+
+type SetStatus = (kube: unknown, resource: Record<string, unknown>, status: Record<string, unknown>) => Promise<void>
+
+const createSetStatus = () => vi.fn<SetStatus>(async () => undefined)
+
+const lastStatus = (setStatus: ReturnType<typeof createSetStatus>) => {
+  const call = setStatus.mock.calls.at(-1)
+  if (!call) {
+    throw new Error('expected a status update')
+  }
+  return call[2]
+}
+
+const createReconcilers = (setStatus: SetStatus) =>
+  createResourceReconcilers({
+    setStatus,
+    nowIso: () => '2026-05-18T14:00:00.000Z',
+    implementationTextLimit: 128 * 1024,
+    resolveVcsAuthMethod: () => 'token',
+    validateVcsAuthConfig: () => ({ ok: true }),
+    parseIntOrString: (value) => (typeof value === 'string' || typeof value === 'number' ? String(value) : null),
+    resolveAuthSecretConfig: () => null,
+    resolveSecretValue: () => null,
+    secretHasKey: () => true,
+    validateAutonomousCodexAuthSecret: () => ({ ok: true }),
+  })
+
+describe('agents controller resource reconcilers', () => {
+  it('marks a provider not ready after a recent capacity failure', async () => {
+    const setStatus = createSetStatus()
+    const { reconcileAgentProvider } = createReconcilers(setStatus)
+    const provider = {
+      metadata: { name: 'codex-spark', namespace: 'agents', generation: 7 },
+      spec: { binary: '/usr/local/bin/agent-runner' },
+    }
+    const agents = [{ metadata: { name: 'codex-agent' }, spec: { providerRef: { name: 'codex-spark' } } }]
+    const runs = [
+      {
+        metadata: { name: 'run-capacity', creationTimestamp: '2026-05-18T13:55:00.000Z' },
+        spec: { agentRef: { name: 'codex-agent' } },
+        status: {
+          phase: 'Failed',
+          reason: PROVIDER_CAPACITY_EXHAUSTED_REASON,
+          message: 'provider capacity exhausted: Quota exceeded. Check your plan and billing details.',
+        },
+      },
+    ]
+
+    await reconcileAgentProvider({ get: vi.fn() }, provider, agents, runs)
+
+    const status = lastStatus(setStatus)
+    expect(status.observedGeneration).toBe(7)
+    expect(status.conditions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'Ready',
+          status: 'False',
+          reason: PROVIDER_CAPACITY_EXHAUSTED_REASON,
+          message: expect.stringContaining('latest failed AgentRun run-capacity'),
+        }),
+        expect.objectContaining({
+          type: 'Degraded',
+          status: 'True',
+          reason: PROVIDER_CAPACITY_EXHAUSTED_REASON,
+        }),
+      ]),
+    )
+  })
+
+  it('clears provider capacity degradation after a newer success', async () => {
+    const setStatus = createSetStatus()
+    const { reconcileAgentProvider } = createReconcilers(setStatus)
+    const provider = {
+      metadata: { name: 'codex-spark', namespace: 'agents' },
+      spec: { binary: '/usr/local/bin/agent-runner' },
+    }
+    const agents = [{ metadata: { name: 'codex-agent' }, spec: { providerRef: { name: 'codex-spark' } } }]
+    const runs = [
+      {
+        metadata: { name: 'run-capacity', creationTimestamp: '2026-05-18T13:20:00.000Z' },
+        spec: { agentRef: { name: 'codex-agent' } },
+        status: {
+          phase: 'Failed',
+          reason: PROVIDER_CAPACITY_EXHAUSTED_REASON,
+        },
+      },
+      {
+        metadata: { name: 'run-ok', creationTimestamp: '2026-05-18T13:55:00.000Z' },
+        spec: { agentRef: { name: 'codex-agent' } },
+        status: { phase: 'Succeeded' },
+      },
+    ]
+
+    await reconcileAgentProvider({ get: vi.fn() }, provider, agents, runs)
+
+    const status = lastStatus(setStatus)
+    expect(status.conditions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'Ready', status: 'True', reason: 'ValidSpec' }),
+        expect.objectContaining({ type: 'Degraded', status: 'False', reason: 'Healthy' }),
+      ]),
+    )
+  })
+})

--- a/services/agents/src/server/agents-controller/resource-reconcilers.ts
+++ b/services/agents/src/server/agents-controller/resource-reconcilers.ts
@@ -1,7 +1,12 @@
 import { asRecord, asString, readNested } from '../primitives'
 
 import { normalizeConditions, upsertCondition } from './conditions'
-import { PROVIDER_AUTH_UNAVAILABLE_REASON, resolveProviderAuthFailureFromText } from './provider-capacity'
+import {
+  PROVIDER_AUTH_UNAVAILABLE_REASON,
+  PROVIDER_CAPACITY_EXHAUSTED_REASON,
+  resolveProviderAuthFailureFromText,
+  resolveProviderCapacityFailureFromText,
+} from './provider-capacity'
 
 type KubeClient = {
   get: (kind: string, name: string, namespace: string) => Promise<Record<string, unknown> | null>
@@ -20,6 +25,7 @@ type VcsAuthValidation = {
 }
 
 const PROVIDER_AUTH_FAILURE_LOOKBACK_MS = 2 * 60 * 60 * 1000
+const PROVIDER_CAPACITY_FAILURE_LOOKBACK_MS = 2 * 60 * 60 * 1000
 
 const parseTimestamp = (value: unknown) => {
   const text = asString(value)
@@ -78,13 +84,26 @@ const hasProviderAuthFailure = (run: Record<string, unknown>) => {
   return resolveProviderAuthFailureFromText(runTextForProviderAuthDetection(run)) !== null
 }
 
+const runTextForProviderCapacityDetection = runTextForProviderAuthDetection
+
+const hasProviderCapacityFailure = (run: Record<string, unknown>) => {
+  const reason = asString(readNested(run, ['status', 'reason']))
+  if (reason === PROVIDER_CAPACITY_EXHAUSTED_REASON) return true
+  return resolveProviderCapacityFailureFromText(runTextForProviderCapacityDetection(run)) !== null
+}
+
 const phaseOf = (run: Record<string, unknown>) => asString(readNested(run, ['status', 'phase']))?.toLowerCase()
 
-const resolveRecentProviderAuthFailure = (
+const resolveRecentProviderFailure = (
   provider: Record<string, unknown>,
   agents: Record<string, unknown>[],
   runs: Record<string, unknown>[],
   nowMs: number,
+  options: {
+    lookbackMs: number
+    hasFailure: (run: Record<string, unknown>) => boolean
+    resolveMessage: (run: Record<string, unknown>, name: string) => string
+  },
 ) => {
   const providerName = asString(readNested(provider, ['metadata', 'name']))
   if (!providerName) return null
@@ -108,11 +127,9 @@ const resolveRecentProviderAuthFailure = (
       latestSuccessAt = Math.max(latestSuccessAt ?? 0, observedAt)
       continue
     }
-    if (phase !== 'failed' || !hasProviderAuthFailure(run)) continue
+    if (phase !== 'failed' || !options.hasFailure(run)) continue
     const name = asString(readNested(run, ['metadata', 'name'])) ?? 'unknown'
-    const message =
-      resolveProviderAuthFailureFromText(runTextForProviderAuthDetection(run))?.message ??
-      `provider auth unavailable: ${name}`
+    const message = options.resolveMessage(run, name)
     if (!latestFailure || observedAt > latestFailure.at) {
       latestFailure = { at: observedAt, name, message }
     }
@@ -120,9 +137,37 @@ const resolveRecentProviderAuthFailure = (
 
   if (!latestFailure) return null
   if (latestSuccessAt !== null && latestSuccessAt > latestFailure.at) return null
-  if (nowMs - latestFailure.at > PROVIDER_AUTH_FAILURE_LOOKBACK_MS) return null
+  if (nowMs - latestFailure.at > options.lookbackMs) return null
   return latestFailure
 }
+
+const resolveRecentProviderAuthFailure = (
+  provider: Record<string, unknown>,
+  agents: Record<string, unknown>[],
+  runs: Record<string, unknown>[],
+  nowMs: number,
+) =>
+  resolveRecentProviderFailure(provider, agents, runs, nowMs, {
+    lookbackMs: PROVIDER_AUTH_FAILURE_LOOKBACK_MS,
+    hasFailure: hasProviderAuthFailure,
+    resolveMessage: (run, name) =>
+      resolveProviderAuthFailureFromText(runTextForProviderAuthDetection(run))?.message ??
+      `provider auth unavailable: ${name}`,
+  })
+
+const resolveRecentProviderCapacityFailure = (
+  provider: Record<string, unknown>,
+  agents: Record<string, unknown>[],
+  runs: Record<string, unknown>[],
+  nowMs: number,
+) =>
+  resolveRecentProviderFailure(provider, agents, runs, nowMs, {
+    lookbackMs: PROVIDER_CAPACITY_FAILURE_LOOKBACK_MS,
+    hasFailure: hasProviderCapacityFailure,
+    resolveMessage: (run, name) =>
+      resolveProviderCapacityFailureFromText(runTextForProviderCapacityDetection(run))?.message ??
+      `provider capacity exhausted: latest failed AgentRun ${name}`,
+  })
 
 export const createResourceReconcilers = (deps: {
   setStatus: (kube: unknown, resource: Record<string, unknown>, status: Record<string, unknown>) => Promise<void>
@@ -250,6 +295,7 @@ export const createResourceReconcilers = (deps: {
         })
       } else {
         const recentAuthFailure = resolveRecentProviderAuthFailure(provider, agents, runs, nowMs)
+        const recentCapacityFailure = resolveRecentProviderCapacityFailure(provider, agents, runs, nowMs)
         updated = upsertCondition(updated, { type: 'InvalidSpec', status: 'False', reason: 'ValidSpec', message: '' })
         if (recentAuthFailure) {
           const message = `${recentAuthFailure.message}; latest failed AgentRun ${recentAuthFailure.name}`
@@ -265,8 +311,24 @@ export const createResourceReconcilers = (deps: {
             reason: PROVIDER_AUTH_UNAVAILABLE_REASON,
             message,
           })
+        } else if (recentCapacityFailure) {
+          const message = `${recentCapacityFailure.message}; latest failed AgentRun ${recentCapacityFailure.name}`
+          updated = upsertCondition(updated, { type: 'Unreachable', status: 'False', reason: 'Reachable', message: '' })
+          updated = upsertCondition(updated, {
+            type: 'Degraded',
+            status: 'True',
+            reason: PROVIDER_CAPACITY_EXHAUSTED_REASON,
+            message,
+          })
+          updated = upsertCondition(updated, {
+            type: 'Ready',
+            status: 'False',
+            reason: PROVIDER_CAPACITY_EXHAUSTED_REASON,
+            message,
+          })
         } else {
           updated = upsertCondition(updated, { type: 'Unreachable', status: 'False', reason: 'Reachable', message: '' })
+          updated = upsertCondition(updated, { type: 'Degraded', status: 'False', reason: 'Healthy', message: '' })
           updated = upsertCondition(updated, { type: 'Ready', status: 'True', reason: 'ValidSpec' })
         }
       }


### PR DESCRIPTION
## Summary

- Marks AgentProviders as not ready when recent related AgentRuns fail with provider-capacity exhaustion.
- Blocks new AgentRuns from submitting runner Jobs while their provider is already in a non-retryable capacity or auth failure state.
- Adds focused controller tests for provider capacity degradation, recovery after newer success, and AgentRun blocking before Job creation.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/agents/src/server/agents-controller/resource-reconcilers.ts services/agents/src/server/agents-controller/resource-reconcilers.test.ts services/agents/src/server/agents-controller/agent-run-reconciler.ts services/agents/src/server/agents-controller/agent-run-reconciler.test.ts`
- `bun test services/agents/src/server/agents-controller/resource-reconcilers.test.ts services/agents/src/server/agents-controller/agent-run-reconciler.test.ts`
- `bun run --cwd services/agents test`
- `bun run --cwd services/agents tsc`
- `bun run --cwd services/agents lint`
- `scripts/agents/guard-extraction-boundaries.sh`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
