### PR TITLE
chore(symphony): promote image 1fa7005f

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-19T06:23:45Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-19T09:12:00Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "f9cec68e"
-    digest: sha256:e5ae5aad911cf41c84bb338b350bc6baaee53e17e7abd3ffe897baaab48b09cb
+    newTag: "1fa7005f"
+    digest: sha256:336214d4712a47c575976c1735239f1c120b674665d32f66879a94545d8215dc

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-19T06:23:45Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-19T09:12:00Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "f9cec68e"
-    digest: sha256:e5ae5aad911cf41c84bb338b350bc6baaee53e17e7abd3ffe897baaab48b09cb
+    newTag: "1fa7005f"
+    digest: sha256:336214d4712a47c575976c1735239f1c120b674665d32f66879a94545d8215dc

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-19T06:23:45Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-19T09:12:00Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "f9cec68e"
-    digest: sha256:e5ae5aad911cf41c84bb338b350bc6baaee53e17e7abd3ffe897baaab48b09cb
+    newTag: "1fa7005f"
+    digest: sha256:336214d4712a47c575976c1735239f1c120b674665d32f66879a94545d8215dc


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `1fa7005fb6ea3e5585b5690c18a555f590d4d17f`
- Image tag: `1fa7005f`
- Image digest: `sha256:336214d4712a47c575976c1735239f1c120b674665d32f66879a94545d8215dc`