### PR TITLE
chore(agents): promote images beb88d66

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: 29345f09
-  digest: sha256:9a22b915c656cbf4ffc63bda3a1a186ca018d168c40ac3e7d4f5f08aace58f8d
+  tag: beb88d66
+  digest: sha256:d797b2c21fc9375784fd283c366c153e0ee744fdac022bb61fc311ec777d195a
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,23 +11,23 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: 29345f09
-    digest: sha256:a123db7e5ed554327ade9757d268f41194821f1bf769f0dc67628c8625ac8dda
+    tag: beb88d66
+    digest: sha256:b05e89714932b8c97848d32fbdbddd83023a6e999b0a8d6931840dc94c8677dd
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
-      AGENTS_SOURCE_HEAD_SHA: 29345f0905b1c4a01bc692fadbffd9e140744f92
-      AGENTS_GITOPS_REVISION: 29345f0905b1c4a01bc692fadbffd9e140744f92
-      AGENTS_SOURCE_CI_RUN_ID: "26052663062"
+      AGENTS_SOURCE_HEAD_SHA: beb88d660670c7fb8273186d38f6ffb5e60cd1c9
+      AGENTS_GITOPS_REVISION: beb88d660670c7fb8273186d38f6ffb5e60cd1c9
+      AGENTS_SOURCE_CI_RUN_ID: "26055215312"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:a123db7e5ed554327ade9757d268f41194821f1bf769f0dc67628c8625ac8dda
-      AGENTS_SERVING_BUILD_COMMIT: 29345f0905b1c4a01bc692fadbffd9e140744f92
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:a123db7e5ed554327ade9757d268f41194821f1bf769f0dc67628c8625ac8dda
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:b05e89714932b8c97848d32fbdbddd83023a6e999b0a8d6931840dc94c8677dd
+      AGENTS_SERVING_BUILD_COMMIT: beb88d660670c7fb8273186d38f6ffb5e60cd1c9
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:b05e89714932b8c97848d32fbdbddd83023a6e999b0a8d6931840dc94c8677dd
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: 29345f09
-    digest: sha256:8ba28b04a4916030fd3310962860c4448d90be3ec6c1c068bd0e550ff531306f
+    tag: beb88d66
+    digest: sha256:dd14f4e11021a21277e1f28e7c116cf64efbe4c894cb846e1581b10ba2ea5965
 argocdHooks:
   enabled: true
   image:
@@ -82,8 +82,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: 29345f09
-    digest: sha256:9a22b915c656cbf4ffc63bda3a1a186ca018d168c40ac3e7d4f5f08aace58f8d
+    tag: beb88d66
+    digest: sha256:d797b2c21fc9375784fd283c366c153e0ee744fdac022bb61fc311ec777d195a
   autoscaling:
     enabled: false
   env:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `beb88d660670c7fb8273186d38f6ffb5e60cd1c9`
- Image tag: `beb88d66`
- Source CI run: `26055215312`
- Runner image pin preserved