### PR TITLE
fix(torghut): renew microstructure proof lane

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -35,7 +35,7 @@ spec:
                     --strategy-spec-ref intraday_tsmom_v2@research \
                     --runtime-window-import \
                     --runtime-window-target hypothesis_id=H-TSMOM-01,candidate_id=spec-83161ae16d17828eabcc58cc,strategy_family=intraday_tsmom_consistent,strategy_name=intraday-tsmom-profit-v3,source_manifest_ref=config/trading/hypotheses/h-tsmom-01.json \
-                    --runtime-window-target hypothesis_id=H-PAIRS-01,candidate_id=spec-d74b07b2aaab8d0cfa8a4c38,strategy_family=microbar_cross_sectional_pairs,strategy_name=microbar-cross-sectional-pairs-v1,source_manifest_ref=config/trading/hypotheses/h-pairs-01.json \
+                    --runtime-window-target hypothesis_id=H-MICRO-01,candidate_id=chip-paper-microbar-composite@execution-proof,strategy_family=microstructure_breakout,strategy_name=microbar-volume-continuation-long-top2-chip-v1,source_manifest_ref=config/trading/hypotheses/h-micro-01.json,dataset_snapshot_ref=torghut-chip-full-day-20260505-4c330ce9-r1 \
                     --runtime-window-hypothesis-id H-TSMOM-01 \
                     --runtime-window-candidate-id spec-83161ae16d17828eabcc58cc \
                     --runtime-window-strategy-family intraday_tsmom_consistent \

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -768,11 +768,12 @@ class TestLiveConfigManifestContract(TestCase):
             args,
         )
         self.assertIn(
-            "--runtime-window-target hypothesis_id=H-PAIRS-01,"
-            "candidate_id=spec-d74b07b2aaab8d0cfa8a4c38,"
-            "strategy_family=microbar_cross_sectional_pairs,"
-            "strategy_name=microbar-cross-sectional-pairs-v1,"
-            "source_manifest_ref=config/trading/hypotheses/h-pairs-01.json",
+            "--runtime-window-target hypothesis_id=H-MICRO-01,"
+            "candidate_id=chip-paper-microbar-composite@execution-proof,"
+            "strategy_family=microstructure_breakout,"
+            "strategy_name=microbar-volume-continuation-long-top2-chip-v1,"
+            "source_manifest_ref=config/trading/hypotheses/h-micro-01.json,"
+            "dataset_snapshot_ref=torghut-chip-full-day-20260505-4c330ce9-r1",
             args,
         )
         self.assertIn("--runtime-window-account-label TORGHUT_SIM", args)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -336,10 +336,11 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                 "portfolio-profit-autoresearch-500-v1",
                 "--runtime-window-target",
                 (
-                    "hypothesis_id=H-PAIRS-01,candidate_id=spec-d74b07b2aaab8d0cfa8a4c38,"
-                    "strategy_family=microbar_cross_sectional_pairs,"
-                    "strategy_name=microbar-cross-sectional-pairs-v1,"
-                    "source_manifest_ref=config/trading/hypotheses/h-pairs-01.json"
+                    "hypothesis_id=H-MICRO-01,candidate_id=chip-paper-microbar-composite@execution-proof,"
+                    "strategy_family=microstructure_breakout,"
+                    "strategy_name=microbar-volume-continuation-long-top2-chip-v1,"
+                    "source_manifest_ref=config/trading/hypotheses/h-micro-01.json,"
+                    "dataset_snapshot_ref=torghut-chip-full-day-20260505-4c330ce9-r1"
                 ),
                 "--json",
             ],
@@ -363,7 +364,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             "portfolio-profit-autoresearch-500-v1",
         )
         self.assertEqual(len(args.runtime_window_target), 1)
-        self.assertIn("H-PAIRS-01", args.runtime_window_target[0])
+        self.assertIn("H-MICRO-01", args.runtime_window_target[0])
         self.assertTrue(args.json)
 
     def test_runtime_window_target_accepts_json_payload(self) -> None:
@@ -526,12 +527,12 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             ),
             encoding="utf-8",
         )
-        pairs_path = self.tmp_dir / "h-pairs-01.json"
-        pairs_path.write_text(
+        micro_path = self.tmp_dir / "h-micro-01.json"
+        micro_path.write_text(
             json.dumps(
                 {
-                    "candidate_id": "spec-d74b07b2aaab8d0cfa8a4c38",
-                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                    "candidate_id": "chip-paper-microbar-composite@execution-proof",
+                    "dataset_snapshot_ref": "torghut-chip-full-day-20260505-4c330ce9-r1",
                 }
             ),
             encoding="utf-8",
@@ -548,10 +549,11 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                     f"source_manifest_ref={tsmom_path}"
                 ),
                 (
-                    "hypothesis_id=H-PAIRS-01,candidate_id=spec-d74b07b2aaab8d0cfa8a4c38,"
-                    f"strategy_family=microbar_cross_sectional_pairs,"
-                    f"strategy_name=microbar-cross-sectional-pairs-v1,"
-                    f"source_manifest_ref={pairs_path}"
+                    "hypothesis_id=H-MICRO-01,candidate_id=chip-paper-microbar-composite@execution-proof,"
+                    f"strategy_family=microstructure_breakout,"
+                    f"strategy_name=microbar-volume-continuation-long-top2-chip-v1,"
+                    f"source_manifest_ref={micro_path},"
+                    f"dataset_snapshot_ref=torghut-chip-full-day-20260505-4c330ce9-r1"
                 ),
             ],
             runtime_window_hypothesis_id="H-TSMOM-01",
@@ -589,14 +591,15 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual(payload["target_count"], 2)
         self.assertEqual(
             [item["hypothesis_id"] for item in payload["imports"]],
-            ["H-TSMOM-01", "H-PAIRS-01"],
+            ["H-TSMOM-01", "H-MICRO-01"],
         )
         commands = [call.args[0] for call in run_mock.call_args_list]
         self.assertEqual(len(commands), 2)
         joined = "\n".join(" ".join(command) for command in commands)
         self.assertIn("spec-83161ae16d17828eabcc58cc", joined)
-        self.assertIn("spec-d74b07b2aaab8d0cfa8a4c38", joined)
-        self.assertIn("microbar-cross-sectional-pairs-v1", joined)
+        self.assertIn("chip-paper-microbar-composite@execution-proof", joined)
+        self.assertIn("microbar-volume-continuation-long-top2-chip-v1", joined)
+        self.assertIn("torghut-chip-full-day-20260505-4c330ce9-r1", joined)
 
     def test_main_writes_manifest_and_runs_empirical_promotion_job(self) -> None:
         created_at = datetime(2026, 5, 18, 8, 13, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary

- Routes the empirical promotion renewal CronJob toward `H-MICRO-01`, the current microstructure lane with observed paper activity.
- Keeps `H-TSMOM-01` as the incumbent renewal target while replacing the stale `H-PAIRS-01` import target.
- Updates Torghut manifest and renewal-script tests so the GitOps contract preserves the H-MICRO candidate, runtime strategy, manifest, and dataset snapshot.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k empirical_promotion_renewal_imports_paper_windows_from_sim_db`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k "parse_args_accepts_strategy_and_json_flag or runtime_window_import_runs_multiple_observed_paper_imports"`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k strategy_name_candidates_include_catalog_aliases`
- `uv run --frozen pytest tests/test_runtime_window_import.py -k "blocks_zero_activity_evidence or reject"`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
