### PR TITLE
fix(agents): declare control-plane runtime profile

### DIFF
--- a/charts/agents/templates/deployment.yaml
+++ b/charts/agents/templates/deployment.yaml
@@ -179,6 +179,10 @@ spec:
             - name: AGENTS_AUDIT_SINK_HTTP_HEADERS_JSON
               value: {{ toJson .Values.audit.sink.http.headers | quote }}
             {{- end }}
+            {{- if not (hasKey $envVars "AGENTS_SERVER_PROFILE") }}
+            - name: AGENTS_SERVER_PROFILE
+              value: "agents-control-plane"
+            {{- end }}
             {{- range $name, $value := $envVars }}
             - name: {{ $name }}
               value: {{ $value | quote }}

--- a/packages/scripts/src/agents/__tests__/build-image.test.ts
+++ b/packages/scripts/src/agents/__tests__/build-image.test.ts
@@ -1,3 +1,7 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { afterEach, describe, expect, it } from 'bun:test'
 
 import { __private } from '../build-image'
@@ -84,5 +88,26 @@ describe('agents build-image helpers', () => {
       '@proompteng/agents',
       '@proompteng/jangar',
     ])
+  })
+
+  it('copies only server output when prebuilt transitional Jangar output is used', () => {
+    const root = mkdtempSync(join(tmpdir(), 'agents-build-image-test-'))
+    try {
+      const source = join(root, 'source')
+      const destination = join(root, 'destination')
+      mkdirSync(join(source, 'server/proto/proompteng/jangar/v1'), { recursive: true })
+      mkdirSync(join(source, 'public/assets'), { recursive: true })
+      writeFileSync(join(source, 'server/index.mjs'), 'export {}')
+      writeFileSync(join(source, 'server/proto/proompteng/jangar/v1/agentctl.proto'), 'syntax = "proto3";')
+      writeFileSync(join(source, 'public/assets/app.js'), 'console.log("client")')
+
+      __private.copyPrebuiltServerOutput(source, destination)
+
+      expect(existsSync(join(destination, 'server/index.mjs'))).toBeTrue()
+      expect(existsSync(join(destination, 'server/proto/proompteng/jangar/v1/agentctl.proto'))).toBeTrue()
+      expect(existsSync(join(destination, 'public'))).toBeFalse()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/scripts/src/agents/build-image.ts
+++ b/packages/scripts/src/agents/build-image.ts
@@ -68,6 +68,11 @@ const parseCacheMode = (value: string | undefined): DockerCacheMode | undefined 
 const readAgentsEnv = (agentsName: string, legacyJangarName?: string) =>
   process.env[agentsName]?.trim() || (legacyJangarName ? process.env[legacyJangarName]?.trim() : undefined)
 
+const copyPrebuiltServerOutput = (source: string, destination: string) => {
+  cpSync(source, destination, { recursive: true })
+  rmSync(resolve(destination, 'public'), { recursive: true, force: true })
+}
+
 const createPrunedContext = async (): Promise<{ dir: string; cleanup: () => void }> => {
   ensureCli('bunx')
 
@@ -113,7 +118,7 @@ const createPrunedContext = async (): Promise<{ dir: string; cleanup: () => void
       const outputEntry = resolve(outputSource, 'server/index.mjs')
       const outputProto = resolve(outputSource, 'server/proto/proompteng/jangar/v1/agentctl.proto')
       if (existsSync(outputEntry) && existsSync(outputProto)) {
-        cpSync(outputSource, resolve(dir, 'full/services/jangar/.output'), { recursive: true })
+        copyPrebuiltServerOutput(outputSource, resolve(dir, 'full/services/jangar/.output'))
       } else if (existsSync(outputSource)) {
         console.warn('Skipping prebuilt .output: missing services/jangar/.output/server/index.mjs or agentctl.proto')
       }
@@ -242,6 +247,7 @@ if (import.meta.main) {
 
 export const __private = {
   buildArgsFromEnv,
+  copyPrebuiltServerOutput,
   execGit,
   parsePlatforms,
   parsePruneScopes,

--- a/scripts/agents/validate-agents.sh
+++ b/scripts/agents/validate-agents.sh
@@ -92,27 +92,48 @@ render_path = sys.argv[1]
 with open(render_path, encoding="utf-8") as handle:
     docs = list(yaml.safe_load_all(handle))
 
-deployment = next(
-    (
-        doc
-        for doc in docs
-        if isinstance(doc, dict)
-        and doc.get("kind") == "Deployment"
-        and doc.get("metadata", {}).get("name") == "release-name-agents"
-    ),
-    None,
-)
+def find_deployment(name: str):
+    return next(
+        (
+            doc
+            for doc in docs
+            if isinstance(doc, dict)
+            and doc.get("kind") == "Deployment"
+            and doc.get("metadata", {}).get("name") == name
+        ),
+        None,
+    )
+
+
+def first_container_env(deployment: dict, label: str):
+    containers = deployment.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+    if not containers:
+        print(f"Rendered {label} Deployment has no containers.", file=sys.stderr)
+        sys.exit(1)
+
+    env = {}
+    names = []
+    for entry in containers[0].get("env", []):
+        if isinstance(entry, dict) and isinstance(entry.get("name"), str):
+            names.append(entry["name"])
+            env[entry["name"]] = entry.get("value")
+    return env, names
+
+
+deployment = find_deployment("release-name-agents")
 if deployment is None:
     print("Rendered agents control-plane Deployment was not found.", file=sys.stderr)
     sys.exit(1)
 
-containers = deployment.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
-if not containers:
-    print("Rendered agents control-plane Deployment has no containers.", file=sys.stderr)
+controllers_deployment = find_deployment("release-name-agents-controllers")
+if controllers_deployment is None:
+    print("Rendered agents controllers Deployment was not found.", file=sys.stderr)
     sys.exit(1)
 
-env_names = [entry.get("name") for entry in containers[0].get("env", []) if isinstance(entry, dict)]
-nats_url_count = env_names.count("NATS_URL")
+control_plane_env, control_plane_env_names = first_container_env(deployment, "agents control-plane")
+controllers_env, _controllers_env_names = first_container_env(controllers_deployment, "agents controllers")
+
+nats_url_count = control_plane_env_names.count("NATS_URL")
 if nats_url_count != 1:
     message = (
         "Expected exactly one NATS_URL env var on the control-plane Deployment "
@@ -124,6 +145,19 @@ if nats_url_count != 1:
         file=sys.stderr,
     )
     sys.exit(1)
+
+expected_profiles = {
+    "control-plane": (control_plane_env, "agents-control-plane"),
+    "controllers": (controllers_env, "agents-controllers"),
+}
+for label, (env, expected) in expected_profiles.items():
+    actual = env.get("AGENTS_SERVER_PROFILE")
+    if actual != expected:
+        print(
+            f"Expected {label} AGENTS_SERVER_PROFILE={expected}, found {actual!r}.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 PY
 
 if run_with_helm3 helm template "${CHART_DIR}" \


### PR DESCRIPTION
## Summary

- Render `AGENTS_SERVER_PROFILE=agents-control-plane` from the Agents Helm chart for the control-plane deployment instead of relying only on the image default.
- Keep the typed Agents image-build helper from copying Jangar client assets when `AGENTS_USE_PREBUILT_OUTPUT=true` opts into a transitional prebuilt server bundle.
- Extend Agents chart validation and package-script tests to lock the control-plane and controllers runtime profile contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/build-image.test.ts`
- `scripts/agents/guard-extraction-boundaries.sh`
- `scripts/agents/validate-agents.sh`
- `bunx oxfmt --check packages/scripts/src/agents/build-image.ts packages/scripts/src/agents/__tests__/build-image.test.ts`
- `bun test packages/scripts/src/agents/__tests__`
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/agents/build-image.ts packages/scripts/src/agents/__tests__/build-image.test.ts`
- `BUILD_IMAGE=0 scripts/agents/kind-e2e.sh`
- `kubectl --context kind-agents -n agents get deploy agents -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' | rg 'AGENTS_SERVER_PROFILE|AGENTS_AGENT_RUNNER_IMAGE'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
