### PR TITLE
chore(jangar): promote image 6507a00d

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-18T10:49:58Z
+    deploy.knative.dev/rollout: 2026-05-18T15:15:43Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:8f244fa8@sha256:453e2ab4ae6d57f9120e504293ee9bc559085a8319951ed7854140484339cc9e
+              value: registry.ide-newton.ts.net/lab/jangar:6507a00d@sha256:219e421cf6393827b882709562475b18fdb3642e51880e1adc69b46fe7fdba13
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 8f244fa8eb8237994febbb5923d69cfc440b0d44
+              value: 6507a00d68cdca54dac7d695bc639ca0dc0932e8
             - name: JANGAR_GITOPS_REVISION
-              value: 8f244fa8eb8237994febbb5923d69cfc440b0d44
+              value: 6507a00d68cdca54dac7d695bc639ca0dc0932e8
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26028749841"
+              value: "26042433316"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:7a3cb34f968ac01d5af283af6e641ed507f509e10e9782e72d5f5a220702a46d
+              value: sha256:500ae1108ed8e9a213ca37dd83fe8579f12c38b44fa1473c194b70a631e5188c
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 8f244fa8eb8237994febbb5923d69cfc440b0d44
+              value: 6507a00d68cdca54dac7d695bc639ca0dc0932e8
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:7a3cb34f968ac01d5af283af6e641ed507f509e10e9782e72d5f5a220702a46d
+              value: sha256:500ae1108ed8e9a213ca37dd83fe8579f12c38b44fa1473c194b70a631e5188c
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 8f244fa8
-    digest: sha256:453e2ab4ae6d57f9120e504293ee9bc559085a8319951ed7854140484339cc9e
+    newTag: 6507a00d
+    digest: sha256:219e421cf6393827b882709562475b18fdb3642e51880e1adc69b46fe7fdba13


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `6507a00d68cdca54dac7d695bc639ca0dc0932e8`
- Image tag: `6507a00d`
- Image digest: `sha256:219e421cf6393827b882709562475b18fdb3642e51880e1adc69b46fe7fdba13`
- Source CI run: `26042433316`
- Control-plane serving digest: `sha256:500ae1108ed8e9a213ca37dd83fe8579f12c38b44fa1473c194b70a631e5188c`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates