### PR TITLE
refactor(jangar): localize implementation source webhook config

### DIFF
--- a/services/jangar/src/server/__tests__/implementation-source-webhook-config.test.ts
+++ b/services/jangar/src/server/__tests__/implementation-source-webhook-config.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveImplementationSourceWebhookConfig } from '~/server/implementation-source-webhook-config'
+
+describe('implementation source webhook config', () => {
+  it('reads canonical Agents webhook environment values locally', () => {
+    const config = resolveImplementationSourceWebhookConfig({
+      AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_NAMESPACES: 'agents,jangar',
+      AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_QUEUE_SIZE: '25',
+      AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_RETRY_BASE_DELAY_SECONDS: '2',
+      AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_RETRY_MAX_DELAY_SECONDS: '30',
+      AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_RETRY_MAX_ATTEMPTS: '4',
+    })
+
+    expect(config).toEqual({
+      namespacesRaw: 'agents,jangar',
+      queueSize: 25,
+      retryBaseDelaySeconds: 2,
+      retryMaxDelaySeconds: 30,
+      retryMaxAttempts: 4,
+    })
+  })
+
+  it('ignores legacy Jangar webhook aliases', () => {
+    const config = resolveImplementationSourceWebhookConfig({
+      JANGAR_IMPLEMENTATION_SOURCE_WEBHOOK_QUEUE_SIZE: '50',
+    })
+
+    expect(config.queueSize).toBeNull()
+  })
+})

--- a/services/jangar/src/server/implementation-source-webhook-config.ts
+++ b/services/jangar/src/server/implementation-source-webhook-config.ts
@@ -1,0 +1,52 @@
+type EnvSource = Record<string, string | undefined>
+
+export type ImplementationSourceWebhookConfig = {
+  namespacesRaw: string | null
+  queueSize: number | null
+  retryBaseDelaySeconds: number | null
+  retryMaxDelaySeconds: number | null
+  retryMaxAttempts: number | null
+}
+
+const normalizeNonEmpty = (value: string | undefined | null) => {
+  const normalized = value?.trim()
+  return normalized && normalized.length > 0 ? normalized : null
+}
+
+const parsePositiveInt = (value: string | undefined, fallback: number) => {
+  const normalized = normalizeNonEmpty(value)
+  if (!normalized) return fallback
+  const parsed = Number.parseInt(normalized, 10)
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback
+  return Math.floor(parsed)
+}
+
+const readAgentsEnv = (env: EnvSource, name: string): string | undefined => env[name]
+
+export const resolveImplementationSourceWebhookConfig = (
+  env: EnvSource = process.env,
+): ImplementationSourceWebhookConfig => ({
+  namespacesRaw: normalizeNonEmpty(readAgentsEnv(env, 'AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_NAMESPACES')),
+  queueSize: normalizeNonEmpty(readAgentsEnv(env, 'AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_QUEUE_SIZE'))
+    ? Math.max(1, parsePositiveInt(readAgentsEnv(env, 'AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_QUEUE_SIZE'), 0))
+    : null,
+  retryBaseDelaySeconds: normalizeNonEmpty(
+    readAgentsEnv(env, 'AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_RETRY_BASE_DELAY_SECONDS'),
+  )
+    ? Math.max(
+        0,
+        parsePositiveInt(readAgentsEnv(env, 'AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_RETRY_BASE_DELAY_SECONDS'), 0),
+      )
+    : null,
+  retryMaxDelaySeconds: normalizeNonEmpty(
+    readAgentsEnv(env, 'AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_RETRY_MAX_DELAY_SECONDS'),
+  )
+    ? Math.max(
+        0,
+        parsePositiveInt(readAgentsEnv(env, 'AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_RETRY_MAX_DELAY_SECONDS'), 0),
+      )
+    : null,
+  retryMaxAttempts: normalizeNonEmpty(readAgentsEnv(env, 'AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_RETRY_MAX_ATTEMPTS'))
+    ? Math.max(1, parsePositiveInt(readAgentsEnv(env, 'AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_RETRY_MAX_ATTEMPTS'), 1))
+    : null,
+})

--- a/services/jangar/src/server/implementation-source-webhooks.ts
+++ b/services/jangar/src/server/implementation-source-webhooks.ts
@@ -1,7 +1,7 @@
 import { createHash, createHmac, timingSafeEqual } from 'node:crypto'
 
 import { createKubeGateway } from '~/server/kube-gateway'
-import { resolveImplementationSourceWebhookConfig } from '@proompteng/agents/server/agents-controller/runtime-config'
+import { resolveImplementationSourceWebhookConfig } from '~/server/implementation-source-webhook-config'
 import { assertClusterScopedForWildcard } from '~/server/namespace-scope'
 import { asRecord, asString, errorResponse, okResponse, readNested } from '~/server/primitives-http'
 import { createKubernetesClient, RESOURCE_MAP } from '~/server/primitives-kube'


### PR DESCRIPTION
## Summary

- Adds a Jangar-owned implementation-source webhook config parser.
- Updates implementation-source webhook handling to use the local config module instead of Agents controller runtime internals.
- Adds regression coverage for canonical Agents env handling and ignored legacy Jangar aliases.

## Related Issues

None

## Testing

- `bun run --cwd services/jangar test -- src/server/__tests__/implementation-source-webhook-config.test.ts src/server/__tests__/implementation-source-webhooks.test.ts`
- `bunx oxfmt --check services/jangar/src/server/implementation-source-webhook-config.ts services/jangar/src/server/implementation-source-webhooks.ts services/jangar/src/server/__tests__/implementation-source-webhook-config.test.ts`
- `bun run --cwd services/jangar tsc`
- `bun run --cwd services/jangar docs:inventory:check && bun run --cwd services/jangar check:module-sizes && git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
