### PR TITLE
fix(torghut): gate strategy validation on cost stress

### DIFF
--- a/services/torghut/app/trading/discovery/validation.py
+++ b/services/torghut/app/trading/discovery/validation.py
@@ -171,6 +171,7 @@ def _candidate_status(*, passed: bool) -> str:
 
 _SURFACE_CORRELATION_METRICS = ("sharpe", "cagr", "total_return")
 _MIN_WALK_FORWARD_SURFACE_CORRELATION = 0.20
+_TRANSACTION_COST_STRESS_MULTIPLIERS = (1.5, 2.0)
 
 
 def _summary_metric(summary: PerformanceSummary, metric: str) -> float | None:
@@ -217,6 +218,37 @@ def _walk_forward_surface_correlation_bundle(
         "metric_correlations": correlations,
         "surface_correlation": surface_correlation,
         "min_surface_correlation": _MIN_WALK_FORWARD_SURFACE_CORRELATION,
+    }
+
+
+def _transaction_cost_stress_bundle(
+    *,
+    gross_edge_mean: float,
+    cost_drag_mean: float,
+    net_edge_mean: float,
+) -> dict[str, Any]:
+    stressed_cases = [
+        {
+            "cost_multiplier": multiplier,
+            "projected_net_return_mean": float(
+                gross_edge_mean - abs(cost_drag_mean) * multiplier
+            ),
+        }
+        for multiplier in _TRANSACTION_COST_STRESS_MULTIPLIERS
+    ]
+    worst_projected_net = min(
+        (item["projected_net_return_mean"] for item in stressed_cases),
+        default=net_edge_mean,
+    )
+    return {
+        "source": "transaction_cost_trap_ssrn_6422358_2025",
+        "proxy_method": "gross_return_minus_stressed_cost_drag",
+        "base_net_return_mean": net_edge_mean,
+        "gross_return_mean": gross_edge_mean,
+        "cost_drag_mean": cost_drag_mean,
+        "stress_cases": stressed_cases,
+        "worst_projected_net_return_mean": worst_projected_net,
+        "required_min_projected_net_return_mean": 0.0,
     }
 
 
@@ -470,6 +502,11 @@ def build_strategy_factory_evaluation(
         all_candidates
     )
     surface_correlation = surface_correlation_bundle["surface_correlation"]
+    cost_stress_bundle = _transaction_cost_stress_bundle(
+        gross_edge_mean=gross_edge_mean,
+        cost_drag_mean=cost_drag_mean,
+        net_edge_mean=net_edge_mean,
+    )
 
     validation_tests = [
         ValidationTestResult(
@@ -540,6 +577,15 @@ def build_strategy_factory_evaluation(
                 "calibration_status": cost_status,
             },
             artifact_name="execution-reality-report-v1.json",
+        ),
+        ValidationTestResult(
+            test_name="transaction_cost_stress",
+            status=_candidate_status(
+                passed=float(cost_stress_bundle["worst_projected_net_return_mean"])
+                > 0.0
+            ),
+            metric_bundle=cost_stress_bundle,
+            artifact_name="transaction-cost-stress-report-v1.json",
         ),
         ValidationTestResult(
             test_name="posterior_edge",

--- a/services/torghut/tests/test_strategy_factory_validation.py
+++ b/services/torghut/tests/test_strategy_factory_validation.py
@@ -243,3 +243,109 @@ class TestStrategyFactoryValidation(TestCase):
             surface_test.metric_bundle["surface_correlation"],
             surface_test.metric_bundle["min_surface_correlation"],
         )
+
+    def test_strategy_factory_evaluation_gates_transaction_cost_stress(
+        self,
+    ) -> None:
+        def candidate(
+            *,
+            lookback_days: int,
+            train_sharpe: float,
+            test_sharpe: float,
+            train_return: float,
+            test_return: float,
+        ) -> CandidateResult:
+            return CandidateResult(
+                config=CandidateConfig(
+                    lookback_days=lookback_days,
+                    vol_lookback_days=10,
+                    target_daily_vol=0.01,
+                    max_gross_leverage=1.0,
+                ),
+                train=PerformanceSummary(
+                    total_return=train_return,
+                    cagr=train_return,
+                    annualized_vol=0.10,
+                    sharpe=train_sharpe,
+                    max_drawdown=-0.02,
+                    days=60,
+                ),
+                test=PerformanceSummary(
+                    total_return=test_return,
+                    cagr=test_return,
+                    annualized_vol=0.10,
+                    sharpe=test_sharpe,
+                    max_drawdown=-0.02,
+                    days=60,
+                ),
+            )
+
+        index = pd.date_range("2026-04-01", periods=8, freq="B", tz="UTC")
+        debug_frame = pd.DataFrame(
+            {
+                "port_ret_net": [0.0001] * 8,
+                "port_ret_gross": [0.0005] * 8,
+                "turnover": [0.3] * 8,
+                "cost_ret": [0.0004] * 8,
+            },
+            index=index,
+        )
+        candidates = [
+            candidate(
+                lookback_days=20,
+                train_sharpe=2.0,
+                test_sharpe=1.8,
+                train_return=0.10,
+                test_return=0.09,
+            ),
+            candidate(
+                lookback_days=30,
+                train_sharpe=1.5,
+                test_sharpe=1.4,
+                train_return=0.08,
+                test_return=0.07,
+            ),
+            candidate(
+                lookback_days=40,
+                train_sharpe=1.0,
+                test_sharpe=0.9,
+                train_return=0.05,
+                test_return=0.04,
+            ),
+        ]
+
+        evaluation = build_strategy_factory_evaluation(
+            run_id="run-cost-stress-1",
+            candidate_id="cand-cost-stress-1",
+            best_candidate=candidates[0],
+            all_candidates=candidates,
+            train_debug=debug_frame,
+            test_debug=debug_frame,
+            train_summary=candidates[0].train,
+            test_summary=candidates[0].test,
+            incumbent_summary=PerformanceSummary(
+                total_return=0.01,
+                cagr=0.02,
+                annualized_vol=0.09,
+                sharpe=0.2,
+                max_drawdown=-0.03,
+                days=60,
+            ),
+            cost_bps_per_turnover=0.1,
+            evaluated_at=datetime(2026, 5, 19, tzinfo=UTC),
+        )
+
+        stress_test = next(
+            item
+            for item in evaluation.validation_tests
+            if item.test_name == "transaction_cost_stress"
+        )
+        self.assertEqual(stress_test.status, "fail")
+        self.assertEqual(
+            stress_test.metric_bundle["source"],
+            "transaction_cost_trap_ssrn_6422358_2025",
+        )
+        self.assertLess(
+            stress_test.metric_bundle["worst_projected_net_return_mean"],
+            stress_test.metric_bundle["required_min_projected_net_return_mean"],
+        )


### PR DESCRIPTION
## Summary

- Adds a transaction-cost stress validation test to Torghut strategy-factory evaluations.
- Requires candidates to keep projected mean net return positive under 1.5x and 2.0x cost-drag shocks before the validation row passes.
- Records the stress bundle with a 2025 transaction-cost-trap source marker so paper research becomes an enforceable harness artifact.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_strategy_factory_validation.py -q`
- `uv run --frozen ruff format app/trading/discovery/validation.py tests/test_strategy_factory_validation.py`
- `uv run --frozen ruff check app/trading/discovery/validation.py tests/test_strategy_factory_validation.py`
- `uv run --frozen pytest tests/test_strategy_factory_validation.py tests/test_profit_target_oracle.py tests/test_portfolio_optimizer.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
