### PR TITLE
fix(agents): validate chart artifacthub version

### DIFF
--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-version: 0.9.17
+version: 0.9.18
 name: agents
 displayName: Agents Control Plane (Jangar)
 description: Minimal Agents control plane with CRDs and native workflow runtime.

--- a/scripts/agents/validate-agents.sh
+++ b/scripts/agents/validate-agents.sh
@@ -46,6 +46,13 @@ git -C "${ROOT_DIR}" diff --exit-code -- "${CHART_DIR}/crds" \
 
 run_with_helm3 helm lint --kube-version "${KUBE_VERSION_FOR_HELM}" "${CHART_DIR}"
 
+chart_version="$(awk -F': *' '$1 == "version" {print $2; exit}' "${CHART_DIR}/Chart.yaml" | sed "s/[\"']//g")"
+artifacthub_version="$(awk -F': *' '$1 == "version" {print $2; exit}' "${CHART_DIR}/artifacthub-pkg.yml" | sed "s/[\"']//g")"
+if [[ -z "${chart_version}" || -z "${artifacthub_version}" || "${chart_version}" != "${artifacthub_version}" ]]; then
+  echo "artifacthub-pkg.yml version (${artifacthub_version:-missing}) must match Chart.yaml (${chart_version:-missing})." >&2
+  exit 1
+fi
+
 render_and_check() {
   local values_file="$1"
   local output


### PR DESCRIPTION
## Summary

- Align `charts/agents/artifacthub-pkg.yml` with chart version `0.9.18`.
- Add a validation guard so `./scripts/agents/validate-agents.sh` fails when Artifact Hub metadata and `Chart.yaml` diverge.
- Unblocks the `agents-sync` chart publication path after the controller split chart change.

## Related Issues

None

## Testing

- `helm lint charts/agents -f argocd/applications/agents/values.yaml`
- `AGENTS_CHART_DRY_RUN=1 bun packages/scripts/src/agents/publish-chart.ts --chart-dir charts/agents`
- `./scripts/agents/validate-agents.sh`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
