### PR TITLE
feat(agents): own agent run v1 routes

### DIFF
--- a/services/agents/package.json
+++ b/services/agents/package.json
@@ -22,6 +22,7 @@
     "./server/primitives-policy": "./src/server/primitives-policy.ts",
     "./server/ready": "./src/server/ready.ts",
     "./server/runtime-identity": "./src/server/runtime-identity.ts",
+    "./server/server-route": "./src/server/server-route.ts",
     "./server/status-utils": "./src/server/status-utils.ts",
     "./server/agents-controller": "./src/server/agents-controller/index.ts",
     "./server/agents-controller/agent-run-reconciler": "./src/server/agents-controller/agent-run-reconciler.ts",
@@ -29,6 +30,9 @@
     "./server/agents-controller/rate-limits": "./src/server/agents-controller/rate-limits.ts",
     "./server/agents-controller/*": "./src/server/agents-controller/*.ts",
     "./server/v1/*": "./src/server/v1/*.ts",
+    "./routes/v1/agent-runs": "./src/routes/v1/agent-runs.ts",
+    "./routes/v1/agent-runs/$id": "./src/routes/v1/agent-runs/$id.ts",
+    "./routes/v1/runs/$id": "./src/routes/v1/runs/$id.ts",
     "./runner/*": "./src/runner/*.ts"
   },
   "scripts": {

--- a/services/agents/src/routes/v1/agent-runs.test.ts
+++ b/services/agents/src/routes/v1/agent-runs.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { AgentRunsApiStore } from '../../server/v1/agent-runs'
+import { configureAgentsV1Runtime, resetAgentsV1RuntimeForTests } from '../../server/v1/runtime'
+
+import { getAgentRunsHandler } from './agent-runs'
+
+const createStore = (runs: unknown[] = []): AgentRunsApiStore =>
+  ({
+    ready: Promise.resolve(),
+    close: vi.fn(async () => {}),
+    getAgentRunsByAgent: vi.fn(async () => runs),
+  }) as unknown as AgentRunsApiStore
+
+describe('Agents v1 AgentRun route ownership', () => {
+  afterEach(() => {
+    resetAgentsV1RuntimeForTests()
+  })
+
+  it('returns a 503 when the Agents route runtime has no store dependency', async () => {
+    const response = await getAgentRunsHandler(new Request('http://agents.local/v1/agent-runs?agentId=demo'))
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'AgentRuns API runtime dependencies are not configured: storeFactory is required',
+    })
+  })
+
+  it('uses the configured Agents route runtime dependencies', async () => {
+    const store = createStore([{ id: 'run-1' }])
+    configureAgentsV1Runtime({
+      agentRuns: {
+        storeFactory: () => store,
+      },
+    })
+
+    const response = await getAgentRunsHandler(new Request('http://agents.local/v1/agent-runs?agentId=demo'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true, runs: [{ id: 'run-1' }] })
+    expect(store.getAgentRunsByAgent).toHaveBeenCalledWith('demo')
+    expect(store.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('lets tests and compatibility callers override configured route dependencies', async () => {
+    const configuredStore = createStore([{ id: 'configured-run' }])
+    const overrideStore = createStore([{ id: 'override-run' }])
+    configureAgentsV1Runtime({
+      agentRuns: {
+        storeFactory: () => configuredStore,
+      },
+    })
+
+    const response = await getAgentRunsHandler(new Request('http://agents.local/v1/agent-runs?agentId=demo'), {
+      storeFactory: () => overrideStore,
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true, runs: [{ id: 'override-run' }] })
+    expect(configuredStore.getAgentRunsByAgent).not.toHaveBeenCalled()
+    expect(overrideStore.getAgentRunsByAgent).toHaveBeenCalledWith('demo')
+  })
+})

--- a/services/agents/src/routes/v1/agent-runs.ts
+++ b/services/agents/src/routes/v1/agent-runs.ts
@@ -1,0 +1,30 @@
+import { createFileRoute, type AgentsServerRouteArgs } from '../../server/server-route'
+import {
+  getAgentRunsHandler as getAgentRunsApiHandler,
+  postAgentRunsHandler as postAgentRunsApiHandler,
+  type AgentRunsApiDependencies,
+} from '../../server/v1/agent-runs'
+import { resolveAgentRunsApiDependencies, runtimeDependencyErrorResponse } from '../../server/v1/runtime'
+
+export type { AgentRunsApiDependencies } from '../../server/v1/agent-runs'
+
+export const Route = createFileRoute('/v1/agent-runs')({
+  server: {
+    handlers: {
+      GET: async ({ request }: AgentsServerRouteArgs) => getAgentRunsHandler(request),
+      POST: async ({ request }: AgentsServerRouteArgs) => postAgentRunsHandler(request),
+    },
+  },
+})
+
+export const getAgentRunsHandler = async (request: Request, deps: Partial<AgentRunsApiDependencies> = {}) => {
+  const resolved = await resolveAgentRunsApiDependencies(deps)
+  if (!resolved.ok) return runtimeDependencyErrorResponse(resolved.error)
+  return getAgentRunsApiHandler(request, resolved.value)
+}
+
+export const postAgentRunsHandler = async (request: Request, deps: Partial<AgentRunsApiDependencies> = {}) => {
+  const resolved = await resolveAgentRunsApiDependencies(deps)
+  if (!resolved.ok) return runtimeDependencyErrorResponse(resolved.error)
+  return postAgentRunsApiHandler(request, resolved.value)
+}

--- a/services/agents/src/routes/v1/agent-runs/$id.ts
+++ b/services/agents/src/routes/v1/agent-runs/$id.ts
@@ -1,0 +1,19 @@
+import { createFileRoute, type AgentsServerRouteArgs } from '../../../server/server-route'
+import { getAgentRunHandler as getAgentRunApiHandler, type RunReadApiDependencies } from '../../../server/v1/run-read'
+import { resolveRunReadApiDependencies, runtimeDependencyErrorResponse } from '../../../server/v1/runtime'
+
+export type { RunReadApiDependencies } from '../../../server/v1/run-read'
+
+export const Route = createFileRoute('/v1/agent-runs/$id')({
+  server: {
+    handlers: {
+      GET: async ({ params, request }: AgentsServerRouteArgs) => getAgentRunHandler(params.id, request),
+    },
+  },
+})
+
+export const getAgentRunHandler = async (id: string, request: Request, deps: Partial<RunReadApiDependencies> = {}) => {
+  const resolved = await resolveRunReadApiDependencies(deps)
+  if (!resolved.ok) return runtimeDependencyErrorResponse(resolved.error)
+  return getAgentRunApiHandler(id, request, resolved.value)
+}

--- a/services/agents/src/routes/v1/runs/$id.ts
+++ b/services/agents/src/routes/v1/runs/$id.ts
@@ -1,0 +1,19 @@
+import { createFileRoute, type AgentsServerRouteArgs } from '../../../server/server-route'
+import { getRunHandler as getRunApiHandler, type RunReadApiDependencies } from '../../../server/v1/run-read'
+import { resolveRunReadApiDependencies, runtimeDependencyErrorResponse } from '../../../server/v1/runtime'
+
+export type { RunReadApiDependencies } from '../../../server/v1/run-read'
+
+export const Route = createFileRoute('/v1/runs/$id')({
+  server: {
+    handlers: {
+      GET: async ({ params, request }: AgentsServerRouteArgs) => getRunHandler(params.id, request),
+    },
+  },
+})
+
+export const getRunHandler = async (id: string, request: Request, deps: Partial<RunReadApiDependencies> = {}) => {
+  const resolved = await resolveRunReadApiDependencies(deps)
+  if (!resolved.ok) return runtimeDependencyErrorResponse(resolved.error)
+  return getRunApiHandler(id, request, resolved.value)
+}

--- a/services/agents/src/server/server-route.ts
+++ b/services/agents/src/server/server-route.ts
@@ -1,0 +1,23 @@
+import type { AgentsServerRouteHandler } from './http-runtime'
+
+type AgentsServerRouteMethod = 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT'
+
+export type AgentsServerRouteArgs = Parameters<AgentsServerRouteHandler>[0]
+
+export type AgentsFileRouteOptions = {
+  server?: {
+    handlers?: Partial<Record<AgentsServerRouteMethod, AgentsServerRouteHandler>>
+  }
+}
+
+export type AgentsFileRoute = {
+  path: string
+  options: AgentsFileRouteOptions
+}
+
+export const createFileRoute =
+  (path: string) =>
+  (options: AgentsFileRouteOptions): AgentsFileRoute => ({
+    path,
+    options,
+  })

--- a/services/agents/src/server/v1/runtime.ts
+++ b/services/agents/src/server/v1/runtime.ts
@@ -1,0 +1,120 @@
+import { Context, Effect, Layer, ManagedRuntime, pipe } from 'effect'
+
+import { errorResponse } from '../http'
+
+import type { AgentRunsApiDependencies } from './agent-runs'
+import type { RunReadApiDependencies } from './run-read'
+
+export class AgentsV1RuntimeConfigurationError extends Error {
+  readonly _tag = 'AgentsV1RuntimeConfigurationError'
+}
+
+export type AgentsV1RuntimeDependencies = {
+  agentRuns?: Partial<AgentRunsApiDependencies>
+  runRead?: Partial<RunReadApiDependencies>
+}
+
+export type AgentsV1RuntimeService = {
+  resolveAgentRunsDependencies: (
+    overrides?: Partial<AgentRunsApiDependencies>,
+  ) => Effect.Effect<AgentRunsApiDependencies, AgentsV1RuntimeConfigurationError>
+  resolveRunReadDependencies: (
+    overrides?: Partial<RunReadApiDependencies>,
+  ) => Effect.Effect<RunReadApiDependencies, AgentsV1RuntimeConfigurationError>
+}
+
+export class AgentsV1Runtime extends Context.Tag('AgentsV1Runtime')<AgentsV1Runtime, AgentsV1RuntimeService>() {}
+
+type RequiredStoreFactoryDependency = {
+  storeFactory?: unknown
+}
+
+type ResolvedDependencyResult<T> =
+  | {
+      ok: true
+      value: T
+    }
+  | {
+      ok: false
+      error: AgentsV1RuntimeConfigurationError
+    }
+
+const ensureStoreFactory = <T extends RequiredStoreFactoryDependency>(label: string, deps: T) => {
+  if (typeof deps.storeFactory !== 'function') {
+    return Effect.fail(
+      new AgentsV1RuntimeConfigurationError(
+        `${label} runtime dependencies are not configured: storeFactory is required`,
+      ),
+    )
+  }
+  return Effect.succeed(deps as T & { storeFactory: NonNullable<T['storeFactory']> })
+}
+
+export const createAgentsV1RuntimeService = (
+  dependencies: AgentsV1RuntimeDependencies = {},
+): AgentsV1RuntimeService => ({
+  resolveAgentRunsDependencies: (overrides = {}) =>
+    pipe(
+      Effect.succeed({ ...dependencies.agentRuns, ...overrides }),
+      Effect.flatMap((resolved) => ensureStoreFactory('AgentRuns API', resolved)),
+      Effect.map((resolved) => resolved as AgentRunsApiDependencies),
+    ),
+  resolveRunReadDependencies: (overrides = {}) =>
+    pipe(
+      Effect.succeed({ ...dependencies.runRead, ...overrides }),
+      Effect.flatMap((resolved) => ensureStoreFactory('Run read API', resolved)),
+      Effect.map((resolved) => resolved as RunReadApiDependencies),
+    ),
+})
+
+export const AgentsV1RuntimeLive = (dependencies: AgentsV1RuntimeDependencies = {}) =>
+  Layer.succeed(AgentsV1Runtime, createAgentsV1RuntimeService(dependencies))
+
+let configuredRuntime: ManagedRuntime.ManagedRuntime<AgentsV1Runtime, never> | null = null
+
+export const configureAgentsV1Runtime = (dependencies: AgentsV1RuntimeDependencies) => {
+  configuredRuntime = ManagedRuntime.make(AgentsV1RuntimeLive(dependencies))
+}
+
+const runWithConfiguredOrAdHocRuntime = <A, E>(
+  effectFactory: (service: AgentsV1RuntimeService) => Effect.Effect<A, E>,
+): Promise<A> => {
+  if (configuredRuntime) {
+    return configuredRuntime.runPromise(Effect.flatMap(AgentsV1Runtime, effectFactory))
+  }
+
+  return Effect.runPromise(effectFactory(createAgentsV1RuntimeService()))
+}
+
+const toResolvedDependencyResult = <T>(promise: Promise<T>): Promise<ResolvedDependencyResult<T>> =>
+  promise.then(
+    (value) => ({ ok: true, value }),
+    (error) => ({
+      ok: false,
+      error:
+        error instanceof AgentsV1RuntimeConfigurationError
+          ? error
+          : new AgentsV1RuntimeConfigurationError(error instanceof Error ? error.message : String(error)),
+    }),
+  )
+
+export const resolveAgentRunsApiDependencies = (
+  overrides: Partial<AgentRunsApiDependencies> = {},
+): Promise<ResolvedDependencyResult<AgentRunsApiDependencies>> =>
+  toResolvedDependencyResult(
+    runWithConfiguredOrAdHocRuntime((service) => service.resolveAgentRunsDependencies(overrides)),
+  )
+
+export const resolveRunReadApiDependencies = (
+  overrides: Partial<RunReadApiDependencies> = {},
+): Promise<ResolvedDependencyResult<RunReadApiDependencies>> =>
+  toResolvedDependencyResult(
+    runWithConfiguredOrAdHocRuntime((service) => service.resolveRunReadDependencies(overrides)),
+  )
+
+export const runtimeDependencyErrorResponse = (error: AgentsV1RuntimeConfigurationError) =>
+  errorResponse(error.message, 503, { tag: error._tag })
+
+export const resetAgentsV1RuntimeForTests = () => {
+  configuredRuntime = null
+}

--- a/services/jangar/src/routes/v1/agent-runs.ts
+++ b/services/jangar/src/routes/v1/agent-runs.ts
@@ -3,17 +3,8 @@ import {
   getAgentRunsHandler as getAgentsServiceAgentRunsHandler,
   postAgentRunsHandler as postAgentsServiceAgentRunsHandler,
   type AgentRunsApiDependencies,
-  type AgentRunsApiStore,
-} from '@proompteng/agents/server/v1/agent-runs'
-import {
-  resolveAuditContextFromRequest,
-  resolveRepositoryFromParameters as resolveRepositoryFromParameterMap,
-} from '~/server/audit-logging'
-import { requireLeaderForMutationHttp } from '~/server/leader-election'
-import { recordAgentQueueDepth } from '~/server/metrics'
-import { createKubernetesClient } from '~/server/primitives-kube'
-import { validatePolicies } from '~/server/primitives-policy'
-import { createPrimitivesStore } from '~/server/primitives-store'
+} from '@proompteng/agents/routes/v1/agent-runs'
+import '~/server/agents-v1-runtime'
 
 export const Route = createFileRoute('/v1/agent-runs')({
   server: {
@@ -26,22 +17,8 @@ export const Route = createFileRoute('/v1/agent-runs')({
 
 type JangarAgentRunsApiDependencies = Partial<AgentRunsApiDependencies>
 
-const createJangarPrimitivesStore = (): AgentRunsApiStore => createPrimitivesStore()
-
-const buildAgentRunsApiDependencies = (deps: JangarAgentRunsApiDependencies = {}): AgentRunsApiDependencies => ({
-  storeFactory: deps.storeFactory ?? createJangarPrimitivesStore,
-  kubeClient: deps.kubeClient,
-  kubeClientFactory: deps.kubeClientFactory ?? createKubernetesClient,
-  requireLeaderForMutation: deps.requireLeaderForMutation ?? requireLeaderForMutationHttp,
-  recordAgentQueueDepth: deps.recordAgentQueueDepth ?? recordAgentQueueDepth,
-  resolveAuditContextFromRequest: deps.resolveAuditContextFromRequest ?? resolveAuditContextFromRequest,
-  resolveRepositoryFromParameters:
-    deps.resolveRepositoryFromParameters ?? ((params) => resolveRepositoryFromParameterMap(params) ?? undefined),
-  validatePolicies: deps.validatePolicies ?? validatePolicies,
-})
-
 export const getAgentRunsHandler = async (request: Request, deps: JangarAgentRunsApiDependencies = {}) =>
-  getAgentsServiceAgentRunsHandler(request, buildAgentRunsApiDependencies(deps))
+  getAgentsServiceAgentRunsHandler(request, deps)
 
 export const postAgentRunsHandler = async (request: Request, deps: JangarAgentRunsApiDependencies = {}) =>
-  postAgentsServiceAgentRunsHandler(request, buildAgentRunsApiDependencies(deps))
+  postAgentsServiceAgentRunsHandler(request, deps)

--- a/services/jangar/src/routes/v1/agent-runs/$id.ts
+++ b/services/jangar/src/routes/v1/agent-runs/$id.ts
@@ -2,10 +2,8 @@ import { createFileRoute } from '@tanstack/react-router'
 import {
   getAgentRunHandler as getAgentsServiceAgentRunHandler,
   type RunReadApiDependencies,
-  type RunReadApiStore,
-} from '@proompteng/agents/server/v1/run-read'
-import { createKubernetesClient } from '~/server/primitives-kube'
-import { createPrimitivesStore } from '~/server/primitives-store'
+} from '@proompteng/agents/routes/v1/agent-runs/$id'
+import '~/server/agents-v1-runtime'
 
 export const Route = createFileRoute('/v1/agent-runs/$id')({
   server: {
@@ -17,14 +15,5 @@ export const Route = createFileRoute('/v1/agent-runs/$id')({
 
 type JangarRunReadApiDependencies = Partial<RunReadApiDependencies>
 
-const createJangarPrimitivesStore = (): RunReadApiStore => createPrimitivesStore()
-
-const buildRunReadApiDependencies = (deps: JangarRunReadApiDependencies = {}): RunReadApiDependencies => ({
-  storeFactory: deps.storeFactory ?? createJangarPrimitivesStore,
-  kubeClient: deps.kubeClient,
-  kubeClientFactory: deps.kubeClientFactory ?? createKubernetesClient,
-  defaultNamespace: deps.defaultNamespace,
-})
-
 export const getAgentRunHandler = async (id: string, request: Request, deps: JangarRunReadApiDependencies = {}) =>
-  getAgentsServiceAgentRunHandler(id, request, buildRunReadApiDependencies(deps))
+  getAgentsServiceAgentRunHandler(id, request, deps)

--- a/services/jangar/src/routes/v1/runs/$id.ts
+++ b/services/jangar/src/routes/v1/runs/$id.ts
@@ -2,10 +2,8 @@ import { createFileRoute } from '@tanstack/react-router'
 import {
   getRunHandler as getAgentsServiceRunHandler,
   type RunReadApiDependencies,
-  type RunReadApiStore,
-} from '@proompteng/agents/server/v1/run-read'
-import { createKubernetesClient } from '~/server/primitives-kube'
-import { createPrimitivesStore } from '~/server/primitives-store'
+} from '@proompteng/agents/routes/v1/runs/$id'
+import '~/server/agents-v1-runtime'
 
 export const Route = createFileRoute('/v1/runs/$id')({
   server: {
@@ -17,14 +15,5 @@ export const Route = createFileRoute('/v1/runs/$id')({
 
 type JangarRunReadApiDependencies = Partial<RunReadApiDependencies>
 
-const createJangarPrimitivesStore = (): RunReadApiStore => createPrimitivesStore()
-
-const buildRunReadApiDependencies = (deps: JangarRunReadApiDependencies = {}): RunReadApiDependencies => ({
-  storeFactory: deps.storeFactory ?? createJangarPrimitivesStore,
-  kubeClient: deps.kubeClient,
-  kubeClientFactory: deps.kubeClientFactory ?? createKubernetesClient,
-  defaultNamespace: deps.defaultNamespace,
-})
-
 export const getRunHandler = async (id: string, request: Request, deps: JangarRunReadApiDependencies = {}) =>
-  getAgentsServiceRunHandler(id, request, buildRunReadApiDependencies(deps))
+  getAgentsServiceRunHandler(id, request, deps)

--- a/services/jangar/src/server/agents-v1-runtime.ts
+++ b/services/jangar/src/server/agents-v1-runtime.ts
@@ -1,0 +1,30 @@
+import { configureAgentsV1Runtime, type AgentsV1RuntimeDependencies } from '@proompteng/agents/server/v1/runtime'
+import {
+  resolveAuditContextFromRequest,
+  resolveRepositoryFromParameters as resolveRepositoryFromParameterMap,
+} from '~/server/audit-logging'
+import { requireLeaderForMutationHttp } from '~/server/leader-election'
+import { recordAgentQueueDepth } from '~/server/metrics'
+import { createKubernetesClient } from '~/server/primitives-kube'
+import { validatePolicies } from '~/server/primitives-policy'
+import { createPrimitivesStore } from '~/server/primitives-store'
+
+const createJangarPrimitivesStore = () => createPrimitivesStore()
+
+export const JANGAR_AGENTS_V1_RUNTIME_DEPENDENCIES = {
+  agentRuns: {
+    storeFactory: createJangarPrimitivesStore,
+    kubeClientFactory: createKubernetesClient,
+    requireLeaderForMutation: requireLeaderForMutationHttp,
+    recordAgentQueueDepth,
+    resolveAuditContextFromRequest,
+    resolveRepositoryFromParameters: (params) => resolveRepositoryFromParameterMap(params) ?? undefined,
+    validatePolicies,
+  },
+  runRead: {
+    storeFactory: createJangarPrimitivesStore,
+    kubeClientFactory: createKubernetesClient,
+  },
+} satisfies AgentsV1RuntimeDependencies
+
+configureAgentsV1Runtime(JANGAR_AGENTS_V1_RUNTIME_DEPENDENCIES)


### PR DESCRIPTION
## Summary

- Adds Agents-owned v1 route modules for AgentRun list/create, AgentRun read, and generic run read endpoints.
- Adds an Effect-backed Agents v1 runtime dependency layer so route modules can run with configured service dependencies or explicit test overrides.
- Reduces the matching Jangar v1 route files to compatibility shells that register TanStack routes and delegate to `@proompteng/agents`.

## Related Issues

None

## Testing

- `bun run --cwd services/agents tsc`
- `bun run --cwd services/agents test`
- `bun run --cwd services/agents test -- src/routes/v1/agent-runs.test.ts src/server/http-runtime.test.ts`
- `bun run --cwd services/agents lint`
- `bun run --cwd services/agents lint:oxlint`
- `bun run --cwd services/agents lint:oxlint:type`
- `bun run --cwd services/jangar tsc`
- `bun run --cwd services/jangar test`
- `bun run --cwd services/jangar test -- src/server/__tests__/primitives-endpoints.test.ts`
- `bun run --cwd services/jangar test -- src/server/__tests__/primitives-endpoints.test.ts src/server/__tests__/runtime-startup.test.ts src/server/__tests__/runtime-profile.test.ts`
- `bun run --cwd services/jangar lint`
- `bun run --cwd services/jangar lint:oxlint`
- `bun run --cwd services/jangar check:module-sizes`
- `bun run --cwd services/jangar build:server`
- `scripts/agents/guard-extraction-boundaries.sh`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
