### PR TITLE
chore(torghut): promote image f5aae7e3

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-169-g682d0f440
+              value: v0.571.1-172-gf5aae7e31
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 682d0f44026774073a961945542ebbdace3ec6d3
+              value: f5aae7e313922289b1d953f3194e7a252270cd54
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-169-g682d0f440
+              value: v0.571.1-172-gf5aae7e31
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 682d0f44026774073a961945542ebbdace3ec6d3
+              value: f5aae7e313922289b1d953f3194e7a252270cd54
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -75,7 +75,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+                  value: sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-19T04:14:26Z"
+        client.knative.dev/updateTimestamp: "2026-05-19T05:05:21Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
           ports:
             - name: http1
               containerPort: 8181
@@ -497,11 +497,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-169-g682d0f440
+              value: v0.571.1-172-gf5aae7e31
             - name: TORGHUT_COMMIT
-              value: 682d0f44026774073a961945542ebbdace3ec6d3
+              value: f5aae7e313922289b1d953f3194e7a252270cd54
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+              value: sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-19T04:14:26Z"
+        client.knative.dev/updateTimestamp: "2026-05-19T05:05:21Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
           ports:
             - name: http1
               containerPort: 8181
@@ -318,11 +318,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-169-g682d0f440
+              value: v0.571.1-172-gf5aae7e31
             - name: TORGHUT_COMMIT
-              value: 682d0f44026774073a961945542ebbdace3ec6d3
+              value: f5aae7e313922289b1d953f3194e7a252270cd54
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+              value: sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -111,7 +111,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:787e5241e0299649b6617eab1cba4f5067be30501779990b94827d552bc8fc76
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `f5aae7e313922289b1d953f3194e7a252270cd54`
- Image tag: `f5aae7e3`
- Image digest: `sha256:a08a7a8a6a4b498ae115513c893eccce7f1f0de77c6573e3491db24b22442f53`