### PR TITLE
refactor(agents): resolve system prompts with effect

### DIFF
--- a/services/agents/src/server/agents-controller/system-prompt.test.ts
+++ b/services/agents/src/server/agents-controller/system-prompt.test.ts
@@ -116,6 +116,61 @@ describe('agents controller system-prompt module', () => {
     })
   })
 
+  it('fails when agent default ConfigMap ref is missing the requested key', async () => {
+    const kube = {
+      get: vi.fn().mockResolvedValue({
+        data: { 'other-key': 'not-used' },
+      }),
+    }
+    const result = await resolveSystemPrompt({
+      kube,
+      namespace: 'agents',
+      agentRun: { spec: {} },
+      agent: {
+        spec: {
+          defaults: {
+            systemPromptRef: { kind: 'ConfigMap', name: 'prompt-config', key: 'system-prompt.md' },
+          },
+        },
+      },
+      runSecrets: [],
+      allowedSecrets: [],
+    })
+
+    expect(kube.get).toHaveBeenCalledWith('configmap', 'prompt-config', 'agents')
+    expect(result).toEqual({
+      ok: false,
+      reason: 'MissingSystemPromptRef',
+      message: 'ConfigMap prompt-config is missing key system-prompt.md',
+    })
+  })
+
+  it('categorizes kube transport errors while reading system prompt refs', async () => {
+    const kube = {
+      get: vi.fn().mockRejectedValue(new Error('apiserver unavailable')),
+    }
+    const result = await resolveSystemPrompt({
+      kube,
+      namespace: 'agents',
+      agentRun: { spec: {} },
+      agent: {
+        spec: {
+          defaults: {
+            systemPromptRef: { kind: 'ConfigMap', name: 'prompt-config', key: 'system-prompt.md' },
+          },
+        },
+      },
+      runSecrets: [],
+      allowedSecrets: [],
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'SystemPromptRefReadFailed',
+      message: 'failed to read ConfigMap prompt-config: apiserver unavailable',
+    })
+  })
+
   it('fails when Agent defaults have no system prompt configured', async () => {
     const result = await resolveSystemPrompt({
       kube: { get: vi.fn() },

--- a/services/agents/src/server/agents-controller/system-prompt.ts
+++ b/services/agents/src/server/agents-controller/system-prompt.ts
@@ -1,6 +1,6 @@
-import { asRecord, asString, readNested } from '../primitives'
-import { Effect } from 'effect'
+import { Data, Effect } from 'effect'
 
+import { asRecord, asString, readNested } from '../primitives'
 import { isNonBlankString, sha256Hex } from './template-hash'
 import { evaluateSystemPromptPolicy } from './system-prompt-policy'
 
@@ -16,6 +16,57 @@ type KubeClient = {
   get: (kind: string, name: string, namespace: string) => Promise<Record<string, unknown> | null>
 }
 
+type ResolveSystemPromptOptions = {
+  kube: KubeClient
+  namespace: string
+  agentRun: Record<string, unknown>
+  agent: Record<string, unknown> | null
+  runSecrets: string[]
+  allowedSecrets: string[]
+  maxInlineLength?: number
+}
+
+export type ResolvedSystemPrompt = {
+  ok: true
+  systemPrompt: string | null
+  systemPromptRef: SystemPromptRef | null
+  systemPromptHash: string
+  resolvedSystemPrompt: string
+}
+
+export type RejectedSystemPrompt = {
+  ok: false
+  reason:
+    | 'InvalidSystemPrompt'
+    | 'InvalidSystemPromptRef'
+    | 'MissingSystemPromptConfiguration'
+    | 'MissingSystemPromptRef'
+    | 'SecretNotAllowed'
+    | 'SystemPromptOverrideNotAllowed'
+    | 'SystemPromptRefReadFailed'
+    | 'SystemPromptTooLong'
+  message: string
+}
+
+export type SystemPromptResolution = ResolvedSystemPrompt | RejectedSystemPrompt
+
+type SystemPromptRefParseResult =
+  | {
+      ok: true
+      ref: SystemPromptRef
+    }
+  | {
+      ok: false
+      reason: 'InvalidSystemPromptRef'
+      message: string
+    }
+
+class SystemPromptRefReadError extends Data.TaggedError('SystemPromptRefReadError')<{
+  readonly ref: SystemPromptRef
+  readonly namespace: string
+  readonly cause: unknown
+}> {}
+
 const normalizeSystemPromptKind = (value: string): SystemPromptRef['kind'] | null => {
   const normalized = value.trim().toLowerCase()
   if (normalized === 'secret') return 'Secret'
@@ -23,7 +74,7 @@ const normalizeSystemPromptKind = (value: string): SystemPromptRef['kind'] | nul
   return null
 }
 
-export const parseSystemPromptRef = (raw: unknown) => {
+export const parseSystemPromptRef = (raw: unknown): SystemPromptRefParseResult => {
   const record = asRecord(raw)
   if (!record) {
     return {
@@ -46,131 +97,153 @@ export const parseSystemPromptRef = (raw: unknown) => {
   return { ok: true as const, ref: { kind, name, key } satisfies SystemPromptRef }
 }
 
-export const resolveSystemPrompt = async (options: {
-  kube: KubeClient
-  namespace: string
-  agentRun: Record<string, unknown>
-  agent: Record<string, unknown> | null
-  runSecrets: string[]
-  allowedSecrets: string[]
-  maxInlineLength?: number
-}) => {
-  const spec = asRecord(options.agentRun.spec) ?? {}
-  const defaults = asRecord(readNested(options.agent, ['spec', 'defaults'])) ?? {}
-  const maxInlineLength = options.maxInlineLength ?? SYSTEM_PROMPT_INLINE_MAX_LENGTH
+const describeUnknownError = (error: unknown) => {
+  if (error instanceof Error && error.message.trim() !== '') return error.message
+  if (typeof error === 'string' && error.trim() !== '') return error
+  return 'unknown error'
+}
 
-  const policy = Effect.runSync(
-    evaluateSystemPromptPolicy({
+const readSystemPromptResource = (options: ResolveSystemPromptOptions, ref: SystemPromptRef) =>
+  Effect.tryPromise({
+    try: () => options.kube.get(ref.kind === 'Secret' ? 'secret' : 'configmap', ref.name, options.namespace),
+    catch: (cause) => new SystemPromptRefReadError({ ref, namespace: options.namespace, cause }),
+  })
+
+const readSystemPromptResourceResult = (options: ResolveSystemPromptOptions, ref: SystemPromptRef) =>
+  readSystemPromptResource(options, ref).pipe(
+    Effect.map((resource) => ({ ok: true as const, resource })),
+    Effect.catchAll((error) =>
+      Effect.succeed({
+        ok: false as const,
+        reason: 'SystemPromptRefReadFailed' as const,
+        message: `failed to read ${error.ref.kind} ${error.ref.name}: ${describeUnknownError(error.cause)}`,
+      }),
+    ),
+  )
+
+export const resolveSystemPromptEffect = (options: ResolveSystemPromptOptions): Effect.Effect<SystemPromptResolution> =>
+  Effect.gen(function* () {
+    const spec = asRecord(options.agentRun.spec) ?? {}
+    const defaults = asRecord(readNested(options.agent, ['spec', 'defaults'])) ?? {}
+    const maxInlineLength = options.maxInlineLength ?? SYSTEM_PROMPT_INLINE_MAX_LENGTH
+
+    const policy = yield* evaluateSystemPromptPolicy({
       hasRunOverride: spec.systemPrompt != null || spec.systemPromptRef != null,
       hasDefaultRef: defaults.systemPromptRef != null,
       hasDefaultInline: defaults.systemPrompt != null,
-    }),
-  )
-  if (!policy.ok) {
-    return policy
-  }
+    })
+    if (!policy.ok) {
+      return policy
+    }
 
-  const candidates: Array<{ type: 'ref'; raw: unknown } | { type: 'inline'; raw: unknown }> = policy.candidateOrder.map(
-    (type) => (type === 'ref' ? { type, raw: defaults.systemPromptRef } : { type, raw: defaults.systemPrompt }),
-  )
+    const candidates: Array<{ type: 'ref'; raw: unknown } | { type: 'inline'; raw: unknown }> =
+      policy.candidateOrder.map((type) =>
+        type === 'ref' ? { type, raw: defaults.systemPromptRef } : { type, raw: defaults.systemPrompt },
+      )
 
-  for (const candidate of candidates) {
-    if (candidate.raw == null) continue
+    for (const candidate of candidates) {
+      if (candidate.raw == null) continue
 
-    if (candidate.type === 'inline') {
-      if (typeof candidate.raw !== 'string') {
+      if (candidate.type === 'inline') {
+        if (typeof candidate.raw !== 'string') {
+          return {
+            ok: false as const,
+            reason: 'InvalidSystemPrompt',
+            message: 'systemPrompt must be a string',
+          }
+        }
+        const value = candidate.raw
+        if (!isNonBlankString(value)) continue
+        if (value.length > maxInlineLength) {
+          return {
+            ok: false as const,
+            reason: 'SystemPromptTooLong',
+            message: `systemPrompt exceeds ${maxInlineLength} characters`,
+          }
+        }
         return {
-          ok: false as const,
-          reason: 'InvalidSystemPrompt',
-          message: 'systemPrompt must be a string',
+          ok: true as const,
+          systemPrompt: value,
+          systemPromptRef: null,
+          systemPromptHash: sha256Hex(value),
+          resolvedSystemPrompt: value,
         }
       }
-      const value = candidate.raw
-      if (!isNonBlankString(value)) continue
-      if (value.length > maxInlineLength) {
-        return {
-          ok: false as const,
-          reason: 'SystemPromptTooLong',
-          message: `systemPrompt exceeds ${maxInlineLength} characters`,
+
+      const parsed = parseSystemPromptRef(candidate.raw)
+      if (!parsed.ok) return parsed
+      const ref = parsed.ref
+
+      if (ref.kind === 'Secret') {
+        if (!options.runSecrets.includes(ref.name)) {
+          return {
+            ok: false as const,
+            reason: 'SecretNotAllowed',
+            message: `system prompt secret ${ref.name} is not included in spec.secrets`,
+          }
+        }
+        if (options.allowedSecrets.length > 0 && !options.allowedSecrets.includes(ref.name)) {
+          return {
+            ok: false as const,
+            reason: 'SecretNotAllowed',
+            message: `system prompt secret ${ref.name} is not allowlisted by the Agent`,
+          }
         }
       }
+
+      const resourceRead = yield* readSystemPromptResourceResult(options, ref)
+      if (!resourceRead.ok) return resourceRead
+
+      const resource = resourceRead.resource
+      if (!resource) {
+        return {
+          ok: false as const,
+          reason: 'MissingSystemPromptRef',
+          message: `${ref.kind} ${ref.name} not found`,
+        }
+      }
+
+      const contents = (() => {
+        if (ref.kind === 'ConfigMap') {
+          const data = asRecord(resource.data) ?? {}
+          const value = data[ref.key]
+          return typeof value === 'string' ? value : null
+        }
+
+        const stringData = asRecord(resource.stringData) ?? null
+        const fromStringData = stringData ? stringData[ref.key] : null
+        if (typeof fromStringData === 'string') {
+          return fromStringData
+        }
+        const data = asRecord(resource.data) ?? {}
+        const encoded = data[ref.key]
+        if (typeof encoded !== 'string' || encoded.length === 0) return null
+        return Buffer.from(encoded, 'base64').toString('utf8')
+      })()
+
+      if (!isNonBlankString(contents)) {
+        return {
+          ok: false as const,
+          reason: 'MissingSystemPromptRef',
+          message: `${ref.kind} ${ref.name} is missing key ${ref.key}`,
+        }
+      }
+
       return {
         ok: true as const,
-        systemPrompt: value,
-        systemPromptRef: null,
-        systemPromptHash: sha256Hex(value),
-        resolvedSystemPrompt: value,
-      }
-    }
-
-    const parsed = parseSystemPromptRef(candidate.raw)
-    if (!parsed.ok) return parsed
-    const ref = parsed.ref
-
-    if (ref.kind === 'Secret') {
-      if (!options.runSecrets.includes(ref.name)) {
-        return {
-          ok: false as const,
-          reason: 'SecretNotAllowed',
-          message: `system prompt secret ${ref.name} is not included in spec.secrets`,
-        }
-      }
-      if (options.allowedSecrets.length > 0 && !options.allowedSecrets.includes(ref.name)) {
-        return {
-          ok: false as const,
-          reason: 'SecretNotAllowed',
-          message: `system prompt secret ${ref.name} is not allowlisted by the Agent`,
-        }
-      }
-    }
-
-    const resource = await options.kube.get(ref.kind === 'Secret' ? 'secret' : 'configmap', ref.name, options.namespace)
-    if (!resource) {
-      return {
-        ok: false as const,
-        reason: 'MissingSystemPromptRef',
-        message: `${ref.kind} ${ref.name} not found`,
-      }
-    }
-
-    const contents = (() => {
-      if (ref.kind === 'ConfigMap') {
-        const data = asRecord(resource.data) ?? {}
-        const value = data[ref.key]
-        return typeof value === 'string' ? value : null
-      }
-
-      const stringData = asRecord(resource.stringData) ?? null
-      const fromStringData = stringData ? stringData[ref.key] : null
-      if (typeof fromStringData === 'string') {
-        return fromStringData
-      }
-      const data = asRecord(resource.data) ?? {}
-      const encoded = data[ref.key]
-      if (typeof encoded !== 'string' || encoded.length === 0) return null
-      return Buffer.from(encoded, 'base64').toString('utf8')
-    })()
-
-    if (!isNonBlankString(contents)) {
-      return {
-        ok: false as const,
-        reason: 'MissingSystemPromptRef',
-        message: `${ref.kind} ${ref.name} is missing key ${ref.key}`,
+        systemPrompt: null,
+        systemPromptRef: ref,
+        systemPromptHash: sha256Hex(contents),
+        resolvedSystemPrompt: contents,
       }
     }
 
     return {
-      ok: true as const,
-      systemPrompt: null,
-      systemPromptRef: ref,
-      systemPromptHash: sha256Hex(contents),
-      resolvedSystemPrompt: contents,
+      ok: false as const,
+      reason: 'MissingSystemPromptConfiguration',
+      message: 'Agent.spec.defaults.systemPrompt or Agent.spec.defaults.systemPromptRef is required',
     }
-  }
+  })
 
-  return {
-    ok: false as const,
-    reason: 'MissingSystemPromptConfiguration',
-    message: 'Agent.spec.defaults.systemPrompt or Agent.spec.defaults.systemPromptRef is required',
-  }
-}
+export const resolveSystemPrompt = async (options: ResolveSystemPromptOptions) =>
+  Effect.runPromise(resolveSystemPromptEffect(options))


### PR DESCRIPTION
## Summary

- Reworks Agents controller system prompt resolution around an internal `Effect.gen` pipeline while preserving the existing async `resolveSystemPrompt` facade.
- Adds a tagged `SystemPromptRefReadError` and maps kube transport failures into a stable `SystemPromptRefReadFailed` resolution reason.
- Adds regression coverage for ConfigMap missing-key handling and kube read failures.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test -- src/server/agents-controller/system-prompt.test.ts src/server/agents-controller/system-prompt-policy.test.ts`
- `bunx tsc --noEmit --project services/agents/tsconfig.json`
- `bunx oxfmt --check services/agents/src/server/agents-controller/system-prompt.ts services/agents/src/server/agents-controller/system-prompt.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
