### PR TITLE
refactor(agents): cut jangar env aliases from controller

### DIFF
--- a/docs/agents/jangar-controller-design.md
+++ b/docs/agents/jangar-controller-design.md
@@ -142,9 +142,7 @@ AgentProvider defines how to invoke `/usr/local/bin/agent-runner`:
 - Render `argsTemplate` and `envTemplate` against resolved AgentRun + ImplementationSpec data.
 - Materialize `inputFiles` into the runtime workspace.
 - Collect `outputArtifacts` paths.
-- Payload key compatibility:
-  - prefer `payloads.eventFilePath` in provider `argsTemplate`,
-  - `payloads.eventBodyPath` is emitted as a compatibility alias to the same `/workspace/run.json` payload.
+- Provider templates use the versioned `payloads.eventFilePath` contract for the `/workspace/run.json` payload.
 
 Agent-runner spec (contract):
 

--- a/services/agents/src/runner/codex-app-server.test.ts
+++ b/services/agents/src/runner/codex-app-server.test.ts
@@ -121,6 +121,34 @@ describe('codex app-server runner adapter', () => {
     expect(await readFile(logPath, 'utf8')).toContain('"delta":"done"')
   })
 
+  it('requires the versioned payload eventFilePath contract', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'agents-codex-runner-'))
+    const statusPath = join(dir, 'status.json')
+
+    await expect(
+      runCodexAppServerAdapter(
+        {
+          provider: 'codex-runner',
+          payloads: {},
+          artifacts: { statusPath },
+        },
+        {},
+        {
+          createClient: () => {
+            throw new Error('client should not start')
+          },
+        },
+      ),
+    ).rejects.toBeInstanceOf(CodexRunnerInputError)
+
+    const status = JSON.parse(await readFile(statusPath, 'utf8')) as Record<string, unknown>
+    expect(status).toMatchObject({
+      exitCode: 1,
+      status: 'failed',
+    })
+    expect(String(status.error)).toContain('payloads.eventFilePath')
+  })
+
   it('creates a non-VCS cwd before starting Codex app-server', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'agents-codex-runner-'))
     const runPath = join(dir, 'run.json')

--- a/services/agents/src/runner/codex-app-server.ts
+++ b/services/agents/src/runner/codex-app-server.ts
@@ -190,9 +190,13 @@ const readJsonFile = async (path: string): Promise<AgentRunPayload> => {
 }
 
 const loadRunPayload = async (spec: AgentRunnerSpec): Promise<AgentRunPayload> => {
-  const payloadPath = asString(spec.payloads?.eventFilePath) ?? asString(spec.payloads?.eventBodyPath)
+  const payloadPath = asString(spec.payloads?.eventFilePath)
   if (!payloadPath) {
-    return {}
+    throw new CodexRunnerInputError({
+      operation: 'load-payload',
+      path: 'payloads.eventFilePath',
+      cause: new Error('agent-runner payloads.eventFilePath is required'),
+    })
   }
   return readJsonFile(payloadPath)
 }

