### PR TITLE
fix(torghut): retain imported runtime proof

### DIFF
--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -950,9 +950,20 @@ def compile_hypothesis_runtime_statuses(
         or 0,
     )
     feature_batch_rows_total = max(feature_batch_rows_total, persisted_feature_rows)
+    persisted_drift_checks = max(
+        0,
+        _optional_int(
+            readiness.get("drift_detection_checks_total")
+            or readiness.get("drift_detection_checks")
+            or readiness.get("drift_checks")
+            or 0
+        )
+        or 0,
+    )
     drift_detection_checks_total = max(
         0,
         _optional_int(getattr(metrics, "drift_detection_checks_total", 0)) or 0,
+        persisted_drift_checks,
     )
     evidence_continuity_checks_total = max(
         0,

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -451,6 +451,18 @@ def build_hypothesis_runtime_summary(
         ),
         route_symbol_filter_enabled=settings.trading_pipeline_mode == "simple",
     )
+    evidence = _load_latest_certificate_evidence(
+        session,
+        hypothesis_ids=[item.hypothesis_id for item in registry.items],
+    )
+    items = _merge_runtime_certificate_evidence(
+        items,
+        evidence=evidence,
+        now=datetime.now(timezone.utc),
+        max_age_seconds=max(
+            0, int(settings.trading_drift_live_promotion_max_evidence_age_seconds)
+        ),
+    )
     summary = summarize_hypothesis_runtime_statuses(
         items,
         registry=registry,
@@ -566,6 +578,163 @@ def _load_latest_certificate_evidence(
             }
         )
     return evidence
