### PR TITLE
refactor(agents): remove jangar chart ownership leftovers

### DIFF
--- a/argocd/applications/agents/swarm-agentrun-templates.yaml
+++ b/argocd/applications/agents/swarm-agentrun-templates.yaml
@@ -1,7 +1,7 @@
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: jangar-swarm-discover-template
+  name: agents-platform-swarm-discover-template
   namespace: agents
   annotations:
     agents.proompteng.ai/template: "true"
@@ -25,25 +25,25 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/swarm-jangar-control-plane-discover
-    issueNumber: swarm-jangar-control-plane-discover
-    issueTitle: Jangar Engineering discover mission
-    swarmName: jangar-control-plane
+    head: codex/swarm-agents-platform-discover
+    issueNumber: swarm-agents-platform-discover
+    issueTitle: Agents Platform Engineering discover mission
+    swarmName: agents-platform
     swarmStage: discover
     swarmAgentRole: architect
-    swarmAgentWorkerId: worker-jangar-discover
-    swarmAgentIdentity: victor-chen-jangar-architect
+    swarmAgentWorkerId: worker-agents-discover
+    swarmAgentIdentity: victor-chen-agents-architect
     swarmHumanName: Victor Chen
-    swarmTeamName: Jangar Engineering
+    swarmTeamName: Agents Platform Engineering
     ownerChannel: swarm://owner/platform
     natsChannel: general
     natsSubjectPrefix: workflow
-    objective: assess cluster/source/database state and create/update+merge required design-document PRs that improve, maintain, and innovate the Jangar control plane
-    swarmMissionLedgerRef: /workspace/.agentrun/swarm/jangar-control-plane-mission-ledger.md
-    swarmBusinessMetric: reduce failed AgentRuns and shorten green PR-to-healthy GitOps rollout time for the Jangar control plane
+    objective: assess cluster/source/database state and create/update+merge required design-document PRs that improve, maintain, and innovate the Agents Platform control plane
+    swarmMissionLedgerRef: /workspace/.agentrun/swarm/agents-platform-mission-ledger.md
+    swarmBusinessMetric: reduce failed AgentRuns and shorten green PR-to-healthy GitOps rollout time for the Agents Platform control plane
     swarmBusinessEvidenceUrl: http://agents.agents.svc.cluster.local/ready
     swarmValidationContract: >-
-      ["cite the governing Jangar design or runtime requirement before changing code","produce production PRs with tests or report the exact blocker to code","merge only green PRs and prove Argo, workload readiness, and service health after rollout","name the control-plane metric improved or the smallest blocker preventing improvement"]
+      ["cite the governing Agents Platform design or runtime requirement before changing code","produce production PRs with tests or report the exact blocker to code","merge only green PRs and prove Argo, workload readiness, and service health after rollout","name the control-plane metric improved or the smallest blocker preventing improvement"]
     swarmValueGates: >-
       ["failed_agentrun_rate","pr_to_rollout_latency","ready_status_truth","manual_intervention_count","handoff_evidence_quality"]
     swarmHandoffRequiredFields: >-
@@ -63,7 +63,7 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: jangar-swarm-plan-template
+  name: agents-platform-swarm-plan-template
   namespace: agents
   annotations:
     agents.proompteng.ai/template: "true"
@@ -87,25 +87,25 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/swarm-jangar-control-plane-plan
-    issueNumber: swarm-jangar-control-plane-plan
-    issueTitle: Jangar Engineering plan mission
-    swarmName: jangar-control-plane
+    head: codex/swarm-agents-platform-plan
+    issueNumber: swarm-agents-platform-plan
+    issueTitle: Agents Platform Engineering plan mission
+    swarmName: agents-platform
     swarmStage: plan
     swarmAgentRole: architect
-    swarmAgentWorkerId: worker-jangar-plan
-    swarmAgentIdentity: victor-chen-jangar-architect
+    swarmAgentWorkerId: worker-agents-plan
+    swarmAgentIdentity: victor-chen-agents-architect
     swarmHumanName: Victor Chen
-    swarmTeamName: Jangar Engineering
+    swarmTeamName: Agents Platform Engineering
     ownerChannel: swarm://owner/platform
     natsChannel: general
     natsSubjectPrefix: workflow
-    objective: assess cluster/source/database state and create/update+merge required design-document PRs that improve, maintain, and innovate the Jangar control plane
-    swarmMissionLedgerRef: /workspace/.agentrun/swarm/jangar-control-plane-mission-ledger.md
-    swarmBusinessMetric: reduce failed AgentRuns and shorten green PR-to-healthy GitOps rollout time for the Jangar control plane
+    objective: assess cluster/source/database state and create/update+merge required design-document PRs that improve, maintain, and innovate the Agents Platform control plane
+    swarmMissionLedgerRef: /workspace/.agentrun/swarm/agents-platform-mission-ledger.md
+    swarmBusinessMetric: reduce failed AgentRuns and shorten green PR-to-healthy GitOps rollout time for the Agents Platform control plane
     swarmBusinessEvidenceUrl: http://agents.agents.svc.cluster.local/ready
     swarmValidationContract: >-
-      ["cite the governing Jangar design or runtime requirement before changing code","produce production PRs with tests or report the exact blocker to code","merge only green PRs and prove Argo, workload readiness, and service health after rollout","name the control-plane metric improved or the smallest blocker preventing improvement"]
+      ["cite the governing Agents Platform design or runtime requirement before changing code","produce production PRs with tests or report the exact blocker to code","merge only green PRs and prove Argo, workload readiness, and service health after rollout","name the control-plane metric improved or the smallest blocker preventing improvement"]
     swarmValueGates: >-
       ["failed_agentrun_rate","pr_to_rollout_latency","ready_status_truth","manual_intervention_count","handoff_evidence_quality"]
     swarmHandoffRequiredFields: >-
@@ -125,7 +125,7 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: jangar-swarm-implement-template
+  name: agents-platform-swarm-implement-template
   namespace: agents
   annotations:
     agents.proompteng.ai/template: "true"
