### PR TITLE
chore(agents): bump chart version for controller split

### DIFF
--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/proompteng/charts/tree/main/charts/agents
 type: application
 kubeVersion: '>=1.25.0-0'
-version: 0.9.17
+version: 0.9.18
 appVersion: '0.9.0'
 icon: https://avatars.githubusercontent.com/u/234536857
 keywords:


### PR DESCRIPTION
## Summary

- Bump the Agents Helm chart version from `0.9.17` to `0.9.18`.
- Unblocks the `agents-sync` chart publication path after the controller split changed chart contents.
- Keeps the already-promoted `6507a00d` image values unchanged.

## Related Issues

None

## Testing

- `helm lint charts/agents -f argocd/applications/agents/values.yaml`
- `./scripts/agents/validate-agents.sh`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
