### PR TITLE
refactor(jangar): localize http runtime

### DIFF
--- a/services/jangar/src/server/app.ts
+++ b/services/jangar/src/server/app.ts
@@ -1,15 +1,11 @@
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import {
-  createAgentsHttpRuntime,
-  type AgentsHttpRuntime,
-  type AgentsHttpRuntimeOptions,
-} from '@proompteng/agents/server/http-runtime'
+import { createJangarHttpRuntime, type JangarHttpRuntime, type JangarHttpRuntimeOptions } from './http-runtime'
 
 import { getPrometheusMetricsPath, isPrometheusMetricsEnabled, renderPrometheusMetrics } from './metrics'
 
-export type JangarRuntime = AgentsHttpRuntime
+export type JangarRuntime = JangarHttpRuntime
 
 const serverRouteModules = import.meta.glob([
   '../routes/api/**/*.{ts,tsx}',
@@ -56,8 +52,8 @@ export const getClientOutputDirCandidates = ({
   )
 
 export const createJangarRuntime = async (options: { serveClient?: boolean } = {}): Promise<JangarRuntime> =>
-  createAgentsHttpRuntime({
-    routeModules: serverRouteModules as AgentsHttpRuntimeOptions['routeModules'],
+  createJangarHttpRuntime({
+    routeModules: serverRouteModules as JangarHttpRuntimeOptions['routeModules'],
     routeSources: serverRouteSources,
     serveClient: options.serveClient,
     clientOutputDirCandidates: getClientOutputDirCandidates,

--- a/services/jangar/src/server/http-runtime.ts
+++ b/services/jangar/src/server/http-runtime.ts
@@ -1,0 +1,344 @@
+import { stat } from 'node:fs/promises'
+import { isAbsolute, relative, resolve } from 'node:path'
+
+import wsAdapter from 'crossws/adapters/bun'
+import { createApp, defineEventHandler, getRouterParams, toWebHandler } from 'h3'
+
+export type JangarServerRouteHandler = (args: {
+  request: Request
+  params: Record<string, string>
+}) => Response | Promise<Response>
+
+export type JangarServerRouteModule = {
+  Route?: {
+    options?: {
+      server?: {
+        handlers?: Partial<Record<string, JangarServerRouteHandler>>
+      }
+    }
+  }
+}
+
+export type JangarServerRouteDefinition = {
+  file: string
+  routePath: string
+  handlers: Partial<Record<string, JangarServerRouteHandler>>
+}
+
+export type JangarHttpRuntime = {
+  handleRequest: (request: Request) => Promise<Response>
+  handleUpgrade: (
+    request: Request,
+    server: Bun.Server<unknown>,
+  ) => Promise<{ kind: 'handled' } | { kind: 'response'; response: Response } | { kind: 'skip' }>
+  websocket: Bun.WebSocketHandler<unknown>
+}
+
+export type JangarHttpRuntimeMetrics = {
+  enabled: () => boolean
+  path: () => string
+  render: () => Promise<{ ok: true; body: string } | { ok: false; message: string }>
+}
+
+export type JangarHttpRuntimeOptions = {
+  routeModules: Record<string, () => Promise<unknown>>
+  routeSources: Record<string, string>
+  serveClient?: boolean
+  clientOutputDirCandidates?: () => string[]
+  clientMissingMessage?: string
+  metrics?: JangarHttpRuntimeMetrics
+}
+
+type WebSocketAdapterOptions = NonNullable<Parameters<typeof wsAdapter>[0]>
+type ResolvedWebSocketHooks = NonNullable<WebSocketAdapterOptions['hooks']>
+type WebSocketRouteProbeResponse = Response & { crossws?: ResolvedWebSocketHooks }
+type WebSocketRequest = Request & {
+  context?: Record<string, unknown> & { __jangarResolvedWebSocketHooks?: ResolvedWebSocketHooks }
+}
+
+const serverRoutePattern = /createFileRoute\(\s*(['"`])([^'"`]+)\1\s*\)/
+const serverMethods = ['DELETE', 'GET', 'PATCH', 'POST', 'PUT'] as const
+const defaultClientOutputDirCandidates = () => [resolve(process.cwd(), '.output/public')]
+
+const isWebSocketUpgradeRequest = (request: Request) => request.headers.get('upgrade')?.toLowerCase() === 'websocket'
+
+const getEventRequest = (event: { req: Request }) => event.req
+
+const normalizeRoutePath = (routePath: string) => {
+  if (routePath === '/') return '/'
+
+  const trimmed = routePath.trim()
+  const withoutTrailingSlash = trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed
+  return withoutTrailingSlash.length > 0 ? withoutTrailingSlash : '/'
+}
+
+const toH3RoutePath = (routePath: string) => {
+  const normalized = normalizeRoutePath(routePath)
+  if (normalized === '/') return '/'
+
+  return normalized
+    .split('/')
+    .map((segment) => {
+      if (!segment) return segment
+      if (segment === '$') return '**'
+      if (segment.startsWith('$')) return `:${segment.slice(1)}`
+      return segment
+    })
+    .join('/')
+}
+
+const getRegistrationPaths = (routePath: string) => {
+  const h3RoutePath = toH3RoutePath(routePath)
+  if (h3RoutePath === '/') return ['/']
+  return Array.from(new Set([h3RoutePath, `${h3RoutePath}/`]))
+}
+
+const hasRegularFile = async (path: string) => {
+  try {
+    return (await stat(path)).isFile()
+  } catch {
+    return false
+  }
+}
+
+const isPathInsideDirectory = (rootDir: string, targetPath: string) => {
+  const relativePath = relative(rootDir, targetPath)
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+}
+
+const getFirstPathSegment = (pathname: string) => pathname.split('/').find(Boolean) ?? null
+
+const getServerRouteRoots = (definitions: JangarServerRouteDefinition[]) =>
+  new Set(
+    definitions
+      .map(({ routePath }) => getFirstPathSegment(normalizeRoutePath(routePath)))
+      .filter((segment): segment is string => segment !== null),
+  )
+
+const shouldServeClientPath = (pathname: string, serverRouteRoots: ReadonlySet<string>) => {
+  const firstSegment = getFirstPathSegment(pathname)
+  return firstSegment === null || !serverRouteRoots.has(firstSegment)
+}
+
+const getResolvedWebSocketHooks = (request: Request) =>
+  (request as WebSocketRequest).context?.__jangarResolvedWebSocketHooks
+
+const storeResolvedWebSocketHooks = (request: Request, hooks: ResolvedWebSocketHooks) => {
+  const websocketRequest = request as WebSocketRequest
+  websocketRequest.context = {
+    ...websocketRequest.context,
+    __jangarResolvedWebSocketHooks: hooks,
+  }
+}
+
+const resolveClientIndexPath = async (getClientOutputDirCandidates: () => string[]) => {
+  for (const clientDir of getClientOutputDirCandidates()) {
+    const indexPath = resolve(clientDir, 'index.html')
+    if (await hasRegularFile(indexPath)) return indexPath
+  }
+
+  return null
+}
+
+const resolveStaticFile = async (pathname: string, getClientOutputDirCandidates: () => string[]) => {
+  let decodedPath: string
+  try {
+    decodedPath = decodeURIComponent(pathname)
+  } catch {
+    return null
+  }
+
+  for (const clientDir of getClientOutputDirCandidates()) {
+    if (decodedPath === '/') {
+      const indexPath = resolve(clientDir, 'index.html')
+      if (await hasRegularFile(indexPath)) return indexPath
+      continue
+    }
+
+    const target = resolve(clientDir, `.${decodedPath}`)
+    if (!isPathInsideDirectory(clientDir, target)) continue
+    if (await hasRegularFile(target)) return target
+  }
+
+  return null
+}
+
+const serveClientResponse = async (
+  request: Request,
+  getClientOutputDirCandidates: () => string[],
+  clientMissingMessage: string,
+) => {
+  const { pathname } = new URL(request.url)
+  const staticFile = await resolveStaticFile(pathname, getClientOutputDirCandidates)
+  if (staticFile) {
+    const file = Bun.file(staticFile)
+    return new Response(file, {
+      headers: file.type ? { 'content-type': file.type } : undefined,
+    })
+  }
+
+  const indexPath = await resolveClientIndexPath(getClientOutputDirCandidates)
+  if (!indexPath) {
+    return new Response(clientMissingMessage, { status: 503 })
+  }
+
+  return new Response(Bun.file(indexPath), {
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+  })
+}
+
+const loadServerRoutes = async (
+  routeModules: JangarHttpRuntimeOptions['routeModules'],
+  routeSources: JangarHttpRuntimeOptions['routeSources'],
+): Promise<JangarServerRouteDefinition[]> => {
+  const definitions: JangarServerRouteDefinition[] = []
+
+  for (const [file, source] of Object.entries(routeSources)) {
+    if (file.includes('.test.') || file.includes('.spec.')) continue
+    if (!source.includes('server:')) continue
+
+    const load = routeModules[file]
+    if (!load) continue
+
+    const match = serverRoutePattern.exec(source)
+    const routePath = match?.[2]
+    if (!routePath) continue
+
+    const module = (await load()) as JangarServerRouteModule
+    const handlers = module.Route?.options?.server?.handlers
+    if (!handlers || Object.keys(handlers).length === 0) continue
+
+    definitions.push({
+      file,
+      routePath,
+      handlers,
+    })
+  }
+
+  return definitions
+}
+
+const registerServerRoutes = (app: ReturnType<typeof createApp>, definitions: JangarServerRouteDefinition[]) => {
+  for (const definition of definitions) {
+    for (const method of serverMethods) {
+      const handler = definition.handlers[method]
+      if (!handler) continue
+
+      const wrappedHandler = defineEventHandler((event) =>
+        handler({
+          request: getEventRequest(event),
+          params: getRouterParams(event, { decode: true }),
+        }),
+      )
+
+      for (const path of getRegistrationPaths(definition.routePath)) {
+        switch (method) {
+          case 'DELETE':
+            app.delete(path, wrappedHandler)
+            break
+          case 'GET':
+            app.get(path, wrappedHandler)
+            break
+          case 'PATCH':
+            app.patch(path, wrappedHandler)
+            break
+          case 'POST':
+            app.post(path, wrappedHandler)
+            break
+          case 'PUT':
+            app.put(path, wrappedHandler)
+            break
+        }
+      }
+    }
+  }
+}
+
+export const createJangarHttpRuntime = async (options: JangarHttpRuntimeOptions): Promise<JangarHttpRuntime> => {
+  const app = createApp()
+  const getClientOutputDirCandidates = options.clientOutputDirCandidates ?? defaultClientOutputDirCandidates
+  const clientMissingMessage =
+    options.clientMissingMessage ?? 'Client build output missing. Run the owning service build before serving client.'
+
+  if (options.metrics) {
+    app.use(
+      defineEventHandler(async (event) => {
+        if (!options.metrics?.enabled()) return
+
+        const request = getEventRequest(event)
+        const url = new URL(request.url)
+        if (url.pathname !== options.metrics.path()) return
+
+        const rendered = await options.metrics.render()
+        if (!rendered.ok) {
+          return new Response(JSON.stringify({ ok: false, message: rendered.message }), {
+            status: 404,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+
+        return new Response(rendered.body, {
+          status: 200,
+          headers: { 'content-type': 'text/plain; version=0.0.4; charset=utf-8' },
+        })
+      }),
+    )
+  }
+
+  const serverRouteDefinitions = await loadServerRoutes(options.routeModules, options.routeSources)
+  const serverRouteRoots = getServerRouteRoots(serverRouteDefinitions)
+  registerServerRoutes(app, serverRouteDefinitions)
+
+  if (options.serveClient === true) {
+    const serveClient = defineEventHandler((event) => {
+      const request = getEventRequest(event)
+      const { pathname } = new URL(request.url)
+      if (!shouldServeClientPath(pathname, serverRouteRoots)) {
+        return new Response('Not Found', { status: 404 })
+      }
+      return serveClientResponse(request, getClientOutputDirCandidates, clientMissingMessage)
+    })
+    app.get('/**', serveClient)
+    app.head('/**', serveClient)
+  }
+
+  const handleRequest = toWebHandler(app)
+  const adapter = wsAdapter({
+    resolve: (request) => getResolvedWebSocketHooks(request) ?? {},
+  })
+
+  return {
+    handleRequest,
+    async handleUpgrade(request, server) {
+      if (!isWebSocketUpgradeRequest(request)) {
+        return { kind: 'skip' }
+      }
+
+      const upgradeProbeResponse = (await handleRequest(request)) as WebSocketRouteProbeResponse
+      const routeHooks = upgradeProbeResponse.crossws
+      if (!routeHooks) {
+        return { kind: 'response', response: upgradeProbeResponse }
+      }
+
+      storeResolvedWebSocketHooks(request, routeHooks)
+
+      const response = await adapter.handleUpgrade(request, server)
+      if (response) {
+        return { kind: 'response', response }
+      }
+
+      return { kind: 'handled' }
+    },
+    websocket: adapter.websocket,
+  }
+}
+
+export const __private = {
+  getRegistrationPaths,
+  getServerRouteRoots,
+  isPathInsideDirectory,
+  loadServerRoutes,
+  normalizeRoutePath,
+  shouldServeClientPath,
+  toH3RoutePath,
+}


### PR DESCRIPTION
## Summary

- Adds a Jangar-owned HTTP runtime for server route registration, client fallback serving, metrics routing, and websocket upgrades.
- Updates Jangar app startup to use the local runtime types and factory instead of Agents internals.
- Preserves existing route glob behavior, static client lookup, and websocket upgrade probing semantics.

## Related Issues

None

## Testing

- `bun run --cwd services/jangar test -- src/server/__tests__/app.test.ts src/__tests__/worker-entrypoint.test.ts`
- `bunx oxfmt --check services/jangar/src/server/http-runtime.ts services/jangar/src/server/app.ts services/jangar/src/server/__tests__/app.test.ts`
- `bun run --cwd services/jangar tsc`
- `bun run --cwd services/jangar docs:inventory:check && bun run --cwd services/jangar check:module-sizes && git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