+
+
+def _window_evidence_issued_at(
+    metric_window: StrategyHypothesisMetricWindow,
+) -> datetime | None:
+    return _coerce_aware_datetime(
+        metric_window.window_ended_at or metric_window.created_at
+    )
+
+
+def _certificate_evidence_is_fresh(
+    metric_window: StrategyHypothesisMetricWindow,
+    *,
+    max_age_seconds: int,
+    now: datetime,
+) -> bool:
+    issued_at = _window_evidence_issued_at(metric_window)
+    if issued_at is None:
+        return False
+    return max_age_seconds <= 0 or issued_at >= now - timedelta(seconds=max_age_seconds)
+
+
+def _certificate_capital_stage(
+    metric_window: StrategyHypothesisMetricWindow,
+    promotion_decision: StrategyPromotionDecision,
+) -> str | None:
+    window_stage = _safe_text(metric_window.capital_stage)
+    decision_stage = _safe_text(promotion_decision.state)
+    ranked_stages = [
+        stage
+        for stage in (window_stage, decision_stage)
+        if stage is not None and _stage_rank(stage) >= 0
+    ]
+    if not ranked_stages:
+        return None
+    return min(ranked_stages, key=_stage_rank)
+
+
+def _merge_runtime_certificate_evidence(
+    items: Sequence[Mapping[str, Any]],
+    *,
+    evidence: Sequence[Mapping[str, object]],
+    now: datetime,
+    max_age_seconds: int,
+) -> list[dict[str, object]]:
+    evidence_by_hypothesis = {
+        str(row.get("hypothesis_id") or "").strip(): row
+        for row in evidence
+        if str(row.get("hypothesis_id") or "").strip()
+    }
+    merged: list[dict[str, object]] = []
+    for item in items:
+        updated: dict[str, object] = dict(item)
+        hypothesis_id = str(updated.get("hypothesis_id") or "").strip()
+        row = evidence_by_hypothesis.get(hypothesis_id)
+        if not row:
+            merged.append(updated)
+            continue
+
+        metric_window = cast(
+            StrategyHypothesisMetricWindow | None, row.get("metric_window")
+        )
+        promotion_decision = cast(
+            StrategyPromotionDecision | None, row.get("promotion_decision")
+        )
+        if metric_window is None or promotion_decision is None:
+            merged.append(updated)
+            continue
+        if _safe_bool(getattr(promotion_decision, "allowed", True)) is False:
+            merged.append(updated)
+            continue
+        if not _certificate_evidence_is_fresh(
+            metric_window,
+            max_age_seconds=max_age_seconds,
+            now=now,
+        ):
+            merged.append(updated)
+            continue
+        if not bool(metric_window.continuity_ok) or not bool(metric_window.drift_ok):
+            merged.append(updated)
+            continue
+        if _safe_text(metric_window.dependency_quorum_decision) != "allow":
+            merged.append(updated)
+            continue
+
+        capital_stage = _certificate_capital_stage(metric_window, promotion_decision)
+        if capital_stage is None or _stage_rank(capital_stage) <= _stage_rank("shadow"):
+            merged.append(updated)
+            continue
+
+        issued_at = _window_evidence_issued_at(metric_window)
+        candidate_id = (
+            _safe_text(metric_window.candidate_id)
+            or _safe_text(promotion_decision.candidate_id)
+            or _safe_text(updated.get("candidate_id"))
+        )
+        observed = (
+            dict(cast(Mapping[str, Any], updated.get("observed")))
+            if isinstance(updated.get("observed"), Mapping)
+            else {}
+        )
+        observed.update(
+            {
+                "runtime_window_certificate_applied": True,
+                "runtime_window_prior_reasons": list(
+                    cast(Sequence[object], updated.get("reasons") or [])
+                ),
+                "metric_window_id": str(metric_window.id),
+                "promotion_decision_id": str(promotion_decision.id),
+                "metric_window_issued_at": issued_at.isoformat()
+                if issued_at is not None
+                else None,
+                "metric_window_market_session_count": metric_window.market_session_count,
+                "metric_window_decision_count": metric_window.decision_count,
+                "metric_window_trade_count": metric_window.trade_count,
+                "metric_window_order_count": metric_window.order_count,
+                "metric_window_avg_abs_slippage_bps": metric_window.avg_abs_slippage_bps,
+                "metric_window_post_cost_expectancy_bps": metric_window.post_cost_expectancy_bps,
+            }
+        )
+        if candidate_id is not None:
+            updated["candidate_id"] = candidate_id
+        updated.update(
+            {
+                "state": "canary_live"
+                if _stage_rank(capital_stage) < _stage_rank("0.50x live")
+                else "scaled_live",
+                "capital_stage": capital_stage,
+                "capital_multiplier": {
+                    "0.10x canary": "0.10",
+                    "0.25x canary": "0.25",
+                    "0.50x live": "0.50",
+                    "1.00x live": "1.00",
+                }.get(capital_stage, str(updated.get("capital_multiplier") or "0")),
+                "promotion_eligible": True,
+                "rollback_required": False,
+                "reasons": [],
+                "informational_reasons": sorted(
+                    {
+                        *[
+                            str(reason)
+                            for reason in cast(
+                                Sequence[object],
+                                updated.get("informational_reasons") or [],
+                            )
+                            if str(reason).strip()
+                        ],
+                        "runtime_window_certificate_applied",
+                    }
+                ),
+                "promotion_decision_id": str(promotion_decision.id),
+                "metric_window_id": str(metric_window.id),
+                "observed": observed,
+            }
+        )
+        merged.append(updated)
+    return merged
 
 
 def _segment_summary(

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -252,6 +252,32 @@ class TestHypothesisReadiness(TestCase):
         self.assertEqual(cont["observed"]["signal_lag_seconds"], None)
         self.assertEqual(cont["observed"]["feature_batch_rows_total"], 12)
 
+    def test_compile_hypothesis_runtime_statuses_uses_persisted_drift_readiness(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=_state(feature_rows=12, drift_checks=0),
+            tca_summary={
+                "order_count": 0,
+                "avg_abs_slippage_bps": 0,
+                "avg_realized_shortfall_bps": 0,
+            },
+            market_context_status={"last_freshness_seconds": None},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            feature_readiness={"drift_detection_checks_total": 3},
+            now=datetime(2026, 3, 6, 16, 0, tzinfo=timezone.utc),
+        )
+
+        micro = next(item for item in statuses if item["hypothesis_id"] == "H-MICRO-01")
+        self.assertNotIn("drift_checks_missing", micro["reasons"])
+        self.assertEqual(micro["observed"]["drift_detection_checks_total"], 3)
+
     def test_compile_hypothesis_runtime_statuses_promotes_canary_when_thresholds_are_met(
         self,
     ) -> None:

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -19,12 +19,17 @@ from app.models import (
     AutoresearchProposalScore,
     Base,
     Strategy,
+    StrategyHypothesisMetricWindow,
+    StrategyPromotionDecision,
     TradeDecision,
 )
+from app.trading.hypotheses import JangarDependencyQuorumStatus
 from app.trading.submission_council import (
     _QUANT_HEALTH_CACHE,
     _coerce_aware_datetime,
     _load_profit_promotion_table_counts,
+    _merge_runtime_certificate_evidence,
+    build_hypothesis_runtime_summary,
     build_live_submission_gate_payload,
     load_quant_evidence_status,
     resolve_quant_health_url,
@@ -60,6 +65,7 @@ class TestSubmissionCouncil(TestCase):
             "trading_jangar_control_plane_cache_ttl_seconds": settings.trading_jangar_control_plane_cache_ttl_seconds,
             "trading_jangar_control_plane_status_url": settings.trading_jangar_control_plane_status_url,
             "trading_market_context_url": settings.trading_market_context_url,
+            "trading_drift_live_promotion_max_evidence_age_seconds": settings.trading_drift_live_promotion_max_evidence_age_seconds,
         }
         _QUANT_HEALTH_CACHE.clear()
         settings.trading_enabled = True
@@ -98,6 +104,11 @@ class TestSubmissionCouncil(TestCase):
         settings.trading_market_context_url = self._settings_snapshot[
             "trading_market_context_url"
         ]
+        settings.trading_drift_live_promotion_max_evidence_age_seconds = (
+            self._settings_snapshot[
+                "trading_drift_live_promotion_max_evidence_age_seconds"
+            ]
+        )
         _QUANT_HEALTH_CACHE.clear()
 
     def _metric_window(self, capital_stage: str = "0.10x canary") -> SimpleNamespace:
@@ -133,6 +144,329 @@ class TestSubmissionCouncil(TestCase):
             "status": "healthy",
             "source_url": "http://jangar.test/api/torghut/trading/control-plane/quant/health?account=paper&window=15m",
         }
