### PR TITLE
feat(torghut): enforce whitepaper validation evidence

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -27,6 +27,20 @@ def _string(value: Any) -> str:
     return str(value or "").strip()
 
 
+def _is_synthetic_dataset_snapshot(dataset_snapshot_id: str) -> bool:
+    normalized = dataset_snapshot_id.strip().lower()
+    return any(
+        token in normalized
+        for token in (
+            "synthetic",
+            "simulated",
+            "pre-replay",
+            "proposal-prior",
+            "placeholder",
+        )
+    )
+
+
 def _decomposition_symbol_contribution_shares(
     candidate: Mapping[str, Any],
 ) -> dict[str, str]:
@@ -241,6 +255,16 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
     ).lower()
     if freshness in {"stale", "expired", "not_fresh"}:
         blockers.append("stale_tape")
+    validation_contract = _mapping(
+        scorecard.get("validation_contract")
+        or bundle.promotion_readiness.get("validation_contract")
+    )
+    if _string(
+        validation_contract.get("synthetic_evidence_policy")
+    ) == "validation_only_not_promotion_proof" and _is_synthetic_dataset_snapshot(
+        bundle.dataset_snapshot_id
+    ):
+        blockers.append("synthetic_evidence_not_promotion_proof")
     return tuple(dict.fromkeys(blockers))
 
 

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -210,6 +210,8 @@ def _candidate_passes_minimums(bundle: CandidateEvidenceBundle) -> bool:
         "scheduler_v3_parity_missing",
         "scheduler_v3_approval_missing",
         "shadow_validation_missing",
+        "validation_contract_pending",
+        "validation_live_paper_parity_pending",
     }
     if blocking - allowed_blockers:
         return False

--- a/services/torghut/app/whitepapers/claim_compiler.py
+++ b/services/torghut/app/whitepapers/claim_compiler.py
@@ -623,6 +623,212 @@ RECENT_WHITEPAPER_SEEDS: tuple[WhitepaperResearchSource, ...] = (
             },
         ),
     ),