--- a/services/agents/src/server/agents-controller/agentrun-artifacts.test.ts
+++ b/services/agents/src/server/agents-controller/agentrun-artifacts.test.ts
@@ -7,14 +7,14 @@ import {
 } from '~/server/agents-controller/agentrun-artifacts'
 
 afterEach(() => {
-  delete process.env.JANGAR_AGENTRUN_ARTIFACTS_MAX
-  delete process.env.JANGAR_AGENTRUN_ARTIFACTS_STRICT
+  delete process.env.AGENTS_AGENTRUN_ARTIFACTS_MAX
+  delete process.env.AGENTS_AGENTRUN_ARTIFACTS_STRICT
 })
 
 describe('agentrun artifacts limits module', () => {
   it('uses env parsing fallbacks and accepts override values', () => {
-    process.env.JANGAR_AGENTRUN_ARTIFACTS_MAX = '7'
-    process.env.JANGAR_AGENTRUN_ARTIFACTS_STRICT = 'yes'
+    process.env.AGENTS_AGENTRUN_ARTIFACTS_MAX = '7'
+    process.env.AGENTS_AGENTRUN_ARTIFACTS_STRICT = 'yes'
 
     const fromEnv = resolveAgentRunArtifactsLimitConfig()
     expect(fromEnv).toEqual({
@@ -23,8 +23,8 @@ describe('agentrun artifacts limits module', () => {
       urlMaxLength: 2048,
     })
 
-    process.env.JANGAR_AGENTRUN_ARTIFACTS_MAX = 'invalid'
-    process.env.JANGAR_AGENTRUN_ARTIFACTS_STRICT = 'maybe'
+    process.env.AGENTS_AGENTRUN_ARTIFACTS_MAX = 'invalid'
+    process.env.AGENTS_AGENTRUN_ARTIFACTS_STRICT = 'maybe'
 
     const fallback = resolveAgentRunArtifactsLimitConfig()
     expect(fallback).toEqual({
@@ -42,7 +42,7 @@ describe('agentrun artifacts limits module', () => {
   })
 
   it('caps maxEntries to the hard limit of 50', () => {
-    process.env.JANGAR_AGENTRUN_ARTIFACTS_MAX = '100'
+    process.env.AGENTS_AGENTRUN_ARTIFACTS_MAX = '100'
     const config = resolveAgentRunArtifactsLimitConfig()
     expect(config.maxEntries).toBe(50)
   })

--- a/services/agents/src/server/agents-controller/controller-config.ts
+++ b/services/agents/src/server/agents-controller/controller-config.ts
@@ -5,8 +5,6 @@ import { normalizeRepositoryKey, type RepoConcurrencyConfig } from './queue-stat
 type EnvSource = Record<string, string | undefined>
 
 const readAgentsEnv = (env: EnvSource, name: string): string | undefined => {
-  if (name.startsWith('AGENTS_')) return env[name] ?? env[`JANGAR_${name.slice('AGENTS_'.length)}`]
-  if (name.startsWith('JANGAR_')) return env[`AGENTS_${name.slice('JANGAR_'.length)}`] ?? env[name]
   return env[name]
 }
 

--- a/services/agents/src/server/agents-controller/env-config.test.ts
+++ b/services/agents/src/server/agents-controller/env-config.test.ts
@@ -13,7 +13,7 @@ import {
   parseStringList,
 } from '~/server/agents-controller/env-config'
 
-const TEST_ENV_KEY = 'JANGAR_AGENTS_CONTROLLER_ENV_CONFIG_TEST'
+const TEST_ENV_KEY = 'AGENTS_AGENTS_CONTROLLER_ENV_CONFIG_TEST'
 
 afterEach(() => {
   delete process.env[TEST_ENV_KEY]

--- a/services/agents/src/server/agents-controller/env-config.ts
+++ b/services/agents/src/server/agents-controller/env-config.ts
@@ -16,8 +16,6 @@ export const parseNumberEnv = (value: string | undefined, fallback: number, min 
 }
 
 export const readAgentsEnv = (name: string): string | undefined => {
-  if (name.startsWith('AGENTS_')) return process.env[name] ?? process.env[`JANGAR_${name.slice('AGENTS_'.length)}`]
-  if (name.startsWith('JANGAR_')) return process.env[`AGENTS_${name.slice('JANGAR_'.length)}`] ?? process.env[name]
   return process.env[name]
 }
 

--- a/services/agents/src/server/agents-controller/index.integration.test.ts
+++ b/services/agents/src/server/agents-controller/index.integration.test.ts
@@ -218,7 +218,40 @@ const buildVcsProvider = (overrides: Record<string, unknown> = {}) => ({
 })
 
 describe('agents controller startup', () => {
+  it('uses the Agents-owned startup feature flag without the legacy Jangar gate', async () => {
+    const previousNodeEnv = process.env.NODE_ENV
+    const previousVitest = process.env.VITEST
+    process.env.NODE_ENV = 'development'
+    delete process.env.VITEST
+    featureFlagsMocks.resolveBooleanFeatureToggle.mockClear()
+    featureFlagsMocks.resolveBooleanFeatureToggle.mockResolvedValueOnce(true)
+
+    try {
+      await expect(__test.resolveAgentsControllerFeatureEnabled()).resolves.toBe(true)
+
+      expect(featureFlagsMocks.resolveBooleanFeatureToggle).toHaveBeenCalledTimes(1)
+      expect(featureFlagsMocks.resolveBooleanFeatureToggle).toHaveBeenCalledWith({
+        key: 'agents.agents_controller.enabled',
+        keyEnvVar: 'AGENTS_AGENTS_CONTROLLER_ENABLED_FLAG_KEY',
+        fallbackEnvVar: 'AGENTS_AGENTS_CONTROLLER_ENABLED',
+        defaultValue: true,
+      })
+    } finally {
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = previousNodeEnv
+      }
+      if (previousVitest === undefined) {
+        delete process.env.VITEST
+      } else {
+        process.env.VITEST = previousVitest
+      }
+    }
+  })
+
   it('avoids duplicate startup when feature flag lookup is pending', async () => {
+    featureFlagsMocks.resolveBooleanFeatureToggle.mockClear()
     const previousNodeEnv = process.env.NODE_ENV
     const previousVitest = process.env.VITEST
     process.env.NODE_ENV = 'development'
@@ -511,7 +544,7 @@ describe('agents controller startup', () => {
 
   it('gates debug adoption logs behind the debug env flag', async () => {
     stopAgentsController()
-    const previousDebug = process.env.JANGAR_AGENTS_CONTROLLER_DEBUG_LOGS
+    const previousDebug = process.env.AGENTS_AGENTS_CONTROLLER_DEBUG_LOGS
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
     const state = { namespaces: new Map() }
     const kube = buildKube({
@@ -552,22 +585,22 @@ describe('agents controller startup', () => {
     })
 
     try {
-      delete process.env.JANGAR_AGENTS_CONTROLLER_DEBUG_LOGS
+      delete process.env.AGENTS_AGENTS_CONTROLLER_DEBUG_LOGS
       await __test.resyncAgentRunsForNamespace(kube as never, 'agents', state as never, defaultConcurrency, 'manual')
       let messages = infoSpy.mock.calls.map((call) => String(call[0]))
       expect(messages.some((message) => message.includes('agentrun_resync_adopted'))).toBe(false)
 
       infoSpy.mockClear()
-      process.env.JANGAR_AGENTS_CONTROLLER_DEBUG_LOGS = 'true'
+      process.env.AGENTS_AGENTS_CONTROLLER_DEBUG_LOGS = 'true'
       await __test.resyncAgentRunsForNamespace(kube as never, 'agents', state as never, defaultConcurrency, 'manual')
       messages = infoSpy.mock.calls.map((call) => String(call[0]))
       expect(messages.some((message) => message.includes('agentrun_resync_adopted'))).toBe(true)
     } finally {
       infoSpy.mockRestore()
       if (previousDebug === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_DEBUG_LOGS
+        delete process.env.AGENTS_AGENTS_CONTROLLER_DEBUG_LOGS
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_DEBUG_LOGS = previousDebug
+        process.env.AGENTS_AGENTS_CONTROLLER_DEBUG_LOGS = previousDebug
       }
     }
   })
@@ -660,7 +693,7 @@ describe('AgentRun artifacts limits', () => {
     const kube = buildKube()
     const agentRun = buildAgentRun()
 
-    process.env.JANGAR_AGENTRUN_ARTIFACTS_MAX = '100'
+    process.env.AGENTS_AGENTRUN_ARTIFACTS_MAX = '100'
 
     try {
       const artifacts = Array.from({ length: 60 }, (_, index) => ({
@@ -673,7 +706,7 @@ describe('AgentRun artifacts limits', () => {
         artifacts,
       })
     } finally {
-      delete process.env.JANGAR_AGENTRUN_ARTIFACTS_MAX
+      delete process.env.AGENTS_AGENTRUN_ARTIFACTS_MAX
     }
 
     const status = getLastStatus(kube as never)
@@ -697,8 +730,8 @@ describe('AgentRun artifacts limits', () => {
     const kube = buildKube()
     const agentRun = buildAgentRun()
 
-    process.env.JANGAR_AGENTRUN_ARTIFACTS_MAX = '2'
-    process.env.JANGAR_AGENTRUN_ARTIFACTS_STRICT = 'true'
+    process.env.AGENTS_AGENTRUN_ARTIFACTS_MAX = '2'
+    process.env.AGENTS_AGENTRUN_ARTIFACTS_STRICT = 'true'
 
     try {
       await __test.setStatus(kube as never, agentRun, {
@@ -706,8 +739,8 @@ describe('AgentRun artifacts limits', () => {
         artifacts: [{ name: 'a1' }, { name: 'a2' }, { name: 'a3' }],
       })
     } finally {
-      delete process.env.JANGAR_AGENTRUN_ARTIFACTS_MAX
-      delete process.env.JANGAR_AGENTRUN_ARTIFACTS_STRICT
+      delete process.env.AGENTS_AGENTRUN_ARTIFACTS_MAX
+      delete process.env.AGENTS_AGENTRUN_ARTIFACTS_STRICT
     }
 
     const status = getLastStatus(kube as never)
@@ -797,8 +830,8 @@ describe('agents controller reconcileAgentRun', () => {
   })
 
   it('applies configured runner resource defaults when an AgentRun omits workload resources', async () => {
-    const previousResources = process.env.JANGAR_AGENT_RUNNER_RESOURCES
-    process.env.JANGAR_AGENT_RUNNER_RESOURCES = JSON.stringify({
+    const previousResources = process.env.AGENTS_AGENT_RUNNER_RESOURCES
+    process.env.AGENTS_AGENT_RUNNER_RESOURCES = JSON.stringify({
       requests: {
         cpu: '1',
         memory: '2Gi',
@@ -866,9 +899,9 @@ describe('agents controller reconcileAgentRun', () => {
       })
     } finally {
       if (previousResources === undefined) {
-        delete process.env.JANGAR_AGENT_RUNNER_RESOURCES
+        delete process.env.AGENTS_AGENT_RUNNER_RESOURCES
       } else {
-        process.env.JANGAR_AGENT_RUNNER_RESOURCES = previousResources
+        process.env.AGENTS_AGENT_RUNNER_RESOURCES = previousResources
       }
     }
   })
@@ -926,8 +959,8 @@ describe('agents controller reconcileAgentRun', () => {
   })
 
   it('fails AgentRun when immutable spec fields drift after Accepted', async () => {
-    const previousEnforcement = process.env.JANGAR_AGENTRUN_IMMUTABILITY_ENFORCED
-    process.env.JANGAR_AGENTRUN_IMMUTABILITY_ENFORCED = 'true'
+    const previousEnforcement = process.env.AGENTS_AGENTRUN_IMMUTABILITY_ENFORCED
+    process.env.AGENTS_AGENTRUN_IMMUTABILITY_ENFORCED = 'true'
     try {
       const kube = buildKube({
         get: vi.fn(async (resource: string) => {
@@ -969,16 +1002,16 @@ describe('agents controller reconcileAgentRun', () => {
       expect(findCondition(status, 'Failed')?.reason).toBe('SpecImmutableViolation')
     } finally {
       if (previousEnforcement === undefined) {
-        delete process.env.JANGAR_AGENTRUN_IMMUTABILITY_ENFORCED
+        delete process.env.AGENTS_AGENTRUN_IMMUTABILITY_ENFORCED
       } else {
-        process.env.JANGAR_AGENTRUN_IMMUTABILITY_ENFORCED = previousEnforcement
+        process.env.AGENTS_AGENTRUN_IMMUTABILITY_ENFORCED = previousEnforcement
       }
     }
   }, 15_000)
 
   it('does not fail terminal AgentRuns when an older stored immutable spec hash differs', async () => {
-    const previousEnforcement = process.env.JANGAR_AGENTRUN_IMMUTABILITY_ENFORCED
-    process.env.JANGAR_AGENTRUN_IMMUTABILITY_ENFORCED = 'true'
+    const previousEnforcement = process.env.AGENTS_AGENTRUN_IMMUTABILITY_ENFORCED
+    process.env.AGENTS_AGENTRUN_IMMUTABILITY_ENFORCED = 'true'
     try {
       const kube = buildKube()
       const terminalRun = buildAgentRun({
@@ -1007,9 +1040,9 @@ describe('agents controller reconcileAgentRun', () => {
       expect(kube.applyStatus).not.toHaveBeenCalled()
     } finally {
       if (previousEnforcement === undefined) {
-        delete process.env.JANGAR_AGENTRUN_IMMUTABILITY_ENFORCED
+        delete process.env.AGENTS_AGENTRUN_IMMUTABILITY_ENFORCED
       } else {
-        process.env.JANGAR_AGENTRUN_IMMUTABILITY_ENFORCED = previousEnforcement
+        process.env.AGENTS_AGENTRUN_IMMUTABILITY_ENFORCED = previousEnforcement
       }
     }
   })
@@ -1414,10 +1447,10 @@ describe('agents controller reconcileAgentRun', () => {
   })
 
   it('marks AgentRun failed when job runtime lacks an image', async () => {
-    const previousImage = process.env.JANGAR_AGENT_RUNNER_IMAGE
-    const previousAgentImage = process.env.JANGAR_AGENT_IMAGE
-    delete process.env.JANGAR_AGENT_RUNNER_IMAGE
-    delete process.env.JANGAR_AGENT_IMAGE
+    const previousImage = process.env.AGENTS_AGENT_RUNNER_IMAGE
+    const previousAgentImage = process.env.AGENTS_AGENT_IMAGE
+    delete process.env.AGENTS_AGENT_RUNNER_IMAGE
+    delete process.env.AGENTS_AGENT_IMAGE
     const kube = buildKube()
     const agentRun = buildAgentRun({
       spec: {
@@ -1434,8 +1467,8 @@ describe('agents controller reconcileAgentRun', () => {
     const condition = findCondition(status, 'InvalidSpec')
     expect(condition?.reason).toBe('MissingWorkloadImage')
 
-    if (previousImage) process.env.JANGAR_AGENT_RUNNER_IMAGE = previousImage
-    if (previousAgentImage) process.env.JANGAR_AGENT_IMAGE = previousAgentImage
+    if (previousImage) process.env.AGENTS_AGENT_RUNNER_IMAGE = previousImage
+    if (previousAgentImage) process.env.AGENTS_AGENT_IMAGE = previousAgentImage
   })
 
   it('marks AgentRun failed when temporal runtime lacks workflowType and taskQueue', async () => {
@@ -1473,8 +1506,8 @@ describe('agents controller reconcileAgentRun', () => {
   })
 
   it('deletes completed AgentRun after retention window', async () => {
-    const previousRetention = process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
-    process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = '60'
+    const previousRetention = process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
+    process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = '60'
 
     try {
       const kube = buildKube()
@@ -1488,16 +1521,16 @@ describe('agents controller reconcileAgentRun', () => {
       expect(kube.delete).toHaveBeenCalledWith(RESOURCE_MAP.AgentRun, 'run-1', 'agents', { wait: false })
     } finally {
       if (previousRetention === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
+        delete process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = previousRetention
+        process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = previousRetention
       }
     }
   })
 
   it('respects per-run ttlSecondsAfterFinished override', async () => {
-    const previousRetention = process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
-    process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = '3600'
+    const previousRetention = process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
+    process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = '3600'
 
     try {
       const kube = buildKube()
@@ -1518,16 +1551,16 @@ describe('agents controller reconcileAgentRun', () => {
       expect(kube.delete).toHaveBeenCalledWith(RESOURCE_MAP.AgentRun, 'run-1', 'agents', { wait: false })
     } finally {
       if (previousRetention === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
+        delete process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = previousRetention
+        process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = previousRetention
       }
     }
   })
 
   it('disables retention when per-run ttlSecondsAfterFinished is zero', async () => {
-    const previousRetention = process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
-    process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = '60'
+    const previousRetention = process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
+    process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = '60'
 
     try {
       const kube = buildKube()
@@ -1548,16 +1581,16 @@ describe('agents controller reconcileAgentRun', () => {
       expect(kube.delete).not.toHaveBeenCalled()
     } finally {
       if (previousRetention === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
+        delete process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = previousRetention
+        process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = previousRetention
       }
     }
   })
 
   it('keeps completed AgentRun before retention window', async () => {
-    const previousRetention = process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
-    process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = '3600'
+    const previousRetention = process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
+    process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = '3600'
 
     try {
       const kube = buildKube()
@@ -1570,9 +1603,9 @@ describe('agents controller reconcileAgentRun', () => {
       expect(kube.delete).not.toHaveBeenCalled()
     } finally {
       if (previousRetention === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
+        delete process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = previousRetention
+        process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = previousRetention
       }
     }
   })
@@ -1631,7 +1664,7 @@ describe('agents controller reconcileAgentRun', () => {
     expect(agentRunnerSpec.provider).toBe('provider-1')
     expect(agentRunnerSpec.adapter).toEqual({ type: 'codex-app-server' })
     expect(payloads.eventFilePath).toBe('/workspace/run.json')
-    expect(payloads.eventBodyPath).toBe('/workspace/run.json')
+    expect(payloads).not.toHaveProperty('eventBodyPath')
 
     const jobLabels = (job?.metadata as Record<string, unknown> | undefined)?.labels as
       | Record<string, string>
@@ -1645,12 +1678,12 @@ describe('agents controller reconcileAgentRun', () => {
   })
 
   it('injects NATS auth env from configured runner auth secret when allowlisted', async () => {
-    const previousSecretName = process.env.JANGAR_AGENT_RUNNER_NATS_AUTH_SECRET_NAME
-    const previousUsernameKey = process.env.JANGAR_AGENT_RUNNER_NATS_AUTH_USERNAME_KEY
-    const previousPasswordKey = process.env.JANGAR_AGENT_RUNNER_NATS_AUTH_PASSWORD_KEY
-    process.env.JANGAR_AGENT_RUNNER_NATS_AUTH_SECRET_NAME = 'codex-nats-credentials'
-    process.env.JANGAR_AGENT_RUNNER_NATS_AUTH_USERNAME_KEY = 'NATS_USER'
-    process.env.JANGAR_AGENT_RUNNER_NATS_AUTH_PASSWORD_KEY = 'NATS_PASSWORD'
+    const previousSecretName = process.env.AGENTS_AGENT_RUNNER_NATS_AUTH_SECRET_NAME
+    const previousUsernameKey = process.env.AGENTS_AGENT_RUNNER_NATS_AUTH_USERNAME_KEY
+    const previousPasswordKey = process.env.AGENTS_AGENT_RUNNER_NATS_AUTH_PASSWORD_KEY
+    process.env.AGENTS_AGENT_RUNNER_NATS_AUTH_SECRET_NAME = 'codex-nats-credentials'
+    process.env.AGENTS_AGENT_RUNNER_NATS_AUTH_USERNAME_KEY = 'NATS_USER'
+    process.env.AGENTS_AGENT_RUNNER_NATS_AUTH_PASSWORD_KEY = 'NATS_PASSWORD'
     try {
       const apply = vi.fn(async (resource: Record<string, unknown>) => {
         const metadata = (resource.metadata ?? {}) as Record<string, unknown>
@@ -1710,12 +1743,12 @@ describe('agents controller reconcileAgentRun', () => {
         secretKeyRef: { name: 'codex-nats-credentials', key: 'NATS_PASSWORD' },
       })
     } finally {
-      if (previousSecretName === undefined) delete process.env.JANGAR_AGENT_RUNNER_NATS_AUTH_SECRET_NAME
-      else process.env.JANGAR_AGENT_RUNNER_NATS_AUTH_SECRET_NAME = previousSecretName
-      if (previousUsernameKey === undefined) delete process.env.JANGAR_AGENT_RUNNER_NATS_AUTH_USERNAME_KEY
-      else process.env.JANGAR_AGENT_RUNNER_NATS_AUTH_USERNAME_KEY = previousUsernameKey
-      if (previousPasswordKey === undefined) delete process.env.JANGAR_AGENT_RUNNER_NATS_AUTH_PASSWORD_KEY
-      else process.env.JANGAR_AGENT_RUNNER_NATS_AUTH_PASSWORD_KEY = previousPasswordKey
+      if (previousSecretName === undefined) delete process.env.AGENTS_AGENT_RUNNER_NATS_AUTH_SECRET_NAME
+      else process.env.AGENTS_AGENT_RUNNER_NATS_AUTH_SECRET_NAME = previousSecretName
+      if (previousUsernameKey === undefined) delete process.env.AGENTS_AGENT_RUNNER_NATS_AUTH_USERNAME_KEY
+      else process.env.AGENTS_AGENT_RUNNER_NATS_AUTH_USERNAME_KEY = previousUsernameKey
+      if (previousPasswordKey === undefined) delete process.env.AGENTS_AGENT_RUNNER_NATS_AUTH_PASSWORD_KEY
+      else process.env.AGENTS_AGENT_RUNNER_NATS_AUTH_PASSWORD_KEY = previousPasswordKey
     }
   })
 
@@ -2187,12 +2220,12 @@ describe('agents controller reconcileAgentRun', () => {
   })
 
   it('injects auth secret volume and CODEX_AUTH env var', async () => {
-    const previousName = process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_NAME
-    const previousKey = process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_KEY
-    const previousMountPath = process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_MOUNT_PATH
-    process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_NAME = 'codex-auth'
-    process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_KEY = 'auth.json'
-    process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_MOUNT_PATH = '/root/.codex'
+    const previousName = process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_NAME
+    const previousKey = process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_KEY
+    const previousMountPath = process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_MOUNT_PATH
+    process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_NAME = 'codex-auth'
+    process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_KEY = 'auth.json'
+    process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_MOUNT_PATH = '/root/.codex'
 
     try {
       const apply = vi.fn(async (resource: Record<string, unknown>) => {
@@ -2269,30 +2302,30 @@ describe('agents controller reconcileAgentRun', () => {
       expect(authMount?.readOnly).toBe(true)
     } finally {
       if (previousName === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_NAME
+        delete process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_NAME
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_NAME = previousName
+        process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_NAME = previousName
       }
       if (previousKey === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_KEY
+        delete process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_KEY
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_KEY = previousKey
+        process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_KEY = previousKey
       }
       if (previousMountPath === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_MOUNT_PATH
+        delete process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_MOUNT_PATH
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_MOUNT_PATH = previousMountPath
+        process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_MOUNT_PATH = previousMountPath
       }
     }
   })
 
   it('applies default scheduling config and allows per-run overrides', async () => {
     const previousEnv = {
-      nodeSelector: process.env.JANGAR_AGENT_RUNNER_NODE_SELECTOR,
-      affinity: process.env.JANGAR_AGENT_RUNNER_AFFINITY,
-      topologySpread: process.env.JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS,
-      priorityClass: process.env.JANGAR_AGENT_RUNNER_PRIORITY_CLASS,
-      schedulerName: process.env.JANGAR_AGENT_RUNNER_SCHEDULER_NAME,
+      nodeSelector: process.env.AGENTS_AGENT_RUNNER_NODE_SELECTOR,
+      affinity: process.env.AGENTS_AGENT_RUNNER_AFFINITY,
+      topologySpread: process.env.AGENTS_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS,
+      priorityClass: process.env.AGENTS_AGENT_RUNNER_PRIORITY_CLASS,
+      schedulerName: process.env.AGENTS_AGENT_RUNNER_SCHEDULER_NAME,
     }
     const defaultAffinity = {
       nodeAffinity: {
@@ -2312,11 +2345,11 @@ describe('agents controller reconcileAgentRun', () => {
         whenUnsatisfiable: 'ScheduleAnyway',
       },
     ]
-    process.env.JANGAR_AGENT_RUNNER_NODE_SELECTOR = JSON.stringify({ disktype: 'ssd' })
-    process.env.JANGAR_AGENT_RUNNER_AFFINITY = JSON.stringify(defaultAffinity)
-    process.env.JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS = JSON.stringify(defaultTopology)
-    process.env.JANGAR_AGENT_RUNNER_PRIORITY_CLASS = 'default-priority'
-    process.env.JANGAR_AGENT_RUNNER_SCHEDULER_NAME = 'default-scheduler'
+    process.env.AGENTS_AGENT_RUNNER_NODE_SELECTOR = JSON.stringify({ disktype: 'ssd' })
+    process.env.AGENTS_AGENT_RUNNER_AFFINITY = JSON.stringify(defaultAffinity)
+    process.env.AGENTS_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS = JSON.stringify(defaultTopology)
+    process.env.AGENTS_AGENT_RUNNER_PRIORITY_CLASS = 'default-priority'
+    process.env.AGENTS_AGENT_RUNNER_SCHEDULER_NAME = 'default-scheduler'
 
     try {
       let lastJob: Record<string, unknown> | null = null
@@ -2422,36 +2455,36 @@ describe('agents controller reconcileAgentRun', () => {
       expect(overridePodSpec.schedulerName).toBe('run-scheduler')
     } finally {
       if (previousEnv.nodeSelector === undefined) {
-        delete process.env.JANGAR_AGENT_RUNNER_NODE_SELECTOR
+        delete process.env.AGENTS_AGENT_RUNNER_NODE_SELECTOR
       } else {
-        process.env.JANGAR_AGENT_RUNNER_NODE_SELECTOR = previousEnv.nodeSelector
+        process.env.AGENTS_AGENT_RUNNER_NODE_SELECTOR = previousEnv.nodeSelector
       }
       if (previousEnv.affinity === undefined) {
-        delete process.env.JANGAR_AGENT_RUNNER_AFFINITY
+        delete process.env.AGENTS_AGENT_RUNNER_AFFINITY
       } else {
-        process.env.JANGAR_AGENT_RUNNER_AFFINITY = previousEnv.affinity
+        process.env.AGENTS_AGENT_RUNNER_AFFINITY = previousEnv.affinity
       }
       if (previousEnv.topologySpread === undefined) {
-        delete process.env.JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS
+        delete process.env.AGENTS_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS
       } else {
-        process.env.JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS = previousEnv.topologySpread
+        process.env.AGENTS_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS = previousEnv.topologySpread
       }
       if (previousEnv.priorityClass === undefined) {
-        delete process.env.JANGAR_AGENT_RUNNER_PRIORITY_CLASS
+        delete process.env.AGENTS_AGENT_RUNNER_PRIORITY_CLASS
       } else {
-        process.env.JANGAR_AGENT_RUNNER_PRIORITY_CLASS = previousEnv.priorityClass
+        process.env.AGENTS_AGENT_RUNNER_PRIORITY_CLASS = previousEnv.priorityClass
       }
       if (previousEnv.schedulerName === undefined) {
-        delete process.env.JANGAR_AGENT_RUNNER_SCHEDULER_NAME
+        delete process.env.AGENTS_AGENT_RUNNER_SCHEDULER_NAME
       } else {
-        process.env.JANGAR_AGENT_RUNNER_SCHEDULER_NAME = previousEnv.schedulerName
+        process.env.AGENTS_AGENT_RUNNER_SCHEDULER_NAME = previousEnv.schedulerName
       }
     }
   })
 
   it('ignores invalid topology spread env JSON with warnings', async () => {
-    const previousEnv = process.env.JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS
-    process.env.JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS = '{invalid'
+    const previousEnv = process.env.AGENTS_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS
+    process.env.AGENTS_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS = '{invalid'
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     try {
@@ -2495,15 +2528,15 @@ describe('agents controller reconcileAgentRun', () => {
     } finally {
       warnSpy.mockRestore()
       if (previousEnv === undefined) {
-        delete process.env.JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS
+        delete process.env.AGENTS_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS
       } else {
-        process.env.JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS = previousEnv
+        process.env.AGENTS_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS = previousEnv
       }
     }
   })
   it('marks AgentRun failed when controller blocks secrets', async () => {
-    const previousBlocked = process.env.JANGAR_AGENTS_CONTROLLER_BLOCKED_SECRETS
-    process.env.JANGAR_AGENTS_CONTROLLER_BLOCKED_SECRETS = 'blocked-secret'
+    const previousBlocked = process.env.AGENTS_AGENTS_CONTROLLER_BLOCKED_SECRETS
+    process.env.AGENTS_AGENTS_CONTROLLER_BLOCKED_SECRETS = 'blocked-secret'
 
     try {
       const kube = buildKube({
@@ -2540,16 +2573,16 @@ describe('agents controller reconcileAgentRun', () => {
       expect(condition?.reason).toBe('SecretBlocked')
     } finally {
       if (previousBlocked === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_BLOCKED_SECRETS
+        delete process.env.AGENTS_AGENTS_CONTROLLER_BLOCKED_SECRETS
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_BLOCKED_SECRETS = previousBlocked
+        process.env.AGENTS_AGENTS_CONTROLLER_BLOCKED_SECRETS = previousBlocked
       }
     }
   })
 
   it('marks AgentRun failed when auth secret is not allowlisted', async () => {
-    const previousName = process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_NAME
-    process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_NAME = 'codex-auth'
+    const previousName = process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_NAME
+    process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_NAME = 'codex-auth'
 
     try {
       const kube = buildKube({
@@ -2583,9 +2616,9 @@ describe('agents controller reconcileAgentRun', () => {
       expect(condition?.reason).toBe('SecretNotAllowed')
     } finally {
       if (previousName === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_NAME
+        delete process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_NAME
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_NAME = previousName
+        process.env.AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_NAME = previousName
       }
     }
   })
@@ -2794,8 +2827,8 @@ describe('agents controller reconcileAgentRun', () => {
   })
 
   it('continues and stops loop workflow steps with CEL expressions', async () => {
-    const previousLoopsEnabled = process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
-    process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
+    const previousLoopsEnabled = process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+    process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
     try {
       const jobStatuses = new Map<string, Record<string, unknown>>()
       const apply = vi.fn(async (resource: Record<string, unknown>) => {
@@ -2948,17 +2981,17 @@ describe('agents controller reconcileAgentRun', () => {
       expect((fourthStep.loop as Record<string, unknown> | undefined)?.stopReason).toBe('LoopConditionFalse')
     } finally {
       if (previousLoopsEnabled === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+        delete process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
+        process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
       }
     }
   })
 
   it('reads loop control payload from a custom source path', async () => {
-    const previousLoopsEnabled = process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+    const previousLoopsEnabled = process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
     const loopControlPath = '/tmp/.agentrun/loop-control.json'
-    process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
+    process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
     try {
       const jobStatuses = new Map<string, Record<string, unknown>>()
       const apply = vi.fn(async (resource: Record<string, unknown>) => {
@@ -3118,16 +3151,16 @@ describe('agents controller reconcileAgentRun', () => {
       expect((fourthStep.loop as Record<string, unknown> | undefined)?.stopReason).toBe('LoopConditionFalse')
     } finally {
       if (previousLoopsEnabled === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+        delete process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
+        process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
       }
     }
   })
 
   it('stops loop when control payload is missing and onMissing=stop', async () => {
-    const previousLoopsEnabled = process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
-    process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
+    const previousLoopsEnabled = process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+    process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
     try {
       const jobStatuses = new Map<string, Record<string, unknown>>()
       const apply = vi.fn(async (resource: Record<string, unknown>) => {
@@ -3228,16 +3261,16 @@ describe('agents controller reconcileAgentRun', () => {
       expect((secondStep.loop as Record<string, unknown> | undefined)?.completedIterations).toBe(1)
     } finally {
       if (previousLoopsEnabled === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+        delete process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
+        process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
       }
     }
   })
 
   it('fails loop when control payload is missing and onMissing=fail', async () => {
-    const previousLoopsEnabled = process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
-    process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
+    const previousLoopsEnabled = process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+    process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
     try {
       const jobStatuses = new Map<string, Record<string, unknown>>()
       const apply = vi.fn(async (resource: Record<string, unknown>) => {
@@ -3338,16 +3371,16 @@ describe('agents controller reconcileAgentRun', () => {
       expect((secondStep.loop as Record<string, unknown> | undefined)?.stopReason).toBe('LoopConditionError')
     } finally {
       if (previousLoopsEnabled === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+        delete process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
+        process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
       }
     }
   })
 
   it('fails loop when control payload is invalid and onInvalid=fail', async () => {
-    const previousLoopsEnabled = process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
-    process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
+    const previousLoopsEnabled = process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+    process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
     try {
       const jobStatuses = new Map<string, Record<string, unknown>>()
       const apply = vi.fn(async (resource: Record<string, unknown>) => {
@@ -3452,16 +3485,16 @@ describe('agents controller reconcileAgentRun', () => {
       expect((secondStep.loop as Record<string, unknown> | undefined)?.stopReason).toBe('LoopConditionError')
     } finally {
       if (previousLoopsEnabled === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+        delete process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
+        process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
       }
     }
   })
 
   it('stops loop at maxIterations when no condition is provided', async () => {
-    const previousLoopsEnabled = process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
-    process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
+    const previousLoopsEnabled = process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+    process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
     try {
       const jobStatuses = new Map<string, Record<string, unknown>>()
       const apply = vi.fn(async (resource: Record<string, unknown>) => {
@@ -3590,9 +3623,9 @@ describe('agents controller reconcileAgentRun', () => {
       expect((fourthStep.loop as Record<string, unknown> | undefined)?.stopReason).toBe('LoopMaxIterationsReached')
     } finally {
       if (previousLoopsEnabled === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+        delete process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
+        process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
       }
     }
   })
@@ -4396,8 +4429,8 @@ describe('agents controller reconcileAgentRun', () => {
   })
 
   it('uses controller retention default when spec override is missing', async () => {
-    const previousRetention = process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
-    process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = '60'
+    const previousRetention = process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
+    process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = '60'
 
     try {
       const deleteMock = vi.fn(async () => ({}))
@@ -4412,9 +4445,9 @@ describe('agents controller reconcileAgentRun', () => {
       expect(deleteMock).toHaveBeenCalledWith(RESOURCE_MAP.AgentRun, 'run-1', 'agents', { wait: false })
     } finally {
       if (previousRetention === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
+        delete process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = previousRetention
+        process.env.AGENTS_AGENTS_CONTROLLER_AGENTRUN_RETENTION_SECONDS = previousRetention
       }
     }
   })
@@ -4440,8 +4473,8 @@ describe('agents controller reconcileAgentRun', () => {
 
 describe('agents controller queue and rate limits', () => {
   it('blocks AgentRun when queue limit is exceeded', async () => {
-    const previousQueue = process.env.JANGAR_AGENTS_CONTROLLER_QUEUE_NAMESPACE
-    process.env.JANGAR_AGENTS_CONTROLLER_QUEUE_NAMESPACE = '1'
+    const previousQueue = process.env.AGENTS_AGENTS_CONTROLLER_QUEUE_NAMESPACE
+    process.env.AGENTS_AGENTS_CONTROLLER_QUEUE_NAMESPACE = '1'
 
     try {
       const kube = buildKube()
@@ -4475,9 +4508,9 @@ describe('agents controller queue and rate limits', () => {
       expect(condition?.message).toContain('queue limit')
     } finally {
       if (previousQueue === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_QUEUE_NAMESPACE
+        delete process.env.AGENTS_AGENTS_CONTROLLER_QUEUE_NAMESPACE
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_QUEUE_NAMESPACE = previousQueue
+        process.env.AGENTS_AGENTS_CONTROLLER_QUEUE_NAMESPACE = previousQueue
       }
     }
   })
@@ -4520,13 +4553,13 @@ describe('agents controller queue and rate limits', () => {
   })
 
   it('blocks AgentRun when rate limit is exceeded', async () => {
-    const previousWindow = process.env.JANGAR_AGENTS_CONTROLLER_RATE_WINDOW_SECONDS
-    const previousNamespace = process.env.JANGAR_AGENTS_CONTROLLER_RATE_NAMESPACE
-    const previousCluster = process.env.JANGAR_AGENTS_CONTROLLER_RATE_CLUSTER
+    const previousWindow = process.env.AGENTS_AGENTS_CONTROLLER_RATE_WINDOW_SECONDS
+    const previousNamespace = process.env.AGENTS_AGENTS_CONTROLLER_RATE_NAMESPACE
+    const previousCluster = process.env.AGENTS_AGENTS_CONTROLLER_RATE_CLUSTER
 
-    process.env.JANGAR_AGENTS_CONTROLLER_RATE_WINDOW_SECONDS = '60'
-    process.env.JANGAR_AGENTS_CONTROLLER_RATE_NAMESPACE = '1'
-    process.env.JANGAR_AGENTS_CONTROLLER_RATE_CLUSTER = '1'
+    process.env.AGENTS_AGENTS_CONTROLLER_RATE_WINDOW_SECONDS = '60'
+    process.env.AGENTS_AGENTS_CONTROLLER_RATE_NAMESPACE = '1'
+    process.env.AGENTS_AGENTS_CONTROLLER_RATE_CLUSTER = '1'
     __test.resetControllerRateState()
 
     try {
@@ -4569,19 +4602,19 @@ describe('agents controller queue and rate limits', () => {
       __test.resetControllerRateState()
 
       if (previousWindow === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_RATE_WINDOW_SECONDS
+        delete process.env.AGENTS_AGENTS_CONTROLLER_RATE_WINDOW_SECONDS
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_RATE_WINDOW_SECONDS = previousWindow
+        process.env.AGENTS_AGENTS_CONTROLLER_RATE_WINDOW_SECONDS = previousWindow
       }
       if (previousNamespace === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_RATE_NAMESPACE
+        delete process.env.AGENTS_AGENTS_CONTROLLER_RATE_NAMESPACE
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_RATE_NAMESPACE = previousNamespace
+        process.env.AGENTS_AGENTS_CONTROLLER_RATE_NAMESPACE = previousNamespace
       }
       if (previousCluster === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_RATE_CLUSTER
+        delete process.env.AGENTS_AGENTS_CONTROLLER_RATE_CLUSTER
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_RATE_CLUSTER = previousCluster
+        process.env.AGENTS_AGENTS_CONTROLLER_RATE_CLUSTER = previousCluster
       }
     }
   })

--- a/services/agents/src/server/agents-controller/index.ts
+++ b/services/agents/src/server/agents-controller/index.ts
@@ -91,7 +91,6 @@ const DEFAULT_TEMPORAL_PORT = 7233
 const DEFAULT_TEMPORAL_ADDRESS = `${DEFAULT_TEMPORAL_HOST}:${DEFAULT_TEMPORAL_PORT}`
 const IMPLEMENTATION_TEXT_LIMIT = 128 * 1024
 const DEFAULT_AGENTS_CONTROLLER_ENABLED_FLAG_KEY = 'agents.agents_controller.enabled'
-const LEGACY_AGENTS_CONTROLLER_ENABLED_FLAG_KEY = 'jangar.agents_controller.enabled'
 
 const BASE_REQUIRED_CRDS = [
   'agents.agents.proompteng.ai',
@@ -382,18 +381,11 @@ const shouldStartWithFeatureFlag = async () => {
   if (resolveAgentsControllerBehaviorConfig(process.env).enabled === false) return false
 
   const resolveToggle = runtimeDependencies.resolveBooleanFeatureToggle ?? resolveBooleanFeatureToggle
-  const legacyDefault = await resolveToggle({
-    key: LEGACY_AGENTS_CONTROLLER_ENABLED_FLAG_KEY,
-    keyEnvVar: 'JANGAR_AGENTS_CONTROLLER_ENABLED_FLAG_KEY',
-    fallbackEnvVar: 'JANGAR_AGENTS_CONTROLLER_ENABLED',
-    defaultValue: true,
-  })
-  if (!legacyDefault) return false
   return resolveToggle({
     key: DEFAULT_AGENTS_CONTROLLER_ENABLED_FLAG_KEY,
     keyEnvVar: 'AGENTS_AGENTS_CONTROLLER_ENABLED_FLAG_KEY',
     fallbackEnvVar: 'AGENTS_AGENTS_CONTROLLER_ENABLED',
-    defaultValue: legacyDefault,
+    defaultValue: true,
   })
 }
 
@@ -1417,6 +1409,7 @@ export const __test = {
   resolveAgentRunArtifactsLimitConfig,
   limitAgentRunStatusArtifacts,
   buildArtifactsLimitMessage,
+  resolveAgentsControllerFeatureEnabled: shouldStartWithFeatureFlag,
   reconcileAgentRun: reconcileAgentRunWithMetrics,
   reconcileVersionControlProvider,
   reconcileMemory,

--- a/services/agents/src/server/agents-controller/job-runtime.test.ts
+++ b/services/agents/src/server/agents-controller/job-runtime.test.ts
@@ -11,7 +11,7 @@ import {
 
 describe('agents controller job-runtime module', () => {
   afterEach(() => {
-    delete process.env.JANGAR_AGENT_RUNNER_SERVICE_ACCOUNT
+    delete process.env.AGENTS_AGENT_RUNNER_SERVICE_ACCOUNT
   })
 
   it('creates DNS-safe names and appends stable hash when needed', () => {
@@ -30,7 +30,7 @@ describe('agents controller job-runtime module', () => {
   })
 
   it('resolves runner service account from runtime config aliases or env default', () => {
-    process.env.JANGAR_AGENT_RUNNER_SERVICE_ACCOUNT = 'runner-default'
+    process.env.AGENTS_AGENT_RUNNER_SERVICE_ACCOUNT = 'runner-default'
     expect(resolveRunnerServiceAccount({ serviceAccount: 'runtime-sa' })).toBe('runtime-sa')
     expect(resolveRunnerServiceAccount({ serviceAccountName: 'runtime-sa-name' })).toBe('runtime-sa-name')
     expect(resolveRunnerServiceAccount({})).toBe('runner-default')

--- a/services/agents/src/server/agents-controller/job-runtime.ts
+++ b/services/agents/src/server/agents-controller/job-runtime.ts
@@ -338,8 +338,6 @@ const buildAgentRunnerSpec = (
     ...(asRecord(runSpec.goal) ? { goal: runSpec.goal } : {}),
     payloads: {
       eventFilePath: '/workspace/run.json',
-      // Keep legacy key as an alias so older provider templates keep working.
-      eventBodyPath: '/workspace/run.json',
     },
     artifacts: {
       statusPath: '/workspace/.agent/status.json',

--- a/services/agents/src/server/agents-controller/policy.test.ts
+++ b/services/agents/src/server/agents-controller/policy.test.ts
@@ -9,11 +9,11 @@ import {
 } from '~/server/agents-controller/policy'
 
 afterEach(() => {
-  delete process.env.JANGAR_AGENTS_CONTROLLER_LABELS_REQUIRED
-  delete process.env.JANGAR_AGENTS_CONTROLLER_LABELS_ALLOWED
-  delete process.env.JANGAR_AGENTS_CONTROLLER_LABELS_DENIED
-  delete process.env.JANGAR_AGENTS_CONTROLLER_IMAGES_ALLOWED
-  delete process.env.JANGAR_AGENTS_CONTROLLER_IMAGES_DENIED
+  delete process.env.AGENTS_AGENTS_CONTROLLER_LABELS_REQUIRED
+  delete process.env.AGENTS_AGENTS_CONTROLLER_LABELS_ALLOWED
+  delete process.env.AGENTS_AGENTS_CONTROLLER_LABELS_DENIED
+  delete process.env.AGENTS_AGENTS_CONTROLLER_IMAGES_ALLOWED
+  delete process.env.AGENTS_AGENTS_CONTROLLER_IMAGES_DENIED
 })
 
 describe('agents controller policy module', () => {
@@ -35,7 +35,7 @@ describe('agents controller policy module', () => {
   })
 
   it('validates required, denied, and allowed label policies', () => {
-    process.env.JANGAR_AGENTS_CONTROLLER_LABELS_REQUIRED = JSON.stringify(['team', 'service'])
+    process.env.AGENTS_AGENTS_CONTROLLER_LABELS_REQUIRED = JSON.stringify(['team', 'service'])
     const required = validateLabelPolicy({ team: 'platform' })
     expect(required).toEqual({
       ok: false,
@@ -43,8 +43,8 @@ describe('agents controller policy module', () => {
       message: 'missing required labels: service',
     })
 
-    process.env.JANGAR_AGENTS_CONTROLLER_LABELS_REQUIRED = ''
-    process.env.JANGAR_AGENTS_CONTROLLER_LABELS_DENIED = JSON.stringify(['internal/*'])
+    process.env.AGENTS_AGENTS_CONTROLLER_LABELS_REQUIRED = ''
+    process.env.AGENTS_AGENTS_CONTROLLER_LABELS_DENIED = JSON.stringify(['internal/*'])
     const denied = validateLabelPolicy({ 'internal/secret': '1' })
     expect(denied).toEqual({
       ok: false,
@@ -52,8 +52,8 @@ describe('agents controller policy module', () => {
       message: 'labels blocked by controller policy: internal/secret',
     })
 
-    process.env.JANGAR_AGENTS_CONTROLLER_LABELS_DENIED = ''
-    process.env.JANGAR_AGENTS_CONTROLLER_LABELS_ALLOWED = JSON.stringify(['team', 'app.kubernetes.io/*'])
+    process.env.AGENTS_AGENTS_CONTROLLER_LABELS_DENIED = ''
+    process.env.AGENTS_AGENTS_CONTROLLER_LABELS_ALLOWED = JSON.stringify(['team', 'app.kubernetes.io/*'])
     const allowed = validateLabelPolicy({ team: 'platform', forbidden: 'x' })
     expect(allowed).toEqual({
       ok: false,
@@ -63,7 +63,7 @@ describe('agents controller policy module', () => {
   })
 
   it('validates image allow/deny policy with contextual messages', () => {
-    process.env.JANGAR_AGENTS_CONTROLLER_IMAGES_DENIED = JSON.stringify(['registry.bad/*'])
+    process.env.AGENTS_AGENTS_CONTROLLER_IMAGES_DENIED = JSON.stringify(['registry.bad/*'])
     const blocked = validateImagePolicy([{ image: 'registry.bad/app:1', context: 'job runtime' }])
     expect(blocked).toEqual({
       ok: false,
@@ -71,8 +71,8 @@ describe('agents controller policy module', () => {
       message: 'image registry.bad/app:1 for job runtime is blocked by controller policy',
     })
 
-    process.env.JANGAR_AGENTS_CONTROLLER_IMAGES_DENIED = ''
-    process.env.JANGAR_AGENTS_CONTROLLER_IMAGES_ALLOWED = JSON.stringify(['registry.good/*'])
+    process.env.AGENTS_AGENTS_CONTROLLER_IMAGES_DENIED = ''
+    process.env.AGENTS_AGENTS_CONTROLLER_IMAGES_ALLOWED = JSON.stringify(['registry.good/*'])
     const notAllowed = validateImagePolicy([{ image: 'registry.other/app:2' }])
     expect(notAllowed).toEqual({
       ok: false,

--- a/services/agents/src/server/agents-controller/runtime-config.test.ts
+++ b/services/agents/src/server/agents-controller/runtime-config.test.ts
@@ -7,16 +7,12 @@ import {
 } from './runtime-config'
 
 describe('Agents controller runtime config', () => {
-  it('prefers canonical AGENTS env names over JANGAR compatibility aliases', () => {
+  it('reads canonical AGENTS env names', () => {
     const env = {
       AGENTS_AGENT_RUNNER_IMAGE: 'registry.example/agents-runner:next',
-      JANGAR_AGENT_RUNNER_IMAGE: 'registry.example/jangar-runner:old',
       AGENTS_AGENT_RUNNER_JOB_TTL_SECONDS: '900',
-      JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS: '60',
       AGENTS_AGENTRUN_ARTIFACTS_MAX: '7',
-      JANGAR_AGENTRUN_ARTIFACTS_MAX: '3',
       AGENTS_AGENTS_CONTROLLER_AUTH_SECRET_NAME: 'agents-auth',
-      JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_NAME: 'jangar-auth',
     }
 
     expect(resolveAgentRunnerDefaultsConfig(env).defaultRunnerImage).toBe('registry.example/agents-runner:next')
@@ -25,7 +21,7 @@ describe('Agents controller runtime config', () => {
     expect(resolveAgentsControllerAuthSecretConfig(env)?.name).toBe('agents-auth')
   })
 
-  it('keeps JANGAR env names as compatibility aliases', () => {
+  it('does not read legacy Jangar env names in the Agents controller', () => {
     const env = {
       JANGAR_AGENT_RUNNER_IMAGE: 'registry.example/jangar-runner:compat',
       JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS: '120',
@@ -33,9 +29,9 @@ describe('Agents controller runtime config', () => {
       JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_NAME: 'jangar-auth',
     }
 
-    expect(resolveAgentRunnerDefaultsConfig(env).defaultRunnerImage).toBe('registry.example/jangar-runner:compat')
-    expect(resolveAgentRunnerDefaultsConfig(env).jobTtlSeconds).toBe(120)
-    expect(resolveAgentsControllerBehaviorConfig(env).artifactsMaxEntries).toBe(5)
-    expect(resolveAgentsControllerAuthSecretConfig(env)?.name).toBe('jangar-auth')
+    expect(resolveAgentRunnerDefaultsConfig(env).defaultRunnerImage).toBeNull()
+    expect(resolveAgentRunnerDefaultsConfig(env).jobTtlSeconds).toBe(600)
+    expect(resolveAgentsControllerBehaviorConfig(env).artifactsMaxEntries).toBe(50)
+    expect(resolveAgentsControllerAuthSecretConfig(env)).toBeNull()
   })
 })

--- a/services/agents/src/server/agents-controller/runtime-config.ts
+++ b/services/agents/src/server/agents-controller/runtime-config.ts
@@ -42,8 +42,6 @@ const parseJson = (value: string | undefined) => {
 }
 
 const readAgentsEnv = (env: EnvSource, name: string): string | undefined => {
-  if (name.startsWith('AGENTS_')) return env[name] ?? env[`JANGAR_${name.slice('AGENTS_'.length)}`]
-  if (name.startsWith('JANGAR_')) return env[`AGENTS_${name.slice('JANGAR_'.length)}`] ?? env[name]
   return env[name]
 }
 

--- a/services/agents/src/server/agents-controller/vcs-auth.test.ts
+++ b/services/agents/src/server/agents-controller/vcs-auth.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { normalizeVcsMode, resolveVcsAuthMethod, validateVcsAuthConfig } from '~/server/agents-controller/vcs-auth'
 
 afterEach(() => {
-  delete process.env.JANGAR_AGENTS_CONTROLLER_VCS_DEPRECATED_TOKEN_TYPES
+  delete process.env.AGENTS_AGENTS_CONTROLLER_VCS_DEPRECATED_TOKEN_TYPES
 })
 
 describe('agents controller vcs-auth module', () => {
@@ -64,7 +64,7 @@ describe('agents controller vcs-auth module', () => {
   })
 
   it('respects deprecated token override map from env json', () => {
-    process.env.JANGAR_AGENTS_CONTROLLER_VCS_DEPRECATED_TOKEN_TYPES = JSON.stringify({
+    process.env.AGENTS_AGENTS_CONTROLLER_VCS_DEPRECATED_TOKEN_TYPES = JSON.stringify({
       gitlab: ['access_token'],
     })
     const result = validateVcsAuthConfig('gitlab', {

--- a/services/agents/src/server/agents-controller/workflow.test.ts
+++ b/services/agents/src/server/agents-controller/workflow.test.ts
@@ -121,8 +121,8 @@ describe('agents controller workflow module', () => {
   })
 
   it('validates loop condition source policies', () => {
-    const previousLoopsEnabled = process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
-    process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
+    const previousLoopsEnabled = process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+    process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
     try {
       const steps = parseWorkflowSteps({
         spec: {
@@ -156,9 +156,9 @@ describe('agents controller workflow module', () => {
       })
     } finally {
       if (previousLoopsEnabled === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+        delete process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
+        process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
       }
     }
   })
@@ -189,8 +189,8 @@ describe('agents controller workflow module', () => {
   })
 
   it('validates loop state volume requirements for persistence', () => {
-    const previousLoopsEnabled = process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
-    process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
+    const previousLoopsEnabled = process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+    process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'
     try {
       const validSteps: WorkflowStepSpec[] = [
         {
@@ -262,9 +262,9 @@ describe('agents controller workflow module', () => {
       })
     } finally {
       if (previousLoopsEnabled === undefined) {
-        delete process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
+        delete process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
       } else {
-        process.env.JANGAR_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
+        process.env.AGENTS_AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = previousLoopsEnabled
       }
     }
   })


### PR DESCRIPTION
## Summary

- Removes `JANGAR_*` env alias lookup from the Agents controller config readers.
- Cuts the legacy `jangar.agents_controller.enabled` startup gate so controller startup uses the Agents-owned flag/env only.
- Tightens the runner contract by requiring `payloads.eventFilePath` and no longer emitting or accepting `payloads.eventBodyPath`.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test -- src/server/agents-controller/runtime-config.test.ts src/server/agents-controller/env-config.test.ts src/server/agents-controller/agentrun-artifacts.test.ts src/server/agents-controller/job-runtime.test.ts src/server/agents-controller/vcs-auth.test.ts src/server/agents-controller/policy.test.ts src/server/agents-controller/workflow.test.ts`
- `bun run --cwd services/agents test -- src/runner/codex-app-server.test.ts src/server/agents-controller/index.integration.test.ts -t "runner contract|eventFilePath|versioned|agent-runner|agents controller startup"`
- `bun run --cwd services/agents test -- src/server/agents-controller/runtime-config.test.ts src/server/agents-controller/env-config.test.ts src/server/agents-controller/agentrun-artifacts.test.ts src/server/agents-controller/job-runtime.test.ts src/server/agents-controller/vcs-auth.test.ts src/server/agents-controller/policy.test.ts src/server/agents-controller/workflow.test.ts src/server/agents-controller/index.integration.test.ts src/runner/codex-app-server.test.ts`
- `bun run --cwd services/agents tsc`
- `bunx oxfmt --check services/agents/src/server/agents-controller`
- `git diff --check`
- `rg -n "JANGAR_|installAgentsEnvCompatibility|toJangarEnvName|x-jangar-token|eventBodyPath" services/agents/src/server/agents-controller services/agents/src/runner docs/agents/jangar-controller-design.md --glob '!**/*.test.ts'`

## Screenshots (if applicable)

N/A

## Breaking Changes

Agents controller runtime env is now canonical `AGENTS_*` only. Legacy `JANGAR_*` env aliases and `payloads.eventBodyPath` are no longer honored in this controller/runner path.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
