### PR TITLE
chore(agents): promote images 32b7ec0f

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: 2a00fb9b
-  digest: sha256:f316fc55b68149976e8a48b061db13eb8be5000972f2463af2fd0c54ac05de12
+  tag: 32b7ec0f
+  digest: sha256:184abaf9a5e42c63c604b1be1370ddf4f43c138f8be920f599ca4252c548a42b
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,23 +11,23 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: 2a00fb9b
-    digest: sha256:787ca064dbff2eef465c51569424a84e6c8671d1f85868c4e6ebb5f3ca214a41
+    tag: 32b7ec0f
+    digest: sha256:2044b9a34dabfbca5ddf9a13dcd6ac60941012e18dd8c8724db205a9730f19f0
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
-      AGENTS_SOURCE_HEAD_SHA: 2a00fb9ba372df3e1e2bae50ef5e2d45dcbadc8a
-      AGENTS_GITOPS_REVISION: 2a00fb9ba372df3e1e2bae50ef5e2d45dcbadc8a
-      AGENTS_SOURCE_CI_RUN_ID: "26081195075"
+      AGENTS_SOURCE_HEAD_SHA: 32b7ec0fc3dbf6cd66b01c6296cc1913b49370d6
+      AGENTS_GITOPS_REVISION: 32b7ec0fc3dbf6cd66b01c6296cc1913b49370d6
+      AGENTS_SOURCE_CI_RUN_ID: "26081834475"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:787ca064dbff2eef465c51569424a84e6c8671d1f85868c4e6ebb5f3ca214a41
-      AGENTS_SERVING_BUILD_COMMIT: 2a00fb9ba372df3e1e2bae50ef5e2d45dcbadc8a
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:787ca064dbff2eef465c51569424a84e6c8671d1f85868c4e6ebb5f3ca214a41
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:2044b9a34dabfbca5ddf9a13dcd6ac60941012e18dd8c8724db205a9730f19f0
+      AGENTS_SERVING_BUILD_COMMIT: 32b7ec0fc3dbf6cd66b01c6296cc1913b49370d6
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:2044b9a34dabfbca5ddf9a13dcd6ac60941012e18dd8c8724db205a9730f19f0
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: 2a00fb9b
-    digest: sha256:3f53dff6790e57ec5abe31b493880174e919b95294750a07dadf576b1353f206
+    tag: 32b7ec0f
+    digest: sha256:df2cc339d96d6fd26f57b873551dc03fdb4981eb47c51943761760a26ea023d0
 argocdHooks:
   enabled: true
   image:
@@ -82,8 +82,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: 2a00fb9b
-    digest: sha256:f316fc55b68149976e8a48b061db13eb8be5000972f2463af2fd0c54ac05de12
+    tag: 32b7ec0f
+    digest: sha256:184abaf9a5e42c63c604b1be1370ddf4f43c138f8be920f599ca4252c548a42b
   autoscaling:
     enabled: false
   env:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `32b7ec0fc3dbf6cd66b01c6296cc1913b49370d6`
- Image tag: `32b7ec0f`
- Source CI run: `26081834475`
- Runner image pin preserved