### PR TITLE
refactor(agents): drop jangar db secret source fallback

### DIFF
--- a/packages/scripts/src/agents/__tests__/deploy-service.test.ts
+++ b/packages/scripts/src/agents/__tests__/deploy-service.test.ts
@@ -250,38 +250,15 @@ runner:
   })
 
   it('defaults database secret alias source to the Agents-owned target secret', () => {
-    const previousNamespace = process.env.AGENTS_DB_SECRET_SOURCE_NAMESPACE
-    const previousName = process.env.AGENTS_DB_SECRET_SOURCE_NAME
-    try {
-      delete process.env.AGENTS_DB_SECRET_SOURCE_NAMESPACE
-      delete process.env.AGENTS_DB_SECRET_SOURCE_NAME
-      expect(
-        __private.resolveDatabaseSecretSource({
-          namespace: 'agents',
-          name: 'agents-db-app',
-        }),
-      ).toEqual({
-        sourceNamespace: 'agents',
-        sourceName: 'agents-db-app',
-      })
-
-      process.env.AGENTS_DB_SECRET_SOURCE_NAMESPACE = 'jangar'
-      process.env.AGENTS_DB_SECRET_SOURCE_NAME = 'jangar-db-app'
-      expect(
-        __private.resolveDatabaseSecretSource({
-          namespace: 'agents',
-          name: 'agents-db-app',
-        }),
-      ).toEqual({
-        sourceNamespace: 'jangar',
-        sourceName: 'jangar-db-app',
-      })
-    } finally {
-      if (previousNamespace === undefined) delete process.env.AGENTS_DB_SECRET_SOURCE_NAMESPACE
-      else process.env.AGENTS_DB_SECRET_SOURCE_NAMESPACE = previousNamespace
-      if (previousName === undefined) delete process.env.AGENTS_DB_SECRET_SOURCE_NAME
-      else process.env.AGENTS_DB_SECRET_SOURCE_NAME = previousName
-    }
+    expect(
+      __private.resolveDatabaseSecretSource({
+        namespace: 'agents',
+        name: 'agents-db-app',
+      }),
+    ).toEqual({
+      sourceNamespace: 'agents',
+      sourceName: 'agents-db-app',
+    })
   })
 
   it('builds an Agents-owned compatibility database secret without source ownership metadata', () => {
@@ -294,19 +271,19 @@ runner:
           uri: 'cG9zdGdyZXNxbDovL2FnZW50cw==',
         },
         metadata: {
-          name: 'jangar-db-app',
+          name: 'agents-db-app',
           namespace: 'agents',
           uid: 'source-uid',
           resourceVersion: '123',
           ownerReferences: [{ name: 'source-owner' }],
           annotations: {
-            'reflector.v1.k8s.emberstack.com/reflects': 'jangar/jangar-db-app',
+            'reflector.v1.k8s.emberstack.com/reflects': 'agents/agents-db-app',
           },
         },
       },
       {
         sourceNamespace: 'agents',
-        sourceName: 'jangar-db-app',
+        sourceName: 'agents-db-app',
         targetNamespace: 'agents',
         targetName: 'agents-db-app',
       },
@@ -320,7 +297,7 @@ runner:
     expect(manifest.metadata).not.toHaveProperty('ownerReferences')
     expect(manifest.metadata?.annotations).toEqual({
       'agents.proompteng.ai/created-by': 'agents-deploy-service',
-      'agents.proompteng.ai/compat-source-secret': 'agents/jangar-db-app',
+      'agents.proompteng.ai/compat-source-secret': 'agents/agents-db-app',
     })
   })
 })

--- a/packages/scripts/src/agents/deploy-service.ts
+++ b/packages/scripts/src/agents/deploy-service.ts
@@ -493,7 +493,7 @@ const buildDatabaseSecretAliasManifest = (
       'app.kubernetes.io/name': 'agents',
       'app.kubernetes.io/component': 'database',
       'agents.proompteng.ai/compat-source-secret': options.sourceName,
-      ...(source.metadata?.labels ?? {}),
+      ...source.metadata?.labels,
     },
     annotations: {
       'agents.proompteng.ai/created-by': 'agents-deploy-service',
@@ -503,8 +503,8 @@ const buildDatabaseSecretAliasManifest = (
 })
 
 const resolveDatabaseSecretSource = (requirement: DatabaseSecretRequirement) => ({
-  sourceNamespace: process.env.AGENTS_DB_SECRET_SOURCE_NAMESPACE ?? requirement.namespace,
-  sourceName: process.env.AGENTS_DB_SECRET_SOURCE_NAME ?? requirement.name,
+  sourceNamespace: requirement.namespace,
+  sourceName: requirement.name,
 })
 
 const ensureDatabaseSecretReady = async (requirement: DatabaseSecretRequirement | null) => {
@@ -528,7 +528,7 @@ const ensureDatabaseSecretReady = async (requirement: DatabaseSecretRequirement 
 
   if (!parseBoolean(process.env.AGENTS_CREATE_DB_SECRET_ALIAS, false)) {
     fatal(
-      `Database secret ${requirement.namespace}/${requirement.name} is missing. Create/migrate the Agents database secret before applying, or set AGENTS_CREATE_DB_SECRET_ALIAS=true with AGENTS_DB_SECRET_SOURCE_NAME set explicitly to copy a compatibility source secret for this rollout.`,
+      `Database secret ${requirement.namespace}/${requirement.name} is missing. Create/migrate the Agents database secret before applying, or set AGENTS_CREATE_DB_SECRET_ALIAS=true to re-apply the Agents-owned target secret for this rollout.`,
     )
   }
 


### PR DESCRIPTION
## Summary

- Remove deploy-service support for `AGENTS_DB_SECRET_SOURCE_NAMESPACE` and `AGENTS_DB_SECRET_SOURCE_NAME`.
- Keep database secret aliasing pinned to the Agents-owned `agents/agents-db-app` target secret.
- Update tests so deploy tooling no longer models `jangar/jangar-db-app` as a valid Agents secret source.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/deploy-service.test.ts`
- `bun run --filter @proompteng/scripts lint:oxlint`
- `bunx oxfmt --check packages/scripts/src/agents/deploy-service.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

Deploy tooling no longer supports copying an Agents database secret from a Jangar-owned source secret. Operators must create or migrate the Agents-owned `agents-db-app` secret before rollout.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
