### PR TITLE
chore(bilig): promote app image a2349d8e

### DIFF
--- a/argocd/applications/bilig/kustomization.yaml
+++ b/argocd/applications/bilig/kustomization.yaml
@@ -23,4 +23,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bilig-app
     newName: registry.ide-newton.ts.net/lab/bilig-app
-    newTag: 3744476d38cee1fe1ae7abe4dbdc99096012f0ec
+    newTag: a2349d8e5b55a312bc140d92d5b4d85fcdcdf58d


### PR DESCRIPTION
## Summary

- Promotes the Bilig app image from `3744476d38cee1fe1ae7abe4dbdc99096012f0ec` to `a2349d8e5b55a312bc140d92d5b4d85fcdcdf58d`.
- Rolls out the Forgejo-built Bilig app image that includes the hosted WorkPaper MCP endpoint.
- Keeps the change scoped to the Bilig Argo CD image tag.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `docker manifest inspect registry.ide-newton.ts.net/lab/bilig-app:a2349d8e5b55a312bc140d92d5b4d85fcdcdf58d`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
