### PR TITLE
refactor(agents): remove runtime jangar aliases

### DIFF
--- a/services/agents/package.json
+++ b/services/agents/package.json
@@ -42,6 +42,7 @@
     "./server/ready": "./src/server/ready.ts",
     "./server/runtime-identity": "./src/server/runtime-identity.ts",
     "./server/runtime-entry-config": "./src/server/runtime-entry-config.ts",
+    "./server/runtime-env": "./src/server/runtime-env.ts",
     "./server/server-route": "./src/server/server-route.ts",
     "./server/storage-config": "./src/server/storage-config.ts",
     "./server/status-utils": "./src/server/status-utils.ts",

--- a/services/agents/src/server/__tests__/control-plane-grpc.test.ts
+++ b/services/agents/src/server/__tests__/control-plane-grpc.test.ts
@@ -9,11 +9,6 @@ const grpcEnvNames = [
   'AGENTS_GRPC_PORT',
   'AGENTS_GRPC_ADDRESS',
   'AGENTS_GRPC_HEALTH_TIMEOUT_MS',
-  'JANGAR_GRPC_ENABLED',
-  'JANGAR_GRPC_HOST',
-  'JANGAR_GRPC_PORT',
-  'JANGAR_GRPC_ADDRESS',
-  'JANGAR_GRPC_HEALTH_TIMEOUT_MS',
 ] as const
 
 const withEnv = async <T>(updates: Record<string, string | undefined>, fn: () => Promise<T>): Promise<T> => {
@@ -87,14 +82,14 @@ describe('resolveGrpcStatus', () => {
     expect(status.message).toContain('invalid AGENTS_GRPC_ENABLED value')
   })
 
-  it('returns degraded with the legacy env name when only JANGAR_GRPC_ENABLED is invalid', async () => {
+  it('ignores legacy JANGAR_GRPC_ENABLED when only the legacy name is set', async () => {
     const status = await withEnv({ JANGAR_GRPC_ENABLED: 'bogus' }, () => resolveGrpcStatus())
 
     expect(status).toMatchObject({
       enabled: false,
-      status: 'degraded',
+      status: 'disabled',
     })
-    expect(status.message).toContain('invalid JANGAR_GRPC_ENABLED value')
+    expect(status.message).toBe('gRPC disabled')
   })
 
   it('returns degraded when AGENTS_GRPC_PORT is malformed and no address override is set', async () => {

--- a/services/agents/src/server/agent-resource-labels.test.ts
+++ b/services/agents/src/server/agent-resource-labels.test.ts
@@ -11,20 +11,16 @@ import {
 } from './agent-resource-labels'
 
 describe('Agents resource labels', () => {
-  it('emits canonical labels while preserving legacy labels for existing clients', () => {
+  it('emits canonical labels only for new resources', () => {
     expect(buildDeliveryIdLabels('delivery-1')).toEqual({
       [AGENTS_RESOURCE_LABELS.deliveryId.canonical]: 'delivery-1',
-      [AGENTS_RESOURCE_LABELS.deliveryId.legacy]: 'delivery-1',
     })
     expect(buildOrchestrationChildLabels('orch-1', 'step-1')).toMatchObject({
       [AGENTS_RESOURCE_LABELS.orchestrationRun.canonical]: 'orch-1',
-      [AGENTS_RESOURCE_LABELS.orchestrationRun.legacy]: 'orch-1',
       [AGENTS_RESOURCE_LABELS.orchestrationStep.canonical]: 'step-1',
-      [AGENTS_RESOURCE_LABELS.orchestrationStep.legacy]: 'step-1',
     })
     expect(buildToolRunJobLabels('toolrun-1')).toEqual({
       [AGENTS_RESOURCE_LABELS.toolRun.canonical]: 'toolrun-1',
-      [AGENTS_RESOURCE_LABELS.toolRun.legacy]: 'toolrun-1',
     })
   })
 

--- a/services/agents/src/server/agent-resource-labels.ts
+++ b/services/agents/src/server/agent-resource-labels.ts
@@ -25,7 +25,6 @@ const buildCompatibleLabel = (label: AgentsResourceLabel, value: string): Record
   const keys = AGENTS_RESOURCE_LABELS[label]
   return {
     [keys.canonical]: value,
-    [keys.legacy]: value,
   }
 }
 

--- a/services/agents/src/server/agentctl-grpc-config.ts
+++ b/services/agents/src/server/agentctl-grpc-config.ts
@@ -1,4 +1,4 @@
-type EnvSource = Record<string, string | undefined>
+import { readAgentsEnv, type EnvSource } from './runtime-env'
 
 const DEFAULT_GRPC_PORT = 50051
 const ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on'])
@@ -16,30 +16,27 @@ export type AgentctlGrpcConfig = {
   agentsControllerEnabled: boolean
 }
 
-const readAgentsEnv = (env: EnvSource, agentsName: string, legacyJangarName?: string) =>
-  env[agentsName]?.trim() || (legacyJangarName ? env[legacyJangarName]?.trim() : undefined)
-
 const parsePort = (value: string | undefined) => {
   const parsed = Number.parseInt(value ?? '', 10)
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_GRPC_PORT
 }
 
 export const resolveAgentctlGrpcConfig = (env: EnvSource = process.env): AgentctlGrpcConfig => {
-  const host = readAgentsEnv(env, 'AGENTS_GRPC_HOST', 'JANGAR_GRPC_HOST') || '127.0.0.1'
-  const port = parsePort(readAgentsEnv(env, 'AGENTS_GRPC_PORT', 'JANGAR_GRPC_PORT'))
+  const host = readAgentsEnv(env, 'AGENTS_GRPC_HOST') || '127.0.0.1'
+  const port = parsePort(readAgentsEnv(env, 'AGENTS_GRPC_PORT') ?? undefined)
   return {
-    enabled: ENABLED_VALUES.has((readAgentsEnv(env, 'AGENTS_GRPC_ENABLED', 'JANGAR_GRPC_ENABLED') ?? '').toLowerCase()),
-    authToken: readAgentsEnv(env, 'AGENTS_GRPC_TOKEN', 'JANGAR_GRPC_TOKEN') || null,
+    enabled: ENABLED_VALUES.has((readAgentsEnv(env, 'AGENTS_GRPC_ENABLED') ?? '').toLowerCase()),
+    authToken: readAgentsEnv(env, 'AGENTS_GRPC_TOKEN') || null,
     host,
     port,
-    address: readAgentsEnv(env, 'AGENTS_GRPC_ADDRESS', 'JANGAR_GRPC_ADDRESS') || `${host}:${port}`,
-    protoPathOverride: readAgentsEnv(env, 'AGENTS_GRPC_PROTO_PATH', 'JANGAR_GRPC_PROTO_PATH') || null,
-    version: readAgentsEnv(env, 'AGENTS_VERSION', 'JANGAR_VERSION') ?? 'dev',
-    buildSha: readAgentsEnv(env, 'AGENTS_COMMIT', 'JANGAR_BUILD_SHA') ?? '',
-    buildTime: readAgentsEnv(env, 'AGENTS_BUILD_TIME', 'JANGAR_BUILD_TIME') ?? '',
+    address: readAgentsEnv(env, 'AGENTS_GRPC_ADDRESS') || `${host}:${port}`,
+    protoPathOverride: readAgentsEnv(env, 'AGENTS_GRPC_PROTO_PATH') || null,
+    version: readAgentsEnv(env, 'AGENTS_VERSION') ?? 'dev',
+    buildSha: readAgentsEnv(env, 'AGENTS_COMMIT') ?? '',
+    buildTime: readAgentsEnv(env, 'AGENTS_BUILD_TIME') ?? '',
     agentsControllerEnabled:
-      readAgentsEnv(env, 'AGENTS_AGENTS_CONTROLLER_ENABLED', 'JANGAR_AGENTS_CONTROLLER_ENABLED') === '1' ||
-      readAgentsEnv(env, 'AGENTS_SERVER_PROFILE', 'JANGAR_SERVER_PROFILE') === 'agents-controllers',
+      readAgentsEnv(env, 'AGENTS_AGENTS_CONTROLLER_ENABLED') === '1' ||
+      readAgentsEnv(env, 'AGENTS_SERVER_PROFILE') === 'agents-controllers',
   }
 }
 

--- a/services/agents/src/server/agentctl-grpc-logging.test.ts
+++ b/services/agents/src/server/agentctl-grpc-logging.test.ts
@@ -9,7 +9,6 @@ describe('agentctl gRPC runtime logging', () => {
     vi.restoreAllMocks()
     process.env = { ...ORIGINAL_ENV }
     delete process.env.AGENTS_RUNTIME_SERVICE
-    delete process.env.JANGAR_GRPC_ENABLED
     delete process.env.AGENTS_GRPC_ENABLED
   })
 
@@ -27,11 +26,11 @@ describe('agentctl gRPC runtime logging', () => {
     expect(info).toHaveBeenCalledWith('[agents] agentctl grpc disabled for control plane')
   })
 
-  it('keeps legacy Jangar labels outside Agents runtime mode', () => {
+  it('uses Agents log labels without runtime identity env', () => {
     const info = vi.spyOn(console, 'info').mockImplementation(() => {})
 
     expect(startAgentctlGrpcServer()).toBeNull()
 
-    expect(info).toHaveBeenCalledWith('[jangar] agentctl grpc disabled for control plane')
+    expect(info).toHaveBeenCalledWith('[agents] agentctl grpc disabled for control plane')
   })
 })

--- a/services/agents/src/server/audit-logging.ts
+++ b/services/agents/src/server/audit-logging.ts
@@ -21,7 +21,6 @@ const normalizeHeaderValue = (value: string | null) => {
 export const resolveActorFromRequest = (request: Request) => {
   const candidates = [
     'x-agents-actor',
-    'x-jangar-actor',
     'x-forwarded-user',
     'x-forwarded-email',
     'x-auth-request-email',

--- a/services/agents/src/server/audit-sink.ts
+++ b/services/agents/src/server/audit-sink.ts
@@ -1,4 +1,5 @@
 import type { AuditEventRecord } from './primitives-store'
+import { normalizeEnvValue, readAgentsEnv, type EnvSource } from './runtime-env'
 
 type AuditSinkType = 'none' | 'stdout' | 'http'
 
@@ -10,20 +11,10 @@ type AuditHttpSinkConfig = {
 
 type AuditSinkConfig = { type: 'none' } | { type: 'stdout' } | { type: 'http'; http: AuditHttpSinkConfig }
 
-type EnvSource = Record<string, string | undefined>
-
 const DEFAULT_HTTP_TIMEOUT_MS = 2000
 
-const normalizeString = (value: string | undefined) => {
-  const trimmed = value?.trim() ?? ''
-  return trimmed.length > 0 ? trimmed : null
-}
-
-const readAgentsEnv = (env: EnvSource, agentsName: string, legacyJangarName?: string) =>
-  normalizeString(env[agentsName]) ?? (legacyJangarName ? normalizeString(env[legacyJangarName]) : null)
-
 const parseOptionalJsonRecord = (value: string | undefined) => {
-  const trimmed = normalizeString(value)
+  const trimmed = normalizeEnvValue(value)
   if (!trimmed) return {}
   try {
     const parsed = JSON.parse(trimmed) as unknown
@@ -40,7 +31,7 @@ const parseOptionalJsonRecord = (value: string | undefined) => {
 }
 
 const parseOptionalInt = (value: string | undefined) => {
-  const trimmed = normalizeString(value)
+  const trimmed = normalizeEnvValue(value)
   if (!trimmed) return null
   const parsed = Number.parseInt(trimmed, 10)
   if (!Number.isFinite(parsed) || parsed <= 0) return null
@@ -50,28 +41,23 @@ const parseOptionalInt = (value: string | undefined) => {
 let cachedConfig: AuditSinkConfig | null = null
 
 export const resolveAgentsAuditSinkConfig = (env: EnvSource = process.env): AuditSinkConfig => {
-  const type = (readAgentsEnv(env, 'AGENTS_AUDIT_SINK_TYPE', 'JANGAR_AUDIT_SINK_TYPE') ?? 'none')
-    .trim()
-    .toLowerCase() as AuditSinkType
+  const type = (readAgentsEnv(env, 'AGENTS_AUDIT_SINK_TYPE') ?? 'none').trim().toLowerCase() as AuditSinkType
 
   if (type === 'stdout') {
     return { type: 'stdout' }
   }
 
   if (type === 'http') {
-    const url = readAgentsEnv(env, 'AGENTS_AUDIT_SINK_HTTP_URL', 'JANGAR_AUDIT_SINK_HTTP_URL')
+    const url = readAgentsEnv(env, 'AGENTS_AUDIT_SINK_HTTP_URL')
     if (!url) return { type: 'none' }
     return {
       type: 'http',
       http: {
         url,
-        headers: parseOptionalJsonRecord(
-          readAgentsEnv(env, 'AGENTS_AUDIT_SINK_HTTP_HEADERS_JSON', 'JANGAR_AUDIT_SINK_HTTP_HEADERS_JSON') ?? undefined,
-        ),
+        headers: parseOptionalJsonRecord(readAgentsEnv(env, 'AGENTS_AUDIT_SINK_HTTP_HEADERS_JSON') ?? undefined),
         timeoutMs:
-          parseOptionalInt(
-            readAgentsEnv(env, 'AGENTS_AUDIT_SINK_HTTP_TIMEOUT_MS', 'JANGAR_AUDIT_SINK_HTTP_TIMEOUT_MS') ?? undefined,
-          ) ?? DEFAULT_HTTP_TIMEOUT_MS,
+          parseOptionalInt(readAgentsEnv(env, 'AGENTS_AUDIT_SINK_HTTP_TIMEOUT_MS') ?? undefined) ??
+          DEFAULT_HTTP_TIMEOUT_MS,
       },
     }
   }

--- a/services/agents/src/server/control-plane-cache-config.ts
+++ b/services/agents/src/server/control-plane-cache-config.ts
@@ -1,4 +1,4 @@
-type EnvSource = Record<string, string | undefined>
+import { parseBooleanEnv, parsePositiveIntEnv, readAgentsEnv, type EnvSource } from './runtime-env'
 
 const DEFAULT_CACHE_CLUSTER_ID = 'default'
 
@@ -15,53 +15,22 @@ export type ControlPlaneCacheFreshnessConfig = {
 export const isRuntimeTestEnv = (env: EnvSource = process.env) =>
   env.NODE_ENV === 'test' || Boolean(env.VITEST) || Boolean(env.VITEST_POOL_ID) || Boolean(env.VITEST_WORKER_ID)
 
-const readEnv = (env: EnvSource, agentsName: string, legacyJangarName: string) =>
-  env[agentsName]?.trim() || env[legacyJangarName]?.trim() || undefined
-
-const parseBoolean = (value: string | undefined, fallback: boolean) => {
-  const normalized = value?.trim().toLowerCase()
-  if (!normalized) return fallback
-  if (['1', 'true', 'yes', 'y', 'on', 'enabled'].includes(normalized)) return true
-  if (['0', 'false', 'no', 'n', 'off', 'disabled'].includes(normalized)) return false
-  return fallback
-}
-
-const parsePositiveInt = (value: string | undefined, fallback: number, minimum = 1, maximum?: number) => {
-  const normalized = value?.trim()
-  if (!normalized) return fallback
-  const parsed = Number.parseInt(normalized, 10)
-  if (!Number.isFinite(parsed)) return fallback
-  if (parsed < minimum) return fallback
-  const bounded = Math.floor(parsed)
-  return maximum === undefined ? bounded : Math.min(bounded, maximum)
-}
-
 export const resolveControlPlaneCacheReadConfig = (env: EnvSource = process.env): ControlPlaneCacheReadConfig => ({
-  enabled: parseBoolean(
-    readEnv(env, 'AGENTS_CONTROL_PLANE_CACHE_ENABLED', 'JANGAR_CONTROL_PLANE_CACHE_ENABLED'),
-    false,
-  ),
-  clusterId:
-    readEnv(env, 'AGENTS_CONTROL_PLANE_CACHE_CLUSTER', 'JANGAR_CONTROL_PLANE_CACHE_CLUSTER') ??
-    DEFAULT_CACHE_CLUSTER_ID,
+  enabled: parseBooleanEnv(readAgentsEnv(env, 'AGENTS_CONTROL_PLANE_CACHE_ENABLED'), false),
+  clusterId: readAgentsEnv(env, 'AGENTS_CONTROL_PLANE_CACHE_CLUSTER') ?? DEFAULT_CACHE_CLUSTER_ID,
 })
 
 export const resolveControlPlaneCacheFreshnessConfig = (
   env: EnvSource = process.env,
 ): ControlPlaneCacheFreshnessConfig => ({
-  maxAgeSeconds: parsePositiveInt(
-    readEnv(env, 'AGENTS_CONTROL_PLANE_CACHE_STALE_SECONDS', 'JANGAR_CONTROL_PLANE_CACHE_STALE_SECONDS'),
-    120,
-    0,
-  ),
-  allowStale: parseBoolean(
-    readEnv(env, 'AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE', 'JANGAR_CONTROL_PLANE_CACHE_ALLOW_STALE'),
-    true,
-  ),
+  maxAgeSeconds: parsePositiveIntEnv(readAgentsEnv(env, 'AGENTS_CONTROL_PLANE_CACHE_STALE_SECONDS'), 120, {
+    minimum: 0,
+  }),
+  allowStale: parseBooleanEnv(readAgentsEnv(env, 'AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE'), true),
 })
 
 export const __private = {
-  parseBoolean,
-  parsePositiveInt,
-  readEnv,
+  parseBoolean: parseBooleanEnv,
+  parsePositiveInt: parsePositiveIntEnv,
+  readEnv: readAgentsEnv,
 }

--- a/services/agents/src/server/control-plane-grpc.ts
+++ b/services/agents/src/server/control-plane-grpc.ts
@@ -22,15 +22,10 @@ type RuntimeEnvValue = {
   value: string
 }
 
-const readRuntimeEnv = (canonicalName: string, legacyName: string): RuntimeEnvValue => {
+const readRuntimeEnv = (canonicalName: string): RuntimeEnvValue => {
   const canonicalValue = process.env[canonicalName]?.trim()
   if (canonicalValue) {
     return { name: canonicalName, value: canonicalValue }
-  }
-
-  const legacyValue = process.env[legacyName]?.trim()
-  if (legacyValue) {
-    return { name: legacyName, value: legacyValue }
   }
 
   return { name: canonicalName, value: '' }
@@ -69,7 +64,7 @@ const parseGrpcPort = (portInput: string, fallback: number): number | null => {
 }
 
 const parseGrpcTimeoutMs = () => {
-  const raw = process.env.AGENTS_GRPC_HEALTH_TIMEOUT_MS ?? process.env.JANGAR_GRPC_HEALTH_TIMEOUT_MS
+  const raw = process.env.AGENTS_GRPC_HEALTH_TIMEOUT_MS
   const parsed = Number.parseInt(raw ?? '', 10)
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_GRPC_HEALTH_TIMEOUT_MS
 }
@@ -118,7 +113,7 @@ const checkGrpcEndpointReachability = async (host: string, port: number, timeout
 
 export const resolveGrpcStatus = async (): Promise<GrpcStatus> => {
   const grpcConfig = resolveAgentctlGrpcConfig(process.env)
-  const enabledEnv = readRuntimeEnv('AGENTS_GRPC_ENABLED', 'JANGAR_GRPC_ENABLED')
+  const enabledEnv = readRuntimeEnv('AGENTS_GRPC_ENABLED')
   const parsedEnabled = parseBooleanFlag(enabledEnv.value)
   if (!parsedEnabled.valid) {
     return {
@@ -139,9 +134,9 @@ export const resolveGrpcStatus = async (): Promise<GrpcStatus> => {
   }
 
   const host = grpcConfig.host
-  const addressOverride = readRuntimeEnv('AGENTS_GRPC_ADDRESS', 'JANGAR_GRPC_ADDRESS').value
+  const addressOverride = readRuntimeEnv('AGENTS_GRPC_ADDRESS').value
   if (!addressOverride) {
-    const portEnv = readRuntimeEnv('AGENTS_GRPC_PORT', 'JANGAR_GRPC_PORT')
+    const portEnv = readRuntimeEnv('AGENTS_GRPC_PORT')
     const resolvedPort = parseGrpcPort(portEnv.value, DEFAULT_GRPC_PORT)
     if (resolvedPort === null) {
       return {

--- a/services/agents/src/server/control-plane.test.ts
+++ b/services/agents/src/server/control-plane.test.ts
@@ -13,8 +13,8 @@ import { createAgentsControlPlaneRuntime } from './control-plane'
 const previousEnv = {
   AGENTS_AGENTS_CONTROLLER_ENABLED: process.env.AGENTS_AGENTS_CONTROLLER_ENABLED,
   AGENTS_PROMETHEUS_METRICS_ENABLED: process.env.AGENTS_PROMETHEUS_METRICS_ENABLED,
+  AGENTS_MIGRATIONS: process.env.AGENTS_MIGRATIONS,
   DATABASE_URL: process.env.DATABASE_URL,
-  JANGAR_MIGRATIONS: process.env.JANGAR_MIGRATIONS,
 }
 
 afterEach(() => {
@@ -43,7 +43,7 @@ describe('Agents control-plane runtime', () => {
   it('serves v1 AgentRun routes through configured Agents dependencies', async () => {
     process.env.AGENTS_AGENTS_CONTROLLER_ENABLED = '0'
     delete process.env.DATABASE_URL
-    process.env.JANGAR_MIGRATIONS = 'skip'
+    process.env.AGENTS_MIGRATIONS = 'skip'
     const runtime = await createAgentsControlPlaneRuntime()
 
     const response = await runtime.handleHttpRequest(new Request('http://agents.test/v1/agent-runs?agentName=demo'))

--- a/services/agents/src/server/control-plane.ts
+++ b/services/agents/src/server/control-plane.ts
@@ -146,12 +146,11 @@ const assessAgentRunIngestion = (
 }
 
 const isMetricsEnabled = () => {
-  const raw = process.env.AGENTS_PROMETHEUS_METRICS_ENABLED ?? process.env.JANGAR_PROMETHEUS_METRICS_ENABLED
+  const raw = process.env.AGENTS_PROMETHEUS_METRICS_ENABLED
   return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on'
 }
 
-const metricsPath = () =>
-  process.env.AGENTS_PROMETHEUS_METRICS_PATH ?? process.env.JANGAR_PROMETHEUS_METRICS_PATH ?? defaultMetricsPath
+const metricsPath = () => process.env.AGENTS_PROMETHEUS_METRICS_PATH ?? defaultMetricsPath
 
 const renderMetrics = async () => ({
   ok: true as const,

--- a/services/agents/src/server/controller-runtime-config.ts
+++ b/services/agents/src/server/controller-runtime-config.ts
@@ -1,6 +1,4 @@
-import { isAgentsRuntimeService } from '@proompteng/agents/server/runtime-identity'
-
-type EnvSource = Record<string, string | undefined>
+import { readAgentsEnv, type EnvSource } from './runtime-env'
 
 type ControllerToggleConfig = {
   enabled: boolean
@@ -19,15 +17,6 @@ export type PrimitivesReconcilerConfig = ControllerToggleConfig
 export type SupportingControllerConfig = ControllerToggleConfig
 
 const DNS_LABEL_REGEX = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/
-
-const readEnv = (env: EnvSource, name: string) => {
-  if (name.startsWith('AGENTS_')) return env[name] ?? env[`JANGAR_${name.slice('AGENTS_'.length)}`]
-  if (name.startsWith('JANGAR_')) return env[`AGENTS_${name.slice('JANGAR_'.length)}`] ?? env[name]
-  return env[name]
-}
-
-const defaultFeatureFlagKey = (env: EnvSource, agentsKey: string, jangarKey: string) =>
-  isAgentsRuntimeService(env) ? agentsKey : jangarKey
 
 const parseBooleanEnv = (value: string | undefined, fallback: boolean) => {
   if (value == null) return fallback
@@ -63,56 +52,54 @@ const parseNamespaces = (raw: string | undefined, fallback: string[], label: str
 }
 
 export const isControllerClusterScoped = (env: EnvSource = process.env) =>
-  parseBooleanEnv(readEnv(env, 'AGENTS_RBAC_CLUSTER_SCOPED'), false)
+  parseBooleanEnv(readAgentsEnv(env, 'AGENTS_RBAC_CLUSTER_SCOPED') ?? undefined, false)
 
 export const resolveControlPlaneCacheConfig = (env: EnvSource = process.env): ControlPlaneCacheConfig => ({
-  enabled: parseBooleanEnv(readEnv(env, 'AGENTS_CONTROL_PLANE_CACHE_ENABLED'), false),
+  enabled: parseBooleanEnv(readAgentsEnv(env, 'AGENTS_CONTROL_PLANE_CACHE_ENABLED') ?? undefined, false),
   namespaces: parseNamespaces(
-    readEnv(env, 'AGENTS_CONTROL_PLANE_CACHE_NAMESPACES') ?? readEnv(env, 'AGENTS_PRIMITIVES_NAMESPACES'),
+    readAgentsEnv(env, 'AGENTS_CONTROL_PLANE_CACHE_NAMESPACES') ??
+      readAgentsEnv(env, 'AGENTS_PRIMITIVES_NAMESPACES') ??
+      undefined,
     ['agents'],
     'control plane cache',
     isControllerClusterScoped(env),
   ),
-  clusterId: readEnv(env, 'AGENTS_CONTROL_PLANE_CACHE_CLUSTER')?.trim() || 'default',
+  clusterId: readAgentsEnv(env, 'AGENTS_CONTROL_PLANE_CACHE_CLUSTER') || 'default',
 })
 
 export const resolveOrchestrationControllerConfig = (env: EnvSource = process.env): OrchestrationControllerConfig => ({
-  enabled: parseBooleanEnv(readEnv(env, 'AGENTS_ORCHESTRATION_CONTROLLER_ENABLED'), true),
+  enabled: parseBooleanEnv(readAgentsEnv(env, 'AGENTS_ORCHESTRATION_CONTROLLER_ENABLED') ?? undefined, true),
   namespaces: parseNamespaces(
-    readEnv(env, 'AGENTS_ORCHESTRATION_CONTROLLER_NAMESPACES'),
+    readAgentsEnv(env, 'AGENTS_ORCHESTRATION_CONTROLLER_NAMESPACES') ?? undefined,
     ['agents'],
     'orchestration controller',
     isControllerClusterScoped(env),
   ),
   enabledFlagKey:
-    readEnv(env, 'AGENTS_ORCHESTRATION_CONTROLLER_ENABLED_FLAG_KEY')?.trim() ||
-    defaultFeatureFlagKey(env, 'agents.orchestration_controller.enabled', 'jangar.orchestration_controller.enabled'),
+    readAgentsEnv(env, 'AGENTS_ORCHESTRATION_CONTROLLER_ENABLED_FLAG_KEY') || 'agents.orchestration_controller.enabled',
 })
 
 export const resolvePrimitivesReconcilerConfig = (env: EnvSource = process.env): PrimitivesReconcilerConfig => ({
-  enabled: parseBooleanEnv(readEnv(env, 'AGENTS_PRIMITIVES_RECONCILER'), true),
+  enabled: parseBooleanEnv(readAgentsEnv(env, 'AGENTS_PRIMITIVES_RECONCILER') ?? undefined, true),
   namespaces: parseNamespaces(
-    readEnv(env, 'AGENTS_PRIMITIVES_NAMESPACES'),
+    readAgentsEnv(env, 'AGENTS_PRIMITIVES_NAMESPACES') ?? undefined,
     ['agents'],
     'primitives reconciler',
     isControllerClusterScoped(env),
   ),
-  enabledFlagKey:
-    readEnv(env, 'AGENTS_PRIMITIVES_RECONCILER_FLAG_KEY')?.trim() ||
-    defaultFeatureFlagKey(env, 'agents.primitives_reconciler.enabled', 'jangar.primitives_reconciler.enabled'),
+  enabledFlagKey: readAgentsEnv(env, 'AGENTS_PRIMITIVES_RECONCILER_FLAG_KEY') || 'agents.primitives_reconciler.enabled',
 })
 
 export const resolveSupportingControllerConfig = (env: EnvSource = process.env): SupportingControllerConfig => ({
-  enabled: parseBooleanEnv(readEnv(env, 'AGENTS_SUPPORTING_CONTROLLER_ENABLED'), true),
+  enabled: parseBooleanEnv(readAgentsEnv(env, 'AGENTS_SUPPORTING_CONTROLLER_ENABLED') ?? undefined, true),
   namespaces: parseNamespaces(
-    readEnv(env, 'AGENTS_SUPPORTING_CONTROLLER_NAMESPACES'),
+    readAgentsEnv(env, 'AGENTS_SUPPORTING_CONTROLLER_NAMESPACES') ?? undefined,
     ['agents'],
     'supporting controller',
     isControllerClusterScoped(env),
   ),
   enabledFlagKey:
-    readEnv(env, 'AGENTS_SUPPORTING_CONTROLLER_ENABLED_FLAG_KEY')?.trim() ||
-    defaultFeatureFlagKey(env, 'agents.supporting_controller.enabled', 'jangar.supporting_controller.enabled'),
+    readAgentsEnv(env, 'AGENTS_SUPPORTING_CONTROLLER_ENABLED_FLAG_KEY') || 'agents.supporting_controller.enabled',
 })
 
 export const validateControllerRuntimeConfig = (env: EnvSource = process.env) => {
@@ -123,8 +110,7 @@ export const validateControllerRuntimeConfig = (env: EnvSource = process.env) =>
 }
 
 export const __private = {
-  defaultFeatureFlagKey,
   parseBooleanEnv,
   parseNamespaces,
-  readEnv,
+  readEnv: readAgentsEnv,
 }

--- a/services/agents/src/server/integrations-config.test.ts
+++ b/services/agents/src/server/integrations-config.test.ts
@@ -22,7 +22,7 @@ describe('Agents integrations config', () => {
     })
   })
 
-  it('keeps JANGAR feature flag and agent comms names as compatibility aliases', () => {
+  it('ignores legacy JANGAR feature flag and agent comms aliases', () => {
     const featureFlags = resolveFeatureFlagsClientConfig({
       JANGAR_FEATURE_FLAGS_ENABLED: 'false',
       JANGAR_FEATURE_FLAGS_URL: 'http://jangar-flags.local/',
@@ -33,10 +33,15 @@ describe('Agents integrations config', () => {
       JANGAR_AGENT_COMMS_SUBJECTS: 'agents.workflow.>,workflow.>',
     })
 
-    expect(featureFlags.enabled).toBe(false)
-    expect(featureFlags.endpoint).toBe('http://jangar-flags.local')
-    expect(featureFlags.timeoutMs).toBe(250)
-    expect(agentComms.disabled).toBe(true)
-    expect(agentComms.filterSubjects).toEqual(['agents.workflow.>', 'workflow.>'])
+    expect(featureFlags.enabled).toBe(true)
+    expect(featureFlags.endpoint).toBeNull()
+    expect(featureFlags.timeoutMs).toBe(500)
+    expect(agentComms.disabled).toBe(false)
+    expect(agentComms.filterSubjects).toEqual([
+      'workflow.>',
+      'agents.workflow.>',
+      'argo.workflow.>',
+      'workflow_comms.agent_messages.>',
+    ])
   })
 })

--- a/services/agents/src/server/integrations-config.ts
+++ b/services/agents/src/server/integrations-config.ts
@@ -1,4 +1,4 @@
-type EnvSource = Record<string, string | undefined>
+import { normalizeEnvValue, parseBooleanEnv, parsePositiveIntEnv, readAgentsEnv, type EnvSource } from './runtime-env'
 
 const DEFAULT_NATS_URL = 'nats://nats.nats.svc.cluster.local:4222'
 const DEFAULT_FEATURE_FLAGS_TIMEOUT_MS = 500
@@ -10,33 +10,6 @@ const DEFAULT_AGENT_COMMS_FILTER_SUBJECTS = [
   'argo.workflow.>',
   'workflow_comms.agent_messages.>',
 ]
-
-const TRUE_BOOLEAN_VALUES = new Set(['1', 'true', 'yes', 'on', 'enabled'])
-const FALSE_BOOLEAN_VALUES = new Set(['0', 'false', 'no', 'off', 'disabled'])
-
-const normalizeNonEmpty = (value: string | undefined | null) => {
-  const normalized = value?.trim()
-  return normalized && normalized.length > 0 ? normalized : null
-}
-
-const readAgentsEnv = (env: EnvSource, name: string) =>
-  env[name] ?? (name.startsWith('AGENTS_') ? env[`JANGAR_${name.slice('AGENTS_'.length)}`] : undefined)
-
-const parseBoolean = (value: string | undefined, fallback: boolean) => {
-  const normalized = normalizeNonEmpty(value)?.toLowerCase()
-  if (!normalized) return fallback
-  if (TRUE_BOOLEAN_VALUES.has(normalized)) return true
-  if (FALSE_BOOLEAN_VALUES.has(normalized)) return false
-  return fallback
-}
-
-const parsePositiveInt = (value: string | undefined, fallback: number) => {
-  const normalized = normalizeNonEmpty(value)
-  if (!normalized) return fallback
-  const parsed = Number.parseInt(normalized, 10)
-  if (!Number.isFinite(parsed) || parsed <= 0) return fallback
-  return Math.floor(parsed)
-}
 
 const parseFilterSubjects = (value: string | undefined) =>
   (value ?? '')
@@ -69,15 +42,15 @@ export type FeatureFlagsClientConfig = {
 }
 
 export const resolveAgentCommsSubscriberConfig = (env: EnvSource = process.env): AgentCommsSubscriberConfig => {
-  const filterSubjects = parseFilterSubjects(readAgentsEnv(env, 'AGENTS_AGENT_COMMS_SUBJECTS'))
+  const filterSubjects = parseFilterSubjects(readAgentsEnv(env, 'AGENTS_AGENT_COMMS_SUBJECTS') ?? undefined)
   return {
     disabled:
       env.NODE_ENV === 'test' ||
       Boolean(env.VITEST) ||
       readAgentsEnv(env, 'AGENTS_AGENT_COMMS_SUBSCRIBER_DISABLED') === 'true',
-    natsUrl: normalizeNonEmpty(env.NATS_URL) ?? DEFAULT_NATS_URL,
-    natsUser: normalizeNonEmpty(env.NATS_USER) ?? undefined,
-    natsPassword: normalizeNonEmpty(env.NATS_PASSWORD) ?? undefined,
+    natsUrl: normalizeEnvValue(env.NATS_URL) ?? DEFAULT_NATS_URL,
+    natsUser: normalizeEnvValue(env.NATS_USER) ?? undefined,
+    natsPassword: normalizeEnvValue(env.NATS_PASSWORD) ?? undefined,
     streamName: 'agent-comms',
     consumerName: 'agents-agent-comms',
     pullBatchSize: 250,
@@ -91,12 +64,15 @@ export const resolveAgentCommsSubscriberConfig = (env: EnvSource = process.env):
 }
 
 export const resolveFeatureFlagsClientConfig = (env: EnvSource = process.env): FeatureFlagsClientConfig => ({
-  enabled: parseBoolean(readAgentsEnv(env, 'AGENTS_FEATURE_FLAGS_ENABLED'), true),
-  endpoint: normalizeNonEmpty(readAgentsEnv(env, 'AGENTS_FEATURE_FLAGS_URL'))?.replace(/\/+$/, '') ?? null,
-  timeoutMs: parsePositiveInt(readAgentsEnv(env, 'AGENTS_FEATURE_FLAGS_TIMEOUT_MS'), DEFAULT_FEATURE_FLAGS_TIMEOUT_MS),
+  enabled: parseBooleanEnv(readAgentsEnv(env, 'AGENTS_FEATURE_FLAGS_ENABLED'), true),
+  endpoint: normalizeEnvValue(readAgentsEnv(env, 'AGENTS_FEATURE_FLAGS_URL'))?.replace(/\/+$/, '') ?? null,
+  timeoutMs: parsePositiveIntEnv(
+    readAgentsEnv(env, 'AGENTS_FEATURE_FLAGS_TIMEOUT_MS'),
+    DEFAULT_FEATURE_FLAGS_TIMEOUT_MS,
+  ),
   namespaceKey:
-    normalizeNonEmpty(readAgentsEnv(env, 'AGENTS_FEATURE_FLAGS_NAMESPACE')) ?? DEFAULT_FEATURE_FLAGS_NAMESPACE,
-  entityId: normalizeNonEmpty(readAgentsEnv(env, 'AGENTS_FEATURE_FLAGS_ENTITY_ID')) ?? DEFAULT_FEATURE_FLAGS_ENTITY_ID,
+    normalizeEnvValue(readAgentsEnv(env, 'AGENTS_FEATURE_FLAGS_NAMESPACE')) ?? DEFAULT_FEATURE_FLAGS_NAMESPACE,
+  entityId: normalizeEnvValue(readAgentsEnv(env, 'AGENTS_FEATURE_FLAGS_ENTITY_ID')) ?? DEFAULT_FEATURE_FLAGS_ENTITY_ID,
 })
 
 export const validateIntegrationsConfig = (env: EnvSource = process.env) => {

--- a/services/agents/src/server/leader-election-config.ts
+++ b/services/agents/src/server/leader-election-config.ts
@@ -1,4 +1,4 @@
-type EnvSource = Record<string, string | undefined>
+import { normalizeEnvValue, parseBooleanEnv, parsePositiveIntEnv, readAgentsEnv, type EnvSource } from './runtime-env'
 
 const DEFAULT_LEADER_ELECTION_LEASE_NAME = 'agents-controller-leader'
 const DEFAULT_LEADER_ELECTION_ENABLED = true
@@ -6,32 +6,8 @@ const DEFAULT_LEADER_ELECTION_LEASE_DURATION_SECONDS = 30
 const DEFAULT_LEADER_ELECTION_RENEW_DEADLINE_SECONDS = 20
 const DEFAULT_LEADER_ELECTION_RETRY_PERIOD_SECONDS = 5
 
-const normalizeNonEmpty = (value: string | undefined | null) => {
-  const normalized = value?.trim()
-  return normalized && normalized.length > 0 ? normalized : null
-}
-
-const readAgentsEnv = (env: EnvSource, agentsName: string, legacyJangarName?: string) =>
-  normalizeNonEmpty(env[agentsName]) ?? (legacyJangarName ? normalizeNonEmpty(env[legacyJangarName]) : null)
-
-const parseBoolean = (value: string | undefined | null, fallback: boolean) => {
-  const normalized = normalizeNonEmpty(value)?.toLowerCase()
-  if (!normalized) return fallback
-  if (['1', 'true', 'yes', 'y', 'on', 'enabled'].includes(normalized)) return true
-  if (['0', 'false', 'no', 'n', 'off', 'disabled'].includes(normalized)) return false
-  return fallback
-}
-
-const parsePositiveInt = (value: string | undefined | null, fallback: number, minimum = 1) => {
-  const normalized = normalizeNonEmpty(value)
-  if (!normalized) return fallback
-  const parsed = Number.parseInt(normalized, 10)
-  if (!Number.isFinite(parsed) || parsed < minimum) return fallback
-  return Math.floor(parsed)
-}
-
 const isControllerWorkloadFlagEnabled = (value: string | undefined | null, defaultValue: boolean) =>
-  parseBoolean(value, defaultValue)
+  parseBooleanEnv(value, defaultValue)
 
 export type LeaderElectionSettings = {
   enabled: boolean
@@ -50,24 +26,16 @@ export const isRuntimeTestEnv = (env: EnvSource = process.env) =>
   env.NODE_ENV === 'test' || Boolean(env.VITEST) || Boolean(env.VITEST_POOL_ID) || Boolean(env.VITEST_WORKER_ID)
 
 export const resolveLeaderElectionSettings = (env: EnvSource = process.env): LeaderElectionSettings => {
-  let leaseDurationSeconds = parsePositiveInt(
-    readAgentsEnv(
-      env,
-      'AGENTS_LEADER_ELECTION_LEASE_DURATION_SECONDS',
-      'JANGAR_LEADER_ELECTION_LEASE_DURATION_SECONDS',
-    ),
+  let leaseDurationSeconds = parsePositiveIntEnv(
+    readAgentsEnv(env, 'AGENTS_LEADER_ELECTION_LEASE_DURATION_SECONDS'),
     DEFAULT_LEADER_ELECTION_LEASE_DURATION_SECONDS,
   )
-  let renewDeadlineSeconds = parsePositiveInt(
-    readAgentsEnv(
-      env,
-      'AGENTS_LEADER_ELECTION_RENEW_DEADLINE_SECONDS',
-      'JANGAR_LEADER_ELECTION_RENEW_DEADLINE_SECONDS',
-    ),
+  let renewDeadlineSeconds = parsePositiveIntEnv(
+    readAgentsEnv(env, 'AGENTS_LEADER_ELECTION_RENEW_DEADLINE_SECONDS'),
     DEFAULT_LEADER_ELECTION_RENEW_DEADLINE_SECONDS,
   )
-  let retryPeriodSeconds = parsePositiveInt(
-    readAgentsEnv(env, 'AGENTS_LEADER_ELECTION_RETRY_PERIOD_SECONDS', 'JANGAR_LEADER_ELECTION_RETRY_PERIOD_SECONDS'),
+  let retryPeriodSeconds = parsePositiveIntEnv(
+    readAgentsEnv(env, 'AGENTS_LEADER_ELECTION_RETRY_PERIOD_SECONDS'),
     DEFAULT_LEADER_ELECTION_RETRY_PERIOD_SECONDS,
   )
 
@@ -82,47 +50,26 @@ export const resolveLeaderElectionSettings = (env: EnvSource = process.env): Lea
   }
 
   return {
-    enabled: parseBoolean(
-      readAgentsEnv(env, 'AGENTS_LEADER_ELECTION_ENABLED', 'JANGAR_LEADER_ELECTION_ENABLED'),
-      DEFAULT_LEADER_ELECTION_ENABLED,
-    ),
+    enabled: parseBooleanEnv(readAgentsEnv(env, 'AGENTS_LEADER_ELECTION_ENABLED'), DEFAULT_LEADER_ELECTION_ENABLED),
     required:
       !isRuntimeTestEnv(env) &&
-      (isControllerWorkloadFlagEnabled(
-        readAgentsEnv(env, 'AGENTS_AGENTS_CONTROLLER_ENABLED', 'JANGAR_AGENTS_CONTROLLER_ENABLED'),
-        true,
-      ) ||
-        isControllerWorkloadFlagEnabled(
-          readAgentsEnv(env, 'AGENTS_ORCHESTRATION_CONTROLLER_ENABLED', 'JANGAR_ORCHESTRATION_CONTROLLER_ENABLED'),
-          true,
-        ) ||
-        isControllerWorkloadFlagEnabled(
-          readAgentsEnv(env, 'AGENTS_SUPPORTING_CONTROLLER_ENABLED', 'JANGAR_SUPPORTING_CONTROLLER_ENABLED'),
-          true,
-        ) ||
-        isControllerWorkloadFlagEnabled(
-          readAgentsEnv(env, 'AGENTS_PRIMITIVES_RECONCILER', 'JANGAR_PRIMITIVES_RECONCILER'),
-          true,
-        )),
-    leaseName:
-      readAgentsEnv(env, 'AGENTS_LEADER_ELECTION_LEASE_NAME', 'JANGAR_LEADER_ELECTION_LEASE_NAME') ??
-      DEFAULT_LEADER_ELECTION_LEASE_NAME,
-    leaseNamespace:
-      readAgentsEnv(env, 'AGENTS_LEADER_ELECTION_LEASE_NAMESPACE', 'JANGAR_LEADER_ELECTION_LEASE_NAMESPACE') ?? '',
+      (isControllerWorkloadFlagEnabled(readAgentsEnv(env, 'AGENTS_AGENTS_CONTROLLER_ENABLED'), true) ||
+        isControllerWorkloadFlagEnabled(readAgentsEnv(env, 'AGENTS_ORCHESTRATION_CONTROLLER_ENABLED'), true) ||
+        isControllerWorkloadFlagEnabled(readAgentsEnv(env, 'AGENTS_SUPPORTING_CONTROLLER_ENABLED'), true) ||
+        isControllerWorkloadFlagEnabled(readAgentsEnv(env, 'AGENTS_PRIMITIVES_RECONCILER'), true)),
+    leaseName: readAgentsEnv(env, 'AGENTS_LEADER_ELECTION_LEASE_NAME') ?? DEFAULT_LEADER_ELECTION_LEASE_NAME,
+    leaseNamespace: readAgentsEnv(env, 'AGENTS_LEADER_ELECTION_LEASE_NAMESPACE') ?? '',
     leaseDurationSeconds,
     renewDeadlineSeconds,
     retryPeriodSeconds,
-    podNamespace:
-      readAgentsEnv(env, 'AGENTS_POD_NAMESPACE', 'JANGAR_POD_NAMESPACE') ??
-      normalizeNonEmpty(env.POD_NAMESPACE) ??
-      'default',
-    podName: normalizeNonEmpty(env.HOSTNAME) ?? 'unknown',
-    podUid: readAgentsEnv(env, 'AGENTS_POD_UID', 'JANGAR_POD_UID'),
+    podNamespace: readAgentsEnv(env, 'AGENTS_POD_NAMESPACE') ?? normalizeEnvValue(env.POD_NAMESPACE) ?? 'default',
+    podName: normalizeEnvValue(env.HOSTNAME) ?? 'unknown',
+    podUid: readAgentsEnv(env, 'AGENTS_POD_UID'),
   }
 }
 
 export const __test__ = {
-  parseBoolean,
-  parsePositiveInt,
+  parseBoolean: parseBooleanEnv,
+  parsePositiveInt: parsePositiveIntEnv,
   readAgentsEnv,
 }

--- a/services/agents/src/server/memory-config.ts
+++ b/services/agents/src/server/memory-config.ts
@@ -89,7 +89,7 @@ export const resolveMemoriesIvfflatProbes = (
     MAX_MEMORIES_IVFFLAT_PROBES,
     parsePositiveInt(
       'AGENTS_MEMORIES_IVFFLAT_PROBES',
-      env.AGENTS_MEMORIES_IVFFLAT_PROBES ?? env.JANGAR_MEMORIES_IVFFLAT_PROBES ?? env.MEMORIES_IVFFLAT_PROBES,
+      env.AGENTS_MEMORIES_IVFFLAT_PROBES ?? env.MEMORIES_IVFFLAT_PROBES,
       fallback,
     ),
   )

--- a/services/agents/src/server/memory-provider.ts
+++ b/services/agents/src/server/memory-provider.ts
@@ -91,7 +91,7 @@ const getMemoryPool = (connectionString: string) => {
   if (existing) return existing
 
   const max = parsePositiveInt(
-    process.env.AGENTS_MEMORY_DB_POOL_MAX ?? process.env.JANGAR_MEMORY_DB_POOL_MAX ?? process.env.AGENTS_DB_POOL_MAX,
+    process.env.AGENTS_MEMORY_DB_POOL_MAX ?? process.env.AGENTS_DB_POOL_MAX,
     DEFAULT_MEMORY_DATABASE_POOL_MAX,
   )
   const created = new Pool({ connectionString, ssl: { rejectUnauthorized: false }, max })

--- a/services/agents/src/server/migrations-config.ts
+++ b/services/agents/src/server/migrations-config.ts
@@ -1,4 +1,4 @@
-type EnvSource = Record<string, string | undefined>
+import { normalizeEnvValue, readAgentsEnv, type EnvSource } from './runtime-env'
 
 export type AgentsMigrationsMode = 'auto' | 'skip'
 
@@ -8,28 +8,16 @@ export type AgentsMigrationsConfig = {
   skipMigrations: boolean
 }
 
-const normalizeNonEmpty = (value: string | undefined | null) => {
-  const normalized = value?.trim()
-  return normalized && normalized.length > 0 ? normalized : null
-}
-
-const readAgentsEnv = (env: EnvSource, agentsName: string, legacyJangarName?: string) =>
-  normalizeNonEmpty(env[agentsName]) ?? (legacyJangarName ? normalizeNonEmpty(env[legacyJangarName]) : null)
-
 export const resolveAgentsMigrationsConfig = (env: EnvSource = process.env): AgentsMigrationsConfig => {
-  const rawMode = readAgentsEnv(env, 'AGENTS_MIGRATIONS', 'JANGAR_MIGRATIONS')?.toLowerCase()
+  const rawMode = readAgentsEnv(env, 'AGENTS_MIGRATIONS')?.toLowerCase()
   const mode: AgentsMigrationsMode =
     rawMode && ['skip', 'disabled', 'false', '0', 'off'].includes(rawMode) ? 'skip' : 'auto'
-  const unorderedRaw = readAgentsEnv(
-    env,
-    'AGENTS_ALLOW_UNORDERED_MIGRATIONS',
-    'JANGAR_ALLOW_UNORDERED_MIGRATIONS',
-  )?.toLowerCase()
+  const unorderedRaw = readAgentsEnv(env, 'AGENTS_ALLOW_UNORDERED_MIGRATIONS')?.toLowerCase()
   const allowUnorderedMigrations = !unorderedRaw || !['false', '0', 'off', 'disabled', 'no'].includes(unorderedRaw)
   return {
     mode,
     allowUnorderedMigrations,
-    skipMigrations: env.AGENTS_SKIP_MIGRATIONS === '1' || env.JANGAR_SKIP_MIGRATIONS === '1' || mode === 'skip',
+    skipMigrations: normalizeEnvValue(env.AGENTS_SKIP_MIGRATIONS) === '1' || mode === 'skip',
   }
 }
 

--- a/services/agents/src/server/namespace-scope.ts
+++ b/services/agents/src/server/namespace-scope.ts
@@ -1,21 +1,9 @@
-type EnvSource = Record<string, string | undefined>
+import { parseBooleanEnv, readAgentsEnv, readAgentsRawEnv, type EnvSource } from './runtime-env'
 
-const TRUE_VALUES = new Set(['1', 'true', 'yes', 'y', 'on', 'enabled'])
-const FALSE_VALUES = new Set(['0', 'false', 'no', 'n', 'off', 'disabled'])
 const DNS_LABEL_REGEX = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/
 
-const readEnv = (env: EnvSource, name: string) => env[name] ?? env[`JANGAR_${name.slice('AGENTS_'.length)}`]
-
-const parseBooleanEnv = (value: string | undefined, fallback: boolean) => {
-  if (value == null) return fallback
-  const normalized = value.trim().toLowerCase()
-  if (TRUE_VALUES.has(normalized)) return true
-  if (FALSE_VALUES.has(normalized)) return false
-  return fallback
-}
-
 const isControllerClusterScoped = (env: EnvSource = process.env) =>
-  parseBooleanEnv(env.AGENTS_RBAC_CLUSTER_SCOPED ?? env.JANGAR_RBAC_CLUSTER_SCOPED, false)
+  parseBooleanEnv(readAgentsEnv(env, 'AGENTS_RBAC_CLUSTER_SCOPED'), false)
 
 export const assertClusterScopedForWildcard = (namespaces: string[], label: string, env: EnvSource = process.env) => {
   if (!namespaces.includes('*')) return
@@ -99,9 +87,7 @@ export const parseNamespaceScopeEnv = (
   options: { fallback: string[]; label: string },
   env: EnvSource = process.env,
 ): string[] => {
-  const raw = envName.startsWith('AGENTS_')
-    ? readEnv(env, envName)
-    : (env[envName] ?? env[`AGENTS_${envName.slice('JANGAR_'.length)}`])
+  const raw = readAgentsRawEnv(env, envName)
   if (raw == null) return options.fallback
   if (raw.trim() === '') {
     throw new NamespaceScopeConfigError(

--- a/services/agents/src/server/runtime-entry-config.ts
+++ b/services/agents/src/server/runtime-entry-config.ts
@@ -1,17 +1,4 @@
-type EnvSource = Record<string, string | undefined>
-
-const normalizeNonEmpty = (value: string | undefined | null) => {
-  const normalized = value?.trim()
-  return normalized && normalized.length > 0 ? normalized : null
-}
-
-const parsePositiveInt = (value: string | undefined, fallback: number) => {
-  const normalized = normalizeNonEmpty(value)
-  if (!normalized) return fallback
-  const parsed = Number.parseInt(normalized, 10)
-  if (!Number.isFinite(parsed) || parsed <= 0) return fallback
-  return Math.floor(parsed)
-}
+import { normalizeEnvValue, parsePositiveIntEnv, readAgentsEnv, type EnvSource } from './runtime-env'
 
 export type AgentsListenConfig = {
   port: number
@@ -20,12 +7,9 @@ export type AgentsListenConfig = {
 }
 
 export const resolveAgentsHttpServerListenConfig = (env: EnvSource = process.env): AgentsListenConfig => ({
-  port: parsePositiveInt(env.PORT ?? env.AGENTS_PORT ?? env.JANGAR_PORT, 3000),
-  hostname: normalizeNonEmpty(env.HOST) ?? '0.0.0.0',
-  idleTimeoutSeconds: parsePositiveInt(
-    env.AGENTS_HTTP_IDLE_TIMEOUT_SECONDS ?? env.JANGAR_HTTP_IDLE_TIMEOUT_SECONDS,
-    120,
-  ),
+  port: parsePositiveIntEnv(env.PORT ?? readAgentsEnv(env, 'AGENTS_PORT'), 3000),
+  hostname: normalizeEnvValue(env.HOST) ?? '0.0.0.0',
+  idleTimeoutSeconds: parsePositiveIntEnv(readAgentsEnv(env, 'AGENTS_HTTP_IDLE_TIMEOUT_SECONDS'), 120),
 })
 
 export const validateRuntimeEntryConfig = (env: EnvSource = process.env) => {

--- a/services/agents/src/server/runtime-env.ts
+++ b/services/agents/src/server/runtime-env.ts
@@ -1,0 +1,54 @@
+import { Context, Data, Effect, Layer } from 'effect'
+
+export type EnvSource = Record<string, string | undefined>
+
+export class AgentsEnvConfigError extends Data.TaggedError('AgentsEnvConfigError')<{
+  readonly name: string
+  readonly value: string
+  readonly reason: 'invalid-boolean' | 'invalid-positive-int'
+}> {}
+
+export type AgentsRuntimeEnvService = {
+  read: (name: string) => Effect.Effect<string | null>
+  readRaw: (name: string) => Effect.Effect<string | undefined>
+}
+
+export class AgentsRuntimeEnv extends Context.Tag('AgentsRuntimeEnv')<AgentsRuntimeEnv, AgentsRuntimeEnvService>() {}
+
+export const normalizeEnvValue = (value: string | undefined | null) => {
+  const normalized = value?.trim()
+  return normalized && normalized.length > 0 ? normalized : null
+}
+
+export const makeAgentsRuntimeEnv = (env: EnvSource): AgentsRuntimeEnvService => ({
+  read: (name) => Effect.sync(() => normalizeEnvValue(env[name])),
+  readRaw: (name) => Effect.sync(() => env[name]),
+})
+
+export const AgentsRuntimeEnvLive = Layer.succeed(AgentsRuntimeEnv, makeAgentsRuntimeEnv(process.env))
+
+export const readAgentsEnv = (env: EnvSource, name: string) => Effect.runSync(makeAgentsRuntimeEnv(env).read(name))
+
+export const readAgentsRawEnv = (env: EnvSource, name: string) =>
+  Effect.runSync(makeAgentsRuntimeEnv(env).readRaw(name))
+
+export const parseBooleanEnv = (value: string | undefined | null, fallback: boolean) => {
+  const normalized = normalizeEnvValue(value)?.toLowerCase()
+  if (!normalized) return fallback
+  if (['1', 'true', 'yes', 'y', 'on', 'enabled'].includes(normalized)) return true
+  if (['0', 'false', 'no', 'n', 'off', 'disabled'].includes(normalized)) return false
+  return fallback
+}
+
+export const parsePositiveIntEnv = (
+  value: string | undefined | null,
+  fallback: number,
+  options: { minimum?: number; maximum?: number } = {},
+) => {
+  const normalized = normalizeEnvValue(value)
+  if (!normalized) return fallback
+  const parsed = Number.parseInt(normalized, 10)
+  if (!Number.isFinite(parsed) || parsed < (options.minimum ?? 1)) return fallback
+  const bounded = Math.floor(parsed)
+  return options.maximum === undefined ? bounded : Math.min(bounded, options.maximum)
+}

--- a/services/agents/src/server/runtime-identity.test.ts
+++ b/services/agents/src/server/runtime-identity.test.ts
@@ -8,16 +8,16 @@ describe('runtime identity', () => {
     expect(resolveRuntimeServiceName({ AGENTS_GITOPS_REVISION: 'abc123' })).toBe('agents')
   })
 
-  it('allows explicit compatibility override back to Jangar identity', () => {
+  it('ignores explicit compatibility override back to Jangar identity', () => {
     expect(
       isAgentsRuntimeService({
         AGENTS_RUNTIME_SERVICE: 'jangar',
         AGENTS_IMAGE: 'registry.example/lab/agents-controller:abc',
       }),
-    ).toBe(false)
+    ).toBe(true)
   })
 
-  it('keeps Jangar identity when no Agents runtime signal is present', () => {
-    expect(resolveRuntimeServiceName({ JANGAR_IMAGE: 'registry.example/lab/jangar:abc' })).toBe('jangar')
+  it('keeps Agents identity when only Jangar runtime signals are present', () => {
+    expect(resolveRuntimeServiceName({ JANGAR_IMAGE: 'registry.example/lab/jangar:abc' })).toBe('agents')
   })
 })

--- a/services/agents/src/server/runtime-identity.ts
+++ b/services/agents/src/server/runtime-identity.ts
@@ -1,19 +1,5 @@
-export type AgentsRuntimeServiceName = 'agents' | 'jangar'
+export type AgentsRuntimeServiceName = 'agents'
 
-const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on', 'agents'])
-const FALSE_VALUES = new Set(['0', 'false', 'no', 'off', 'jangar'])
+export const isAgentsRuntimeService = (_env: NodeJS.ProcessEnv = process.env) => true
 
-const normalize = (value: string | undefined) => value?.trim().toLowerCase()
-
-export const isAgentsRuntimeService = (env: NodeJS.ProcessEnv = process.env) => {
-  const explicitMode = normalize(env.AGENTS_RUNTIME_SERVICE)
-  if (explicitMode !== undefined) {
-    if (TRUE_VALUES.has(explicitMode)) return true
-    if (FALSE_VALUES.has(explicitMode)) return false
-  }
-
-  return Boolean(env.AGENTS_IMAGE || env.AGENTS_RUNTIME_IMAGE || env.AGENTS_GITOPS_REVISION)
-}
-
-export const resolveRuntimeServiceName = (env: NodeJS.ProcessEnv = process.env): AgentsRuntimeServiceName =>
-  isAgentsRuntimeService(env) ? 'agents' : 'jangar'
+export const resolveRuntimeServiceName = (_env: NodeJS.ProcessEnv = process.env): AgentsRuntimeServiceName => 'agents'

--- a/services/agents/src/server/storage-config.ts
+++ b/services/agents/src/server/storage-config.ts
@@ -1,22 +1,6 @@
-type EnvSource = Record<string, string | undefined>
+import { normalizeEnvValue, parsePositiveIntEnv, readAgentsEnv, type EnvSource } from './runtime-env'
 
 const DEFAULT_DATABASE_POOL_MAX = 4
-
-const normalizeNonEmpty = (value: string | undefined | null) => {
-  const normalized = value?.trim()
-  return normalized && normalized.length > 0 ? normalized : null
-}
-
-const parsePositiveInt = (value: string | undefined, fallback: number) => {
-  const normalized = normalizeNonEmpty(value)
-  if (!normalized) return fallback
-  const parsed = Number.parseInt(normalized, 10)
-  if (!Number.isFinite(parsed) || parsed <= 0) return fallback
-  return Math.floor(parsed)
-}
-
-const readAgentsEnv = (env: EnvSource, agentsName: string, legacyJangarName?: string) =>
-  normalizeNonEmpty(env[agentsName]) ?? (legacyJangarName ? normalizeNonEmpty(env[legacyJangarName]) : null)
 
 export type AgentsDatabaseConfig = {
   url: string | null
@@ -28,15 +12,12 @@ export type AgentsDatabaseConfig = {
 }
 
 export const resolveAgentsDatabaseConfig = (env: EnvSource = process.env): AgentsDatabaseConfig => ({
-  url: normalizeNonEmpty(env.DATABASE_URL),
-  sslMode: normalizeNonEmpty(env.PGSSLMODE),
-  caCertPath: normalizeNonEmpty(env.PGSSLROOTCERT) ?? readAgentsEnv(env, 'AGENTS_DB_CA_CERT', 'JANGAR_DB_CA_CERT'),
-  poolMax: parsePositiveInt(
-    readAgentsEnv(env, 'AGENTS_DB_POOL_MAX', 'JANGAR_DB_POOL_MAX') ?? env.PGPOOL_MAX,
-    DEFAULT_DATABASE_POOL_MAX,
-  ),
-  connectTimeoutMs: parsePositiveInt(env.PGCONNECT_TIMEOUT_MS, 10_000),
-  queryTimeoutMs: parsePositiveInt(env.PGQUERY_TIMEOUT_MS, 30_000),
+  url: normalizeEnvValue(env.DATABASE_URL),
+  sslMode: normalizeEnvValue(env.PGSSLMODE),
+  caCertPath: normalizeEnvValue(env.PGSSLROOTCERT) ?? readAgentsEnv(env, 'AGENTS_DB_CA_CERT'),
+  poolMax: parsePositiveIntEnv(readAgentsEnv(env, 'AGENTS_DB_POOL_MAX') ?? env.PGPOOL_MAX, DEFAULT_DATABASE_POOL_MAX),
+  connectTimeoutMs: parsePositiveIntEnv(env.PGCONNECT_TIMEOUT_MS, 10_000),
+  queryTimeoutMs: parsePositiveIntEnv(env.PGQUERY_TIMEOUT_MS, 30_000),
 })
 
 export const validateAgentsStorageConfig = (

--- a/services/agents/src/server/supporting-primitives-controller.test.ts
+++ b/services/agents/src/server/supporting-primitives-controller.test.ts
@@ -140,13 +140,12 @@ describe('supporting primitives controller', () => {
     })
   })
 
-  it('materializes both new and legacy delivery placeholders in the schedule runner', () => {
+  it('materializes canonical delivery placeholders in the schedule runner', () => {
     const manifest = scheduleRunnerTest.materializeManifest(
       JSON.stringify({
         metadata: {
           labels: {
             'agents.proompteng.ai/delivery-id': '__AGENTS_DELIVERY_ID__',
-            'jangar.proompteng.ai/delivery-id': '__JANGAR_DELIVERY_ID__',
           },
         },
         spec: { idempotencyKey: '__AGENTS_DELIVERY_ID__' },
@@ -154,7 +153,6 @@ describe('supporting primitives controller', () => {
     )
     const labels = manifest.metadata as { labels: Record<string, string> }
     expect(labels.labels['agents.proompteng.ai/delivery-id']).not.toContain('__AGENTS')
-    expect(labels.labels['jangar.proompteng.ai/delivery-id']).not.toContain('__JANGAR')
     expect((manifest.spec as { idempotencyKey: string }).idempotencyKey).not.toContain('__AGENTS')
   })
 })

--- a/services/agents/src/server/supporting-primitives-controller.ts
+++ b/services/agents/src/server/supporting-primitives-controller.ts
@@ -66,20 +66,17 @@ const queuedResourceKeysByNamespace = new Map<string, Map<string, { rerun: boole
 
 const nowIso = () => new Date().toISOString()
 
-const readEnv = (agentsName: string, jangarName?: string) =>
-  process.env[agentsName]?.trim() || (jangarName ? process.env[jangarName]?.trim() : undefined) || ''
+const readEnv = (agentsName: string) => process.env[agentsName]?.trim() || ''
 
 const resolveSupportingRuntimeConfig = () => {
   const image =
-    readEnv('AGENTS_SCHEDULE_RUNNER_IMAGE', 'JANGAR_SCHEDULE_RUNNER_IMAGE') ||
-    readEnv('AGENTS_IMAGE', 'JANGAR_IMAGE') ||
+    readEnv('AGENTS_SCHEDULE_RUNNER_IMAGE') ||
+    readEnv('AGENTS_IMAGE') ||
     readEnv('AGENTS_RUNTIME_IMAGE') ||
     'ghcr.io/proompteng/agents-controller:latest'
   const serviceAccountName =
-    readEnv('AGENTS_SCHEDULE_SERVICE_ACCOUNT', 'JANGAR_SCHEDULE_SERVICE_ACCOUNT') ||
-    readEnv('AGENTS_SERVICE_ACCOUNT_NAME', 'JANGAR_SERVICE_ACCOUNT_NAME') ||
-    undefined
-  const nodeSelectorRaw = readEnv('AGENTS_SCHEDULE_RUNNER_NODE_SELECTOR', 'JANGAR_SCHEDULE_RUNNER_NODE_SELECTOR')
+    readEnv('AGENTS_SCHEDULE_SERVICE_ACCOUNT') || readEnv('AGENTS_SERVICE_ACCOUNT_NAME') || undefined
+  const nodeSelectorRaw = readEnv('AGENTS_SCHEDULE_RUNNER_NODE_SELECTOR')
   const nodeSelector = (() => {
     if (!nodeSelectorRaw) return null
     try {

--- a/services/agents/src/server/supporting-schedule-runner.ts
+++ b/services/agents/src/server/supporting-schedule-runner.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises'
 
 import { createKubernetesClient } from './kube-types'
 
-const DELIVERY_PLACEHOLDERS = ['__AGENTS_DELIVERY_ID__', '__JANGAR_DELIVERY_ID__']
+const DELIVERY_PLACEHOLDERS = ['__AGENTS_DELIVERY_ID__']
 
 const materializeManifest = (raw: string) => {
   const deliveryId = randomUUID()


### PR DESCRIPTION
## Summary

- Adds a shared Agents runtime env helper and makes `services/agents` runtime config read canonical `AGENTS_*` names only.
- Stops new Agents-owned resources from emitting legacy `jangar.proompteng.ai/*` labels while preserving legacy label reads for existing objects.
- Locks runtime identity and agentctl logging to Agents and removes remaining server-side Jangar alias behavior from focused tests.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test`
- `bun run --cwd services/agents test -- src/server/agent-resource-labels.test.ts src/server/supporting-primitives-controller.test.ts src/server/integrations-config.test.ts src/server/__tests__/control-plane-grpc.test.ts src/server/control-plane.test.ts src/server/runtime-identity.test.ts src/server/agentctl-grpc-logging.test.ts src/server/agents-controller/runtime-config.test.ts`
- `bun run --cwd services/agents tsc`
- `bun run --cwd services/agents lint`
- `git diff --check origin/main...HEAD`
- `rg -n "JANGAR_|x-jangar|__JANGAR|codex-implement|/app/services/jangar" services/agents/src/server services/agents/src/runner services/agents/package.json --glob '!**/*.test.ts'`

## Screenshots (if applicable)

N/A

## Breaking Changes

Agents runtime configuration now uses canonical `AGENTS_*` env names only. Legacy `JANGAR_*` runtime env aliases are no longer read by `services/agents`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