+    WhitepaperResearchSource(
+        run_id="seed-ssrn-6440898",
+        title="Market Depth and Execution Delays",
+        source_url="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6440898",
+        published_at="2026-05-15",
+        claims=(
+            {
+                "claim_id": "delay-adjusted-depth-fillability",
+                "claim_type": "feature_recipe",
+                "claim_text": (
+                    "Market depth and execution delay jointly determine practical fillability, so "
+                    "route scoring should use delay-adjusted depth rather than spread alone."
+                ),
+                "asset_scope": "us_equities_execution",
+                "horizon_scope": "intraday_execution",
+                "expected_direction": "neutral",
+                "data_requirements": [
+                    "depth_proxy",
+                    "execution_delay",
+                    "route_tca",
+                    "spread_bps",
+                ],
+                "confidence": "0.74",
+            },
+            {
+                "claim_id": "delay-adjusted-liquidity-validation",
+                "claim_type": "validation_requirement",
+                "claim_text": (
+                    "Execution-delay sensitivity should block promotion when paper fills depend on "
+                    "optimistic no-delay liquidity assumptions."
+                ),
+                "asset_scope": "us_equities_execution",
+                "horizon_scope": "intraday_execution",
+                "expected_direction": "neutral",
+                "data_requirements": [
+                    "execution_delay",
+                    "fill_model",
+                    "route_tca",
+                    "live_paper_parity",
+                ],
+                "confidence": "0.74",
+            },
+        ),
+        claim_relations=(
+            {
+                "relation_id": "delay-depth-validates-fillability",
+                "relation_type": "requires_validation",
+                "source_claim_id": "delay-adjusted-liquidity-validation",
+                "target_claim_id": "delay-adjusted-depth-fillability",
+            },
+        ),
+    ),
+    WhitepaperResearchSource(
+        run_id="seed-arxiv-2605-15746",
+        title="The Privacy Subsidy: Kyle's Lambda under Noise-Perturbed Order-Flow Observation",
+        source_url="https://arxiv.org/abs/2605.15746",
+        published_at="2026-05-15",
+        claims=(
+            {
+                "claim_id": "orderflow-attribution-noise-state",
+                "claim_type": "signal_mechanism",
+                "claim_text": (
+                    "Noise-perturbed order-flow observation changes inferred adverse selection and "
+                    "market-impact estimates, so OFI signals need source-quality state."
+                ),
+                "asset_scope": "us_equities_intraday",
+                "horizon_scope": "intraday_microstructure",
+                "expected_direction": "neutral",
+                "data_requirements": [
+                    "order_flow_imbalance",
+                    "quote_attribution_quality",
+                    "impact_lambda_estimate",
+                ],
+                "confidence": "0.72",
+            },
+            {
+                "claim_id": "attribution-quality-impact-stress",
+                "claim_type": "risk_constraint",
+                "claim_text": (
+                    "Noisy or partially private flow observations can understate Kyle-lambda style "
+                    "impact, requiring attribution-quality stress before treating flow as alpha."
+                ),
+                "asset_scope": "us_equities_intraday",
+                "horizon_scope": "intraday_execution",
+                "expected_direction": "neutral",
+                "data_requirements": [
+                    "quote_attribution_quality",
+                    "route_tca",
+                    "market_impact_stress",
+                    "live_paper_parity",
+                ],
+                "confidence": "0.72",
+            },
+        ),
+        claim_relations=(
+            {
+                "relation_id": "flow-noise-validates-attribution-quality",
+                "relation_type": "requires_validation",
+                "source_claim_id": "attribution-quality-impact-stress",
+                "target_claim_id": "orderflow-attribution-noise-state",
+            },
+        ),
+    ),
+    WhitepaperResearchSource(
+        run_id="seed-arxiv-2605-12151",
+        title="RED-2400: A Public Benchmark of Algorithmically-Rejected Trading Events with Outcome Labels",
+        source_url="https://arxiv.org/abs/2605.12151",
+        published_at="2026-05-12",
+        claims=(
+            {
+                "claim_id": "rejected-event-outcome-learning",
+                "claim_type": "signal_mechanism",
+                "claim_text": (
+                    "Algorithmically rejected trading events with realized outcome labels can turn "
+                    "skipped-signal logs into counterfactual training examples for veto calibration."
+                ),
+                "asset_scope": "intraday_execution",
+                "horizon_scope": "rejected_event_learning",
+                "expected_direction": "neutral",
+                "data_requirements": [
+                    "rejected_signal_log",
+                    "outcome_labels",
+                    "executable_quote",
+                ],
+                "confidence": "0.76",
+            },
+            {
+                "claim_id": "counterfactual-reject-validation",
+                "claim_type": "validation_requirement",
+                "claim_text": (
+                    "Rejected-event benchmarks should measure whether current vetoes discard "
+                    "profitable executable opportunities or correctly block bad fills."
+                ),
+                "asset_scope": "intraday_execution",
+                "horizon_scope": "rejected_event_learning",
+                "expected_direction": "neutral",
+                "data_requirements": [
+                    "rejected_signal_log",
+                    "counterfactual_return",
+                    "route_tca",
+                    "post_cost_net_pnl",
+                ],
+                "confidence": "0.76",
+            },
+        ),
+        claim_relations=(
+            {
+                "relation_id": "rejected-outcomes-validate-vetoes",
+                "relation_type": "requires_validation",
+                "source_claim_id": "counterfactual-reject-validation",
+                "target_claim_id": "rejected-event-outcome-learning",
+            },
+        ),
+    ),
+    WhitepaperResearchSource(
+        run_id="seed-arxiv-2605-11423",
+        title="A Validated Volatility-Volume-Gap Classifier for Regime Identification in MNQ Intraday Data",
+        source_url="https://arxiv.org/abs/2605.11423",
+        published_at="2026-05-12",
+        claims=(
+            {
+                "claim_id": "vvg-descriptive-regime-filter",
+                "claim_type": "feature_recipe",
+                "claim_text": (
+                    "Opening volatility, overnight gap, and abnormal volume can classify descriptive "
+                    "intraday regimes, but should be used as context filters rather than direct alpha."
+                ),
+                "asset_scope": "intraday_momentum",
+                "horizon_scope": "intraday",
+                "expected_direction": "neutral",
+                "data_requirements": [
+                    "opening_window_return_bps",
+                    "opening_window_return_from_prev_close_bps",
+                    "volume_regime",
+                    "realized_volatility",
+                ],
+                "confidence": "0.71",
+            },
+            {
+                "claim_id": "vvg-directional-strategy-falsification",
+                "claim_type": "validation_requirement",
+                "claim_text": (
+                    "Directional strategies derived from the classifier failed institutional "
+                    "post-cost and multi-year stability gates, so promotion requires replay proof."
+                ),
+                "asset_scope": "intraday_momentum",
+                "horizon_scope": "intraday",
+                "expected_direction": "neutral",
+                "data_requirements": [
+                    "walk_forward_replay",
+                    "transaction_cost_stress",
+                    "drawdown_validation",
+                    "live_paper_parity",
+                ],
+                "confidence": "0.75",
+            },
+        ),
+        claim_relations=(
+            {
+                "relation_id": "vvg-falsification-requires-replay-proof",
+                "relation_type": "invalidates",
+                "source_claim_id": "vvg-directional-strategy-falsification",
+                "target_claim_id": "vvg-descriptive-regime-filter",
+            },
+        ),
+    ),
 )
 
 

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -962,7 +962,9 @@ def _risk_adjusted_drawdown_passes(
 ) -> bool:
     normal_limit = max(Decimal("0"), start_equity * normal_pct)
     percent_limit = max(normal_limit, start_equity * extended_pct)
