### PR TITLE
chore(jangar): promote image 41fb435d

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-18T19:32:07Z
+    deploy.knative.dev/rollout: 2026-05-18T21:32:00Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:beb88d66@sha256:bb18d8e272ed3920e7b38d2e7712346ba02db4f3d06881024aef0d49af7a4640
+              value: registry.ide-newton.ts.net/lab/jangar:41fb435d@sha256:39e661a5583c21cd4b69581f3d3d5333b3acc678454968f1f7d9f4e38f699372
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: beb88d660670c7fb8273186d38f6ffb5e60cd1c9
+              value: 41fb435d4174024f093c522be2afc86a57502a32
             - name: JANGAR_GITOPS_REVISION
-              value: beb88d660670c7fb8273186d38f6ffb5e60cd1c9
+              value: 41fb435d4174024f093c522be2afc86a57502a32
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26055707272"
+              value: "26061644415"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:ffe3a11aa6586e8f51738f0c9cfecb5838aa0f1c11cffbee8194ba6b202de4c9
+              value: sha256:22499a3b86650182852242ee056544e2553bbac2a0ad631fbfcafbcc4778c571
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: beb88d660670c7fb8273186d38f6ffb5e60cd1c9
+              value: 41fb435d4174024f093c522be2afc86a57502a32
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:ffe3a11aa6586e8f51738f0c9cfecb5838aa0f1c11cffbee8194ba6b202de4c9
+              value: sha256:22499a3b86650182852242ee056544e2553bbac2a0ad631fbfcafbcc4778c571
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: beb88d66
-    digest: sha256:bb18d8e272ed3920e7b38d2e7712346ba02db4f3d06881024aef0d49af7a4640
+    newTag: 41fb435d
+    digest: sha256:39e661a5583c21cd4b69581f3d3d5333b3acc678454968f1f7d9f4e38f699372


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `41fb435d4174024f093c522be2afc86a57502a32`
- Image tag: `41fb435d`
- Image digest: `sha256:39e661a5583c21cd4b69581f3d3d5333b3acc678454968f1f7d9f4e38f699372`
- Source CI run: `26061644415`
- Control-plane serving digest: `sha256:22499a3b86650182852242ee056544e2553bbac2a0ad631fbfcafbcc4778c571`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates