### PR TITLE
fix(torghut): fail closed profitability proof gates

### DIFF
--- a/services/torghut/scripts/build_historical_profitability_proof.py
+++ b/services/torghut/scripts/build_historical_profitability_proof.py
@@ -22,8 +22,17 @@ from app.trading.evaluation import (
 )
 
 _SERVICE_ROOT = Path(__file__).resolve().parent.parent
-_PROFITABILITY_PROOF_SCHEMA_VERSION = 'torghut.historical-profitability-proof.v1'
-_DEFAULT_BASELINE_ID = 'cash-flat@baseline'
+_PROFITABILITY_PROOF_SCHEMA_VERSION = "torghut.historical-profitability-proof.v1"
+_DEFAULT_BASELINE_ID = "cash-flat@baseline"
+_DEFAULT_TARGET_NET_PNL_PER_DAY = Decimal("500")
+_DEFAULT_MIN_SAMPLE_SIZE = 20
+_DEFAULT_MIN_ACTIVE_DAY_RATIO = Decimal("0.90")
+_DEFAULT_MIN_POSITIVE_DAY_RATIO = Decimal("0.60")
+_DEFAULT_MAX_BEST_DAY_SHARE = Decimal("0.25")
+_DEFAULT_START_EQUITY = Decimal("31590.02")
+_DEFAULT_MAX_DRAWDOWN_PCT_EQUITY = Decimal("0.10")
+_DEFAULT_EXTENDED_MAX_DRAWDOWN_PCT_EQUITY = Decimal("0.15")
+_DEFAULT_MIN_TOTAL_NET_PNL_TO_DRAWDOWN_RATIO = Decimal("2.00")
 
 
 @dataclass(frozen=True)
@@ -53,40 +62,101 @@ class HistoricalRunSummary:
     trade_pnl_csv_path: Path | None
 
 
+@dataclass(frozen=True)
+class ProfitabilityProofGatePolicy:
+    target_net_pnl_per_day: Decimal = _DEFAULT_TARGET_NET_PNL_PER_DAY
+    min_sample_size: int = _DEFAULT_MIN_SAMPLE_SIZE
+    min_active_day_ratio: Decimal = _DEFAULT_MIN_ACTIVE_DAY_RATIO
+    min_positive_day_ratio: Decimal = _DEFAULT_MIN_POSITIVE_DAY_RATIO
+    max_best_day_share: Decimal = _DEFAULT_MAX_BEST_DAY_SHARE
+    min_daily_notional: Decimal = Decimal("0")
+    start_equity: Decimal = _DEFAULT_START_EQUITY
+    max_drawdown_pct_equity: Decimal = _DEFAULT_MAX_DRAWDOWN_PCT_EQUITY
+    extended_max_drawdown_pct_equity: Decimal = (
+        _DEFAULT_EXTENDED_MAX_DRAWDOWN_PCT_EQUITY
+    )
+    min_total_net_pnl_to_drawdown_ratio: Decimal = (
+        _DEFAULT_MIN_TOTAL_NET_PNL_TO_DRAWDOWN_RATIO
+    )
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description='Build profitability proof artifacts from historical Torghut simulation outputs.',
+        description="Build profitability proof artifacts from historical Torghut simulation outputs.",
     )
-    parser.add_argument('--run-dir', action='append', required=True, help='Historical simulation run directory.')
     parser.add_argument(
-        '--baseline-run-dir',
-        action='append',
-        default=[],
-        help='Optional baseline historical simulation run directory.',
+        "--run-dir",
+        action="append",
+        required=True,
+        help="Historical simulation run directory.",
     )
-    parser.add_argument('--output-dir', required=True, help='Directory for generated proof artifacts.')
-    parser.add_argument('--hypothesis', default='', help='Explicit hypothesis text for the proof manifest.')
-    parser.add_argument('--baseline-id', default='', help='Optional baseline identifier override.')
-    parser.add_argument('--json', action='store_true')
+    parser.add_argument(
+        "--baseline-run-dir",
+        action="append",
+        default=[],
+        help="Optional baseline historical simulation run directory.",
+    )
+    parser.add_argument(
+        "--output-dir", required=True, help="Directory for generated proof artifacts."
+    )
+    parser.add_argument(
+        "--hypothesis",
+        default="",
+        help="Explicit hypothesis text for the proof manifest.",
+    )
+    parser.add_argument(
+        "--baseline-id", default="", help="Optional baseline identifier override."
+    )
+    parser.add_argument(
+        "--target-net-pnl-per-day", default=str(_DEFAULT_TARGET_NET_PNL_PER_DAY)
+    )
+    parser.add_argument("--min-sample-size", type=int, default=_DEFAULT_MIN_SAMPLE_SIZE)
+    parser.add_argument(
+        "--min-active-day-ratio", default=str(_DEFAULT_MIN_ACTIVE_DAY_RATIO)
+    )
+    parser.add_argument(
+        "--min-positive-day-ratio", default=str(_DEFAULT_MIN_POSITIVE_DAY_RATIO)
+    )
+    parser.add_argument(
+        "--max-best-day-share", default=str(_DEFAULT_MAX_BEST_DAY_SHARE)
+    )
+    parser.add_argument("--min-daily-notional", default="0")
+    parser.add_argument("--start-equity", default=str(_DEFAULT_START_EQUITY))
+    parser.add_argument(
+        "--max-drawdown-pct-equity", default=str(_DEFAULT_MAX_DRAWDOWN_PCT_EQUITY)
+    )
+    parser.add_argument(
+        "--extended-max-drawdown-pct-equity",
+        default=str(_DEFAULT_EXTENDED_MAX_DRAWDOWN_PCT_EQUITY),
+    )
+    parser.add_argument(
+        "--min-total-net-pnl-to-drawdown-ratio",
+        default=str(_DEFAULT_MIN_TOTAL_NET_PNL_TO_DRAWDOWN_RATIO),
+    )
+    parser.add_argument("--json", action="store_true")
     return parser.parse_args()
 
 
 def _load_json(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding='utf-8'))
+    payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, Mapping):
-        raise RuntimeError(f'json_mapping_required:{path}')
+        raise RuntimeError(f"json_mapping_required:{path}")
     return {str(key): value for key, value in payload.items()}
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
-    payload = yaml.safe_load(path.read_text(encoding='utf-8'))
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(payload, Mapping):
-        raise RuntimeError(f'yaml_mapping_required:{path}')
+        raise RuntimeError(f"yaml_mapping_required:{path}")
     return {str(key): value for key, value in payload.items()}
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
-    return {str(key): item for key, item in value.items()} if isinstance(value, Mapping) else {}
+    return (
+        {str(key): item for key, item in value.items()}
+        if isinstance(value, Mapping)
+        else {}
+    )
 
 
 def _as_list(value: Any) -> list[Any]:
@@ -104,7 +174,7 @@ def _as_decimal(value: Any) -> Decimal:
     try:
         return Decimal(str(value))
     except Exception:
-        return Decimal('0')
+        return Decimal("0")
 
 
 def _as_int(value: Any) -> int:
@@ -116,9 +186,9 @@ def _as_int(value: Any) -> int:
 
 def _clamp_confidence(value: Decimal) -> Decimal:
     if value < 0:
-        return Decimal('0')
+        return Decimal("0")
     if value > 1:
-        return Decimal('1')
+        return Decimal("1")
     return value
 
 
@@ -128,19 +198,21 @@ def _sha256_bytes(payload: bytes) -> str:
 
 def _sha256_json(payload: Mapping[str, Any]) -> str:
     return _sha256_bytes(
-        json.dumps(payload, indent=2, sort_keys=True, default=str).encode('utf-8')
+        json.dumps(payload, indent=2, sort_keys=True, default=str).encode("utf-8")
     )
 
 
 def _stable_hash_payload(payload: Any) -> str:
     return _sha256_bytes(
-        json.dumps(payload, sort_keys=True, separators=(',', ':'), default=str).encode('utf-8')
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode(
+            "utf-8"
+        )
     )
 
 
 def _resolve_manifest_path(run_dir: Path, report: Mapping[str, Any]) -> Path | None:
-    run_metadata = _as_dict(report.get('run_metadata'))
-    raw = _as_text(run_metadata.get('manifest_path'))
+    run_metadata = _as_dict(report.get("run_metadata"))
+    raw = _as_text(run_metadata.get("manifest_path"))
     if raw is None:
         return None
     candidate = Path(raw)
@@ -152,11 +224,13 @@ def _resolve_manifest_path(run_dir: Path, report: Mapping[str, Any]) -> Path | N
     return None
 
 
-def _load_source_manifest(run_dir: Path, report: Mapping[str, Any]) -> tuple[dict[str, Any], Path | None]:
+def _load_source_manifest(
+    run_dir: Path, report: Mapping[str, Any]
+) -> tuple[dict[str, Any], Path | None]:
     path = _resolve_manifest_path(run_dir, report)
     if path is None:
         return {}, None
-    if path.suffix.lower() in {'.yaml', '.yml'}:
+    if path.suffix.lower() in {".yaml", ".yml"}:
         return _load_yaml(path), path
     return _load_json(path), path
 
@@ -167,7 +241,7 @@ def _lineage_text(
     run_manifest: Mapping[str, Any],
     source_manifest: Mapping[str, Any],
 ) -> str | None:
-    lineage = _as_dict(run_manifest.get('evidence_lineage'))
+    lineage = _as_dict(run_manifest.get("evidence_lineage"))
     return _as_text(lineage.get(key)) or _as_text(source_manifest.get(key))
 
 
@@ -177,7 +251,7 @@ def _lineage_list(
     run_manifest: Mapping[str, Any],
     source_manifest: Mapping[str, Any],
 ) -> list[str]:
-    lineage = _as_dict(run_manifest.get('evidence_lineage'))
+    lineage = _as_dict(run_manifest.get("evidence_lineage"))
     raw = lineage.get(key)
     if isinstance(raw, list):
         return [text for item in raw if (text := _as_text(item))]
@@ -191,19 +265,21 @@ def _load_trade_contributions(path: Path | None) -> list[Decimal]:
     if path is None or not path.exists():
         return []
     contributions: list[Decimal] = []
-    with path.open(newline='', encoding='utf-8') as handle:
+    with path.open(newline="", encoding="utf-8") as handle:
         reader = csv.DictReader(handle)
-        rows = sorted(reader, key=lambda row: str(row.get('created_at') or ''))
+        rows = sorted(reader, key=lambda row: str(row.get("created_at") or ""))
         for row in rows:
-            contributions.append(_as_decimal(row.get('realized_pnl_contribution')))
+            contributions.append(_as_decimal(row.get("realized_pnl_contribution")))
     return contributions
 
 
-def _estimate_day_drawdown(*, net_pnl: Decimal, trade_pnl_csv_path: Path | None) -> Decimal:
-    equity = Decimal('0')
-    peak = Decimal('0')
-    max_drawdown = Decimal('0')
-    realized_total = Decimal('0')
+def _estimate_day_drawdown(
+    *, net_pnl: Decimal, trade_pnl_csv_path: Path | None
+) -> Decimal:
+    equity = Decimal("0")
+    peak = Decimal("0")
+    max_drawdown = Decimal("0")
+    realized_total = Decimal("0")
     for contribution in _load_trade_contributions(trade_pnl_csv_path):
         realized_total += contribution
         equity += contribution
@@ -225,122 +301,134 @@ def _estimate_day_drawdown(*, net_pnl: Decimal, trade_pnl_csv_path: Path | None)
 
 
 def _best_signal_hash(run_dir: Path, replay_report: Mapping[str, Any]) -> str:
-    replay_hash = _as_text(replay_report.get('dump_sha256'))
+    replay_hash = _as_text(replay_report.get("dump_sha256"))
     if replay_hash:
         return replay_hash
-    dump_manifest_path = run_dir / 'source-dump.jsonl.zst.manifest.json'
+    dump_manifest_path = run_dir / "source-dump.jsonl.zst.manifest.json"
     if dump_manifest_path.exists():
         dump_manifest = _load_json(dump_manifest_path)
-        chunks = _as_list(dump_manifest.get('chunks'))
+        chunks = _as_list(dump_manifest.get("chunks"))
         chunk_hashes = [
-            _as_text(_as_dict(item).get('payload_sha256')) or _as_text(_as_dict(item).get('sha256')) or ''
+            _as_text(_as_dict(item).get("payload_sha256"))
+            or _as_text(_as_dict(item).get("sha256"))
+            or ""
             for item in chunks
         ]
         normalized = [item for item in chunk_hashes if item]
         if normalized:
             return _stable_hash_payload(normalized)
         return _sha256_bytes(dump_manifest_path.read_bytes())
-    source_dump_path = run_dir / 'source-dump.jsonl.zst'
+    source_dump_path = run_dir / "source-dump.jsonl.zst"
     if source_dump_path.exists():
         return _sha256_bytes(source_dump_path.read_bytes())
-    raise RuntimeError(f'signal_hash_missing:{run_dir}')
+    raise RuntimeError(f"signal_hash_missing:{run_dir}")
 
 
 def _load_run_summary(run_dir: Path) -> HistoricalRunSummary:
-    run_manifest_path = run_dir / 'run-manifest.json'
-    simulation_report_path = run_dir / 'report' / 'simulation-report.json'
-    replay_report_path = run_dir / 'replay-report.json'
-    trade_pnl_csv_path = run_dir / 'report' / 'trade-pnl.csv'
+    run_manifest_path = run_dir / "run-manifest.json"
+    simulation_report_path = run_dir / "report" / "simulation-report.json"
+    replay_report_path = run_dir / "replay-report.json"
+    trade_pnl_csv_path = run_dir / "report" / "trade-pnl.csv"
 
     run_manifest = _load_json(run_manifest_path)
     report = _load_json(simulation_report_path)
-    replay_report = _load_json(replay_report_path) if replay_report_path.exists() else {}
+    replay_report = (
+        _load_json(replay_report_path) if replay_report_path.exists() else {}
+    )
     source_manifest, source_manifest_path = _load_source_manifest(run_dir, report)
 
     candidate_id = _lineage_text(
-        key='candidate_id',
+        key="candidate_id",
         run_manifest=run_manifest,
         source_manifest=source_manifest,
     )
     if candidate_id is None:
-        raise RuntimeError(f'candidate_id_missing:{run_dir}')
-    baseline_candidate_id = _lineage_text(
-        key='baseline_candidate_id',
-        run_manifest=run_manifest,
-        source_manifest=source_manifest,
-    ) or _DEFAULT_BASELINE_ID
+        raise RuntimeError(f"candidate_id_missing:{run_dir}")
+    baseline_candidate_id = (
+        _lineage_text(
+            key="baseline_candidate_id",
+            run_manifest=run_manifest,
+            source_manifest=source_manifest,
+        )
+        or _DEFAULT_BASELINE_ID
+    )
     strategy_spec_ref = _lineage_text(
-        key='strategy_spec_ref',
+        key="strategy_spec_ref",
         run_manifest=run_manifest,
         source_manifest=source_manifest,
     )
     if strategy_spec_ref is None:
-        raise RuntimeError(f'strategy_spec_ref_missing:{run_dir}')
+        raise RuntimeError(f"strategy_spec_ref_missing:{run_dir}")
     model_refs = _lineage_list(
-        key='model_refs',
+        key="model_refs",
         run_manifest=run_manifest,
         source_manifest=source_manifest,
     )
     runtime_version_refs = _lineage_list(
-        key='runtime_version_refs',
+        key="runtime_version_refs",
         run_manifest=run_manifest,
         source_manifest=source_manifest,
     )
     if not model_refs or not runtime_version_refs:
-        raise RuntimeError(f'evidence_lineage_incomplete:{run_dir}')
+        raise RuntimeError(f"evidence_lineage_incomplete:{run_dir}")
 