-    extended_limit = percent_limit if absolute_cap <= 0 else min(absolute_cap, percent_limit)
+    extended_limit = (
+        percent_limit if absolute_cap <= 0 else min(absolute_cap, percent_limit)
+    )
     if observed <= normal_limit:
         return True
     if observed <= extended_limit and observed > 0:
@@ -2650,6 +2652,52 @@ def _candidate_payload_with_feedback_metadata(
         **metadata,
         **scorecard,
     }
+    validation_requirements = _list_of_mappings(
+        spec.feature_contract.get("validation_requirements")
+    )
+    validation_requirement_claim_ids = [
+        _string(item.get("claim_id"))
+        for item in validation_requirements
+        if _string(item.get("claim_id"))
+    ]
+    if validation_requirements or spec.promotion_contract.get(
+        "synthetic_evidence_policy"
+    ):
+        validation_contract = {
+            "schema_version": "torghut.candidate-validation-contract.v1",
+            "source": "candidate_spec",
+            "validation_requirements": validation_requirements,
+            "validation_requirement_claim_ids": validation_requirement_claim_ids,
+            "requires_historical_replay": bool(
+                spec.promotion_contract.get("requires_historical_replay")
+            ),
+            "requires_live_paper_parity": bool(
+                spec.promotion_contract.get("requires_live_paper_parity")
+            ),
+            "synthetic_evidence_policy": _string(
+                spec.promotion_contract.get("synthetic_evidence_policy")
+            ),
+        }
+        next_candidate["objective_scorecard"] = {
+            **_mapping(next_candidate.get("objective_scorecard")),
+            "validation_contract": validation_contract,
+        }
+        readiness = _mapping(next_candidate.get("promotion_readiness"))
+        blockers = _string_list_from_value(readiness.get("blockers"))
+        blockers.append("validation_contract_pending")
+        if validation_contract["requires_live_paper_parity"]:
+            blockers.append("validation_live_paper_parity_pending")
+        if validation_contract["synthetic_evidence_policy"]:
+            blockers.append("synthetic_evidence_not_promotion_proof")
+        next_candidate["promotion_readiness"] = {
+            **readiness,
+            "stage": _string(readiness.get("stage")) or "research_candidate",
+            "status": _string(readiness.get("status"))
+            or "blocked_pending_validation_contract",
+            "promotable": False,
+            "blockers": list(dict.fromkeys(blockers)),
+            "validation_contract": validation_contract,
+        }
     return next_candidate
 
 

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -200,6 +200,97 @@ class TestPortfolioOptimizer(TestCase):
         self.assertTrue(portfolio.objective_scorecard["target_met"])
         self.assertTrue(portfolio.objective_scorecard["oracle_passed"])
 
