### PR TITLE
fix(agents): stop pinning universal runner examples

### DIFF
--- a/charts/agents/examples/agentrun-mapped-linear.yaml
+++ b/charts/agents/examples/agentrun-mapped-linear.yaml
@@ -22,7 +22,7 @@ spec:
         parameters:
           stage: implement
   workload:
-    image: registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl
+    # Intentionally omit workload.image so the controller-managed runner image is used.
     resources:
       requests:
         cpu: 250m

--- a/charts/agents/examples/agentrun-native-workflow.yaml
+++ b/charts/agents/examples/agentrun-native-workflow.yaml
@@ -17,7 +17,7 @@ spec:
         parameters:
           stage: implement
   workload:
-    image: registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl
+    # Intentionally omit workload.image so the controller-managed runner image is used.
     resources:
       requests:
         cpu: 250m

--- a/charts/agents/examples/agentrun-sample.yaml
+++ b/charts/agents/examples/agentrun-sample.yaml
@@ -22,7 +22,7 @@ spec:
         parameters:
           stage: implement
   workload:
-    image: registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl
+    # Intentionally omit workload.image so the controller-managed runner image is used.
     resources:
       requests:
         cpu: 250m

--- a/docs/agents/designs/runner-image-defaults-job-ttl.md
+++ b/docs/agents/designs/runner-image-defaults-job-ttl.md
@@ -11,34 +11,34 @@ cleanup.
 
 ## Current State
 
-- Runtime image selection in `services/jangar/src/server/agents-controller.ts`:
-  - Job runtime requires `spec.workload.image`, `JANGAR_AGENT_RUNNER_IMAGE`, or `JANGAR_AGENT_IMAGE`.
+- Runtime image selection in `services/agents/src/server/agents-controller/**`:
+  - Job runtime requires `spec.workload.image`, `AGENTS_AGENT_RUNNER_IMAGE`, or `AGENTS_AGENT_IMAGE`.
   - Workflow runtime requires the same image inputs.
 - Chart defaults:
-  - `runner.image.repository` defaults to `registry.ide-newton.ts.net/lab/codex-universal` in
+  - `runner.image.repository` defaults to the Agents-owned Codex runner image in
     `charts/agents/values.yaml`.
-  - The deployment template sets `JANGAR_AGENT_RUNNER_IMAGE` when `runner.image.repository` is present.
+  - The deployment template sets `AGENTS_AGENT_RUNNER_IMAGE` when `runner.image.repository` is present.
 - Job TTL:
-  - `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS` defaults to 600 seconds.
+  - `AGENTS_AGENT_RUNNER_JOB_TTL_SECONDS` defaults to 600 seconds.
   - `spec.runtime.config.ttlSecondsAfterFinished` overrides the env value.
   - TTL is clamped to `[30s, 7d]`.
-- Cluster (GitOps desired state): `JANGAR_AGENT_RUNNER_IMAGE` resolves to
-  `registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl`
-  via `runner.image.*` in `argocd/applications/agents/values.yaml`. `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS` is set
+- Cluster (GitOps desired state): `AGENTS_AGENT_RUNNER_IMAGE` resolves to
+  `registry.ide-newton.ts.net/lab/agents-codex-runner:<promoted tag>`
+  via `runner.image.*` in `argocd/applications/agents/values.yaml`. `AGENTS_AGENT_RUNNER_JOB_TTL_SECONDS` is set
   to 600, matching chart defaults.
 
 ## Design
 
-- Ensure `JANGAR_AGENT_RUNNER_IMAGE` is always set in chart values for production.
+- Ensure `AGENTS_AGENT_RUNNER_IMAGE` is always set in chart values for production.
 - Keep Job TTL defaults high enough to allow status reconciliation and artifact collection.
 - Allow per-run overrides via `spec.runtime.config.ttlSecondsAfterFinished`.
 
 ## Configuration
 
-- `runner.image.repository`, `runner.image.tag`, `runner.image.digest` map to `JANGAR_AGENT_RUNNER_IMAGE`.
-- `controller.jobTtlSecondsAfterFinished` maps to `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`.
+- `runner.image.repository`, `runner.image.tag`, `runner.image.digest` map to `AGENTS_AGENT_RUNNER_IMAGE`.
+- `controller.jobTtlSecondsAfterFinished` maps to `AGENTS_AGENT_RUNNER_JOB_TTL_SECONDS`.
 - AgentRun retention is controlled separately by `spec.ttlSecondsAfterFinished` and
-  `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`.
+  `AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`.
 
 ## Validation
 
@@ -128,14 +128,14 @@ Common mappings:
 - `controller.concurrency.*` → `JANGAR_AGENTS_CONTROLLER_CONCURRENCY_{NAMESPACE,AGENT,CLUSTER}`
 - `controller.queue.*` → `JANGAR_AGENTS_CONTROLLER_QUEUE_{NAMESPACE,REPO,CLUSTER}`
 - `controller.rate.*` → `JANGAR_AGENTS_CONTROLLER_RATE_{WINDOW_SECONDS,NAMESPACE,REPO,CLUSTER}`
