### PR TITLE
fix(torghut): index options catalog freshness scans

### DIFF
--- a/services/torghut/migrations/versions/0032_options_catalog_active_underlying_index.py
+++ b/services/torghut/migrations/versions/0032_options_catalog_active_underlying_index.py
@@ -1,0 +1,40 @@
+"""Add active-underlying index for options catalog freshness checks.
+
+Revision ID: 0032_options_catalog_active_underlying_index
+Revises: 0031_autoresearch_candidate_spec_epoch_uniqueness
+Create Date: 2026-05-18 10:45:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0032_options_catalog_active_underlying_index"
+down_revision = "0031_autoresearch_candidate_spec_epoch_uniqueness"
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = "ix_torghut_options_contract_catalog_active_underlying_freshness"
+TABLE_NAME = "torghut_options_contract_catalog"
+
+
+def upgrade() -> None:
+    op.create_index(
+        INDEX_NAME,
+        TABLE_NAME,
+        ["underlying_symbol"],
+        unique=False,
+        postgresql_where=sa.text("status = 'active'"),
+        postgresql_include=[
+            "last_seen_ts",
+            "provider_updated_ts",
+            "close_price",
+            "open_interest",
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(INDEX_NAME, table_name=TABLE_NAME)

--- a/services/torghut/tests/test_options_catalog_active_underlying_index_migration.py
+++ b/services/torghut/tests/test_options_catalog_active_underlying_index_migration.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from unittest import TestCase
+from unittest.mock import patch
+
+
+def _load_migration_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "migrations"
+        / "versions"
+        / "0032_options_catalog_active_underlying_index.py"
+    )
+    spec = importlib.util.spec_from_file_location("torghut_migration_0032", path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("failed_to_load_migration_0032")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestOptionsCatalogActiveUnderlyingIndexMigration(TestCase):
+    def test_revision_follows_current_head(self) -> None:
+        module = _load_migration_module()
+
+        self.assertEqual(
+            module.revision, "0032_options_catalog_active_underlying_index"
+        )
+        self.assertEqual(
+            module.down_revision, "0031_autoresearch_candidate_spec_epoch_uniqueness"
+        )
+
+    def test_upgrade_adds_partial_covering_index_for_active_route_symbols(
+        self,
+    ) -> None:
+        module = _load_migration_module()
+
+        with patch.object(module.op, "create_index") as create_index:
+            module.upgrade()
+
+        create_index.assert_called_once()
+        _name, table_name, columns = create_index.call_args.args[:3]
+        kwargs = create_index.call_args.kwargs
+        self.assertEqual(table_name, "torghut_options_contract_catalog")
+        self.assertEqual(columns, ["underlying_symbol"])
+        self.assertIn("status = 'active'", str(kwargs["postgresql_where"]))
+        self.assertEqual(
+            kwargs["postgresql_include"],
+            [
+                "last_seen_ts",
+                "provider_updated_ts",
+                "close_price",
+                "open_interest",
+            ],
+        )
+
+    def test_downgrade_drops_index(self) -> None:
+        module = _load_migration_module()
+
+        with patch.object(module.op, "drop_index") as drop_index:
+            module.downgrade()
+
+        drop_index.assert_called_once_with(
+            "ix_torghut_options_contract_catalog_active_underlying_freshness",
+            table_name="torghut_options_contract_catalog",
+        )


### PR DESCRIPTION
## Summary

- Adds migration `0032_options_catalog_active_underlying_index` for a partial covering index on active option contracts by underlying symbol.
- Targets the live `/trading/status` timeout path where route-scoped options catalog freshness scans were hitting `statement_timeout` while evaluating route/fillability proof.
- Adds a focused migration regression test that locks the index shape, downgrade behavior, and migration parent.

## Related Issues

None

## Testing

- `uv run --frozen ruff format --check tests/test_options_catalog_active_underlying_index_migration.py`
- `uv run --frozen ruff check tests/test_options_catalog_active_underlying_index_migration.py`
- `uv run --frozen pytest tests/test_options_catalog_active_underlying_index_migration.py tests/test_trading_api.py -k 'options_catalog_freshness_summary or OptionsCatalogActiveUnderlyingIndex' -q`
- `uv run --frozen python scripts/check_migration_graph.py --versions-dir migrations/versions`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

Requires applying Torghut migration `0032_options_catalog_active_underlying_index`; it adds an index only and does not change table data or runtime behavior.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
