### PR TITLE
refactor(agentctl): remove jangar env aliases

### DIFF
--- a/services/agents/agentctl/README.md
+++ b/services/agents/agentctl/README.md
@@ -84,8 +84,6 @@ Environment overrides:
 - `AGENTCTL_CA_CERT` (path to CA cert, optional)
 - `AGENTCTL_CLIENT_CERT` / `AGENTCTL_CLIENT_KEY` (mTLS, optional)
 
-`JANGAR_GRPC_ADDRESS` and `JANGAR_GRPC_TOKEN` remain accepted as deprecated compatibility aliases.
-
 ## Usage
 
 ```bash

--- a/services/agents/agentctl/src/__tests__/config.test.ts
+++ b/services/agents/agentctl/src/__tests__/config.test.ts
@@ -8,22 +8,34 @@ describe('resolveConfig', () => {
     expect(warnings.length).toBeGreaterThan(0)
   })
 
-  it('prefers Agents gRPC env names over Jangar compatibility aliases', () => {
+  it('ignores Jangar compatibility aliases for gRPC config', () => {
+    const previousServer = process.env.AGENTCTL_SERVER
+    const previousAgentctlAddress = process.env.AGENTCTL_ADDRESS
+    const previousAgentctlToken = process.env.AGENTCTL_TOKEN
     const previousAddress = process.env.AGENTS_GRPC_ADDRESS
     const previousLegacyAddress = process.env.JANGAR_GRPC_ADDRESS
     const previousToken = process.env.AGENTS_GRPC_TOKEN
     const previousLegacyToken = process.env.JANGAR_GRPC_TOKEN
     try {
-      process.env.AGENTS_GRPC_ADDRESS = 'agents-grpc.agents.svc.cluster.local:50051'
+      delete process.env.AGENTCTL_SERVER
+      delete process.env.AGENTCTL_ADDRESS
+      delete process.env.AGENTCTL_TOKEN
+      delete process.env.AGENTS_GRPC_ADDRESS
       process.env.JANGAR_GRPC_ADDRESS = 'jangar-grpc.jangar.svc.cluster.local:50051'
-      process.env.AGENTS_GRPC_TOKEN = 'agents-token'
+      delete process.env.AGENTS_GRPC_TOKEN
       process.env.JANGAR_GRPC_TOKEN = 'jangar-token'
 
       const { resolved } = resolveConfig({ grpc: true }, {})
 
       expect(resolved.address).toBe('agents-grpc.agents.svc.cluster.local:50051')
-      expect(resolved.token).toBe('agents-token')
+      expect(resolved.token).toBeUndefined()
     } finally {
+      if (previousServer === undefined) delete process.env.AGENTCTL_SERVER
+      else process.env.AGENTCTL_SERVER = previousServer
+      if (previousAgentctlAddress === undefined) delete process.env.AGENTCTL_ADDRESS
+      else process.env.AGENTCTL_ADDRESS = previousAgentctlAddress
+      if (previousAgentctlToken === undefined) delete process.env.AGENTCTL_TOKEN
+      else process.env.AGENTCTL_TOKEN = previousAgentctlToken
       if (previousAddress === undefined) delete process.env.AGENTS_GRPC_ADDRESS
       else process.env.AGENTS_GRPC_ADDRESS = previousAddress
       if (previousLegacyAddress === undefined) delete process.env.JANGAR_GRPC_ADDRESS

--- a/services/agents/agentctl/src/cli/commands/run.ts
+++ b/services/agents/agentctl/src/cli/commands/run.ts
@@ -143,7 +143,7 @@ const submitRunKube = async (
       generateName: `${input.agent}-`,
       namespace,
       labels: {
-        'jangar.proompteng.ai/delivery-id': deliveryId,
+        'agents.proompteng.ai/delivery-id': deliveryId,
       },
     },
     spec: buildRunSpec(input),

--- a/services/agents/agentctl/src/config.ts
+++ b/services/agents/agentctl/src/config.ts
@@ -97,7 +97,6 @@ const resolveExplicitAddress = (flags: GlobalFlags, config: Config) =>
   process.env.AGENTCTL_SERVER ||
   process.env.AGENTCTL_ADDRESS ||
   process.env.AGENTS_GRPC_ADDRESS ||
-  process.env.JANGAR_GRPC_ADDRESS ||
   config.address ||
   ''
 
@@ -106,12 +105,7 @@ export const resolveConfig = (flags: GlobalFlags, config: Config): ResolvedConfi
   const mode = resolveMode(flags, config)
   const explicitAddress = resolveExplicitAddress(flags, config)
   const address = explicitAddress || DEFAULT_ADDRESS
-  const token =
-    flags.token ||
-    process.env.AGENTCTL_TOKEN ||
-    process.env.AGENTS_GRPC_TOKEN ||
-    process.env.JANGAR_GRPC_TOKEN ||
-    config.token
+  const token = flags.token || process.env.AGENTCTL_TOKEN || process.env.AGENTS_GRPC_TOKEN || config.token
   const tls = flags.tls !== undefined ? flags.tls : (parseBoolean(process.env.AGENTCTL_TLS) ?? config.tls ?? false)
   const kubeconfig = flags.kubeconfig || process.env.AGENTCTL_KUBECONFIG || config.kubeconfig
   const context = flags.context || process.env.AGENTCTL_CONTEXT || config.context

--- a/services/agents/agentctl/src/legacy.ts
+++ b/services/agents/agentctl/src/legacy.ts
@@ -930,7 +930,6 @@ const resolveExplicitAddress = (flags: GlobalFlags, config: Config) =>
   process.env.AGENTCTL_SERVER ||
   process.env.AGENTCTL_ADDRESS ||
   process.env.AGENTS_GRPC_ADDRESS ||
-  process.env.JANGAR_GRPC_ADDRESS ||
   config.address ||
   ''
 
@@ -952,11 +951,7 @@ const resolveAddress = (flags: GlobalFlags, config: Config, mode: TransportMode)
 }
 
 const resolveToken = (flags: GlobalFlags, config: Config) =>
-  flags.token ||
-  process.env.AGENTCTL_TOKEN ||
-  process.env.AGENTS_GRPC_TOKEN ||
-  process.env.JANGAR_GRPC_TOKEN ||
-  config.token
+  flags.token || process.env.AGENTCTL_TOKEN || process.env.AGENTS_GRPC_TOKEN || config.token
 
 const resolveTls = (flags: GlobalFlags, config: Config) => {
   if (flags.tls !== undefined) return flags.tls
@@ -2280,7 +2275,7 @@ const _main = async () => {
               generateName: `${options.agent}-`,
               namespace,
               labels: {
-                'jangar.proompteng.ai/delivery-id': deliveryId,
+                'agents.proompteng.ai/delivery-id': deliveryId,
               },
             },
             spec: runSpec,


### PR DESCRIPTION
## Summary

- Removes `JANGAR_GRPC_ADDRESS` and `JANGAR_GRPC_TOKEN` fallback handling from `@proompteng/agentctl` config resolution.
- Emits canonical `agents.proompteng.ai/delivery-id` labels for kube-submitted AgentRuns in both current and legacy agentctl command paths.
- Updates the agentctl README and config regression test to reflect Agents-only env names.

## Related Issues

None

## Testing

- `bun run --cwd services/agents/agentctl test`
- `bun run --cwd services/agents/agentctl lint`
- `bun run --cwd services/agents/agentctl build`
- `git grep -n -E "JANGAR_GRPC|x-jangar|jangar\\.proompteng|proompteng/jangar" -- services/agents/agentctl services/agents/proto services/agents/src/server/agentctl-grpc.ts ':!services/agents/agentctl/src/**/*.test.ts'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

`agentctl` no longer reads `JANGAR_GRPC_ADDRESS` or `JANGAR_GRPC_TOKEN`; use `AGENTCTL_SERVER`, `AGENTCTL_ADDRESS`, `AGENTCTL_TOKEN`, `AGENTS_GRPC_ADDRESS`, or `AGENTS_GRPC_TOKEN` instead.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
