### PR TITLE
refactor(agents): remove jangar build env aliases

### DIFF
--- a/packages/scripts/src/agents/__tests__/build-image.test.ts
+++ b/packages/scripts/src/agents/__tests__/build-image.test.ts
@@ -19,12 +19,8 @@ const envKeys = [
   'AGENTS_IMAGE_REPOSITORY',
   'AGENTS_IMAGE_TAG',
   'AGENTS_VERSION',
-  'JANGAR_BUILD_CACHE_MODE',
   'JANGAR_BUILD_CI',
-  'JANGAR_BUILD_LOG_LEVEL',
   'JANGAR_BUILD_MINIFY',
-  'JANGAR_BUILD_NODE_OPTIONS',
-  'JANGAR_BUILD_SOURCEMAP',
 ]
 
 afterEach(() => {
@@ -48,13 +44,11 @@ describe('agents build-image helpers', () => {
     })
   })
 
-  it('uses AGENTS build environment names before legacy Jangar aliases', () => {
+  it('uses canonical AGENTS build environment names', () => {
     process.env.AGENTS_BUILD_NODE_OPTIONS = '--max-old-space-size=4096'
     process.env.AGENTS_BUILD_SOURCEMAP = '0'
     process.env.AGENTS_BUILD_CI = 'true'
     process.env.AGENTS_BUILD_LOG_LEVEL = 'warn'
-    process.env.JANGAR_BUILD_NODE_OPTIONS = '--max-old-space-size=1024'
-    process.env.JANGAR_BUILD_SOURCEMAP = '1'
 
     expect(__private.buildArgsFromEnv('v1', 'commit1')).toEqual({
       AGENTS_VERSION: 'v1',
@@ -66,15 +60,13 @@ describe('agents build-image helpers', () => {
     })
   })
 
-  it('keeps legacy Jangar build env as read-only compatibility for one release', () => {
+  it('ignores legacy Jangar build env names', () => {
     process.env.JANGAR_BUILD_MINIFY = '0'
     process.env.JANGAR_BUILD_CI = 'true'
 
     expect(__private.buildArgsFromEnv('v1', 'commit1')).toEqual({
       AGENTS_VERSION: 'v1',
       AGENTS_COMMIT: 'commit1',
-      AGENTS_BUILD_MINIFY: '0',
-      AGENTS_BUILD_CI: 'true',
     })
   })
 

--- a/packages/scripts/src/agents/__tests__/deploy-service.test.ts
+++ b/packages/scripts/src/agents/__tests__/deploy-service.test.ts
@@ -1,9 +1,25 @@
-import { describe, expect, it } from 'bun:test'
+import { afterEach, describe, expect, it } from 'bun:test'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { __private } from '../deploy-service'
+
+const envKeys = [
+  'AGENTS_IMAGE_TAG',
+  'AGENTS_IMAGE_PLATFORMS',
+  'JANGAR_IMAGE_REGISTRY',
+  'JANGAR_IMAGE_REPOSITORY',
+  'JANGAR_CONTROL_PLANE_IMAGE_REPOSITORY',
+  'JANGAR_IMAGE_TAG',
+  'JANGAR_IMAGE_PLATFORMS',
+]
+
+afterEach(() => {
+  for (const key of envKeys) {
+    delete process.env[key]
+  }
+})
 
 describe('agents deploy-service helpers', () => {
   it('parses runner and apply rollout flags', () => {
@@ -38,6 +54,22 @@ describe('agents deploy-service helpers', () => {
         platforms: ['linux/arm64'],
       },
     ])
+  })
+
+  it('ignores legacy Jangar image env aliases', () => {
+    process.env.JANGAR_IMAGE_REGISTRY = 'registry.example/jangar'
+    process.env.JANGAR_IMAGE_REPOSITORY = 'lab/jangar'
+    process.env.JANGAR_CONTROL_PLANE_IMAGE_REPOSITORY = 'lab/jangar-control-plane'
+    process.env.JANGAR_IMAGE_TAG = 'jangar-tag'
+    process.env.JANGAR_IMAGE_PLATFORMS = 'linux/s390x'
+
+    const options = __private.resolveOptions()
+
+    expect(options.registry).toBe('registry.ide-newton.ts.net')
+    expect(options.repository).toBe('lab/agents-controller')
+    expect(options.controlPlaneRepository).toBe('lab/agents-control-plane')
+    expect(options.tag).not.toBe('jangar-tag')
+    expect(options.platforms).toEqual(['linux/amd64', 'linux/arm64'])
   })
 
   it('treats local Codex auth as optional for runner image builds', () => {

--- a/packages/scripts/src/agents/build-image.ts
+++ b/packages/scripts/src/agents/build-image.ts
@@ -76,8 +76,7 @@ const parseCacheMode = (value: string | undefined): DockerCacheMode | undefined 
   return undefined
 }
 
-const readAgentsEnv = (agentsName: string, legacyJangarName?: string) =>
-  process.env[agentsName]?.trim() || (legacyJangarName ? process.env[legacyJangarName]?.trim() : undefined)
+const readAgentsEnv = (agentsName: string) => process.env[agentsName]?.trim()
 
 const createPrunedContext = async (target?: string): Promise<{ dir: string; cleanup: () => void }> => {
   ensureCli('bunx')
@@ -122,19 +121,19 @@ const buildArgsFromEnv = (version: string, commit: string): Record<string, strin
     AGENTS_COMMIT: commit,
   }
 
-  const buildNodeOptions = readAgentsEnv('AGENTS_BUILD_NODE_OPTIONS', 'JANGAR_BUILD_NODE_OPTIONS')
+  const buildNodeOptions = readAgentsEnv('AGENTS_BUILD_NODE_OPTIONS')
   if (buildNodeOptions) buildArgs.AGENTS_BUILD_NODE_OPTIONS = buildNodeOptions
 
-  const buildMinify = readAgentsEnv('AGENTS_BUILD_MINIFY', 'JANGAR_BUILD_MINIFY')
+  const buildMinify = readAgentsEnv('AGENTS_BUILD_MINIFY')
   if (buildMinify) buildArgs.AGENTS_BUILD_MINIFY = buildMinify
 
-  const buildSourceMap = readAgentsEnv('AGENTS_BUILD_SOURCEMAP', 'JANGAR_BUILD_SOURCEMAP')
+  const buildSourceMap = readAgentsEnv('AGENTS_BUILD_SOURCEMAP')
   if (buildSourceMap) buildArgs.AGENTS_BUILD_SOURCEMAP = buildSourceMap
 
-  const buildCi = readAgentsEnv('AGENTS_BUILD_CI', 'JANGAR_BUILD_CI')
+  const buildCi = readAgentsEnv('AGENTS_BUILD_CI')
   if (buildCi) buildArgs.AGENTS_BUILD_CI = buildCi
 
-  const buildLogLevel = readAgentsEnv('AGENTS_BUILD_LOG_LEVEL', 'JANGAR_BUILD_LOG_LEVEL')
+  const buildLogLevel = readAgentsEnv('AGENTS_BUILD_LOG_LEVEL')
   if (buildLogLevel) buildArgs.AGENTS_BUILD_LOG_LEVEL = buildLogLevel
 
   if (process.env.BUILDX_VERSION) {
@@ -159,8 +158,7 @@ const resolveBuildConfiguration = (options: BuildImageOptions = {}): BuildConfig
   const codexAuthPath =
     options.codexAuthPath ?? process.env.CODEX_AUTH_PATH ?? resolve(process.env.HOME ?? '', '.codex/auth.json')
   const cacheRef = options.cacheRef ?? process.env.AGENTS_BUILD_CACHE_REF ?? `${registry}/${repository}:buildcache`
-  const cacheMode =
-    options.cacheMode ?? parseCacheMode(process.env.AGENTS_BUILD_CACHE_MODE ?? process.env.JANGAR_BUILD_CACHE_MODE)
+  const cacheMode = options.cacheMode ?? parseCacheMode(process.env.AGENTS_BUILD_CACHE_MODE)
   const platforms =
     options.platforms ??
     parsePlatforms(process.env.AGENTS_IMAGE_PLATFORMS) ??

--- a/packages/scripts/src/agents/deploy-service.ts
+++ b/packages/scripts/src/agents/deploy-service.ts
@@ -217,22 +217,14 @@ const parseArgs = (argv: string[]): Partial<Options> => {
 
 const resolveOptions = (): Options => {
   const args = parseArgs(process.argv.slice(2))
-  const registry =
-    args.registry ??
-    process.env.AGENTS_IMAGE_REGISTRY ??
-    process.env.JANGAR_IMAGE_REGISTRY ??
-    'registry.ide-newton.ts.net'
+  const registry = args.registry ?? process.env.AGENTS_IMAGE_REGISTRY ?? 'registry.ide-newton.ts.net'
   const repository =
     args.repository ??
     process.env.AGENTS_CONTROLLER_IMAGE_REPOSITORY ??
     process.env.AGENTS_IMAGE_REPOSITORY ??
-    process.env.JANGAR_IMAGE_REPOSITORY ??
     'lab/agents-controller'
   const controlPlaneRepository =
-    args.controlPlaneRepository ??
-    process.env.AGENTS_CONTROL_PLANE_IMAGE_REPOSITORY ??
-    process.env.JANGAR_CONTROL_PLANE_IMAGE_REPOSITORY ??
-    'lab/agents-control-plane'
+    args.controlPlaneRepository ?? process.env.AGENTS_CONTROL_PLANE_IMAGE_REPOSITORY ?? 'lab/agents-control-plane'
   const runnerRepository =
     args.runnerRepository ??
     process.env.AGENTS_RUNNER_IMAGE_REPOSITORY ??
@@ -241,13 +233,8 @@ const resolveOptions = (): Options => {
   const runnerDockerfile =
     args.runnerDockerfile ?? process.env.AGENTS_RUNNER_DOCKERFILE ?? 'services/agents/Dockerfile.codex-runner'
   const codexAuthPath = resolveCodexAuthPath(args.codexAuthPath ?? process.env.CODEX_AUTH_PATH)
-  const tag =
-    args.tag ??
-    process.env.AGENTS_IMAGE_TAG ??
-    process.env.JANGAR_IMAGE_TAG ??
-    execGit(['rev-parse', '--short', 'HEAD'])
-  const platforms = parsePlatforms(process.env.AGENTS_IMAGE_PLATFORMS) ??
-    parsePlatforms(process.env.JANGAR_IMAGE_PLATFORMS) ?? ['linux/amd64', 'linux/arm64']
+  const tag = args.tag ?? process.env.AGENTS_IMAGE_TAG ?? execGit(['rev-parse', '--short', 'HEAD'])
+  const platforms = parsePlatforms(process.env.AGENTS_IMAGE_PLATFORMS) ?? ['linux/amd64', 'linux/arm64']
 
   return {
     kustomizePath: resolve(


### PR DESCRIPTION
## Summary

- Removes `JANGAR_IMAGE_*` and `JANGAR_CONTROL_PLANE_IMAGE_REPOSITORY` fallbacks from the Agents deploy helper.
- Removes `JANGAR_BUILD_*` and `JANGAR_IMAGE_PLATFORMS` fallbacks from the Agents image build helper.
- Adds regression tests proving legacy Jangar build/deploy env names are ignored by Agents tooling.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/build-image.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`
- `bunx oxfmt --check packages/scripts/src/agents/build-image.ts packages/scripts/src/agents/deploy-service.ts packages/scripts/src/agents/__tests__/build-image.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts`
- `git diff --check`
- `rg -n "JANGAR_IMAGE|JANGAR_BUILD|JANGAR_CONTROL_PLANE|JANGAR_" packages/scripts/src/agents --glob '!**/__tests__/**'`

## Screenshots (if applicable)

N/A

## Breaking Changes

Agents build/deploy scripts now require canonical `AGENTS_*` env names for image registry, repository, tag, platforms, and build arguments. `JANGAR_*` aliases are ignored.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
