### PR TITLE
fix(torghut): preserve paper mechanism contracts

### DIFF
--- a/services/torghut/app/trading/discovery/autoresearch.py
+++ b/services/torghut/app/trading/discovery/autoresearch.py
@@ -236,13 +236,32 @@ class ResearchClaim:
     claim_id: str
     summary: str
     implication: str
+    claim_text: str = ''
+    claim_type: str = ''
+    data_requirements: tuple[str, ...] = ()
+    asset_scope: str = ''
+    horizon_scope: str = ''
+    expected_direction: str = ''
 
-    def to_payload(self) -> dict[str, str]:
-        return {
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
             'claim_id': self.claim_id,
             'summary': self.summary,
             'implication': self.implication,
         }
+        if self.claim_text:
+            payload['claim_text'] = self.claim_text
+        if self.claim_type:
+            payload['claim_type'] = self.claim_type
+        if self.data_requirements:
+            payload['data_requirements'] = list(self.data_requirements)
+        if self.asset_scope:
+            payload['asset_scope'] = self.asset_scope
+        if self.horizon_scope:
+            payload['horizon_scope'] = self.horizon_scope
+        if self.expected_direction:
+            payload['expected_direction'] = self.expected_direction
+        return payload
 
 
 @dataclass(frozen=True)
@@ -583,6 +602,16 @@ def load_strategy_autoresearch_program(
                             claim_id=claim_id,
                             summary=_string(claim_payload.get('summary')),
                             implication=_string(claim_payload.get('implication')),
+                            claim_text=_string(claim_payload.get('claim_text')),
+                            claim_type=_string(claim_payload.get('claim_type')),
+                            data_requirements=_string_list(
+                                claim_payload.get('data_requirements')
+                            ),
+                            asset_scope=_string(claim_payload.get('asset_scope')),
+                            horizon_scope=_string(claim_payload.get('horizon_scope')),
+                            expected_direction=_string(
+                                claim_payload.get('expected_direction')
+                            ),
                         )
                     )
             source_id = _string(source_payload.get('source_id'))

--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -2847,6 +2847,166 @@ def _requires_synthetic_validation_only_policy(card: HypothesisCard) -> bool:
     )
 
 
