### PR TITLE
ci(agents): detach agents ci from jangar

### DIFF
--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -17,12 +17,10 @@ on:
       - 'packages/discord/**'
       - 'packages/otel/**'
       - 'packages/scripts/src/agents/**'
-      - 'packages/scripts/src/jangar/**'
       - 'packages/scripts/src/shared/**'
       - 'packages/temporal-bun-sdk/**'
       - 'services/agents/**'
       - 'services/bumba/**'
-      - 'services/jangar/**'
       - 'scripts/agents/**'
       - 'scripts/download_crd_schema.py'
       - '.github/workflows/agents-build-push.yml'
@@ -43,12 +41,10 @@ on:
       - 'packages/discord/**'
       - 'packages/otel/**'
       - 'packages/scripts/src/agents/**'
-      - 'packages/scripts/src/jangar/**'
       - 'packages/scripts/src/shared/**'
       - 'packages/temporal-bun-sdk/**'
       - 'services/agents/**'
       - 'services/bumba/**'
-      - 'services/jangar/**'
       - 'scripts/agents/**'
       - 'scripts/download_crd_schema.py'
       - '.github/workflows/agents-build-push.yml'
@@ -179,7 +175,6 @@ jobs:
           --filter @proompteng/design
           --filter @proompteng/discord
           --filter @proompteng/agents
-          --filter @proompteng/jangar
           --filter @proompteng/otel
           --filter @proompteng/scripts
           --filter @proompteng/temporal-bun-sdk
@@ -192,7 +187,6 @@ jobs:
             packages/scripts/src/agents/__tests__/resolve-published-agents-images.test.ts \
             packages/scripts/src/agents/__tests__/smoke-agents.test.ts \
             packages/scripts/src/agents/__tests__/deploy-service.test.ts \
-            packages/scripts/src/jangar/__tests__/release-contract.test.ts \
             packages/scripts/src/shared/__tests__/docker.test.ts
 
       - name: Run Agents service unit tests

--- a/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
+++ b/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
@@ -141,6 +141,15 @@ describe('agents-ci workflow local Agents image build', () => {
     expect(workflow).not.toContain('jangar-release-contract')
   })
 
