### PR TITLE
chore(jangar): promote image c4de4eb3

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-18T22:17:16Z
+    deploy.knative.dev/rollout: 2026-05-18T23:15:52Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:bcacbae3@sha256:c7fec0996294ca55ba82532149f380f8cd213b594bd011c7c10e95b1229cbb02
+              value: registry.ide-newton.ts.net/lab/jangar:c4de4eb3@sha256:1c0c92ae8794fa02af856eb9f1178e41a3d741bda7aac17511e11ea5bec084f6
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: bcacbae3a38cc7746aa20909728b6c37c3d9034c
+              value: c4de4eb3605f938b3da4d11ba602fe91c659f829
             - name: JANGAR_GITOPS_REVISION
-              value: bcacbae3a38cc7746aa20909728b6c37c3d9034c
+              value: c4de4eb3605f938b3da4d11ba602fe91c659f829
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26063608094"
+              value: "26065825718"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:07bd6eb4100a0f084bea71042a9c749c4fe1dc3d19d5a36527b5d6765fc5fa39
+              value: sha256:4dddbdc79f7ad9ba3e684b7889431eafc2d02ec093147da02de23d49b43d3f78
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: bcacbae3a38cc7746aa20909728b6c37c3d9034c
+              value: c4de4eb3605f938b3da4d11ba602fe91c659f829
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:07bd6eb4100a0f084bea71042a9c749c4fe1dc3d19d5a36527b5d6765fc5fa39
+              value: sha256:4dddbdc79f7ad9ba3e684b7889431eafc2d02ec093147da02de23d49b43d3f78
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: bcacbae3
-    digest: sha256:c7fec0996294ca55ba82532149f380f8cd213b594bd011c7c10e95b1229cbb02
+    newTag: c4de4eb3
+    digest: sha256:1c0c92ae8794fa02af856eb9f1178e41a3d741bda7aac17511e11ea5bec084f6


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `c4de4eb3605f938b3da4d11ba602fe91c659f829`
- Image tag: `c4de4eb3`
- Image digest: `sha256:1c0c92ae8794fa02af856eb9f1178e41a3d741bda7aac17511e11ea5bec084f6`
- Source CI run: `26065825718`
- Control-plane serving digest: `sha256:4dddbdc79f7ad9ba3e684b7889431eafc2d02ec093147da02de23d49b43d3f78`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates