### PR TITLE
refactor(jangar): read agents health and readiness via service boundary

### DIFF
--- a/services/jangar/src/routes/health.test.tsx
+++ b/services/jangar/src/routes/health.test.tsx
@@ -1,26 +1,32 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const originalEnv = { ...process.env }
+const originalFetch = globalThis.fetch
 
-const agentsControllerMocks = vi.hoisted(() => ({
-  getAgentsControllerHealth: vi.fn(),
-}))
-
-vi.mock('@proompteng/agents/server/agents-controller', () => agentsControllerMocks)
+const buildJsonResponse = (payload: unknown, status = 200) =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
 
 describe('health route', () => {
   beforeEach(() => {
     process.env = { ...originalEnv }
+    globalThis.fetch = vi.fn(async () =>
+      buildJsonResponse({
+        status: 'ok',
+        service: 'agents',
+        agentsController: {
+          enabled: true,
+          crdsReady: true,
+        },
+      }),
+    ) as unknown as typeof globalThis.fetch
     vi.clearAllMocks()
-    agentsControllerMocks.getAgentsControllerHealth.mockReturnValue({
-      enabled: true,
-      started: true,
-      namespaces: ['agents'],
-      crdsReady: true,
-      missingCrds: [],
-      lastCheckedAt: '2026-03-08T21:00:00Z',
-      agentRunIngestion: [],
-    })
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
   })
 
   it('reports Agents service identity under Agents runtime env', async () => {
@@ -33,6 +39,9 @@ describe('health route', () => {
     await expect(response.json()).resolves.toMatchObject({
       status: 'ok',
       service: 'agents',
+      agentsService: {
+        service: 'agents',
+      },
     })
   })
 
@@ -44,6 +53,34 @@ describe('health route', () => {
     await expect(response.json()).resolves.toMatchObject({
       status: 'ok',
       service: 'jangar',
+      agentsController: {
+        enabled: true,
+        crdsReady: true,
+      },
+    })
+  })
+
+  it('degrades when the Agents service health endpoint is unreachable', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('connect ECONNREFUSED')
+    }) as unknown as typeof globalThis.fetch
+
+    const { Route } = await import('./health')
+    const response = await Route.options.server.handlers.GET()
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toMatchObject({
+      status: 'degraded',
+      service: 'jangar',
+      agentsService: {
+        status: 'unavailable',
+        error: 'connect ECONNREFUSED',
+        httpStatus: 0,
+      },
+      agentsController: {
+        enabled: true,
+        crdsReady: false,
+      },
     })
   })
 })

--- a/services/jangar/src/routes/health.tsx
+++ b/services/jangar/src/routes/health.tsx
@@ -1,14 +1,38 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { getAgentsControllerHealth } from '@proompteng/agents/server/agents-controller'
 
+import { fetchAgentsServiceJson } from '~/server/agents-service-proxy'
 import { resolveRuntimeServiceName } from '~/server/runtime-identity'
 