+def _paper_mechanism_haystack(card: HypothesisCard) -> str:
+    validation_requirements = _list_of_mappings(
+        card.implementation_constraints.get("validation_requirements")
+    )
+    validation_text = " ".join(
+        " ".join(
+            (
+                str(item.get("claim_id") or ""),
+                str(item.get("claim_type") or ""),
+                str(item.get("claim_text") or ""),
+                " ".join(_string_sequence(item.get("data_requirements"))),
+            )
+        )
+        for item in validation_requirements
+    )
+    return f"{_hypothesis_haystack(card)} {validation_text}".lower()
+
+
+def _mechanism_overlays_for_card(card: HypothesisCard) -> dict[str, Any]:
+    haystack = _paper_mechanism_haystack(card)
+    overlay_ids: list[str] = []
+    overlay_contracts: list[dict[str, Any]] = []
+    hard_vetoes: dict[str, Any] = {}
+    promotion_contract: dict[str, Any] = {}
+
+    def has_any(tokens: Sequence[str]) -> bool:
+        return any(token in haystack for token in tokens)
+
+    if has_any(
+        (
+            "clusterlob",
+            "clustered order",
+            "clustered_order",
+            "order arrival clustering",
+            "arrival clustering",
+            "event stream",
+            "event-stream",
+            "lob event",
+            "hawkes",
+            "order_arrival_intensity",
+            "state_dependent_hawkes_intensity",
+        )
+    ):
+        overlay_ids.append("cluster_lob_event_clustering")
+        overlay_contracts.append(
+            {
+                "overlay_id": "cluster_lob_event_clustering",
+                "required_evidence": [
+                    "clustered_order_events",
+                    "event_cluster_stability",
+                    "quote_quality_parity",
+                ],
+                "evidence_policy": "event_stream_required_not_ohlcv_only",
+            }
+        )
+        hard_vetoes.update(
+            {
+                "required_min_event_cluster_stability_score": "0.60",
+                "required_max_event_stream_latency_ms": "250",
+            }
+        )
+        promotion_contract.update(
+            {
+                "requires_lob_event_stream_parity": True,
+                "requires_event_cluster_stability": True,
+                "rejects_ohlcv_only_evidence": True,
+            }
+        )
+
+    if has_any(
+        (
+            "nonlinear impact",
+            "nonlinear_impact",
+            "square-root",
+            "square root",
+            "power-law market impact",
+            "power law market impact",
+            "almgren",
+            "route/tca",
+            "route_tca",
+            "market impact stress",
+            "impact stress",
+        )
+    ):
+        overlay_ids.append("nonlinear_market_impact_tca")
+        overlay_contracts.append(
+            {
+                "overlay_id": "nonlinear_market_impact_tca",
+                "required_evidence": [
+                    "route_tca",
+                    "nonlinear_impact_curve",
+                    "realized_slippage_bps",
+                    "turnover",
+                ],
+                "rank_metric": "post_cost_net_pnl_after_nonlinear_impact",
+            }
+        )
+        hard_vetoes.update(
+            {
+                "required_min_route_tca_sample_count": "60",
+                "required_max_realized_slippage_bps": "8",
+                "required_impact_stress_model": "square_root_or_power_law",
+            }
+        )
+        promotion_contract.update(
+            {
+                "requires_route_tca": True,
+                "requires_nonlinear_impact_curve": True,
+                "requires_impact_stress_replay": True,
+                "ranking_cost_model": "post_cost_nonlinear_impact",
+            }
+        )
+
+    if has_any(
+        (
+            "ohlcv-only",
+            "ohlcv only",
+            "ohlcv_derived",
+            "ohlcv-derived",
+            "bar-only",
+            "bar only",
+            "systematic falsification",
+        )
+    ):
+        overlay_ids.append("ohlcv_only_falsification")
+        overlay_contracts.append(
+            {
+                "overlay_id": "ohlcv_only_falsification",
+                "required_evidence": [
+                    "walk_forward_replay",
+                    "executable_quote_evidence",
+                    "route_tca",
+                    "live_paper_parity",
+                ],
+                "evidence_policy": "ohlcv_only_is_falsification_not_promotion_proof",
+            }
+        )
+        promotion_contract.update(
+            {
+                "rejects_ohlcv_only_promotion_evidence": True,
+                "requires_walk_forward_replay": True,
+                "requires_executable_quote_evidence": True,
+                "requires_route_tca": True,
+            }
+        )
+
+    if not overlay_ids:
+        return {}
+    return {
+        "feature_contract": {
+            "mechanism_overlays": overlay_contracts,
+        },
+        "parameter_space": {
+            "mechanism_overlay_ids": overlay_ids,
+        },
+        "hard_vetoes": hard_vetoes,
+        "promotion_contract": promotion_contract,
+    }
+
+
 def _family_scores_for_hypothesis(
     card: HypothesisCard,
 ) -> list[tuple[str, int, tuple[str, ...]]]:
@@ -2924,6 +3084,21 @@ def _family_scores_for_hypothesis(
             "clustered_arrival_regime",
         )
         bump("microbar_cross_sectional_pairs_v1", 2, "clustered_arrival_regime")
+    impact_ranking_only = has_any(
+        (
+            "nonlinear impact",
+            "nonlinear_impact",
+            "square-root",
+            "square root",
+            "power-law market impact",
+            "power law market impact",
+            "almgren",
+            "route/tca",
+            "route_tca",
+            "market impact stress",
+            "impact stress",
+        )
+    )
     if has_any(
         (
             "liquidity",
@@ -2944,18 +3119,39 @@ def _family_scores_for_hypothesis(
             "maker taker",
         )
     ):
-        bump("mean_reversion_rebound_v1", 4, "liquidity_response_or_execution_stress")
-        bump("washout_rebound_v2", 3, "liquidity_response_or_execution_stress")
-        bump(
-            "mean_reversion_exhaustion_short_v1",
-            2,
-            "liquidity_response_or_execution_stress",
-        )
-        bump(
-            "microstructure_continuation_matched_filter_v1",
-            3,
-            "liquidity_response_or_execution_stress",
-        )
+        if impact_ranking_only:
+            bump(
+                "microstructure_continuation_matched_filter_v1",
+                6,
+                "nonlinear_impact_route_tca_constraint",
+            )
+            bump(
+                "microbar_cross_sectional_pairs_v1",
+                3,
+                "nonlinear_impact_route_tca_constraint",
+            )
+            bump(
+                "intraday_tsmom_v2",
+                2,
+                "nonlinear_impact_route_tca_constraint",
+            )
+        else:
+            bump(
+                "mean_reversion_rebound_v1",
+                4,
+                "liquidity_response_or_execution_stress",
+            )
+            bump("washout_rebound_v2", 3, "liquidity_response_or_execution_stress")
+            bump(
+                "mean_reversion_exhaustion_short_v1",
+                2,
+                "liquidity_response_or_execution_stress",
+            )
+            bump(
+                "microstructure_continuation_matched_filter_v1",
+                3,
+                "liquidity_response_or_execution_stress",
+            )
     if has_any(
         (
             "volatility",
@@ -3444,6 +3640,9 @@ def compile_candidate_specs(
                     "source_run_id": card.source_run_id,
                     "source_claim_ids": list(card.source_claim_ids),
                     "mechanism": card.mechanism,
+                    "asset_scope": card.asset_scope,
+                    "horizon_scope": card.horizon_scope,
+                    "expected_direction": card.expected_direction,
                     "required_features": list(card.required_features),
                     "entry_motifs": list(card.entry_motifs),
                     "exit_motifs": list(card.exit_motifs),
@@ -3474,6 +3673,13 @@ def compile_candidate_specs(
                 if validation_requirements:
                     feature_contract["validation_requirements"] = [
                         dict(item) for item in validation_requirements
+                    ]
+                source_claims = _list_of_mappings(
+                    card.implementation_constraints.get("source_claims")
+                )
+                if source_claims:
+                    feature_contract["source_claims"] = [
+                        dict(item) for item in source_claims
                     ]
                 objective = {
                     "target_net_pnl_per_day": str(target_net_pnl_per_day),
@@ -3522,6 +3728,17 @@ def compile_candidate_specs(
                             ),
                         }
                     )
+                mechanism_overlays = _mechanism_overlays_for_card(card)
+                feature_contract.update(
+                    _mapping(mechanism_overlays.get("feature_contract"))
+                )
+                parameter_space.update(
+                    _mapping(mechanism_overlays.get("parameter_space"))
+                )
+                hard_vetoes.update(_mapping(mechanism_overlays.get("hard_vetoes")))
+                promotion_contract.update(
+                    _mapping(mechanism_overlays.get("promotion_contract"))
+                )
                 base_payload = {
                     "hypothesis_id": card.hypothesis_id,
                     "family_template_id": family_template_id,

--- a/services/torghut/app/trading/discovery/hypothesis_cards.py
+++ b/services/torghut/app/trading/discovery/hypothesis_cards.py
@@ -284,6 +284,21 @@ def build_hypothesis_cards(
         return []
     first_claim = normalized_claims[0]
     claim_relation_blockers = _claim_relation_blockers(source_claim_ids, relations)
+    source_claims: list[dict[str, Any]] = []
+    for index, claim in enumerate(normalized_claims, start=1):
+        source_claims.append(
+            {
+                "claim_id": _claim_id(claim, index=index),
+                "claim_type": _claim_type(claim),
+                "claim_text": _claim_text(claim),
+                "data_requirements": list(
+                    _metadata_terms(claim, kind="required_features")
+                ),
+                "asset_scope": _string(claim.get("asset_scope")),
+                "horizon_scope": _string(claim.get("horizon_scope")),
+                "expected_direction": _string(claim.get("expected_direction")),
+            }
+        )
     base_payload = {
         "source_run_id": source_run_id,
         "source_claim_ids": list(source_claim_ids),
@@ -296,6 +311,7 @@ def build_hypothesis_cards(
         "requires_runtime_family": True,
         "requires_scheduler_v3_replay": True,
         "requires_shadow_validation": True,
+        "source_claims": source_claims,
     }
     if claim_relation_blockers:
         implementation_constraints["claim_relation_blockers"] = [

--- a/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
@@ -253,11 +253,29 @@ research_sources:
     published_at: '2026-03-30'
     claims:
       - claim_id: nonlinear_market_impact_changes_strategy_ranking
+        claim_type: feature_recipe
         summary: Nonlinear market-impact models materially change trading behavior and strategy ranking versus fixed-cost assumptions.
         implication: Rank candidate sleeves on realized route/TCA and stressed impact curves, not only fixed-bps replay costs.
+        data_requirements:
+          - route_tca
+          - turnover
+          - nonlinear_impact_curve
+          - market_impact_stress
+        asset_scope: us_equities_intraday
+        horizon_scope: intraday_execution
+        expected_direction: neutral
       - claim_id: turnover_penalty_prevents_pathological_trading
+        claim_type: risk_constraint
         summary: Cost-model-aware optimization sharply reduces pathological turnover and total daily costs.
         implication: Add turnover and impact stress as first-class promotion blockers for high-activity candidates.
+        data_requirements:
+          - route_tca
+          - turnover
+          - realized_slippage_bps
+          - market_impact_stress
+        asset_scope: us_equities_intraday
+        horizon_scope: intraday_execution
+        expected_direction: neutral
   - source_id: overreaction_intraday_momentum_aapl_2026
     title: 'Overreaction as an Indicator for Momentum in Algorithmic Trading: A Case of AAPL Stocks'
     url: https://arxiv.org/abs/2602.18912
@@ -297,11 +315,29 @@ research_sources:
     published_at: '2026-05-05'
     claims:
       - claim_id: ohlcv_only_intraday_falsification
+        claim_type: validation_requirement
         summary: OHLCV-only intraday momentum signals can fail under realistic execution constraints despite attractive naive backtests.
         implication: Require executable quote, route/TCA, and walk-forward evidence before any OHLCV-derived sleeve enters promotion review.
+        data_requirements:
+          - executable_quote_evidence
+          - route_tca
+          - walk_forward_replay
+          - live_paper_parity
+        asset_scope: futures_intraday
+        horizon_scope: intraday_ohlcv_falsification
+        expected_direction: neutral
       - claim_id: walk_forward_cost_constraints_required
+        claim_type: validation_requirement
         summary: Walk-forward validation and market-microstructure cost constraints are necessary to falsify overfit intraday signals.
         implication: Keep the no-cheating promotion path anchored to held-out replay, live-paper, and post-cost ledger proof.
+        data_requirements:
+          - held_out_replay
+          - post_cost_ledger
+          - market_microstructure_costs
+          - live_paper_parity
+        asset_scope: futures_intraday
+        horizon_scope: intraday_ohlcv_falsification
+        expected_direction: neutral
   - source_id: latent_microstructure_regime_detection_2026
     title: 'Early Detection of Latent Microstructure Regimes in Limit Order Books'
     url: https://arxiv.org/abs/2604.20949
@@ -440,11 +476,28 @@ research_sources:
     published_at: '2026-05-12'
     claims:
       - claim_id: orderbook_hawkes_impact
+        claim_type: feature_recipe
         summary: Order-book variables can enter Hawkes trade-arrival intensity through exogenous and endogenous components.
         implication: Add order-arrival clustering and depth-state features to execution-aware entry timing.
+        data_requirements:
+          - order_arrival_intensity
+          - depth_state
+          - clustered_order_events
+          - spread_bps
+        asset_scope: us_equities_intraday
+        horizon_scope: intraday_microstructure
+        expected_direction: neutral
       - claim_id: session_specific_endogenous_intensity
+        claim_type: validation_requirement
         summary: Opening, main-session, and closing-period order-book impact should be estimated separately.
         implication: Keep session-segment validation mandatory before promoting continuation or reversal candidates.
+        data_requirements:
+          - session_segment
+          - order_arrival_intensity
+          - walk_forward_replay
+        asset_scope: us_equities_intraday
+        horizon_scope: intraday_microstructure
+        expected_direction: neutral
   - source_id: payment_for_order_flow_execution_quality_2026
     title: 'Payment for Order Flow, Demystified: How Your Free Trade Actually Works'
     url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6704839
@@ -495,11 +548,29 @@ research_sources:
     published_at: '2026-04-27'
     claims:
       - claim_id: state_dependent_lob_hawkes_intensity
+        claim_type: feature_recipe
         summary: State-dependent Hawkes intensities for LOB events can encode volatility-signature dynamics missed by fixed-window OFI.
         implication: Add state-dependent order-arrival clustering as a validation feature for execution-aware entry timing.
+        data_requirements:
+          - lob_event_stream
+          - state_dependent_hawkes_intensity
+          - volatility_signature
+          - clustered_order_events
+        asset_scope: us_equities_intraday
+        horizon_scope: intraday_microstructure
+        expected_direction: neutral
       - claim_id: volatility_signature_hawkes_calibration
+        claim_type: validation_requirement
         summary: State-dependent Hawkes features require replay calibration against volatility-signature behavior.
         implication: Keep Hawkes-derived entry timing in research until quote quality, volatility signature, and walk-forward replay agree.
+        data_requirements:
+          - quote_quality
+          - volatility_signature
+          - walk_forward_replay
+          - live_paper_parity
+        asset_scope: us_equities_intraday
+        horizon_scope: intraday_microstructure
+        expected_direction: neutral
   - source_id: mpc_trade_execution_2026
     title: 'Model Predictive Control For Trade Execution'
     url: https://arxiv.org/abs/2603.28898

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -694,6 +694,9 @@ def _load_autoresearch_feedback_evidence_bundles(
 
 
 def _program_claim_type(claim: ResearchClaim) -> str:
+    explicit_claim_type = str(claim.claim_type or "").strip().lower()
+    if explicit_claim_type:
+        return explicit_claim_type
     text = f"{claim.summary} {claim.implication}".lower()
     if any(
         token in text
@@ -748,7 +751,7 @@ def _program_research_source_to_whitepaper_source(
     claims: list[dict[str, Any]] = []
     for claim in source.claims:
         claim_id = str(claim.claim_id or "").strip()
-        claim_text = ". ".join(
+        claim_text = str(claim.claim_text or "").strip() or ". ".join(
             part
             for part in (
                 str(claim.summary or "").strip(),
@@ -759,20 +762,32 @@ def _program_research_source_to_whitepaper_source(
         if not claim_id or not claim_text:
             continue
         claim_type = _program_claim_type(claim)
+        data_requirements = [
+            item for item in claim.data_requirements if str(item or "").strip()
+        ]
+        expected_direction = str(claim.expected_direction or "").strip()
+        if not expected_direction:
+            expected_direction = (
+                "neutral"
+                if claim_type in {"risk_constraint", "validation_requirement"}
+                else "positive"
+            )
         claims.append(
             {
                 "claim_id": claim_id,
                 "claim_type": claim_type,
                 "claim_text": claim_text,
-                "asset_scope": "us_equities_intraday",
-                "horizon_scope": "intraday_microstructure",
-                "expected_direction": "neutral"
-                if claim_type in {"risk_constraint", "validation_requirement"}
-                else "positive",
+                "asset_scope": str(claim.asset_scope or "").strip()
+                or "us_equities_intraday",
+                "horizon_scope": str(claim.horizon_scope or "").strip()
+                or "intraday_microstructure",
+                "expected_direction": expected_direction,
+                "data_requirements": data_requirements,
                 "confidence": _PROGRAM_SOURCE_DEFAULT_CONFIDENCE,
                 "metadata": {
                     "program_source_id": run_id,
                     "program_implication": str(claim.implication or "").strip(),
+                    "data_requirements": data_requirements,
                 },
             }
         )

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -132,6 +132,162 @@ class TestCandidateSpecs(TestCase):
         reloaded = candidate_spec_from_payload(first[0].to_payload())
         self.assertEqual(reloaded.candidate_spec_id, first[0].candidate_spec_id)
 
+    def test_structured_source_claims_survive_candidate_spec_payload(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-structured-claims",
+            claims=[
+                {
+                    "claim_id": "claim-structured-flow",
+                    "claim_type": "feature_recipe",
+                    "claim_text": "Order flow imbalance requires route/TCA aware feature contracts.",
+                    "data_requirements": ["order_flow_imbalance", "route_tca"],
+                    "asset_scope": "us_equities_intraday",
+                    "horizon_scope": "intraday_microstructure",
+                    "expected_direction": "neutral",
+                    "confidence": "0.82",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("300")
+        )
+
+        source_claims = specs[0].feature_contract["source_claims"]
+        self.assertEqual(source_claims[0]["claim_id"], "claim-structured-flow")
+        self.assertEqual(source_claims[0]["claim_type"], "feature_recipe")
+        self.assertIn("route_tca", source_claims[0]["data_requirements"])
+        self.assertEqual(
+            specs[0].to_vnext_experiment_payload()["candidate_spec"][
+                "feature_contract"
+            ]["source_claims"][0]["horizon_scope"],
+            "intraday_microstructure",
+        )
+
+    def test_cluster_lob_claim_adds_event_clustering_overlay_contract(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-clusterlob",
+            claims=[
+                {
+                    "claim_id": "clusterlob-clustered-ofi-alpha",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": (
+                        "ClusterLOB clustered order events and order-flow imbalance "
+                        "improve short-horizon LOB signals."
+                    ),
+                    "data_requirements": [
+                        "clustered_order_events",
+                        "order_flow_imbalance",
+                        "spread_bps",
+                    ],
+                    "confidence": "0.82",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("300")
+        )
+
+        self.assertEqual(
+            specs[0].parameter_space["mechanism_overlay_ids"],
+            ["cluster_lob_event_clustering"],
+        )
+        self.assertEqual(
+            specs[0].hard_vetoes["required_min_event_cluster_stability_score"],
+            "0.60",
+        )
+        self.assertTrue(
+            specs[0].promotion_contract["requires_lob_event_stream_parity"]
+        )
+
+    def test_nonlinear_market_impact_claim_adds_route_tca_contract(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-realistic-impact",
+            claims=[
+                {
+                    "claim_id": "nonlinear-market-impact",
+                    "claim_type": "feature_recipe",
+                    "claim_text": (
+                        "Nonlinear market impact and square-root impact curves change "
+                        "strategy ranking under route/TCA stress."
+                    ),
+                    "data_requirements": [
+                        "route_tca",
+                        "turnover",
+                        "nonlinear_impact_curve",
+                        "market_impact_stress",
+                    ],
+                    "confidence": "0.82",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("300")
+        )
+
+        self.assertEqual(
+            specs[0].family_template_id,
+            "microstructure_continuation_matched_filter_v1",
+        )
+        self.assertNotEqual(specs[0].family_template_id, "mean_reversion_rebound_v1")
+        self.assertIn(
+            "nonlinear_market_impact_tca",
+            specs[0].parameter_space["mechanism_overlay_ids"],
+        )
+        self.assertEqual(
+            specs[0].hard_vetoes["required_impact_stress_model"],
+            "square_root_or_power_law",
+        )
+        self.assertEqual(
+            specs[0].promotion_contract["ranking_cost_model"],
+            "post_cost_nonlinear_impact",
+        )
+
+    def test_ohlcv_only_claim_adds_falsification_contract(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-ohlcv-falsification",
+            claims=[
+                {
+                    "claim_id": "ohlcv-alpha",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": (
+                        "OHLCV-derived intraday momentum can look attractive in "
+                        "naive backtests."
+                    ),
+                    "confidence": "0.75",
+                },
+                {
+                    "claim_id": "ohlcv-only-falsification",
+                    "claim_type": "validation_requirement",
+                    "claim_text": (
+                        "OHLCV-only signals require systematic falsification with "
+                        "executable quote, route/TCA, and walk-forward replay evidence."
+                    ),
+                    "data_requirements": [
+                        "executable_quote_evidence",
+                        "route_tca",
+                        "walk_forward_replay",
+                    ],
+                    "confidence": "0.80",
+                },
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("300")
+        )
+
+        self.assertIn(
+            "ohlcv_only_falsification",
+            specs[0].parameter_space["mechanism_overlay_ids"],
+        )
+        self.assertTrue(
+            specs[0].promotion_contract["rejects_ohlcv_only_promotion_evidence"]
+        )
+        self.assertTrue(specs[0].promotion_contract["requires_walk_forward_replay"])
+
     def test_morning_momentum_claim_selects_opening_drive_family(self) -> None:
         cards = build_hypothesis_cards(
             source_run_id="paper-morning-momentum",

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -2603,8 +2603,13 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         impact_claim_types = {
             str(claim["claim_type"]) for claim in impact_source.claims
         }
-        self.assertIn("validation_requirement", impact_claim_types)
-        self.assertFalse(runner.compile_sources_to_hypothesis_cards([impact_source]))
+        self.assertIn("feature_recipe", impact_claim_types)
+        self.assertIn("risk_constraint", impact_claim_types)
+        self.assertIn("route_tca", impact_source.claims[0]["data_requirements"])
+        self.assertEqual(
+            impact_source.claims[0]["horizon_scope"], "intraday_execution"
+        )
+        self.assertTrue(runner.compile_sources_to_hypothesis_cards([impact_source]))
 
         latent_regime_source = next(
             source

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -522,6 +522,14 @@ class TestStrategyAutoresearch(TestCase):
                 "intraday_price_asymmetry_sp500_2026",
             }.issubset(source_ids)
         )
+        impact_source = next(
+            source
+            for source in program.research_sources
+            if source.source_id == "realistic_market_impact_rl_envs_2026"
+        )
+        self.assertEqual(impact_source.claims[0].claim_type, "feature_recipe")
+        self.assertIn("route_tca", impact_source.claims[0].data_requirements)
+        self.assertEqual(impact_source.claims[0].horizon_scope, "intraday_execution")
 
         microbar_seed_names = {
             plan.seed_sweep_config.name


### PR DESCRIPTION
## Summary

- Preserve structured whitepaper claims from Torghut research programs through autoresearch source loading, whitepaper compiler conversion, hypothesis cards, and candidate specs.
- Add mechanism overlay contracts for LOB event clustering, nonlinear market-impact route/TCA evidence, and OHLCV-only falsification so promotion gates retain paper-derived proof requirements.
- Update the $500/day portfolio autoresearch program with explicit data requirements, scopes, and claim types for recent 2026 execution/microstructure sources.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_candidate_specs.py -k "structured_source_claims or cluster_lob or nonlinear_market_impact or ohlcv_only"`
- `uv run --frozen pytest tests/test_strategy_autoresearch.py -k checked_in_500_portfolio_profit_program_includes_reversal_surfaces`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k program_research_sources_feed_whitepaper_claim_compiler`
- `uv run --frozen pytest tests/test_whitepaper_candidate_compiler.py -k "recent_portable_lob_impact_and_ofi_response or structured or nonlinear or ohlcv or cluster"`
- `uv run --frozen ruff check app/trading/discovery/autoresearch.py app/trading/discovery/hypothesis_cards.py app/trading/discovery/candidate_specs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_candidate_specs.py tests/test_strategy_autoresearch.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_candidate_specs.py tests/test_whitepaper_candidate_compiler.py`
- `uv run --frozen pytest tests/test_strategy_autoresearch.py -k checked_in_500_portfolio_profit_program_includes_reversal_surfaces tests/test_run_whitepaper_autoresearch_profit_target.py -k program_research_sources_feed_whitepaper_claim_compiler`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
