### PR TITLE
chore(jangar): promote image 2a00fb9b

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-19T06:25:26Z
+    deploy.knative.dev/rollout: 2026-05-19T06:59:38Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:f9cec68e@sha256:8aabd3e2cd86ef61d0e126767c68860bfc74ff6caa5a4cc7d4d617277fae5804
+              value: registry.ide-newton.ts.net/lab/jangar:2a00fb9b@sha256:16243d7a76161d8e4aae640c0e53c34ea8ef098ccec14147ea6bfa6ff1e26589
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: f9cec68edfc15a16af4854dd7bd953e8e17ab407
+              value: 2a00fb9ba372df3e1e2bae50ef5e2d45dcbadc8a
             - name: JANGAR_GITOPS_REVISION
-              value: f9cec68edfc15a16af4854dd7bd953e8e17ab407
+              value: 2a00fb9ba372df3e1e2bae50ef5e2d45dcbadc8a
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -407,15 +407,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26080180318"
+              value: "26081563954"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:ba111cfd6c26ec055c707fd499ee10e12fa562d812a0454a798cad511b6be60e
+              value: sha256:38f8b22626a0cfa1c1131e764f9a54594cc639d094ce3841272a478f80581eb0
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: f9cec68edfc15a16af4854dd7bd953e8e17ab407
+              value: 2a00fb9ba372df3e1e2bae50ef5e2d45dcbadc8a
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:ba111cfd6c26ec055c707fd499ee10e12fa562d812a0454a798cad511b6be60e
+              value: sha256:38f8b22626a0cfa1c1131e764f9a54594cc639d094ce3841272a478f80581eb0
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: f9cec68e
-    digest: sha256:8aabd3e2cd86ef61d0e126767c68860bfc74ff6caa5a4cc7d4d617277fae5804
+    newTag: 2a00fb9b
+    digest: sha256:16243d7a76161d8e4aae640c0e53c34ea8ef098ccec14147ea6bfa6ff1e26589


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `2a00fb9ba372df3e1e2bae50ef5e2d45dcbadc8a`
- Image tag: `2a00fb9b`
- Image digest: `sha256:16243d7a76161d8e4aae640c0e53c34ea8ef098ccec14147ea6bfa6ff1e26589`
- Source CI run: `26081563954`
- Control-plane serving digest: `sha256:38f8b22626a0cfa1c1131e764f9a54594cc639d094ce3841272a478f80581eb0`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates