### PR TITLE
docs(agents): rebrand runtime operator references

### DIFF
--- a/docs/agents/agentctl.md
+++ b/docs/agents/agentctl.md
@@ -50,7 +50,6 @@ agentctl --grpc --server 127.0.0.1:50051 status
 
 If you set a token here, the Agents server must be configured with the same
 `AGENTS_GRPC_TOKEN` value (for example via `env.vars.AGENTS_GRPC_TOKEN` in the chart values).
-`JANGAR_GRPC_TOKEN` is still accepted as a deprecated compatibility alias.
 
 Kube mode uses:
 

--- a/docs/agents/agents-helm-chart-implementation.md
+++ b/docs/agents/agents-helm-chart-implementation.md
@@ -222,8 +222,8 @@ flowchart LR
 - If `spec.runtime.type == "job"`, Agents submits a Kubernetes Job in the target namespace.
 - Image resolution priority:
   1. `AgentRun.spec.workload.image`
-  2. `JANGAR_AGENT_RUNNER_IMAGE`
-  3. `JANGAR_AGENT_IMAGE`
+  2. `AGENTS_AGENT_RUNNER_IMAGE`
+  3. `AGENTS_AGENT_IMAGE`
 - Job inputs must include a JSON spec (e.g., `run.json`) and optional provider input files.
 - Job should be labeled with `agents.proompteng.ai/agent-run` for tracking.
 
@@ -296,7 +296,7 @@ sequenceDiagram
 - Orchestration and OrchestrationRun execute in-cluster by default with no external workflow engine.
 - Native controller currently supports `AgentRun`, `ToolRun`, `SubOrchestration`, and `ApprovalGate` steps; other step kinds require adapters or future extensions.
 - Codex reruns/system-improvements should point at native OrchestrationRuns via `workflowRuntime.native.*`
-  values (or the equivalent `JANGAR_CODEX_RERUN_ORCHESTRATION` and `JANGAR_SYSTEM_IMPROVEMENT_ORCHESTRATION` env vars).
+  values (or the equivalent `AGENTS_CODEX_RERUN_ORCHESTRATION` and `AGENTS_SYSTEM_IMPROVEMENT_ORCHESTRATION` env vars).
 
 ### RBAC alignment
 

--- a/docs/agents/rbac-matrix.md
+++ b/docs/agents/rbac-matrix.md
@@ -12,11 +12,11 @@ See also:
 
 ## Components
 
-- Jangar controller (namespaced)
+- Agents controller (namespaced)
 - agentctl (user client)
 - Runtime adapters (Workflow/Temporal/Custom)
 
-## Jangar Controller (namespaced Role)
+## Agents Controller (namespaced Role)
 
 Required verbs (namespaced):
 
@@ -38,22 +38,22 @@ Optional (if enabled):
 
 - `events` for publishing Kubernetes events
 
-## Jangar Controller (cluster-scoped ClusterRole)
+## Agents Controller (cluster-scoped ClusterRole)
 
 Use when `controller.namespaces` spans multiple namespaces or `"*"`.
 Required verbs mirror the namespaced Role, but with cluster scope and a ClusterRoleBinding
-to the Jangar service account.
+to the Agents service account.
 Additional verbs for namespace discovery when using `"*"`:
 
 - `get`, `list`, `watch` on `namespaces`
 
 ## agentctl (user)
 
-Uses Kubernetes API by default (kubeconfig + context). Optional gRPC mode uses Jangar endpoints.
+Uses Kubernetes API by default (kubeconfig + context). Optional gRPC mode uses Agents endpoints.
 
 ## Runtime Adapter Service Accounts
 
-If adapters run outside Jangar:
+If adapters run outside Agents:
 
 - Minimal rights to create their runtime resources.
 - No access to CRDs beyond their scope.

--- a/docs/agents/topology-spread-constraints.md
+++ b/docs/agents/topology-spread-constraints.md
@@ -6,7 +6,7 @@ Docs index: [README](README.md)
 
 ## Context
 
-AgentRun workloads execute as Kubernetes Jobs created by Jangar. Those job pods already support scheduling controls such as node selectors, tolerations, and affinity. We want first-class topology spread constraints so operators can distribute AgentRun pods across zones, nodes, or other topology domains without changing controller code or hand-editing workloads.
+AgentRun workloads execute as Kubernetes Jobs created by the Agents controller. Those job pods already support scheduling controls such as node selectors, tolerations, and affinity. We want first-class topology spread constraints so operators can distribute AgentRun pods across zones, nodes, or other topology domains without changing controller code or hand-editing workloads.
 
 This doc specifies the Helm chart values, template wiring, and runtime behavior for topology spread constraints applied to AgentRun pods in `charts/agents`.
 
@@ -19,7 +19,7 @@ This doc specifies the Helm chart values, template wiring, and runtime behavior 
 
 ## Non-goals
 
-- Adding topology spread constraints to the Jangar controller Deployment pod.
+- Adding topology spread constraints to the Agents controller Deployment pod.
 - Changing the AgentRun CRD schema.
 - Enforcing or validating constraint schemas beyond Helm value shape checks.
 - Altering runtime scheduling logic outside of existing default/override behavior.
@@ -54,14 +54,14 @@ controller:
 
 ## Template Wiring
 
-The chart passes default workload settings to Jangar via environment variables in `charts/agents/templates/deployment.yaml`:
+The chart passes default workload settings to Agents via environment variables in `charts/agents/templates/deployment.yaml`:
 
-- `controller.defaultWorkload.topologySpreadConstraints` -> `JANGAR_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS`
-- `controller.defaultWorkload.nodeSelector` -> `JANGAR_AGENT_RUNNER_NODE_SELECTOR`
-- `controller.defaultWorkload.tolerations` -> `JANGAR_AGENT_RUNNER_TOLERATIONS`
-- `controller.defaultWorkload.affinity` -> `JANGAR_AGENT_RUNNER_AFFINITY`
+- `controller.defaultWorkload.topologySpreadConstraints` -> `AGENTS_AGENT_RUNNER_TOPOLOGY_SPREAD_CONSTRAINTS`
+- `controller.defaultWorkload.nodeSelector` -> `AGENTS_AGENT_RUNNER_NODE_SELECTOR`
+- `controller.defaultWorkload.tolerations` -> `AGENTS_AGENT_RUNNER_TOLERATIONS`
+- `controller.defaultWorkload.affinity` -> `AGENTS_AGENT_RUNNER_AFFINITY`
 
-Jangar reads those environment variables, then applies them to the Job pod spec unless overridden by `AgentRun.spec.runtime.config.*` fields. Topology spread constraints are only written to the pod spec when the array is non-empty.
+Agents reads those environment variables, then applies them to the Job pod spec unless overridden by `AgentRun.spec.runtime.config.*` fields. Topology spread constraints are only written to the pod spec when the array is non-empty.
 
 ## Interactions With Node Selector, Affinity, and Tolerations
 
@@ -74,7 +74,7 @@ Topology spread constraints are evaluated by the scheduler after the node select
   - `DoNotSchedule` enforces strict spread and will leave pods Pending if constraints cannot be met.
   - `ScheduleAnyway` prefers spread but allows co-location when the cluster cannot satisfy the constraint.
 
-Label selectors should target labels that exist on AgentRun pods. Jangar applies standard labels such as:
+Label selectors should target labels that exist on AgentRun pods. Agents applies standard labels such as:
 
 - `agents.proompteng.ai/agent-run`
 - `agents.proompteng.ai/agent`


### PR DESCRIPTION
## Summary

- Updates active Agents operator docs to name the Agents controller/service account instead of Jangar.
- Replaces stale `JANGAR_*` runtime env references with canonical `AGENTS_*` names.
- Removes the obsolete `JANGAR_GRPC_TOKEN` compatibility note from agentctl docs.

## Related Issues

None

## Testing

- `rg -n "Jangar|JANGAR_|Jangar controller|Jangar endpoints" docs/agents/agentctl.md docs/agents/topology-spread-constraints.md docs/agents/rbac-matrix.md docs/agents/agents-helm-chart-implementation.md || true`
- `bunx oxfmt --check docs/agents/agentctl.md docs/agents/topology-spread-constraints.md docs/agents/rbac-matrix.md docs/agents/agents-helm-chart-implementation.md`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
