### PR TITLE
refactor(jangar): localize agent utility helpers

### DIFF
--- a/services/jangar/src/server/__tests__/torghut-simulation-control-plane-submit.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-simulation-control-plane-submit.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { stableJsonStringifyForHash } from '@proompteng/agents/server/agents-controller/template-hash'
+import { stableJsonStringifyForHash } from '~/server/stable-json-hash'
 
 type FakeState = {
   runs: Map<string, Record<string, unknown>>

--- a/services/jangar/src/server/primitives-policy.ts
+++ b/services/jangar/src/server/primitives-policy.ts
@@ -1,1 +1,209 @@
-export * from '@proompteng/agents/server/primitives-policy'
+import { asRecord, asString, readNested } from '~/server/primitives-http'
+import { RESOURCE_MAP, type KubernetesClient } from '~/server/primitives-kube'
+
+const asArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+}
+
+const parseNumber = (value: unknown) => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const parsed = Number.parseFloat(trimmed)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const parseQuantity = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const match = trimmed.match(/^(-?\d+(?:\.\d+)?)([a-zA-Z]+)?$/)
+  if (!match) return null
+  const amount = Number.parseFloat(match[1] ?? '')
+  if (!Number.isFinite(amount)) return null
+  const suffix = match[2] ?? ''
+  if (!suffix) return amount
+  if (suffix === 'm') return amount / 1000
+
+  const binary = {
+    Ki: 1024,
+    Mi: 1024 ** 2,
+    Gi: 1024 ** 3,
+    Ti: 1024 ** 4,
+    Pi: 1024 ** 5,
+    Ei: 1024 ** 6,
+  } as const
+  const decimal = {
+    K: 1000,
+    M: 1000 ** 2,
+    G: 1000 ** 3,
+    T: 1000 ** 4,
+    P: 1000 ** 5,
+    E: 1000 ** 6,
+  } as const
+
+  if (suffix in binary) {
+    return amount * binary[suffix as keyof typeof binary]
+  }
+  if (suffix in decimal) {
+    return amount * decimal[suffix as keyof typeof decimal]
+  }
+
+  return amount
+}
+
+export type PolicyChecks = {
+  approvalPolicies?: string[]
+  budgetRef?: string
+  secretBindingRef?: string
+  requiredSecrets?: string[]
+  subject?: { kind: string; name: string; namespace?: string }
+}
+
+export const validateApprovalPolicies = async (namespace: string, policies: string[], kube: KubernetesClient) => {
+  const missing: string[] = []
+  for (const policy of policies) {
+    const resource = await kube.get(RESOURCE_MAP.ApprovalPolicy, policy, namespace)
+    if (!resource) {
+      missing.push(policy)
+      continue
+    }
+    const phase = asString(readNested(resource, ['status', 'phase']))?.toLowerCase()
+    if (phase && ['denied', 'rejected', 'blocked', 'failed'].includes(phase)) {
+      throw new Error(`approval policy ${policy} is ${phase}`)
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(`approval policies not found: ${missing.join(', ')}`)
+  }
+}
+
+export const validateBudget = async (namespace: string, budgetRef: string, kube: KubernetesClient) => {
+  const budget = await kube.get(RESOURCE_MAP.Budget, budgetRef, namespace)
+  if (!budget) {
+    throw new Error(`budget not found: ${budgetRef}`)
+  }
+
+  const phase = asString(readNested(budget, ['status', 'phase']))?.toLowerCase()
+  if (phase && ['exceeded', 'blocked', 'failed', 'denied'].includes(phase)) {
+    throw new Error(`budget ${budgetRef} is ${phase}`)
+  }
+
+  const limits = (readNested(budget, ['spec', 'limits']) ?? {}) as Record<string, unknown>
+  const used = (readNested(budget, ['status', 'used']) ?? {}) as Record<string, unknown>
+
+  const tokensLimit = parseNumber(limits.tokens)
+  const tokensUsed = parseNumber(used.tokens)
+  if (tokensLimit != null && tokensUsed != null && tokensUsed > tokensLimit) {
+    throw new Error(`budget ${budgetRef} tokens exceeded (${tokensUsed}/${tokensLimit})`)
+  }
+
+  const dollarsLimit = parseNumber(limits.dollars)
+  const dollarsUsed = parseNumber(used.dollars)
+  if (dollarsLimit != null && dollarsUsed != null && dollarsUsed > dollarsLimit) {
+    throw new Error(`budget ${budgetRef} dollars exceeded (${dollarsUsed}/${dollarsLimit})`)
+  }
+
+  const cpuLimit = parseQuantity(limits.cpu)
+  const cpuUsed = parseQuantity(used.cpu)
+  if (cpuLimit != null && cpuUsed != null && cpuUsed > cpuLimit) {
+    throw new Error(`budget ${budgetRef} cpu exceeded (${used.cpu}/${limits.cpu})`)
+  }
+
+  const memoryLimit = parseQuantity(limits.memory)
+  const memoryUsed = parseQuantity(used.memory)
+  if (memoryLimit != null && memoryUsed != null && memoryUsed > memoryLimit) {
+    throw new Error(`budget ${budgetRef} memory exceeded (${used.memory}/${limits.memory})`)
+  }
+
+  const gpuLimit = parseQuantity(limits.gpu)
+  const gpuUsed = parseQuantity(used.gpu)
+  if (gpuLimit != null && gpuUsed != null && gpuUsed > gpuLimit) {
+    throw new Error(`budget ${budgetRef} gpu exceeded (${used.gpu}/${limits.gpu})`)
+  }
+}
+
+export const validateSecretBinding = async (
+  namespace: string,
+  bindingName: string,
+  subject: { kind: string; name: string; namespace?: string },
+  requiredSecrets: string[],
+  kube: KubernetesClient,
+) => {
+  const binding = await kube.get(RESOURCE_MAP.SecretBinding, bindingName, namespace)
+  if (!binding) {
+    throw new Error(`secret binding not found: ${bindingName}`)
+  }
+
+  const spec = readNested(binding, ['spec']) as Record<string, unknown> | null
+  const subjects = Array.isArray(spec?.subjects) ? (spec?.subjects as Record<string, unknown>[]) : []
+  const allowedSecrets = asArray(spec?.allowedSecrets)
+
+  const matchesSubject = subjects.some((entry) => {
+    const kind = asString(entry.kind)
+    const name = asString(entry.name)
+    const subjectNamespace = asString(entry.namespace)
+    if (!kind || !name) return false
+    if (kind !== subject.kind || name !== subject.name) return false
+    if (subjectNamespace && subject.namespace && subjectNamespace !== subject.namespace) return false
+    return true
+  })
+
+  if (!matchesSubject) {
+    throw new Error(`secret binding ${bindingName} does not include subject ${subject.kind}/${subject.name}`)
+  }
+
+  const missingSecrets = requiredSecrets.filter((secret) => !allowedSecrets.includes(secret))
+  if (missingSecrets.length > 0) {
+    throw new Error(`secret binding ${bindingName} missing secrets: ${missingSecrets.join(', ')}`)
+  }
+}
+
+export const validatePolicies = async (namespace: string, checks: PolicyChecks, kube: KubernetesClient) => {
+  const approvalPolicies = asArray(checks.approvalPolicies)
+  if (approvalPolicies.length > 0) {
+    await validateApprovalPolicies(namespace, approvalPolicies, kube)
+  }
+
+  const budgetRef = asString(checks.budgetRef)
+  if (budgetRef) {
+    await validateBudget(namespace, budgetRef, kube)
+  }
+
+  const bindingRef = asString(checks.secretBindingRef)
+  if (bindingRef) {
+    const subject = checks.subject
+    if (!subject) {
+      throw new Error('secret binding requires a subject')
+    }
+    await validateSecretBinding(namespace, bindingRef, subject, asArray(checks.requiredSecrets), kube)
+  }
+}
+
+export const extractApprovalPolicies = (steps: Array<Record<string, unknown>>) => {
+  const policies: string[] = []
+  for (const step of steps) {
+    const policyRef = asString(step.policyRef)
+    if (policyRef) policies.push(policyRef)
+  }
+  return policies
+}
+
+export const extractRequiredSecrets = (spec: Record<string, unknown>) => {
+  const security = asRecord(spec.security) ?? {}
+  return asArray(security.allowedSecrets)
+}
+
+export const extractAllowedServiceAccounts = (spec: Record<string, unknown>) => {
+  const security = asRecord(spec.security) ?? {}
+  return asArray(security.allowedServiceAccounts)
+}
+
+export const extractRuntimeServiceAccount = (spec: Record<string, unknown>) => {
+  const runtime = asRecord(spec.runtime) ?? {}
+  const config = asRecord(runtime.config) ?? {}
+  return asString(config.serviceAccount) ?? asString(config.serviceAccountName)
+}

--- a/services/jangar/src/server/provider-capacity-reasons.ts
+++ b/services/jangar/src/server/provider-capacity-reasons.ts
@@ -1,0 +1,1 @@
+export const PROVIDER_CAPACITY_EXHAUSTED_REASON = 'ProviderCapacityExhausted'

--- a/services/jangar/src/server/stable-json-hash.ts
+++ b/services/jangar/src/server/stable-json-hash.ts
@@ -1,0 +1,20 @@
+import { asRecord } from '~/server/primitives-http'
+
+export const canonicalizeForJsonHash = (value: unknown): unknown => {
+  if (value == null) return null
+  if (Array.isArray(value)) return value.map((entry) => canonicalizeForJsonHash(entry))
+  if (typeof value !== 'object') return value
+
+  const record = asRecord(value)
+  if (!record) return value
+
+  const output: Record<string, unknown> = {}
+  for (const key of Object.keys(record).sort()) {
+    const entry = record[key]
+    if (entry === undefined) continue
+    output[key] = canonicalizeForJsonHash(entry)
+  }
+  return output
+}
+
+export const stableJsonStringifyForHash = (value: unknown) => JSON.stringify(canonicalizeForJsonHash(value))

--- a/services/jangar/src/server/status-utils.ts
+++ b/services/jangar/src/server/status-utils.ts
@@ -1,1 +1,92 @@
-export * from '@proompteng/agents/server/status-utils'
+import { asRecord, asString } from '~/server/primitives-http'
+
+type ConditionForCompare = {
+  type: string | null
+  status: string | null
+  reason: string | null
+  message: string | null
+}
+
+const normalizeCondition = (value: Record<string, unknown>): ConditionForCompare => ({
+  type: asString(value.type),
+  status: asString(value.status),
+  reason: asString(value.reason),
+  message: asString(value.message),
+})
+
+const normalizeConditionsForCompare = (raw: unknown): ConditionForCompare[] | undefined => {
+  if (!Array.isArray(raw)) return undefined
+  const normalized = raw
+    .map((entry) => asRecord(entry))
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry))
+    .map(normalizeCondition)
+    .filter((entry) => entry.type || entry.status || entry.reason || entry.message)
+  if (normalized.length === 0) return undefined
+  normalized.sort((a, b) => {
+    const typeCompare = (a.type ?? '').localeCompare(b.type ?? '')
+    if (typeCompare !== 0) return typeCompare
+    const statusCompare = (a.status ?? '').localeCompare(b.status ?? '')
+    if (statusCompare !== 0) return statusCompare
+    const reasonCompare = (a.reason ?? '').localeCompare(b.reason ?? '')
+    if (reasonCompare !== 0) return reasonCompare
+    return (a.message ?? '').localeCompare(b.message ?? '')
+  })
+  return normalized
+}
+
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(',')}]`
+  }
+  const record = value as Record<string, unknown>
+  const keys = Object.keys(record)
+    .filter((key) => record[key] !== undefined)
+    .sort()
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`).join(',')}}`
+}
+
+export const normalizeStatusForCompare = (status: Record<string, unknown> | null | undefined) => {
+  const record = asRecord(status) ?? {}
+  const next: Record<string, unknown> = { ...record }
+  delete next.updatedAt
+  const normalizedConditions = normalizeConditionsForCompare(record.conditions)
+  if (normalizedConditions) {
+    next.conditions = normalizedConditions
+  } else {
+    delete next.conditions
+  }
+  return next
+}
+
+const normalizeMetadataForCompare = (metadata: Record<string, unknown> | null | undefined) => {
+  const record = asRecord(metadata) ?? {}
+  const next: Record<string, unknown> = { ...record }
+  delete next.resourceVersion
+  delete next.managedFields
+  return next
+}
+
+export const shouldApplyStatus = (
+  currentStatus: Record<string, unknown> | null | undefined,
+  nextStatus: Record<string, unknown>,
+) => {
+  const normalizedCurrent = normalizeStatusForCompare(currentStatus)
+  const normalizedNext = normalizeStatusForCompare(nextStatus)
+  return stableStringify(normalizedCurrent) !== stableStringify(normalizedNext)
+}
+
+export const buildResourceFingerprint = (summary: Record<string, unknown>) => {
+  const metadata = asRecord(summary.metadata)
+  const spec = asRecord(summary.spec) ?? {}
+  const status = asRecord(summary.status)
+  return stableStringify({
+    apiVersion: asString(summary.apiVersion),
+    kind: asString(summary.kind),
+    metadata: normalizeMetadataForCompare(metadata),
+    spec,
+    status: normalizeStatusForCompare(status),
+  })
+}

--- a/services/jangar/src/server/supporting-primitives-swarm-analysis.ts
+++ b/services/jangar/src/server/supporting-primitives-swarm-analysis.ts
@@ -1,6 +1,6 @@
 import { asRecord, asString, readNested } from '~/server/primitives-http'
 import { createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'
-import { PROVIDER_CAPACITY_EXHAUSTED_REASON } from '@proompteng/agents/server/agents-controller/provider-capacity'
+import { PROVIDER_CAPACITY_EXHAUSTED_REASON } from '~/server/provider-capacity-reasons'
 import { hashNameSuffix, makeHashedName } from '~/server/supporting-primitives-naming'
 import {
   deriveStageStaggerMinute,

--- a/services/jangar/src/server/torghut-simulation-control-plane.ts
+++ b/services/jangar/src/server/torghut-simulation-control-plane.ts
@@ -1,10 +1,10 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { posix as pathPosix } from 'node:path'
 
-import { stableJsonStringifyForHash } from '@proompteng/agents/server/agents-controller/template-hash'
 import { getDb } from '~/server/db'
 import { ensureMigrations } from '~/server/kysely-migrations'
 import { createKubernetesClient } from '~/server/primitives-kube'
+import { stableJsonStringifyForHash } from '~/server/stable-json-hash'
 import { resolveTorghutSimulationStorageConfig } from './torghut-config'
 
 type JsonRecord = Record<string, unknown>


### PR DESCRIPTION
## Summary

- Localizes Jangar status comparison and resource fingerprint helpers instead of re-exporting Agents internals.
- Localizes Jangar primitive policy validation helpers instead of re-exporting Agents internals.
- Moves Torghut simulation stable hashing and swarm provider-capacity reason usage to Jangar-owned helper modules.

## Related Issues

None

## Testing

- `bun run --cwd services/jangar test -- src/server/__tests__/status-utils.test.ts src/server/__tests__/torghut-simulation-control-plane-submit.test.ts src/server/__tests__/orchestration-submit.test.ts`
- `bunx oxfmt --check services/jangar/src/server/status-utils.ts services/jangar/src/server/primitives-policy.ts services/jangar/src/server/stable-json-hash.ts services/jangar/src/server/provider-capacity-reasons.ts services/jangar/src/server/torghut-simulation-control-plane.ts services/jangar/src/server/supporting-primitives-swarm-analysis.ts services/jangar/src/server/__tests__/torghut-simulation-control-plane-submit.test.ts`
- `bun run --cwd services/jangar tsc`
- `bun run --cwd services/jangar check:module-sizes && git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
