### PR TITLE
fix(agents): isolate migration ledger

### DIFF
--- a/services/agents/src/server/kysely-migrations.test.ts
+++ b/services/agents/src/server/kysely-migrations.test.ts
@@ -1,0 +1,24 @@
+import { readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+import { __test__ } from './kysely-migrations'
+
+describe('Agents migration registration', () => {
+  it('keeps the migration provider registry in lockstep with migration files', () => {
+    const migrationDir = new URL('./migrations', import.meta.url)
+    const migrationFiles = readdirSync(fileURLToPath(migrationDir))
+      .filter((name) => name.endsWith('.ts'))
+      .map((name) => name.replace(/\.ts$/, ''))
+      .sort()
+
+    expect(__test__.getRegisteredMigrations()).toEqual(migrationFiles)
+  })
+
+  it('keeps Agents migrations isolated from host application migration history', () => {
+    expect(__test__.AGENTS_MIGRATION_TABLE).toBe('agents_kysely_migration')
+    expect(__test__.AGENTS_MIGRATION_LOCK_TABLE).toBe('agents_kysely_migration_lock')
+    expect(__test__.AGENTS_MIGRATION_TABLE).not.toBe('kysely_migration')
+    expect(__test__.AGENTS_MIGRATION_LOCK_TABLE).not.toBe('kysely_migration_lock')
+  })
+})

--- a/services/agents/src/server/kysely-migrations.ts
+++ b/services/agents/src/server/kysely-migrations.ts
@@ -24,6 +24,9 @@ const migrations: MigrationMap = {
   '20260208_agents_agentrun_idempotency': agentsAgentRunIdempotencyMigration,
 }
 
+const AGENTS_MIGRATION_TABLE = 'agents_kysely_migration'
+const AGENTS_MIGRATION_LOCK_TABLE = 'agents_kysely_migration_lock'
+
 export const getRegisteredMigrationNames = () => Object.keys(migrations).sort()
 
 const migrationProvider = new StaticMigrationProvider(migrations)
@@ -37,6 +40,8 @@ const runMigrations = async (db: Db) => {
   const migrator = new Migrator({
     db,
     provider: migrationProvider,
+    migrationTableName: AGENTS_MIGRATION_TABLE,
+    migrationLockTableName: AGENTS_MIGRATION_LOCK_TABLE,
     allowUnorderedMigrations: resolveAllowUnorderedMigrations(),
   })
 
@@ -72,6 +77,8 @@ export const ensureMigrations = async (db: Db) => {
 }
 
 export const __test__ = {
+  AGENTS_MIGRATION_LOCK_TABLE,
+  AGENTS_MIGRATION_TABLE,
   getRegisteredMigrations: getRegisteredMigrationNames,
   resolveAllowUnorderedMigrations,
 }


### PR DESCRIPTION
## Summary

- Isolate Agents Kysely migration history into `agents_kysely_migration`.
- Isolate the matching Agents migration lock table into `agents_kysely_migration_lock`.
- Add regression coverage for migration registry completeness and non-default Agents migration table names.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test -- kysely-migrations.test.ts`
- `bun run --cwd services/agents tsc`
- `scripts/agents/guard-extraction-boundaries.sh`
- `bun run --cwd services/agents test`
- `bun run --cwd services/agents lint`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
