### PR TITLE
build(agents): slim codex runner image

### DIFF
--- a/services/agents/Dockerfile.codex-runner
+++ b/services/agents/Dockerfile.codex-runner
@@ -5,10 +5,58 @@ ARG NODE_VERSION=24.11.1
 
 FROM node:${NODE_VERSION}-bookworm-slim AS node-runtime
 
+FROM oven/bun:${BUN_VERSION}-slim AS codex-cli
+
+ARG CODEX_VERSION=0.130.0
+
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+RUN npm install -g "@openai/codex@${CODEX_VERSION}" \
+    && npm cache clean --force \
+    && test -x /usr/local/bin/codex
+
+FROM oven/bun:${BUN_VERSION}-slim AS codex-package-build
+
+RUN set -eux; \
+    apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20 \
+    && apt-get install -y -V --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      git \
+      pkg-config \
+      python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY packages/codex/package.json /opt/proompteng/packages/codex/package.json
+COPY packages/codex/tsconfig.json /opt/proompteng/packages/codex/tsconfig.json
+COPY packages/codex/src /opt/proompteng/packages/codex/src
+COPY tsconfig.base.json /opt/proompteng/tsconfig.base.json
+
+RUN bash -lc 'cd /opt/proompteng/packages/codex && bun install --no-save && bun run build && rm -rf node_modules'
+
+FROM oven/bun:${BUN_VERSION}-slim AS agents-runner-build
+
+WORKDIR /opt/proompteng
+
+COPY --from=codex-package-build /opt/proompteng/packages/codex/package.json packages/codex/package.json
+COPY --from=codex-package-build /opt/proompteng/packages/codex/dist packages/codex/dist
+COPY services/agents/package.json services/agents/package.json
+COPY services/agents/src/runner services/agents/src/runner
+COPY services/agents/scripts/codex services/agents/scripts/codex
+
+RUN printf '%s\n' '{"type":"module","dependencies":{"effect":"3.21.2"}}' > package.json \
+    && bun install --production --no-save \
+    && mkdir -p node_modules/@proompteng \
+    && ln -s /opt/proompteng/packages/codex node_modules/@proompteng/codex \
+    && bun build services/agents/scripts/codex/agent-runner.ts --target bun --outfile /opt/agents-runner/agent-runner.js
+
 FROM oven/bun:${BUN_VERSION}-slim
 
 ARG CODEX_AUTH_CHECKSUM=unspecified
-ARG CODEX_VERSION=0.130.0
 
 ENV DEBIAN_FRONTEND=noninteractive \
     WORKSPACE=/workspace \
@@ -21,32 +69,27 @@ ENV DEBIAN_FRONTEND=noninteractive \
     BUN_INSTALL_CACHE_SEED_DIR=/opt/bun/install/cache
 
 COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
-COPY --from=node-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=codex-cli /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
-    && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+    && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && ln -sf ../lib/node_modules/@openai/codex/bin/codex.js /usr/local/bin/codex \
+    && ln -sf /usr/local/bin/codex /usr/bin/codex \
+    && test -x /usr/local/bin/codex \
+    && test -x /usr/bin/codex
 
 RUN set -eux; \
     apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20 \
     && apt-get install -y -V --no-install-recommends \
       bash \
-      build-essential \
       ca-certificates \
       curl \
       gh \
       git \
       jq \
       openssh-client \