-export const getHealthHandler = () => {
-  const agentsController = getAgentsControllerHealth()
-  const ready = agentsController.enabled ? agentsController.crdsReady !== false : true
+type AgentsHealthController = {
+  enabled: boolean
+  crdsReady: boolean | null
+}
+
+type AgentsHealthPayload = {
+  status?: string
+  service?: string
+  agentsController?: AgentsHealthController
+}
+
+const unavailableAgentsController = (): AgentsHealthController => ({
+  enabled: true,
+  crdsReady: false,
+})
+
+export const getHealthHandler = async () => {
+  const agentsHealth = await fetchAgentsServiceJson<AgentsHealthPayload>('/health')
+  const agentsController = agentsHealth.body?.agentsController ?? unavailableAgentsController()
+  const ready = agentsHealth.ok && (agentsController.enabled ? agentsController.crdsReady !== false : true)
   const body = JSON.stringify({
     status: ready ? 'ok' : 'degraded',
     service: resolveRuntimeServiceName(),
+    agentsService: agentsHealth.ok
+      ? agentsHealth.body
+      : {
+          status: 'unavailable',
+          error: agentsHealth.error,
+          httpStatus: agentsHealth.status,
+        },
     agentsController,
   })
 
@@ -24,7 +48,7 @@ export const getHealthHandler = () => {
 export const Route = createFileRoute('/health')({
   server: {
     handlers: {
-      GET: getHealthHandler,
+      GET: () => getHealthHandler(),
     },
   },
 })

--- a/services/jangar/src/routes/ready.test.ts
+++ b/services/jangar/src/routes/ready.test.ts
@@ -11,21 +11,8 @@ const buildJsonResponse = (payload: unknown, status = 200) =>
     headers: { 'content-type': 'application/json' },
   })
 
-const agentsControllerMocks = vi.hoisted(() => ({
-  getAgentsControllerHealth: vi.fn(),
-  assessAgentRunIngestion: vi.fn(),
-}))
-
-const leaderElectionMocks = vi.hoisted(() => ({
-  getLeaderElectionStatus: vi.fn(),
-}))
-
-const orchestrationControllerMocks = vi.hoisted(() => ({
-  getOrchestrationControllerHealth: vi.fn(),
-}))
-
-const supportingControllerMocks = vi.hoisted(() => ({
-  getSupportingControllerHealth: vi.fn(),
+const agentsControlPlaneClientMocks = vi.hoisted(() => ({
+  getAgentsReadySnapshot: vi.fn(),
 }))
 
 const controlPlaneStatusMocks = vi.hoisted(() => ({
@@ -53,10 +40,15 @@ const githubReviewIngestMocks = vi.hoisted(() => ({
   getGithubReviewIngestPressureSummary: vi.fn(),
 }))
 
-vi.mock('@proompteng/agents/server/agents-controller', () => agentsControllerMocks)
-vi.mock('~/server/leader-election', () => leaderElectionMocks)
-vi.mock('@proompteng/agents/server/orchestration-controller', () => orchestrationControllerMocks)
-vi.mock('~/server/supporting-primitives-controller', () => supportingControllerMocks)
+vi.mock('~/server/agents-control-plane-client', async () => {
+  const actual = await vi.importActual<typeof import('~/server/agents-control-plane-client')>(
+    '~/server/agents-control-plane-client',
+  )
+  return {
+    ...actual,
+    getAgentsReadySnapshot: agentsControlPlaneClientMocks.getAgentsReadySnapshot,
+  }
+})
 vi.mock('~/server/memory-provider-health', () => memoryProviderHealthMocks)
 vi.mock('~/server/control-plane-watch-reliability', () => watchReliabilityMocks)
 vi.mock('~/server/metrics', () => metricsMocks)
@@ -216,6 +208,72 @@ const buildRuntimeAdmissionSnapshot = (
   ],
 })
 
+const buildAgentsControllerHealth = (overrides: Record<string, unknown> = {}) => ({
+  enabled: true,
+  started: true,
+  namespaces: ['agents'],
+  crdsReady: true,
+  missingCrds: [],
+  lastCheckedAt: '2026-03-08T21:00:00Z',
+  agentRunIngestion: [],
+  ...overrides,
+})
+
+const buildLeaderElection = (overrides: Record<string, unknown> = {}) => ({
+  enabled: true,
+  required: true,
+  isLeader: true,
+  leaseName: 'agents-controller-leader',
+  leaseNamespace: 'agents',
+  identity: 'agents-controllers-1',
+  lastTransitionAt: '2026-03-08T21:00:00Z',
+  lastAttemptAt: '2026-03-08T21:00:00Z',
+  lastSuccessAt: '2026-03-08T21:00:00Z',
+  lastError: null,
+  ...overrides,
+})
+
+const buildAgentsReadySnapshot = (overrides: Record<string, unknown> = {}) => {
+  const agentsController =
+    (overrides.agentsController as Record<string, unknown> | undefined) ?? buildAgentsControllerHealth()
+  const orchestrationController =
+    (overrides.orchestrationController as Record<string, unknown> | undefined) ?? buildAgentsControllerHealth()
+  const supportingController =
+    (overrides.supportingController as Record<string, unknown> | undefined) ?? buildAgentsControllerHealth()
+  const namespaces = (overrides.namespaces as string[] | undefined) ?? ['agents']
+  const status = (overrides.status as 'ok' | 'degraded' | undefined) ?? 'ok'
+  const httpReady = (overrides.httpReady as boolean | undefined) ?? true
+  const reasonCodes = (overrides.reasonCodes as string[] | undefined) ?? []
+  const leaderElection = (overrides.leaderElection as Record<string, unknown> | undefined) ?? buildLeaderElection()
+
+  return {
+    available: true,
+    httpStatus: httpReady ? 200 : 503,
+    status,
+    httpReady,
+    reasonCodes,
+    namespaces,
+    leaderElection,
+    agentsController,
+    orchestrationController,
+    supportingController,
+    raw: {
+      schemaVersion: 'agents.proompteng.ai/ready/v1',
+      status,
+      service: 'agents',
+      httpReady,
+      reason_codes: reasonCodes,
+      namespaces,
+      leaderElection,
+      agentsController,
+      orchestrationController,
+      supportingController,
+    },
+    error: null,
+    ...overrides,
+  }
+}
+
 describe('getReadyHandler', () => {
   beforeEach(() => {
     process.env = { ...originalEnv }
@@ -285,53 +343,7 @@ describe('getReadyHandler', () => {
       evidence_refs: [],
     })
 
-    agentsControllerMocks.getAgentsControllerHealth.mockReturnValue({
-      enabled: true,
-      started: true,
-      namespaces: ['agents'],
-      crdsReady: true,
-      missingCrds: [],
-      lastCheckedAt: '2026-03-08T21:00:00Z',
-      agentRunIngestion: [],
-    })
-    agentsControllerMocks.assessAgentRunIngestion.mockReturnValue({
-      namespace: 'agents',
-      status: 'healthy',
-      message: 'AgentRun ingestion healthy',
-      dispatchPaused: false,
-      lastWatchEventAt: '2026-03-08T21:00:00Z',
-      lastResyncAt: '2026-03-08T21:00:00Z',
-      untouchedRunCount: 0,
-      oldestUntouchedAgeSeconds: null,
-    })
-    leaderElectionMocks.getLeaderElectionStatus.mockReturnValue({
-      enabled: true,
-      required: true,
-      isLeader: true,
-      leaseName: 'jangar-controller-leader',
-      leaseNamespace: 'agents',
-      identity: 'agents-controllers-1',
-      lastTransitionAt: '2026-03-08T21:00:00Z',
-      lastAttemptAt: '2026-03-08T21:00:00Z',
-      lastSuccessAt: '2026-03-08T21:00:00Z',
-      lastError: null,
-    })
-    orchestrationControllerMocks.getOrchestrationControllerHealth.mockReturnValue({
-      enabled: true,
-      started: true,
-      namespaces: ['agents'],
-      crdsReady: true,
-      missingCrds: [],
-      lastCheckedAt: '2026-03-08T21:00:00Z',
-    })
-    supportingControllerMocks.getSupportingControllerHealth.mockReturnValue({
-      enabled: true,
-      started: true,
-      namespaces: ['agents'],
-      crdsReady: true,
-      missingCrds: [],
-      lastCheckedAt: '2026-03-08T21:00:00Z',
-    })
+    agentsControlPlaneClientMocks.getAgentsReadySnapshot.mockResolvedValue(buildAgentsReadySnapshot())
   })
 
   it('returns 200 when leader is ready and AgentRun ingestion is healthy', async () => {
@@ -407,16 +419,12 @@ describe('getReadyHandler', () => {
 
   it('keeps Agents runtime readiness HTTP-ready while backlog adoption is still degraded', async () => {
     process.env.AGENTS_IMAGE = 'registry.example/lab/agents-controller:abc123'
-    agentsControllerMocks.assessAgentRunIngestion.mockReturnValue({
-      namespace: 'agents',
-      status: 'degraded',
-      message: 'untouched AgentRuns detected for 180s',
-      dispatchPaused: true,
-      lastWatchEventAt: null,
-      lastResyncAt: '2026-03-08T21:00:00Z',
-      untouchedRunCount: 3,
-      oldestUntouchedAgeSeconds: 180,
-    })
+    agentsControlPlaneClientMocks.getAgentsReadySnapshot.mockResolvedValue(
+      buildAgentsReadySnapshot({
+        status: 'degraded',
+        reasonCodes: ['agentrun_ingestion_not_ready'],
+      }),
+    )
 
     const { getReadyHandler } = await import('./ready')
 
@@ -822,16 +830,12 @@ describe('getReadyHandler', () => {
   })
 
   it('returns 200 with degraded status when AgentRun ingestion is degraded', async () => {
-    agentsControllerMocks.assessAgentRunIngestion.mockReturnValue({
-      namespace: 'agents',
-      status: 'degraded',
-      message: 'untouched AgentRuns detected for 180s',
-      dispatchPaused: true,
-      lastWatchEventAt: null,
-      lastResyncAt: '2026-03-08T21:00:00Z',
-      untouchedRunCount: 3,
-      oldestUntouchedAgeSeconds: 180,
-    })
+    agentsControlPlaneClientMocks.getAgentsReadySnapshot.mockResolvedValue(
+      buildAgentsReadySnapshot({
+        status: 'degraded',
+        reasonCodes: ['agentrun_ingestion_not_ready'],
+      }),
+    )
 
     const { getReadyHandler } = await import('./ready')
 
@@ -843,33 +847,23 @@ describe('getReadyHandler', () => {
   })
 
   it('returns 200 with degraded status when the active controller is still adopting backlog', async () => {
-    agentsControllerMocks.getAgentsControllerHealth.mockReturnValue({
-      enabled: true,
-      started: false,
-      namespaces: ['agents'],
-      crdsReady: true,
-      missingCrds: [],
-      lastCheckedAt: '2026-03-08T21:00:00Z',
-      agentRunIngestion: [
-        {
-          namespace: 'agents',
-          lastWatchEventAt: '2026-03-08T21:01:00Z',
-          lastResyncAt: '2026-03-08T21:00:00Z',
-          untouchedRunCount: 12,
-          oldestUntouchedAgeSeconds: 4_769_263,
-        },
-      ],
-    })
-    agentsControllerMocks.assessAgentRunIngestion.mockReturnValue({
-      namespace: 'agents',
-      status: 'unknown',
-      message: 'agents controller not started',
-      dispatchPaused: false,
-      lastWatchEventAt: '2026-03-08T21:01:00Z',
-      lastResyncAt: '2026-03-08T21:00:00Z',
-      untouchedRunCount: 12,
-      oldestUntouchedAgeSeconds: 4_769_263,
-    })
+    agentsControlPlaneClientMocks.getAgentsReadySnapshot.mockResolvedValue(
+      buildAgentsReadySnapshot({
+        status: 'degraded',
+        agentsController: buildAgentsControllerHealth({
+          started: false,
+          agentRunIngestion: [
+            {
+              namespace: 'agents',
+              lastWatchEventAt: '2026-03-08T21:01:00Z',
+              lastResyncAt: '2026-03-08T21:00:00Z',
+              untouchedRunCount: 12,
+              oldestUntouchedAgeSeconds: 4_769_263,
+            },
+          ],
+        }),
+      }),
+    )
 
     const { getReadyHandler } = await import('./ready')
 
@@ -885,18 +879,14 @@ describe('getReadyHandler', () => {
   })
 
   it('returns 200 when leader election is required but this instance is a healthy standby', async () => {
-    leaderElectionMocks.getLeaderElectionStatus.mockReturnValue({
-      enabled: true,
-      required: true,
-      isLeader: false,
-      leaseName: 'jangar-controller-leader',
-      leaseNamespace: 'agents',
-      identity: 'agents-controllers-2',
-      lastTransitionAt: '2026-03-08T21:00:00Z',
-      lastAttemptAt: '2026-03-08T21:00:00Z',
-      lastSuccessAt: '2026-03-08T21:00:00Z',
-      lastError: null,
-    })
+    agentsControlPlaneClientMocks.getAgentsReadySnapshot.mockResolvedValue(
+      buildAgentsReadySnapshot({
+        leaderElection: buildLeaderElection({
+          isLeader: false,
+          identity: 'agents-controllers-2',
+        }),
+      }),
+    )
 
     const { getReadyHandler } = await import('./ready')
 
@@ -908,18 +898,20 @@ describe('getReadyHandler', () => {
   })
 
   it('returns 503 when leader election is required but standby has not observed a healthy lease attempt', async () => {
-    leaderElectionMocks.getLeaderElectionStatus.mockReturnValue({
-      enabled: true,
-      required: true,
-      isLeader: false,
-      leaseName: 'jangar-controller-leader',
-      leaseNamespace: 'agents',
-      identity: 'agents-controllers-2',
-      lastTransitionAt: null,
-      lastAttemptAt: null,
-      lastSuccessAt: null,
-      lastError: 'lease watch failed',
-    })
+    agentsControlPlaneClientMocks.getAgentsReadySnapshot.mockResolvedValue(
+      buildAgentsReadySnapshot({
+        status: 'degraded',
+        httpReady: false,
+        leaderElection: buildLeaderElection({
+          isLeader: false,
+          identity: 'agents-controllers-2',
+          lastTransitionAt: null,
+          lastAttemptAt: null,
+          lastSuccessAt: null,
+          lastError: 'lease watch failed',
+        }),
+      }),
+    )
 
     const { getReadyHandler } = await import('./ready')
 
@@ -1070,15 +1062,14 @@ describe('getReadyHandler', () => {
         servingPassportId: 'passport:serving:blocked',
       }),
     )
-    agentsControllerMocks.getAgentsControllerHealth.mockReturnValue({
-      enabled: true,
-      started: true,
-      namespaces: ['agents', 'staging'],
-      crdsReady: true,
-      missingCrds: [],
-      lastCheckedAt: '2026-03-08T21:00:00Z',
-      agentRunIngestion: [],
-    })
+    agentsControlPlaneClientMocks.getAgentsReadySnapshot.mockResolvedValue(
+      buildAgentsReadySnapshot({
+        namespaces: ['agents', 'staging'],
+        agentsController: buildAgentsControllerHealth({
+          namespaces: ['agents', 'staging'],
+        }),
+      }),
+    )
     controlPlaneStatusMocks.buildExecutionTrust
       .mockResolvedValueOnce({
         executionTrust: {

--- a/services/jangar/src/routes/ready.tsx
+++ b/services/jangar/src/routes/ready.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
 import {
-  buildAgentsRuntimeReadyResponse,
-  isAgentRunIngestionReady,
+  type AgentsControllerHealthSnapshot,
   isControllerHealthReady,
-  isStandbyLeaderElectionReady,
+  buildAgentsRuntimeReadyResponse,
+  getAgentsReadySnapshot,
   uniqueStrings,
-} from '@proompteng/agents/server/ready'
+} from '~/server/agents-control-plane-client'
 
 import type {
   ControlPlaneControllerWitnessQuorum,
@@ -14,7 +14,6 @@ import type {
   TorghutRevenueRepairQueueItem,
 } from '~/data/agents-control-plane'
 import { isAgentsRuntimeService, resolveRuntimeServiceName } from '~/server/runtime-identity'
-import { assessAgentRunIngestion, getAgentsControllerHealth } from '@proompteng/agents/server/agents-controller'
 import { buildControllerIngestionSettlement } from '~/server/control-plane-controller-ingestion-settlement'
 import { buildRuntimeAdmissionSnapshot, findAdmissionPassport } from '~/server/control-plane-runtime-admission'
 import {
@@ -24,11 +23,8 @@ import {
 } from '~/server/control-plane-evidence-pressure-ledger'
 import { buildRepairBidAdmissionState } from '~/server/control-plane-repair-bid-admission'
 import { getGithubReviewIngestPressureSummary } from '~/server/github-review-ingest'
-import { getLeaderElectionStatus } from '~/server/leader-election'
 import { getMemoryProviderHealth } from '~/server/memory-provider-health'
 import { getMetricsSinkPressureSummary } from '~/server/metrics'
-import { getOrchestrationControllerHealth } from '@proompteng/agents/server/orchestration-controller'
-import { getSupportingControllerHealth } from '~/server/supporting-primitives-controller'
 import { buildExecutionTrust } from '~/server/control-plane-status'
 import {
   resolveTorghutConsumerEvidence,
@@ -53,7 +49,7 @@ import { getWatchReliabilitySummary } from '~/server/control-plane-watch-reliabi
 
 const buildReadyControllerReadiness = (
   name: string,
-  health: ReturnType<typeof getAgentsControllerHealth>,
+  health: AgentsControllerHealthSnapshot,
 ): EvidencePressureControllerReadiness => ({
   name,
   enabled: health.enabled,
@@ -244,7 +240,7 @@ const readyPathWitnessId = (namespace: string, surface: string) => `witness:${su
 const buildReadyPathControllerWitness = (input: {
   now: Date
   namespace: string
-  agentsController: ReturnType<typeof getAgentsControllerHealth>
+  agentsController: AgentsControllerHealthSnapshot
   agentRunIngestion: AgentRunIngestionStatus
   watchReliability: ReturnType<typeof getWatchReliabilitySummary>
 }): ControlPlaneControllerWitnessQuorum => {
@@ -401,20 +397,15 @@ export const Route = createFileRoute('/ready')({
 
 export const getReadyHandler = async () => {
   const now = new Date()
-  const leaderElection = getLeaderElectionStatus()
-  const agentsController = getAgentsControllerHealth()
-  const orchestrationController = getOrchestrationControllerHealth()
-  const supportingController = getSupportingControllerHealth()
+  const agentsReady = await getAgentsReadySnapshot()
+  const leaderElection = agentsReady.leaderElection
+  const agentsController = agentsReady.agentsController
+  const orchestrationController = agentsReady.orchestrationController
+  const supportingController = agentsReady.supportingController
   if (isAgentsRuntimeService()) {
-    return buildAgentsRuntimeReadyResponse({
-      leaderElection,
-      agentsController,
-      orchestrationController,
-      supportingController,
-      assessAgentRunIngestion,
-    })
+    return buildAgentsRuntimeReadyResponse(agentsReady)
   }
-  const namespaces = agentsController.namespaces?.length ? agentsController.namespaces : ['agents']
+  const namespaces = agentsReady.namespaces.length ? agentsReady.namespaces : ['agents']
   const trust = await executionTrustStatus(namespaces)
   const torghutConsumerEvidence = await resolveTorghutConsumerEvidence(now)
   const repairBidAdmission = buildRepairBidAdmissionState({
@@ -470,20 +461,20 @@ export const getReadyHandler = async () => {
     isControllerHealthReady(agentsController) &&
     isControllerHealthReady(orchestrationController) &&
     isControllerHealthReady(supportingController)
-  const leaderRequired = leaderElection.required
-  const activeControllerReplica = !leaderRequired || leaderElection.isLeader
-  const leaderElectionReady = activeControllerReplica || isStandbyLeaderElectionReady(leaderElection)
-  const agentsControllerHealthy = activeControllerReplica
-    ? isAgentRunIngestionReady(agentsController, assessAgentRunIngestion)
-    : leaderElectionReady
+  const agentsControllerHealthy = !agentsReady.reasonCodes.includes('agentrun_ingestion_not_ready')
   const servingPassportReady =
     servingPassport !== undefined && servingPassport.decision !== 'block' && servingPassport.decision !== 'hold'
   const memoryProviderReady = memoryProvider.status !== 'blocked'
-  const ready = controllersOk && leaderElectionReady && memoryProviderReady
-  const status = ready && agentsControllerHealthy && servingPassportReady ? 'ok' : 'degraded'
+  const ready = controllersOk && agentsReady.httpReady && memoryProviderReady
+  const status =
+    ready && agentsReady.status === 'ok' && agentsControllerHealthy && servingPassportReady ? 'ok' : 'degraded'
   const readyPathRolloutHealth = buildReadyPathRolloutHealth(ready)
   const readyPathSourceServingExchange = buildReadyPathSourceServingExchange(now, namespaces[0] ?? 'agents')
-  const readyPathAgentRunIngestion = buildAgentRunIngestionStatus(namespaces[0] ?? 'agents', agentsController)
+  const readyPathAgentRunIngestion = buildAgentRunIngestionStatus(
+    namespaces[0] ?? 'agents',
+    agentsController,
+    agentsReady.reasonCodes,
+  )
   const readyPathControllerWitness = buildReadyPathControllerWitness({
     now,
     namespace: namespaces[0] ?? 'agents',

--- a/services/jangar/src/server/__tests__/agents-control-plane-client.test.ts
+++ b/services/jangar/src/server/__tests__/agents-control-plane-client.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  buildAgentsReadySnapshot,
+  buildAgentsRuntimeReadyResponse,
+  getAgentsReadySnapshot,
+} from '../agents-control-plane-client'
+
+const originalFetch = globalThis.fetch
+
+describe('agents-control-plane-client', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('keeps a degraded Agents /ready payload authoritative when HTTP status is 503', async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          schemaVersion: 'agents.proompteng.ai/ready/v1',
+          status: 'degraded',
+          service: 'agents',
+          httpReady: false,
+          reason_codes: ['leader_election_not_ready'],
+          namespaces: ['agents'],
+          leaderElection: {
+            required: true,
+            isLeader: false,
+            lastAttemptAt: null,
+            lastError: 'lease watch failed',
+          },
+          agentsController: {
+            enabled: true,
+            started: false,
+            namespaces: ['agents'],
+            crdsReady: true,
+            missingCrds: [],
+            lastCheckedAt: '2026-03-08T21:00:00Z',
+            agentRunIngestion: [],
+          },
+        }),
+        {
+          status: 503,
+          statusText: 'Service Unavailable',
+          headers: { 'content-type': 'application/json' },
+        },
+      )
+    })
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+
+    const snapshot = await getAgentsReadySnapshot()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(snapshot).toMatchObject({
+      available: true,
+      httpStatus: 503,
+      status: 'degraded',
+      httpReady: false,
+      reasonCodes: ['leader_election_not_ready'],
+      leaderElection: {
+        lastError: 'lease watch failed',
+      },
+    })
+
+    const response = buildAgentsRuntimeReadyResponse(snapshot)
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toMatchObject({
+      status: 'degraded',
+      reason_codes: ['leader_election_not_ready'],
+    })
+  })
+
+  it('builds a degraded fallback snapshot when Agents /ready is unavailable', () => {
+    const snapshot = buildAgentsReadySnapshot({
+      payload: null,
+      httpStatus: 0,
+      error: 'connect ECONNREFUSED',
+    })
+
+    expect(snapshot).toMatchObject({
+      available: false,
+      status: 'degraded',
+      httpReady: false,
+      error: 'connect ECONNREFUSED',
+      agentsController: {
+        enabled: true,
+        started: false,
+        crdsReady: false,
+      },
+    })
+  })
+})

--- a/services/jangar/src/server/__tests__/agents-control-plane-summary.test.ts
+++ b/services/jangar/src/server/__tests__/agents-control-plane-summary.test.ts
@@ -44,9 +44,12 @@ describe('control plane summary route', () => {
     delete process.env.AGENTS_CONTROL_PLANE_CACHE_ENABLED
     delete process.env.AGENTS_CONTROL_PLANE_CACHE_STALE_SECONDS
     delete process.env.AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE
+    delete process.env.AGENTS_SWARM_PRIMITIVE_ENABLED
   })
 
   it('aggregates totals and run phases without cache when cache is disabled', async () => {
+    process.env.AGENTS_SWARM_PRIMITIVE_ENABLED = 'true'
+
     const lists: Record<string, Record<string, unknown>> = {
       [RESOURCE_MAP.Agent]: buildList([{}, {}]),
       [RESOURCE_MAP.AgentRun]: buildList([

--- a/services/jangar/src/server/__tests__/agents-service-proxy.test.ts
+++ b/services/jangar/src/server/__tests__/agents-service-proxy.test.ts
@@ -2,13 +2,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   buildAgentsServiceProxyUrl,
+  fetchAgentsServiceJson,
   proxyAgentsServiceRequest,
   resolveAgentsServiceBaseUrl,
 } from '~/server/agents-service-proxy'
 
+const originalFetch = globalThis.fetch
+
 describe('agents-service-proxy', () => {
   afterEach(() => {
-    vi.unstubAllGlobals()
+    globalThis.fetch = originalFetch
   })
 
   it('defaults to the in-cluster Agents service', () => {
@@ -43,7 +46,7 @@ describe('agents-service-proxy', () => {
         status: 202,
       })
     })
-    vi.stubGlobal('fetch', fetchMock)
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
 
     const response = await proxyAgentsServiceRequest(
       new Request('http://jangar.test/api/agents/control-plane/resource?kind=Agent', {
@@ -76,5 +79,31 @@ describe('agents-service-proxy', () => {
     expect(response.headers.get('x-agents-result')).toBe('ok')
     expect(response.headers.get('content-length')).toBeNull()
     await expect(response.json()).resolves.toEqual({ ok: true })
+  })
+
+  it('fetches Agents service JSON contracts without importing Agents runtime modules', async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ status: 'ok' }), {
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      })
+    })
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch
+
+    const result = await fetchAgentsServiceJson<{ status: string }>('/health', {
+      AGENTS_SERVICE_BASE_URL: 'http://agents.test',
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [URL, RequestInit]
+    expect(url.toString()).toBe('http://agents.test/health')
+    expect(init.method).toBe('GET')
+    expect((init.headers as Headers).get('accept')).toBe('application/json')
+    expect((init.headers as Headers).get('x-jangar-agents-proxy')).toBe('true')
+    expect(result).toEqual({
+      ok: true,
+      status: 200,
+      body: { status: 'ok' },
+    })
   })
 })

--- a/services/jangar/src/server/__tests__/control-plane-status.test.ts
+++ b/services/jangar/src/server/__tests__/control-plane-status.test.ts
@@ -18,6 +18,7 @@ import { ROLLOUT_PROOF_PASSPORT_DESIGN_ARTIFACT } from '~/server/control-plane-r
 import { SOURCE_SERVING_CONTRACT_VERDICT_DESIGN_ARTIFACT } from '~/server/control-plane-source-serving-contract-verdict'
 import { STAGE_CREDIT_LEDGER_DESIGN_ARTIFACT } from '~/server/control-plane-stage-credit-ledger'
 import { TERMINAL_DEBT_COMPACTION_DESIGN_ARTIFACT } from '~/server/control-plane-terminal-debt-compaction'
+import { buildAgentsReadySnapshot } from '~/server/agents-control-plane-client'
 import * as kubeGatewayModule from '~/server/kube-gateway'
 import type {
   ControlPlaneHeartbeatRow,
@@ -2156,9 +2157,19 @@ describe('control-plane status', () => {
             },
           }),
         ),
-        getAgentsControllerHealth: () => degradedController,
-        getSupportingControllerHealth: () => healthyController,
-        getOrchestrationControllerHealth: () => healthyController,
+        getAgentsReadySnapshot: async () =>
+          buildAgentsReadySnapshot({
+            httpStatus: 503,
+            payload: {
+              status: 'degraded',
+              httpReady: false,
+              reason_codes: ['agentrun_ingestion_not_ready'],
+              namespaces: ['agents'],
+              agentsController: degradedController,
+              supportingController: healthyController,
+              orchestrationController: healthyController,
+            },
+          }),
         resolveTemporalAdapter: async () =>
           buildTemporalAdapter({
             available: false,

--- a/services/jangar/src/server/agents-control-plane-client.ts
+++ b/services/jangar/src/server/agents-control-plane-client.ts
@@ -1,0 +1,179 @@
+import { fetchAgentsServiceJson } from '~/server/agents-service-proxy'
+
+export type AgentsControllerHealthSnapshot = {
+  enabled: boolean
+  started: boolean
+  namespaces: string[] | null
+  crdsReady: boolean | null
+  missingCrds: string[]
+  lastCheckedAt: string | null
+  agentRunIngestion?: Array<{
+    namespace: string
+    lastWatchEventAt: string | null
+    lastResyncAt: string | null
+    untouchedRunCount: number
+    oldestUntouchedAgeSeconds: number | null
+  }>
+}
+
+export type AgentsLeaderElectionSnapshot = {
+  required: boolean
+  isLeader: boolean
+  lastAttemptAt: string | null
+  lastError: string | null
+  [key: string]: unknown
+}
+
+export type AgentsReadyPayload = {
+  schemaVersion?: string
+  status?: 'ok' | 'degraded'
+  service?: 'agents' | string
+  httpReady?: boolean
+  reason_codes?: string[]
+  namespaces?: string[]
+  leaderElection?: AgentsLeaderElectionSnapshot
+  agentsController?: AgentsControllerHealthSnapshot
+  orchestrationController?: AgentsControllerHealthSnapshot
+  supportingController?: AgentsControllerHealthSnapshot
+}
+
+export type AgentsReadySnapshot = {
+  available: boolean
+  httpStatus: number
+  status: 'ok' | 'degraded'
+  httpReady: boolean
+  reasonCodes: string[]
+  namespaces: string[]
+  leaderElection: AgentsLeaderElectionSnapshot
+  agentsController: AgentsControllerHealthSnapshot
+  orchestrationController: AgentsControllerHealthSnapshot
+  supportingController: AgentsControllerHealthSnapshot
+  raw: AgentsReadyPayload
+  error: string | null
+}
+
+export const uniqueStrings = (values: string[]) => [...new Set(values.filter((value) => value.length > 0))]
+
+const fallbackController = (namespace = 'agents'): AgentsControllerHealthSnapshot => ({
+  enabled: true,
+  started: false,
+  namespaces: [namespace],
+  crdsReady: false,
+  missingCrds: [],
+  lastCheckedAt: null,
+  agentRunIngestion: [],
+})
+
+const fallbackLeaderElection = (error: string | null): AgentsLeaderElectionSnapshot => ({
+  required: true,
+  isLeader: false,
+  lastAttemptAt: null,
+  lastError: error ?? 'Agents service readiness unavailable',
+})
+
+const normalizeStatus = (value: unknown): 'ok' | 'degraded' => (value === 'ok' ? 'ok' : 'degraded')
+
+const normalizeController = (
+  value: AgentsControllerHealthSnapshot | undefined,
+  namespace: string,
+): AgentsControllerHealthSnapshot => {
+  if (!value || typeof value !== 'object') return fallbackController(namespace)
+  return {
+    enabled: Boolean(value.enabled),
+    started: Boolean(value.started),
+    namespaces: Array.isArray(value.namespaces) ? value.namespaces.filter((item) => typeof item === 'string') : null,
+    crdsReady:
+      typeof value.crdsReady === 'boolean' || value.crdsReady === null || value.crdsReady === undefined
+        ? (value.crdsReady ?? null)
+        : false,
+    missingCrds: Array.isArray(value.missingCrds) ? value.missingCrds.filter((item) => typeof item === 'string') : [],
+    lastCheckedAt: typeof value.lastCheckedAt === 'string' ? value.lastCheckedAt : null,
+    agentRunIngestion: Array.isArray(value.agentRunIngestion) ? value.agentRunIngestion : [],
+  }
+}
+
+const normalizeLeaderElection = (
+  value: AgentsLeaderElectionSnapshot | undefined,
+  error: string | null,
+): AgentsLeaderElectionSnapshot => {
+  if (!value || typeof value !== 'object') return fallbackLeaderElection(error)
+  return {
+    ...value,
+    required: Boolean(value.required),
+    isLeader: Boolean(value.isLeader),
+    lastAttemptAt: typeof value.lastAttemptAt === 'string' ? value.lastAttemptAt : null,
+    lastError: typeof value.lastError === 'string' ? value.lastError : null,
+  }
+}
+
+export const isControllerHealthReady = (health: Pick<AgentsControllerHealthSnapshot, 'enabled' | 'crdsReady'>) =>
+  !health.enabled || health.crdsReady !== false
+
+export const buildAgentsReadySnapshot = (input: {
+  payload: AgentsReadyPayload | null
+  httpStatus: number
+  error?: string | null
+}): AgentsReadySnapshot => {
+  const payload = input.payload ?? {}
+  const error = input.error ?? null
+  const status = normalizeStatus(payload.status)
+  const agentsController = normalizeController(payload.agentsController, 'agents')
+  const namespaces = uniqueStrings(
+    payload.namespaces?.length
+      ? payload.namespaces
+      : agentsController.namespaces?.length
+        ? agentsController.namespaces
+        : ['agents'],
+  )
+  const primaryNamespace = namespaces[0] ?? 'agents'
+  const leaderElection = normalizeLeaderElection(payload.leaderElection, error)
+  const orchestrationController = normalizeController(payload.orchestrationController, primaryNamespace)
+  const supportingController = normalizeController(payload.supportingController, primaryNamespace)
+  const raw: AgentsReadyPayload = {
+    schemaVersion: payload.schemaVersion ?? 'agents.proompteng.ai/ready/v1',
+    status,
+    service: payload.service ?? 'agents',
+    httpReady: payload.httpReady ?? false,
+    reason_codes: Array.isArray(payload.reason_codes) ? payload.reason_codes : [],
+    namespaces,
+    leaderElection,
+    agentsController,
+    orchestrationController,
+    supportingController,
+  }
+
+  return {
+    available: input.payload !== null,
+    httpStatus: input.httpStatus,
+    status,
+    httpReady: raw.httpReady ?? false,
+    reasonCodes: raw.reason_codes ?? [],
+    namespaces,
+    leaderElection,
+    agentsController,
+    orchestrationController,
+    supportingController,
+    raw,
+    error,
+  }
+}
+
+export const getAgentsReadySnapshot = async (): Promise<AgentsReadySnapshot> => {
+  const result = await fetchAgentsServiceJson<AgentsReadyPayload>('/ready')
+  return buildAgentsReadySnapshot({
+    payload: result.body,
+    httpStatus: result.status,
+    error: result.ok ? null : result.error,
+  })
+}
+
+export const buildAgentsRuntimeReadyResponse = (snapshot: AgentsReadySnapshot) => {
+  const body = JSON.stringify(snapshot.raw)
+  return new Response(body, {
+    status: snapshot.httpReady ? 200 : 503,
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+  })
+}

--- a/services/jangar/src/server/agents-control-plane-client.ts
+++ b/services/jangar/src/server/agents-control-plane-client.ts
@@ -167,6 +167,33 @@ export const getAgentsReadySnapshot = async (): Promise<AgentsReadySnapshot> => 
   })
 }
 
+export type AgentsControllerHealthSnapshotDeps = {
+  getAgentsReadySnapshot?: () => Promise<AgentsReadySnapshot>
+  getAgentsControllerHealth?: () => AgentsControllerHealthSnapshot
+  getSupportingControllerHealth?: () => AgentsControllerHealthSnapshot
+  getOrchestrationControllerHealth?: () => AgentsControllerHealthSnapshot
+}
+
+export const resolveAgentsControllerHealthSnapshots = async (deps: AgentsControllerHealthSnapshotDeps = {}) => {
+  let snapshot: AgentsReadySnapshot | null = null
+  const resolveSnapshot = async (): Promise<AgentsReadySnapshot> => {
+    snapshot ??= await (deps.getAgentsReadySnapshot ?? getAgentsReadySnapshot)()
+    return snapshot
+  }
+  const readySnapshot = await resolveSnapshot()
+
+  return {
+    reasonCodes: readySnapshot.reasonCodes,
+    agentsHealth: deps.getAgentsControllerHealth ? deps.getAgentsControllerHealth() : readySnapshot.agentsController,
+    supportingHealth: deps.getSupportingControllerHealth
+      ? deps.getSupportingControllerHealth()
+      : readySnapshot.supportingController,
+    orchestrationHealth: deps.getOrchestrationControllerHealth
+      ? deps.getOrchestrationControllerHealth()
+      : readySnapshot.orchestrationController,
+  }
+}
+
 export const buildAgentsRuntimeReadyResponse = (snapshot: AgentsReadySnapshot) => {
   const body = JSON.stringify(snapshot.raw)
   return new Response(body, {

--- a/services/jangar/src/server/agents-service-proxy.ts
+++ b/services/jangar/src/server/agents-service-proxy.ts
@@ -45,6 +45,61 @@ export const buildAgentsServiceProxyUrl = (request: Request, path: string, env: 
   return targetUrl
 }
 
+export type AgentsServiceJsonResult<T> =
+  | {
+      ok: true
+      status: number
+      body: T
+    }
+  | {
+      ok: false
+      status: number
+      body: T | null
+      error: string | null
+    }
+
+const getErrorMessage = (error: unknown) => (error instanceof Error ? error.message : String(error))
+
+export const fetchAgentsServiceJson = async <T>(
+  path: string,
+  env: EnvSource = process.env,
+): Promise<AgentsServiceJsonResult<T>> => {
+  const baseUrl = resolveAgentsServiceBaseUrl(env)
+  const targetUrl = new URL(path.startsWith('/') ? path : `/${path}`, `${baseUrl}/`)
+  const requestHeaders = new Headers({
+    accept: 'application/json',
+    'x-jangar-agents-proxy': 'true',
+  })
+
+  try {
+    const upstream = await fetch(targetUrl, {
+      headers: requestHeaders,
+      method: 'GET',
+    })
+    const body = (await upstream.json().catch(() => null)) as T | null
+    if (upstream.ok && body !== null) {
+      return {
+        ok: true,
+        status: upstream.status,
+        body,
+      }
+    }
+    return {
+      ok: false,
+      status: upstream.status,
+      body,
+      error: upstream.statusText || `Agents service returned HTTP ${upstream.status}`,
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      body: null,
+      error: getErrorMessage(error),
+    }
+  }
+}
+
 export const proxyAgentsServiceRequest = async (request: Request, path: string, env: EnvSource = process.env) => {
   const method = request.method.toUpperCase()
   const targetUrl = buildAgentsServiceProxyUrl(request, path, env)

--- a/services/jangar/src/server/control-plane-authority-status.ts
+++ b/services/jangar/src/server/control-plane-authority-status.ts
@@ -1,8 +1,8 @@
-import type { getAgentsControllerHealth } from '@proompteng/agents/server/agents-controller'
+import type { AgentsControllerHealthSnapshot } from '~/server/agents-control-plane-client'
 import { isHeartbeatFresh, type ControlPlaneHeartbeatRow } from '~/server/control-plane-heartbeat-store'
 import type { ControllerStatus, RuntimeAdapterStatus } from '~/server/control-plane-status-types'
 
-type ControllerHealth = ReturnType<typeof getAgentsControllerHealth>
+type ControllerHealth = AgentsControllerHealthSnapshot
 
 const buildAuthorityFromHeartbeat = (input: {
   component: string

--- a/services/jangar/src/server/control-plane-serving-process-status.ts
+++ b/services/jangar/src/server/control-plane-serving-process-status.ts
@@ -1,19 +1,38 @@
-import { assessAgentRunIngestion, getAgentsControllerHealth } from '@proompteng/agents/server/agents-controller'
 import type { AgentRunIngestionStatus, ControllerStatus } from '~/server/control-plane-status-types'
+import type { AgentsControllerHealthSnapshot } from '~/server/agents-control-plane-client'
 
-type ControllerHealth = ReturnType<typeof getAgentsControllerHealth>
+type ControllerHealth = AgentsControllerHealthSnapshot
 
-export const buildAgentRunIngestionStatus = (namespace: string, health: ControllerHealth): AgentRunIngestionStatus => {
-  const assessment = assessAgentRunIngestion(namespace, health)
+const buildDefaultIngestion = (namespace: string) => ({
+  namespace,
+  lastWatchEventAt: null,
+  lastResyncAt: null,
+  untouchedRunCount: 0,
+  oldestUntouchedAgeSeconds: null,
+})
+
+export const buildAgentRunIngestionStatus = (
+  namespace: string,
+  health: ControllerHealth,
+  reasonCodes: string[] = [],
+): AgentRunIngestionStatus => {
+  const entry =
+    health.agentRunIngestion?.find((item) => item.namespace === namespace) ?? buildDefaultIngestion(namespace)
+  const degraded = reasonCodes.includes('agentrun_ingestion_not_ready')
+  const status = degraded ? 'degraded' : health.started ? 'healthy' : 'unknown'
 
   return {
     namespace,
-    status: assessment.status,
-    message: assessment.message,
-    last_watch_event_at: assessment.lastWatchEventAt,
-    last_resync_at: assessment.lastResyncAt,
-    untouched_run_count: assessment.untouchedRunCount,
-    oldest_untouched_age_seconds: assessment.oldestUntouchedAgeSeconds,
+    status,
+    message: degraded
+      ? 'AgentRun ingestion not ready according to Agents service'
+      : health.started
+        ? 'AgentRun ingestion healthy'
+        : 'agents controller not started',
+    last_watch_event_at: entry.lastWatchEventAt,
+    last_resync_at: entry.lastResyncAt,
+    untouched_run_count: entry.untouchedRunCount,
+    oldest_untouched_age_seconds: entry.oldestUntouchedAgeSeconds,
   }
 }
 

--- a/services/jangar/src/server/control-plane-status.ts
+++ b/services/jangar/src/server/control-plane-status.ts
@@ -1,4 +1,8 @@
-import { getAgentsControllerHealth } from '@proompteng/agents/server/agents-controller'
+import {
+  getAgentsReadySnapshot,
+  type AgentsControllerHealthSnapshot,
+  type AgentsReadySnapshot,
+} from '~/server/agents-control-plane-client'
 import { buildReconciledActionClocks } from '~/server/control-plane-action-clock'
 import { buildAuthorityProvenanceSettlement } from '~/server/control-plane-authority-provenance-settlement'
 import {
@@ -112,8 +116,6 @@ import {
   type ControlPlaneWatchReliabilitySummary,
 } from '~/server/control-plane-watch-reliability'
 import { createKubeGateway, type KubeGateway } from '~/server/kube-gateway'
-import { getOrchestrationControllerHealth } from '@proompteng/agents/server/orchestration-controller'
-import { getSupportingControllerHealth } from '~/server/supporting-primitives-controller'
 import { getGithubReviewIngestPressureSummary } from '~/server/github-review-ingest'
 import { getMetricsSinkPressureSummary } from '~/server/metrics'
 import type { ExecutionTrustStatus, WorkflowsReliabilityStatus } from '~/data/agents-control-plane'
@@ -122,7 +124,7 @@ export type { ControlPlaneStatus, DatabaseStatus, GrpcStatus } from './control-p
 export { projectControlPlaneStatus, type ControlPlaneStatusView } from './control-plane-status-projection'
 export { buildExecutionTrust } from './control-plane-execution-trust'
 
-type ControllerHealth = ReturnType<typeof getAgentsControllerHealth>
+type ControllerHealth = AgentsControllerHealthSnapshot
 
 export type ControlPlaneStatusOptions = {
   namespace: string
@@ -132,6 +134,7 @@ export type ControlPlaneStatusOptions = {
 
 export type ControlPlaneStatusDeps = {
   now?: () => Date
+  getAgentsReadySnapshot?: () => Promise<AgentsReadySnapshot>
   getAgentsControllerHealth?: () => ControllerHealth
   getSupportingControllerHealth?: () => ControllerHealth
   getOrchestrationControllerHealth?: () => ControllerHealth
@@ -204,9 +207,24 @@ export const buildControlPlaneStatus = async (
   const now = (deps.now ?? (() => new Date()))()
   const kubeGateway = deps.kubeGateway ?? createKubeGateway()
   const heartbeatResolver = deps.getHeartbeat ?? defaultGetHeartbeat
-  const agentsHealth = (deps.getAgentsControllerHealth ?? getAgentsControllerHealth)()
-  const supportingHealth = (deps.getSupportingControllerHealth ?? getSupportingControllerHealth)()
-  const orchestrationHealth = (deps.getOrchestrationControllerHealth ?? getOrchestrationControllerHealth)()
+  let agentsReadySnapshot: AgentsReadySnapshot | null = null
+  let agentsReadyReasonCodes: string[] = []
+  const resolveAgentsReadySnapshot = async (): Promise<AgentsReadySnapshot> => {
+    if (!agentsReadySnapshot) {
+      agentsReadySnapshot = await (deps.getAgentsReadySnapshot ?? getAgentsReadySnapshot)()
+      agentsReadyReasonCodes = agentsReadySnapshot.reasonCodes
+    }
+    return agentsReadySnapshot
+  }
+  const agentsHealth = deps.getAgentsControllerHealth
+    ? deps.getAgentsControllerHealth()
+    : (await resolveAgentsReadySnapshot()).agentsController
+  const supportingHealth = deps.getSupportingControllerHealth
+    ? deps.getSupportingControllerHealth()
+    : (await resolveAgentsReadySnapshot()).supportingController
+  const orchestrationHealth = deps.getOrchestrationControllerHealth
+    ? deps.getOrchestrationControllerHealth()
+    : (await resolveAgentsReadySnapshot()).orchestrationController
   const [agentsHeartbeat, supportingHeartbeat, orchestrationHeartbeat, workflowRuntimeHeartbeat] = await Promise.all([
     heartbeatResolver({ namespace: options.namespace, component: 'agents-controller', workloadRole: 'controllers' }),
     heartbeatResolver({
@@ -417,7 +435,7 @@ export const buildControlPlaneStatus = async (
   const isWorkflowsDataUnavailable = isWorkflowsDataUnknown || isWorkflowsDataDegraded
   const isWorkflowsWarning = workflows.backoff_limit_exceeded_jobs >= warningBackoffThreshold
   const isWorkflowsDegraded = workflows.backoff_limit_exceeded_jobs >= degradedBackoffThreshold
-  const agentRunIngestion = buildAgentRunIngestionStatus(options.namespace, agentsHealth)
+  const agentRunIngestion = buildAgentRunIngestionStatus(options.namespace, agentsHealth, agentsReadyReasonCodes)
   const servingProcessController = buildServingProcessControllerStatus(options.namespace, agentsHealth, now)
   const effectiveAgentsController =
     effectiveControllers.find((controller) => controller.name === 'agents-controller') ?? agentsController

--- a/services/jangar/src/server/control-plane-status.ts
+++ b/services/jangar/src/server/control-plane-status.ts
@@ -1,5 +1,5 @@
 import {
-  getAgentsReadySnapshot,
+  resolveAgentsControllerHealthSnapshots,
   type AgentsControllerHealthSnapshot,
   type AgentsReadySnapshot,
 } from '~/server/agents-control-plane-client'
@@ -124,8 +124,6 @@ export type { ControlPlaneStatus, DatabaseStatus, GrpcStatus } from './control-p
 export { projectControlPlaneStatus, type ControlPlaneStatusView } from './control-plane-status-projection'
 export { buildExecutionTrust } from './control-plane-execution-trust'
 
-type ControllerHealth = AgentsControllerHealthSnapshot
-
 export type ControlPlaneStatusOptions = {
   namespace: string
   service?: string
@@ -135,9 +133,9 @@ export type ControlPlaneStatusOptions = {
 export type ControlPlaneStatusDeps = {
   now?: () => Date
   getAgentsReadySnapshot?: () => Promise<AgentsReadySnapshot>
-  getAgentsControllerHealth?: () => ControllerHealth
-  getSupportingControllerHealth?: () => ControllerHealth
-  getOrchestrationControllerHealth?: () => ControllerHealth
+  getAgentsControllerHealth?: () => AgentsControllerHealthSnapshot
+  getSupportingControllerHealth?: () => AgentsControllerHealthSnapshot
+  getOrchestrationControllerHealth?: () => AgentsControllerHealthSnapshot
   getHeartbeat?: (input: ControlPlaneHeartbeatStoreGetInput) => Promise<ControlPlaneHeartbeatRow | null>
   resolveTemporalAdapter?: () => Promise<RuntimeAdapterStatus>
   checkDatabase?: () => Promise<DatabaseStatus>
@@ -207,24 +205,12 @@ export const buildControlPlaneStatus = async (
   const now = (deps.now ?? (() => new Date()))()
   const kubeGateway = deps.kubeGateway ?? createKubeGateway()
   const heartbeatResolver = deps.getHeartbeat ?? defaultGetHeartbeat
-  let agentsReadySnapshot: AgentsReadySnapshot | null = null
-  let agentsReadyReasonCodes: string[] = []
-  const resolveAgentsReadySnapshot = async (): Promise<AgentsReadySnapshot> => {
-    if (!agentsReadySnapshot) {
-      agentsReadySnapshot = await (deps.getAgentsReadySnapshot ?? getAgentsReadySnapshot)()
-      agentsReadyReasonCodes = agentsReadySnapshot.reasonCodes
-    }
-    return agentsReadySnapshot
-  }
-  const agentsHealth = deps.getAgentsControllerHealth
-    ? deps.getAgentsControllerHealth()
-    : (await resolveAgentsReadySnapshot()).agentsController
-  const supportingHealth = deps.getSupportingControllerHealth
-    ? deps.getSupportingControllerHealth()
-    : (await resolveAgentsReadySnapshot()).supportingController
-  const orchestrationHealth = deps.getOrchestrationControllerHealth
-    ? deps.getOrchestrationControllerHealth()
-    : (await resolveAgentsReadySnapshot()).orchestrationController
+  const {
+    reasonCodes: agentsReadyReasonCodes,
+    agentsHealth,
+    supportingHealth,
+    orchestrationHealth,
+  } = await resolveAgentsControllerHealthSnapshots(deps)
   const [agentsHeartbeat, supportingHeartbeat, orchestrationHeartbeat, workflowRuntimeHeartbeat] = await Promise.all([
     heartbeatResolver({ namespace: options.namespace, component: 'agents-controller', workloadRole: 'controllers' }),
     heartbeatResolver({


### PR DESCRIPTION
## Summary

- Route Jangar `/health` through the Agents service `/health` contract instead of importing the Agents controller module.
- Add a Jangar-side Agents control-plane client for `/ready` snapshots and use it in Jangar `/ready`.
- Read Jangar control-plane status defaults from the Agents `/ready` snapshot instead of direct Agents controller/orchestration imports.
- Remove direct Agents controller, readiness, orchestration-controller, and authority-status type imports from the touched Jangar boundary code.
- Update the Jangar summary compatibility test to opt into the Swarm primitive gate before asserting Swarm totals.

## Related Issues

None

## Testing

- `bun run --cwd services/jangar test -- src/server/__tests__/agents-control-plane-summary.test.ts src/server/__tests__/control-plane-status.test.ts src/routes/ready.test.ts src/server/__tests__/agents-control-plane-client.test.ts src/routes/health.test.tsx src/server/__tests__/agents-service-proxy.test.ts`
- `bun run --cwd services/jangar tsc`
- `bunx oxfmt --check services/jangar/src/server/__tests__/agents-control-plane-summary.test.ts services/jangar/src/server/control-plane-status.ts services/jangar/src/server/control-plane-authority-status.ts services/jangar/src/server/__tests__/control-plane-status.test.ts services/jangar/src/server/agents-control-plane-client.ts services/jangar/src/server/control-plane-serving-process-status.ts services/jangar/src/routes/ready.tsx services/jangar/src/routes/ready.test.ts services/jangar/src/server/__tests__/agents-control-plane-client.test.ts`
- `git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