@@ -150,25 +150,25 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/swarm-jangar-control-plane
-    issueNumber: swarm-jangar-control-plane
-    issueTitle: Jangar Engineering autonomous implementation mission
-    swarmName: jangar-control-plane
+    head: codex/swarm-agents-platform
+    issueNumber: swarm-agents-platform
+    issueTitle: Agents Platform Engineering autonomous implementation mission
+    swarmName: agents-platform
     swarmStage: implement
     swarmAgentRole: engineer
-    swarmAgentWorkerId: worker-jangar-implement
-    swarmAgentIdentity: elise-novak-jangar-engineer
+    swarmAgentWorkerId: worker-agents-implement
+    swarmAgentIdentity: elise-novak-agents-engineer
     swarmHumanName: Elise Novak
-    swarmTeamName: Jangar Engineering
+    swarmTeamName: Agents Platform Engineering
     objective: grab the system design document, implement high-quality engineering changes, update impacted documentation, and deliver a production-ready PR
     ownerChannel: swarm://owner/platform
     natsChannel: general
     natsSubjectPrefix: workflow
-    swarmMissionLedgerRef: /workspace/.agentrun/swarm/jangar-control-plane-mission-ledger.md
-    swarmBusinessMetric: reduce failed AgentRuns and shorten green PR-to-healthy GitOps rollout time for the Jangar control plane
+    swarmMissionLedgerRef: /workspace/.agentrun/swarm/agents-platform-mission-ledger.md
+    swarmBusinessMetric: reduce failed AgentRuns and shorten green PR-to-healthy GitOps rollout time for the Agents Platform control plane
     swarmBusinessEvidenceUrl: http://agents.agents.svc.cluster.local/ready
     swarmValidationContract: >-
-      ["cite the governing Jangar design or runtime requirement before changing code","produce production PRs with tests or report the exact blocker to code","merge only green PRs and prove Argo, workload readiness, and service health after rollout","name the control-plane metric improved or the smallest blocker preventing improvement"]
+      ["cite the governing Agents Platform design or runtime requirement before changing code","produce production PRs with tests or report the exact blocker to code","merge only green PRs and prove Argo, workload readiness, and service health after rollout","name the control-plane metric improved or the smallest blocker preventing improvement"]
     swarmValueGates: >-
       ["failed_agentrun_rate","pr_to_rollout_latency","ready_status_truth","manual_intervention_count","handoff_evidence_quality"]
     swarmHandoffRequiredFields: >-
@@ -188,7 +188,7 @@ spec:
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: AgentRun
 metadata:
-  name: jangar-swarm-verify-template
+  name: agents-platform-swarm-verify-template
   namespace: agents
   annotations:
     agents.proompteng.ai/template: "true"
@@ -222,28 +222,28 @@ spec:
   parameters:
     repository: proompteng/lab
     base: main
-    head: codex/swarm-jangar-control-plane-verify
-    issueNumber: swarm-jangar-control-plane-verify
-    issueTitle: Jangar Engineering verify mission
-    swarmName: jangar-control-plane
+    head: codex/swarm-agents-platform-verify
+    issueNumber: swarm-agents-platform-verify
+    issueTitle: Agents Platform Engineering verify mission
+    swarmName: agents-platform
     swarmStage: verify
     swarmAgentRole: deployer
-    swarmAgentWorkerId: worker-jangar-verify
-    swarmAgentIdentity: marco-silva-jangar-deployer
+    swarmAgentWorkerId: worker-agents-verify
+    swarmAgentIdentity: marco-silva-agents-deployer
     swarmHumanName: Marco Silva
-    swarmTeamName: Jangar Engineering
+    swarmTeamName: Agents Platform Engineering
     ownerChannel: swarm://owner/platform
     natsChannel: general
     natsSubjectPrefix: workflow
-    targetApplications: agents,jangar
-    targetDeployments: agents/agents,agents/agents-controllers,jangar/jangar
+    targetApplications: agents
+    targetDeployments: agents/agents,agents/agents-controllers
     readinessUrl: http://agents.agents.svc.cluster.local/ready
-    objective: as release engineer, make Jangar PRs production-ready by fixing blockers until all required checks are green, then squash-merge and verify in-cluster GitOps rollout health
-    swarmMissionLedgerRef: /workspace/.agentrun/swarm/jangar-control-plane-mission-ledger.md
-    swarmBusinessMetric: reduce failed AgentRuns and shorten green PR-to-healthy GitOps rollout time for the Jangar control plane
+    objective: as release engineer, make Agents Platform PRs production-ready by fixing blockers until all required checks are green, then squash-merge and verify in-cluster GitOps rollout health
+    swarmMissionLedgerRef: /workspace/.agentrun/swarm/agents-platform-mission-ledger.md
+    swarmBusinessMetric: reduce failed AgentRuns and shorten green PR-to-healthy GitOps rollout time for the Agents Platform control plane
     swarmBusinessEvidenceUrl: http://agents.agents.svc.cluster.local/ready
     swarmValidationContract: >-
-      ["cite the governing Jangar design or runtime requirement before changing code","produce production PRs with tests or report the exact blocker to code","merge only green PRs and prove Argo, workload readiness, and service health after rollout","name the control-plane metric improved or the smallest blocker preventing improvement"]
+      ["cite the governing Agents Platform design or runtime requirement before changing code","produce production PRs with tests or report the exact blocker to code","merge only green PRs and prove Argo, workload readiness, and service health after rollout","name the control-plane metric improved or the smallest blocker preventing improvement"]
     swarmValueGates: >-
       ["failed_agentrun_rate","pr_to_rollout_latency","ready_status_truth","manual_intervention_count","handoff_evidence_quality"]
     swarmHandoffRequiredFields: >-