+  it('keeps Agents CI detached from Jangar source and package paths', () => {
+    const workflow = readFileSync(new URL('../../../../../.github/workflows/agents-ci.yml', import.meta.url), 'utf8')
+
+    expect(workflow).not.toContain('services/jangar/**')
+    expect(workflow).not.toContain('packages/scripts/src/jangar/**')
+    expect(workflow).not.toContain('--filter @proompteng/jangar')
+    expect(workflow).not.toContain('packages/scripts/src/jangar/__tests__/release-contract.test.ts')
+  })
+
   it('builds local Agents smoke images from the Agents Dockerfile', () => {
     const workflow = readFileSync(new URL('../../../../../.github/workflows/agents-ci.yml', import.meta.url), 'utf8')
 

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -531,6 +531,16 @@ Error from server (Forbidden): unknown`
     expect(isPermissionDeniedKubectlError(error)).toBe(false)
   })
 
+  it('treats kind etcd request timeouts during apply as transient', () => {
+    const error = `Error from server: error when retrieving current configuration of:
+Resource: "/v1, Resource=services", GroupVersionKind: "/v1, Kind=Service"
+Name: "agents-ci-postgres", Namespace: "agents-ci"
+from server for: "STDIN": etcdserver: request timed out`
+
+    expect(isTransientKubectlError(error)).toBe(true)
+    expect(isPermissionDeniedKubectlError(error)).toBe(false)
+  })
+
   it('keeps real namespace RBAC denials classified as permission errors', () => {
     const error =
       'Error from server (Forbidden): namespaces is forbidden: User "system:serviceaccount:agents:agents-sa" cannot get resource "namespaces" in API group "" at the cluster scope'

--- a/packages/scripts/src/agents/smoke-agents.ts
+++ b/packages/scripts/src/agents/smoke-agents.ts
@@ -104,6 +104,30 @@ const execCapture = async (cmd: string[], env?: Record<string, string | undefine
   }
 }
 
+const execCaptureWithInput = async (cmd: string[], input: string, env?: Record<string, string | undefined>) => {
+  const subprocess = Bun.spawn(cmd, {
+    stdin: 'pipe',
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: buildEnv(env),
+  })
+
+  void subprocess.stdin?.write(input)
+  void subprocess.stdin?.end()
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    subprocess.exited,
+    new Response(subprocess.stdout).text(),
+    new Response(subprocess.stderr).text(),
+  ])
+
+  return {
+    exitCode,
+    stdout: stdout.trim(),
+    stderr: stderr.trim(),
+  }
+}
+
 const buildEnv = (env?: Record<string, string | undefined>) =>
   Object.fromEntries(
     Object.entries(env ? { ...process.env, ...env } : process.env).filter(([, value]) => value !== undefined),
@@ -121,6 +145,7 @@ const transientKubectlErrorPatterns = [
   /connection refused/i,
   /unable to connect to the server/i,
   /no route to host/i,
+  /etcdserver: request timed out/i,
   /server is currently unable to handle the request/i,
   /service unavailable/i,
   /Error from server \(Forbidden\): unknown/i,
@@ -512,19 +537,31 @@ const runDiagnosticsCommand = async (cmd: string[]) => {
 }
 
 const applyYaml = async (namespace: string, manifest: string) => {
-  const subprocess = Bun.spawn(['kubectl', ...buildKubectlApplyArgs({ namespace })], {
-    stdin: 'pipe',
-    stdout: 'inherit',
-    stderr: 'inherit',
-  })
+  const cmd = ['kubectl', ...buildKubectlApplyArgs({ namespace })]
+  const deadline = Date.now() + 60_000
+  let attempt = 1
+  let lastError = ''
 
-  void subprocess.stdin?.write(manifest)
-  void subprocess.stdin?.end()
+  while (Date.now() < deadline) {
+    const result = await execCaptureWithInput(cmd, manifest)
+    const details = formatCommandResult(result)
+    if (result.exitCode === 0) {
+      if (details) console.log(details)
+      return
+    }
 
-  const exitCode = await subprocess.exited
-  if (exitCode !== 0) {
-    fatal(`kubectl apply failed (${exitCode})`)
+    lastError = details
+    if (!isTransientKubectlError(details)) {
+      fatal(`kubectl apply failed (${result.exitCode})`, details)
+    }
+
+    const delayMs = Math.min(1000 * attempt, 5000)
+    console.error(`kubectl apply failed with a transient API error; retrying attempt ${attempt + 1} in ${delayMs}ms.`)
+    await sleep(delayMs)
+    attempt += 1
   }
+
+  fatal('Timed out retrying kubectl apply after transient API errors.', lastError)
 }
 
 const waitForAgentRun = async (namespace: string, name: string, timeoutMs: number) => {


### PR DESCRIPTION
## Summary

- Removed Jangar source and script paths from the Agents CI trigger set.
- Stopped installing `@proompteng/jangar` in the Agents integration job.
- Removed the Jangar release-contract test from the Agents script-test slice and added a regression assertion that the workflow stays detached from Jangar paths.
- Hardened the Agents smoke harness to retry transient stdin-based `kubectl apply` failures such as kind `etcdserver: request timed out` during Postgres bootstrap.

## Related Issues

None.

## Testing

- `bun test packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`
- `bun test packages/scripts/src/agents/__tests__/build-image.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts packages/scripts/src/agents/__tests__/resolve-published-agents-images.test.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/shared/__tests__/docker.test.ts`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/shared/__tests__/docker.test.ts`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts .github/workflows/agents-ci.yml`
- `bunx oxfmt --check packages/scripts/src/agents/smoke-agents.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts .github/workflows/agents-ci.yml packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
