### PR TITLE
chore(symphony): promote image f9cec68e

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-19T03:55:38Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-19T06:23:45Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "575e5fd9"
-    digest: sha256:3d0cee69a939789c2d50788959cdde3a33f62a6f3ce9fb2b4e7978b371c3ac4f
+    newTag: "f9cec68e"
+    digest: sha256:e5ae5aad911cf41c84bb338b350bc6baaee53e17e7abd3ffe897baaab48b09cb

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-19T03:55:38Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-19T06:23:45Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "575e5fd9"
-    digest: sha256:3d0cee69a939789c2d50788959cdde3a33f62a6f3ce9fb2b4e7978b371c3ac4f
+    newTag: "f9cec68e"
+    digest: sha256:e5ae5aad911cf41c84bb338b350bc6baaee53e17e7abd3ffe897baaab48b09cb

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-19T03:55:38Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-19T06:23:45Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "575e5fd9"
-    digest: sha256:3d0cee69a939789c2d50788959cdde3a33f62a6f3ce9fb2b4e7978b371c3ac4f
+    newTag: "f9cec68e"
+    digest: sha256:e5ae5aad911cf41c84bb338b350bc6baaee53e17e7abd3ffe897baaab48b09cb


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `f9cec68edfc15a16af4854dd7bd953e8e17ab407`
- Image tag: `f9cec68e`
- Image digest: `sha256:e5ae5aad911cf41c84bb338b350bc6baaee53e17e7abd3ffe897baaab48b09cb`