--- a/argocd/applications/agents/swarm-implspecs.yaml
+++ b/argocd/applications/agents/swarm-implspecs.yaml
@@ -17,7 +17,7 @@ spec:
       - swarmBusinessMetric
       - swarmValidationContract
       - swarmValueGates
-  summary: "Architect: ship and merge ambitious architecture changes for Jangar/Torghut."
+  summary: "Architect: ship and merge ambitious architecture changes for Agents Platform/Torghut."
   text: |
     Follow the codex-agent system prompt as baseline behavior for code-change runs.
 
@@ -31,7 +31,7 @@ spec:
     - Role voice: write as ${swarmHumanName}, an experienced architecture lead on ${swarmTeamName}; be specific, plain-spoken, and willing to name tradeoffs.
 
     Primary outcomes:
-    - Jangar: increase control-plane resilience/reliability with explicit failure-mode reduction and safer rollout behavior.
+    - Agents Platform: increase control-plane resilience/reliability with explicit failure-mode reduction and safer rollout behavior.
     - Torghut: increase profitability with innovative architecture changes that define measurable trading hypotheses and guardrails.
     - Architecture lane completion requires merged architecture outputs, not just draft notes.
 
@@ -82,9 +82,9 @@ spec:
     NATS collaboration (required):
     1) Resolve active channel from swarmRequirementChannel, then natsChannel, then general.
     2) Read the NATS context soak before action and use the latest teammate messages as shared state.
-    3) Publish concise progress, risk, validation, and handoff updates through `codex-nats-publish`; Jangar is the visibility surface.
+    3) Publish concise progress, risk, validation, and handoff updates through `codex-nats-publish`; Agents Platform is the visibility surface.
     4) Keep updates human-readable and evidence-based; do not dump raw subjects, worker IDs, or JSON metadata unless needed for debugging.
-    5) Use durable repo artifacts and PRs for audit evidence; NATS is for live coordination and Jangar visibility.
+    5) Use durable repo artifacts and PRs for audit evidence; NATS is for live coordination and Agents Platform visibility.
 
     Communication contract:
     - Write in first person as a teammate on ${swarmTeamName}.
@@ -103,7 +103,7 @@ spec:
     - Merged artifacts contain long-form decision content (not empty placeholders).
     - Engineer/deployer handoff contract is explicit and testable.
     - Mission ledger records the validation contract, business metric, and next implementation milestone.
-    - NATS/Jangar updates include concrete evidence and next action.
+    - NATS/Agents Platform updates include concrete evidence and next action.
 
     Deliverables:
     - `ownerUpdateMessage` PR URL, and merge commit SHA.
@@ -206,9 +206,9 @@ spec:
     NATS collaboration (required):
     1) Resolve active channel from swarmRequirementChannel, then natsChannel, then general.
     2) Read the NATS context soak before action and use the latest teammate messages as shared state.
-    3) Publish concise progress, risk, validation, and handoff updates through `codex-nats-publish`; Jangar is the visibility surface.
+    3) Publish concise progress, risk, validation, and handoff updates through `codex-nats-publish`; Agents Platform is the visibility surface.
     4) Keep updates human-readable and evidence-based; do not dump raw subjects, worker IDs, or JSON metadata unless needed for debugging.
-    5) Use durable repo artifacts and PRs for audit evidence; NATS is for live coordination and Jangar visibility.
+    5) Use durable repo artifacts and PRs for audit evidence; NATS is for live coordination and Agents Platform visibility.
 
     Communication contract:
     - Write in first person as a teammate on ${swarmTeamName}.
@@ -227,7 +227,7 @@ spec:
     - The shipped change is tied to `${swarmBusinessMetric}` and one or more value gates with before/after business evidence, or the exact blocker preventing business impact is recorded.
     - PR is merge-ready with required checks green.
     - Evidence includes validation, risk, rollback, and requirement/design provenance.
-    - NATS/Jangar updates are thread-aware and human-readable.
+    - NATS/Agents Platform updates are thread-aware and human-readable.
 
     Deliverables:
     - `ownerUpdateMessage` for channel post.
@@ -295,7 +295,7 @@ spec:
     - Treat `${swarmValidationContract}` as the rollout acceptance contract; record whether the live rollout advances `${swarmBusinessMetric}` or which value gate is blocked.
     - If `${swarmBusinessEvidenceUrl}` is set, read it after rollout and record the live business state. For Torghut, include `/trading/revenue-repair` fields `business_state`, `revenue_ready`, top `repair_queue` item, and routeable/profit evidence gates.
     - Update `${swarmMissionLedgerRef}` with GitOps evidence, workload readiness, service readiness, business metric/value gate evidence, blocker, rollback path, and exact next action.
-    - Treat `jangar-control-plane:verify:verify stage is stale` as a self-referential blocker for this run only. If
+    - Treat `agents-platform:verify:verify stage is stale` as a self-referential blocker for this run only. If
       every other rollout signal is healthy and that is the only readiness blocker, complete successfully so this
       AgentRun can refresh the verify stage.
     - Fail if Argo CD applications are not Synced/Healthy, target deployments are not available, live images do not
@@ -412,9 +412,9 @@ spec:
     NATS collaboration (required):
     1) Resolve active channel from swarmRequirementChannel, then natsChannel, then general.
     2) Read the NATS context soak before action and use the latest teammate messages as shared state.
-    3) Publish concise progress, risk, validation, and handoff updates through `codex-nats-publish`; Jangar is the visibility surface.
+    3) Publish concise progress, risk, validation, and handoff updates through `codex-nats-publish`; Agents Platform is the visibility surface.
     4) Keep updates human-readable and evidence-based; do not dump raw subjects, worker IDs, or JSON metadata unless needed for debugging.
-    5) Use durable repo artifacts and PRs for audit evidence; NATS is for live coordination and Jangar visibility.
+    5) Use durable repo artifacts and PRs for audit evidence; NATS is for live coordination and Agents Platform visibility.
 
     Communication contract:
     - Write in first person as a teammate on ${swarmTeamName}.
