### PR TITLE
fix(agents): unblock controller readiness startup

### DIFF
--- a/services/agents/src/server/agents-controller/index.ts
+++ b/services/agents/src/server/agents-controller/index.ts
@@ -783,6 +783,22 @@ const resyncAgentRunsForNamespace = async (
   }
 }
 
+const queueAgentRunResync = (
+  kube: ReturnType<typeof createKubernetesClient>,
+  namespace: string,
+  state: ControllerState,
+  concurrency: ReturnType<typeof parseConcurrency>,
+  reason: 'periodic' | 'watch_restart' | 'manual',
+) => {
+  void resyncAgentRunsForNamespace(kube, namespace, state, concurrency, reason).catch((error) => {
+    logAgentsControllerWarn('agentrun_resync_failed', {
+      namespace,
+      reason,
+      ...toLogError(error),
+    })
+  })
+}
+
 const {
   reconcileAgent,
   reconcileAgentProvider,
@@ -1146,7 +1162,7 @@ const startNamespaceWatches = async (
           namespace,
           reason: restartReason,
         })
-        void resyncAgentRunsForNamespace(kube, namespace, state, concurrency, 'watch_restart')
+        queueAgentRunResync(kube, namespace, state, concurrency, 'watch_restart')
       },
     }),
   )
@@ -1212,13 +1228,15 @@ const startNamespaceWatches = async (
 
   const resyncInterval = resolveAgentRunResyncIntervalSeconds() * 1000
   const timer = setInterval(() => {
-    void resyncAgentRunsForNamespace(kube, namespace, state, concurrency, 'periodic')
+    queueAgentRunResync(kube, namespace, state, concurrency, 'periodic')
   }, resyncInterval)
   handles.push({
     stop: () => clearInterval(timer),
   })
 
-  await resyncAgentRunsForNamespace(kube, namespace, state, concurrency, 'manual')
+  // The initial resync can be large in production. Watches are already live here, so run it
+  // in the background instead of blocking controller startup and readiness.
+  queueAgentRunResync(kube, namespace, state, concurrency, 'manual')
 }
 
 const stopWatchHandles = (handles: Array<{ stop: () => void }>) => {
@@ -1407,6 +1425,7 @@ export const __test = {
   resolveVcsContext,
   getAgentRunUntouchedReasons,
   resyncAgentRunsForNamespace,
+  startNamespaceWatches,
   syncControllerAgentRunIngestionHealth,
   assessAgentRunIngestion,
   stopWatchHandles,

--- a/services/agents/src/server/agents-controller/startup-resync.test.ts
+++ b/services/agents/src/server/agents-controller/startup-resync.test.ts
@@ -1,0 +1,86 @@
+import { setTimeout as delay } from 'node:timers/promises'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const watchMocks = vi.hoisted(() => ({
+  startResourceWatch: vi.fn(() => ({ stop: vi.fn() })),
+}))
+
+vi.mock('../kube-watch', () => ({
+  startResourceWatch: watchMocks.startResourceWatch,
+}))
+
+import { RESOURCE_MAP } from '../kube-types'
+import { __test, stopAgentsController } from './index'
+
+const defaultConcurrency = {
+  perNamespace: 10,
+  perAgent: 5,
+  cluster: 100,
+  repoConcurrency: { enabled: false, defaultLimit: 0, overrides: new Map<string, number>() },
+}
+
+const buildKube = (overrides: Record<string, unknown> = {}) => ({
+  apply: vi.fn(async (resource: Record<string, unknown>) => resource),
+  applyStatus: vi.fn(async (resource: Record<string, unknown>) => resource),
+  delete: vi.fn(async () => ({})),
+  patch: vi.fn(async () => ({})),
+  get: vi.fn(async () => null),
+  list: vi.fn(async () => ({ items: [] })),
+  ...overrides,
+})
+
+describe('agents controller startup resync', () => {
+  beforeEach(() => {
+    stopAgentsController()
+    watchMocks.startResourceWatch.mockClear()
+  })
+
+  afterEach(() => {
+    stopAgentsController()
+  })
+
+  it('does not block namespace watch startup on the initial AgentRun resync', async () => {
+    let releaseManualResync!: () => void
+    const manualResyncList = new Promise<{ items: [] }>((resolve) => {
+      releaseManualResync = () => resolve({ items: [] })
+    })
+    let agentRunListCalls = 0
+    const kube = buildKube({
+      list: vi.fn(async (resource: string) => {
+        if (resource === RESOURCE_MAP.AgentRun) {
+          agentRunListCalls += 1
+          return manualResyncList
+        }
+        return { items: [] }
+      }),
+    })
+    const handles: Array<{ stop: () => void }> = []
+    const startup = __test.startNamespaceWatches(
+      kube as never,
+      'agents',
+      { namespaces: new Map() } as never,
+      defaultConcurrency,
+      handles,
+      { agentRunResourceVersion: '42' },
+    )
+
+    try {
+      const result = await Promise.race([startup.then(() => 'started'), delay(25).then(() => 'blocked')])
+
+      expect(result).toBe('started')
+      expect(agentRunListCalls).toBe(1)
+      expect(watchMocks.startResourceWatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          namespace: 'agents',
+          resource: RESOURCE_MAP.AgentRun,
+          resourceVersion: '42',
+        }),
+      )
+    } finally {
+      releaseManualResync()
+      await startup
+      __test.stopWatchHandles(handles)
+    }
+  })
+})

--- a/services/agents/vitest.config.ts
+++ b/services/agents/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vitest/config'
 
 const root = fileURLToPath(new URL('./src', import.meta.url))
 const codexSource = fileURLToPath(new URL('../../packages/codex/src/index.ts', import.meta.url))
+const temporalSdkSource = fileURLToPath(new URL('../../packages/temporal-bun-sdk/src/index.ts', import.meta.url))
 
 export default defineConfig({
   resolve: {
@@ -11,6 +12,7 @@ export default defineConfig({
       '~': root,
       '@': root,
       '@proompteng/codex': codexSource,
+      '@proompteng/temporal-bun-sdk': temporalSdkSource,
     },
   },
   test: {
@@ -19,6 +21,7 @@ export default defineConfig({
       '~': root,
       '@': root,
       '@proompteng/codex': codexSource,
+      '@proompteng/temporal-bun-sdk': temporalSdkSource,
     },
     include: ['src/**/*.{test,spec}.{ts,tsx}', 'scripts/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['**/node_modules/**'],


### PR DESCRIPTION
## Summary

- Runs the initial AgentRun manual resync in the background after namespace watches and the periodic timer are installed.
- Wraps all queued AgentRun resync paths with structured warning logs on failure instead of leaving non-awaited promise failures unhandled.
- Adds a regression test proving namespace watch startup is not blocked by a slow initial AgentRun resync, plus the Vitest workspace alias it needs in CI.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test -- src/server/agents-controller/startup-resync.test.ts`
- `bun run --cwd services/agents test -- src/server/agents-controller/startup-resync.test.ts src/server/ready.test.ts`
- `bun run --cwd services/agents test`
- `bun run --cwd services/agents tsc`
- `bun run --cwd services/jangar tsc`
- `bunx oxfmt --check services/agents/src/server/agents-controller/index.ts services/agents/src/server/agents-controller/startup-resync.test.ts`
- `bun run --cwd services/agents lint:oxlint`
- `scripts/agents/guard-extraction-boundaries.sh`
- `scripts/agents/validate-agents.sh`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
