### PR TITLE
fix(torghut): allow reducing-sell paper route probes

### DIFF
--- a/docs/torghut/README.md
+++ b/docs/torghut/README.md
@@ -4,6 +4,8 @@
 
 Start here:
 
+- `docs/torghut/rollouts/2026-05-18-post-promotion-strategy-selection.md`
+  (current best post-promotion strategy selection and promotion risk parameters)
 - `docs/agents/designs/207-jangar-consumer-evidence-transport-split-and-source-serving-contract-canary-2026-05-15.md`
   (current Jangar consumer-evidence transport split and source-serving contract canary contract)
 - `docs/torghut/design-system/v6/213-torghut-consumer-evidence-contract-canary-and-alpha-reentry-transport-2026-05-15.md`

--- a/docs/torghut/rollouts/2026-05-18-post-promotion-strategy-selection.md
+++ b/docs/torghut/rollouts/2026-05-18-post-promotion-strategy-selection.md
@@ -1,0 +1,86 @@
+# Torghut Post-Promotion Strategy Selection
+
+## Status
+
+- Date: 2026-05-18
+- GitOps revision observed: `13bb93ee2f80d1beb1fdd11cafa0ec7b1ee9b09d`
+- Runtime build observed: `v0.571.1-105-ga7f6c5b1c`
+- Runtime commit observed: `a7f6c5b1c45b69543bbf19f5d3c7224dfc50e96a`
+- Runtime image digest observed: `sha256:93ffbdfc9e8b93b7f2b909b4fdb28d5da5dadffc75ae324b928cce0437a2a28f`
+
+## Current Best Candidate
+
+The best current research candidate is `spec-83161ae16d17828eabcc58cc`, mapped by the checked-in
+`H-TSMOM-01` manifest to the `intraday_tsmom_consistent` family and the
+`intraday-tsmom-profit-v3` runtime harness.
+
+Evidence:
+
+- Latest production `autoresearch_proposal_scores` epoch ranked `spec-83161ae16d17828eabcc58cc`
+  first with proposal score `2.52157822`.
+- `H-TSMOM-01` has production lineage in `strategy_hypotheses` and a paper-runtime metric window.
+- `H-PAIRS-01` / `spec-d74b07b2aaab8d0cfa8a4c38` is not the best current candidate: production
+  lineage is still missing, no current metric window exists, and the inspected sim window produced
+  no `microbar-cross-sectional-pairs-v1` decisions.
+
+This is not a live-promotion approval. The active `/trading/status` still reports
+`live_submission_gate.allowed=false` with blockers including `alpha_readiness_not_promotion_eligible`
+and `simple_submit_disabled`. `H-TSMOM-01` is the nearest candidate to repair and validate, not a
+strategy with current live-capital authority.
+
+## Acceptable Promotion Parameters
+
+Use the `portfolio-profit-autoresearch-500-v1` objective as the promotion standard:
+
+- Target net PnL: at least `$500/day` post cost, measured per trading day, not cumulative headline PnL.
+- Active day ratio: at least `0.90`.
+- Positive day ratio: at least `0.60`.
+- Minimum daily notional: at least `$300,000`, unless a lower-notional paper probe is explicitly scoped
+  as repair evidence only.
+- Best-day concentration: no single day may contribute more than `25%` of total PnL.
+- Worst day loss: normal cap `5%` of start equity; extended review cap `8%`.
+- Max drawdown: normal cap `10%` of start equity; extended review cap `15%`.
+- Net-PnL-to-drawdown ratio: at least `2.00`.
+- Gross exposure: no more than `100%` of start equity.
+- Cash: must not go negative.
+- Runtime closure: checked-in runtime family, scheduler parity replay, scheduler approval replay,
+  live-shadow validation, and fresh empirical metric windows.
+- Execution evidence: positive post-cost expectancy, TCA/slippage within manifest budget, fresh signal
+  continuity, drift checks recent, and shadow parity within budget.
+
+External drawdown research supports this posture: professional and retail trading references generally
+place ordinary acceptable drawdowns around `10%` to `20%`, with more conservative automated or
+capital-preservation strategies closer to `10%`. Torghut should therefore keep `10%` as the normal
+promotion cap and treat `15%` as an extended-review ceiling, not a default allowance.
+
+## H-TSMOM Promotion Parameters
+
+For `H-TSMOM-01` specifically, promotion repair should use:
+
+- Strategy family: `intraday_tsmom_consistent`.
+- Runtime strategy: `intraday-tsmom-profit-v3`.
+- Candidate id: `spec-83161ae16d17828eabcc58cc`.
+- Dataset snapshot ref: `portfolio-profit-autoresearch-500-v1`.
+- Max allowed slippage: `6 bps`.
+- Max rolling drawdown: `1000 bps`.
+- Minimum samples for live canary: `60`.
+- Minimum samples for scale-up: `120`.
+- Entry freshness: signal lag at most `90 seconds`; evidence age at most `30 minutes`.
+- Required features: trend strength, intraday momentum rank, realized volatility, turnover, and TCA.
+
+The frontier sweep currently allows `intraday_tsmom_consistent` candidates with a holdout target of
+`$300/day`, worst holdout day loss up to `$200`, profit factor at least `1.1`, and consistency drawdown
+up to `$600`. Those are search filters, not promotion authority. The promotion bar remains the
+portfolio-level `$500/day` and drawdown policy above.
+
+## Next Repair Target
+
+The next production work should make the paper runtime produce fresh, executable TCA-backed decisions
+for `intraday-tsmom-profit-v3`. Current evidence windows contain zero orders/trades and zero TCA rows,
+so renewing imports alone cannot make the strategy promotable.
+
+## References
+
+- CFI maximum drawdown overview: https://corporatefinanceinstitute.com/resources/career-map/sell-side/capital-markets/maximum-drawdown/
+- BacktestBase drawdown risk guide: https://www.backtestbase.com/education/drawdown-risk-analysis
+- TradingStrategy.ai Calmar ratio overview: https://tradingstrategy.ai/glossary/calmar-ratio

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -584,6 +584,36 @@ class SimpleTradingPipeline(TradingPipeline):
                 return price
         return None
 
+    @staticmethod
+    def _paper_route_probe_short_increasing_sell(decision: StrategyDecision) -> bool:
+        if decision.action != "sell":
+            return False
+        for key in ("simple_lane", "sizing"):
+            section = decision.params.get(key)
+            if not isinstance(section, Mapping):
+                continue
+            quantity_resolution = cast(Mapping[str, Any], section).get(
+                "quantity_resolution"
+            )
+            if not isinstance(quantity_resolution, Mapping):
+                continue
+            resolution = cast(Mapping[str, Any], quantity_resolution)
+            short_increasing = resolution.get("short_increasing")
+            if isinstance(short_increasing, bool):
+                return short_increasing
+            if isinstance(short_increasing, str):
+                normalized = short_increasing.strip().lower()
+                if normalized in {"true", "1", "yes", "on"}:
+                    return True
+                if normalized in {"false", "0", "no", "off"}:
+                    return False
+            reason = str(resolution.get("reason") or "").strip().lower()
+            if reason.startswith("sell_reducing_"):
+                return False
+            if "short_increasing" in reason:
+                return True
+        return True
+
     def _paper_route_probe_context(
         self,
         *,
@@ -596,7 +626,11 @@ class SimpleTradingPipeline(TradingPipeline):
             return None
         if not settings.trading_simple_submit_enabled:
             return None
-        if decision.action == "sell" and not settings.trading_allow_shorts:
+        if (
+            decision.action == "sell"
+            and not settings.trading_allow_shorts
+            and self._paper_route_probe_short_increasing_sell(decision)
+        ):
             return None
         if decision.action not in {"buy", "sell"}:
             return None

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -2472,6 +2472,31 @@ class TestTradingPipeline(TestCase):
                 decision=sell_decision,
             )
         )