@@ -433,7 +433,7 @@ spec:
     - Post-merge rollout health is verified with cluster/GitOps evidence.
     - Runtime or business-value evidence is recorded against `${swarmBusinessMetric}` and `${swarmValueGates}`, or the exact blocker is named.
     - Rollback path and residual risk are documented.
-    - NATS/Jangar updates are thread-aware and human-readable.
+    - NATS/Agents Platform updates are thread-aware and human-readable.
 
     Deliverables:
     - `ownerUpdateMessage` with merge and rollout status.

--- a/argocd/applications/agents/swarm-implspecs.yaml
+++ b/argocd/applications/agents/swarm-implspecs.yaml
@@ -305,7 +305,7 @@ spec:
 
     NATS collaboration (required):
     1) Resolve active channel from natsChannel, then general.
-    2) Publish concise progress and final go/no-go updates through `codex-nats-publish`.
+    2) Publish concise progress and final go/no-go updates through `codex-nats-publish`; Agents Platform is the visibility surface.
     3) Keep updates human-readable and evidence-based; do not dump raw JSON unless needed for debugging.
 
     Done criteria (all required):

--- a/argocd/applications/agents/swarm-instances.yaml
+++ b/argocd/applications/agents/swarm-instances.yaml
@@ -1,7 +1,7 @@
 apiVersion: swarm.proompteng.ai/v1alpha1
 kind: Swarm
 metadata:
-  name: jangar-control-plane
+  name: agents-platform
   namespace: agents
 spec:
   owner:
@@ -11,13 +11,13 @@ spec:
     - platform-reliability
     - platform-evolution
   objectives:
-    - operate as the Jangar Engineering team through NATS-backed swarm communication
+    - operate as the Agents Platform Engineering team through NATS-backed swarm communication
     - continuously discover and implement control-plane improvements
     - deliver Torghut platform requirements safely to production
   mission:
-    ledgerRef: /workspace/.agentrun/swarm/jangar-control-plane-mission-ledger.md
+    ledgerRef: /workspace/.agentrun/swarm/agents-platform-mission-ledger.md
     sourceDesign: docs/agents/designs/swarm-agentic-mission-architecture-2026-05-08.md
-    businessMetric: reduce failed AgentRuns and shorten green PR-to-healthy GitOps rollout time for the Jangar control plane
+    businessMetric: reduce failed AgentRuns and shorten green PR-to-healthy GitOps rollout time for the Agents Platform control plane
     validationContract:
       - every run must cite the governing design or runtime requirement before changing code
       - implement stages must produce production PRs with tests or report the exact blocker to code
@@ -52,13 +52,13 @@ spec:
       personas:
         architect:
           humanName: Victor Chen
-          workerIdentity: victor-chen-jangar-architect
+          workerIdentity: victor-chen-agents-architect
         engineer:
           humanName: Elise Novak
-          workerIdentity: elise-novak-jangar-engineer
+          workerIdentity: elise-novak-agents-engineer
         deployer:
           humanName: Marco Silva
-          workerIdentity: marco-silva-jangar-deployer
+          workerIdentity: marco-silva-agents-deployer
   discovery:
     minCitations: 2
     minConfidence: 0.75
@@ -95,19 +95,19 @@ spec:
     discover:
       targetRef:
         kind: AgentRun
-        name: jangar-swarm-discover-template
+        name: agents-platform-swarm-discover-template
     plan:
       targetRef:
         kind: AgentRun
-        name: jangar-swarm-plan-template
+        name: agents-platform-swarm-plan-template
     implement:
       targetRef:
         kind: AgentRun
-        name: jangar-swarm-implement-template
+        name: agents-platform-swarm-implement-template
     verify:
       targetRef:
         kind: AgentRun
-        name: jangar-swarm-verify-template
+        name: agents-platform-swarm-verify-template
 ---
 apiVersion: swarm.proompteng.ai/v1alpha1
 kind: Swarm
@@ -124,7 +124,7 @@ spec:
   objectives:
     - operate as the Torghut Traders team through NATS-backed swarm communication
     - continuously discover and implement quant alpha and risk-control improvements
-    - issue platform requirements to jangar-control-plane via NATS requirement channels
+    - issue platform requirements to agents-platform via NATS requirement channels
   mission:
     ledgerRef: /workspace/.agentrun/swarm/torghut-quant-mission-ledger.md
     sourceDesign: docs/agents/designs/swarm-agentic-mission-architecture-2026-05-08.md

--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -1,22 +1,22 @@
 # Agents Helm Chart
 
-Agents installs **Jangar**, a Kubernetes-native control plane for running agent and automation work as normal Kubernetes resources.
+Agents installs the **Agents Platform**, a Kubernetes-native control plane for running agent and automation work as normal Kubernetes resources.
 
 If you already understand Deployments and Jobs, this is the shortest mental model:
 
 - You create an `AgentRun` custom resource when you want work done.
-- Jangar watches that resource and launches Kubernetes Jobs/Pods to do the work.
+- The Agents controller watches that resource and launches Kubernetes Jobs/Pods to do the work.
 - The run status is written back to the `AgentRun`, so Kubernetes stays the source of truth.
 
 The chart is published on Artifact Hub:
 
 - Artifact Hub: <https://artifacthub.io/packages/helm/agents/agents>
 - OCI chart: `oci://ghcr.io/proompteng/charts/agents`
-- Current chart version: `0.9.15`
+- Current chart version: `0.9.19`
 
 ## Start Here
 
-Use the local end-to-end path first. It builds a Jangar image from this repository, creates a kind cluster, installs Postgres, deploys the chart, submits a smoke `AgentRun`, and waits for that run to succeed.
+Use the local end-to-end path first. It builds Agents control-plane, controller, and Codex runner images from this repository, creates a kind cluster, installs Postgres, deploys the chart, submits a smoke `AgentRun`, and waits for that run to succeed.
 
 ```bash
 git clone https://github.com/proompteng/lab.git
@@ -136,7 +136,7 @@ Install:
 
 ```bash
 helm upgrade --install agents oci://ghcr.io/proompteng/charts/agents \
