### PR TITLE
chore(symphony): promote image 575e5fd9

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-18T04:01:59Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-19T03:55:38Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "cff8aea8"
-    digest: sha256:587ca5ed07ee3383e64af5be92a4972c2fe4a7f6e12b4bd422897b8438f7ab35
+    newTag: "575e5fd9"
+    digest: sha256:3d0cee69a939789c2d50788959cdde3a33f62a6f3ce9fb2b4e7978b371c3ac4f

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-18T04:01:59Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-19T03:55:38Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "cff8aea8"
-    digest: sha256:587ca5ed07ee3383e64af5be92a4972c2fe4a7f6e12b4bd422897b8438f7ab35
+    newTag: "575e5fd9"
+    digest: sha256:3d0cee69a939789c2d50788959cdde3a33f62a6f3ce9fb2b4e7978b371c3ac4f

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-18T04:01:59Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-19T03:55:38Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "cff8aea8"
-    digest: sha256:587ca5ed07ee3383e64af5be92a4972c2fe4a7f6e12b4bd422897b8438f7ab35
+    newTag: "575e5fd9"
+    digest: sha256:3d0cee69a939789c2d50788959cdde3a33f62a6f3ce9fb2b4e7978b371c3ac4f


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `575e5fd96315622b25b55cf5f93108c943ddefdc`
- Image tag: `575e5fd9`
- Image digest: `sha256:3d0cee69a939789c2d50788959cdde3a33f62a6f3ce9fb2b4e7978b371c3ac4f`