+        reducing_sell_decision = decision.model_copy(
+            update={
+                "action": "sell",
+                "params": {
+                    "price": "100",
+                    "simple_lane": {
+                        "quantity_resolution": {
+                            "action": "sell",
+                            "reason": "sell_reducing_long_fractional_allowed",
+                            "short_increasing": False,
+                        }
+                    },
+                },
+            }
+        )
+        reducing_sell_probe_context = pipeline._paper_route_probe_context(
+            proof_floor=proof_floor,
+            decision=reducing_sell_decision,
+        )
+        self.assertIsNotNone(reducing_sell_probe_context)
+        assert reducing_sell_probe_context is not None
+        self.assertEqual(reducing_sell_probe_context.get("side"), "sell")
+        self.assertEqual(
+            reducing_sell_probe_context.get("mode"), "paper_route_acquisition"
+        )
         config.settings.trading_allow_shorts = True
         sell_probe_context = pipeline._paper_route_probe_context(
             proof_floor=proof_floor,
@@ -2520,6 +2545,102 @@ class TestTradingPipeline(TestCase):
             pipeline._paper_route_probe_context(
                 proof_floor=wrong_symbol_floor,
                 decision=decision,
+            )
+        )
+
+    def test_paper_route_probe_short_increasing_sell_classification(self) -> None:
+        decision = StrategyDecision(
+            strategy_id="strategy-1",
+            symbol="NVDA",
+            event_ts=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="route-probe-short-classification",
+            params={"price": "100"},
+        )
+
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_probe_short_increasing_sell(decision)
+        )
+        self.assertTrue(
+            SimpleTradingPipeline._paper_route_probe_short_increasing_sell(
+                decision.model_copy(
+                    update={
+                        "action": "sell",
+                        "params": {"simple_lane": "missing-resolution"},
+                    }
+                )
+            )
+        )
+        self.assertTrue(
+            SimpleTradingPipeline._paper_route_probe_short_increasing_sell(
+                decision.model_copy(
+                    update={
+                        "action": "sell",
+                        "params": {"simple_lane": {"quantity_resolution": "missing"}},
+                    }
+                )
+            )
+        )
+        self.assertTrue(
+            SimpleTradingPipeline._paper_route_probe_short_increasing_sell(
+                decision.model_copy(
+                    update={
+                        "action": "sell",
+                        "params": {
+                            "simple_lane": {
+                                "quantity_resolution": {"short_increasing": "yes"}
+                            }
+                        },
+                    }
+                )
+            )
+        )
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_probe_short_increasing_sell(
+                decision.model_copy(
+                    update={
+                        "action": "sell",
+                        "params": {
+                            "simple_lane": {
+                                "quantity_resolution": {"short_increasing": "off"}
+                            }
+                        },
+                    }
+                )
+            )
+        )
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_probe_short_increasing_sell(
+                decision.model_copy(
+                    update={
+                        "action": "sell",
+                        "params": {
+                            "sizing": {
+                                "quantity_resolution": {
+                                    "reason": "sell_reducing_long_fractional_allowed"
+                                }
+                            }
+                        },
+                    }
+                )
+            )
+        )
+        self.assertTrue(
+            SimpleTradingPipeline._paper_route_probe_short_increasing_sell(
+                decision.model_copy(
+                    update={
+                        "action": "sell",
+                        "params": {
+                            "sizing": {
+                                "quantity_resolution": {
+                                    "reason": "sell_short_increasing_fractional_allowed"
+                                }
+                            }
+                        },
+                    }
+                )
             )
         )
 


### PR DESCRIPTION
## Summary

- Allows simple-lane paper route probes for sell decisions only when quantity-resolution metadata proves the sell reduces an existing long position.
- Keeps short-increasing sell probes blocked when shorts are disabled.
- Records the current post-promotion Torghut best-candidate and risk-parameter decision in the rollout docs.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_route_probe or profitability_floor_zero_notional'`
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