-  --version 0.9.13 \
+  --version 0.9.19 \
   --namespace agents \
   --values agents-values.yaml \
   --wait
@@ -155,7 +155,7 @@ curl -sf http://127.0.0.1:8080/health
 Run the chart smoke examples from the published package:
 
 ```bash
-helm pull oci://ghcr.io/proompteng/charts/agents --version 0.9.13 --untar
+helm pull oci://ghcr.io/proompteng/charts/agents --version 0.9.19 --untar
 
 kubectl -n agents apply -f agents/examples/agentprovider-smoke.yaml
 kubectl -n agents apply -f agents/examples/agent-smoke.yaml
@@ -172,7 +172,7 @@ You do not need to understand every CRD before installing the chart. These are t
 
 | Concept                | What it means                                                                       | First example                                 |
 | ---------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------- |
-| Jangar                 | The control plane installed by this chart. It watches CRDs and coordinates work.    | `Deployment/agents`                           |
+| Agents Platform        | The control plane installed by this chart. It watches CRDs and coordinates work.    | `Deployment/agents`                           |
 | AgentRun               | One requested unit of work. This is what you create when you want something to run. | `examples/agentrun-workflow-smoke.yaml`       |
 | Agent                  | A reusable worker profile. It points at an AgentProvider and can define defaults.   | `examples/agent-smoke.yaml`                   |
 | AgentProvider          | How an agent is executed, such as a command, adapter, or runner entrypoint.         | `examples/agentprovider-smoke.yaml`           |
@@ -185,7 +185,7 @@ You do not need to understand every CRD before installing the chart. These are t
 
 The chart installs:
 
-- Jangar control-plane `Deployment` and HTTP `Service`
+- Agents control-plane `Deployment` and HTTP `Service`
 - Optional gRPC `Service`
 - Optional controllers deployment for reconciliation/runtime work
 - Optional metrics `Service`, `ServiceMonitor`, and Grafana dashboard ConfigMap
@@ -208,7 +208,7 @@ That is deliberate. The chart should be safe to install into a namespace and the
 
 ```bash
 helm template agents oci://ghcr.io/proompteng/charts/agents \
-  --version 0.9.13 \
+  --version 0.9.19 \
   --namespace agents \
   --values agents-values.yaml
 ```
@@ -219,7 +219,7 @@ The chart includes an opt-in test Pod that curls the in-cluster health endpoint 
 
 ```bash
 helm upgrade --install agents oci://ghcr.io/proompteng/charts/agents \
-  --version 0.9.13 \
+  --version 0.9.19 \
   --namespace agents \
   --values agents-values.yaml \
   --set tests.enabled=true \
@@ -254,7 +254,7 @@ image:
 
 runner:
   image:
-    repository: registry.example.com/platform/agent-runner
+    repository: registry.example.com/platform/agents-codex-runner
     tag: 2026-05-05
     digest: sha256:...
     pullSecrets:
@@ -523,7 +523,7 @@ Frequent render failures:
 
 | Value                                                                | Purpose                                                                   |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `image.repository`, `image.tag`, `image.digest`                      | Default Jangar image used by the control-plane and controllers.           |
+| `image.repository`, `image.tag`, `image.digest`                      | Default Agents control-plane image used by the control-plane deployment.  |
 | `controlPlane.image.*`, `controllers.image.*`                        | Optional per-deployment overrides when those images differ.               |
 | `runner.image.repository`, `runner.image.tag`, `runner.image.digest` | Default image for AgentRun Jobs.                                          |
 | `imagePolicy.requireDigest`                                          | Require immutable image digests for chart-managed images.                 |

--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,6 +1,6 @@
 version: 0.9.19
 name: agents
-displayName: Agents Control Plane (Jangar)
+displayName: Agents Platform Control Plane
 description: Minimal Agents control plane with CRDs and native workflow runtime.
 license: MIT
 homeURL: https://github.com/proompteng/charts/tree/main/charts/agents
@@ -9,7 +9,6 @@ repository:
   url: https://github.com/proompteng/charts
 keywords:
   - agents
-  - jangar
   - control-plane
   - codex
 maintainers:

--- a/charts/agents/dashboards/agents-observability.json
+++ b/charts/agents/dashboards/agents-observability.json
@@ -39,7 +39,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (outcome) (rate(jangar_agent_run_outcomes_total[5m]))",
+          "expr": "sum by (outcome) (rate(agents_agent_run_outcomes_total[5m]))",
           "legendFormat": "{{outcome}}",
           "refId": "A"
         }
@@ -69,7 +69,7 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(jangar_reconcile_duration_ms_bucket{kind=\"agentrun\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(agents_reconcile_duration_ms_bucket{kind=\"agentrun\"}[5m])) by (le))",
           "legendFormat": "p95",
           "refId": "A"
         }
@@ -97,7 +97,7 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(jangar_agents_queue_depth_bucket[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(agents_queue_depth_bucket[5m])) by (le))",
           "legendFormat": "p95 queue depth",
           "refId": "A"
         }
@@ -125,7 +125,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (state) (rate(jangar_sse_connections_total[5m]))",
+          "expr": "sum by (state) (rate(agents_sse_connections_total[5m]))",
           "legendFormat": "{{state}}",
           "refId": "A"
         }
@@ -137,7 +137,7 @@
   "refresh": "30s",
   "schemaVersion": 36,
   "style": "dark",
-  "tags": ["agents", "jangar"],
+  "tags": ["agents"],
   "templating": {
     "list": []
   },

--- a/charts/agents/examples/signal-torghut-to-agents-platform-requirement.yaml
+++ b/charts/agents/examples/signal-torghut-to-agents-platform-requirement.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     swarm.proompteng.ai/type: requirement
     swarm.proompteng.ai/from: torghut-quant
