### PR TITLE
fix(agents): label leader election logs

### DIFF
--- a/services/jangar/src/server/__tests__/leader-election.test.ts
+++ b/services/jangar/src/server/__tests__/leader-election.test.ts
@@ -56,6 +56,8 @@ vi.mock('@proompteng/otel/api', () => ({
   },
 }))
 
+const originalAgentsRuntimeService = process.env.AGENTS_RUNTIME_SERVICE
+
 const stopLeaderElectionRuntime = () => {
   const state = globalThis as typeof globalThis & {
     __jangarLeaderElection?: { stop?: () => void }
@@ -64,51 +66,65 @@ const stopLeaderElectionRuntime = () => {
   Reflect.deleteProperty(state, '__jangarLeaderElection')
 }
 
+const restoreAgentsRuntimeService = () => {
+  if (originalAgentsRuntimeService === undefined) {
+    delete process.env.AGENTS_RUNTIME_SERVICE
+    return
+  }
+  process.env.AGENTS_RUNTIME_SERVICE = originalAgentsRuntimeService
+}
+
+const mockInitialLeaseAcquire = () => {
+  mocks.getLease.mockResolvedValueOnce(null)
+  mocks.createLease.mockResolvedValueOnce({
+    apiVersion: 'coordination.k8s.io/v1',
+    kind: 'Lease',
+    metadata: {
+      name: 'jangar-controller-leader',
+      namespace: 'agents',
+      resourceVersion: '1',
+    },
+    spec: {
+      holderIdentity: 'jangar-0_pod-uid',
+      leaseDurationSeconds: 30,
+      leaseTransitions: 0,
+      renewTime: new Date().toISOString(),
+    },
+  })
+  mocks.replaceLease.mockResolvedValueOnce({
+    apiVersion: 'coordination.k8s.io/v1',
+    kind: 'Lease',
+    metadata: {
+      name: 'jangar-controller-leader',
+      namespace: 'agents',
+      resourceVersion: '2',
+    },
+    spec: {
+      holderIdentity: 'jangar-0_pod-uid',
+      leaseDurationSeconds: 30,
+      leaseTransitions: 0,
+      renewTime: new Date().toISOString(),
+    },
+  })
+}
+
 describe('leader election', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
     vi.useFakeTimers()
+    restoreAgentsRuntimeService()
     stopLeaderElectionRuntime()
   })
 
   afterEach(() => {
     stopLeaderElectionRuntime()
     vi.useRealTimers()
+    restoreAgentsRuntimeService()
   })
 
   it('creates the lease when the initial read returns null and then promotes to leader', async () => {
-    mocks.getLease.mockResolvedValueOnce(null)
-    mocks.createLease.mockResolvedValueOnce({
-      apiVersion: 'coordination.k8s.io/v1',
-      kind: 'Lease',
-      metadata: {
-        name: 'jangar-controller-leader',
-        namespace: 'agents',
-        resourceVersion: '1',
-      },
-      spec: {
-        holderIdentity: 'jangar-0_pod-uid',
-        leaseDurationSeconds: 30,
-        leaseTransitions: 0,
-        renewTime: new Date().toISOString(),
-      },
-    })
-    mocks.replaceLease.mockResolvedValueOnce({
-      apiVersion: 'coordination.k8s.io/v1',
-      kind: 'Lease',
-      metadata: {
-        name: 'jangar-controller-leader',
-        namespace: 'agents',
-        resourceVersion: '2',
-      },
-      spec: {
-        holderIdentity: 'jangar-0_pod-uid',
-        leaseDurationSeconds: 30,
-        leaseTransitions: 0,
-        renewTime: new Date().toISOString(),
-      },
-    })
+    mockInitialLeaseAcquire()
 
     const onLeader = vi.fn()
     const onFollower = vi.fn()
@@ -126,5 +142,30 @@ describe('leader election', () => {
     expect(status.isLeader).toBe(true)
     expect(status.lastSuccessAt).not.toBeNull()
     expect(onFollower).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    ['agents', '[agents]'],
+    [undefined, '[jangar]'],
+  ])('labels transition logs for runtime service %s', async (runtimeService, expectedPrefix) => {
+    if (runtimeService === undefined) {
+      delete process.env.AGENTS_RUNTIME_SERVICE
+    } else {
+      process.env.AGENTS_RUNTIME_SERVICE = runtimeService
+    }
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    mockInitialLeaseAcquire()
+
+    const onLeader = vi.fn()
+    const onFollower = vi.fn()
+    const { ensureLeaderElectionRuntime } = await import('../leader-election')
+
+    ensureLeaderElectionRuntime({ onLeader, onFollower })
+
+    await vi.waitFor(() => {
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`${expectedPrefix} leader election transition: leader`),
+      )
+    })
   })
 })

--- a/services/jangar/src/server/leader-election.ts
+++ b/services/jangar/src/server/leader-election.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 
 import { type V1Lease, V1MicroTime } from '@kubernetes/client-node'
+import { resolveRuntimeServiceName } from '@proompteng/agents/server/runtime-identity'
 import { type Counter, metrics as otelMetrics } from '@proompteng/otel/api'
 import { isRuntimeTestEnv, resolveLeaderElectionSettings } from '~/server/control-plane-config'
 import { createKubeGateway } from '~/server/kube-gateway'
@@ -194,8 +195,9 @@ const setLeaderStatus = (isLeader: boolean, error?: string | null) => {
     const leaseNamespace = state.status.leaseNamespace
     const identity = state.status.identity
     const suffix = error ? ` (${error})` : ''
+    const serviceName = resolveRuntimeServiceName()
     console.info(
-      `[jangar] leader election transition: ${isLeader ? 'leader' : 'follower'} lease=${leaseNamespace}/${leaseName} identity=${identity}${suffix}`,
+      `[${serviceName}] leader election transition: ${isLeader ? 'leader' : 'follower'} lease=${leaseNamespace}/${leaseName} identity=${identity}${suffix}`,
     )
     try {
       state.metrics?.changesCounter.add(1, { to: isLeader ? 'leader' : 'follower' })


### PR DESCRIPTION
## Summary

- Label leader-election transition logs from runtime identity so Agents deployments emit `[agents]`.
- Preserve the default `[jangar]` label for the Jangar runtime.
- Add regression coverage for both runtime log prefixes.

## Related Issues

None

## Testing

- `bun run --cwd services/jangar test -- src/server/__tests__/leader-election.test.ts src/server/__tests__/agentctl-grpc-logging.test.ts`
- `bunx oxfmt --check services/jangar/src/server/leader-election.ts services/jangar/src/server/__tests__/leader-election.test.ts`
- `bunx oxlint --config .oxlintrc.json services/jangar/src/server/leader-election.ts services/jangar/src/server/__tests__/leader-election.test.ts`
- `bun run --filter @proompteng/jangar tsc`
- `bun run --cwd services/jangar docs:inventory:check`
- `bun run --cwd services/jangar check:module-sizes`
- `scripts/agents/guard-extraction-boundaries.sh`
- `scripts/agents/validate-agents.sh`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
