### PR TITLE
fix(agents): stop defaulting db secret alias to jangar

### DIFF
--- a/packages/scripts/src/agents/__tests__/deploy-service.test.ts
+++ b/packages/scripts/src/agents/__tests__/deploy-service.test.ts
@@ -217,6 +217,41 @@ runner:
     ).toBeNull()
   })
 
+  it('defaults database secret alias source to the Agents-owned target secret', () => {
+    const previousNamespace = process.env.AGENTS_DB_SECRET_SOURCE_NAMESPACE
+    const previousName = process.env.AGENTS_DB_SECRET_SOURCE_NAME
+    try {
+      delete process.env.AGENTS_DB_SECRET_SOURCE_NAMESPACE
+      delete process.env.AGENTS_DB_SECRET_SOURCE_NAME
+      expect(
+        __private.resolveDatabaseSecretSource({
+          namespace: 'agents',
+          name: 'agents-db-app',
+        }),
+      ).toEqual({
+        sourceNamespace: 'agents',
+        sourceName: 'agents-db-app',
+      })
+
+      process.env.AGENTS_DB_SECRET_SOURCE_NAMESPACE = 'jangar'
+      process.env.AGENTS_DB_SECRET_SOURCE_NAME = 'jangar-db-app'
+      expect(
+        __private.resolveDatabaseSecretSource({
+          namespace: 'agents',
+          name: 'agents-db-app',
+        }),
+      ).toEqual({
+        sourceNamespace: 'jangar',
+        sourceName: 'jangar-db-app',
+      })
+    } finally {
+      if (previousNamespace === undefined) delete process.env.AGENTS_DB_SECRET_SOURCE_NAMESPACE
+      else process.env.AGENTS_DB_SECRET_SOURCE_NAMESPACE = previousNamespace
+      if (previousName === undefined) delete process.env.AGENTS_DB_SECRET_SOURCE_NAME
+      else process.env.AGENTS_DB_SECRET_SOURCE_NAME = previousName
+    }
+  })
+
   it('builds an Agents-owned compatibility database secret without source ownership metadata', () => {
     const manifest = __private.buildDatabaseSecretAliasManifest(
       {

--- a/packages/scripts/src/agents/deploy-service.ts
+++ b/packages/scripts/src/agents/deploy-service.ts
@@ -515,6 +515,11 @@ const buildDatabaseSecretAliasManifest = (
   },
 })
 
+const resolveDatabaseSecretSource = (requirement: DatabaseSecretRequirement) => ({
+  sourceNamespace: process.env.AGENTS_DB_SECRET_SOURCE_NAMESPACE ?? requirement.namespace,
+  sourceName: process.env.AGENTS_DB_SECRET_SOURCE_NAME ?? requirement.name,
+})
+
 const ensureDatabaseSecretReady = async (requirement: DatabaseSecretRequirement | null) => {
   if (!requirement) return
   ensureCli('kubectl')
@@ -536,12 +541,11 @@ const ensureDatabaseSecretReady = async (requirement: DatabaseSecretRequirement 
 
   if (!parseBoolean(process.env.AGENTS_CREATE_DB_SECRET_ALIAS, false)) {
     fatal(
-      `Database secret ${requirement.namespace}/${requirement.name} is missing. Create/migrate the Agents database secret before applying, or set AGENTS_CREATE_DB_SECRET_ALIAS=true to copy the configured compatibility source secret for this rollout.`,
+      `Database secret ${requirement.namespace}/${requirement.name} is missing. Create/migrate the Agents database secret before applying, or set AGENTS_CREATE_DB_SECRET_ALIAS=true with AGENTS_DB_SECRET_SOURCE_NAME set explicitly to copy a compatibility source secret for this rollout.`,
     )
   }
 
-  const sourceNamespace = process.env.AGENTS_DB_SECRET_SOURCE_NAMESPACE ?? requirement.namespace
-  const sourceName = process.env.AGENTS_DB_SECRET_SOURCE_NAME ?? 'jangar-db-app'
+  const { sourceNamespace, sourceName } = resolveDatabaseSecretSource(requirement)
   const source = await capture(['kubectl', '-n', sourceNamespace, 'get', 'secret', sourceName, '-o', 'json'])
   const manifest = buildDatabaseSecretAliasManifest(JSON.parse(source) as KubernetesSecretManifest, {
     sourceNamespace,
@@ -694,5 +698,6 @@ export const __private = {
   updateValuesFile,
   readRunnerImagePin,
   resolveDatabaseSecretRequirement,
+  resolveDatabaseSecretSource,
   buildDatabaseSecretAliasManifest,
 }


### PR DESCRIPTION
## Summary

- Stops Agents deploy-service database alias creation from implicitly copying `jangar-db-app`.
- Defaults the alias source to the Agents-owned target secret and requires explicit `AGENTS_DB_SECRET_SOURCE_NAME` for compatibility copies.
- Adds regression coverage for default Agents-owned source resolution and explicit legacy-source override.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/deploy-service.test.ts`
- `bunx oxfmt --check packages/scripts/src/agents/deploy-service.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts`
- `git diff --check`
- `bun test packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/build-image.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

Operators using `AGENTS_CREATE_DB_SECRET_ALIAS=true` to copy from `jangar-db-app` must now set `AGENTS_DB_SECRET_SOURCE_NAME=jangar-db-app` explicitly.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
