### PR TITLE
refactor(jangar): localize control plane cache runtime

### DIFF
--- a/services/jangar/src/server/control-plane-cache.ts
+++ b/services/jangar/src/server/control-plane-cache.ts
@@ -1,1 +1,264 @@
-export { startControlPlaneCache, stopControlPlaneCache } from '@proompteng/agents/server/control-plane-cache'
+import { resolveControlPlaneCacheConfig } from './controller-runtime-config'
+import { createControlPlaneCacheStore } from './control-plane-cache-store'
+import { startResourceWatch } from './kube-watch'
+import { createKubernetesClient, RESOURCE_MAP } from './primitives-kube'
+import { asRecord, asString, readNested } from './primitives-http'
+import { resolveRuntimeServiceName } from './runtime-identity'
+import { buildResourceFingerprint } from './status-utils'
+
+type CacheKind =
+  | 'Agent'
+  | 'AgentRun'
+  | 'AgentProvider'
+  | 'ImplementationSpec'
+  | 'ImplementationSource'
+  | 'VersionControlProvider'
+
+type CacheResource = { kind: CacheKind; resource: string }
+
+const DEFAULT_CLUSTER_ID = 'default'
+
+const CACHE_RESOURCES: CacheResource[] = [
+  { kind: 'Agent', resource: RESOURCE_MAP.Agent },
+  { kind: 'AgentRun', resource: RESOURCE_MAP.AgentRun },
+  { kind: 'AgentProvider', resource: RESOURCE_MAP.AgentProvider },
+  { kind: 'ImplementationSpec', resource: RESOURCE_MAP.ImplementationSpec },
+  { kind: 'ImplementationSource', resource: RESOURCE_MAP.ImplementationSource },
+  { kind: 'VersionControlProvider', resource: RESOURCE_MAP.VersionControlProvider },
+]
+
+let started = false
+let watchHandles: Array<{ stop: () => void }> = []
+
+const isRuntimeTestEnv = (env: Record<string, string | undefined> = process.env) =>
+  env.NODE_ENV === 'test' || Boolean(env.VITEST) || Boolean(env.VITEST_POOL_ID) || Boolean(env.VITEST_WORKER_ID)
+
+const getLogPrefix = () => `[${resolveRuntimeServiceName()}][control-plane-cache]`
+
+const shouldStart = () => {
+  if (isRuntimeTestEnv()) return false
+  return resolveControlPlaneCacheConfig().enabled
+}
+
+const parseNamespaces = () => resolveControlPlaneCacheConfig().namespaces
+
+const resolveClusterId = () => resolveControlPlaneCacheConfig().clusterId || DEFAULT_CLUSTER_ID
+
+const toSummary = (resource: Record<string, unknown>) => ({
+  apiVersion: asString(resource.apiVersion) ?? null,
+  kind: asString(resource.kind) ?? null,
+  metadata: asRecord(resource.metadata) ?? {},
+  spec: asRecord(resource.spec) ?? {},
+  status: asRecord(resource.status) ?? {},
+})
+
+const resolveResourceUpdatedAt = (summary: ReturnType<typeof toSummary>) => {
+  const candidates = [
+    asString(readNested(summary, ['status', 'updatedAt'])),
+    asString(readNested(summary, ['status', 'lastUpdatedAt'])),
+    asString(readNested(summary, ['status', 'lastSyncedAt'])),
+    asString(readNested(summary, ['status', 'syncedAt'])),
+    asString(readNested(summary, ['status', 'completedAt'])),
+    asString(readNested(summary, ['status', 'finishedAt'])),
+    asString(readNested(summary, ['status', 'startedAt'])),
+    asString(readNested(summary, ['metadata', 'annotations', 'agents.proompteng.ai/updatedAt'])),
+    asString(readNested(summary, ['metadata', 'creationTimestamp'])),
+  ]
+  return candidates.find((value) => value && value.length > 0) ?? null
+}
+
+const coerceStringArray = (value: unknown, limit = 100) => {
+  if (!Array.isArray(value)) return []
+  const result = value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+  return result.slice(0, limit)
+}
+
+const extractFields = (resourceKind: CacheKind, summary: ReturnType<typeof toSummary>) => {
+  const metadata = asRecord(summary.metadata) ?? {}
+  const spec = asRecord(summary.spec) ?? {}
+  const status = asRecord(summary.status) ?? {}
+
+  const statusPhase = resourceKind === 'AgentRun' ? (asString(status.phase) ?? null) : null
+  const specRuntimeType = resourceKind === 'AgentRun' ? (asString(readNested(spec, ['runtime', 'type'])) ?? null) : null
+  const specAgentRefName =
+    resourceKind === 'AgentRun' ? (asString(readNested(spec, ['agentRef', 'name'])) ?? null) : null
+  const specImplementationSpecRefName =
+    resourceKind === 'AgentRun' ? (asString(readNested(spec, ['implementationSpecRef', 'name'])) ?? null) : null
+
+  const specSourceProvider =
+    resourceKind === 'ImplementationSpec' ? (asString(readNested(spec, ['source', 'provider'])) ?? null) : null
+  const specSourceExternalId =
+    resourceKind === 'ImplementationSpec' ? (asString(readNested(spec, ['source', 'externalId'])) ?? null) : null
+  const specSummary = resourceKind === 'ImplementationSpec' ? (asString(spec.summary) ?? null) : null
+  const specLabels = resourceKind === 'ImplementationSpec' ? coerceStringArray(spec.labels, 50) : []
+
+  return {
+    uid: asString(metadata.uid) ?? null,
+    apiVersion: summary.apiVersion,
+    resourceVersion: asString(metadata.resourceVersion) ?? null,
+    generation:
+      typeof metadata.generation === 'number' && Number.isFinite(metadata.generation) ? metadata.generation : null,
+    labels: asRecord(metadata.labels) ?? {},
+    annotations: asRecord(metadata.annotations) ?? {},
+    resourceCreatedAt: asString(metadata.creationTimestamp) ?? null,
+    resourceUpdatedAt: resolveResourceUpdatedAt(summary),
+    statusPhase,
+    specRuntimeType,
+    specAgentRefName,
+    specImplementationSpecRefName,
+    specSourceProvider,
+    specSourceExternalId,
+    specSummary,
+    specLabels,
+  }
+}
+
+const listOnce = async (namespace: string, store: ReturnType<typeof createControlPlaneCacheStore>) => {
+  const kube = createKubernetesClient()
+  const cluster = resolveClusterId()
+
+  for (const entry of CACHE_RESOURCES) {
+    const syncStartedAt = await store.getDbNow()
+    try {
+      const list = await kube.list(entry.resource, namespace)
+      const items = Array.isArray(list.items) ? list.items : []
+      for (const item of items) {
+        const summary = toSummary(asRecord(item) ?? {})
+        const metadata = asRecord(summary.metadata) ?? {}
+        const name = asString(metadata.name)
+        const resourceNamespace = asString(metadata.namespace) ?? namespace
+        if (!name) continue
+        const fingerprint = buildResourceFingerprint(summary)
+        const fields = extractFields(entry.kind, summary)
+        await store.upsertResource({
+          key: { cluster: resolveClusterId(), kind: entry.kind, namespace: resourceNamespace, name },
+          uid: fields.uid,
+          apiVersion: fields.apiVersion,
+          resourceVersion: fields.resourceVersion,
+          generation: fields.generation,
+          labels: fields.labels,
+          annotations: fields.annotations,
+          resource: summary,
+          fingerprint,
+          resourceCreatedAt: fields.resourceCreatedAt,
+          resourceUpdatedAt: fields.resourceUpdatedAt,
+          statusPhase: fields.statusPhase,
+          specRuntimeType: fields.specRuntimeType,
+          specAgentRefName: fields.specAgentRefName,
+          specImplementationSpecRefName: fields.specImplementationSpecRefName,
+          specSourceProvider: fields.specSourceProvider,
+          specSourceExternalId: fields.specSourceExternalId,
+          specSummary: fields.specSummary,
+          specLabels: fields.specLabels,
+        })
+      }
+
+      await store.markNotSeenSince({
+        cluster,
+        kind: entry.kind,
+        namespace,
+        since: syncStartedAt,
+      })
+    } catch (error) {
+      console.warn(`${getLogPrefix()} list failed`, { kind: entry.kind, namespace, error })
+    }
+  }
+}
+
+const startNamespaceWatches = (namespace: string, store: ReturnType<typeof createControlPlaneCacheStore>) => {
+  for (const entry of CACHE_RESOURCES) {
+    watchHandles.push(
+      startResourceWatch({
+        resource: entry.resource,
+        namespace,
+        logPrefix: getLogPrefix(),
+        onEvent: async (event) => {
+          const payload = asRecord(event.object) ?? {}
+          const summary = toSummary(payload)
+          const metadata = asRecord(summary.metadata) ?? {}
+          const resourceNamespace = asString(metadata.namespace) ?? namespace
+          const name = asString(metadata.name)
+          if (!name) return
+
+          const key = { cluster: resolveClusterId(), kind: entry.kind, namespace: resourceNamespace, name }
+          if (event.type === 'DELETED') {
+            await store.markDeleted(key)
+            return
+          }
+
+          const fingerprint = buildResourceFingerprint(summary)
+          const fields = extractFields(entry.kind, summary)
+          await store.upsertResource({
+            key,
+            uid: fields.uid,
+            apiVersion: fields.apiVersion,
+            resourceVersion: fields.resourceVersion,
+            generation: fields.generation,
+            labels: fields.labels,
+            annotations: fields.annotations,
+            resource: summary,
+            fingerprint,
+            resourceCreatedAt: fields.resourceCreatedAt,
+            resourceUpdatedAt: fields.resourceUpdatedAt,
+            statusPhase: fields.statusPhase,
+            specRuntimeType: fields.specRuntimeType,
+            specAgentRefName: fields.specAgentRefName,
+            specImplementationSpecRefName: fields.specImplementationSpecRefName,
+            specSourceProvider: fields.specSourceProvider,
+            specSourceExternalId: fields.specSourceExternalId,
+            specSummary: fields.specSummary,
+            specLabels: fields.specLabels,
+          })
+        },
+        onError: (error) => {
+          console.warn(`${getLogPrefix()} watch failed`, { kind: entry.kind, namespace, error })
+        },
+      }),
+    )
+  }
+}
+
+export const startControlPlaneCache = async () => {
+  if (started || !shouldStart()) return
+  started = true
+
+  let store: ReturnType<typeof createControlPlaneCacheStore> | null = null
+  try {
+    store = createControlPlaneCacheStore()
+    await store.ready
+
+    const namespaces = parseNamespaces()
+    for (const namespace of namespaces) {
+      await listOnce(namespace, store)
+      startNamespaceWatches(namespace, store)
+    }
+  } catch (error) {
+    console.warn(`${getLogPrefix()} failed to start`, error)
+    try {
+      stopControlPlaneCache()
+    } catch {
+      // ignore
+    }
+    try {
+      await store?.close()
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export const stopControlPlaneCache = () => {
+  for (const handle of watchHandles) {
+    handle.stop()
+  }
+  watchHandles = []
+  started = false
+}
+
+export const __test__ = {
+  extractFields,
+  resolveResourceUpdatedAt,
+}


### PR DESCRIPTION
## Summary

- Localizes Jangar control-plane cache startup, list, and watch reconciliation logic instead of re-exporting Agents internals.
- Keeps Jangar runtime identity, cache config, Kubernetes client, and local fingerprint helper on the cache path.
- Preserves cache resource field extraction and watch deletion/upsert behavior for Agent control-plane resources.

## Related Issues

None

## Testing

- `bun run --cwd services/jangar test -- src/server/__tests__/runtime-startup.test.ts src/server/__tests__/agents-control-plane-summary.test.ts src/server/__tests__/agents-control-plane-resources.test.ts src/server/__tests__/agents-control-plane-resource.test.ts`
- `bunx oxfmt --check services/jangar/src/server/control-plane-cache.ts`
- `bun run --cwd services/jangar tsc`
- `bun run --cwd services/jangar docs:inventory:check && bun run --cwd services/jangar check:module-sizes && git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
