### PR TITLE
refactor(agents): simplify runtime identity

### DIFF
--- a/services/agents/src/server/runtime-identity.test.ts
+++ b/services/agents/src/server/runtime-identity.test.ts
@@ -1,23 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { isAgentsRuntimeService, resolveRuntimeServiceName } from './runtime-identity'
+import { AGENTS_RUNTIME_SERVICE_NAME, resolveRuntimeServiceName } from './runtime-identity'
 
 describe('runtime identity', () => {
-  it('uses Agents identity when canonical Agents image env is present', () => {
-    expect(resolveRuntimeServiceName({ AGENTS_IMAGE: 'registry.example/lab/agents-controller:abc' })).toBe('agents')
-    expect(resolveRuntimeServiceName({ AGENTS_GITOPS_REVISION: 'abc123' })).toBe('agents')
-  })
-
-  it('ignores explicit compatibility override back to Jangar identity', () => {
-    expect(
-      isAgentsRuntimeService({
-        AGENTS_RUNTIME_SERVICE: 'jangar',
-        AGENTS_IMAGE: 'registry.example/lab/agents-controller:abc',
-      }),
-    ).toBe(true)
-  })
-
-  it('keeps Agents identity when only Jangar runtime signals are present', () => {
-    expect(resolveRuntimeServiceName({ JANGAR_IMAGE: 'registry.example/lab/jangar:abc' })).toBe('agents')
+  it('uses a fixed Agents identity', () => {
+    expect(AGENTS_RUNTIME_SERVICE_NAME).toBe('agents')
+    expect(resolveRuntimeServiceName()).toBe('agents')
   })
 })

--- a/services/agents/src/server/runtime-identity.ts
+++ b/services/agents/src/server/runtime-identity.ts
@@ -1,5 +1,5 @@
 export type AgentsRuntimeServiceName = 'agents'
 
-export const isAgentsRuntimeService = (_env: NodeJS.ProcessEnv = process.env) => true
+export const AGENTS_RUNTIME_SERVICE_NAME: AgentsRuntimeServiceName = 'agents'
 
-export const resolveRuntimeServiceName = (_env: NodeJS.ProcessEnv = process.env): AgentsRuntimeServiceName => 'agents'
+export const resolveRuntimeServiceName = (): AgentsRuntimeServiceName => AGENTS_RUNTIME_SERVICE_NAME


### PR DESCRIPTION
## Summary

- Removes the unused `isAgentsRuntimeService` compatibility helper from Agents runtime identity.
- Makes runtime identity a fixed Agents constant instead of an env-shaped resolver.
- Deletes tests that implied `AGENTS_RUNTIME_SERVICE=jangar` or `JANGAR_IMAGE` are meaningful for Agents identity.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test -- src/server/runtime-identity.test.ts src/server/health.test.ts src/server/agentctl-grpc-logging.test.ts src/server/leader-election.test.ts`
- `bunx tsc --noEmit --project services/agents/tsconfig.json`
- `bunx oxfmt --check services/agents/src/server/runtime-identity.ts services/agents/src/server/runtime-identity.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
