### PR TITLE
chore(agents): promote images 3b6c02e9

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: 0112732a
-  digest: sha256:c3aaf6861801776206da2736e050ed824571aedccc7e34d7c08c1cffb986e3c3
+  tag: 3b6c02e9
+  digest: sha256:a065a1e35846afea7445bbaf79accacf66c37a7da3301139eb241b1f73163a9f
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,23 +11,23 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: 0112732a
-    digest: sha256:398bad354e140f23ad2e223c59918e7f71b2990e12af2b8bf460ae5fe4d2cd5e
+    tag: 3b6c02e9
+    digest: sha256:34db622508187e9f252487ead6d97a963f897be96ae16a67119eec4f4e2c60f8
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
-      AGENTS_SOURCE_HEAD_SHA: 0112732aef678e84183c46a4ff88d6a1bff24d45
-      AGENTS_GITOPS_REVISION: 0112732aef678e84183c46a4ff88d6a1bff24d45
-      AGENTS_SOURCE_CI_RUN_ID: "26083058778"
+      AGENTS_SOURCE_HEAD_SHA: 3b6c02e948ab3c992129958744e41fd9437431d7
+      AGENTS_GITOPS_REVISION: 3b6c02e948ab3c992129958744e41fd9437431d7
+      AGENTS_SOURCE_CI_RUN_ID: "26086635102"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:398bad354e140f23ad2e223c59918e7f71b2990e12af2b8bf460ae5fe4d2cd5e
-      AGENTS_SERVING_BUILD_COMMIT: 0112732aef678e84183c46a4ff88d6a1bff24d45
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:398bad354e140f23ad2e223c59918e7f71b2990e12af2b8bf460ae5fe4d2cd5e
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:34db622508187e9f252487ead6d97a963f897be96ae16a67119eec4f4e2c60f8
+      AGENTS_SERVING_BUILD_COMMIT: 3b6c02e948ab3c992129958744e41fd9437431d7
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:34db622508187e9f252487ead6d97a963f897be96ae16a67119eec4f4e2c60f8
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: 0112732a
-    digest: sha256:6f53a028922e2df4a32995d94408df884a1977b40d2d6331db104f676626d3da
+    tag: 3b6c02e9
+    digest: sha256:954cb108ece9df370aa441117723144948141ba02fd52c2e3fa1ff91847dda7a
 argocdHooks:
   enabled: true
   image:
@@ -82,8 +82,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: 0112732a
-    digest: sha256:c3aaf6861801776206da2736e050ed824571aedccc7e34d7c08c1cffb986e3c3
+    tag: 3b6c02e9
+    digest: sha256:a065a1e35846afea7445bbaf79accacf66c37a7da3301139eb241b1f73163a9f
   autoscaling:
     enabled: false
   env:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `3b6c02e948ab3c992129958744e41fd9437431d7`
- Image tag: `3b6c02e9`
- Source CI run: `26086635102`
- Runner image pin preserved