-- `controller.agentRunRetentionSeconds` → `JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
+- `controller.agentRunRetentionSeconds` → `AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS`
 - `controller.admissionPolicy.*` → `JANGAR_AGENTS_CONTROLLER_{LABELS_REQUIRED,LABELS_ALLOWED,LABELS_DENIED,IMAGES_ALLOWED,IMAGES_DENIED,BLOCKED_SECRETS}`
 - `controller.vcsProviders.*` → `JANGAR_AGENTS_CONTROLLER_VCS_{PROVIDERS_ENABLED,DEPRECATED_TOKEN_TYPES,PR_RATE_LIMITS}`
 - `controller.authSecret.*` → `JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_{NAME,KEY,MOUNT_PATH}`
 - `orchestrationController.*` → `JANGAR_ORCHESTRATION_CONTROLLER_{ENABLED,NAMESPACES}`
 - `supportingController.*` → `JANGAR_SUPPORTING_CONTROLLER_{ENABLED,NAMESPACES}`
 - `grpc.*` → `JANGAR_GRPC_{ENABLED,HOST,PORT}` (unless overridden via `env.vars`)
-- `controller.jobTtlSecondsAfterFinished` → `JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS`
+- `controller.jobTtlSecondsAfterFinished` → `AGENTS_AGENT_RUNNER_JOB_TTL_SECONDS`
 - `runtime.*` → `JANGAR_{AGENT_RUNNER_IMAGE,AGENT_IMAGE,SCHEDULE_RUNNER_IMAGE,SCHEDULE_SERVICE_ACCOUNT}` (unless overridden via `env.vars`)
 
 ### Rollout plan (GitOps)

--- a/scripts/agents/native-workflow-e2e.sh
+++ b/scripts/agents/native-workflow-e2e.sh
@@ -19,7 +19,7 @@ ISSUE_URL="${AGENTS_E2E_ISSUE_URL:-https://github.com/${REPOSITORY}/issues/${ISS
 BASE_BRANCH="${AGENTS_E2E_BASE:-main}"
 HEAD_BRANCH="${AGENTS_E2E_HEAD:-codex/agents/${ISSUE_NUMBER}}"
 PROMPT="${AGENTS_E2E_PROMPT:-Identify and implement a meaningful improvement to the Agents Helm chart. Prefer changes that touch templates plus values.yaml and values.schema.json (for example, missing validations, optional settings, or security hardening). Keep scope to charts/agents/** and docs/agents/**. Avoid doc-only updates. Deliver a real feature or hardening change with supporting tests/examples if needed.}"
-WORKLOAD_IMAGE="${AGENTS_E2E_WORKLOAD_IMAGE:-registry.ide-newton.ts.net/lab/codex-universal:20260219-234214-2a44dd59-dl}"
+WORKLOAD_IMAGE="${AGENTS_E2E_WORKLOAD_IMAGE:-}"
 SECRET_NAME="${AGENTS_E2E_SECRET_NAME:-codex-github-token}"
 OPENAI_SECRET_NAME="${AGENTS_E2E_OPENAI_SECRET_NAME:-codex-openai-key}"
 OPENAI_KEY="${AGENTS_E2E_OPENAI_KEY:-${OPENAI_API_KEY:-}}"
@@ -45,6 +45,12 @@ log() {
 indent_prompt() {
   local indented="${PROMPT//$'\n'/$'\n      '}"
   printf '      %s\n' "${indented}"
+}
+
+render_workload_image() {
+  if [[ -n "${WORKLOAD_IMAGE}" ]]; then
+    printf '    image: %s\n' "${WORKLOAD_IMAGE}"
+  fi
 }
 
 wait_for_phase() {
@@ -142,7 +148,7 @@ spec:
         parameters:
           stage: implement
   workload:
-    image: ${WORKLOAD_IMAGE}
+$(render_workload_image)
     resources:
       requests:
         cpu: 250m

--- a/scripts/agents/validate-agents.sh
+++ b/scripts/agents/validate-agents.sh
@@ -10,6 +10,20 @@ KUBE_VERSION_FOR_HELM="${KUBE_VERSION_FOR_HELM:-${HELM_KUBE_VERSION:-1.35.0}}"
 DUMMY_IMAGE_DIGEST="sha256:0000000000000000000000000000000000000000000000000000000000000000"
 TEST_IMAGE_DIGEST="sha256:c1fe1679c34d9784c1b0d1e5f62ac0a79fca01fb6377cdd33e90473c6f9f9a69"
 
+if command -v rg >/dev/null 2>&1; then
+  if rg -n "codex-universal|ghcr.io/openai/codex-universal" \
+    "${CHART_DIR}/examples" \
+    "${ROOT_DIR}/scripts/agents/native-workflow-e2e.sh"; then
+    echo "Agents examples must use the chart-managed agents-codex-runner image, not codex-universal." >&2
+    exit 1
+  fi
+elif grep -R -n -E "codex-universal|ghcr\.io/openai/codex-universal" \
+  "${CHART_DIR}/examples" \
+  "${ROOT_DIR}/scripts/agents/native-workflow-e2e.sh"; then
+  echo "Agents examples must use the chart-managed agents-codex-runner image, not codex-universal." >&2
+  exit 1
+fi
+
 curl_with_retry() {
   curl \
     --connect-timeout 20 \


### PR DESCRIPTION
## Summary

- Removes `codex-universal` image pins from shipped Agents AgentRun examples so they use the chart-managed runner image default.
- Makes `AGENTS_E2E_WORKLOAD_IMAGE` optional in the native workflow e2e script while preserving explicit image override support.
- Adds a validation guard preventing Agents examples and the native workflow e2e script from reintroducing `codex-universal`.

## Related Issues

None

## Testing

- `bash -n scripts/agents/validate-agents.sh scripts/agents/native-workflow-e2e.sh`
- `scripts/agents/validate-agents.sh`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
