### PR TITLE
fix(torghut): require delay-adjusted depth stress

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -2962,6 +2962,55 @@ def _mechanism_overlays_for_card(card: HypothesisCard) -> dict[str, Any]:
 
     if has_any(
         (
+            "delay-adjusted depth",
+            "delay adjusted depth",
+            "execution delay",
+            "execution_delay",
+            "market depth",
+            "market_depth",
+            "depth state",
+            "depth_state",
+            "latency stress",
+            "latency_stress",
+            "fillable",
+            "fillability",
+            "limit_fill_probability",
+        )
+    ):
+        overlay_ids.append("delay_adjusted_depth_stress")
+        overlay_contracts.append(
+            {
+                "overlay_id": "delay_adjusted_depth_stress",
+                "required_evidence": [
+                    "depth_proxy",
+                    "execution_delay",
+                    "fill_model",
+                    "route_tca",
+                    "live_paper_parity",
+                ],
+                "rank_metric": "post_cost_net_pnl_after_delay_adjusted_depth_stress",
+                "evidence_policy": "no_delay_fill_assumptions_are_not_promotion_proof",
+            }
+        )
+        hard_vetoes.update(
+            {
+                "required_delay_adjusted_depth_stress": True,
+                "required_max_route_latency_ms": "250",
+                "required_min_delay_depth_sample_count": "60",
+            }
+        )
+        promotion_contract.update(
+            {
+                "requires_delay_adjusted_depth_stress": True,
+                "requires_execution_delay_replay": True,
+                "requires_depth_proxy_fill_model": True,
+                "requires_route_tca": True,
+                "rejects_no_delay_fill_assumptions": True,
+            }
+        )
+
+    if has_any(
+        (
             "ohlcv-only",
             "ohlcv only",
             "ohlcv_derived",

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -391,6 +391,57 @@ def _market_impact_stress_cost_bps(bundle: CandidateEvidenceBundle) -> Decimal:
     )
 
 
+def _delay_adjusted_depth_stress_passed(bundle: CandidateEvidenceBundle) -> bool:
+    scorecard = _scorecard(bundle)
+    return _boolish(
+        scorecard.get("delay_adjusted_depth_stress_passed")
+        or scorecard.get("delay_depth_stress_passed")
+        or scorecard.get("latency_depth_stress_passed")
+    )
+
+
+def _delay_adjusted_depth_stress_artifact_ref(
+    bundle: CandidateEvidenceBundle,
+) -> str:
+    scorecard = _scorecard(bundle)
+    return _string(
+        scorecard.get("delay_adjusted_depth_stress_artifact_ref")
+        or scorecard.get("delay_depth_stress_artifact_ref")
+        or scorecard.get("latency_depth_stress_artifact_ref")
+    )
+
+
+def _delay_adjusted_depth_stress_net_per_day(
+    bundle: CandidateEvidenceBundle,
+) -> Decimal:
+    scorecard = _scorecard(bundle)
+    return _decimal(
+        scorecard.get("delay_adjusted_depth_stress_net_pnl_per_day")
+        or scorecard.get("delay_depth_stress_net_pnl_per_day")
+        or scorecard.get("latency_depth_stress_net_pnl_per_day")
+    )
+
+
+def _delay_adjusted_depth_stress_ms(bundle: CandidateEvidenceBundle) -> Decimal:
+    scorecard = _scorecard(bundle)
+    return _decimal(
+        scorecard.get("delay_adjusted_depth_stress_ms")
+        or scorecard.get("delay_depth_stress_delay_ms")
+        or scorecard.get("latency_depth_stress_ms")
+    )
+
+
+def _delay_adjusted_depth_fillable_notional_per_day(
+    bundle: CandidateEvidenceBundle,
+) -> Decimal:
+    scorecard = _scorecard(bundle)
+    return _decimal(
+        scorecard.get("delay_adjusted_depth_fillable_notional_per_day")
+        or scorecard.get("delay_depth_stress_fillable_notional_per_day")
+        or scorecard.get("latency_depth_fillable_notional_per_day")
+    )
+
+
 def _positive_net_contribution(bundle: CandidateEvidenceBundle) -> Decimal:
     return max(_net_per_day(bundle), Decimal("0"))
 
@@ -677,6 +728,27 @@ def _portfolio_scorecard(
         ),
         Decimal("0"),
     )
+    delay_depth_artifact_refs = [
+        ref
+        for ref in (
+            _delay_adjusted_depth_stress_artifact_ref(bundle) for bundle in selected
+        )
+        if ref
+    ]
+    delay_depth_stress_net_pnl_per_day = sum(
+        (
+            _delay_adjusted_depth_stress_net_per_day(bundle) * weight
+            for bundle, weight in zip(selected, weights, strict=True)
+        ),
+        Decimal("0"),
+    )
+    delay_depth_fillable_notional_per_day = sum(
+        (
+            _delay_adjusted_depth_fillable_notional_per_day(bundle) * weight
+            for bundle, weight in zip(selected, weights, strict=True)
+        ),
+        Decimal("0"),
+    )
     scorecard = {
         "net_pnl_per_day": str(net_per_day),
         "portfolio_post_cost_net_pnl_per_day": str(net_per_day),
@@ -752,6 +824,25 @@ def _portfolio_scorecard(
         "market_impact_stress_net_pnl_per_day": str(
             market_impact_stress_net_pnl_per_day
         ),
+        "delay_adjusted_depth_stress_passed": bool(selected)
+        and all(_delay_adjusted_depth_stress_passed(bundle) for bundle in selected),
+        "delay_adjusted_depth_stress_artifact_refs": delay_depth_artifact_refs,
+        "delay_adjusted_depth_stress_artifact_ref": delay_depth_artifact_refs[0]
+        if delay_depth_artifact_refs
+        else "",
+        "delay_adjusted_depth_stress_model": "portfolio_latency_depth_haircut",
+        "delay_adjusted_depth_stress_ms": str(
+            max(
+                (_delay_adjusted_depth_stress_ms(bundle) for bundle in selected),
+                default=Decimal("0"),
+            )
+        ),
+        "delay_adjusted_depth_fillable_notional_per_day": str(
+            delay_depth_fillable_notional_per_day
+        ),
+        "delay_adjusted_depth_stress_net_pnl_per_day": str(
+            delay_depth_stress_net_pnl_per_day
+        ),
         "daily_net": {day: str(value) for day, value in sorted(daily_net.items())},
         "daily_filled_notional": {
             day: str(value) for day, value in sorted(daily_notional.items())
@@ -809,6 +900,10 @@ def _portfolio_selection_key(
         Decimal(1 if bool(scorecard.get("market_impact_stress_passed")) else 0),
         _scorecard_decimal(scorecard, "market_impact_stress_net_pnl_per_day"),
         -_scorecard_decimal(scorecard, "market_impact_stress_cost_bps"),
+        Decimal(1 if bool(scorecard.get("delay_adjusted_depth_stress_passed")) else 0),
+        _scorecard_decimal(scorecard, "delay_adjusted_depth_stress_net_pnl_per_day"),
+        _scorecard_decimal(scorecard, "delay_adjusted_depth_fillable_notional_per_day"),
+        -_scorecard_decimal(scorecard, "delay_adjusted_depth_stress_ms"),
         _scorecard_decimal(scorecard, "net_pnl_per_day"),
         -_scorecard_decimal(scorecard, "missing_sleeve_daily_net_count"),
         _scorecard_decimal(scorecard, "avg_filled_notional_per_day"),

--- a/services/torghut/app/trading/discovery/profit_target_oracle.py
+++ b/services/torghut/app/trading/discovery/profit_target_oracle.py
@@ -20,6 +20,13 @@ _ACCEPTED_MARKET_IMPACT_STRESS_MODELS = frozenset(
         "portfolio_power_law_impact",
     }
 )
+_ACCEPTED_DELAY_ADJUSTED_DEPTH_STRESS_MODELS = frozenset(
+    {
+        "latency_depth_haircut",
+        "delay_depth_haircut",
+        "portfolio_latency_depth_haircut",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -52,6 +59,9 @@ class ProfitTargetOraclePolicy:
     require_executable_replay_notional_within_buying_power: bool = True
     require_market_impact_stress: bool = True
     min_market_impact_stress_cost_bps: Decimal = Decimal("1")
+    require_delay_adjusted_depth_stress: bool = True
+    min_delay_adjusted_depth_stress_ms: Decimal = Decimal("50")
+    min_delay_adjusted_depth_fillable_notional_per_day: Decimal = Decimal("300000")
     max_missing_sleeve_daily_net_count: int = 0
 
     def to_payload(self) -> dict[str, Any]:
@@ -98,6 +108,16 @@ class ProfitTargetOraclePolicy:
             ),
             "accepted_market_impact_stress_models": sorted(
                 _ACCEPTED_MARKET_IMPACT_STRESS_MODELS
+            ),
+            "require_delay_adjusted_depth_stress": self.require_delay_adjusted_depth_stress,
+            "min_delay_adjusted_depth_stress_ms": str(
+                self.min_delay_adjusted_depth_stress_ms
+            ),
+            "min_delay_adjusted_depth_fillable_notional_per_day": str(
+                self.min_delay_adjusted_depth_fillable_notional_per_day
+            ),
+            "accepted_delay_adjusted_depth_stress_models": sorted(
+                _ACCEPTED_DELAY_ADJUSTED_DEPTH_STRESS_MODELS
             ),
             "max_missing_sleeve_daily_net_count": self.max_missing_sleeve_daily_net_count,
         }
@@ -635,6 +655,109 @@ def evaluate_profit_target_oracle(
         {
             **market_impact_net_check,
             "source_marker": "double_oos_cost_sensitivity_arxiv_2602_10785_2026",
+        }
+    )
+    delay_depth_artifact_refs = _artifact_refs(
+        scorecard,
+        "delay_adjusted_depth_stress_artifact_ref",
+        "delay_adjusted_depth_stress_artifact_refs",
+        "delay_depth_stress_artifact_ref",
+        "latency_depth_stress_artifact_ref",
+    )
+    delay_depth_artifact_present = bool(delay_depth_artifact_refs)
+    delay_depth_passed = _boolish(
+        scorecard.get("delay_adjusted_depth_stress_passed")
+        or scorecard.get("delay_depth_stress_passed")
+        or scorecard.get("latency_depth_stress_passed")
+    )
+    delay_depth_model = _string(
+        scorecard.get("delay_adjusted_depth_stress_model")
+        or scorecard.get("delay_depth_stress_model")
+        or scorecard.get("latency_depth_stress_model")
+    ).lower()
+    checks.append(
+        {
+            "metric": "delay_adjusted_depth_stress_passed",
+            "observed": str(delay_depth_passed).lower(),
+            "operator": "eq",
+            "threshold": "true",
+            "source_marker": "market_depth_execution_delays_ssrn_6440898_2026",
+            "passed": delay_depth_passed
+            if policy.require_delay_adjusted_depth_stress
+            else True,
+        }
+    )
+    checks.append(
+        {
+            "metric": "delay_adjusted_depth_stress_artifact_present",
+            "observed": str(delay_depth_artifact_present).lower(),
+            "operator": "eq",
+            "threshold": "true",
+            "source_marker": "market_depth_execution_delays_ssrn_6440898_2026",
+            "passed": delay_depth_artifact_present
+            if policy.require_delay_adjusted_depth_stress
+            else True,
+        }
+    )
+    checks.append(
+        {
+            "metric": "delay_adjusted_depth_stress_model",
+            "observed": delay_depth_model,
+            "operator": "in",
+            "threshold": sorted(_ACCEPTED_DELAY_ADJUSTED_DEPTH_STRESS_MODELS),
+            "source_marker": "latency_execution_policy_arxiv_2504_00846_2025",
+            "passed": (
+                delay_depth_model in _ACCEPTED_DELAY_ADJUSTED_DEPTH_STRESS_MODELS
+            )
+            if policy.require_delay_adjusted_depth_stress
+            else True,
+        }
+    )
+    checks.append(
+        _numeric_check(
+            metric="delay_adjusted_depth_stress_ms",
+            observed=_decimal(
+                scorecard.get("delay_adjusted_depth_stress_ms")
+                or scorecard.get("delay_depth_stress_delay_ms")
+                or scorecard.get("latency_depth_stress_ms")
+            ),
+            operator="gte",
+            threshold=policy.min_delay_adjusted_depth_stress_ms
+            if policy.require_delay_adjusted_depth_stress
+            else Decimal("0"),
+        )
+    )
+    checks.append(
+        _numeric_check(
+            metric="delay_adjusted_depth_fillable_notional_per_day",
+            observed=_decimal(
+                scorecard.get("delay_adjusted_depth_fillable_notional_per_day")
+                or scorecard.get("delay_depth_stress_fillable_notional_per_day")
+                or scorecard.get("latency_depth_fillable_notional_per_day")
+            ),
+            operator="gte",
+            threshold=policy.min_delay_adjusted_depth_fillable_notional_per_day
+            if policy.require_delay_adjusted_depth_stress
+            else Decimal("0"),
+        )
+    )
+    delay_depth_net_pnl = _decimal(
+        scorecard.get("delay_adjusted_depth_stress_net_pnl_per_day")
+        or scorecard.get("delay_depth_stress_net_pnl_per_day")
+        or scorecard.get("latency_depth_stress_net_pnl_per_day")
+    )
+    delay_depth_net_check = _numeric_check(
+        metric="delay_adjusted_depth_stress_net_pnl_per_day",
+        observed=delay_depth_net_pnl,
+        operator="gte",
+        threshold=target_net_pnl_per_day,
+    )
+    if not policy.require_delay_adjusted_depth_stress:
+        delay_depth_net_check["passed"] = True
+    checks.append(
+        {
+            **delay_depth_net_check,
+            "source_marker": "rl_market_limit_execution_arxiv_2507_06345_2026",
         }
     )
     blockers = [

--- a/services/torghut/app/trading/discovery/runtime_closure.py
+++ b/services/torghut/app/trading/discovery/runtime_closure.py
@@ -283,7 +283,9 @@ def _runtime_closure_policy(
         "promotion_require_expert_router_registry": False,
         "promotion_require_shadow_live_deviation": False,
         "promotion_require_simulation_calibration": False,
-        "promotion_require_stress_evidence": False,
+        "promotion_require_stress_evidence": True,
+        "promotion_min_stress_case_count": 4,
+        "promotion_stress_max_age_hours": 24,
         "promotion_require_janus_evidence": False,
         "gate6_require_profitability_evidence": False,
         "gate6_require_janus_evidence": False,
@@ -1467,6 +1469,8 @@ def _gate_report(
     shadow_plan: Mapping[str, Any],
     portfolio_optimizer_evidence_ref: str | None = None,
     portfolio_proof_receipt_ref: str | None = None,
+    stress_metrics_ref: str | None = None,
+    stress_metrics_count: int = 0,
 ) -> dict[str, Any]:
     runtime_family = _runtime_family(best_candidate) or "unknown"
     parity_pass = (
@@ -1597,6 +1601,16 @@ def _gate_report(
                     }
                 }
                 if portfolio_optimizer_evidence
+                else {}
+            ),
+            **(
+                {
+                    "stress_metrics": {
+                        "artifact_ref": stress_metrics_ref,
+                        "count": stress_metrics_count,
+                    }
+                }
+                if stress_metrics_ref
                 else {}
             ),
         },
@@ -1855,6 +1869,198 @@ def _market_impact_stress_report(
     }
 
 
+def _delay_adjusted_depth_stress_report(
+    *,
+    runner_run_id: str,
+    best_candidate: Mapping[str, Any],
+    approval_report: Mapping[str, Any],
+    program: StrategyAutoresearchProgram,
+    cost_model_config: CostModelConfig | None = None,
+) -> dict[str, Any]:
+    config = cost_model_config or CostModelConfig()
+    report = _mapping(approval_report)
+    summary = _mapping(report.get("summary"))
+    scorecard = _mapping(report.get("scorecard"))
+    daily_net = {
+        day: _decimal(value)
+        for day, value in _mapping(summary.get("daily_net")).items()
+    }
+    daily_notional = {
+        day: _decimal(value)
+        for day, value in _mapping(summary.get("daily_filled_notional")).items()
+    }
+    trading_days = max(_int(summary.get("trading_day_count")), len(daily_net))
+    total_filled_notional = sum(daily_notional.values(), Decimal("0"))
+    avg_filled_notional = (
+        total_filled_notional / Decimal(trading_days)
+        if trading_days > 0
+        else Decimal("0")
+    )
+    stress_delay_ms = Decimal("250")
+    depth_haircut_rate = min(
+        Decimal("0.50"),
+        max(Decimal("0.10"), stress_delay_ms / Decimal("1000")),
+    )
+    reference_notional = max(
+        program.objective.min_daily_notional,
+        avg_filled_notional,
+        Decimal("1"),
+    )
+    max_participation = (
+        config.max_participation_rate
+        if config.max_participation_rate > 0
+        else Decimal("0.1")
+    )
+    reference_adv = reference_notional / max_participation
+    daily_rows: list[dict[str, str]] = []
+    total_delay_depth_cost = Decimal("0")
+    total_fillable_notional = Decimal("0")
+    weighted_delay_depth_bps_notional = Decimal("0")
+    for day in sorted(daily_net):
+        notional = daily_notional.get(day, Decimal("0"))
+        participation = (
+            min(Decimal("1"), notional / reference_adv)
+            if reference_adv > 0 and notional > 0
+            else Decimal("0")
+        )
+        fillable_notional = notional * (Decimal("1") - depth_haircut_rate)
+        delay_depth_cost_bps = max(
+            Decimal("1"),
+            config.impact_bps_at_full_participation
+            * _decimal_sqrt(participation)
+            * depth_haircut_rate,
+        )
+        delay_depth_cost = (notional * delay_depth_cost_bps) / BPS_SCALE
+        post_delay_depth_net = daily_net[day] - delay_depth_cost
+        total_fillable_notional += fillable_notional
+        total_delay_depth_cost += delay_depth_cost
+        weighted_delay_depth_bps_notional += delay_depth_cost_bps * notional
+        daily_rows.append(
+            {
+                "day": day,
+                "net_pnl": _decimal_string(daily_net[day]),
+                "filled_notional": _decimal_string(notional),
+                "stress_delay_ms": _decimal_string(stress_delay_ms),
+                "depth_haircut_rate": _decimal_string(depth_haircut_rate),
+                "fillable_notional": _decimal_string(fillable_notional),
+                "participation_rate_proxy": _decimal_string(participation),
+                "delay_depth_cost_bps": _decimal_string(delay_depth_cost_bps),
+                "delay_depth_cost": _decimal_string(delay_depth_cost),
+                "post_delay_depth_net_pnl": _decimal_string(post_delay_depth_net),
+            }
+        )
+    delay_depth_cost_bps = (
+        weighted_delay_depth_bps_notional / total_filled_notional
+        if total_filled_notional > 0
+        else Decimal("0")
+    )
+    fillable_notional_per_day = (
+        total_fillable_notional / Decimal(trading_days)
+        if trading_days > 0
+        else Decimal("0")
+    )
+    net_pnl = _decimal(summary.get("net_pnl"))
+    post_delay_depth_net_pnl = net_pnl - total_delay_depth_cost
+    post_delay_depth_net_pnl_per_day = (
+        post_delay_depth_net_pnl / Decimal(trading_days)
+        if trading_days > 0
+        else Decimal("0")
+    )
+    reasons: list[str] = []
+    if trading_days <= 0:
+        reasons.append("delay_adjusted_depth_stress_trading_days_missing")
+    if total_filled_notional <= 0:
+        reasons.append("delay_adjusted_depth_stress_filled_notional_missing")
+    if delay_depth_cost_bps <= 0:
+        reasons.append("delay_adjusted_depth_stress_cost_bps_zero")
+    if fillable_notional_per_day < program.objective.min_daily_notional:
+        reasons.append("delay_adjusted_depth_fillable_notional_below_minimum")
+    if post_delay_depth_net_pnl_per_day < program.objective.target_net_pnl_per_day:
+        reasons.append("delay_adjusted_depth_stress_net_pnl_below_target")
+    if not bool(report.get("objective_met")):
+        reasons.append("approval_replay_objective_not_met")
+    objective_met = not reasons
+    return {
+        "schema_version": "torghut.delay-adjusted-depth-stress-report.v1",
+        "run_id": runner_run_id,
+        "candidate_id": _string(best_candidate.get("candidate_id")),
+        "runtime_family": _runtime_family(best_candidate),
+        "runtime_strategy_name": _runtime_strategy_name(best_candidate),
+        "runtime_strategy_names": list(
+            _portfolio_runtime_strategy_names(best_candidate)
+        ),
+        "model": "latency_depth_haircut",
+        "source_markers": [
+            "market_depth_execution_delays_ssrn_6440898_2026",
+            "latency_execution_policy_arxiv_2504_00846_2025",
+            "rl_market_limit_execution_arxiv_2507_06345_2026",
+        ],
+        "objective_met": objective_met,
+        "passed": objective_met,
+        "reasons": reasons,
+        "target_net_pnl_per_day": _decimal_string(
+            program.objective.target_net_pnl_per_day
+        ),
+        "net_pnl_per_day": _decimal_string(_decimal(scorecard.get("net_pnl_per_day"))),
+        "post_delay_depth_net_pnl_per_day": _decimal_string(
+            post_delay_depth_net_pnl_per_day
+        ),
+        "stressed_net_pnl_per_day": _decimal_string(post_delay_depth_net_pnl_per_day),
+        "net_pnl": _decimal_string(net_pnl),
+        "post_delay_depth_net_pnl": _decimal_string(post_delay_depth_net_pnl),
+        "delay_depth_cost": _decimal_string(total_delay_depth_cost),
+        "delay_depth_cost_bps": _decimal_string(delay_depth_cost_bps),
+        "stress_delay_ms": _decimal_string(stress_delay_ms),
+        "depth_haircut_rate": _decimal_string(depth_haircut_rate),
+        "reference_notional": _decimal_string(reference_notional),
+        "reference_adv_proxy": _decimal_string(reference_adv),
+        "max_participation_rate": _decimal_string(max_participation),
+        "trading_day_count": trading_days,
+        "total_filled_notional": _decimal_string(total_filled_notional),
+        "avg_filled_notional_per_day": _decimal_string(avg_filled_notional),
+        "fillable_notional_per_day": _decimal_string(fillable_notional_per_day),
+        "daily": daily_rows,
+    }
+
+
+def _stress_metrics_payload(
+    *,
+    market_impact_report: Mapping[str, Any] | None,
+    market_impact_ref: str | None,
+    delay_depth_report: Mapping[str, Any] | None,
+    delay_depth_ref: str | None,
+) -> dict[str, Any]:
+    items: list[dict[str, Any]] = []
+    if market_impact_report is not None and market_impact_ref:
+        for row_mapping in _list_of_mappings(market_impact_report.get("daily")):
+            items.append(
+                {
+                    "case_id": f"market_impact:{_string(row_mapping.get('day'))}",
+                    "stress_type": "market_impact",
+                    "artifact_ref": market_impact_ref,
+                    "day": _string(row_mapping.get("day")),
+                    "passed": bool(market_impact_report.get("passed")),
+                }
+            )
+    if delay_depth_report is not None and delay_depth_ref:
+        for row_mapping in _list_of_mappings(delay_depth_report.get("daily")):
+            items.append(
+                {
+                    "case_id": f"delay_adjusted_depth:{_string(row_mapping.get('day'))}",
+                    "stress_type": "delay_adjusted_depth",
+                    "artifact_ref": delay_depth_ref,
+                    "day": _string(row_mapping.get("day")),
+                    "passed": bool(delay_depth_report.get("passed")),
+                }
+            )
+    return {
+        "schema_version": "stress-metrics-v1",
+        "generated_at": _now_iso(),
+        "count": len(items),
+        "items": items,
+    }
+
+
 def _profitability_stage_manifest(
     *,
     root: Path,
@@ -1869,6 +2075,8 @@ def _profitability_stage_manifest(
     portfolio_optimizer_evidence_path: Path | None,
     portfolio_proof_receipt_path: Path | None,
     market_impact_stress_report_path: Path | None,
+    delay_adjusted_depth_stress_report_path: Path | None,
+    stress_metrics_path: Path | None,
     parity_replay_path: Path | None,
     approval_replay_path: Path | None,
     shadow_validation_path: Path | None,
@@ -1932,6 +2140,17 @@ def _profitability_stage_manifest(
     ):
         artifact_hashes[str(market_impact_stress_report_path.relative_to(root))] = (
             _sha256_path(market_impact_stress_report_path)
+        )
+    if (
+        delay_adjusted_depth_stress_report_path is not None
+        and delay_adjusted_depth_stress_report_path.exists()
+    ):
+        artifact_hashes[
+            str(delay_adjusted_depth_stress_report_path.relative_to(root))
+        ] = _sha256_path(delay_adjusted_depth_stress_report_path)
+    if stress_metrics_path is not None and stress_metrics_path.exists():
+        artifact_hashes[str(stress_metrics_path.relative_to(root))] = _sha256_path(
+            stress_metrics_path
         )
     payload = {
         "schema_version": "profitability-stage-manifest-v1",
@@ -2052,6 +2271,20 @@ def _profitability_stage_manifest(
                         and market_impact_stress_report_path.exists()
                         else "fail",
                     },
+                    {
+                        "check": "delay_adjusted_depth_stress_present",
+                        "status": "pass"
+                        if delay_adjusted_depth_stress_report_path is not None
+                        and delay_adjusted_depth_stress_report_path.exists()
+                        else "fail",
+                    },
+                    {
+                        "check": "stress_metrics_present",
+                        "status": "pass"
+                        if stress_metrics_path is not None
+                        and stress_metrics_path.exists()
+                        else "fail",
+                    },
                 ],
                 "artifacts": {
                     "evaluation_report": _artifact(
@@ -2081,6 +2314,30 @@ def _profitability_stage_manifest(
                         }
                         if market_impact_stress_report_path is not None
                         and market_impact_stress_report_path.exists()
+                        else {}
+                    ),
+                    **(
+                        {
+                            "delay_adjusted_depth_stress": _artifact(
+                                delay_adjusted_depth_stress_report_path,
+                                stage="validation",
+                                check="delay_adjusted_depth_stress_present",
+                            )
+                        }
+                        if delay_adjusted_depth_stress_report_path is not None
+                        and delay_adjusted_depth_stress_report_path.exists()
+                        else {}
+                    ),
+                    **(
+                        {
+                            "stress_metrics": _artifact(
+                                stress_metrics_path,
+                                stage="validation",
+                                check="stress_metrics_present",
+                            )
+                        }
+                        if stress_metrics_path is not None
+                        and stress_metrics_path.exists()
                         else {}
                     ),
                 },
@@ -2223,6 +2480,8 @@ class RuntimeClosureBundleSummary:
     portfolio_optimizer_evidence_path: str
     portfolio_proof_receipt_path: str
     market_impact_stress_report_path: str
+    delay_adjusted_depth_stress_report_path: str
+    stress_metrics_path: str
     profitability_stage_manifest_path: str
     promotion_prerequisites_path: str
     replay_plan_path: str
@@ -2251,6 +2510,8 @@ class RuntimeClosureBundleSummary:
             "portfolio_optimizer_evidence_path": self.portfolio_optimizer_evidence_path,
             "portfolio_proof_receipt_path": self.portfolio_proof_receipt_path,
             "market_impact_stress_report_path": self.market_impact_stress_report_path,
+            "delay_adjusted_depth_stress_report_path": self.delay_adjusted_depth_stress_report_path,
+            "stress_metrics_path": self.stress_metrics_path,
             "profitability_stage_manifest_path": self.profitability_stage_manifest_path,
             "promotion_prerequisites_path": self.promotion_prerequisites_path,
             "replay_plan_path": self.replay_plan_path,
@@ -2292,6 +2553,8 @@ def write_runtime_closure_bundle(
             portfolio_optimizer_evidence_path="",
             portfolio_proof_receipt_path="",
             market_impact_stress_report_path="",
+            delay_adjusted_depth_stress_report_path="",
+            stress_metrics_path="",
             profitability_stage_manifest_path="",
             promotion_prerequisites_path="",
             replay_plan_path="",
@@ -2341,6 +2604,10 @@ def write_runtime_closure_bundle(
     market_impact_stress_report_path = (
         closure_root / "backtest" / "market-impact-stress.json"
     )
+    delay_adjusted_depth_stress_report_path = (
+        closure_root / "backtest" / "delay-adjusted-depth-stress.json"
+    )
+    stress_metrics_path = closure_root / "promotion" / "stress-metrics.json"
 
     candidate_spec = _candidate_spec(
         runner_run_id=runner_run_id,
@@ -2438,6 +2705,8 @@ def write_runtime_closure_bundle(
             _write_json(approval_report_path, approval_report)
 
     market_impact_stress_report: dict[str, Any] | None = None
+    delay_adjusted_depth_stress_report: dict[str, Any] | None = None
+    stress_metrics: dict[str, Any] | None = None
     if approval_report is not None:
         market_impact_stress_report = _market_impact_stress_report(
             runner_run_id=runner_run_id,
@@ -2446,6 +2715,27 @@ def write_runtime_closure_bundle(
             program=program,
         )
         _write_json(market_impact_stress_report_path, market_impact_stress_report)
+        delay_adjusted_depth_stress_report = _delay_adjusted_depth_stress_report(
+            runner_run_id=runner_run_id,
+            best_candidate=best_candidate,
+            approval_report=approval_report,
+            program=program,
+        )
+        _write_json(
+            delay_adjusted_depth_stress_report_path,
+            delay_adjusted_depth_stress_report,
+        )
+        stress_metrics = _stress_metrics_payload(
+            market_impact_report=market_impact_stress_report,
+            market_impact_ref=str(
+                market_impact_stress_report_path.relative_to(closure_root)
+            ),
+            delay_depth_report=delay_adjusted_depth_stress_report,
+            delay_depth_ref=str(
+                delay_adjusted_depth_stress_report_path.relative_to(closure_root)
+            ),
+        )
+        _write_json(stress_metrics_path, stress_metrics)
 
     shadow_plan = _shadow_validation_artifact(
         best_candidate=best_candidate,
@@ -2467,6 +2757,22 @@ def write_runtime_closure_bundle(
                 if market_impact_stress_report is not None
                 else ()
             ),
+            *(
+                (
+                    str(
+                        delay_adjusted_depth_stress_report_path.relative_to(
+                            closure_root
+                        )
+                    ),
+                )
+                if delay_adjusted_depth_stress_report is not None
+                else ()
+            ),
+            *(
+                (str(stress_metrics_path.relative_to(closure_root)),)
+                if stress_metrics is not None
+                else ()
+            ),
         ),
     )
     _write_json(portfolio_proof_receipt_path, portfolio_proof_receipt)
@@ -2485,6 +2791,14 @@ def write_runtime_closure_bundle(
         portfolio_proof_receipt_ref=str(
             portfolio_proof_receipt_path.relative_to(closure_root)
         ),
+        stress_metrics_ref=(
+            str(stress_metrics_path.relative_to(closure_root))
+            if stress_metrics is not None
+            else None
+        ),
+        stress_metrics_count=int(stress_metrics.get("count", 0))
+        if stress_metrics is not None
+        else 0,
     )
     _write_json(gate_report_path, gate_report)
     candidate_state = _candidate_state(
@@ -2536,6 +2850,12 @@ def write_runtime_closure_bundle(
         else None,
         market_impact_stress_report_path=market_impact_stress_report_path
         if market_impact_stress_report_path.exists()
+        else None,
+        delay_adjusted_depth_stress_report_path=delay_adjusted_depth_stress_report_path
+        if delay_adjusted_depth_stress_report_path.exists()
+        else None,
+        stress_metrics_path=stress_metrics_path
+        if stress_metrics_path.exists()
         else None,
         parity_replay_path=parity_replay_path if parity_replay_path.exists() else None,
         approval_replay_path=approval_replay_path
@@ -2604,6 +2924,14 @@ def write_runtime_closure_bundle(
         portfolio_proof_receipt_path=str(portfolio_proof_receipt_path),
         market_impact_stress_report_path=str(market_impact_stress_report_path)
         if market_impact_stress_report_path.exists()
+        else "",
+        delay_adjusted_depth_stress_report_path=str(
+            delay_adjusted_depth_stress_report_path
+        )
+        if delay_adjusted_depth_stress_report_path.exists()
+        else "",
+        stress_metrics_path=str(stress_metrics_path)
+        if stress_metrics_path.exists()
         else "",
         profitability_stage_manifest_path=str(profitability_stage_manifest_path),
         promotion_prerequisites_path=str(promotion_prerequisites_path),

--- a/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
@@ -465,11 +465,27 @@ research_sources:
     published_at: '2026-05-15'
     claims:
       - claim_id: execution_delay_depth_state
+        claim_type: feature_recipe
         summary: Market-depth state and execution delay jointly determine whether apparent liquidity is practically fillable.
         implication: Add delay-adjusted depth and route latency stress to fillability scoring instead of using spread alone.
+        horizon_scope: intraday_execution
+        data_requirements:
+          - market_depth
+          - execution_delay
+          - latency_stress
+          - limit_fill_probability
+          - route_tca
       - claim_id: delay_adjusted_liquidity_cost
+        claim_type: validation_requirement
         summary: Apparent liquidity can decay before an order reaches the venue.
         implication: Reject candidates whose live-paper fills depend on optimistic no-delay execution assumptions.
+        horizon_scope: intraday_execution
+        data_requirements:
+          - depth_proxy
+          - execution_delay
+          - fill_model
+          - route_tca
+          - live_paper_parity
   - source_id: orderbook_hawkes_random_environment_2026
     title: 'Assessing the Impact of the Order Book with a Hawkes Process in a Random Environment'
     url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5170318

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -5014,6 +5014,10 @@ def _runtime_closure_artifact_refs(
         "portfolio_proof_receipt_path",
         "market_impact_stress_report_path",
         "market_impact_stress_artifact_path",
+        "delay_adjusted_depth_stress_report_path",
+        "delay_depth_stress_report_path",
+        "latency_depth_stress_artifact_path",
+        "stress_metrics_path",
         "profitability_stage_manifest_path",
         "promotion_prerequisites_path",
         "replay_plan_path",
@@ -5093,6 +5097,46 @@ def _runtime_closure_market_impact_stress_update(
     }
 
 
+def _runtime_closure_delay_adjusted_depth_stress_update(
+    runtime_closure: Mapping[str, Any],
+) -> dict[str, Any]:
+    delay_depth_report_path = _string(
+        runtime_closure.get("delay_adjusted_depth_stress_report_path")
+        or runtime_closure.get("delay_depth_stress_report_path")
+        or runtime_closure.get("latency_depth_stress_artifact_path")
+    )
+    delay_depth_report = _load_json_mapping_artifact(delay_depth_report_path)
+    if not delay_depth_report:
+        return {}
+    return {
+        "delay_adjusted_depth_stress_passed": _boolish(
+            delay_depth_report.get("objective_met") or delay_depth_report.get("passed")
+        ),
+        "delay_adjusted_depth_stress_artifact_ref": delay_depth_report_path,
+        "delay_adjusted_depth_stress_model": _string(
+            delay_depth_report.get("model") or delay_depth_report.get("stress_model")
+        ),
+        "delay_adjusted_depth_stress_ms": str(
+            _decimal(
+                delay_depth_report.get("stress_delay_ms")
+                or delay_depth_report.get("delay_ms")
+            )
+        ),
+        "delay_adjusted_depth_fillable_notional_per_day": str(
+            _decimal(
+                delay_depth_report.get("fillable_notional_per_day")
+                or delay_depth_report.get("depth_fillable_notional_per_day")
+            )
+        ),
+        "delay_adjusted_depth_stress_net_pnl_per_day": str(
+            _decimal(
+                delay_depth_report.get("post_delay_depth_net_pnl_per_day")
+                or delay_depth_report.get("stressed_net_pnl_per_day")
+            )
+        ),
+    }
+
+
 def _runtime_closure_scorecard_update(
     *,
     portfolio: PortfolioCandidateSpec,
@@ -5125,6 +5169,9 @@ def _runtime_closure_scorecard_update(
     )
     shadow_status = _string(shadow_validation.get("status")) or "missing"
     market_impact_update = _runtime_closure_market_impact_stress_update(runtime_closure)
+    delay_depth_update = _runtime_closure_delay_adjusted_depth_stress_update(
+        runtime_closure
+    )
     return {
         "runtime_closure_proof": {
             "status": _string(runtime_closure.get("status")) or "missing",
@@ -5135,6 +5182,9 @@ def _runtime_closure_scorecard_update(
             "executable_replay_artifact_refs": list(executable_artifact_refs),
             "market_impact_stress_artifact_ref": market_impact_update.get(
                 "market_impact_stress_artifact_ref", ""
+            ),
+            "delay_adjusted_depth_stress_artifact_ref": delay_depth_update.get(
+                "delay_adjusted_depth_stress_artifact_ref", ""
             ),
         },
         "runtime_closure_artifact_refs": list(artifact_refs),
@@ -5157,6 +5207,7 @@ def _runtime_closure_scorecard_update(
             _portfolio_executable_max_notional(portfolio)
         ),
         **market_impact_update,
+        **delay_depth_update,
     }
 
 

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -197,9 +197,7 @@ class TestCandidateSpecs(TestCase):
             specs[0].hard_vetoes["required_min_event_cluster_stability_score"],
             "0.60",
         )
-        self.assertTrue(
-            specs[0].promotion_contract["requires_lob_event_stream_parity"]
-        )
+        self.assertTrue(specs[0].promotion_contract["requires_lob_event_stream_parity"])
 
     def test_nonlinear_market_impact_claim_adds_route_tca_contract(self) -> None:
         cards = build_hypothesis_cards(
@@ -243,6 +241,51 @@ class TestCandidateSpecs(TestCase):
         self.assertEqual(
             specs[0].promotion_contract["ranking_cost_model"],
             "post_cost_nonlinear_impact",
+        )
+
+    def test_execution_delay_depth_claim_adds_delay_adjusted_stress_contract(
+        self,
+    ) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-depth-delay",
+            claims=[
+                {
+                    "claim_id": "execution-delay-depth-state",
+                    "claim_type": "feature_recipe",
+                    "claim_text": (
+                        "Market depth and execution delay jointly determine "
+                        "whether apparent liquidity is practically fillable."
+                    ),
+                    "data_requirements": [
+                        "market_depth",
+                        "execution_delay",
+                        "latency_stress",
+                        "limit_fill_probability",
+                        "route_tca",
+                    ],
+                    "confidence": "0.81",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("300")
+        )
+
+        self.assertIn(
+            "delay_adjusted_depth_stress",
+            specs[0].parameter_space["mechanism_overlay_ids"],
+        )
+        self.assertTrue(specs[0].hard_vetoes["required_delay_adjusted_depth_stress"])
+        self.assertEqual(
+            specs[0].hard_vetoes["required_max_route_latency_ms"],
+            "250",
+        )
+        self.assertTrue(
+            specs[0].promotion_contract["requires_delay_adjusted_depth_stress"]
+        )
+        self.assertTrue(
+            specs[0].promotion_contract["rejects_no_delay_fill_assumptions"]
         )
 
     def test_ohlcv_only_claim_adds_falsification_contract(self) -> None:

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -29,6 +29,12 @@ def _executable_scorecard_fields(index: int | str = 0) -> dict[str, object]:
         "market_impact_stress_model": "square_root",
         "market_impact_stress_cost_bps": "6",
         "market_impact_stress_net_pnl_per_day": "535",
+        "delay_adjusted_depth_stress_passed": True,
+        "delay_adjusted_depth_stress_artifact_ref": f"/tmp/delay-adjusted-depth-stress-{index}.json",
+        "delay_adjusted_depth_stress_model": "latency_depth_haircut",
+        "delay_adjusted_depth_stress_ms": "250",
+        "delay_adjusted_depth_fillable_notional_per_day": "525000",
+        "delay_adjusted_depth_stress_net_pnl_per_day": "520",
     }
 
 
@@ -444,9 +450,21 @@ class TestPortfolioOptimizer(TestCase):
             portfolio.objective_scorecard["market_impact_stress_net_pnl_per_day"],
             "575",
         )
+        self.assertEqual(
+            portfolio.objective_scorecard[
+                "delay_adjusted_depth_stress_net_pnl_per_day"
+            ],
+            "1040",
+        )
+        self.assertEqual(
+            portfolio.objective_scorecard[
+                "delay_adjusted_depth_fillable_notional_per_day"
+            ],
+            "1050000",
+        )
         self.assertTrue(portfolio.objective_scorecard["oracle_passed"])
 
-    def test_portfolio_oracle_blocks_missing_market_impact_stress(
+    def test_portfolio_oracle_blocks_missing_stress_evidence(
         self,
     ) -> None:
         bundle = evidence_bundle_from_frontier_candidate(
@@ -506,6 +524,10 @@ class TestPortfolioOptimizer(TestCase):
         self.assertFalse(portfolio.objective_scorecard["oracle_passed"])
         self.assertIn(
             "market_impact_stress_passed_failed",
+            portfolio.objective_scorecard["profit_target_oracle"]["blockers"],
+        )
+        self.assertIn(
+            "delay_adjusted_depth_stress_passed_failed",
             portfolio.objective_scorecard["profit_target_oracle"]["blockers"],
         )
 

--- a/services/torghut/tests/test_profit_target_oracle.py
+++ b/services/torghut/tests/test_profit_target_oracle.py
@@ -21,6 +21,12 @@ def _executable_scorecard_fields() -> dict[str, object]:
         "market_impact_stress_model": "square_root",
         "market_impact_stress_cost_bps": "6",
         "market_impact_stress_net_pnl_per_day": "535",
+        "delay_adjusted_depth_stress_passed": True,
+        "delay_adjusted_depth_stress_artifact_ref": "/tmp/delay-adjusted-depth-stress.json",
+        "delay_adjusted_depth_stress_model": "latency_depth_haircut",
+        "delay_adjusted_depth_stress_ms": "250",
+        "delay_adjusted_depth_fillable_notional_per_day": "525000",
+        "delay_adjusted_depth_stress_net_pnl_per_day": "520",
     }
 
 
@@ -98,6 +104,68 @@ class TestProfitTargetOracle(TestCase):
         self.assertIn("market_impact_stress_model_failed", result["blockers"])
         self.assertIn("market_impact_stress_cost_bps_failed", result["blockers"])
         self.assertIn("market_impact_stress_net_pnl_per_day_failed", result["blockers"])
+
+    def test_profit_target_oracle_rejects_missing_delay_adjusted_depth_stress(
+        self,
+    ) -> None:
+        scorecard = _passing_scorecard()
+        for key in tuple(scorecard):
+            if key.startswith("delay_adjusted_depth_stress") or key.startswith(
+                "delay_adjusted_depth_fillable"
+            ):
+                del scorecard[key]
+
+        result = evaluate_profit_target_oracle(
+            scorecard,
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertFalse(result["passed"])
+        self.assertIn("delay_adjusted_depth_stress_passed_failed", result["blockers"])
+        self.assertIn(
+            "delay_adjusted_depth_stress_artifact_present_failed",
+            result["blockers"],
+        )
+        self.assertIn("delay_adjusted_depth_stress_model_failed", result["blockers"])
+        self.assertIn("delay_adjusted_depth_stress_ms_failed", result["blockers"])
+        self.assertIn(
+            "delay_adjusted_depth_fillable_notional_per_day_failed",
+            result["blockers"],
+        )
+        self.assertIn(
+            "delay_adjusted_depth_stress_net_pnl_per_day_failed",
+            result["blockers"],
+        )
+
+    def test_profit_target_oracle_rejects_failed_delay_adjusted_depth_stress(
+        self,
+    ) -> None:
+        scorecard = {
+            **_passing_scorecard(),
+            "delay_adjusted_depth_stress_passed": False,
+            "delay_adjusted_depth_stress_model": "optimistic_no_delay_fill",
+            "delay_adjusted_depth_stress_ms": "0",
+            "delay_adjusted_depth_fillable_notional_per_day": "250000",
+            "delay_adjusted_depth_stress_net_pnl_per_day": "460",
+        }
+
+        result = evaluate_profit_target_oracle(
+            scorecard,
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertFalse(result["passed"])
+        self.assertIn("delay_adjusted_depth_stress_passed_failed", result["blockers"])
+        self.assertIn("delay_adjusted_depth_stress_model_failed", result["blockers"])
+        self.assertIn("delay_adjusted_depth_stress_ms_failed", result["blockers"])
+        self.assertIn(
+            "delay_adjusted_depth_fillable_notional_per_day_failed",
+            result["blockers"],
+        )
+        self.assertIn(
+            "delay_adjusted_depth_stress_net_pnl_per_day_failed",
+            result["blockers"],
+        )
 
     def test_profit_target_oracle_accepts_controlled_down_days(self) -> None:
         result = evaluate_profit_target_oracle(

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -2582,6 +2582,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn("learning_from_book_short_run_efficiency_2026", source_ids)
         self.assertIn("idiosyncratic_trade_imbalance_2026", source_ids)
         self.assertIn("intraday_price_asymmetry_sp500_2026", source_ids)
+        self.assertIn("market_depth_execution_delays_2026", source_ids)
 
         weighted_microprice = next(
             source
@@ -2606,9 +2607,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn("feature_recipe", impact_claim_types)
         self.assertIn("risk_constraint", impact_claim_types)
         self.assertIn("route_tca", impact_source.claims[0]["data_requirements"])
-        self.assertEqual(
-            impact_source.claims[0]["horizon_scope"], "intraday_execution"
-        )
+        self.assertEqual(impact_source.claims[0]["horizon_scope"], "intraday_execution")
         self.assertTrue(runner.compile_sources_to_hypothesis_cards([impact_source]))
 
         latent_regime_source = next(
@@ -2630,6 +2629,21 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         book_claim_types = {str(claim["claim_type"]) for claim in book_source.claims}
         self.assertIn("feature_recipe", book_claim_types)
         self.assertIn("validation_requirement", book_claim_types)
+
+        depth_delay_source = next(
+            source
+            for source in sources
+            if source.run_id == "market_depth_execution_delays_2026"
+        )
+        depth_delay_claim_types = {
+            str(claim["claim_type"]) for claim in depth_delay_source.claims
+        }
+        self.assertIn("feature_recipe", depth_delay_claim_types)
+        self.assertIn("validation_requirement", depth_delay_claim_types)
+        self.assertIn("market_depth", depth_delay_source.claims[0]["data_requirements"])
+        self.assertIn(
+            "execution_delay", depth_delay_source.claims[0]["data_requirements"]
+        )
 
     def test_runtime_closure_replay_is_disabled_when_candidate_already_failed_oracle(
         self,
@@ -2768,6 +2782,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             shadow_path = replay_dir / "shadow-validation-plan.json"
             replay_plan_path = replay_dir / "runtime-replay-plan.json"
             market_impact_path = replay_dir / "market-impact-stress.json"
+            delay_depth_path = replay_dir / "delay-adjusted-depth-stress.json"
             gate_path = gates_dir / "gate-evaluation.json"
             proof_path = promotion_dir / "portfolio-proof-receipt.json"
             summary_path = runtime_root / "summary.json"
@@ -2820,6 +2835,19 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                         "model": "square_root",
                         "impact_cost_bps": "5",
                         "post_impact_net_pnl_per_day": "610",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            delay_depth_path.write_text(
+                json.dumps(
+                    {
+                        "objective_met": True,
+                        "model": "latency_depth_haircut",
+                        "stress_delay_ms": "250",
+                        "fillable_notional_per_day": "300000",
+                        "post_delay_depth_net_pnl_per_day": "605",
                     }
                 )
                 + "\n",
@@ -2896,6 +2924,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                     "portfolio_proof_receipt_path": str(proof_path),
                     "replay_plan_path": str(replay_plan_path),
                     "market_impact_stress_report_path": str(market_impact_path),
+                    "delay_adjusted_depth_stress_report_path": str(delay_depth_path),
                 },
                 target=Decimal("500"),
                 oracle_policy=policy,

--- a/services/torghut/tests/test_runtime_closure.py
+++ b/services/torghut/tests/test_runtime_closure.py
@@ -1291,6 +1291,10 @@ data:
             self.assertTrue(Path(summary.parity_replay_path).exists())
             self.assertTrue(Path(summary.approval_replay_path).exists())
             self.assertTrue(Path(summary.market_impact_stress_report_path).exists())
+            self.assertTrue(
+                Path(summary.delay_adjusted_depth_stress_report_path).exists()
+            )
+            self.assertTrue(Path(summary.stress_metrics_path).exists())
             self.assertTrue(Path(summary.shadow_validation_path).exists())
             self.assertIn("live_shadow_validation", summary.next_required_steps)
 
@@ -1306,6 +1310,18 @@ data:
             )
             self.assertEqual(market_impact_report["model"], "square_root")
             self.assertGreater(Decimal(market_impact_report["impact_cost_bps"]), 0)
+            delay_depth_report = json.loads(
+                Path(summary.delay_adjusted_depth_stress_report_path).read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(delay_depth_report["model"], "latency_depth_haircut")
+            self.assertGreater(Decimal(delay_depth_report["delay_depth_cost_bps"]), 0)
+            stress_metrics = json.loads(
+                Path(summary.stress_metrics_path).read_text(encoding="utf-8")
+            )
+            self.assertEqual(stress_metrics["schema_version"], "stress-metrics-v1")
+            self.assertGreaterEqual(stress_metrics["count"], 4)
 
             stage_manifest = json.loads(
                 Path(summary.profitability_stage_manifest_path).read_text(
@@ -1314,6 +1330,14 @@ data:
             )
             self.assertIn(
                 "market_impact_stress",
+                stage_manifest["stages"]["validation"]["artifacts"],
+            )
+            self.assertIn(
+                "delay_adjusted_depth_stress",
+                stage_manifest["stages"]["validation"]["artifacts"],
+            )
+            self.assertIn(
+                "stress_metrics",
                 stage_manifest["stages"]["validation"]["artifacts"],
             )
 
@@ -1351,6 +1375,43 @@ data:
         self.assertGreater(Decimal(report["impact_cost_bps"]), Decimal("1"))
         self.assertGreaterEqual(
             Decimal(report["post_impact_net_pnl_per_day"]), Decimal("500")
+        )
+
+    def test_delay_adjusted_depth_stress_report_blocks_no_delay_fill_assumption(
+        self,
+    ) -> None:
+        report = runtime_closure._delay_adjusted_depth_stress_report(
+            runner_run_id="run-depth-delay",
+            best_candidate={
+                "candidate_id": "cand-depth-delay",
+                "runtime_family": "microstructure_continuation",
+                "runtime_strategy_name": "microbar-volume-continuation-long-v1",
+            },
+            approval_report={
+                "objective_met": True,
+                "summary": {
+                    "trading_day_count": 2,
+                    "net_pnl": "1100",
+                    "daily_net": {
+                        "2026-05-18": "550",
+                        "2026-05-19": "550",
+                    },
+                    "daily_filled_notional": {
+                        "2026-05-18": "300000",
+                        "2026-05-19": "300000",
+                    },
+                },
+                "scorecard": {"net_pnl_per_day": "550"},
+            },
+            program=_program(),
+        )
+
+        self.assertFalse(report["objective_met"])
+        self.assertEqual(report["model"], "latency_depth_haircut")
+        self.assertEqual(report["stress_delay_ms"], "250")
+        self.assertIn(
+            "delay_adjusted_depth_fillable_notional_below_minimum",
+            report["reasons"],
         )
 
     def test_write_runtime_closure_bundle_keeps_pending_parity_when_execution_skipped(

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -520,6 +520,7 @@ class TestStrategyAutoresearch(TestCase):
                 "learning_from_book_short_run_efficiency_2026",
                 "idiosyncratic_trade_imbalance_2026",
                 "intraday_price_asymmetry_sp500_2026",
+                "market_depth_execution_delays_2026",
             }.issubset(source_ids)
         )
         impact_source = next(
@@ -530,6 +531,17 @@ class TestStrategyAutoresearch(TestCase):
         self.assertEqual(impact_source.claims[0].claim_type, "feature_recipe")
         self.assertIn("route_tca", impact_source.claims[0].data_requirements)
         self.assertEqual(impact_source.claims[0].horizon_scope, "intraday_execution")
+        depth_delay_source = next(
+            source
+            for source in program.research_sources
+            if source.source_id == "market_depth_execution_delays_2026"
+        )
+        self.assertEqual(depth_delay_source.claims[0].claim_type, "feature_recipe")
+        self.assertIn("market_depth", depth_delay_source.claims[0].data_requirements)
+        self.assertIn("execution_delay", depth_delay_source.claims[0].data_requirements)
+        self.assertEqual(
+            depth_delay_source.claims[0].horizon_scope, "intraday_execution"
+        )
 
         microbar_seed_names = {
             plan.seed_sweep_config.name

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -654,6 +654,14 @@ class TestSubmissionCouncil(TestCase):
                         "market_impact_stress_model": "square_root",
                         "market_impact_stress_cost_bps": "6",
                         "market_impact_stress_net_pnl_per_day": "535",
+                        "delay_adjusted_depth_stress_passed": True,
+                        "delay_adjusted_depth_stress_artifact_ref": (
+                            "s3://proof/current-ready-delay-depth.json"
+                        ),
+                        "delay_adjusted_depth_stress_model": "latency_depth_haircut",
+                        "delay_adjusted_depth_stress_ms": "250",
+                        "delay_adjusted_depth_fillable_notional_per_day": "300000",
+                        "delay_adjusted_depth_stress_net_pnl_per_day": "525",
                     },
                     optimizer_report_json={"method": "current_optimizer"},
                     payload_json={"portfolio_candidate_id": "portfolio-current-ready"},


### PR DESCRIPTION
## Summary

- Adds a fail-closed delay-adjusted depth stress gate to the Torghut profit-target oracle so no-delay fill assumptions cannot pass promotion proof.
- Carries delay/depth stress through portfolio sleeve aggregation, selection ranking, runtime-closure artifacts, and runtime proof scorecard import.
- Actualizes the 2026 market-depth/execution-delay research source into explicit candidate-spec overlays, hard vetoes, and promotion contracts.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_profit_target_oracle.py tests/test_portfolio_optimizer.py tests/test_runtime_closure.py tests/test_candidate_specs.py tests/test_strategy_autoresearch.py tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/profit_target_oracle.py app/trading/discovery/portfolio_optimizer.py app/trading/discovery/runtime_closure.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_profit_target_oracle.py tests/test_portfolio_optimizer.py tests/test_runtime_closure.py tests/test_candidate_specs.py tests/test_strategy_autoresearch.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/discovery/profit_target_oracle.py app/trading/discovery/portfolio_optimizer.py app/trading/discovery/runtime_closure.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_profit_target_oracle.py tests/test_portfolio_optimizer.py tests/test_runtime_closure.py tests/test_candidate_specs.py tests/test_strategy_autoresearch.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen coverage erase && uv run --frozen coverage run -m pytest tests/test_profit_target_oracle.py tests/test_portfolio_optimizer.py tests/test_runtime_closure.py tests/test_candidate_specs.py tests/test_strategy_autoresearch.py tests/test_run_whitepaper_autoresearch_profit_target.py && uv run --frozen coverage xml -o coverage.xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
