### PR TITLE
chore(jangar): promote image 924abac7

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-19T11:21:04Z
+    deploy.knative.dev/rollout: 2026-05-19T13:10:44Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:62d899ba@sha256:61465157160fc4fead5d530df2c354ea09d61f3f6e6594fe7850ae48622d8128
+              value: registry.ide-newton.ts.net/lab/jangar:924abac7@sha256:6a94d2b1ee822276185de21d3f4d2501057281ad90011d5f9f3b355b9770ed52
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 62d899ba245f244b8a5142e41f8e70936617328f
+              value: 924abac7c04b3a94c899b1e983fd28e577ea489b
             - name: JANGAR_GITOPS_REVISION
-              value: 62d899ba245f244b8a5142e41f8e70936617328f
+              value: 924abac7c04b3a94c899b1e983fd28e577ea489b
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -407,15 +407,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26093309024"
+              value: "26099154339"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:7e45a624f4013c658b8d487dc363c60ce215ded0273076ec1b7980cee355ae07
+              value: sha256:691d8451fe1ba2a703407eb3360047285a232338da01da8455f69ce4d775b5e8
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 62d899ba245f244b8a5142e41f8e70936617328f
+              value: 924abac7c04b3a94c899b1e983fd28e577ea489b
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:7e45a624f4013c658b8d487dc363c60ce215ded0273076ec1b7980cee355ae07
+              value: sha256:691d8451fe1ba2a703407eb3360047285a232338da01da8455f69ce4d775b5e8
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -59,5 +59,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 62d899ba
-    digest: sha256:61465157160fc4fead5d530df2c354ea09d61f3f6e6594fe7850ae48622d8128
+    newTag: 924abac7
+    digest: sha256:6a94d2b1ee822276185de21d3f4d2501057281ad90011d5f9f3b355b9770ed52


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `924abac7c04b3a94c899b1e983fd28e577ea489b`
- Image tag: `924abac7`
- Image digest: `sha256:6a94d2b1ee822276185de21d3f4d2501057281ad90011d5f9f3b355b9770ed52`
- Source CI run: `26099154339`
- Control-plane serving digest: `sha256:691d8451fe1ba2a703407eb3360047285a232338da01da8455f69ce4d775b5e8`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates