### PR TITLE
fix(torghut): require promotion readiness proof

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -68,7 +68,6 @@ _TA_CORE_REASON_CODES = frozenset(
     }
 )
 _AUTORESEARCH_PORTFOLIO_READY_STATUSES = (
-    "target_met",
     "paper_candidate",
     "promotion_ready",
     "ready_for_promotion",
@@ -958,7 +957,10 @@ def _load_profit_promotion_table_counts(session: Session) -> dict[str, int]:
             and current_oracle_passed
         ):
             current_oracle_ready += 1
-        if row.status == "blocked" or not current_oracle_passed:
+        if (
+            row.status not in _AUTORESEARCH_PORTFOLIO_READY_STATUSES
+            or not current_oracle_passed
+        ):
             current_policy_blocked += 1
 
     return {

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -102,6 +102,11 @@ _RUNTIME_CLOSURE_PROOF_ORACLE_BLOCKERS = frozenset(
         "executable_replay_account_buying_power_failed",
         "executable_replay_max_notional_per_trade_failed",
         "executable_replay_notional_within_buying_power_failed",
+        "market_impact_stress_passed_failed",
+        "market_impact_stress_artifact_present_failed",
+        "market_impact_stress_model_failed",
+        "market_impact_stress_cost_bps_failed",
+        "market_impact_stress_net_pnl_per_day_failed",
     }
 )
 _FAMILY_PRIOR_HARD_BLOCK_ORACLE_BLOCKERS = frozenset(
@@ -1330,6 +1335,16 @@ def _persist_epoch_ledgers(
             )
         if portfolio is not None:
             portfolio_payload = portfolio.to_payload()
+            promotion_readiness = _mapping(summary.get("promotion_readiness"))
+            if promotion_readiness:
+                portfolio_payload["promotion_readiness"] = dict(promotion_readiness)
+            portfolio_status = "blocked"
+            if bool(portfolio.objective_scorecard.get("oracle_passed")):
+                portfolio_status = (
+                    "promotion_ready"
+                    if _boolish(promotion_readiness.get("promotable"))
+                    else "target_met"
+                )
             session.add(
                 AutoresearchPortfolioCandidate(
                     portfolio_candidate_id=portfolio.portfolio_candidate_id,
@@ -1339,9 +1354,7 @@ def _persist_epoch_ledgers(
                     objective_scorecard_json=dict(portfolio.objective_scorecard),
                     optimizer_report_json=dict(portfolio.optimizer_report),
                     payload_json=portfolio_payload,
-                    status="target_met"
-                    if bool(portfolio.objective_scorecard.get("oracle_passed"))
-                    else "blocked",
+                    status=portfolio_status,
                 )
             )
         session.commit()
@@ -1882,6 +1895,11 @@ def _candidate_search_remediation(
                 "executable_replay_order_count",
                 "executable_replay_account_buying_power",
                 "executable_replay_max_notional_per_trade",
+                "market_impact_stress_passed",
+                "market_impact_stress_artifact_ref",
+                "market_impact_stress_model",
+                "market_impact_stress_cost_bps",
+                "market_impact_stress_net_pnl_per_day",
             ],
         }
         if non_proof_failure_counts:
@@ -5127,6 +5145,75 @@ def _runtime_closure_scorecard_update(
     }
 
 
+def _runtime_closure_pending_promotion_steps(
+    runtime_closure: Mapping[str, Any],
+) -> tuple[str, ...]:
+    return tuple(
+        step
+        for step in (
+            _string(item)
+            for item in cast(
+                Sequence[Any], runtime_closure.get("next_required_steps") or ()
+            )
+        )
+        if step and step != "promotion_review"
+    )
+
+
+def _runtime_closure_promotion_prerequisite_blockers(
+    runtime_closure: Mapping[str, Any],
+) -> tuple[str, ...]:
+    prerequisites = _mapping(runtime_closure.get("promotion_prerequisites"))
+    if not prerequisites:
+        return ("promotion_prerequisites_missing",)
+    if _boolish(prerequisites.get("allowed")):
+        return ()
+    reasons = tuple(
+        reason
+        for reason in (
+            _string(item)
+            for item in cast(Sequence[Any], prerequisites.get("reasons") or ())
+        )
+        if reason
+    )
+    return reasons or ("promotion_prerequisites_denied",)
+
+
+def _promotion_readiness_payload(
+    *,
+    oracle_candidate_found: bool,
+    status: str,
+    blockers: Sequence[str],
+    runtime_closure: Mapping[str, Any],
+) -> dict[str, Any]:
+    blocker_list = list(
+        dict.fromkeys(_string(item) for item in blockers if _string(item))
+    )
+    if oracle_candidate_found:
+        blocker_list = list(
+            dict.fromkeys(
+                (
+                    *blocker_list,
+                    *_runtime_closure_pending_promotion_steps(runtime_closure),
+                    *_runtime_closure_promotion_prerequisite_blockers(runtime_closure),
+                )
+            )
+        )
+    if oracle_candidate_found and not blocker_list:
+        return {
+            "status": "promotion_ready",
+            "promotable": True,
+            "blockers": [],
+        }
+    return {
+        "status": "blocked_pending_promotion_prerequisites"
+        if oracle_candidate_found and blocker_list
+        else status,
+        "promotable": False,
+        "blockers": blocker_list,
+    }
+
+
 def _candidate_board_score_rows(
     rows: Sequence[Mapping[str, Any]],
 ) -> dict[str, Mapping[str, Any]]:
@@ -5206,8 +5293,7 @@ def _candidate_board_payload(
     proposal_rows: Sequence[Mapping[str, Any]],
     evidence_bundles: Sequence[CandidateEvidenceBundle],
     portfolio: PortfolioCandidateSpec | None,
-    promotion_status: str,
-    promotion_blockers: Sequence[str],
+    promotion_readiness: Mapping[str, Any],
     runtime_closure: Mapping[str, Any],
 ) -> dict[str, Any]:
     pre_replay_by_spec = _candidate_board_score_rows(pre_replay_proposal_rows)
@@ -5293,19 +5379,16 @@ def _candidate_board_payload(
         )
     )
     best_research_candidate = rows[0] if rows else None
+    promotion_ready = _boolish(promotion_readiness.get("promotable"))
     return {
         "schema_version": "torghut.profit-candidate-board.v1",
         "epoch_id": epoch_id,
         "run_root": str(output_dir),
         "target_net_pnl_per_day": str(target),
         "current_answer": "promotion_candidate_found"
-        if portfolio_oracle_passed
+        if promotion_ready
         else "no_promotion_ready_candidate",
-        "promotion_readiness": {
-            "status": promotion_status,
-            "promotable": False,
-            "blockers": list(promotion_blockers),
-        },
+        "promotion_readiness": dict(promotion_readiness),
         "best_research_candidate": best_research_candidate,
         "best_portfolio_candidate_id": _string(
             portfolio_payload.get("portfolio_candidate_id")
@@ -5922,6 +6005,12 @@ def run_whitepaper_autoresearch_profit_target(
             "scheduler_v3_parity_missing",
             "shadow_validation_missing",
         ]
+    promotion_readiness = _promotion_readiness_payload(
+        oracle_candidate_found=oracle_candidate_found,
+        status=promotion_status,
+        blockers=promotion_blockers,
+        runtime_closure=runtime_closure,
+    )
     status = "ok" if oracle_candidate_found else "no_profit_target_candidate"
     status_reason = None
     if not oracle_candidate_found:
@@ -5980,8 +6069,7 @@ def run_whitepaper_autoresearch_profit_target(
         proposal_rows=proposal_rows,
         evidence_bundles=replay_result.evidence_bundles,
         portfolio=portfolio,
-        promotion_status=promotion_status,
-        promotion_blockers=promotion_blockers,
+        promotion_readiness=promotion_readiness,
         runtime_closure=runtime_closure,
     )
     candidate_board_path = output_dir / "candidate-board.json"
@@ -6049,11 +6137,7 @@ def run_whitepaper_autoresearch_profit_target(
         else None,
         "oracle_candidate_found": oracle_candidate_found,
         "profit_target_oracle": profit_target_oracle,
-        "promotion_readiness": {
-            "status": promotion_status,
-            "promotable": False,
-            "blockers": promotion_blockers,
-        },
+        "promotion_readiness": promotion_readiness,
         "runtime_closure": runtime_closure,
         "artifacts": {
             "epoch_manifest": str(output_dir / "epoch-manifest.json"),

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -2851,6 +2851,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 policy=policy,
             )
             scorecard["oracle_passed"] = False
+            self.assertIn(
+                "market_impact_stress_artifact_present_failed",
+                scorecard["profit_target_oracle"]["blockers"],
+            )
             portfolio = runner.PortfolioCandidateSpec(
                 schema_version="torghut.portfolio-candidate-spec.v1",
                 portfolio_candidate_id="portfolio-test",
@@ -2903,6 +2907,17 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             updated.objective_scorecard["executable_replay_artifact_ref"],
             str(approval_replay_path),
+        )
+        self.assertEqual(
+            updated.objective_scorecard["market_impact_stress_artifact_ref"],
+            str(market_impact_path),
+        )
+        self.assertEqual(
+            updated.objective_scorecard["market_impact_stress_model"], "square_root"
+        )
+        self.assertEqual(
+            updated.objective_scorecard["market_impact_stress_net_pnl_per_day"],
+            "610",
         )
         self.assertIn(str(approval_replay_path), updated.evidence_refs)
 
@@ -2963,6 +2978,26 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             runner._portfolio_executable_max_notional(portfolio), Decimal("50000")
         )
         self.assertFalse(runner._portfolio_needs_runtime_closure_proof(portfolio))
+        market_impact_only_portfolio = replace(
+            portfolio,
+            objective_scorecard={
+                "target_met": True,
+                "oracle_passed": False,
+                "profit_target_oracle": {
+                    "passed": False,
+                    "blockers": [
+                        "market_impact_stress_passed_failed",
+                        "market_impact_stress_artifact_present_failed",
+                        "market_impact_stress_model_failed",
+                        "market_impact_stress_cost_bps_failed",
+                        "market_impact_stress_net_pnl_per_day_failed",
+                    ],
+                },
+            },
+        )
+        self.assertTrue(
+            runner._portfolio_needs_runtime_closure_proof(market_impact_only_portfolio)
+        )
         self.assertIs(
             runner._runtime_closure_program_for_candidate(
                 program=program,
@@ -3048,6 +3083,36 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             ),
             "portfolio_component_passed_oracle",
         )
+        denied_readiness = runner._promotion_readiness_payload(
+            oracle_candidate_found=True,
+            status="ready_for_promotion_review",
+            blockers=[],
+            runtime_closure={
+                "status": "ready_for_promotion_review",
+                "next_required_steps": ["promotion_review"],
+                "promotion_prerequisites": {
+                    "allowed": False,
+                    "reasons": ["promotion_gate_report_denied"],
+                },
+            },
+        )
+        self.assertFalse(denied_readiness["promotable"])
+        self.assertEqual(
+            denied_readiness["status"], "blocked_pending_promotion_prerequisites"
+        )
+        self.assertEqual(denied_readiness["blockers"], ["promotion_gate_report_denied"])
+        allowed_readiness = runner._promotion_readiness_payload(
+            oracle_candidate_found=True,
+            status="ready_for_promotion_review",
+            blockers=[],
+            runtime_closure={
+                "status": "ready_for_promotion_review",
+                "next_required_steps": ["promotion_review"],
+                "promotion_prerequisites": {"allowed": True, "reasons": []},
+            },
+        )
+        self.assertTrue(allowed_readiness["promotable"])
+        self.assertEqual(allowed_readiness["status"], "promotion_ready")
 
     def test_candidate_universe_symbols_default_to_chip_coverage_when_empty(
         self,
@@ -3447,6 +3512,96 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertEqual(
             {spec.candidate_spec_id for spec in specs}, {"spec-repeatable"}
+        )
+
+    def test_epoch_ledgers_persist_promotion_ready_only_from_readiness_payload(
+        self,
+    ) -> None:
+        portfolio = runner.PortfolioCandidateSpec(
+            schema_version="torghut.portfolio-candidate-spec.v1",
+            portfolio_candidate_id="portfolio-readiness-test",
+            source_candidate_ids=("candidate-test",),
+            target_net_pnl_per_day=Decimal("500"),
+            sleeves=(),
+            capital_budget={},
+            correlation_budget={},
+            drawdown_budget={},
+            evidence_refs=(),
+            objective_scorecard={"oracle_passed": True, "target_met": True},
+            optimizer_report={},
+        )
+        started_at = datetime(2026, 5, 8, 17, 0, 0)
+        completed_at = datetime(2026, 5, 8, 17, 1, 0)
+
+        with patch(
+            "scripts.run_whitepaper_autoresearch_profit_target.SessionLocal",
+            side_effect=lambda: Session(self.engine),
+        ):
+            runner._persist_epoch_ledgers(
+                epoch_id="epoch-readiness-blocked",
+                status="ok",
+                target_net_pnl_per_day=Decimal("500"),
+                paper_run_ids=[],
+                sources=[],
+                candidate_specs=[],
+                proposal_rows=[],
+                portfolio=portfolio,
+                summary={
+                    "promotion_readiness": {
+                        "status": "blocked_pending_promotion_prerequisites",
+                        "promotable": False,
+                        "blockers": ["promotion_gate_report_denied"],
+                    }
+                },
+                runner_config={},
+                started_at=started_at,
+                completed_at=completed_at,
+            )
+            runner._persist_epoch_ledgers(
+                epoch_id="epoch-readiness-ready",
+                status="ok",
+                target_net_pnl_per_day=Decimal("500"),
+                paper_run_ids=[],
+                sources=[],
+                candidate_specs=[],
+                proposal_rows=[],
+                portfolio=replace(
+                    portfolio, portfolio_candidate_id="portfolio-readiness-ready"
+                ),
+                summary={
+                    "promotion_readiness": {
+                        "status": "promotion_ready",
+                        "promotable": True,
+                        "blockers": [],
+                    }
+                },
+                runner_config={},
+                started_at=started_at,
+                completed_at=completed_at,
+            )
+
+        with Session(self.engine) as session:
+            portfolios = (
+                session.execute(
+                    select(AutoresearchPortfolioCandidate).order_by(
+                        AutoresearchPortfolioCandidate.portfolio_candidate_id.asc()
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        self.assertEqual(
+            [item.status for item in portfolios], ["promotion_ready", "target_met"]
+        )
+        blocked_payload = next(
+            item
+            for item in portfolios
+            if item.portfolio_candidate_id == "portfolio-readiness-test"
+        )
+        self.assertEqual(
+            blocked_payload.payload_json["promotion_readiness"]["blockers"],
+            ["promotion_gate_report_denied"],
         )
 
     def test_persistence_failure_preserves_artifacts_and_returns_infra_failure(


### PR DESCRIPTION
## Summary

- Keeps market-impact-only oracle failures eligible for runtime closure so the runner can produce the square-root impact stress artifact required by the 2026 market-impact gate.
- Derives promotion readiness from oracle success, runtime closure pending steps, and promotion prerequisite allowance instead of treating scalar target/oracle success as promotable.
- Persists `promotion_readiness` into portfolio payloads and removes `target_met` from submission-council ready statuses.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'runtime_closure_proof or candidate_board or epoch_ledgers_persist_promotion_ready' -q`
- `uv run --frozen pytest tests/test_submission_council.py -k 'autoresearch_portfolio' -q`
- `uv run --frozen pytest tests/test_trading_api.py -k 'autoresearch' -q`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
