### PR TITLE
fix(torghut): align profit promotion parameters

### DIFF
--- a/docs/torghut/design-system/v6/209-profit-promotion-parameter-rationale-2026-05-19.md
+++ b/docs/torghut/design-system/v6/209-profit-promotion-parameter-rationale-2026-05-19.md
@@ -1,0 +1,86 @@
+# Torghut Profit Promotion Parameter Rationale - 2026-05-19
+
+## Purpose
+
+This note records the promotion parameter set for the `$500/day` Torghut profit objective. The goal is not to make
+promotion impossible; it is to allow ordinary down days while blocking candidates whose apparent edge depends on
+oversized drawdowns, one-off best days, hidden leverage, negative cash, synthetic proof, or unexecuted replay.
+
+## Source-backed constraints
+
+- `AlgoXpert Alpha Research Framework` (2026-03-10, <https://arxiv.org/abs/2603.09219>) is the closest promotion
+  process template: it separates in-sample, walk-forward, and strict out-of-sample stages; prefers stable parameter
+  regions over single optima; uses purge gaps; and includes catastrophic vetoes, spread/leverage guards, circuit
+  breakers, and kill switches.
+- `Interpretable Hypothesis-Driven Trading` (2025-12-15, <https://arxiv.org/abs/2512.12924>) validates market
+  microstructure hypotheses across 34 independent test periods with transaction costs and position constraints. Its
+  modest returns and low drawdown are a useful warning: honest intraday validation should favor reproducibility and
+  downside control over headline backtest PnL.
+- `TradeFM: A Generative Foundation Model for Trade-flow and Market Microstructure` (2026-02-27,
+  <https://arxiv.org/abs/2602.23784>) supports scale-invariant microstructure representations and simulator-based
+  stress testing, but its generated rollouts are research/stress inputs. They must not become promotion authority
+  without real replay and shadow evidence.
+- `A novel approach to trading strategy parameter optimization using double out-of-sample data and walk-forward
+  techniques` (2026-02-11, <https://arxiv.org/abs/2602.10785>) supports walk-forward parameter search, independent
+  out-of-sample evaluation, conservative fees, and cost sensitivity. Torghut promotion should therefore use post-cost
+  net PnL and should not promote from a single optimized in-sample window.
+- `Stochastic Price Dynamics in Response to Order Flow Imbalance` (2025-05-23,
+  <https://arxiv.org/abs/2505.17388>) supports horizon- and regime-dependent treatment of order-flow signals. Torghut
+  should keep regime-slice pass rate as a hard promotion gate and should test continuation/reversal hypotheses by
+  replay horizon.
+- `Returns and Order Flow Imbalances` (2025-08-09, revised 2025-10-08, <https://arxiv.org/abs/2508.06788>) shows
+  one-second intraday price-flow dynamics change materially around macro announcements and liquidity/spread conditions.
+  Torghut should treat news timing, liquidity state, and spread state as execution and regime gates.
+- `Hidden Order in Trades Predicts the Size of Price Moves` (2025-12-02, <https://arxiv.org/abs/2512.15720>)
+  supports information-theoretic order-flow state as a volatility/magnitude signal, not standalone directional proof.
+  Torghut should use this kind of feature as a regime or opportunity filter, then require directional replay evidence.
+- `Explainable Patterns in Cryptocurrency Microstructure` (2026-01-31, <https://arxiv.org/abs/2602.00776>) supports
+  portable order-book/trade feature libraries, but also shows maker/taker behavior can diverge under stress. Torghut
+  should keep executable replay and cost-stress checks separate from signal ranking.
+
+## Promotion parameter set
+
+The active `$500/day` program should use these default promotion gates:
+
+| Gate | Value | Rationale |
+| --- | ---: | --- |
+| `target_net_pnl_per_day` | `500` | Objective is post-cost daily portfolio net PnL, not cumulative paper PnL. |
+| `min_profit_factor` | `1.50` | Provides a loss cushion after slippage/fees and prevents barely-positive churn from passing. |
+| `min_active_day_ratio` | `0.90` | Avoids candidates that hit the target by trading only one or two lucky days. |
+| `min_positive_day_ratio` | `0.60` | Allows down days while requiring repeatability across the window. |
+| `max_best_day_share` | `0.25` | Prevents a single best day from explaining most of the edge. |
+| `max_cluster_contribution_share` | `0.40` | Prevents one mechanism or cluster from dominating portfolio proof. |
+| `max_single_symbol_contribution_share` | `0.35` | Prevents a single ticker from carrying portfolio promotion. |
+| `max_worst_day_loss_pct_equity` | `0.05` | Normal worst-day loss cap. |
+| `extended_max_worst_day_loss_pct_equity` | `0.08` | Allowed only when total net PnL covers drawdown by at least `3.00x`. |
+| `max_drawdown_pct_equity` | `0.08` | Normal max drawdown cap. |
+| `extended_max_drawdown_pct_equity` | `0.12` | Allowed only when total net PnL covers drawdown by at least `3.00x`. |
+| `min_total_net_pnl_to_drawdown_ratio` | `3.00` | Return-adjusted exception for good candidates with tolerable drawdown. |
+| `max_worst_day_loss` | `999999999` | Absolute cap disabled by default; percentage-of-equity gate is canonical. |
+| `max_drawdown` | `999999999` | Absolute cap disabled by default; percentage-of-equity gate is canonical. |
+| `max_gross_exposure_pct_equity` | `1.0` | No hidden leverage for promotion. |
+| `min_cash` | `0` | Negative cash blocks promotion. |
+| `max_negative_cash_observation_count` | `0` | Any negative-cash observation blocks promotion. |
+| `min_avg_filled_notional_per_day` | `300000` | Requires enough executable activity to make `$500/day` plausible after costs. |
+| `min_regime_slice_pass_rate` | `0.45` | Keeps regime dependence visible instead of averaging it away. |
+| `shadow_parity_status` | `within_budget` | Runtime path must match replay budget before promotion. |
+| `executable_replay_passed` | `true` | Candidate must produce executable replay proof. |
+
+## Next harness gates
+
+The current promotion parameter set is the immediate gate. The next harness improvement should add explicit
+walk-forward and cost-stress authority:
+
+- Require at least `5` walk-forward folds when the replay window has enough history.
+- Freeze parameters after candidate selection; no post-selection retuning before live-paper promotion.
+- Require base post-cost expectancy to stay positive under a `50%` transaction-cost shock.
+- Reject sharp single-cell parameter optima by checking neighboring parameter-surface stability.
+- Add bootstrap or Monte Carlo reorder evidence and require the lower confidence bound to stay above zero before
+  promoting beyond shadow.
+
+## Operational interpretation
+
+Down days are acceptable. The promotion blocker is not a red day; it is an oversized red day, excessive peak-to-trough
+drawdown, or concentration that makes the observed `$500/day` look like luck or leverage. Synthetic/model-generated
+evidence may rank or stress candidates, but promotion authority requires real replay, executable order proof, shadow
+parity, and post-cost ledger semantics.

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -784,6 +784,18 @@ def _portfolio_oracle_policy(
         max_single_symbol_contribution_share=Decimal("0.35"),
         max_worst_day_loss=objective.max_worst_day_loss,
         max_drawdown=objective.max_drawdown,
+        default_start_equity=objective.default_start_equity,
+        max_worst_day_loss_pct_equity=objective.max_worst_day_loss_pct_equity,
+        max_drawdown_pct_equity=objective.max_drawdown_pct_equity,
+        extended_max_worst_day_loss_pct_equity=(
+            objective.extended_max_worst_day_loss_pct_equity
+        ),
+        extended_max_drawdown_pct_equity=objective.extended_max_drawdown_pct_equity,
+        min_total_net_pnl_to_drawdown_ratio=(
+            objective.min_total_net_pnl_to_drawdown_ratio
+        ),
+        max_gross_exposure_pct_equity=objective.max_gross_exposure_pct_equity,
+        min_cash=objective.min_cash,
         min_avg_filled_notional_per_day=objective.min_daily_notional,
         min_regime_slice_pass_rate=objective.min_regime_slice_pass_rate,
         require_shadow_parity_within_budget=True,

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -317,12 +317,21 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--min-active-day-ratio", default="0.90")
     parser.add_argument("--min-positive-day-ratio", default="0.60")
+    parser.add_argument("--min-profit-factor", default="1.50")
     parser.add_argument("--min-daily-net-pnl", default=None)
-    parser.add_argument("--max-worst-day-loss", default="350")
-    parser.add_argument("--max-drawdown", default="900")
+    parser.add_argument("--max-worst-day-loss", default="999999999")
+    parser.add_argument("--max-drawdown", default="999999999")
     parser.add_argument("--max-best-day-share", default="0.25")
     parser.add_argument("--max-cluster-contribution-share", default="0.40")
     parser.add_argument("--max-single-symbol-contribution-share", default="0.35")
+    parser.add_argument("--max-worst-day-loss-pct-equity", default="0.05")
+    parser.add_argument("--max-drawdown-pct-equity", default="0.08")
+    parser.add_argument("--extended-max-worst-day-loss-pct-equity", default="0.08")
+    parser.add_argument("--extended-max-drawdown-pct-equity", default="0.12")
+    parser.add_argument("--min-total-net-pnl-to-drawdown-ratio", default="3.00")
+    parser.add_argument("--max-gross-exposure-pct-equity", default="1.0")
+    parser.add_argument("--min-cash", default="0")
+    parser.add_argument("--max-negative-cash-observation-count", type=int, default=0)
     parser.add_argument("--min-avg-filled-notional-per-day", default="300000")
     parser.add_argument("--min-regime-slice-pass-rate", default="0.45")
     parser.add_argument(
@@ -950,6 +959,39 @@ def _scorecard_total_net_pnl(scorecard: Mapping[str, Any]) -> Decimal:
     return net_pnl_per_day * Decimal(trading_day_count)
 
 
+def _scorecard_profit_factor(scorecard: Mapping[str, Any]) -> Decimal:
+    explicit = scorecard.get("profit_factor")
+    if explicit is not None:
+        return _decimal(explicit)
+    daily_net_payload = scorecard.get("daily_net")
+    if isinstance(daily_net_payload, Mapping) and daily_net_payload:
+        positive_total = sum(
+            (
+                _decimal(value)
+                for value in daily_net_payload.values()
+                if _decimal(value) > 0
+            ),
+            Decimal("0"),
+        )
+        negative_total = sum(
+            (
+                -_decimal(value)
+                for value in daily_net_payload.values()
+                if _decimal(value) < 0
+            ),
+            Decimal("0"),
+        )
+        if negative_total > 0:
+            return positive_total / negative_total
+        return Decimal("999999999") if positive_total > 0 else Decimal("0")
+    if (
+        _scorecard_total_net_pnl(scorecard) > 0
+        and _decimal(scorecard.get("worst_day_loss")) <= 0
+    ):
+        return Decimal("999999999")
+    return Decimal("0")
+
+
 def _risk_adjusted_drawdown_passes(
     *,
     observed: Decimal,
@@ -1002,6 +1044,9 @@ def _oracle_policy_from_args(args: argparse.Namespace) -> ProfitTargetOraclePoli
     return ProfitTargetOraclePolicy(
         min_active_day_ratio=min_active_day_ratio,
         min_positive_day_ratio=min_positive_day_ratio,
+        min_profit_factor=_decimal(
+            getattr(args, "min_profit_factor", "1.50"), default="1.50"
+        ),
         min_daily_net_pnl=min_daily_net_pnl,
         max_worst_day_loss=max_worst_day_loss,
         max_drawdown=max_drawdown,
@@ -1025,6 +1070,31 @@ def _oracle_policy_from_args(args: argparse.Namespace) -> ProfitTargetOraclePoli
         default_start_equity=_decimal(
             getattr(args, "start_equity", "31590.02"), default="31590.02"
         ),
+        max_worst_day_loss_pct_equity=_decimal(
+            getattr(args, "max_worst_day_loss_pct_equity", "0.05"), default="0.05"
+        ),
+        max_drawdown_pct_equity=_decimal(
+            getattr(args, "max_drawdown_pct_equity", "0.08"), default="0.08"
+        ),
+        extended_max_worst_day_loss_pct_equity=_decimal(
+            getattr(args, "extended_max_worst_day_loss_pct_equity", "0.08"),
+            default="0.08",
+        ),
+        extended_max_drawdown_pct_equity=_decimal(
+            getattr(args, "extended_max_drawdown_pct_equity", "0.12"),
+            default="0.12",
+        ),
+        min_total_net_pnl_to_drawdown_ratio=_decimal(
+            getattr(args, "min_total_net_pnl_to_drawdown_ratio", "3.00"),
+            default="3.00",
+        ),
+        max_gross_exposure_pct_equity=_decimal(
+            getattr(args, "max_gross_exposure_pct_equity", "1.0"), default="1.0"
+        ),
+        min_cash=_decimal(getattr(args, "min_cash", "0"), default="0"),
+        max_negative_cash_observation_count=max(
+            0, _int_arg(args, "max_negative_cash_observation_count", 0)
+        ),
     )
 
 
@@ -1046,6 +1116,13 @@ def _candidate_spec_with_oracle_policy(
         "required_min_profit_factor": str(oracle_policy.min_profit_factor),
         "required_max_worst_day_loss": str(oracle_policy.max_worst_day_loss),
         "required_max_drawdown": str(oracle_policy.max_drawdown),
+        "required_max_gross_exposure_pct_equity": str(
+            oracle_policy.max_gross_exposure_pct_equity
+        ),
+        "required_min_cash": str(oracle_policy.min_cash),
+        "required_max_negative_cash_observation_count": str(
+            oracle_policy.max_negative_cash_observation_count
+        ),
         "required_max_worst_day_loss_pct_equity": str(
             oracle_policy.max_worst_day_loss_pct_equity
         ),
@@ -1336,6 +1413,8 @@ def _candidate_quality_gate_failures(
         < oracle_policy.min_positive_day_ratio
     ):
         failures.append("positive_day_ratio_below_oracle")
+    if _scorecard_profit_factor(scorecard) < oracle_policy.min_profit_factor:
+        failures.append("profit_factor_below_oracle")
     if (
         _decimal(scorecard.get("best_day_share"), default="1")
         > oracle_policy.max_best_day_share
@@ -5036,15 +5115,21 @@ def run_whitepaper_autoresearch_profit_target(
                     objective.min_daily_net_pnl,
                 )
             ),
+            "min_profit_factor": str(
+                max(
+                    _decimal(getattr(args, "min_profit_factor", "1.50")),
+                    objective.min_profit_factor,
+                )
+            ),
             "max_worst_day_loss": str(
                 min(
-                    _decimal(getattr(args, "max_worst_day_loss", "350")),
+                    _decimal(getattr(args, "max_worst_day_loss", "999999999")),
                     objective.max_worst_day_loss,
                 )
             ),
             "max_drawdown": str(
                 min(
-                    _decimal(getattr(args, "max_drawdown", "900")),
+                    _decimal(getattr(args, "max_drawdown", "999999999")),
                     objective.max_drawdown,
                 )
             ),
@@ -5061,6 +5146,49 @@ def run_whitepaper_autoresearch_profit_target(
                     ),
                     objective.min_daily_notional,
                 )
+            ),
+            "max_worst_day_loss_pct_equity": str(
+                min(
+                    _decimal(getattr(args, "max_worst_day_loss_pct_equity", "0.05")),
+                    objective.max_worst_day_loss_pct_equity,
+                )
+            ),
+            "max_drawdown_pct_equity": str(
+                min(
+                    _decimal(getattr(args, "max_drawdown_pct_equity", "0.08")),
+                    objective.max_drawdown_pct_equity,
+                )
+            ),
+            "extended_max_worst_day_loss_pct_equity": str(
+                min(
+                    _decimal(
+                        getattr(args, "extended_max_worst_day_loss_pct_equity", "0.08")
+                    ),
+                    objective.extended_max_worst_day_loss_pct_equity,
+                )
+            ),
+            "extended_max_drawdown_pct_equity": str(
+                min(
+                    _decimal(getattr(args, "extended_max_drawdown_pct_equity", "0.12")),
+                    objective.extended_max_drawdown_pct_equity,
+                )
+            ),
+            "min_total_net_pnl_to_drawdown_ratio": str(
+                max(
+                    _decimal(
+                        getattr(args, "min_total_net_pnl_to_drawdown_ratio", "3.00")
+                    ),
+                    objective.min_total_net_pnl_to_drawdown_ratio,
+                )
+            ),
+            "max_gross_exposure_pct_equity": str(
+                min(
+                    _decimal(getattr(args, "max_gross_exposure_pct_equity", "1.0")),
+                    objective.max_gross_exposure_pct_equity,
+                )
+            ),
+            "min_cash": str(
+                max(_decimal(getattr(args, "min_cash", "0")), objective.min_cash)
             ),
         }
     )

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -963,6 +963,96 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn("min_cash_below_oracle", failures)
         self.assertIn("negative_cash_observed", failures)
 
+    def test_candidate_quality_gate_flags_weak_profit_factor(self) -> None:
+        policy = runner.ProfitTargetOraclePolicy()
+
+        failures = runner._candidate_quality_gate_failures(
+            {
+                "net_pnl_per_day": "750",
+                "active_day_ratio": "1",
+                "positive_day_ratio": "0.67",
+                "profit_factor": "1.20",
+                "best_day_share": "0.1",
+                "worst_day_loss": "0",
+                "max_drawdown": "0",
+                "max_gross_exposure_pct_equity": "0.5",
+                "min_cash": "0",
+                "negative_cash_observation_count": "0",
+                "avg_filled_notional_per_day": "500000",
+                "regime_slice_pass_rate": "1",
+                "posterior_edge_lower": "0.01",
+                "shadow_parity_status": "within_budget",
+                "executable_replay_passed": True,
+                "executable_replay_artifact_ref": "/tmp/replay.json",
+                "executable_replay_order_count": "5",
+                "executable_replay_account_buying_power": "10000",
+                "executable_replay_max_notional_per_trade": "9000",
+            },
+            oracle_policy=policy,
+        )
+
+        self.assertEqual(failures, ["profit_factor_below_oracle"])
+
+    def test_oracle_policy_from_args_carries_full_promotion_risk_parameters(
+        self,
+    ) -> None:
+        policy = runner._oracle_policy_from_args(
+            Namespace(
+                min_profit_factor="1.65",
+                max_worst_day_loss="999999999",
+                max_drawdown="999999999",
+                max_worst_day_loss_pct_equity="0.06",
+                max_drawdown_pct_equity="0.09",
+                extended_max_worst_day_loss_pct_equity="0.10",
+                extended_max_drawdown_pct_equity="0.14",
+                min_total_net_pnl_to_drawdown_ratio="3.50",
+                max_gross_exposure_pct_equity="0.85",
+                min_cash="250",
+                max_negative_cash_observation_count=0,
+            )
+        )
+
+        self.assertEqual(policy.min_profit_factor, Decimal("1.65"))
+        self.assertEqual(policy.max_worst_day_loss, Decimal("999999999"))
+        self.assertEqual(policy.max_drawdown, Decimal("999999999"))
+        self.assertEqual(policy.max_worst_day_loss_pct_equity, Decimal("0.06"))
+        self.assertEqual(policy.max_drawdown_pct_equity, Decimal("0.09"))
+        self.assertEqual(policy.extended_max_worst_day_loss_pct_equity, Decimal("0.10"))
+        self.assertEqual(policy.extended_max_drawdown_pct_equity, Decimal("0.14"))
+        self.assertEqual(policy.min_total_net_pnl_to_drawdown_ratio, Decimal("3.50"))
+        self.assertEqual(policy.max_gross_exposure_pct_equity, Decimal("0.85"))
+        self.assertEqual(policy.min_cash, Decimal("250"))
+
+    def test_candidate_spec_contract_exposes_full_promotion_risk_parameters(
+        self,
+    ) -> None:
+        policy = runner.ProfitTargetOraclePolicy(
+            max_gross_exposure_pct_equity=Decimal("0.85"),
+            min_cash=Decimal("250"),
+            max_negative_cash_observation_count=0,
+        )
+
+        updated = runner._candidate_spec_with_oracle_policy(
+            self._candidate_spec("spec-full-promotion-policy"),
+            oracle_policy=policy,
+        )
+
+        self.assertEqual(
+            updated.hard_vetoes["required_max_gross_exposure_pct_equity"],
+            "0.85",
+        )
+        self.assertEqual(updated.hard_vetoes["required_min_cash"], "250")
+        self.assertEqual(
+            updated.hard_vetoes["required_max_negative_cash_observation_count"],
+            "0",
+        )
+        self.assertEqual(
+            updated.promotion_contract["profit_target_oracle_policy"][
+                "max_gross_exposure_pct_equity"
+            ],
+            "0.85",
+        )
+
     def test_pre_replay_ranker_keeps_best_duplicate_feedback_and_blocks_rejections(
         self,
     ) -> None:
@@ -4218,6 +4308,17 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(parsed.real_replay_shard_size, 0)
         self.assertEqual(parsed.real_replay_shard_timeout_seconds, 0)
         self.assertEqual(parsed.real_replay_shard_workers, 1)
+        self.assertEqual(parsed.max_worst_day_loss, "999999999")
+        self.assertEqual(parsed.max_drawdown, "999999999")
+        self.assertEqual(parsed.min_profit_factor, "1.50")
+        self.assertEqual(parsed.max_worst_day_loss_pct_equity, "0.05")
+        self.assertEqual(parsed.max_drawdown_pct_equity, "0.08")
+        self.assertEqual(parsed.extended_max_worst_day_loss_pct_equity, "0.08")
+        self.assertEqual(parsed.extended_max_drawdown_pct_equity, "0.12")
+        self.assertEqual(parsed.min_total_net_pnl_to_drawdown_ratio, "3.00")
+        self.assertEqual(parsed.max_gross_exposure_pct_equity, "1.0")
+        self.assertEqual(parsed.min_cash, "0")
+        self.assertEqual(parsed.max_negative_cash_observation_count, 0)
         self.assertFalse(parsed.persist_results)
 
     def test_decimal_arg_or_default_uses_explicit_cli_override(self) -> None:

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -471,6 +471,19 @@ class TestStrategyAutoresearch(TestCase):
         )
         self.assertEqual(program.objective.min_cash, Decimal("0"))
 
+        policy = runner._portfolio_oracle_policy(program)
+        self.assertEqual(policy.min_profit_factor, Decimal("1.50"))
+        self.assertEqual(policy.max_worst_day_loss, Decimal("999999999"))
+        self.assertEqual(policy.max_drawdown, Decimal("999999999"))
+        self.assertEqual(policy.default_start_equity, Decimal("31590.02"))
+        self.assertEqual(policy.max_worst_day_loss_pct_equity, Decimal("0.05"))
+        self.assertEqual(policy.max_drawdown_pct_equity, Decimal("0.08"))
+        self.assertEqual(policy.extended_max_worst_day_loss_pct_equity, Decimal("0.08"))
+        self.assertEqual(policy.extended_max_drawdown_pct_equity, Decimal("0.12"))
+        self.assertEqual(policy.min_total_net_pnl_to_drawdown_ratio, Decimal("3.00"))
+        self.assertEqual(policy.max_gross_exposure_pct_equity, Decimal("1.0"))
+        self.assertEqual(policy.min_cash, Decimal("0"))
+
     def test_checked_in_500_portfolio_profit_program_includes_reversal_surfaces(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Aligns whitepaper profit-target promotion CLI defaults with the documented percentage-of-equity risk gates.
- Propagates profit factor, drawdown, exposure, cash, and return-to-drawdown promotion parameters into candidate contracts and strategy autoresearch portfolio oracle policy.
- Adds regression coverage for full promotion-risk parameter wiring and weak profit-factor diagnostics.
- Documents the 2025-2026 research basis and operational rationale for the current Torghut `$500/day` promotion gates.

## Related Issues

None

## Testing

- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py scripts/run_strategy_autoresearch_loop.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_strategy_autoresearch.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'candidate_quality_gate_flags_capital_safety_failures or candidate_quality_gate_flags_weak_profit_factor or oracle_policy_from_args_carries_full_promotion_risk_parameters or candidate_spec_contract_exposes_full_promotion_risk_parameters or runner_parse_args_covers_cli_defaults_and_flags or seed_recent_whitepapers_honors_top_k_and_exploration_budget' -q`
- `uv run --frozen pytest tests/test_profit_target_oracle.py -q`
- `uv run --frozen pytest tests/test_strategy_autoresearch.py -k 'checked_in_500_portfolio_profit_program_allows_bounded_down_days' -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
