### PR TITLE
refactor(agents): drop legacy jangar label readers

### DIFF
--- a/services/agents/src/server/agent-resource-labels.test.ts
+++ b/services/agents/src/server/agent-resource-labels.test.ts
@@ -24,12 +24,11 @@ describe('Agents resource labels', () => {
     })
   })
 
-  it('prefers canonical labels but still reads legacy labels', () => {
+  it('reads canonical labels only', () => {
     expect(
       readDeliveryIdLabel({
         metadata: {
           labels: {
-            [AGENTS_RESOURCE_LABELS.deliveryId.legacy]: 'legacy-delivery',
             [AGENTS_RESOURCE_LABELS.deliveryId.canonical]: 'canonical-delivery',
           },
         },
@@ -38,14 +37,14 @@ describe('Agents resource labels', () => {
 
     expect(
       readOrchestrationRunLabel({
-        metadata: { labels: { [AGENTS_RESOURCE_LABELS.orchestrationRun.legacy]: 'legacy-orch' } },
+        metadata: { labels: { 'jangar.proompteng.ai/orchestration-run': 'legacy-orch' } },
       }),
-    ).toBe('legacy-orch')
+    ).toBeUndefined()
 
     expect(
       readToolRunLabel({
-        metadata: { labels: { [AGENTS_RESOURCE_LABELS.toolRun.legacy]: 'legacy-toolrun' } },
+        metadata: { labels: { 'jangar.proompteng.ai/tool-run': 'legacy-toolrun' } },
       }),
-    ).toBe('legacy-toolrun')
+    ).toBeUndefined()
   })
 })

--- a/services/agents/src/server/agent-resource-labels.ts
+++ b/services/agents/src/server/agent-resource-labels.ts
@@ -3,19 +3,15 @@ import { asRecord, asString, readNested } from './primitives'
 export const AGENTS_RESOURCE_LABELS = {
   deliveryId: {
     canonical: 'agents.proompteng.ai/delivery-id',
-    legacy: 'jangar.proompteng.ai/delivery-id',
   },
   orchestrationRun: {
     canonical: 'agents.proompteng.ai/orchestration-run',
-    legacy: 'jangar.proompteng.ai/orchestration-run',
   },
   orchestrationStep: {
     canonical: 'agents.proompteng.ai/orchestration-step',
-    legacy: 'jangar.proompteng.ai/orchestration-step',
   },
   toolRun: {
     canonical: 'agents.proompteng.ai/tool-run',
-    legacy: 'jangar.proompteng.ai/tool-run',
   },
 } as const
 
@@ -45,7 +41,7 @@ export const readCompatibleLabel = (
 ): string | undefined => {
   const labels = asRecord(readNested(resource, ['metadata', 'labels']))
   const keys = AGENTS_RESOURCE_LABELS[label]
-  return asString(labels?.[keys.canonical]) ?? asString(labels?.[keys.legacy]) ?? undefined
+  return asString(labels?.[keys.canonical]) ?? undefined
 }
 
 export const readDeliveryIdLabel = (resource: Record<string, unknown>) => readCompatibleLabel(resource, 'deliveryId')

--- a/services/agents/src/server/orchestration-controller.test.ts
+++ b/services/agents/src/server/orchestration-controller.test.ts
@@ -6,9 +6,13 @@ vi.mock('./audit-client', () => ({
 vi.mock('./feature-flags', () => ({
   resolveBooleanFeatureToggle: vi.fn(async () => true),
 }))
+vi.mock('./kube-watch', () => ({
+  startResourceWatch: vi.fn(() => ({ stop: vi.fn() })),
+}))
 
 import { emitAuditEventBestEffort } from './audit-client'
 import { resolveBooleanFeatureToggle } from './feature-flags'
+import { startResourceWatch } from './kube-watch'
 import { __test__ } from './orchestration-controller'
 import type { KubernetesClient } from './kube-types'
 
@@ -411,5 +415,18 @@ describe('orchestration controller', () => {
       checkedAt: '2026-01-20T00:00:00.000Z',
     })
     expect(listCustomResourceDefinitions).toHaveBeenCalledTimes(1)
+  })
+
+  it('watches tool jobs by canonical Agents labels only', () => {
+    const handles: Array<{ stop: () => void }> = []
+
+    __test__.startNamespaceWatches({} as KubernetesClient, 'agents', handles)
+
+    const jobWatches = vi
+      .mocked(startResourceWatch)
+      .mock.calls.map(([options]) => options)
+      .filter((options) => options.resource === 'job')
+    expect(jobWatches).toHaveLength(1)
+    expect(jobWatches[0]?.labelSelector).toBe('agents.proompteng.ai/tool-run')
   })
 })

--- a/services/agents/src/server/orchestration-controller.ts
+++ b/services/agents/src/server/orchestration-controller.ts
@@ -2054,15 +2054,6 @@ const startNamespaceWatches = (
       onError: (error) => console.warn('[agents] tool job watch failed', error),
     }),
   )
-  handles.push(
-    startResourceWatch({
-      resource: 'job',
-      namespace,
-      labelSelector: AGENTS_RESOURCE_LABELS.toolRun.legacy,
-      onEvent: handleJob,
-      onError: (error) => console.warn('[agents] tool job watch failed', error),
-    }),
-  )
 }
 
 export const startOrchestrationController = async () => {
@@ -2139,4 +2130,5 @@ export const __test__ = {
   emitRunEvent,
   shouldStartWithFeatureFlag,
   checkCrds,
+  startNamespaceWatches,
 }

--- a/services/agents/src/server/supporting-primitives-controller.ts
+++ b/services/agents/src/server/supporting-primitives-controller.ts
@@ -552,8 +552,7 @@ const buildScheduleRunTemplate = (
       ([key, value]) =>
         typeof value === 'string' &&
         key !== 'schedules.proompteng.ai/schedule' &&
-        key !== AGENTS_RESOURCE_LABELS.deliveryId.canonical &&
-        key !== AGENTS_RESOURCE_LABELS.deliveryId.legacy,
+        key !== AGENTS_RESOURCE_LABELS.deliveryId.canonical,
     ),
   ) as Record<string, string>
   const labels = {


### PR DESCRIPTION
## Summary

- Removes `jangar.proompteng.ai/*` fallback label reads from the Agents resource-label helpers.
- Stops the orchestration controller from opening a second ToolRun Job watch for legacy Jangar labels.
- Keeps schedule-generated labels canonical and adds test coverage that legacy labels are ignored.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test -- src/server/agent-resource-labels.test.ts src/server/orchestration-controller.test.ts src/server/supporting-primitives-controller.test.ts`
- `bunx tsc --noEmit --project services/agents/tsconfig.json`
- `bunx oxfmt --check services/agents/src/server/agent-resource-labels.ts services/agents/src/server/agent-resource-labels.test.ts services/agents/src/server/orchestration-controller.ts services/agents/src/server/orchestration-controller.test.ts services/agents/src/server/supporting-primitives-controller.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

Agents no longer reads or watches legacy `jangar.proompteng.ai/*` resource labels for orchestration/tool/schedule bookkeeping. Existing resources must use canonical `agents.proompteng.ai/*` labels.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
