### PR TITLE
fix(agents): label runtime startup logs

### DIFF
--- a/services/jangar/src/server/__tests__/agentctl-grpc-logging.test.ts
+++ b/services/jangar/src/server/__tests__/agentctl-grpc-logging.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { startAgentctlGrpcServer } from '../agentctl-grpc'
+
+const ORIGINAL_ENV = { ...process.env }
+
+describe('agentctl gRPC runtime logging', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    process.env = { ...ORIGINAL_ENV }
+    delete process.env.AGENTS_RUNTIME_SERVICE
+    delete process.env.JANGAR_GRPC_ENABLED
+    delete process.env.AGENTS_GRPC_ENABLED
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  it('uses Agents log labels in Agents runtime mode', () => {
+    process.env.AGENTS_RUNTIME_SERVICE = 'agents'
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    expect(startAgentctlGrpcServer()).toBeNull()
+
+    expect(info).toHaveBeenCalledWith('[agents] agentctl grpc disabled for control plane')
+  })
+
+  it('keeps legacy Jangar labels outside Agents runtime mode', () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    expect(startAgentctlGrpcServer()).toBeNull()
+
+    expect(info).toHaveBeenCalledWith('[jangar] agentctl grpc disabled for control plane')
+  })
+})

--- a/services/jangar/src/server/agentctl-grpc.ts
+++ b/services/jangar/src/server/agentctl-grpc.ts
@@ -7,6 +7,7 @@ import * as grpc from '@grpc/grpc-js'
 import { status as GrpcStatus, ServerCredentials, type ServerUnaryCall, type ServerWritableStream } from '@grpc/grpc-js'
 import { loadSync } from '@grpc/proto-loader'
 import { KubeConfig, Log } from '@kubernetes/client-node'
+import { resolveRuntimeServiceName } from '@proompteng/agents/server/runtime-identity'
 import { postAgentRunsHandler } from '~/routes/v1/agent-runs'
 import { resolveAgentctlGrpcConfig } from '~/server/agentctl-grpc-config'
 import { buildControlPlaneStatus, type GrpcStatus as ControlPlaneGrpcStatus } from '~/server/control-plane-status'
@@ -18,7 +19,6 @@ import { createKubernetesClient, type KubernetesClient, RESOURCE_MAP } from '~/s
 const DEFAULT_NAMESPACE = 'agents'
 const DEFAULT_WORKFLOW_STEP = 'implement'
 const SERVICE_NAME = 'jangar'
-
 type AgentctlServer = {
   server: grpc.Server
   address: string
@@ -421,7 +421,7 @@ export const startAgentctlGrpcServer = (): AgentctlServer | null => {
   const component = resolveComponent()
   const config = resolveAgentctlGrpcConfig()
   if (!config.enabled) {
-    console.info(`[jangar] agentctl grpc not enabled for ${component}; set JANGAR_GRPC_ENABLED=true to start listener`)
+    console.info(`[${resolveRuntimeServiceName()}] agentctl grpc disabled for ${component}`)
     return null
   }
 
@@ -1160,10 +1160,10 @@ export const startAgentctlGrpcServer = (): AgentctlServer | null => {
 
   server.bindAsync(config.address, ServerCredentials.createInsecure(), (error) => {
     if (error) {
-      console.error('[jangar] agentctl grpc failed to bind', error)
+      console.error(`[${resolveRuntimeServiceName()}] agentctl grpc failed to bind`, error)
       return
     }
-    console.info(`[jangar] agentctl grpc listening on ${config.address} for ${component}`)
+    console.info(`[${resolveRuntimeServiceName()}] agentctl grpc listening on ${config.address} for ${component}`)
   })
 
   return { server, address: config.address }

--- a/services/jangar/src/server/index.ts
+++ b/services/jangar/src/server/index.ts
@@ -1,4 +1,5 @@
 import { installAgentsEnvCompatibility } from '@proompteng/agents/server/env-compat'
+import { resolveRuntimeServiceName } from '@proompteng/agents/server/runtime-identity'
 
 import { bootRuntimeProfile } from './runtime-boot'
 import { resolveJangarRuntimeProfile } from './runtime-profile'
@@ -32,4 +33,6 @@ const server = Bun.serve({
   },
 })
 
-console.log(`[jangar] ${runtimeProfile.name} listening on http://${server.hostname}:${server.port}`)
+console.log(
+  `[${resolveRuntimeServiceName()}] ${runtimeProfile.name} listening on http://${server.hostname}:${server.port}`,
+)


### PR DESCRIPTION
## Summary

- Labels Jangar server startup logs with the resolved runtime service name so Agents pods emit `[agents]`.
- Labels agentctl gRPC startup, disabled, and bind-failure logs with the resolved runtime service name.
- Keeps legacy Jangar log labels outside Agents runtime mode.

## Related Issues

None

## Testing

- `bun run --cwd services/jangar test -- src/server/__tests__/agentctl-grpc-logging.test.ts`
- `bun run --filter @proompteng/jangar tsc`
- `bunx oxfmt --check services/jangar/src/server/index.ts services/jangar/src/server/agentctl-grpc.ts services/jangar/src/server/__tests__/agentctl-grpc-logging.test.ts`
- `bunx oxlint --config .oxlintrc.json services/jangar/src/server/index.ts services/jangar/src/server/agentctl-grpc.ts services/jangar/src/server/__tests__/agentctl-grpc-logging.test.ts`
- `bun run --cwd services/jangar docs:inventory:check`
- `bun run --cwd services/jangar check:module-sizes`
- `scripts/agents/guard-extraction-boundaries.sh`
- `scripts/agents/validate-agents.sh`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
