### PR TITLE
chore(torghut): promote image 6779dfae

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-175-gf44d111bf
+              value: v0.571.1-181-g6779dfaeb
             - name: TORGHUT_OPTIONS_COMMIT
-              value: f44d111bff0033fcf16670c0a130d41748c04184
+              value: 6779dfaebd201a8182f89e819654aeb85f5e51cd
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-175-gf44d111bf
+              value: v0.571.1-181-g6779dfaeb
             - name: TORGHUT_OPTIONS_COMMIT
-              value: f44d111bff0033fcf16670c0a130d41748c04184
+              value: 6779dfaebd201a8182f89e819654aeb85f5e51cd
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -75,7 +75,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+                  value: sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-19T05:31:33Z"
+        client.knative.dev/updateTimestamp: "2026-05-19T05:56:11Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
           ports:
             - name: http1
               containerPort: 8181
@@ -497,11 +497,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-175-gf44d111bf
+              value: v0.571.1-181-g6779dfaeb
             - name: TORGHUT_COMMIT
-              value: f44d111bff0033fcf16670c0a130d41748c04184
+              value: 6779dfaebd201a8182f89e819654aeb85f5e51cd
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+              value: sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-19T05:31:33Z"
+        client.knative.dev/updateTimestamp: "2026-05-19T05:56:11Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
           ports:
             - name: http1
               containerPort: 8181
@@ -318,11 +318,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-175-gf44d111bf
+              value: v0.571.1-181-g6779dfaeb
             - name: TORGHUT_COMMIT
-              value: f44d111bff0033fcf16670c0a130d41748c04184
+              value: 6779dfaebd201a8182f89e819654aeb85f5e51cd
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+              value: sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -111,7 +111,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:2660aae05aab638350665af4757ca83e62cda9b100237c4dd418103d710898c8
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `6779dfaebd201a8182f89e819654aeb85f5e51cd`
- Image tag: `6779dfae`
- Image digest: `sha256:d50d0a77f34b15da3854826301fa2bdc71ddd5982a46fc7933f114e140d921e0`