-      pkg-config \
       python3 \
     && rm -rf /var/lib/apt/lists/*
-
-RUN npm install -g "@openai/codex@${CODEX_VERSION}" node-gyp \
-    && ln -sf /usr/local/bin/codex /usr/bin/codex \
-    && npm cache clean --force \
-    && test -x /usr/local/bin/codex \
-    && test -x /usr/bin/codex \
-    && test -x /usr/local/bin/node-gyp
 
 RUN mkdir -p "$WORKSPACE" /root/.codex "$BUN_INSTALL_CACHE_DIR"
 
@@ -55,15 +98,13 @@ RUN --mount=type=secret,id=codexauth,target=/tmp/codex_auth.json \
     && printf '%s\n' "${CODEX_AUTH_CHECKSUM}" > /root/.codex/auth.checksum
 
 COPY services/agents/scripts/codex-config-container.toml /root/.codex/config.toml
-COPY services/agents /app/services/agents
-COPY packages/codex /opt/proompteng/packages/codex
-COPY tsconfig.base.json /opt/proompteng/tsconfig.base.json
+RUN mkdir -p /app/services/agents/scripts/codex /app/node_modules/@proompteng/codex
+COPY --from=agents-runner-build /opt/agents-runner/agent-runner.js /app/services/agents/scripts/codex/agent-runner.js
+COPY --from=codex-package-build /opt/proompteng/packages/codex/package.json /app/node_modules/@proompteng/codex/package.json
+COPY --from=codex-package-build /opt/proompteng/packages/codex/dist /app/node_modules/@proompteng/codex/dist
 
-RUN bash -lc 'cd /opt/proompteng/packages/codex && bun install --no-save && bun run build'
-RUN mkdir -p /app/node_modules/@proompteng \
-    && cp -R /opt/proompteng/packages/codex /app/node_modules/@proompteng/codex \
-    && ln -sf /app/services/agents/scripts/codex/agent-runner.ts /usr/local/bin/agent-runner \
-    && chmod +x /app/services/agents/scripts/codex/agent-runner.ts
+RUN printf '%s\n' '#!/bin/sh' 'exec bun /app/services/agents/scripts/codex/agent-runner.js "$@"' > /usr/local/bin/agent-runner \
+    && chmod +x /usr/local/bin/agent-runner /app/services/agents/scripts/codex/agent-runner.js
 
 WORKDIR /workspace
 CMD ["bash"]

--- a/services/agents/src/runner/codex-runner-image-layout.test.ts
+++ b/services/agents/src/runner/codex-runner-image-layout.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+const dockerfile = () => readFileSync(new URL('../../Dockerfile.codex-runner', import.meta.url), 'utf8')
+
+const finalStage = () => {
+  const content = dockerfile()
+  const start = content.lastIndexOf('\nFROM ')
+  expect(start).toBeGreaterThanOrEqual(0)
+  return content.slice(start + 1)
+}
+
+describe('Agents Codex runner image layout', () => {
+  it('does not use the OpenAI universal image or Jangar runner scripts', () => {
+    const content = dockerfile()
+
+    expect(content).not.toContain('ghcr.io/openai/codex-universal')
+    expect(content).not.toContain('services/jangar')
+    expect(content).not.toContain('codex-implement')
+  })
+
+  it('keeps native build tooling out of the final runtime stage', () => {
+    const content = finalStage()
+
+    expect(content).not.toContain('build-essential')
+    expect(content).not.toContain('pkg-config')
+    expect(content).not.toContain('node-gyp')
+  })
+
+  it('copies only built runner and Codex package payloads into the final image', () => {
+    const content = finalStage()
+
+    expect(content).toContain(
+      'COPY --from=agents-runner-build /opt/agents-runner/agent-runner.js /app/services/agents/scripts/codex/agent-runner.js',
+    )
+    expect(content).toContain(
+      'COPY --from=codex-package-build /opt/proompteng/packages/codex/dist /app/node_modules/@proompteng/codex/dist',
+    )
+    expect(content).not.toContain('COPY services/agents /app/services/agents')
+    expect(content).not.toContain('COPY packages/codex /opt/proompteng/packages/codex')
+    expect(content).not.toContain('cp -R /opt/proompteng/packages/codex')
+  })
+})


### PR DESCRIPTION
## Summary

- Splits the Agents Codex runner Dockerfile into build-only stages for Codex package compilation and runner bundling.
- Keeps native build tooling and node-gyp out of the final runtime image while retaining Codex CLI, Node, Bun, git, gh, and jq runtime tools.
- Copies only built Codex package output and bundled `agent-runner.js` into the final image, with regression coverage blocking Jangar and `codex-implement` paths.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test -- src/runner/codex-app-server.test.ts src/runner/spec.test.ts src/runner/codex-runner-image-layout.test.ts`
- `bunx oxfmt --check services/agents/src/runner/codex-runner-image-layout.test.ts`
- `git diff --check`
- `DOCKER_BUILDKIT=1 docker build $SECRET_ARG -f services/agents/Dockerfile.codex-runner --build-arg CODEX_AUTH_CHECKSUM=local --build-arg CODEX_VERSION=0.130.0 -t agents-codex-runner-slim:test .`
- `docker run --rm agents-codex-runner-slim:test bash -lc 'set -euo pipefail; codex --version; node --version; bun --version; if command -v gcc >/dev/null || command -v node-gyp >/dev/null || command -v pkg-config >/dev/null; then echo "unexpected build tooling in final image" >&2; exit 1; fi; agent-runner >/tmp/agent-runner.err 2>&1 && { echo "agent-runner unexpectedly succeeded without spec" >&2; exit 1; } || true; grep -q "agent-runner requires a JSON spec" /tmp/agent-runner.err; test -f /app/node_modules/@proompteng/codex/dist/index.js; test ! -d /app/node_modules/@proompteng/codex/src; test ! -d /app/services/agents/src; du -sh /app/node_modules/@proompteng/codex /app/services/agents/scripts/codex/agent-runner.js'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
