### PR TITLE
chore(agents): promote images 6507a00d

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: a7f6c5b1
-  digest: sha256:08d3a4984edb2bc244286295f5060b58b7ee4904d57aed489d4e960cdb26fcb5
+  tag: 6507a00d
+  digest: sha256:1fed8fb83b28295f8104fc30ab7b55b0ffc23133116027fdcb97b1edc37811fc
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,23 +11,23 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: a7f6c5b1
-    digest: sha256:ff699ab51024fa7e6d31a015a98ff0ce7ade947cbebe45d5efbbda84e781ce8f
+    tag: 6507a00d
+    digest: sha256:bc4dd5787c111fb6f1130a3a78e8d632a30f7c87c9d8670c9b00d401b603e708
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
-      AGENTS_SOURCE_HEAD_SHA: a7f6c5b1c45b69543bbf19f5d3c7224dfc50e96a
-      AGENTS_GITOPS_REVISION: a7f6c5b1c45b69543bbf19f5d3c7224dfc50e96a
-      AGENTS_SOURCE_CI_RUN_ID: "26039437070"
+      AGENTS_SOURCE_HEAD_SHA: 6507a00d68cdca54dac7d695bc639ca0dc0932e8
+      AGENTS_GITOPS_REVISION: 6507a00d68cdca54dac7d695bc639ca0dc0932e8
+      AGENTS_SOURCE_CI_RUN_ID: "26041887038"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:ff699ab51024fa7e6d31a015a98ff0ce7ade947cbebe45d5efbbda84e781ce8f
-      AGENTS_SERVING_BUILD_COMMIT: a7f6c5b1c45b69543bbf19f5d3c7224dfc50e96a
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:ff699ab51024fa7e6d31a015a98ff0ce7ade947cbebe45d5efbbda84e781ce8f
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:bc4dd5787c111fb6f1130a3a78e8d632a30f7c87c9d8670c9b00d401b603e708
+      AGENTS_SERVING_BUILD_COMMIT: 6507a00d68cdca54dac7d695bc639ca0dc0932e8
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:bc4dd5787c111fb6f1130a3a78e8d632a30f7c87c9d8670c9b00d401b603e708
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: a7f6c5b1
-    digest: sha256:846dc0dada2c18ee862357d6d3086d81462cabfd15d1cfdb670ea636e920d272
+    tag: 6507a00d
+    digest: sha256:46a7e5245e2830f903b46e8c9dc18d5392ba67915224104402db56d4c6feecc9
 argocdHooks:
   enabled: true
   image:
@@ -82,8 +82,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: a7f6c5b1
-    digest: sha256:08d3a4984edb2bc244286295f5060b58b7ee4904d57aed489d4e960cdb26fcb5
+    tag: 6507a00d
+    digest: sha256:1fed8fb83b28295f8104fc30ab7b55b0ffc23133116027fdcb97b1edc37811fc
   autoscaling:
     enabled: false
   env:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `6507a00d68cdca54dac7d695bc639ca0dc0932e8`
- Image tag: `6507a00d`
- Source CI run: `26041887038`
- Runner image pin preserved