### PR TITLE
docs(agents): rebrand helm chart install notes

### DIFF
--- a/charts/agents/README.md
+++ b/charts/agents/README.md
@@ -1,11 +1,11 @@
 # Agents Helm Chart
 
-Agents installs **Jangar**, a Kubernetes-native control plane for running agent and automation work as normal Kubernetes resources.
+Agents installs a Kubernetes-native control plane for running agent and automation work as normal Kubernetes resources.
 
 If you already understand Deployments and Jobs, this is the shortest mental model:
 
 - You create an `AgentRun` custom resource when you want work done.
-- Jangar watches that resource and launches Kubernetes Jobs/Pods to do the work.
+- Agents controllers watch that resource and launch Kubernetes Jobs/Pods to do the work.
 - The run status is written back to the `AgentRun`, so Kubernetes stays the source of truth.
 
 The chart is published on Artifact Hub:
@@ -16,7 +16,7 @@ The chart is published on Artifact Hub:
 
 ## Start Here
 
-Use the local end-to-end path first. It builds a Jangar image from this repository, creates a kind cluster, installs Postgres, deploys the chart, submits a smoke `AgentRun`, and waits for that run to succeed.
+Use the local end-to-end path first. It builds Agents images from this repository, creates a kind cluster, installs Postgres, deploys the chart, submits a smoke `AgentRun`, and waits for that run to succeed.
 
 ```bash
 git clone https://github.com/proompteng/lab.git
@@ -172,7 +172,7 @@ You do not need to understand every CRD before installing the chart. These are t
 
 | Concept                | What it means                                                                       | First example                                 |
 | ---------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------- |
-| Jangar                 | The control plane installed by this chart. It watches CRDs and coordinates work.    | `Deployment/agents`                           |
+| Agents control plane   | The control plane installed by this chart. It watches CRDs and coordinates work.    | `Deployment/agents`                           |
 | AgentRun               | One requested unit of work. This is what you create when you want something to run. | `examples/agentrun-workflow-smoke.yaml`       |
 | Agent                  | A reusable worker profile. It points at an AgentProvider and can define defaults.   | `examples/agent-smoke.yaml`                   |
 | AgentProvider          | How an agent is executed, such as a command, adapter, or runner entrypoint.         | `examples/agentprovider-smoke.yaml`           |
@@ -185,7 +185,7 @@ You do not need to understand every CRD before installing the chart. These are t
 
 The chart installs:
 
-- Jangar control-plane `Deployment` and HTTP `Service`
+- Agents control-plane `Deployment` and HTTP `Service`
 - Optional gRPC `Service`
 - Optional controllers deployment for reconciliation/runtime work
 - Optional metrics `Service`, `ServiceMonitor`, and Grafana dashboard ConfigMap
@@ -523,7 +523,7 @@ Frequent render failures:
 
 | Value                                                                | Purpose                                                                   |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `image.repository`, `image.tag`, `image.digest`                      | Default Jangar image used by the control-plane and controllers.           |
+| `image.repository`, `image.tag`, `image.digest`                      | Default Agents image used by the control-plane and controllers.           |
 | `controlPlane.image.*`, `controllers.image.*`                        | Optional per-deployment overrides when those images differ.               |
 | `runner.image.repository`, `runner.image.tag`, `runner.image.digest` | Default image for AgentRun Jobs.                                          |
 | `imagePolicy.requireDigest`                                          | Require immutable image digests for chart-managed images.                 |

--- a/charts/agents/templates/NOTES.txt
+++ b/charts/agents/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Thank you for installing agents (Jangar control plane).
+Thank you for installing the Agents control plane.
 
 Next steps:
 1. Verify deployment:
@@ -9,7 +9,7 @@ Next steps:
    kubectl -n {{ .Release.Namespace }} apply -f charts/agents/examples/memory-sample.yaml
    kubectl -n {{ .Release.Namespace }} apply -f charts/agents/examples/implementationspec-sample.yaml
    kubectl -n {{ .Release.Namespace }} apply -f charts/agents/examples/agentrun-sample.yaml
-3. Port-forward to access Jangar:
+3. Port-forward to access the Agents HTTP API:
    kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "agents.fullname" . }} 8080:{{ .Values.service.port }}
 4. Port-forward gRPC for agentctl (optional when gRPC is enabled):
    kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "agents.fullname" . }}-grpc {{ .Values.grpc.servicePort }}:{{ .Values.grpc.servicePort }}


### PR DESCRIPTION
## Summary

- Rebranded the Agents chart README introduction from Jangar to the Agents control plane.
- Updated first-concepts, installed-resources, and values language to refer to Agents control-plane images and controllers.
- Updated Helm install notes to tell operators to access the Agents HTTP API instead of Jangar.

## Related Issues

None.

## Testing

- `rg -n -i "jangar|torghut|codex-implement|JANGAR_" charts/agents/templates charts/agents/README.md`
- `mise exec helm@3 -- helm lint charts/agents`
- `mise exec helm@3 -- helm template agents charts/agents --namespace agents`
- `git diff --check`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
