### PR TITLE
chore(jangar): promote image 575e5fd9

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-18T23:15:52Z
+    deploy.knative.dev/rollout: 2026-05-19T04:02:54Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:c4de4eb3@sha256:1c0c92ae8794fa02af856eb9f1178e41a3d741bda7aac17511e11ea5bec084f6
+              value: registry.ide-newton.ts.net/lab/jangar:575e5fd9@sha256:cadc6b8b5b57d7fa2a543797272fe9907782900fe7357d71ae6f1a67ff05ce91
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: c4de4eb3605f938b3da4d11ba602fe91c659f829
+              value: 575e5fd96315622b25b55cf5f93108c943ddefdc
             - name: JANGAR_GITOPS_REVISION
-              value: c4de4eb3605f938b3da4d11ba602fe91c659f829
+              value: 575e5fd96315622b25b55cf5f93108c943ddefdc
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -405,15 +405,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26065825718"
+              value: "26075334484"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:4dddbdc79f7ad9ba3e684b7889431eafc2d02ec093147da02de23d49b43d3f78
+              value: sha256:b11ca921a2d0557ff040c35249bf268126e0d5918dea1c9cbb9f2cef11355a2f
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: c4de4eb3605f938b3da4d11ba602fe91c659f829
+              value: 575e5fd96315622b25b55cf5f93108c943ddefdc
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:4dddbdc79f7ad9ba3e684b7889431eafc2d02ec093147da02de23d49b43d3f78
+              value: sha256:b11ca921a2d0557ff040c35249bf268126e0d5918dea1c9cbb9f2cef11355a2f
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: c4de4eb3
-    digest: sha256:1c0c92ae8794fa02af856eb9f1178e41a3d741bda7aac17511e11ea5bec084f6
+    newTag: 575e5fd9
+    digest: sha256:cadc6b8b5b57d7fa2a543797272fe9907782900fe7357d71ae6f1a67ff05ce91


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `575e5fd96315622b25b55cf5f93108c943ddefdc`
- Image tag: `575e5fd9`
- Image digest: `sha256:cadc6b8b5b57d7fa2a543797272fe9907782900fe7357d71ae6f1a67ff05ce91`
- Source CI run: `26075334484`
- Control-plane serving digest: `sha256:b11ca921a2d0557ff040c35249bf268126e0d5918dea1c9cbb9f2cef11355a2f`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates