### PR TITLE
ci(agents): harden extraction build boundaries

### DIFF
--- a/.github/workflows/agents-build-push.yml
+++ b/.github/workflows/agents-build-push.yml
@@ -16,7 +16,6 @@ on:
       - 'packages/scripts/src/shared/**'
       - 'packages/temporal-bun-sdk/**'
       - 'services/agents/**'
-      - 'services/jangar/**'
       - 'skills/**'
       - 'package.json'
       - 'bun.lock'
@@ -25,7 +24,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: agents-build-${{ github.ref }}-${{ github.sha }}
+  group: agents-build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -185,6 +185,7 @@ jobs:
             packages/scripts/src/agents/__tests__/build-image.test.ts \
             packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts \
             packages/scripts/src/agents/__tests__/resolve-published-agents-images.test.ts \
+            packages/scripts/src/agents/__tests__/guard-extraction-boundaries.test.ts \
             packages/scripts/src/agents/__tests__/smoke-agents.test.ts \
             packages/scripts/src/agents/__tests__/deploy-service.test.ts \
             packages/scripts/src/shared/__tests__/docker.test.ts

--- a/packages/scripts/src/agents/__tests__/guard-extraction-boundaries.test.ts
+++ b/packages/scripts/src/agents/__tests__/guard-extraction-boundaries.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'bun:test'
+
+const guardScript = () => readFileSync(resolve(process.cwd(), 'scripts/agents/guard-extraction-boundaries.sh'), 'utf8')
+
+describe('agents extraction boundary guard', () => {
+  it('does not fail on colocated tests that assert forbidden runtime strings are absent', () => {
+    const content = guardScript()
+
+    expect(content).toContain("--glob '!**/__tests__/**'")
+    expect(content).toContain("--glob '!**/*.test.*'")
+  })
+})

--- a/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
+++ b/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
@@ -150,6 +150,18 @@ describe('agents-ci workflow local Agents image build', () => {
     expect(workflow).not.toContain('packages/scripts/src/jangar/__tests__/release-contract.test.ts')
   })
 
+  it('keeps Agents image publication detached from Jangar-only source changes', () => {
+    const workflow = readFileSync(
+      new URL('../../../../../.github/workflows/agents-build-push.yml', import.meta.url),
+      'utf8',
+    )
+
+    expect(workflow).not.toContain("      - 'services/jangar/**'")
+    expect(workflow).toContain('services/agents/**')
+    expect(workflow).toContain('group: agents-build-${{ github.ref }}')
+    expect(workflow).not.toContain('group: agents-build-${{ github.ref }}-${{ github.sha }}')
+  })
+
   it('builds local Agents smoke images from the Agents Dockerfile', () => {
     const workflow = readFileSync(new URL('../../../../../.github/workflows/agents-ci.yml', import.meta.url), 'utf8')
 

--- a/scripts/agents/guard-extraction-boundaries.sh
+++ b/scripts/agents/guard-extraction-boundaries.sh
@@ -10,7 +10,12 @@ fail_if_matches() {
   local pattern="$2"
   shift 2
 
-  if rg -n --glob '!**/__tests__/**' --glob '!guard-extraction-boundaries.sh' "${pattern}" "$@"; then
+  if rg -n \
+    --glob '!**/__tests__/**' \
+    --glob '!**/*.test.*' \
+    --glob '!guard-extraction-boundaries.sh' \
+    "${pattern}" \
+    "$@"; then
     echo "Agents extraction boundary violation: ${description}" >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary

- Ignore colocated `*.test.*` files in the Agents extraction boundary guard so negative assertions do not fail the runtime leakage check.
- Add a regression test for the guard script behavior and include it in the Agents script test set.
- Stop `agents-build-push` from firing on Jangar-only source changes and cancel stale same-ref image builds.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/guard-extraction-boundaries.test.ts`
- `scripts/agents/guard-extraction-boundaries.sh`
- `bunx oxfmt --check .github/workflows/agents-ci.yml packages/scripts/src/agents/__tests__/guard-extraction-boundaries.test.ts scripts/agents/guard-extraction-boundaries.sh`
- `git diff --check`
- `bun test packages/scripts/src/agents/__tests__/build-image.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts packages/scripts/src/agents/__tests__/resolve-published-agents-images.test.ts packages/scripts/src/agents/__tests__/guard-extraction-boundaries.test.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/shared/__tests__/docker.test.ts`
- `bun test packages/scripts/src/agents/__tests__/guard-extraction-boundaries.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`
- `bunx oxfmt --check .github/workflows/agents-build-push.yml .github/workflows/agents-ci.yml packages/scripts/src/agents/__tests__/guard-extraction-boundaries.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts scripts/agents/guard-extraction-boundaries.sh`
- `git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
