### PR TITLE
fix(torghut): harden portfolio proof harness

### DIFF
--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -229,7 +229,7 @@ def _daily_net(bundle: CandidateEvidenceBundle) -> dict[str, Decimal]:
     if isinstance(raw_daily, Mapping):
         daily_mapping = cast(Mapping[Any, Any], raw_daily)
         return {str(day): _decimal(value) for day, value in daily_mapping.items()}
-    return {"synthetic": _net_per_day(bundle)}
+    return {}
 
 
 def _daily_filled_notional(bundle: CandidateEvidenceBundle) -> dict[str, Decimal]:
@@ -246,6 +246,12 @@ def _trading_day_count(bundle: CandidateEvidenceBundle) -> int:
         expected = int(_decimal(_scorecard(bundle).get("trading_day_count")))
     except Exception:
         expected = 0
+    if (
+        expected <= 0
+        and _scorecard(bundle).get("daily_net") is None
+        and _net_per_day(bundle) != 0
+    ):
+        expected = 1
     return max(expected, len(_daily_net(bundle)))
 
 

--- a/services/torghut/app/trading/discovery/validation.py
+++ b/services/torghut/app/trading/discovery/validation.py
@@ -8,7 +8,7 @@ import hashlib
 import json
 from dataclasses import dataclass
 from datetime import datetime
-from math import log, sqrt
+from math import isfinite, log, sqrt
 from statistics import NormalDist
 from typing import Any, Callable, Iterable, Sequence, cast
 
@@ -167,6 +167,57 @@ def _rank_lookup(
 
 def _candidate_status(*, passed: bool) -> str:
     return "pass" if passed else "fail"
+
+
+_SURFACE_CORRELATION_METRICS = ("sharpe", "cagr", "total_return")
+_MIN_WALK_FORWARD_SURFACE_CORRELATION = 0.20
+
+
+def _summary_metric(summary: PerformanceSummary, metric: str) -> float | None:
+    value = getattr(summary, metric)
+    if value is None:
+        return None
+    resolved = float(value)
+    return resolved if isfinite(resolved) else None
+
+
+def _metric_correlation(
+    candidates: Sequence[CandidateResult], *, metric: str
+) -> float | None:
+    train_values: list[float] = []
+    test_values: list[float] = []
+    for item in candidates:
+        train_value = _summary_metric(item.train, metric)
+        test_value = _summary_metric(item.test, metric)
+        if train_value is None or test_value is None:
+            continue
+        train_values.append(train_value)
+        test_values.append(test_value)
+    if len(train_values) < 3 or len(set(train_values)) < 2 or len(set(test_values)) < 2:
+        return None
+    correlation = pd.Series(train_values).corr(pd.Series(test_values))
+    resolved = float(correlation)
+    return resolved if isfinite(resolved) else None
+
+
+def _walk_forward_surface_correlation_bundle(
+    candidates: Sequence[CandidateResult],
+) -> dict[str, Any]:
+    correlations = {
+        metric: _metric_correlation(candidates, metric=metric)
+        for metric in _SURFACE_CORRELATION_METRICS
+    }
+    available = [value for value in correlations.values() if value is not None]
+    surface_correlation = min(available) if available else None
+    return {
+        "proxy_method": "train_test_parameter_surface_correlation",
+        "source": "walk_forward_correlation_ssrn_6324079_2026",
+        "candidate_count": len(candidates),
+        "min_required_candidate_count": 3,
+        "metric_correlations": correlations,
+        "surface_correlation": surface_correlation,
+        "min_surface_correlation": _MIN_WALK_FORWARD_SURFACE_CORRELATION,
+    }
 
 
 _DEFAULT_REGIME_SUPPORTS = (
@@ -415,6 +466,10 @@ def build_strategy_factory_evaluation(
     adjusted_edge_bps = None
     if net_edge_bps is not None:
         adjusted_edge_bps = float(net_edge_bps * (1.0 - selection_penalty))
+    surface_correlation_bundle = _walk_forward_surface_correlation_bundle(
+        all_candidates
+    )
+    surface_correlation = surface_correlation_bundle["surface_correlation"]
 
     validation_tests = [
         ValidationTestResult(
@@ -440,6 +495,15 @@ def build_strategy_factory_evaluation(
                 "pbo_proxy": pbo_proxy,
             },
             artifact_name="cscv-pbo-report-v1.json",
+        ),
+        ValidationTestResult(
+            test_name="walk_forward_surface_correlation",
+            status=_candidate_status(
+                passed=surface_correlation is not None
+                and surface_correlation >= _MIN_WALK_FORWARD_SURFACE_CORRELATION
+            ),
+            metric_bundle=surface_correlation_bundle,
+            artifact_name="walk-forward-surface-correlation-report-v1.json",
         ),
         ValidationTestResult(
             test_name="deflated_sharpe",

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -886,6 +886,62 @@ class TestPortfolioOptimizer(TestCase):
             scorecard["profit_target_oracle"]["blockers"],
         )
 
+    def test_portfolio_optimizer_does_not_synthesize_daily_net_proof_from_scalar_pnl(
+        self,
+    ) -> None:
+        bundle = evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-scalar-pnl-only",
+            candidate={
+                "candidate_id": "cand-scalar-pnl-only",
+                "runtime_family": "microbar_cross_sectional_pairs",
+                "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                "family_template_id": "microbar_cross_sectional_pairs_v1",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "900",
+                    "active_day_ratio": "1.0",
+                    "positive_day_ratio": "1.0",
+                    "worst_day_loss": "0",
+                    "max_drawdown": "0",
+                    "best_day_share": "0.25",
+                    "avg_filled_notional_per_day": "350000",
+                    "regime_slice_pass_rate": "0.55",
+                    "posterior_edge_lower": "0.01",
+                    "shadow_parity_status": "within_budget",
+                    "correlation_cluster": "scalar-pnl-only",
+                    "symbol_contribution_shares": {"AAPL": "1.0"},
+                    **_executable_scorecard_fields("scalar-pnl-only"),
+                },
+            },
+            dataset_snapshot_id="snapshot-scalar-pnl-only",
+            result_path="/tmp/scalar-pnl-only.json",
+        )
+
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=[bundle],
+            target_net_pnl_per_day=Decimal("500"),
+            oracle_policy=ProfitTargetOraclePolicy(
+                max_best_day_share=Decimal("1.0"),
+                max_cluster_contribution_share=Decimal("1.0"),
+                max_single_symbol_contribution_share=Decimal("1.0"),
+            ),
+            portfolio_size_min=1,
+            portfolio_size_max=1,
+        )
+
+        self.assertEqual(portfolio_optimizer_module._daily_net(bundle), {})
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        scorecard = portfolio.objective_scorecard
+        self.assertEqual(scorecard["daily_net"], {})
+        self.assertEqual(scorecard["trading_day_count"], 1)
+        self.assertEqual(scorecard["daily_net_observed_day_count"], 0)
+        self.assertEqual(scorecard["missing_daily_net_count"], 1)
+        self.assertFalse(scorecard["oracle_passed"])
+        self.assertIn(
+            "daily_net_observed_day_count_failed",
+            scorecard["profit_target_oracle"]["blockers"],
+        )
+
     def test_portfolio_optimizer_blocks_missing_sleeve_daily_net_coverage(
         self,
     ) -> None:

--- a/services/torghut/tests/test_strategy_factory_validation.py
+++ b/services/torghut/tests/test_strategy_factory_validation.py
@@ -130,3 +130,116 @@ class TestStrategyFactoryValidation(TestCase):
         self.assertEqual(
             evaluation.cost_calibration.scope_id, "washout_rebound_consistent"
         )
+
+    def test_strategy_factory_evaluation_reports_walk_forward_surface_correlation(
+        self,
+    ) -> None:
+        def candidate(
+            *,
+            lookback_days: int,
+            train_sharpe: float,
+            test_sharpe: float,
+            train_return: float,
+            test_return: float,
+        ) -> CandidateResult:
+            return CandidateResult(
+                config=CandidateConfig(
+                    lookback_days=lookback_days,
+                    vol_lookback_days=10,
+                    target_daily_vol=0.01,
+                    max_gross_leverage=1.0,
+                ),
+                train=PerformanceSummary(
+                    total_return=train_return,
+                    cagr=train_return,
+                    annualized_vol=0.10,
+                    sharpe=train_sharpe,
+                    max_drawdown=-0.02,
+                    days=60,
+                ),
+                test=PerformanceSummary(
+                    total_return=test_return,
+                    cagr=test_return,
+                    annualized_vol=0.10,
+                    sharpe=test_sharpe,
+                    max_drawdown=-0.02,
+                    days=60,
+                ),
+            )
+
+        index = pd.date_range("2026-04-01", periods=8, freq="B", tz="UTC")
+        debug_frame = pd.DataFrame(
+            {
+                "port_ret_net": [0.0015] * 8,
+                "port_ret_gross": [0.0017] * 8,
+                "turnover": [0.3] * 8,
+                "cost_ret": [0.0002] * 8,
+            },
+            index=index,
+        )
+        candidates = [
+            candidate(
+                lookback_days=20,
+                train_sharpe=2.0,
+                test_sharpe=1.8,
+                train_return=0.10,
+                test_return=0.09,
+            ),
+            candidate(
+                lookback_days=30,
+                train_sharpe=1.5,
+                test_sharpe=1.4,
+                train_return=0.08,
+                test_return=0.07,
+            ),
+            candidate(
+                lookback_days=40,
+                train_sharpe=1.0,
+                test_sharpe=0.9,
+                train_return=0.05,
+                test_return=0.04,
+            ),
+            candidate(
+                lookback_days=50,
+                train_sharpe=0.5,
+                test_sharpe=0.4,
+                train_return=0.02,
+                test_return=0.01,
+            ),
+        ]
+
+        evaluation = build_strategy_factory_evaluation(
+            run_id="run-wfc-1",
+            candidate_id="cand-wfc-1",
+            best_candidate=candidates[0],
+            all_candidates=candidates,
+            train_debug=debug_frame,
+            test_debug=debug_frame,
+            train_summary=candidates[0].train,
+            test_summary=candidates[0].test,
+            incumbent_summary=PerformanceSummary(
+                total_return=0.01,
+                cagr=0.02,
+                annualized_vol=0.09,
+                sharpe=0.2,
+                max_drawdown=-0.03,
+                days=60,
+            ),
+            cost_bps_per_turnover=0.1,
+            evaluated_at=datetime(2026, 5, 19, tzinfo=UTC),
+        )
+
+        surface_test = next(
+            item
+            for item in evaluation.validation_tests
+            if item.test_name == "walk_forward_surface_correlation"
+        )
+        self.assertEqual(surface_test.status, "pass")
+        self.assertEqual(
+            surface_test.metric_bundle["source"],
+            "walk_forward_correlation_ssrn_6324079_2026",
+        )
+        self.assertGreaterEqual(
+            surface_test.metric_bundle["surface_correlation"],
+            surface_test.metric_bundle["min_surface_correlation"],
+        )

--- a/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
+++ b/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
@@ -129,6 +129,16 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
                         "max_drawdown": "400",
                         "best_day_share": "0.18",
                     },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": str(625 - (index * 25)),
+                            "2026-02-24": str(625 - (index * 25)),
+                        },
+                        "daily_filled_notional": {
+                            "2026-02-23": "350000",
+                            "2026-02-24": "350000",
+                        },
+                    },
                 },
                 dataset_snapshot_id="snap-1",
                 result_path=f"/tmp/result-{index}.json",


### PR DESCRIPTION
## Summary

- Stops portfolio proof from synthesizing a fake one-day `daily_net` vector from scalar `net_pnl_per_day`.
- Keeps scalar-PnL candidates blocked by the profit oracle until real per-day post-cost replay coverage is present.
- Adds a strategy-factory walk-forward surface-correlation diagnostic so in-sample parameter surfaces must retain out-of-sample shape before promotion evidence looks strong.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen ruff check app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py -k 'synthe or missing_trading_days or missing_sleeve_daily_net or invalid_evidence_bundles or capital_safety' -q`
- `uv run --frozen ruff format app/trading/discovery/validation.py tests/test_strategy_factory_validation.py`
- `uv run --frozen ruff check app/trading/discovery/validation.py tests/test_strategy_factory_validation.py`
- `uv run --frozen pytest tests/test_strategy_factory_validation.py tests/test_portfolio_optimizer.py -k 'walk_forward_surface_correlation or synthesize_daily_net or missing_trading_days or missing_sleeve_daily_net or invalid_evidence_bundles or capital_safety' -q`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py tests/test_strategy_factory_validation.py tests/test_profit_target_oracle.py -q`
- `uv run --frozen pytest tests/test_whitepaper_autoresearch_artifacts.py::TestWhitepaperAutoresearchArtifacts::test_evidence_training_rows_and_portfolio_optimizer tests/test_portfolio_optimizer.py tests/test_strategy_factory_validation.py tests/test_profit_target_oracle.py -q`
- `uv run --frozen pytest -n auto --dist=worksteal --cov --cov-branch --cov-fail-under=0 --cov-report= <CI shard 1 test files>`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
