### PR TITLE
chore(bilig): promote app image 51e2359c

### DIFF
--- a/argocd/applications/bilig/kustomization.yaml
+++ b/argocd/applications/bilig/kustomization.yaml
@@ -23,4 +23,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bilig-app
     newName: registry.ide-newton.ts.net/lab/bilig-app
-    newTag: a2349d8e5b55a312bc140d92d5b4d85fcdcdf58d
+    newTag: 51e2359c9df8f7a36c437a1f4689bf68ddf69800


### PR DESCRIPTION
## Summary

- Promotes the Bilig app image from `a2349d8e5b55a312bc140d92d5b4d85fcdcdf58d` to `51e2359c9df8f7a36c437a1f4689bf68ddf69800`.
- Rolls the deployed app forward to the post-endpoint runtime package release `0.24.0`.
- Keeps the change scoped to the Bilig Argo CD image tag.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `docker manifest inspect registry.ide-newton.ts.net/lab/bilig-app:51e2359c9df8f7a36c437a1f4689bf68ddf69800`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