+    def test_portfolio_allows_research_candidates_pending_validation_contract(
+        self,
+    ) -> None:
+        def bundle(
+            candidate_id: str, symbol: str, blockers: list[str]
+        ) -> CandidateEvidenceBundle:
+            return evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"spec-{candidate_id}",
+                candidate={
+                    "candidate_id": candidate_id,
+                    "runtime_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "family_template_id": "microbar_cross_sectional_pairs_v1",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "280",
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                        "worst_day_loss": "0",
+                        "max_drawdown": "0",
+                        "max_gross_exposure_pct_equity": "0.5",
+                        "min_cash": "5000",
+                        "negative_cash_observation_count": 0,
+                        "best_day_share": "0.2",
+                        "avg_filled_notional_per_day": "150000",
+                        "regime_slice_pass_rate": "0.55",
+                        "posterior_edge_lower": "0.01",
+                        "shadow_parity_status": "within_budget",
+                        "correlation_cluster": candidate_id,
+                        "symbol_contribution_shares": {symbol: "1.0"},
+                        **_executable_scorecard_fields(candidate_id),
+                    },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": "280",
+                            "2026-02-24": "280",
+                            "2026-02-25": "280",
+                            "2026-02-26": "280",
+                            "2026-02-27": "280",
+                        },
+                        "daily_filled_notional": {
+                            "2026-02-23": "150000",
+                            "2026-02-24": "150000",
+                            "2026-02-25": "150000",
+                            "2026-02-26": "150000",
+                            "2026-02-27": "150000",
+                        },
+                    },
+                    "promotion_readiness": {
+                        "stage": "research_candidate",
+                        "status": "blocked_pending_validation_contract",
+                        "promotable": False,
+                        "blockers": blockers,
+                    },
+                },
+                dataset_snapshot_id=f"historical-market-replay-{candidate_id}",
+                result_path=f"/tmp/{candidate_id}.json",
+            )
+
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=[
+                bundle(
+                    "validation-pending-a",
+                    "AAPL",
+                    [
+                        "validation_contract_pending",
+                        "validation_live_paper_parity_pending",
+                    ],
+                ),
+                bundle(
+                    "validation-pending-b",
+                    "AMZN",
+                    ["validation_contract_pending"],
+                ),
+            ],
+            target_net_pnl_per_day=Decimal("500"),
+            oracle_policy=ProfitTargetOraclePolicy(
+                max_cluster_contribution_share=Decimal("0.50"),
+                max_single_symbol_contribution_share=Decimal("0.50"),
+            ),
+            portfolio_size_min=2,
+            portfolio_size_max=2,
+        )
+
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        self.assertEqual(portfolio.objective_scorecard["net_pnl_per_day"], "560")
+        self.assertEqual(
+            {sleeve["candidate_id"] for sleeve in portfolio.sleeves},
+            {"validation-pending-a", "validation-pending-b"},
+        )
+
     def test_portfolio_sleeves_preserve_runtime_params_for_closure(self) -> None:
         def bundle(candidate_id: str, symbol: str) -> CandidateEvidenceBundle:
             return evidence_bundle_from_frontier_candidate(

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -31,6 +31,7 @@ from app.models import (
     WhitepaperDocument,
     WhitepaperDocumentVersion,
 )
+from app.trading.discovery.evidence_bundles import evidence_bundle_blockers
 
 _CHIP_UNIVERSE = list(runner.LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE)
 
@@ -282,6 +283,118 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "cross_section_positive_opening_window_return_from_prev_close_ratio",
         )
         self.assertEqual(scorecard["universe_symbols"], ["NVDA", "AVGO", "AMD"])
+
+    def test_candidate_feedback_metadata_preserves_validation_contract(
+        self,
+    ) -> None:
+        spec = replace(
+            self._candidate_spec("spec-validation-contract"),
+            feature_contract={
+                "mechanism": "scale-invariant trade-flow stress contract",
+                "required_features": ("trade_flow", "relative_volume"),
+                "source_run_id": "paper-arxiv-2602-23784",
+                "family_selection": {"rank": 1},
+                "validation_requirements": [
+                    {
+                        "claim_id": "synthetic-rollout-stress",
+                        "claim_type": "validation_requirement",
+                        "claim_text": (
+                            "Synthetic trade-flow rollouts are stress inputs, not "
+                            "promotion proof."
+                        ),
+                        "data_requirements": [
+                            "historical_replay",
+                            "live_paper_parity",
+                            "market_impact_stress",
+                        ],
+                    }
+                ],
+            },
+            promotion_contract={
+                "requires_historical_replay": True,
+                "requires_live_paper_parity": True,
+                "synthetic_evidence_policy": "validation_only_not_promotion_proof",
+            },
+        )
+
+        candidate = runner._candidate_payload_with_feedback_metadata(
+            spec=spec,
+            candidate={
+                "candidate_id": "candidate-validation-contract",
+                "objective_scorecard": {"net_pnl_per_day": "525"},
+                "promotion_readiness": {
+                    "stage": "research_candidate",
+                    "status": "blocked_pending_runtime_parity",
+                    "promotable": False,
+                    "blockers": ["scheduler_v3_parity_missing"],
+                },
+            },
+        )
+        bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id=spec.candidate_spec_id,
+            candidate=candidate,
+            dataset_snapshot_id="historical-market-replay-2026-05-18",
+            result_path="/tmp/historical-replay.json",
+        )
+
+        validation_contract = bundle.objective_scorecard["validation_contract"]
+        self.assertEqual(
+            validation_contract["validation_requirement_claim_ids"],
+            ["synthetic-rollout-stress"],
+        )
+        self.assertEqual(
+            bundle.promotion_readiness["validation_contract"],
+            validation_contract,
+        )
+        self.assertIn(
+            "validation_live_paper_parity_pending",
+            bundle.promotion_readiness["blockers"],
+        )
+        self.assertNotIn(
+            "synthetic_evidence_not_promotion_proof",
+            evidence_bundle_blockers(bundle),
+        )
+
+    def test_validation_contract_rejects_synthetic_evidence_as_profit_proof(
+        self,
+    ) -> None:
+        spec = replace(
+            self._candidate_spec("spec-synthetic-contract"),
+            feature_contract={
+                **self._candidate_spec("spec-synthetic-contract").feature_contract,
+                "validation_requirements": [
+                    {
+                        "claim_id": "synthetic-stress",
+                        "claim_type": "validation_requirement",
+                        "claim_text": "Synthetic rollouts are stress-only evidence.",
+                        "data_requirements": ["historical_replay"],
+                    }
+                ],
+            },
+            promotion_contract={
+                "requires_historical_replay": True,
+                "synthetic_evidence_policy": "validation_only_not_promotion_proof",
+            },
+        )
+        candidate = runner._candidate_payload_with_feedback_metadata(
+            spec=spec,
+            candidate={
+                "candidate_id": "candidate-synthetic-contract",
+                "objective_scorecard": {"net_pnl_per_day": "800"},
+            },
+        )
+
+        bundle = runner.evidence_bundle_from_frontier_candidate(
+            candidate_spec_id=spec.candidate_spec_id,
+            candidate=candidate,
+            dataset_snapshot_id="synthetic-recent-whitepaper-2025-2026",
+            result_path="/tmp/synthetic-replay.json",
+        )
+
+        self.assertIn(
+            "synthetic_evidence_not_promotion_proof",
+            evidence_bundle_blockers(bundle),
+        )
 
     def test_parse_args_defaults_to_500_daily_profit_program(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_whitepaper_claim_compiler.py
+++ b/services/torghut/tests/test_whitepaper_claim_compiler.py
@@ -23,6 +23,10 @@ class TestWhitepaperClaimCompiler(TestCase):
         self.assertGreaterEqual(len(cards), 10)
         self.assertTrue(
             {
+                "seed-ssrn-6440898",
+                "seed-arxiv-2605-15746",
+                "seed-arxiv-2605-12151",
+                "seed-arxiv-2605-11423",
                 "seed-arxiv-2605-04004",
                 "seed-arxiv-2604-10402",
                 "seed-arxiv-2604-09060",
@@ -31,9 +35,7 @@ class TestWhitepaperClaimCompiler(TestCase):
                 "seed-arxiv-2602-07085",
             }.issubset({source.run_id for source in RECENT_WHITEPAPER_SEEDS})
         )
-        self.assertTrue(
-            all(card.source_run_id.startswith("seed-arxiv-") for card in cards)
-        )
+        self.assertTrue(all(card.source_run_id.startswith("seed-") for card in cards))
         self.assertTrue(all(card.required_features for card in cards))
         self.assertTrue(all(card.risk_controls for card in cards))
 


### PR DESCRIPTION
## Summary

- Adds May 12 and May 15 whitepaper seeds to the default Torghut recent-paper source path, including execution delay, noisy order-flow, rejected-event, and VVG falsification sources.
- Carries compiled validation contracts into candidate scorecards and promotion readiness so historical replay, live-paper parity, and synthetic-evidence policies stay visible in evidence bundles.
- Blocks synthetic/pre-replay dataset snapshots from counting as promotion proof when the candidate contract marks synthetic evidence as validation-only, while allowing portfolio research assembly to continue with pending validation blockers.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/whitepapers/claim_compiler.py app/trading/discovery/evidence_bundles.py app/trading/discovery/portfolio_optimizer.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_whitepaper_claim_compiler.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_portfolio_optimizer.py`
- `uv run --frozen ruff check app/whitepapers/claim_compiler.py app/trading/discovery/evidence_bundles.py app/trading/discovery/portfolio_optimizer.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_whitepaper_claim_compiler.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_portfolio_optimizer.py`
- `uv run --frozen pytest tests/test_whitepaper_claim_compiler.py -k recent_seed_sources`
- `uv run --frozen pytest tests/test_whitepaper_claim_compiler.py tests/test_whitepaper_candidate_compiler.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_portfolio_optimizer.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