-    swarm.proompteng.ai/to: jangar-control-plane
+    swarm.proompteng.ai/to: agents-platform
 spec:
   channel: workflow.general.requirement
   description: Raise platform risk controls for market-open volatility regime.

--- a/charts/agents/examples/swarm-agents-platform.yaml
+++ b/charts/agents/examples/swarm-agents-platform.yaml
@@ -1,7 +1,7 @@
 apiVersion: swarm.proompteng.ai/v1alpha1
 kind: Swarm
 metadata:
-  name: jangar-control-plane
+  name: agents-platform
   namespace: agents
 spec:
   owner:

--- a/charts/agents/templates/NOTES.txt
+++ b/charts/agents/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Thank you for installing agents (Jangar control plane).
+Thank you for installing the Agents Platform control plane.
 
 Next steps:
 1. Verify deployment:
@@ -9,7 +9,7 @@ Next steps:
    kubectl -n {{ .Release.Namespace }} apply -f charts/agents/examples/memory-sample.yaml
    kubectl -n {{ .Release.Namespace }} apply -f charts/agents/examples/implementationspec-sample.yaml
    kubectl -n {{ .Release.Namespace }} apply -f charts/agents/examples/agentrun-sample.yaml
-3. Port-forward to access Jangar:
+3. Port-forward to access the Agents HTTP API:
    kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "agents.fullname" . }} 8080:{{ .Values.service.port }}
 4. Port-forward gRPC for agentctl (optional when gRPC is enabled):
    kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "agents.fullname" . }}-grpc {{ .Values.grpc.servicePort }}:{{ .Values.grpc.servicePort }}

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -362,7 +362,7 @@ describe('scheduled AgentRun templates', () => {
         .filter((entry): entry is [string, Record<string, unknown>] => typeof entry[0] === 'string'),
     )
 
-    for (const name of ['jangar-swarm-verify-template', 'torghut-swarm-verify-template']) {
+    for (const name of ['agents-platform-swarm-verify-template', 'torghut-swarm-verify-template']) {
       const template = agentRunTemplates.get(name)
       const workflow = objectAt(objectAt(template, 'spec'), 'workflow')
       const steps = objectAt(workflow, 'steps') as Record<string, unknown>[] | undefined
@@ -383,10 +383,10 @@ describe('scheduled AgentRun templates', () => {
     )
 
     for (const [name, expectedUrl] of [
-      ['jangar-swarm-discover-template', 'http://agents.agents.svc.cluster.local/ready'],
-      ['jangar-swarm-plan-template', 'http://agents.agents.svc.cluster.local/ready'],
-      ['jangar-swarm-implement-template', 'http://agents.agents.svc.cluster.local/ready'],
-      ['jangar-swarm-verify-template', 'http://agents.agents.svc.cluster.local/ready'],
+      ['agents-platform-swarm-discover-template', 'http://agents.agents.svc.cluster.local/ready'],
+      ['agents-platform-swarm-plan-template', 'http://agents.agents.svc.cluster.local/ready'],
+      ['agents-platform-swarm-implement-template', 'http://agents.agents.svc.cluster.local/ready'],
+      ['agents-platform-swarm-verify-template', 'http://agents.agents.svc.cluster.local/ready'],
       ['torghut-swarm-discover-template', 'http://torghut.torghut.svc.cluster.local/trading/revenue-repair'],
       ['torghut-swarm-plan-template', 'http://torghut.torghut.svc.cluster.local/trading/revenue-repair'],
       ['torghut-swarm-implement-template', 'http://torghut.torghut.svc.cluster.local/trading/revenue-repair'],

--- a/scripts/agents/validate-agents.sh
+++ b/scripts/agents/validate-agents.sh
@@ -284,7 +284,7 @@ required_coordination_parameters = (
     "swarmAgentIdentity",
     "swarmHumanName",
 )
-required_collaboration_terms = ("nats collaboration", "codex-nats-publish", "jangar is the visibility surface")
+required_collaboration_terms = ("nats collaboration", "codex-nats-publish", "agents platform is the visibility surface")
 
 errors = []
 if not swarms:

--- a/services/agents/src/server/metrics.test.ts
+++ b/services/agents/src/server/metrics.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const otelMock = vi.hoisted(() => {
+  const counters = new Map<string, { add: ReturnType<typeof vi.fn> }>()
+  const histograms = new Map<string, { record: ReturnType<typeof vi.fn> }>()
+  const createCounter = vi.fn((name: string) => {
+    const counter = { add: vi.fn() }
+    counters.set(name, counter)
+    return counter
+  })
+  const createHistogram = vi.fn((name: string) => {
+    const histogram = { record: vi.fn() }
+    histograms.set(name, histogram)
+    return histogram
+  })
+  const getMeter = vi.fn(() => ({ createCounter, createHistogram }))
+  return { counters, histograms, createCounter, createHistogram, getMeter }
+})
+
+vi.mock('@proompteng/otel/api', () => ({
+  metrics: {
+    getMeter: otelMock.getMeter,
+  },
+}))
+
+import {
+  __private,
+  configureAgentsMetricsSink,
+  recordAgentQueueDepth,
+  recordAgentRateLimitRejection,
+  recordAgentRunOutcome,
+  recordReconcileDurationMs,
+  recordSseConnection,
+} from './metrics'
+
+describe('agents metrics', () => {
+  beforeEach(() => {
+    __private.resetForTests()
+    otelMock.counters.clear()
+    otelMock.histograms.clear()
+    otelMock.createCounter.mockClear()
+    otelMock.createHistogram.mockClear()
+    otelMock.getMeter.mockClear()
+  })
+
+  it('records generic Agents metric instruments by default', () => {
+    recordAgentRunOutcome('Succeeded', { runtime: 'workflow' })
+    recordAgentQueueDepth(3, { scope: 'namespace', namespace: 'agents' })
+    recordReconcileDurationMs(42, { kind: 'agentrun' })
+    recordSseConnection('control-plane', 'opened')
+    recordAgentRateLimitRejection('cluster')
+
+    expect(otelMock.getMeter).toHaveBeenCalledWith('agents')
+    expect(otelMock.counters.get('agents_agent_run_outcomes_total')?.add).toHaveBeenCalledWith(1, {
+      outcome: 'Succeeded',
+      runtime: 'workflow',
+    })
+    expect(otelMock.histograms.get('agents_queue_depth')?.record).toHaveBeenCalledWith(3, {
+      scope: 'namespace',
+      namespace: 'agents',
+    })
+    expect(otelMock.histograms.get('agents_reconcile_duration_ms')?.record).toHaveBeenCalledWith(42, {
+      kind: 'agentrun',
+    })
+    expect(otelMock.counters.get('agents_sse_connections_total')?.add).toHaveBeenCalledWith(1, {
+      stream: 'control-plane',
+      state: 'opened',
+    })
+    expect(otelMock.counters.get('agents_rate_limit_rejections_total')?.add).toHaveBeenCalledWith(1, {
+      scope: 'cluster',
+    })
+  })
+
+  it('keeps configured sinks as a compatibility override', () => {
+    const recordAgentRunOutcomeOverride = vi.fn()
+    configureAgentsMetricsSink({ recordAgentRunOutcome: recordAgentRunOutcomeOverride })
+
+    recordAgentRunOutcome('Failed', { runtime: 'job' })
+
+    expect(recordAgentRunOutcomeOverride).toHaveBeenCalledWith('Failed', { runtime: 'job' })
+    expect(otelMock.createCounter).not.toHaveBeenCalled()
+  })
+})

--- a/services/agents/src/server/metrics.ts
+++ b/services/agents/src/server/metrics.ts
@@ -1,3 +1,5 @@
+import { type Counter, type Histogram, metrics as otelMetrics } from '@proompteng/otel/api'
+
 type MetricsAttributes = Record<string, string>
 
 export type AgentsMetricsSink = {
@@ -13,48 +15,178 @@ export type AgentsMetricsSink = {
   recordSseError?: (stream: string, phase: string, attributes?: MetricsAttributes) => void
 }
 
-const metricsSink: AgentsMetricsSink = {}
+type AgentsMetricInstruments = {
+  agentConcurrency: Histogram
+  agentQueueDepth: Histogram
+  agentRateLimitRejections: Counter
+  agentRunOutcomes: Counter
+  agentRunResyncAdoptions: Counter
+  agentRunUntouchedBacklog: Histogram
+  agentRunUntouchedOldestAgeSeconds: Histogram
+  reconcileDurationMs: Histogram
+  sseConnections: Counter
+  sseErrors: Counter
+}
+
+const globalState = globalThis as typeof globalThis & {
+  __agentsMetrics?: {
+    instruments?: AgentsMetricInstruments
+  }
+}
+
+const configuredMetricsSink: AgentsMetricsSink = {}
 
 export const configureAgentsMetricsSink = (sink: AgentsMetricsSink) => {
-  Object.assign(metricsSink, sink)
+  Object.assign(configuredMetricsSink, sink)
+}
+
+const recordCounter = (counter: Counter | undefined, value: number, attributes?: MetricsAttributes) => {
+  counter?.add(value, attributes)
+}
+
+const recordHistogram = (histogram: Histogram | undefined, value: number, attributes?: MetricsAttributes) => {
+  if (!Number.isFinite(value)) return
+  histogram?.record(value, attributes)
+}
+
+const getAgentsMetricInstruments = (): AgentsMetricInstruments => {
+  globalState.__agentsMetrics ??= {}
+  if (globalState.__agentsMetrics.instruments) {
+    return globalState.__agentsMetrics.instruments
+  }
+
+  const meter = otelMetrics.getMeter('agents')
+  const instruments: AgentsMetricInstruments = {
+    agentConcurrency: meter.createHistogram('agents_active_concurrency', {
+      description: 'Observed active AgentRun concurrency.',
+    }),
+    agentQueueDepth: meter.createHistogram('agents_queue_depth', {
+      description: 'Observed queue depth for AgentRun admission control.',
+    }),
+    agentRateLimitRejections: meter.createCounter('agents_rate_limit_rejections_total', {
+      description: 'Count of AgentRun submissions rejected due to rate limits.',
+    }),
+    agentRunOutcomes: meter.createCounter('agents_agent_run_outcomes_total', {
+      description: 'Count of AgentRun terminal outcomes by phase.',
+    }),
+    agentRunResyncAdoptions: meter.createCounter('agents_agentrun_resync_adoptions_total', {
+      description: 'Count of AgentRuns adopted for reconciliation by controller resync sweeps.',
+    }),
+    agentRunUntouchedBacklog: meter.createHistogram('agents_agentrun_untouched_backlog', {
+      description: 'Observed count of untouched AgentRuns detected by the controller.',
+    }),
+    agentRunUntouchedOldestAgeSeconds: meter.createHistogram('agents_agentrun_untouched_oldest_age_seconds', {
+      description: 'Observed age in seconds of the oldest untouched AgentRun.',
+      unit: 's',
+    }),
+    reconcileDurationMs: meter.createHistogram('agents_reconcile_duration_ms', {
+      description: 'Time spent reconciling agents controller resources.',
+      unit: 'ms',
+    }),
+    sseConnections: meter.createCounter('agents_sse_connections_total', {
+      description: 'Count of SSE connections opened/closed.',
+    }),
+    sseErrors: meter.createCounter('agents_sse_errors_total', {
+      description: 'Count of SSE errors emitted to clients.',
+    }),
+  }
+  globalState.__agentsMetrics.instruments = instruments
+  return instruments
 }
 
 export const recordAgentQueueDepth = (depth: number, attributes?: MetricsAttributes) => {
-  metricsSink.recordAgentQueueDepth?.(depth, attributes)
+  if (configuredMetricsSink.recordAgentQueueDepth) {
+    configuredMetricsSink.recordAgentQueueDepth(depth, attributes)
+    return
+  }
+  recordHistogram(getAgentsMetricInstruments().agentQueueDepth, depth, attributes)
 }
 
 export const recordAgentRateLimitRejection = (scope: string, attributes?: MetricsAttributes) => {
-  metricsSink.recordAgentRateLimitRejection?.(scope, attributes)
+  if (configuredMetricsSink.recordAgentRateLimitRejection) {
+    configuredMetricsSink.recordAgentRateLimitRejection(scope, attributes)
+    return
+  }
+  recordCounter(getAgentsMetricInstruments().agentRateLimitRejections, 1, { scope, ...attributes })
 }
 
 export const recordAgentConcurrency = (count: number, attributes?: MetricsAttributes) => {
-  metricsSink.recordAgentConcurrency?.(count, attributes)
+  if (configuredMetricsSink.recordAgentConcurrency) {
+    configuredMetricsSink.recordAgentConcurrency(count, attributes)
+    return
+  }
+  recordHistogram(getAgentsMetricInstruments().agentConcurrency, count, attributes)
 }
 
 export const recordAgentRunOutcome = (outcome: string, attributes?: MetricsAttributes) => {
-  metricsSink.recordAgentRunOutcome?.(outcome, attributes)
+  if (configuredMetricsSink.recordAgentRunOutcome) {
+    configuredMetricsSink.recordAgentRunOutcome(outcome, attributes)
+    return
+  }
+  recordCounter(getAgentsMetricInstruments().agentRunOutcomes, 1, { outcome, ...attributes })
 }
 
 export const recordAgentRunResyncAdoptions = (count: number, attributes?: MetricsAttributes) => {
-  metricsSink.recordAgentRunResyncAdoptions?.(count, attributes)
+  if (configuredMetricsSink.recordAgentRunResyncAdoptions) {
+    configuredMetricsSink.recordAgentRunResyncAdoptions(count, attributes)
+    return
+  }
+  if (Number.isFinite(count) && count > 0) {
+    recordCounter(getAgentsMetricInstruments().agentRunResyncAdoptions, count, attributes)
+  }
 }
 
 export const recordAgentRunUntouchedBacklog = (count: number, attributes?: MetricsAttributes) => {
-  metricsSink.recordAgentRunUntouchedBacklog?.(count, attributes)
+  if (configuredMetricsSink.recordAgentRunUntouchedBacklog) {
+    configuredMetricsSink.recordAgentRunUntouchedBacklog(count, attributes)
+    return
+  }
+  if (count >= 0) {
+    recordHistogram(getAgentsMetricInstruments().agentRunUntouchedBacklog, count, attributes)
+  }
 }
 
 export const recordAgentRunUntouchedOldestAgeSeconds = (ageSeconds: number, attributes?: MetricsAttributes) => {
-  metricsSink.recordAgentRunUntouchedOldestAgeSeconds?.(ageSeconds, attributes)
+  if (configuredMetricsSink.recordAgentRunUntouchedOldestAgeSeconds) {
+    configuredMetricsSink.recordAgentRunUntouchedOldestAgeSeconds(ageSeconds, attributes)
+    return
+  }
+  if (ageSeconds >= 0) {
+    recordHistogram(getAgentsMetricInstruments().agentRunUntouchedOldestAgeSeconds, ageSeconds, attributes)
+  }
 }
 
 export const recordReconcileDurationMs = (durationMs: number, attributes?: MetricsAttributes) => {
-  metricsSink.recordReconcileDurationMs?.(durationMs, attributes)
+  if (configuredMetricsSink.recordReconcileDurationMs) {
+    configuredMetricsSink.recordReconcileDurationMs(durationMs, attributes)
+    return
+  }
+  if (durationMs >= 0) {
+    recordHistogram(getAgentsMetricInstruments().reconcileDurationMs, durationMs, attributes)
+  }
 }
 
 export const recordSseConnection = (stream: string, state: string, attributes?: MetricsAttributes) => {
-  metricsSink.recordSseConnection?.(stream, state, attributes)
+  if (configuredMetricsSink.recordSseConnection) {
+    configuredMetricsSink.recordSseConnection(stream, state, attributes)
+    return
+  }
+  recordCounter(getAgentsMetricInstruments().sseConnections, 1, { stream, state, ...attributes })
 }
 
 export const recordSseError = (stream: string, phase: string, attributes?: MetricsAttributes) => {
-  metricsSink.recordSseError?.(stream, phase, attributes)
+  if (configuredMetricsSink.recordSseError) {
+    configuredMetricsSink.recordSseError(stream, phase, attributes)
+    return
+  }
+  recordCounter(getAgentsMetricInstruments().sseErrors, 1, { stream, phase, ...attributes })
+}
+
+export const __private = {
+  resetForTests: () => {
+    delete globalState.__agentsMetrics
+    for (const key of Object.keys(configuredMetricsSink) as Array<keyof AgentsMetricsSink>) {
+      delete configuredMetricsSink[key]
+    }
+  },
 }


### PR DESCRIPTION
## Summary

- Rebrands Agents chart metadata, README, install notes, and platform swarm examples away from Jangar ownership.
- Renames the generic platform swarm manifests from `jangar-control-plane` to `agents-platform`.
- Adds Agents-owned Prometheus metric instruments and switches the chart dashboard to `agents_*` metrics.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test -- src/server/metrics.test.ts`
- `bun run --cwd services/agents tsc`
- `bun run --cwd services/agents lint`
- `bun run --cwd services/agents test`
- `helm lint charts/agents`
- `helm template agents charts/agents --namespace agents`
- `kubectl kustomize argocd/applications/agents --enable-helm`
- `scripts/agents/guard-extraction-boundaries.sh`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

Renames the platform Swarm and its template AgentRuns from `jangar-control-plane` / `jangar-swarm-*` to `agents-platform` / `agents-platform-swarm-*`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