+
+    def test_runtime_certificate_merge_keeps_invalid_evidence_shadow(self) -> None:
+        now = datetime.now(timezone.utc)
+        base_item = {
+            "hypothesis_id": "H-CONT-01",
+            "candidate_id": None,
+            "capital_stage": "shadow",
+            "capital_multiplier": "0",
+            "promotion_eligible": False,
+            "rollback_required": False,
+            "reasons": ["drift_checks_missing"],
+            "informational_reasons": [],
+            "observed": {},
+        }
+
+        def metric_window(**overrides: object) -> SimpleNamespace:
+            payload: dict[str, object] = {
+                "id": "window-invalid",
+                "candidate_id": "cand-runtime",
+                "capital_stage": "0.10x canary",
+                "window_ended_at": now,
+                "created_at": now,
+                "continuity_ok": True,
+                "drift_ok": True,
+                "dependency_quorum_decision": "allow",
+                "market_session_count": 3,
+                "decision_count": 42,
+                "trade_count": 42,
+                "order_count": 42,
+                "avg_abs_slippage_bps": "4.2",
+                "post_cost_expectancy_bps": "8.5",
+            }
+            payload.update(overrides)
+            return SimpleNamespace(**payload)
+
+        def promotion(**overrides: object) -> SimpleNamespace:
+            payload: dict[str, object] = {
+                "id": "promo-invalid",
+                "candidate_id": "cand-runtime",
+                "state": "0.10x canary",
+                "allowed": True,
+            }
+            payload.update(overrides)
+            return SimpleNamespace(**payload)
+
+        scenarios = [
+            [],
+            [
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "metric_window": metric_window(
+                        window_ended_at=None,
+                        created_at=None,
+                    ),
+                    "promotion_decision": promotion(),
+                }
+            ],
+            [
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "metric_window": metric_window(),
+                    "promotion_decision": promotion(allowed=False),
+                }
+            ],
+            [
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "metric_window": metric_window(
+                        window_ended_at=now.replace(year=2020),
+                    ),
+                    "promotion_decision": promotion(),
+                }
+            ],
+            [
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "metric_window": metric_window(
+                        dependency_quorum_decision="block",
+                    ),
+                    "promotion_decision": promotion(),
+                }
+            ],
+            [
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "metric_window": metric_window(capital_stage="observe"),
+                    "promotion_decision": promotion(state="observe"),
+                }
+            ],
+        ]
+
+        for evidence in scenarios:
+            with self.subTest(evidence=evidence):
+                result = _merge_runtime_certificate_evidence(
+                    [base_item],
+                    evidence=evidence,
+                    now=now,
+                    max_age_seconds=3600,
+                )
+
+                self.assertFalse(result[0]["promotion_eligible"])
+                self.assertEqual(result[0]["capital_stage"], "shadow")
+                self.assertEqual(result[0]["reasons"], ["drift_checks_missing"])
+
+    def test_hypothesis_runtime_summary_uses_fresh_imported_runtime_proof(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        now = datetime.now(timezone.utc)
+        settings.trading_drift_live_promotion_max_evidence_age_seconds = 3600
+        registry = SimpleNamespace(
+            loaded=True,
+            path="test-registry",
+            errors=[],
+            items=[SimpleNamespace(hypothesis_id="H-CONT-01")],
+        )
+        runtime_items = [
+            {
+                "hypothesis_id": "H-CONT-01",
+                "candidate_id": None,
+                "strategy_id": "intraday_continuation",
+                "lane_id": "continuation",
+                "strategy_family": "intraday_continuation",
+                "state": "shadow",
+                "capital_stage": "shadow",
+                "capital_multiplier": "0",
+                "promotion_eligible": False,
+                "rollback_required": False,
+                "reasons": ["drift_checks_missing", "post_cost_expectancy_below_edge"],
+                "informational_reasons": [],
+                "observed": {},
+            }
+        ]
+
+        with session_local() as session:
+            session.add(
+                StrategyHypothesisMetricWindow(
+                    run_id="runtime-proof-1",
+                    candidate_id="cand-runtime",
+                    hypothesis_id="H-CONT-01",
+                    observed_stage="paper",
+                    window_started_at=now,
+                    window_ended_at=now,
+                    market_session_count=3,
+                    decision_count=42,
+                    trade_count=42,
+                    order_count=42,
+                    avg_abs_slippage_bps="4.2",
+                    slippage_budget_bps="12",
+                    post_cost_expectancy_bps="8.5",
+                    continuity_ok=True,
+                    drift_ok=True,
+                    dependency_quorum_decision="allow",
+                    capital_stage="0.10x canary",
+                )
+            )
+            session.add(
+                StrategyPromotionDecision(
+                    run_id="runtime-proof-1",
+                    candidate_id="cand-runtime",
+                    hypothesis_id="H-CONT-01",
+                    promotion_target="paper",
+                    state="0.10x canary",
+                    allowed=True,
+                    reason_summary="runtime_evidence_thresholds_satisfied",
+                )
+            )
+            session.commit()
+
+            with (
+                patch(
+                    "app.trading.submission_council.load_hypothesis_registry",
+                    return_value=registry,
+                ),
+                patch(
+                    "app.trading.submission_council.resolve_hypothesis_dependency_quorum",
+                    return_value=JangarDependencyQuorumStatus(
+                        decision="allow",
+                        reasons=[],
+                        message="ready",
+                    ),
+                ),
+                patch(
+                    "app.trading.submission_council.compile_hypothesis_runtime_statuses",
+                    return_value=runtime_items,
+                ),
+                patch(
+                    "app.trading.submission_council.build_tca_gate_inputs",
+                    return_value={},
+                ),
+            ):
+                result = build_hypothesis_runtime_summary(
+                    session,
+                    state=SimpleNamespace(market_session_open=True),
+                    market_context_status={"last_freshness_seconds": 10},
+                )
+
+        self.assertEqual(result["promotion_eligible_total"], 1)
+        item = result["items"][0]
+        self.assertTrue(item["promotion_eligible"])
+        self.assertEqual(item["candidate_id"], "cand-runtime")
+        self.assertEqual(item["capital_stage"], "0.10x canary")
+        self.assertEqual(item["reasons"], [])
+        self.assertEqual(item["observed"]["metric_window_decision_count"], 42)
+        self.assertEqual(
+            item["observed"]["runtime_window_prior_reasons"],
+            ["drift_checks_missing", "post_cost_expectancy_below_edge"],
+        )
+        self.assertEqual(
+            item["informational_reasons"],
+            ["runtime_window_certificate_applied"],
+        )
+
+    def test_hypothesis_runtime_summary_rejects_failed_runtime_proof(self) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        now = datetime.now(timezone.utc)
+        settings.trading_drift_live_promotion_max_evidence_age_seconds = 3600
+        registry = SimpleNamespace(
+            loaded=True,
+            path="test-registry",
+            errors=[],
+            items=[SimpleNamespace(hypothesis_id="H-CONT-01")],
+        )
+        runtime_items = [
+            {
+                "hypothesis_id": "H-CONT-01",
+                "candidate_id": None,
+                "strategy_id": "intraday_continuation",
+                "lane_id": "continuation",
+                "strategy_family": "intraday_continuation",
+                "state": "shadow",
+                "capital_stage": "shadow",
+                "capital_multiplier": "0",
+                "promotion_eligible": False,
+                "rollback_required": False,
+                "reasons": ["drift_checks_missing"],
+                "informational_reasons": [],
+                "observed": {},
+            }
+        ]
+
+        with session_local() as session:
+            session.add(
+                StrategyHypothesisMetricWindow(
+                    run_id="runtime-proof-2",
+                    candidate_id="cand-runtime",
+                    hypothesis_id="H-CONT-01",
+                    observed_stage="paper",
+                    window_started_at=now,
+                    window_ended_at=now,
+                    market_session_count=3,
+                    decision_count=42,
+                    trade_count=42,
+                    order_count=42,
+                    avg_abs_slippage_bps="4.2",
+                    slippage_budget_bps="12",
+                    post_cost_expectancy_bps="8.5",
+                    continuity_ok=True,
+                    drift_ok=False,
+                    dependency_quorum_decision="allow",
+                    capital_stage="0.10x canary",
+                )
+            )
+            session.add(
+                StrategyPromotionDecision(
+                    run_id="runtime-proof-2",
+                    candidate_id="cand-runtime",
+                    hypothesis_id="H-CONT-01",
+                    promotion_target="paper",
+                    state="0.10x canary",
+                    allowed=True,
+                    reason_summary="runtime_evidence_thresholds_satisfied",
+                )
+            )
+            session.commit()
+
+            with (
+                patch(
+                    "app.trading.submission_council.load_hypothesis_registry",
+                    return_value=registry,
+                ),
+                patch(
+                    "app.trading.submission_council.resolve_hypothesis_dependency_quorum",
+                    return_value=JangarDependencyQuorumStatus(
+                        decision="allow",
+                        reasons=[],
+                        message="ready",
+                    ),
+                ),
+                patch(
+                    "app.trading.submission_council.compile_hypothesis_runtime_statuses",
+                    return_value=runtime_items,
+                ),
+                patch(
+                    "app.trading.submission_council.build_tca_gate_inputs",
+                    return_value={},
+                ),
+            ):
+                result = build_hypothesis_runtime_summary(
+                    session,
+                    state=SimpleNamespace(market_session_open=True),
+                    market_context_status={"last_freshness_seconds": 10},
+                )
+
+        self.assertEqual(result["promotion_eligible_total"], 0)
+        item = result["items"][0]
+        self.assertFalse(item["promotion_eligible"])
+        self.assertEqual(item["capital_stage"], "shadow")
+        self.assertEqual(item["reasons"], ["drift_checks_missing"])
 
     def test_coerce_aware_datetime_normalizes_runtime_status_values(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Merge fresh imported `StrategyHypothesisMetricWindow` and allowed `StrategyPromotionDecision` evidence into the hypothesis runtime summary before recomputing promotion totals.
- Keep the merge fail-closed: stale windows, failed continuity/drift, non-allow dependency quorum, missing decisions, and shadow-only stages do not raise eligibility.
- Preserve persisted drift-check readiness across scheduler restarts so real drift repair evidence can clear `drift_checks_missing`.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_hypotheses.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/hypotheses.py app/trading/submission_council.py tests/test_hypotheses.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen coverage erase && uv run --frozen coverage run -m pytest tests/test_hypotheses.py tests/test_submission_council.py && uv run --frozen coverage xml -o coverage.xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