-    coverage = _as_dict(report.get('coverage'))
-    trading_day = (
-        _as_text(_as_dict(source_manifest.get('window')).get('trading_day'))
-        or _as_text(coverage.get('window_start'),)
+    coverage = _as_dict(report.get("coverage"))
+    trading_day = _as_text(
+        _as_dict(source_manifest.get("window")).get("trading_day")
+    ) or _as_text(
+        coverage.get("window_start"),
     )
     if trading_day is None:
-        raise RuntimeError(f'trading_day_missing:{run_dir}')
-    if 'T' in trading_day:
-        trading_day = trading_day.split('T', 1)[0]
+        raise RuntimeError(f"trading_day_missing:{run_dir}")
+    if "T" in trading_day:
+        trading_day = trading_day.split("T", 1)[0]
 
-    funnel = _as_dict(report.get('funnel'))
-    pnl = _as_dict(report.get('pnl'))
-    llm = _as_dict(report.get('llm'))
-    verdict = (_as_text(_as_dict(report.get('verdict')).get('status')) or 'FAIL').upper()
-    if verdict == 'FAIL':
-        raise RuntimeError(f'simulation_report_failed:{run_dir}')
+    funnel = _as_dict(report.get("funnel"))
+    pnl = _as_dict(report.get("pnl"))
+    llm = _as_dict(report.get("llm"))
+    verdict = (
+        _as_text(_as_dict(report.get("verdict")).get("status")) or "FAIL"
+    ).upper()
+    if verdict == "FAIL":
+        raise RuntimeError(f"simulation_report_failed:{run_dir}")
 
     net_pnl = _as_decimal(
-        pnl.get('net_pnl_estimated')
-        or pnl.get('gross_pnl')
-        or pnl.get('realized_pnl')
-        or '0'
+        pnl.get("net_pnl_estimated")
+        or pnl.get("gross_pnl")
+        or pnl.get("realized_pnl")
+        or "0"
     )
-    execution_notional_total = _as_decimal(pnl.get('execution_notional_total'))
-    estimated_cost_total = _as_decimal(pnl.get('estimated_cost_total'))
-    cost_bps = Decimal('0')
+    execution_notional_total = _as_decimal(pnl.get("execution_notional_total"))
+    estimated_cost_total = _as_decimal(pnl.get("estimated_cost_total"))
+    cost_bps = Decimal("0")
     if execution_notional_total > 0:
-        cost_bps = (estimated_cost_total / execution_notional_total) * Decimal('10000')
+        cost_bps = (estimated_cost_total / execution_notional_total) * Decimal("10000")
 
-    raw_confidence = _as_text(llm.get('avg_confidence'))
+    raw_confidence = _as_text(llm.get("avg_confidence"))
     confidence_value = (
         _clamp_confidence(_as_decimal(raw_confidence))
         if raw_confidence is not None
-        else Decimal('1') if net_pnl > 0 else Decimal('0')
+        else Decimal("1")
+        if net_pnl > 0
+        else Decimal("0")
     )
 
     signal_hash = _best_signal_hash(run_dir, replay_report)
     strategy_config_hash = (
         _sha256_bytes(source_manifest_path.read_bytes())
         if source_manifest_path is not None
-        else _sha256_bytes(strategy_spec_ref.encode('utf-8'))
+        else _sha256_bytes(strategy_spec_ref.encode("utf-8"))
     )
     gate_policy_hash = _stable_hash_payload(
         {
-            'monitor': _as_dict(source_manifest.get('monitor')),
-            'window': _as_dict(source_manifest.get('window')),
-            'report_window': coverage,
+            "monitor": _as_dict(source_manifest.get("monitor")),
+            "window": _as_dict(source_manifest.get("window")),
+            "report_window": coverage,
         }
     )
 
     return HistoricalRunSummary(
-        run_id=_as_text(run_manifest.get('run_id')) or run_dir.name,
+        run_id=_as_text(run_manifest.get("run_id")) or run_dir.name,
         run_dir=run_dir,
         trading_day=trading_day,
         candidate_id=candidate_id,
@@ -349,10 +437,12 @@ def _load_run_summary(run_dir: Path) -> HistoricalRunSummary:
         model_refs=model_refs,
         runtime_version_refs=runtime_version_refs,
         net_pnl=net_pnl,
-        max_drawdown=_estimate_day_drawdown(net_pnl=net_pnl, trade_pnl_csv_path=trade_pnl_csv_path),
+        max_drawdown=_estimate_day_drawdown(
+            net_pnl=net_pnl, trade_pnl_csv_path=trade_pnl_csv_path
+        ),
         cost_bps=cost_bps,
-        trade_count=_as_int(funnel.get('executions')),
-        decision_count=_as_int(funnel.get('trade_decisions')),
+        trade_count=_as_int(funnel.get("executions")),
+        decision_count=_as_int(funnel.get("trade_decisions")),
         execution_notional_total=execution_notional_total,
         estimated_cost_total=estimated_cost_total,
         confidence_value=confidence_value,
@@ -366,30 +456,32 @@ def _load_run_summary(run_dir: Path) -> HistoricalRunSummary:
     )
 
 
-def _require_consistent_lineage(run_summaries: list[HistoricalRunSummary], *, label: str) -> None:
+def _require_consistent_lineage(
+    run_summaries: list[HistoricalRunSummary], *, label: str
+) -> None:
     if not run_summaries:
-        raise RuntimeError(f'{label}_run_set_empty')
+        raise RuntimeError(f"{label}_run_set_empty")
     trading_days = [item.trading_day for item in run_summaries]
     if len(set(trading_days)) != len(trading_days):
-        raise RuntimeError(f'{label}_trading_day_duplicate')
+        raise RuntimeError(f"{label}_trading_day_duplicate")
     candidate_ids = {item.candidate_id for item in run_summaries}
     if len(candidate_ids) != 1:
-        raise RuntimeError(f'{label}_candidate_id_mismatch')
+        raise RuntimeError(f"{label}_candidate_id_mismatch")
     strategy_specs = {item.strategy_spec_ref for item in run_summaries}
     if len(strategy_specs) != 1:
-        raise RuntimeError(f'{label}_strategy_spec_mismatch')
+        raise RuntimeError(f"{label}_strategy_spec_mismatch")
     model_refs = {tuple(item.model_refs) for item in run_summaries}
     if len(model_refs) != 1:
-        raise RuntimeError(f'{label}_model_refs_mismatch')
+        raise RuntimeError(f"{label}_model_refs_mismatch")
     runtime_refs = {tuple(item.runtime_version_refs) for item in run_summaries}
     if len(runtime_refs) != 1:
-        raise RuntimeError(f'{label}_runtime_refs_mismatch')
+        raise RuntimeError(f"{label}_runtime_refs_mismatch")
 
 
 def _window_max_drawdown(run_summaries: list[HistoricalRunSummary]) -> Decimal:
-    equity = Decimal('0')
-    peak = Decimal('0')
-    max_drawdown = Decimal('0')
+    equity = Decimal("0")
+    peak = Decimal("0")
+    max_drawdown = Decimal("0")
     for item in sorted(run_summaries, key=lambda value: value.trading_day):
         equity += item.net_pnl
         if equity > peak:
@@ -400,49 +492,182 @@ def _window_max_drawdown(run_summaries: list[HistoricalRunSummary]) -> Decimal:
     return max_drawdown
 
 
-def _build_report_payload(run_summaries: list[HistoricalRunSummary]) -> dict[str, object]:
+def _proof_gate_policy(
+    *,
+    target_net_pnl_per_day: Decimal | str = _DEFAULT_TARGET_NET_PNL_PER_DAY,
+    min_sample_size: int = _DEFAULT_MIN_SAMPLE_SIZE,
+    min_active_day_ratio: Decimal | str = _DEFAULT_MIN_ACTIVE_DAY_RATIO,
+    min_positive_day_ratio: Decimal | str = _DEFAULT_MIN_POSITIVE_DAY_RATIO,
+    max_best_day_share: Decimal | str = _DEFAULT_MAX_BEST_DAY_SHARE,
+    min_daily_notional: Decimal | str = Decimal("0"),
+    start_equity: Decimal | str = _DEFAULT_START_EQUITY,
+    max_drawdown_pct_equity: Decimal | str = _DEFAULT_MAX_DRAWDOWN_PCT_EQUITY,
+    extended_max_drawdown_pct_equity: Decimal
+    | str = _DEFAULT_EXTENDED_MAX_DRAWDOWN_PCT_EQUITY,
+    min_total_net_pnl_to_drawdown_ratio: Decimal
+    | str = _DEFAULT_MIN_TOTAL_NET_PNL_TO_DRAWDOWN_RATIO,
+) -> ProfitabilityProofGatePolicy:
+    return ProfitabilityProofGatePolicy(
+        target_net_pnl_per_day=_as_decimal(target_net_pnl_per_day),
+        min_sample_size=max(1, int(min_sample_size)),
+        min_active_day_ratio=_as_decimal(min_active_day_ratio),
+        min_positive_day_ratio=_as_decimal(min_positive_day_ratio),
+        max_best_day_share=_as_decimal(max_best_day_share),
+        min_daily_notional=_as_decimal(min_daily_notional),
+        start_equity=_as_decimal(start_equity),
+        max_drawdown_pct_equity=_as_decimal(max_drawdown_pct_equity),
+        extended_max_drawdown_pct_equity=_as_decimal(extended_max_drawdown_pct_equity),
+        min_total_net_pnl_to_drawdown_ratio=_as_decimal(
+            min_total_net_pnl_to_drawdown_ratio
+        ),
+    )
+
+
+def _proof_gate_summary(
+    run_summaries: list[HistoricalRunSummary],
+    *,
+    policy: ProfitabilityProofGatePolicy,
+) -> dict[str, Any]:
     ordered = sorted(run_summaries, key=lambda value: value.trading_day)
-    total_net = sum((item.net_pnl for item in ordered), Decimal('0'))
-    total_notional = sum((item.execution_notional_total for item in ordered), Decimal('0'))
-    total_cost = sum((item.estimated_cost_total for item in ordered), Decimal('0'))
+    sample_size = len(ordered)
+    total_net_pnl = sum((item.net_pnl for item in ordered), Decimal("0"))
+    average_daily_net_pnl = (
+        total_net_pnl / Decimal(sample_size) if sample_size else Decimal("0")
+    )
+    active_days = sum(
+        1
+        for item in ordered
+        if item.decision_count > 0
+        and item.trade_count > 0
+        and item.execution_notional_total > 0
+    )
+    positive_days = sum(1 for item in ordered if item.net_pnl > 0)
+    active_day_ratio = (
+        Decimal(active_days) / Decimal(sample_size) if sample_size else Decimal("0")
+    )
+    positive_day_ratio = (
+        Decimal(positive_days) / Decimal(sample_size) if sample_size else Decimal("0")
+    )
+    positive_daily_net = [item.net_pnl for item in ordered if item.net_pnl > 0]
+    positive_net_total = sum(positive_daily_net, Decimal("0"))
+    best_day_share = (
+        max(positive_daily_net) / positive_net_total
+        if positive_daily_net and positive_net_total > 0
+        else Decimal("0")
+    )
+    avg_daily_notional = (
+        sum((item.execution_notional_total for item in ordered), Decimal("0"))
+        / Decimal(sample_size)
+        if sample_size
+        else Decimal("0")
+    )
+    window_drawdown = _window_max_drawdown(ordered)
+    intraday_drawdown = max(
+        (item.max_drawdown for item in ordered), default=Decimal("0")
+    )
+    max_drawdown = max(window_drawdown, intraday_drawdown)
+    max_drawdown_pct = (
+        max_drawdown / policy.start_equity
+        if policy.start_equity > 0 and max_drawdown > 0
+        else Decimal("0")
+    )
+    net_to_drawdown_ratio = (
+        total_net_pnl / max_drawdown
+        if max_drawdown > 0
+        else total_net_pnl
+        if total_net_pnl > 0
+        else Decimal("0")
+    )
+    extended_drawdown_allowed = (
+        max_drawdown_pct <= policy.extended_max_drawdown_pct_equity
+        and net_to_drawdown_ratio >= policy.min_total_net_pnl_to_drawdown_ratio
+    )
+    drawdown_passed = (
+        max_drawdown_pct <= policy.max_drawdown_pct_equity or extended_drawdown_allowed
+    )
+    return {
+        "target_net_pnl_per_day": str(policy.target_net_pnl_per_day),
+        "min_sample_size": policy.min_sample_size,
+        "min_active_day_ratio": str(policy.min_active_day_ratio),
+        "min_positive_day_ratio": str(policy.min_positive_day_ratio),
+        "max_best_day_share": str(policy.max_best_day_share),
+        "min_daily_notional": str(policy.min_daily_notional),
+        "start_equity": str(policy.start_equity),
+        "max_drawdown_pct_equity": str(policy.max_drawdown_pct_equity),
+        "extended_max_drawdown_pct_equity": str(
+            policy.extended_max_drawdown_pct_equity
+        ),
+        "min_total_net_pnl_to_drawdown_ratio": str(
+            policy.min_total_net_pnl_to_drawdown_ratio
+        ),
+        "observed": {
+            "total_net_pnl": str(total_net_pnl),
+            "average_daily_net_pnl": str(average_daily_net_pnl),
+            "sample_size": sample_size,
+            "active_days": active_days,
+            "active_day_ratio": str(active_day_ratio),
+            "positive_days": positive_days,
+            "positive_day_ratio": str(positive_day_ratio),
+            "best_day_share": str(best_day_share),
+            "avg_daily_notional": str(avg_daily_notional),
+            "window_max_drawdown": str(window_drawdown),
+            "intraday_max_drawdown": str(intraday_drawdown),
+            "max_drawdown": str(max_drawdown),
+            "max_drawdown_pct_equity": str(max_drawdown_pct),
+            "net_pnl_to_drawdown_ratio": str(net_to_drawdown_ratio),
+            "extended_drawdown_allowed": extended_drawdown_allowed,
+            "drawdown_passed": drawdown_passed,
+        },
+    }
+
+
+def _build_report_payload(
+    run_summaries: list[HistoricalRunSummary],
+) -> dict[str, object]:
+    ordered = sorted(run_summaries, key=lambda value: value.trading_day)
+    total_net = sum((item.net_pnl for item in ordered), Decimal("0"))
+    total_notional = sum(
+        (item.execution_notional_total for item in ordered), Decimal("0")
+    )
+    total_cost = sum((item.estimated_cost_total for item in ordered), Decimal("0"))
     total_trades = sum(item.trade_count for item in ordered)
     total_decisions = sum(item.decision_count for item in ordered)
     market_cost_bps = (
-        (total_cost / total_notional) * Decimal('10000')
+        (total_cost / total_notional) * Decimal("10000")
         if total_notional > 0
-        else Decimal('0')
+        else Decimal("0")
     )
     folds = [
         {
-            'fold_name': item.trading_day,
-            'trade_count': item.trade_count,
-            'net_pnl': str(item.net_pnl),
-            'max_drawdown': str(item.max_drawdown),
-            'cost_bps': str(item.cost_bps),
-            'turnover_ratio': '0',
-            'regime_label': item.trading_day,
+            "fold_name": item.trading_day,
+            "trade_count": item.trade_count,
+            "net_pnl": str(item.net_pnl),
+            "max_drawdown": str(item.max_drawdown),
+            "cost_bps": str(item.cost_bps),
+            "turnover_ratio": "0",
+            "regime_label": item.trading_day,
         }
         for item in ordered
     ]
     return {
-        'metrics': {
-            'net_pnl': str(total_net),
-            'max_drawdown': str(_window_max_drawdown(ordered)),
-            'cost_bps': str(market_cost_bps),
-            'trade_count': total_trades,
-            'decision_count': total_decisions,
-            'turnover_ratio': '0',
+        "metrics": {
+            "net_pnl": str(total_net),
+            "max_drawdown": str(_window_max_drawdown(ordered)),
+            "cost_bps": str(market_cost_bps),
+            "trade_count": total_trades,
+            "decision_count": total_decisions,
+            "turnover_ratio": "0",
         },
-        'robustness': {
-            'folds': folds,
+        "robustness": {
+            "folds": folds,
         },
-        'impact_assumptions': {
-            'decisions_with_spread': total_decisions,
-            'decisions_with_volatility': total_decisions,
-            'decisions_with_adv': total_decisions,
-            'assumptions': {
-                'recorded_inputs_count': str(total_decisions),
-                'fallback_inputs_count': '0',
+        "impact_assumptions": {
+            "decisions_with_spread": total_decisions,
+            "decisions_with_volatility": total_decisions,
+            "decisions_with_adv": total_decisions,
+            "assumptions": {
+                "recorded_inputs_count": str(total_decisions),
+                "fallback_inputs_count": "0",
             },
         },
     }
@@ -450,49 +675,51 @@ def _build_report_payload(run_summaries: list[HistoricalRunSummary]) -> dict[str
 
 def _build_zero_baseline_payload(trading_days: list[str]) -> dict[str, object]:
     return {
-        'metrics': {
-            'net_pnl': '0',
-            'max_drawdown': '0',
-            'cost_bps': '0',
-            'trade_count': 0,
-            'decision_count': 0,
-            'turnover_ratio': '0',
+        "metrics": {
+            "net_pnl": "0",
+            "max_drawdown": "0",
+            "cost_bps": "0",
+            "trade_count": 0,
+            "decision_count": 0,
+            "turnover_ratio": "0",
         },
-        'robustness': {
-            'folds': [
+        "robustness": {
+            "folds": [
                 {
-                    'fold_name': trading_day,
-                    'trade_count': 0,
-                    'net_pnl': '0',
-                    'max_drawdown': '0',
-                    'cost_bps': '0',
-                    'turnover_ratio': '0',
-                    'regime_label': trading_day,
+                    "fold_name": trading_day,
+                    "trade_count": 0,
+                    "net_pnl": "0",
+                    "max_drawdown": "0",
+                    "cost_bps": "0",
+                    "turnover_ratio": "0",
+                    "regime_label": trading_day,
                 }
                 for trading_day in trading_days
             ],
         },
-        'impact_assumptions': {
-            'decisions_with_spread': 0,
-            'decisions_with_volatility': 0,
-            'decisions_with_adv': 0,
-            'assumptions': {
-                'recorded_inputs_count': '0',
-                'fallback_inputs_count': '0',
+        "impact_assumptions": {
+            "decisions_with_spread": 0,
+            "decisions_with_volatility": 0,
+            "decisions_with_adv": 0,
+            "assumptions": {
+                "recorded_inputs_count": "0",
+                "fallback_inputs_count": "0",
             },
         },
     }
 
 
 def _effect_size(candidate_report_payload: Mapping[str, Any]) -> Decimal:
-    folds = _as_list(_as_dict(candidate_report_payload.get('robustness')).get('folds'))
-    daily_values = [_as_decimal(_as_dict(item).get('net_pnl')) for item in folds]
+    folds = _as_list(_as_dict(candidate_report_payload.get("robustness")).get("folds"))
+    daily_values = [_as_decimal(_as_dict(item).get("net_pnl")) for item in folds]
     if not daily_values:
-        return Decimal('0')
-    mean_value = sum(daily_values, Decimal('0')) / Decimal(len(daily_values))
+        return Decimal("0")
+    mean_value = sum(daily_values, Decimal("0")) / Decimal(len(daily_values))
     if len(daily_values) <= 1:
         return mean_value
-    variance = sum((value - mean_value) ** 2 for value in daily_values) / Decimal(len(daily_values))
+    variance = sum((value - mean_value) ** 2 for value in daily_values) / Decimal(
+        len(daily_values)
+    )
     std_dev = variance.sqrt()
     if std_dev <= 0:
         return mean_value
@@ -517,14 +744,46 @@ def _proof_passed(
     proof_payload: Mapping[str, Any],
 ) -> tuple[bool, list[str]]:
     reasons: list[str] = []
-    if not bool(validation_payload.get('passed')):
-        reasons.append('profitability_evidence_validation_failed')
-    market_net = _as_decimal(_as_dict(candidate_report_payload.get('metrics')).get('net_pnl'))
+    if not bool(validation_payload.get("passed")):
+        reasons.append("profitability_evidence_validation_failed")
+    market_net = _as_decimal(
+        _as_dict(candidate_report_payload.get("metrics")).get("net_pnl")
+    )
     if market_net <= 0:
-        reasons.append('market_net_pnl_not_positive')
-    p_value = _as_decimal(_as_dict(proof_payload.get('statistics')).get('p_value'))
-    if p_value > Decimal('0.05'):
-        reasons.append('p_value_above_0_05')
+        reasons.append("market_net_pnl_not_positive")
+    p_value = _as_decimal(_as_dict(proof_payload.get("statistics")).get("p_value"))
+    if p_value > Decimal("0.05"):
+        reasons.append("p_value_above_0_05")
+    gates = _as_dict(proof_payload.get("proof_gates"))
+    observed = _as_dict(gates.get("observed"))
+    sample_size = _as_int(observed.get("sample_size"))
+    min_sample_size = _as_int(gates.get("min_sample_size"))
+    if sample_size < min_sample_size:
+        reasons.append("sample_size_below_minimum")
+    average_daily_net_pnl = _as_decimal(observed.get("average_daily_net_pnl"))
+    target_net_pnl_per_day = _as_decimal(gates.get("target_net_pnl_per_day"))
+    if average_daily_net_pnl < target_net_pnl_per_day:
+        reasons.append("average_daily_net_pnl_below_target")
+    if _as_decimal(observed.get("active_day_ratio")) < _as_decimal(
+        gates.get("min_active_day_ratio")
+    ):
+        reasons.append("active_day_ratio_below_minimum")
+    if _as_decimal(observed.get("positive_day_ratio")) < _as_decimal(
+        gates.get("min_positive_day_ratio")
+    ):
+        reasons.append("positive_day_ratio_below_minimum")
+    if _as_decimal(observed.get("best_day_share")) > _as_decimal(
+        gates.get("max_best_day_share")
+    ):
+        reasons.append("best_day_share_above_maximum")
+    min_daily_notional = _as_decimal(gates.get("min_daily_notional"))
+    if (
+        min_daily_notional > 0
+        and _as_decimal(observed.get("avg_daily_notional")) < min_daily_notional
+    ):
+        reasons.append("avg_daily_notional_below_minimum")
+    if not bool(observed.get("drawdown_passed")):
+        reasons.append("max_drawdown_above_limit")
     return (not reasons, reasons)
 
 
@@ -532,51 +791,90 @@ def build_historical_profitability_bundle(
     *,
     run_dirs: list[Path],
     output_dir: Path,
-    hypothesis: str = '',
+    hypothesis: str = "",
     baseline_run_dirs: list[Path] | None = None,
-    baseline_id: str = '',
+    baseline_id: str = "",
     generated_at: datetime | None = None,
+    target_net_pnl_per_day: Decimal | str = _DEFAULT_TARGET_NET_PNL_PER_DAY,
+    min_sample_size: int = _DEFAULT_MIN_SAMPLE_SIZE,
+    min_active_day_ratio: Decimal | str = _DEFAULT_MIN_ACTIVE_DAY_RATIO,
+    min_positive_day_ratio: Decimal | str = _DEFAULT_MIN_POSITIVE_DAY_RATIO,
+    max_best_day_share: Decimal | str = _DEFAULT_MAX_BEST_DAY_SHARE,
+    min_daily_notional: Decimal | str = Decimal("0"),
+    start_equity: Decimal | str = _DEFAULT_START_EQUITY,
+    max_drawdown_pct_equity: Decimal | str = _DEFAULT_MAX_DRAWDOWN_PCT_EQUITY,
+    extended_max_drawdown_pct_equity: Decimal
+    | str = _DEFAULT_EXTENDED_MAX_DRAWDOWN_PCT_EQUITY,
+    min_total_net_pnl_to_drawdown_ratio: Decimal
+    | str = _DEFAULT_MIN_TOTAL_NET_PNL_TO_DRAWDOWN_RATIO,
 ) -> dict[str, Any]:
     timestamp = generated_at or datetime.now(timezone.utc)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     candidate_runs = [_load_run_summary(path) for path in run_dirs]
-    _require_consistent_lineage(candidate_runs, label='candidate')
+    _require_consistent_lineage(candidate_runs, label="candidate")
+    gate_policy = _proof_gate_policy(
+        target_net_pnl_per_day=target_net_pnl_per_day,
+        min_sample_size=min_sample_size,
+        min_active_day_ratio=min_active_day_ratio,
+        min_positive_day_ratio=min_positive_day_ratio,
+        max_best_day_share=max_best_day_share,
+        min_daily_notional=min_daily_notional,
+        start_equity=start_equity,
+        max_drawdown_pct_equity=max_drawdown_pct_equity,
+        extended_max_drawdown_pct_equity=extended_max_drawdown_pct_equity,
+        min_total_net_pnl_to_drawdown_ratio=min_total_net_pnl_to_drawdown_ratio,
+    )
 
     candidate_id = candidate_runs[0].candidate_id
-    inferred_baseline_id = baseline_id.strip() or candidate_runs[0].baseline_candidate_id or _DEFAULT_BASELINE_ID
+    inferred_baseline_id = (
+        baseline_id.strip()
+        or candidate_runs[0].baseline_candidate_id
+        or _DEFAULT_BASELINE_ID
+    )
 
     candidate_report_payload = _build_report_payload(candidate_runs)
     baseline_report_payload: dict[str, object]
     if baseline_run_dirs:
         baseline_runs = [_load_run_summary(path) for path in baseline_run_dirs]
-        _require_consistent_lineage(baseline_runs, label='baseline')
+        _require_consistent_lineage(baseline_runs, label="baseline")
         baseline_report_payload = _build_report_payload(baseline_runs)
         inferred_baseline_id = baseline_id.strip() or baseline_runs[0].candidate_id
     else:
         baseline_report_payload = _build_zero_baseline_payload(
-            [item.trading_day for item in sorted(candidate_runs, key=lambda value: value.trading_day)]
+            [
+                item.trading_day
+                for item in sorted(candidate_runs, key=lambda value: value.trading_day)
+            ]
         )
 
-    candidate_report_path = output_dir / 'candidate-report.json'
-    baseline_report_path = output_dir / 'baseline-report.json'
-    candidate_report_path.write_text(json.dumps(candidate_report_payload, indent=2), encoding='utf-8')
-    baseline_report_path.write_text(json.dumps(baseline_report_payload, indent=2), encoding='utf-8')
+    candidate_report_path = output_dir / "candidate-report.json"
+    baseline_report_path = output_dir / "baseline-report.json"
+    candidate_report_path.write_text(
+        json.dumps(candidate_report_payload, indent=2), encoding="utf-8"
+    )
+    baseline_report_path.write_text(
+        json.dumps(baseline_report_payload, indent=2), encoding="utf-8"
+    )
 
     reproducibility_hashes = {
-        'signals': _stable_hash_payload([item.signal_hash for item in candidate_runs]),
-        'strategy_config': _stable_hash_payload(
+        "signals": _stable_hash_payload([item.signal_hash for item in candidate_runs]),
+        "strategy_config": _stable_hash_payload(
             {
-                'candidate_id': candidate_id,
-                'strategy_spec_ref': candidate_runs[0].strategy_spec_ref,
-                'model_refs': candidate_runs[0].model_refs,
-                'runtime_version_refs': candidate_runs[0].runtime_version_refs,
-                'per_run_hashes': [item.strategy_config_hash for item in candidate_runs],
+                "candidate_id": candidate_id,
+                "strategy_spec_ref": candidate_runs[0].strategy_spec_ref,
+                "model_refs": candidate_runs[0].model_refs,
+                "runtime_version_refs": candidate_runs[0].runtime_version_refs,
+                "per_run_hashes": [
+                    item.strategy_config_hash for item in candidate_runs
+                ],
             }
         ),
-        'gate_policy': _stable_hash_payload([item.gate_policy_hash for item in candidate_runs]),
-        'candidate_report': _sha256_json(candidate_report_payload),
-        'baseline_report': _sha256_json(baseline_report_payload),
+        "gate_policy": _stable_hash_payload(
+            [item.gate_policy_hash for item in candidate_runs]
+        ),
+        "candidate_report": _sha256_json(candidate_report_payload),
+        "baseline_report": _sha256_json(baseline_report_payload),
     }
 
     benchmark = execute_profitability_benchmark_v4(
@@ -586,82 +884,112 @@ def build_historical_profitability_bundle(
         baseline_report_payload=dict(baseline_report_payload),
         executed_at=timestamp,
     )
-    benchmark_path = output_dir / 'profitability-benchmark-v4.json'
-    benchmark_path.write_text(json.dumps(benchmark.to_payload(), indent=2), encoding='utf-8')
+    benchmark_path = output_dir / "profitability-benchmark-v4.json"
+    benchmark_path.write_text(
+        json.dumps(benchmark.to_payload(), indent=2), encoding="utf-8"
+    )
 
     confidence_values = [item.confidence_value for item in candidate_runs]
     evidence = build_profitability_evidence_v4(
-        run_id='historical-oos-profitability',
+        run_id="historical-oos-profitability",
         candidate_id=candidate_id,
         baseline_id=inferred_baseline_id,
         candidate_report_payload=dict(candidate_report_payload),
         benchmark=benchmark,
         confidence_values=confidence_values,
         reproducibility_hashes=reproducibility_hashes,
-        artifact_refs=[* _artifact_refs(candidate_runs), str(candidate_report_path), str(baseline_report_path)],
+        artifact_refs=[
+            *_artifact_refs(candidate_runs),
+            str(candidate_report_path),
+            str(baseline_report_path),
+        ],
         generated_at=timestamp,
     )
     evidence_payload = evidence.to_payload()
-    evidence_path = output_dir / 'profitability-evidence-v4.json'
-    evidence_path.write_text(json.dumps(evidence_payload, indent=2), encoding='utf-8')
+    evidence_path = output_dir / "profitability-evidence-v4.json"
+    evidence_path.write_text(json.dumps(evidence_payload, indent=2), encoding="utf-8")
 
     validation = validate_profitability_evidence_v4(evidence, checked_at=timestamp)
     validation_payload = validation.to_payload()
-    validation_path = output_dir / 'profitability-evidence-validation.json'
-    validation_path.write_text(json.dumps(validation_payload, indent=2), encoding='utf-8')
+    validation_path = output_dir / "profitability-evidence-validation.json"
+    validation_path.write_text(
+        json.dumps(validation_payload, indent=2), encoding="utf-8"
+    )
 
     benchmark_payload = benchmark.to_payload()
     market_slice = _as_dict(
         next(
             (
                 item
-                for item in _as_list(benchmark_payload.get('slices'))
-                if _as_text(_as_dict(item).get('slice_key')) == 'market:all'
+                for item in _as_list(benchmark_payload.get("slices"))
+                if _as_text(_as_dict(item).get("slice_key")) == "market:all"
             ),
             {},
         )
     )
     proof_payload: dict[str, Any] = {
-        'schema_version': _PROFITABILITY_PROOF_SCHEMA_VERSION,
-        'generated_at': timestamp.isoformat(),
-        'hypothesis': hypothesis.strip()
-        or f'{candidate_id} is profitable over the historical OOS replay window',
-        'sample_size': len(candidate_runs),
-        'window_days': len(candidate_runs),
-        'statistics': {
-            'effect_size': float(_effect_size(candidate_report_payload)),
-            'p_value': float(_as_decimal(_as_dict(evidence_payload.get('significance')).get('p_value_two_sided'))),
-            'ci_95_low': _as_text(_as_dict(evidence_payload.get('significance')).get('ci_95_low')) or '0',
-            'ci_95_high': _as_text(_as_dict(evidence_payload.get('significance')).get('ci_95_high')) or '0',
-        },
-        'risk_controls': {
-            'max_drawdown_delta': float(_as_decimal(_as_dict(market_slice.get('deltas')).get('max_drawdown_delta'))),
-            'market_net_pnl_delta': _as_text(_as_dict(market_slice.get('deltas')).get('net_pnl_delta')) or '0',
-            'return_over_drawdown': _as_text(
-                _as_dict(evidence_payload.get('risk_adjusted_metrics')).get('return_over_drawdown')
+        "schema_version": _PROFITABILITY_PROOF_SCHEMA_VERSION,
+        "generated_at": timestamp.isoformat(),
+        "hypothesis": hypothesis.strip()
+        or f"{candidate_id} is profitable over the historical OOS replay window",
+        "sample_size": len(candidate_runs),
+        "window_days": len(candidate_runs),
+        "proof_gates": _proof_gate_summary(candidate_runs, policy=gate_policy),
+        "statistics": {
+            "effect_size": float(_effect_size(candidate_report_payload)),
+            "p_value": float(
+                _as_decimal(
+                    _as_dict(evidence_payload.get("significance")).get(
+                        "p_value_two_sided"
+                    )
+                )
+            ),
+            "ci_95_low": _as_text(
+                _as_dict(evidence_payload.get("significance")).get("ci_95_low")
             )
-            or '0',
+            or "0",
+            "ci_95_high": _as_text(
+                _as_dict(evidence_payload.get("significance")).get("ci_95_high")
+            )
+            or "0",
         },
-        'candidate_id': candidate_id,
-        'baseline_id': inferred_baseline_id,
-        'source_runs': [
+        "risk_controls": {
+            "max_drawdown_delta": float(
+                _as_decimal(
+                    _as_dict(market_slice.get("deltas")).get("max_drawdown_delta")
+                )
+            ),
+            "market_net_pnl_delta": _as_text(
+                _as_dict(market_slice.get("deltas")).get("net_pnl_delta")
+            )
+            or "0",
+            "return_over_drawdown": _as_text(
+                _as_dict(evidence_payload.get("risk_adjusted_metrics")).get(
+                    "return_over_drawdown"
+                )
+            )
+            or "0",
+        },
+        "candidate_id": candidate_id,
+        "baseline_id": inferred_baseline_id,
+        "source_runs": [
             {
-                'run_id': item.run_id,
-                'trading_day': item.trading_day,
-                'verdict_status': item.verdict_status,
-                'trade_count': item.trade_count,
-                'decision_count': item.decision_count,
-                'net_pnl': str(item.net_pnl),
-                'max_drawdown': str(item.max_drawdown),
+                "run_id": item.run_id,
+                "trading_day": item.trading_day,
+                "verdict_status": item.verdict_status,
+                "trade_count": item.trade_count,
+                "decision_count": item.decision_count,
+                "net_pnl": str(item.net_pnl),
+                "max_drawdown": str(item.max_drawdown),
             }
             for item in sorted(candidate_runs, key=lambda value: value.trading_day)
         ],
-        'artifacts': {
-            'candidate_report': str(candidate_report_path),
-            'baseline_report': str(baseline_report_path),
-            'profitability_benchmark': str(benchmark_path),
-            'profitability_evidence': str(evidence_path),
-            'profitability_validation': str(validation_path),
+        "artifacts": {
+            "candidate_report": str(candidate_report_path),
+            "baseline_report": str(baseline_report_path),
+            "profitability_benchmark": str(benchmark_path),
+            "profitability_evidence": str(evidence_path),
+            "profitability_validation": str(validation_path),
         },
     }
     passed, failed_reasons = _proof_passed(
@@ -669,21 +997,21 @@ def build_historical_profitability_bundle(
         validation_payload=validation_payload,
         proof_payload=proof_payload,
     )
-    proof_payload['passed'] = passed
-    proof_payload['failed_reasons'] = failed_reasons
-    proof_path = output_dir / 'profitability-proof.json'
-    proof_path.write_text(json.dumps(proof_payload, indent=2), encoding='utf-8')
+    proof_payload["passed"] = passed
+    proof_payload["failed_reasons"] = failed_reasons
+    proof_path = output_dir / "profitability-proof.json"
+    proof_path.write_text(json.dumps(proof_payload, indent=2), encoding="utf-8")
 
     summary = {
-        'candidate_id': candidate_id,
-        'baseline_id': inferred_baseline_id,
-        'output_dir': str(output_dir),
-        'profitability_proof_path': str(proof_path),
-        'profitability_benchmark_path': str(benchmark_path),
-        'profitability_evidence_path': str(evidence_path),
-        'profitability_validation_path': str(validation_path),
-        'passed': passed,
-        'failed_reasons': failed_reasons,
+        "candidate_id": candidate_id,
+        "baseline_id": inferred_baseline_id,
+        "output_dir": str(output_dir),
+        "profitability_proof_path": str(proof_path),
+        "profitability_benchmark_path": str(benchmark_path),
+        "profitability_evidence_path": str(evidence_path),
+        "profitability_validation_path": str(validation_path),
+        "passed": passed,
+        "failed_reasons": failed_reasons,
     }
     return summary
 
@@ -696,15 +1024,25 @@ def main() -> int:
         output_dir=Path(args.output_dir),
         hypothesis=args.hypothesis,
         baseline_id=args.baseline_id,
+        target_net_pnl_per_day=args.target_net_pnl_per_day,
+        min_sample_size=args.min_sample_size,
+        min_active_day_ratio=args.min_active_day_ratio,
+        min_positive_day_ratio=args.min_positive_day_ratio,
+        max_best_day_share=args.max_best_day_share,
+        min_daily_notional=args.min_daily_notional,
+        start_equity=args.start_equity,
+        max_drawdown_pct_equity=args.max_drawdown_pct_equity,
+        extended_max_drawdown_pct_equity=args.extended_max_drawdown_pct_equity,
+        min_total_net_pnl_to_drawdown_ratio=args.min_total_net_pnl_to_drawdown_ratio,
     )
     if args.json:
         print(json.dumps(summary, indent=2))
     else:
         print(json.dumps(summary))
-    if not summary.get('passed'):
+    if not summary.get("passed"):
         raise SystemExit(1)
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/services/torghut/scripts/run_archive_backed_profitability_proof.py
+++ b/services/torghut/scripts/run_archive_backed_profitability_proof.py
@@ -18,27 +18,39 @@ from app.trading.profitability_archive import (
     load_archived_trading_day_bundles,
     summarize_data_sufficiency,
 )
-from scripts.build_historical_profitability_proof import build_historical_profitability_bundle
+from scripts.build_historical_profitability_proof import (
+    build_historical_profitability_bundle,
+)
 
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--archive-root', required=True, help='Root directory containing archived replay bundles.')
-    parser.add_argument('--output-dir', required=True, help='Directory where proof artifacts should be written.')
-    parser.add_argument('--selected-candidate-id', default='', help='Optional candidate override.')
-    parser.add_argument('--profit-target-daily-net-usd', default='250')
-    parser.add_argument('--median-target-daily-net-usd', default='125')
-    parser.add_argument('--profitable-day-ratio-target', default='0.60')
-    parser.add_argument('--min-research-days', type=int, default=20)
-    parser.add_argument('--min-historical-days', type=int, default=60)
-    parser.add_argument('--min-execution-days', type=int, default=20)
-    parser.add_argument('--train-days', type=int, default=40)
-    parser.add_argument('--validation-days', type=int, default=10)
-    parser.add_argument('--test-days', type=int, default=10)
-    parser.add_argument('--step-days', type=int, default=10)
-    parser.add_argument('--embargo-days', type=int, default=1)
-    parser.add_argument('--reality-check-bootstrap-replicates', type=int, default=500)
-    parser.add_argument('--json', action='store_true')
+    parser.add_argument(
+        "--archive-root",
+        required=True,
+        help="Root directory containing archived replay bundles.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory where proof artifacts should be written.",
+    )
+    parser.add_argument(
+        "--selected-candidate-id", default="", help="Optional candidate override."
+    )
+    parser.add_argument("--profit-target-daily-net-usd", default="250")
+    parser.add_argument("--median-target-daily-net-usd", default="125")
+    parser.add_argument("--profitable-day-ratio-target", default="0.60")
+    parser.add_argument("--min-research-days", type=int, default=20)
+    parser.add_argument("--min-historical-days", type=int, default=60)
+    parser.add_argument("--min-execution-days", type=int, default=20)
+    parser.add_argument("--train-days", type=int, default=40)
+    parser.add_argument("--validation-days", type=int, default=10)
+    parser.add_argument("--test-days", type=int, default=10)
+    parser.add_argument("--step-days", type=int, default=10)
+    parser.add_argument("--embargo-days", type=int, default=1)
+    parser.add_argument("--reality-check-bootstrap-replicates", type=int, default=500)
+    parser.add_argument("--json", action="store_true")
     return parser.parse_args()
 
 
@@ -46,7 +58,7 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(payload, indent=2, sort_keys=True, default=str),
-        encoding='utf-8',
+        encoding="utf-8",
     )
 
 
@@ -69,9 +81,9 @@ def run_archive_backed_profitability_proof(
     archive_root: Path,
     output_dir: Path,
     selected_candidate_id: str | None = None,
-    profit_target_daily_net_usd: Decimal = Decimal('250'),
-    median_target_daily_net_usd: Decimal = Decimal('125'),
-    profitable_day_ratio_target: Decimal = Decimal('0.60'),
+    profit_target_daily_net_usd: Decimal = Decimal("250"),
+    median_target_daily_net_usd: Decimal = Decimal("125"),
+    profitable_day_ratio_target: Decimal = Decimal("0.60"),
     min_research_days: int = 20,
     min_historical_days: int = 60,
     min_execution_days: int = 20,
@@ -100,7 +112,11 @@ def run_archive_backed_profitability_proof(
         generated_at=generated_at,
     )
 
-    selected_candidate = selected_candidate_id or str(trial_ledger.get('selected_candidate_id') or '').strip() or None
+    selected_candidate = (
+        selected_candidate_id
+        or str(trial_ledger.get("selected_candidate_id") or "").strip()
+        or None
+    )
     proof_eligible_days = sorted(
         {
             bundle.trading_day
@@ -129,12 +145,16 @@ def run_archive_backed_profitability_proof(
         if selected_run_dirs:
             baseline_candidate_id = next(
                 (
-                    str(bundle.replay_day_manifest.get('baseline_candidate_id') or '').strip()
+                    str(
+                        bundle.replay_day_manifest.get("baseline_candidate_id") or ""
+                    ).strip()
                     for bundle in bundles
                     if bundle.candidate_id == selected_candidate
-                    and str(bundle.replay_day_manifest.get('baseline_candidate_id') or '').strip()
+                    and str(
+                        bundle.replay_day_manifest.get("baseline_candidate_id") or ""
+                    ).strip()
                 ),
-                '',
+                "",
             )
             baseline_run_dirs = (
                 _candidate_run_dirs_for_test_days(
@@ -148,23 +168,26 @@ def run_archive_backed_profitability_proof(
             historical_bundle_summary = build_historical_profitability_bundle(
                 run_dirs=selected_run_dirs,
                 baseline_run_dirs=baseline_run_dirs or None,
-                output_dir=output_dir / 'historical-proof',
+                output_dir=output_dir / "historical-proof",
                 hypothesis=(
-                    f'{selected_candidate} satisfies the archive-backed profitability gate '
-                    f'at ${format(profit_target_daily_net_usd, "f")} average daily net P&L'
+                    f"{selected_candidate} satisfies the archive-backed profitability gate "
+                    f"at ${format(profit_target_daily_net_usd, 'f')} average daily net P&L"
                 ),
                 generated_at=generated_at,
+                target_net_pnl_per_day=profit_target_daily_net_usd,
+                min_sample_size=min_execution_days,
+                min_positive_day_ratio=profitable_day_ratio_target,
             )
             artifact_refs.extend(
                 [
                     str(path)
                     for key, path in historical_bundle_summary.items()
-                    if key.endswith('_path') and str(path).strip()
+                    if key.endswith("_path") and str(path).strip()
                 ]
             )
 
-    data_sufficiency_path = output_dir / 'data-sufficiency.json'
-    trial_ledger_path = output_dir / 'trial-ledger.json'
+    data_sufficiency_path = output_dir / "data-sufficiency.json"
+    trial_ledger_path = output_dir / "trial-ledger.json"
     _write_json(data_sufficiency_path, data_sufficiency)
     _write_json(trial_ledger_path, trial_ledger)
     artifact_refs.extend([str(data_sufficiency_path), str(trial_ledger_path)])
@@ -181,7 +204,7 @@ def run_archive_backed_profitability_proof(
         reality_check_bootstrap_replicates=reality_check_bootstrap_replicates,
         generated_at=generated_at,
     )
-    statistical_validity_report_path = output_dir / 'statistical-validity-report.json'
+    statistical_validity_report_path = output_dir / "statistical-validity-report.json"
     _write_json(statistical_validity_report_path, statistical_validity_report)
     artifact_refs.append(str(statistical_validity_report_path))
 
@@ -194,20 +217,20 @@ def run_archive_backed_profitability_proof(
         profit_target_daily_net_usd=profit_target_daily_net_usd,
         generated_at=generated_at,
     )
-    profitability_certificate_path = output_dir / 'profitability-certificate.json'
+    profitability_certificate_path = output_dir / "profitability-certificate.json"
     _write_json(profitability_certificate_path, profitability_certificate)
     artifact_refs.append(str(profitability_certificate_path))
 
     return {
-        'archive_root': str(archive_root),
-        'output_dir': str(output_dir),
-        'selected_candidate_id': selected_candidate,
-        'data_sufficiency_path': str(data_sufficiency_path),
-        'trial_ledger_path': str(trial_ledger_path),
-        'statistical_validity_report_path': str(statistical_validity_report_path),
-        'profitability_certificate_path': str(profitability_certificate_path),
-        'certificate_status': profitability_certificate['status'],
-        'historical_bundle_summary': historical_bundle_summary,
+        "archive_root": str(archive_root),
+        "output_dir": str(output_dir),
+        "selected_candidate_id": selected_candidate,
+        "data_sufficiency_path": str(data_sufficiency_path),
+        "trial_ledger_path": str(trial_ledger_path),
+        "statistical_validity_report_path": str(statistical_validity_report_path),
+        "profitability_certificate_path": str(profitability_certificate_path),
+        "certificate_status": profitability_certificate["status"],
+        "historical_bundle_summary": historical_bundle_summary,
     }
 
 
@@ -237,5 +260,5 @@ def main() -> int:
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/services/torghut/tests/test_build_historical_profitability_proof.py
+++ b/services/torghut/tests/test_build_historical_profitability_proof.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+import contextlib
+import io
 import json
+import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
+from unittest.mock import patch
 
 import yaml
 
 from scripts.build_historical_profitability_proof import (
+    _load_json,
+    _load_yaml,
     build_historical_profitability_bundle,
+    main,
 )
 
 
@@ -18,78 +25,362 @@ class TestBuildHistoricalProfitabilityProof(TestCase):
             root = Path(tmpdir)
             run_a = _write_run(
                 root=root,
-                run_name='sim-a',
-                trading_day='2026-03-02',
-                net_pnl='10',
+                run_name="sim-a",
+                trading_day="2026-03-02",
+                net_pnl="10",
                 decision_count=8,
                 execution_count=4,
-                avg_confidence='0.9',
-                dump_hash='dump-a',
+                avg_confidence="0.9",
+                dump_hash="dump-a",
             )
             run_b = _write_run(
                 root=root,
-                run_name='sim-b',
-                trading_day='2026-03-03',
-                net_pnl='5',
+                run_name="sim-b",
+                trading_day="2026-03-03",
+                net_pnl="5",
                 decision_count=7,
                 execution_count=3,
-                avg_confidence='0.85',
-                dump_hash='dump-b',
+                avg_confidence="0.85",
+                dump_hash="dump-b",
             )
-            output_dir = root / 'out'
+            output_dir = root / "out"
 
             summary = build_historical_profitability_bundle(
                 run_dirs=[run_a, run_b],
                 output_dir=output_dir,
-                hypothesis='intraday_tsmom_v1 is profitable over the OOS replay window',
+                hypothesis="intraday_tsmom_v1 is profitable over the OOS replay window",
+                target_net_pnl_per_day="5",
+                min_sample_size=2,
+                max_best_day_share="1.0",
             )
 
-            self.assertTrue(summary['passed'])
-            proof_payload = json.loads((output_dir / 'profitability-proof.json').read_text(encoding='utf-8'))
-            self.assertTrue(proof_payload['passed'])
-            self.assertEqual(proof_payload['sample_size'], 2)
-            self.assertEqual(proof_payload['window_days'], 2)
+            self.assertTrue(summary["passed"])
+            proof_payload = json.loads(
+                (output_dir / "profitability-proof.json").read_text(encoding="utf-8")
+            )
+            self.assertTrue(proof_payload["passed"])
+            self.assertEqual(proof_payload["sample_size"], 2)
+            self.assertEqual(proof_payload["window_days"], 2)
+            self.assertEqual(
+                proof_payload["proof_gates"]["target_net_pnl_per_day"], "5"
+            )
+            self.assertEqual(
+                proof_payload["proof_gates"]["observed"]["average_daily_net_pnl"], "7.5"
+            )
 
-            candidate_report = json.loads((output_dir / 'candidate-report.json').read_text(encoding='utf-8'))
-            self.assertEqual(candidate_report['metrics']['net_pnl'], '15')
-            self.assertEqual(candidate_report['metrics']['trade_count'], 7)
-            self.assertEqual(len(candidate_report['robustness']['folds']), 2)
+            candidate_report = json.loads(
+                (output_dir / "candidate-report.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(candidate_report["metrics"]["net_pnl"], "15")
+            self.assertEqual(candidate_report["metrics"]["trade_count"], 7)
+            self.assertEqual(len(candidate_report["robustness"]["folds"]), 2)
 
             validation_payload = json.loads(
-                (output_dir / 'profitability-evidence-validation.json').read_text(encoding='utf-8')
+                (output_dir / "profitability-evidence-validation.json").read_text(
+                    encoding="utf-8"
+                )
             )
-            self.assertTrue(validation_payload['passed'])
+            self.assertTrue(validation_payload["passed"])
+
+    def test_loader_rejects_non_mapping_payloads(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            json_path = root / "payload.json"
+            json_path.write_text(json.dumps(["not", "a", "mapping"]), encoding="utf-8")
+            yaml_path = root / "payload.yaml"
+            yaml_path.write_text("- not\n- a\n- mapping\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "json_mapping_required"):
+                _load_json(json_path)
+            with self.assertRaisesRegex(RuntimeError, "yaml_mapping_required"):
+                _load_yaml(yaml_path)
+
+    def test_cli_parser_threads_fail_closed_gate_overrides_into_bundle(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_a = _write_run(
+                root=root,
+                run_name="sim-a",
+                trading_day="2026-03-02",
+                net_pnl="750",
+                decision_count=8,
+                execution_count=4,
+                avg_confidence="0.9",
+                dump_hash="dump-a",
+            )
+            run_b = _write_run(
+                root=root,
+                run_name="sim-b",
+                trading_day="2026-03-03",
+                net_pnl="700",
+                decision_count=7,
+                execution_count=3,
+                avg_confidence="0.85",
+                dump_hash="dump-b",
+            )
+            output_dir = root / "out"
+            argv = [
+                "build_historical_profitability_proof.py",
+                "--run-dir",
+                str(run_a),
+                "--run-dir",
+                str(run_b),
+                "--output-dir",
+                str(output_dir),
+                "--hypothesis",
+                "candidate clears fail-closed gates",
+                "--baseline-id",
+                "cash-flat@baseline",
+                "--target-net-pnl-per-day",
+                "500",
+                "--min-sample-size",
+                "2",
+                "--min-active-day-ratio",
+                "0.90",
+                "--min-positive-day-ratio",
+                "0.60",
+                "--max-best-day-share",
+                "1.0",
+                "--min-daily-notional",
+                "500",
+                "--start-equity",
+                "10000",
+                "--max-drawdown-pct-equity",
+                "0.10",
+                "--extended-max-drawdown-pct-equity",
+                "0.15",
+                "--min-total-net-pnl-to-drawdown-ratio",
+                "2.0",
+                "--json",
+            ]
+
+            stdout = io.StringIO()
+            with patch.object(sys, "argv", argv), contextlib.redirect_stdout(stdout):
+                exit_code = main()
+
+            self.assertEqual(exit_code, 0)
+            summary = json.loads(stdout.getvalue())
+            self.assertTrue(summary["passed"])
+            proof_payload = json.loads(
+                (output_dir / "profitability-proof.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(proof_payload["proof_gates"]["min_daily_notional"], "500")
+            self.assertEqual(
+                proof_payload["proof_gates"]["observed"]["avg_daily_notional"], "1000"
+            )
+
+    def test_positive_but_below_target_daily_net_fails_proof_gate(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            runs = [
+                _write_run(
+                    root=root,
+                    run_name=f"sim-{index}",
+                    trading_day=f"2026-03-0{index + 2}",
+                    net_pnl=str(net_pnl),
+                    decision_count=8,
+                    execution_count=4,
+                    avg_confidence="0.9",
+                    dump_hash=f"dump-{index}",
+                )
+                for index, net_pnl in enumerate((100, 200, 150))
+            ]
+            output_dir = root / "out"
+
+            summary = build_historical_profitability_bundle(
+                run_dirs=runs,
+                output_dir=output_dir,
+                target_net_pnl_per_day="500",
+                min_sample_size=3,
+                max_best_day_share="1.0",
+            )
+
+            self.assertFalse(summary["passed"])
+            self.assertIn(
+                "average_daily_net_pnl_below_target", summary["failed_reasons"]
+            )
+            proof_payload = json.loads(
+                (output_dir / "profitability-proof.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                proof_payload["proof_gates"]["observed"]["average_daily_net_pnl"], "150"
+            )
+            self.assertIn(
+                "average_daily_net_pnl_below_target", proof_payload["failed_reasons"]
+            )
+
+    def test_inactive_days_fail_active_day_ratio_gate(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_a = _write_run(
+                root=root,
+                run_name="sim-a",
+                trading_day="2026-03-02",
+                net_pnl="750",
+                decision_count=8,
+                execution_count=4,
+                avg_confidence="0.9",
+                dump_hash="dump-a",
+            )
+            run_b = _write_run(
+                root=root,
+                run_name="sim-b",
+                trading_day="2026-03-03",
+                net_pnl="750",
+                decision_count=0,
+                execution_count=0,
+                avg_confidence="0.9",
+                dump_hash="dump-b",
+            )
+            output_dir = root / "out"
+
+            summary = build_historical_profitability_bundle(
+                run_dirs=[run_a, run_b],
+                output_dir=output_dir,
+                target_net_pnl_per_day="500",
+                min_sample_size=2,
+                min_active_day_ratio="0.90",
+                max_best_day_share="1.0",
+            )
+
+            self.assertFalse(summary["passed"])
+            self.assertIn("active_day_ratio_below_minimum", summary["failed_reasons"])
+            proof_payload = json.loads(
+                (output_dir / "profitability-proof.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(proof_payload["proof_gates"]["observed"]["active_days"], 1)
+            self.assertEqual(
+                proof_payload["proof_gates"]["observed"]["active_day_ratio"], "0.5"
+            )
+
+    def test_source_dump_hash_fallback_and_notional_gate_are_recorded(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_a = _write_run(
+                root=root,
+                run_name="sim-a",
+                trading_day="2026-03-02",
+                net_pnl="750",
+                decision_count=8,
+                execution_count=4,
+                avg_confidence="0.9",
+                dump_hash="",
+            )
+            (run_a / "replay-report.json").unlink()
+            (run_a / "source-dump.jsonl.zst.manifest.json").write_text(
+                json.dumps({"chunks": [{"payload_sha256": "chunk-a"}]}),
+                encoding="utf-8",
+            )
+            run_b = _write_run(
+                root=root,
+                run_name="sim-b",
+                trading_day="2026-03-03",
+                net_pnl="700",
+                decision_count=7,
+                execution_count=3,
+                avg_confidence="0.85",
+                dump_hash="",
+            )
+            (run_b / "replay-report.json").unlink()
+            (run_b / "source-dump.jsonl.zst").write_bytes(b"source-dump-b")
+            output_dir = root / "out"
+
+            summary = build_historical_profitability_bundle(
+                run_dirs=[run_a, run_b],
+                output_dir=output_dir,
+                target_net_pnl_per_day="500",
+                min_sample_size=2,
+                max_best_day_share="1.0",
+                min_daily_notional="2000",
+            )
+
+            self.assertFalse(summary["passed"])
+            self.assertIn("avg_daily_notional_below_minimum", summary["failed_reasons"])
+            proof_payload = json.loads(
+                (output_dir / "profitability-proof.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                proof_payload["proof_gates"]["observed"]["avg_daily_notional"], "1000"
+            )
+            self.assertTrue((output_dir / "profitability-evidence-v4.json").exists())
+
+    def test_excessive_drawdown_fails_proof_gate_even_when_average_target_passes(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            runs = [
+                _write_run(
+                    root=root,
+                    run_name=f"sim-{index}",
+                    trading_day=f"2026-03-0{index + 2}",
+                    net_pnl=str(net_pnl),
+                    decision_count=8,
+                    execution_count=4,
+                    avg_confidence="0.9",
+                    dump_hash=f"dump-{index}",
+                )
+                for index, net_pnl in enumerate((2000, -4500, 3000, 3000))
+            ]
+            output_dir = root / "out"
+
+            summary = build_historical_profitability_bundle(
+                run_dirs=runs,
+                output_dir=output_dir,
+                target_net_pnl_per_day="500",
+                min_sample_size=4,
+                min_positive_day_ratio="0.60",
+                max_best_day_share="1.0",
+                start_equity="10000",
+                max_drawdown_pct_equity="0.10",
+                extended_max_drawdown_pct_equity="0.15",
+            )
+
+            self.assertFalse(summary["passed"])
+            self.assertIn("max_drawdown_above_limit", summary["failed_reasons"])
+            proof_payload = json.loads(
+                (output_dir / "profitability-proof.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                proof_payload["proof_gates"]["observed"]["average_daily_net_pnl"], "875"
+            )
+            self.assertEqual(
+                proof_payload["proof_gates"]["observed"]["max_drawdown"], "4500"
+            )
+            self.assertEqual(
+                proof_payload["proof_gates"]["observed"]["drawdown_passed"], False
+            )
 
     def test_rejects_inconsistent_candidate_lineage(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             run_a = _write_run(
                 root=root,
-                run_name='sim-a',
-                trading_day='2026-03-02',
-                net_pnl='10',
+                run_name="sim-a",
+                trading_day="2026-03-02",
+                net_pnl="10",
                 decision_count=8,
                 execution_count=4,
-                avg_confidence='0.9',
-                dump_hash='dump-a',
-                candidate_id='intraday_tsmom_v1@prod',
+                avg_confidence="0.9",
+                dump_hash="dump-a",
+                candidate_id="intraday_tsmom_v1@prod",
             )
             run_b = _write_run(
                 root=root,
-                run_name='sim-b',
-                trading_day='2026-03-03',
-                net_pnl='5',
+                run_name="sim-b",
+                trading_day="2026-03-03",
+                net_pnl="5",
                 decision_count=7,
                 execution_count=3,
-                avg_confidence='0.85',
-                dump_hash='dump-b',
-                candidate_id='other_candidate@prod',
+                avg_confidence="0.85",
+                dump_hash="dump-b",
+                candidate_id="other_candidate@prod",
             )
 
             with self.assertRaises(RuntimeError):
                 build_historical_profitability_bundle(
                     run_dirs=[run_a, run_b],
-                    output_dir=root / 'out',
+                    output_dir=root / "out",
                 )
 
     def test_rejects_duplicate_trading_days(self) -> None:
@@ -97,29 +388,29 @@ class TestBuildHistoricalProfitabilityProof(TestCase):
             root = Path(tmpdir)
             run_a = _write_run(
                 root=root,
-                run_name='sim-a',
-                trading_day='2026-03-02',
-                net_pnl='10',
+                run_name="sim-a",
+                trading_day="2026-03-02",
+                net_pnl="10",
                 decision_count=8,
                 execution_count=4,
-                avg_confidence='0.9',
-                dump_hash='dump-a',
+                avg_confidence="0.9",
+                dump_hash="dump-a",
             )
             run_b = _write_run(
                 root=root,
-                run_name='sim-b',
-                trading_day='2026-03-02',
-                net_pnl='5',
+                run_name="sim-b",
+                trading_day="2026-03-02",
+                net_pnl="5",
                 decision_count=7,
                 execution_count=3,
-                avg_confidence='0.85',
-                dump_hash='dump-b',
+                avg_confidence="0.85",
+                dump_hash="dump-b",
             )
 
             with self.assertRaises(RuntimeError):
                 build_historical_profitability_bundle(
                     run_dirs=[run_a, run_b],
-                    output_dir=root / 'out',
+                    output_dir=root / "out",
                 )
 
 
@@ -133,90 +424,90 @@ def _write_run(
     execution_count: int,
     avg_confidence: str,
     dump_hash: str,
-    candidate_id: str = 'intraday_tsmom_v1@prod',
+    candidate_id: str = "intraday_tsmom_v1@prod",
 ) -> Path:
     run_dir = root / run_name
-    report_dir = run_dir / 'report'
+    report_dir = run_dir / "report"
     report_dir.mkdir(parents=True, exist_ok=True)
 
-    manifest_path = root / f'{run_name}.yaml'
+    manifest_path = root / f"{run_name}.yaml"
     manifest_path.write_text(
         yaml.safe_dump(
             {
-                'window': {
-                    'trading_day': trading_day,
+                "window": {
+                    "trading_day": trading_day,
                 },
-                'candidate_id': candidate_id,
-                'baseline_candidate_id': 'cash-flat@baseline',
-                'strategy_spec_ref': 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
-                'model_refs': ['rules/intraday_tsmom_v1'],
-                'runtime_version_refs': ['services/torghut@sha256:test'],
-                'monitor': {
-                    'min_trade_decisions': 1,
-                    'min_executions': 1,
+                "candidate_id": candidate_id,
+                "baseline_candidate_id": "cash-flat@baseline",
+                "strategy_spec_ref": "strategy-specs/intraday_tsmom_v1@1.1.0.json",
+                "model_refs": ["rules/intraday_tsmom_v1"],
+                "runtime_version_refs": ["services/torghut@sha256:test"],
+                "monitor": {
+                    "min_trade_decisions": 1,
+                    "min_executions": 1,
                 },
             },
             sort_keys=False,
         ),
-        encoding='utf-8',
+        encoding="utf-8",
     )
 
-    (run_dir / 'run-manifest.json').write_text(
+    (run_dir / "run-manifest.json").write_text(
         json.dumps(
             {
-                'run_id': run_name,
-                'evidence_lineage': {
-                    'candidate_id': candidate_id,
-                    'baseline_candidate_id': 'cash-flat@baseline',
-                    'strategy_spec_ref': 'strategy-specs/intraday_tsmom_v1@1.1.0.json',
-                    'model_refs': ['rules/intraday_tsmom_v1'],
-                    'runtime_version_refs': ['services/torghut@sha256:test'],
+                "run_id": run_name,
+                "evidence_lineage": {
+                    "candidate_id": candidate_id,
+                    "baseline_candidate_id": "cash-flat@baseline",
+                    "strategy_spec_ref": "strategy-specs/intraday_tsmom_v1@1.1.0.json",
+                    "model_refs": ["rules/intraday_tsmom_v1"],
+                    "runtime_version_refs": ["services/torghut@sha256:test"],
                 },
             }
         ),
-        encoding='utf-8',
+        encoding="utf-8",
     )
-    (run_dir / 'replay-report.json').write_text(
+    (run_dir / "replay-report.json").write_text(
         json.dumps(
             {
-                'dump_sha256': dump_hash,
+                "dump_sha256": dump_hash,
             }
         ),
-        encoding='utf-8',
+        encoding="utf-8",
     )
-    (report_dir / 'trade-pnl.csv').write_text(
-        'avg_fill_price,created_at,execution_id,filled_qty,realized_pnl_contribution,side,symbol,trade_decision_id\n'
-        f'100,2026-03-16T12:00:00Z,exec-1,1,0,buy,AAPL,td-1\n'
-        f'100,2026-03-16T12:01:00Z,exec-2,1,{net_pnl},sell,AAPL,td-2\n',
-        encoding='utf-8',
+    (report_dir / "trade-pnl.csv").write_text(
+        "avg_fill_price,created_at,execution_id,filled_qty,realized_pnl_contribution,side,symbol,trade_decision_id\n"
+        f"100,2026-03-16T12:00:00Z,exec-1,1,0,buy,AAPL,td-1\n"
+        f"100,2026-03-16T12:01:00Z,exec-2,1,{net_pnl},sell,AAPL,td-2\n",
+        encoding="utf-8",
     )
-    (report_dir / 'simulation-report.json').write_text(
+    (report_dir / "simulation-report.json").write_text(
         json.dumps(
             {
-                'run_metadata': {
-                    'run_id': run_name,
-                    'manifest_path': str(manifest_path),
+                "run_metadata": {
+                    "run_id": run_name,
+                    "manifest_path": str(manifest_path),
                 },
-                'coverage': {
-                    'window_start': f'{trading_day}T13:30:00+00:00',
+                "coverage": {
+                    "window_start": f"{trading_day}T13:30:00+00:00",
                 },
-                'funnel': {
-                    'trade_decisions': decision_count,
-                    'executions': execution_count,
+                "funnel": {
+                    "trade_decisions": decision_count,
+                    "executions": execution_count,
                 },
-                'pnl': {
-                    'net_pnl_estimated': net_pnl,
-                    'estimated_cost_total': '0',
-                    'execution_notional_total': '1000',
+                "pnl": {
+                    "net_pnl_estimated": net_pnl,
+                    "estimated_cost_total": "0",
+                    "execution_notional_total": "1000",
                 },
-                'llm': {
-                    'avg_confidence': avg_confidence,
+                "llm": {
+                    "avg_confidence": avg_confidence,
                 },
-                'verdict': {
-                    'status': 'PASS',
+                "verdict": {
+                    "status": "PASS",
                 },
             }
         ),
-        encoding='utf-8',
+        encoding="utf-8",
     )
     return run_dir

--- a/services/torghut/tests/test_run_archive_backed_profitability_proof.py
+++ b/services/torghut/tests/test_run_archive_backed_profitability_proof.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import json
+import sys
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
+from unittest.mock import patch
 
 from app.trading.profitability_archive import archive_historical_simulation_run
-from scripts.run_archive_backed_profitability_proof import run_archive_backed_profitability_proof
+from scripts.run_archive_backed_profitability_proof import (
+    _parse_args,
+    run_archive_backed_profitability_proof,
+)
 from tests.profitability_archive_test_utils import (
     default_postgres_counts,
     iter_trading_days,
@@ -25,13 +30,13 @@ def _archive_candidate_days(
     daily_net_pnl_fn,
 ) -> None:
     for index, trading_day in enumerate(trading_days):
-        run_name = f'{candidate_id}-{trading_day}'
+        run_name = f"{candidate_id}-{trading_day}"
         run_dir, manifest_path = write_historical_run(
             root=root,
             run_name=run_name,
             trading_day=trading_day,
             candidate_id=candidate_id,
-            net_pnl=format(Decimal(daily_net_pnl_fn(index)), 'f'),
+            net_pnl=format(Decimal(daily_net_pnl_fn(index)), "f"),
             avg_abs_slippage_bps=4.0 + float(index % 3),
             p95_abs_slippage_bps=8.0 + float(index % 5),
         )
@@ -39,61 +44,124 @@ def _archive_candidate_days(
             run_dir=run_dir,
             archive_root=archive_root,
             manifest_path=manifest_path,
-            topic_retention_ms_by_topic={'torghut.trades.v1': 14 * 86_400_000},
+            topic_retention_ms_by_topic={"torghut.trades.v1": 14 * 86_400_000},
             postgres_counts=default_postgres_counts(),
         )
 
 
 class TestRunArchiveBackedProfitabilityProof(TestCase):
+    def test_cli_parser_accepts_archive_profitability_gate_overrides(self) -> None:
+        argv = [
+            "run_archive_backed_profitability_proof.py",
+            "--archive-root",
+            "/tmp/archive",
+            "--output-dir",
+            "/tmp/proof",
+            "--selected-candidate-id",
+            "breakout_continuation_long",
+            "--profit-target-daily-net-usd",
+            "500",
+            "--median-target-daily-net-usd",
+            "250",
+            "--profitable-day-ratio-target",
+            "0.65",
+            "--min-research-days",
+            "30",
+            "--min-historical-days",
+            "90",
+            "--min-execution-days",
+            "30",
+            "--train-days",
+            "50",
+            "--validation-days",
+            "20",
+            "--test-days",
+            "20",
+            "--step-days",
+            "5",
+            "--embargo-days",
+            "2",
+            "--reality-check-bootstrap-replicates",
+            "750",
+            "--json",
+        ]
+
+        with patch.object(sys, "argv", argv):
+            args = _parse_args()
+
+        self.assertEqual(args.archive_root, "/tmp/archive")
+        self.assertEqual(args.output_dir, "/tmp/proof")
+        self.assertEqual(args.selected_candidate_id, "breakout_continuation_long")
+        self.assertEqual(args.profit_target_daily_net_usd, "500")
+        self.assertEqual(args.median_target_daily_net_usd, "250")
+        self.assertEqual(args.profitable_day_ratio_target, "0.65")
+        self.assertEqual(args.min_research_days, 30)
+        self.assertEqual(args.min_historical_days, 90)
+        self.assertEqual(args.min_execution_days, 30)
+        self.assertEqual(args.train_days, 50)
+        self.assertEqual(args.validation_days, 20)
+        self.assertEqual(args.test_days, 20)
+        self.assertEqual(args.step_days, 5)
+        self.assertEqual(args.embargo_days, 2)
+        self.assertEqual(args.reality_check_bootstrap_replicates, 750)
+        self.assertTrue(args.json)
+
     def test_short_archive_resolves_to_insufficient_history(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            archive_root = root / 'archive'
+            archive_root = root / "archive"
             trading_days = iter_trading_days(start_day=date(2026, 3, 2), count=10)
             _archive_candidate_days(
                 root=root,
                 archive_root=archive_root,
-                candidate_id='momentum_pullback_long',
+                candidate_id="momentum_pullback_long",
                 trading_days=trading_days,
-                daily_net_pnl_fn=lambda _: Decimal('180'),
+                daily_net_pnl_fn=lambda _: Decimal("180"),
             )
 
             summary = run_archive_backed_profitability_proof(
                 archive_root=archive_root,
-                output_dir=root / 'proof',
+                output_dir=root / "proof",
             )
 
-            self.assertEqual(summary['certificate_status'], 'insufficient_history')
-            certificate = json.loads(Path(summary['profitability_certificate_path']).read_text(encoding='utf-8'))
-            self.assertEqual(certificate['status'], 'insufficient_history')
-            self.assertIn('replay_ready_market_days_below_research_minimum', certificate['promotion_blockers'])
+            self.assertEqual(summary["certificate_status"], "insufficient_history")
+            certificate = json.loads(
+                Path(summary["profitability_certificate_path"]).read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(certificate["status"], "insufficient_history")
+            self.assertIn(
+                "replay_ready_market_days_below_research_minimum",
+                certificate["promotion_blockers"],
+            )
 
     def test_positive_but_sub_target_candidate_fails_historical_gate(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            archive_root = root / 'archive'
+            archive_root = root / "archive"
             trading_days = iter_trading_days(start_day=date(2026, 1, 5), count=30)
             _archive_candidate_days(
                 root=root,
                 archive_root=archive_root,
-                candidate_id='momentum_pullback_long',
+                candidate_id="momentum_pullback_long",
                 trading_days=trading_days,
-                daily_net_pnl_fn=lambda index: Decimal('100') + Decimal(index % 5),
+                daily_net_pnl_fn=lambda index: Decimal("100") + Decimal(index % 5),
             )
             _archive_candidate_days(
                 root=root,
                 archive_root=archive_root,
-                candidate_id='breakout_continuation_long',
+                candidate_id="breakout_continuation_long",
                 trading_days=trading_days,
-                daily_net_pnl_fn=lambda index: Decimal('80') + Decimal(index % 5),
+                daily_net_pnl_fn=lambda index: Decimal("80") + Decimal(index % 5),
             )
 
             summary = run_archive_backed_profitability_proof(
                 archive_root=archive_root,
-                output_dir=root / 'proof',
-                profit_target_daily_net_usd=Decimal('250'),
-                median_target_daily_net_usd=Decimal('125'),
-                profitable_day_ratio_target=Decimal('0.60'),
+                output_dir=root / "proof",
+                profit_target_daily_net_usd=Decimal("250"),
+                median_target_daily_net_usd=Decimal("125"),
+                profitable_day_ratio_target=Decimal("0.60"),
                 min_research_days=10,
                 min_historical_days=10,
                 min_execution_days=10,
@@ -105,13 +173,19 @@ class TestRunArchiveBackedProfitabilityProof(TestCase):
                 reality_check_bootstrap_replicates=100,
             )
 
-            self.assertEqual(summary['certificate_status'], 'research_only')
-            self.assertIsNotNone(summary['historical_bundle_summary'])
+            self.assertEqual(summary["certificate_status"], "research_only")
+            self.assertIsNotNone(summary["historical_bundle_summary"])
 
             statistical_validity = json.loads(
-                Path(summary['statistical_validity_report_path']).read_text(encoding='utf-8')
+                Path(summary["statistical_validity_report_path"]).read_text(
+                    encoding="utf-8"
+                )
             )
-            self.assertIn('average_daily_net_pnl_below_target', statistical_validity['blockers'])
-            self.assertIsNotNone(statistical_validity['selection_bias_metrics']['pbo'])
-            self.assertIsNotNone(statistical_validity['selection_bias_metrics']['dsr'])
-            self.assertIsNotNone(statistical_validity['selection_bias_metrics']['reality_check_p_value'])
+            self.assertIn(
+                "average_daily_net_pnl_below_target", statistical_validity["blockers"]
+            )
+            self.assertIsNotNone(statistical_validity["selection_bias_metrics"]["pbo"])
+            self.assertIsNotNone(statistical_validity["selection_bias_metrics"]["dsr"])
+            self.assertIsNotNone(
+                statistical_validity["selection_bias_metrics"]["reality_check_p_value"]
+            )


### PR DESCRIPTION
## Summary

- Makes historical profitability proof receipts fail closed on explicit daily profit gates instead of accepting merely positive aggregate net PnL.
- Adds `proof_gates` evidence for target daily net PnL, sample size, active days, positive days, best-day concentration, notional, and drawdown as a percent of starting equity.
- Passes the archive-backed profit target into the historical proof builder and adds regressions for below-target, inactive-day, and excessive-drawdown false positives.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_build_historical_profitability_proof.py tests/test_run_archive_backed_profitability_proof.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check scripts/build_historical_profitability_proof.py scripts/run_archive_backed_profitability_proof.py tests/test_build_historical_profitability_proof.py tests/test_run_archive_backed_profitability_proof.py`
- `uv run --frozen ruff check scripts/build_historical_profitability_proof.py scripts/run_archive_backed_profitability_proof.py tests/test_build_historical_profitability_proof.py tests/test_run_archive_backed_profitability_proof.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

Historical profitability proof generation is intentionally stricter: proof artifacts that are positive but below the configured daily target, too concentrated, too inactive, too short, or above drawdown limits now return `passed=false`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
