### PR TITLE
chore(agents): promote images 41fb435d

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: cfd93bd0
-  digest: sha256:0589c6f6d6c6cf85bbe5dc0bb95fc90ad6bdfb90e60334690112e8c8c3ef0058
+  tag: 41fb435d
+  digest: sha256:481faee28bbd9c0eba7e65c51210d911a57d2d578a264e6363d4fd350ac2044b
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,23 +11,23 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: cfd93bd0
-    digest: sha256:e46afa936d42e2ec872b8844161e9989379c59630d641bcda1f0c96ddaf674db
+    tag: 41fb435d
+    digest: sha256:5345c38e436ce7762215472e6670003c169fbf9979983c80c26020f9b9411cc7
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
-      AGENTS_SOURCE_HEAD_SHA: cfd93bd0d958fd6ff88e6b1accef943271c21838
-      AGENTS_GITOPS_REVISION: cfd93bd0d958fd6ff88e6b1accef943271c21838
-      AGENTS_SOURCE_CI_RUN_ID: "26057513241"
+      AGENTS_SOURCE_HEAD_SHA: 41fb435d4174024f093c522be2afc86a57502a32
+      AGENTS_GITOPS_REVISION: 41fb435d4174024f093c522be2afc86a57502a32
+      AGENTS_SOURCE_CI_RUN_ID: "26061129535"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:e46afa936d42e2ec872b8844161e9989379c59630d641bcda1f0c96ddaf674db
-      AGENTS_SERVING_BUILD_COMMIT: cfd93bd0d958fd6ff88e6b1accef943271c21838
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:e46afa936d42e2ec872b8844161e9989379c59630d641bcda1f0c96ddaf674db
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:5345c38e436ce7762215472e6670003c169fbf9979983c80c26020f9b9411cc7
+      AGENTS_SERVING_BUILD_COMMIT: 41fb435d4174024f093c522be2afc86a57502a32
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:5345c38e436ce7762215472e6670003c169fbf9979983c80c26020f9b9411cc7
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: cfd93bd0
-    digest: sha256:45082b747557b7fa4503b315aaee2a1ea53c211964910ecee3019702f78f54fe
+    tag: 41fb435d
+    digest: sha256:1dfc3a3f2e33ae75269c53d991542585e8e2f3ba3b2145522bfdbf5615222d5b
 argocdHooks:
   enabled: true
   image:
@@ -82,8 +82,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: cfd93bd0
-    digest: sha256:0589c6f6d6c6cf85bbe5dc0bb95fc90ad6bdfb90e60334690112e8c8c3ef0058
+    tag: 41fb435d
+    digest: sha256:481faee28bbd9c0eba7e65c51210d911a57d2d578a264e6363d4fd350ac2044b
   autoscaling:
     enabled: false
   env:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `41fb435d4174024f093c522be2afc86a57502a32`
- Image tag: `41fb435d`
- Source CI run: `26061129535`
- Runner image pin preserved