### PR TITLE
fix(torghut): require h-micro depth proof on imports

### DIFF
--- a/services/torghut/app/trading/discovery/runtime_closure.py
+++ b/services/torghut/app/trading/discovery/runtime_closure.py
@@ -1980,10 +1980,15 @@ def _delay_adjusted_depth_stress_report(
     if not bool(report.get("objective_met")):
         reasons.append("approval_replay_objective_not_met")
     objective_met = not reasons
+    generated_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    candidate_id = _string(best_candidate.get("candidate_id"))
     return {
         "schema_version": "torghut.delay-adjusted-depth-stress-report.v1",
         "run_id": runner_run_id,
-        "candidate_id": _string(best_candidate.get("candidate_id")),
+        "candidate_id": candidate_id,
+        "report_id": f"{runner_run_id}:{candidate_id}:delay-adjusted-depth-stress",
+        "generated_at": generated_at,
+        "checked_at": generated_at,
         "runtime_family": _runtime_family(best_candidate),
         "runtime_strategy_name": _runtime_strategy_name(best_candidate),
         "runtime_strategy_names": list(
@@ -1998,6 +2003,8 @@ def _delay_adjusted_depth_stress_report(
         "objective_met": objective_met,
         "passed": objective_met,
         "reasons": reasons,
+        "case_count": len(daily_rows),
+        "stress_case_count": len(daily_rows),
         "target_net_pnl_per_day": _decimal_string(
             program.objective.target_net_pnl_per_day
         ),

--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -1282,6 +1282,11 @@ def compile_hypothesis_runtime_statuses(
             elif delay_depth_stress.passed is False:
                 reasons.append("delay_adjusted_depth_stress_failed")
             if (
+                delay_depth_stress.checked_at is None
+                and requirements.max_delay_adjusted_depth_stress_age_minutes is not None
+            ):
+                reasons.append("delay_adjusted_depth_stress_missing")
+            if (
                 requirements.max_delay_adjusted_depth_stress_age_minutes is not None
                 and delay_depth_stress_age_minutes is not None
                 and delay_depth_stress_age_minutes

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -92,6 +92,43 @@ def _text(value: Any) -> str | None:
     return text or None
 
 
+def _parse_observation_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return _utc(value)
+    text = _text(value)
+    if text is None:
+        return None
+    try:
+        return _utc(datetime.fromisoformat(text.replace("Z", "+00:00")))
+    except ValueError:
+        return None
+
+
+def _observation_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float, Decimal)):
+        return bool(value)
+    text = _text(value)
+    if text is None:
+        return None
+    normalized = text.lower()
+    if normalized in {"1", "true", "yes", "on", "pass", "passed", "ok", "ready"}:
+        return True
+    if normalized in {"0", "false", "no", "off", "fail", "failed", "blocked"}:
+        return False
+    return None
+
+
+def _observation_int(value: Any) -> int:
+    try:
+        return max(0, int(Decimal(str(value))))
+    except Exception:
+        return 0
+
+
 def _string_list(value: Any) -> list[str]:
     if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
         return []
@@ -100,6 +137,61 @@ def _string_list(value: Any) -> list[str]:
         for item in cast(Sequence[object], value)
         if (text := _text(item)) is not None
     ]
+
+
+def _delay_adjusted_depth_stress_blocking_reasons(
+    *,
+    manifest: HypothesisManifest,
+    runtime_payload: Mapping[str, Any],
+    now: datetime,
+) -> list[str]:
+    requirements = manifest.entry_requirements
+    if not requirements.require_delay_adjusted_depth_stress:
+        return []
+
+    raw_report = runtime_payload.get("delay_adjusted_depth_stress_report")
+    report: Mapping[str, Any]
+    if isinstance(raw_report, Mapping):
+        report = cast(Mapping[str, Any], raw_report)
+    else:
+        report = {}
+    check_count = max(
+        _observation_int(
+            runtime_payload.get("delay_adjusted_depth_stress_checks_total")
+        ),
+        _observation_int(runtime_payload.get("delay_depth_stress_checks_total")),
+        _observation_int(report.get("stress_case_count")),
+        _observation_int(report.get("case_count")),
+        _observation_int(report.get("trading_day_count")),
+    )
+    passed = _observation_bool(
+        runtime_payload.get("delay_adjusted_depth_stress_passed")
+        if runtime_payload.get("delay_adjusted_depth_stress_passed") is not None
+        else report.get("passed", report.get("ok"))
+    )
+    checked_at = (
+        _parse_observation_datetime(
+            runtime_payload.get("delay_adjusted_depth_stress_checked_at")
+        )
+        or _parse_observation_datetime(report.get("generated_at"))
+        or _parse_observation_datetime(report.get("checked_at"))
+    )
+
+    reasons: list[str] = []
+    if check_count < requirements.min_delay_adjusted_depth_stress_checks:
+        reasons.append("delay_adjusted_depth_stress_missing")
+    elif passed is not True:
+        reasons.append("delay_adjusted_depth_stress_failed")
+    if checked_at is None:
+        reasons.append("delay_adjusted_depth_stress_missing")
+    elif (
+        requirements.max_delay_adjusted_depth_stress_age_minutes is not None
+        and checked_at
+        < now
+        - timedelta(minutes=requirements.max_delay_adjusted_depth_stress_age_minutes)
+    ):
+        reasons.append("delay_adjusted_depth_stress_stale")
+    return list(dict.fromkeys(reasons))
 
 
 def _capital_stage_for_runtime_import(
@@ -484,6 +576,22 @@ def persist_observed_runtime_windows(
         latest_three_budget_ok=latest_three_budget_ok,
         manifest=manifest,
         budget=budget,
+    )
+    latest_observation_at = max(
+        (bucket.window_ended_at for bucket in sorted_buckets),
+        default=datetime.now(timezone.utc),
+    )
+    promotion_blocking_reasons = list(
+        dict.fromkeys(
+            [
+                *promotion_blocking_reasons,
+                *_delay_adjusted_depth_stress_blocking_reasons(
+                    manifest=manifest,
+                    runtime_payload=runtime_payload,
+                    now=latest_observation_at,
+                ),
+            ]
+        )
     )
     promotion_allowed = not promotion_blocking_reasons
     running_session_samples = 0

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -49,6 +49,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--source-kind", default="")
     parser.add_argument("--dataset-snapshot-ref", default="")
     parser.add_argument("--artifact-ref", action="append", default=[])
+    parser.add_argument("--delay-adjusted-depth-stress-report-ref", default="")
     parser.add_argument("--dependency-quorum-decision", default="allow")
     parser.add_argument("--continuity-ok", default="true")
     parser.add_argument("--drift-ok", default="true")
@@ -85,6 +86,13 @@ def _decimal_or_none(value: Any) -> Decimal | None:
         return Decimal(text)
     except Exception:
         return None
+
+
+def _nonnegative_int(value: Any) -> int:
+    try:
+        return max(0, int(Decimal(str(value))))
+    except Exception:
+        return 0
 
 
 def _strategy_name_candidates(*values: str | None) -> list[str]:
@@ -133,6 +141,20 @@ def _load_report_post_cost_expectancy_bps(artifact_refs: list[str]) -> Decimal |
             continue
         return (net_pnl / execution_notional) * Decimal("10000")
     return None
+
+
+def _load_json_artifact(ref: str) -> dict[str, Any]:
+    text = ref.strip()
+    if not text:
+        return {}
+    path = Path(text)
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return _as_mapping(payload)
 
 
 def _query_timestamps(
@@ -241,6 +263,12 @@ def main() -> int:
     artifact_refs = [
         str(item).strip() for item in args.artifact_ref if str(item).strip()
     ]
+    delay_depth_report_ref = str(
+        getattr(args, "delay_adjusted_depth_stress_report_ref", "") or ""
+    ).strip()
+    delay_depth_report = _load_json_artifact(delay_depth_report_ref)
+    if delay_depth_report_ref:
+        artifact_refs.append(delay_depth_report_ref)
     report_post_cost_expectancy_bps = _load_report_post_cost_expectancy_bps(
         artifact_refs
     )
@@ -300,6 +328,29 @@ def main() -> int:
             else None
         ),
     }
+    if delay_depth_report_ref:
+        runtime_observation_payload.update(
+            {
+                "delay_adjusted_depth_stress_artifact_ref": delay_depth_report_ref,
+                "delay_adjusted_depth_stress_report": delay_depth_report,
+                "delay_adjusted_depth_stress_checks_total": max(
+                    _nonnegative_int(delay_depth_report.get("stress_case_count")),
+                    _nonnegative_int(delay_depth_report.get("case_count")),
+                    _nonnegative_int(delay_depth_report.get("trading_day_count")),
+                )
+                if delay_depth_report
+                else 0,
+                "delay_adjusted_depth_stress_passed": delay_depth_report.get("passed")
+                if delay_depth_report
+                else False,
+                "delay_adjusted_depth_stress_checked_at": (
+                    delay_depth_report.get("generated_at")
+                    or delay_depth_report.get("checked_at")
+                )
+                if delay_depth_report
+                else None,
+            }
+        )
     with SessionLocal() as session:
         summary = persist_observed_runtime_windows(
             session=session,

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -57,7 +57,8 @@ def _parse_args() -> argparse.Namespace:
             "Repeatable comma-separated key=value runtime import target. "
             "Supported keys: hypothesis_id,candidate_id,strategy_family,"
             "strategy_name,account_label,observed_stage,source_dsn_env,"
-            "dataset_snapshot_ref,source_manifest_ref,source_kind."
+            "dataset_snapshot_ref,source_manifest_ref,source_kind,"
+            "delay_adjusted_depth_stress_report_ref."
         ),
     )
     parser.add_argument("--runtime-window-hypothesis-id", default="H-TSMOM-01")
@@ -154,6 +155,7 @@ class RuntimeWindowImportTarget:
     dataset_snapshot_ref: str
     source_manifest_ref: str
     source_kind: str
+    delay_adjusted_depth_stress_report_ref: str
 
 
 def _parse_runtime_window_target_spec(spec: str) -> dict[str, str]:
@@ -229,6 +231,10 @@ def _runtime_window_targets(
                 ),
                 source_kind=value("source_kind", "runtime_window_source_kind")
                 or "paper_runtime_observed",
+                delay_adjusted_depth_stress_report_ref=value(
+                    "delay_adjusted_depth_stress_report_ref",
+                    "runtime_window_delay_adjusted_depth_stress_report_ref",
+                ),
             )
         )
     return targets
@@ -479,6 +485,15 @@ def _run_runtime_window_import_target(
     )
     if dataset_snapshot_ref is not None:
         command.extend(["--dataset-snapshot-ref", dataset_snapshot_ref])
+    delay_depth_report_ref = (
+        _as_text(target.delay_adjusted_depth_stress_report_ref)
+        or _as_text(runtime_manifest.get("delay_adjusted_depth_stress_report_ref"))
+        or _as_text(runtime_manifest.get("delay_adjusted_depth_stress_report_path"))
+    )
+    if delay_depth_report_ref is not None:
+        command.extend(
+            ["--delay-adjusted-depth-stress-report-ref", delay_depth_report_ref]
+        )
     result = subprocess.run(command, check=True, capture_output=True, text=True)
     payload = json.loads(result.stdout)
     return {

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -5038,6 +5038,13 @@ def _runtime_report_summary_int(
         return default
 
 
+def _runtime_report_int(value: Any, *, default: int = 0) -> int:
+    try:
+        return max(0, int(Decimal(str(value if value is not None else default))))
+    except Exception:
+        return default
+
+
 def _runtime_closure_start_equity(runtime_closure: Mapping[str, Any]) -> Decimal:
     replay_plan = _load_json_mapping_artifact(runtime_closure.get("replay_plan_path"))
     execution_context = _mapping(replay_plan.get("execution_context"))
@@ -5108,11 +5115,21 @@ def _runtime_closure_delay_adjusted_depth_stress_update(
     delay_depth_report = _load_json_mapping_artifact(delay_depth_report_path)
     if not delay_depth_report:
         return {}
+    checked_at = _string(
+        delay_depth_report.get("generated_at") or delay_depth_report.get("checked_at")
+    )
     return {
+        "delay_adjusted_depth_stress_checks_total": max(
+            _runtime_report_int(delay_depth_report.get("stress_case_count")),
+            _runtime_report_int(delay_depth_report.get("case_count")),
+            _runtime_report_int(delay_depth_report.get("trading_day_count")),
+        ),
         "delay_adjusted_depth_stress_passed": _boolish(
             delay_depth_report.get("objective_met") or delay_depth_report.get("passed")
         ),
+        "delay_adjusted_depth_stress_checked_at": checked_at,
         "delay_adjusted_depth_stress_artifact_ref": delay_depth_report_path,
+        "delay_adjusted_depth_stress_report": dict(delay_depth_report),
         "delay_adjusted_depth_stress_model": _string(
             delay_depth_report.get("model") or delay_depth_report.get("stress_model")
         ),

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -483,6 +483,56 @@ class TestHypothesisReadiness(TestCase):
             "proof/h-micro-delay-depth-failed.json",
         )
 
+    def test_compile_hypothesis_runtime_statuses_blocks_h_micro_on_untimed_delay_depth_stress(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        state = _state(
+            feature_rows=5,
+            drift_checks=3,
+            evidence_checks=2,
+            signal_lag_seconds=15,
+            evidence_report={
+                "ok": True,
+                "checked_at": "2026-03-06T15:45:00+00:00",
+            },
+        )
+
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=state,
+            tca_summary={
+                "order_count": 80,
+                "avg_abs_slippage_bps": 4,
+                "avg_realized_shortfall_bps": -12,
+                "last_computed_at": "2026-03-06T15:50:00+00:00",
+            },
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            feature_readiness={
+                "order_book_liquidity_rows": 5,
+                "delay_adjusted_depth_stress_report": {
+                    "case_count": 1,
+                    "passed": True,
+                    "report_id": "proof/h-micro-delay-depth-untimed.json",
+                },
+            },
+            now=datetime(2026, 3, 6, 16, 0, tzinfo=timezone.utc),
+        )
+
+        micro = next(item for item in statuses if item["hypothesis_id"] == "H-MICRO-01")
+        self.assertFalse(micro["promotion_eligible"])
+        self.assertEqual(micro["state"], "blocked")
+        self.assertIn("delay_adjusted_depth_stress_missing", micro["reasons"])
+        self.assertEqual(micro["observed"]["delay_adjusted_depth_stress_passed"], True)
+        self.assertEqual(
+            micro["observed"]["delay_adjusted_depth_stress_age_minutes"], None
+        )
+
     def test_compile_hypothesis_runtime_statuses_uses_route_filtered_tca_when_enabled(
         self,
     ) -> None:

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -10,7 +10,9 @@ from unittest.mock import patch
 
 from scripts.import_hypothesis_runtime_windows import (
     EXECUTION_ELIGIBLE_DECISION_STATUSES,
+    _load_json_artifact,
     _load_report_post_cost_expectancy_bps,
+    _nonnegative_int,
     _parse_args,
     _query_timestamps,
     _strategy_name_candidates,
@@ -139,6 +141,23 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             value = _load_report_post_cost_expectancy_bps([str(report_path)])
 
         self.assertEqual(value, Decimal("3.306984755680006238084907933"))
+
+    def test_json_artifact_and_nonnegative_int_helpers_fail_closed(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            missing_path = Path(temp_dir) / "missing.json"
+            invalid_path = Path(temp_dir) / "invalid.json"
+            valid_path = Path(temp_dir) / "valid.json"
+            invalid_path.write_text("{", encoding="utf-8")
+            valid_path.write_text('{"case_count": 2}', encoding="utf-8")
+
+            self.assertEqual(_load_json_artifact(""), {})
+            self.assertEqual(_load_json_artifact(str(missing_path)), {})
+            self.assertEqual(_load_json_artifact(str(invalid_path)), {})
+            self.assertEqual(_load_json_artifact(str(valid_path)), {"case_count": 2})
+
+        self.assertEqual(_nonnegative_int("3.9"), 3)
+        self.assertEqual(_nonnegative_int("-2"), 0)
+        self.assertEqual(_nonnegative_int("bad"), 0)
 
     def test_strategy_name_candidates_include_catalog_aliases(self) -> None:
         candidates = _strategy_name_candidates(
@@ -308,3 +327,95 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "intraday-tsmom-v1",
             ],
         )
+
+    def test_main_attaches_delay_adjusted_depth_report_to_runtime_payload(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temp_dir:
+            report_path = Path(temp_dir) / "delay-depth.json"
+            report_path.write_text(
+                '{"passed": true, "case_count": 2, "checked_at": "2026-03-06T15:20:00Z"}',
+                encoding="utf-8",
+            )
+            args = SimpleNamespace(
+                run_id="run-depth",
+                candidate_id="chip-paper-microbar-composite@execution-proof",
+                hypothesis_id="H-MICRO-01",
+                observed_stage="paper",
+                strategy_family="microstructure_breakout",
+                source_dsn="postgresql://example",
+                source_dsn_env="DB_DSN",
+                strategy_name="microbar_volume_continuation_long_top2_chip_v1@paper",
+                account_label="TORGHUT_SIM",
+                window_start="2026-03-06T14:30:00Z",
+                window_end="2026-03-06T15:00:00Z",
+                bucket_minutes=30,
+                sample_minutes=5,
+                source_manifest_ref="config/trading/hypotheses/h-micro-01.json",
+                source_kind="simulation_paper_runtime",
+                dataset_snapshot_ref="runtime-depth-snapshot",
+                artifact_ref=[],
+                delay_adjusted_depth_stress_report_ref=str(report_path),
+                dependency_quorum_decision="allow",
+                continuity_ok="true",
+                drift_ok="true",
+                json=False,
+            )
+            fake_session = _FakeSession()
+            manifest = SimpleNamespace(
+                strategy_family="microstructure_breakout",
+                strategy_id="microbar_volume_continuation_long_top2_chip_v1@paper",
+                max_allowed_slippage_bps=Decimal("12"),
+            )
+
+            with (
+                patch(
+                    "scripts.import_hypothesis_runtime_windows._parse_args",
+                    return_value=args,
+                ),
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.resolve_hypothesis_manifest",
+                    return_value=(
+                        SimpleNamespace(path="config/trading/hypotheses/h-micro-01.json"),
+                        manifest,
+                    ),
+                ),
+                patch(
+                    "scripts.import_hypothesis_runtime_windows._query_timestamps",
+                    return_value=([], [], []),
+                ),
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.build_regular_session_buckets",
+                    return_value=[],
+                ),
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.build_observed_runtime_buckets",
+                    return_value=[],
+                ),
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.persist_observed_runtime_windows",
+                    return_value={"run_id": "run-depth"},
+                ) as persist_windows,
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.SessionLocal",
+                    return_value=fake_session,
+                ),
+                patch("builtins.print"),
+            ):
+                exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        runtime_payload = persist_windows.call_args.kwargs[
+            "runtime_observation_payload"
+        ]
+        self.assertEqual(
+            runtime_payload["delay_adjusted_depth_stress_artifact_ref"],
+            str(report_path),
+        )
+        self.assertEqual(runtime_payload["delay_adjusted_depth_stress_checks_total"], 2)
+        self.assertEqual(runtime_payload["delay_adjusted_depth_stress_passed"], True)
+        self.assertEqual(
+            runtime_payload["delay_adjusted_depth_stress_checked_at"],
+            "2026-03-06T15:20:00Z",
+        )
+        self.assertIn(str(report_path), runtime_payload["artifact_refs"])

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -553,7 +553,8 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                     f"strategy_family=microstructure_breakout,"
                     f"strategy_name=microbar-volume-continuation-long-top2-chip-v1,"
                     f"source_manifest_ref={micro_path},"
-                    f"dataset_snapshot_ref=torghut-chip-full-day-20260505-4c330ce9-r1"
+                    f"dataset_snapshot_ref=torghut-chip-full-day-20260505-4c330ce9-r1,"
+                    "delay_adjusted_depth_stress_report_ref=/proof/h-micro-delay-depth.json"
                 ),
             ],
             runtime_window_hypothesis_id="H-TSMOM-01",
@@ -600,6 +601,8 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertIn("chip-paper-microbar-composite@execution-proof", joined)
         self.assertIn("microbar-volume-continuation-long-top2-chip-v1", joined)
         self.assertIn("torghut-chip-full-day-20260505-4c330ce9-r1", joined)
+        self.assertIn("--delay-adjusted-depth-stress-report-ref", joined)
+        self.assertIn("/proof/h-micro-delay-depth.json", joined)
 
     def test_main_writes_manifest_and_runs_empirical_promotion_job(self) -> None:
         created_at = datetime(2026, 5, 18, 8, 13, tzinfo=timezone.utc)

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -2846,6 +2846,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                         "objective_met": True,
                         "model": "latency_depth_haircut",
                         "stress_delay_ms": "250",
+                        "case_count": 2,
+                        "generated_at": "2026-05-19T13:00:00Z",
                         "fillable_notional_per_day": "300000",
                         "post_delay_depth_net_pnl_per_day": "605",
                     }
@@ -2953,6 +2955,17 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             updated.objective_scorecard["market_impact_stress_net_pnl_per_day"],
             "610",
         )
+        self.assertEqual(
+            updated.objective_scorecard["delay_adjusted_depth_stress_checks_total"],
+            2,
+        )
+        self.assertEqual(
+            updated.objective_scorecard["delay_adjusted_depth_stress_checked_at"],
+            "2026-05-19T13:00:00Z",
+        )
+        self.assertTrue(
+            updated.objective_scorecard["delay_adjusted_depth_stress_passed"]
+        )
         self.assertIn(str(approval_replay_path), updated.evidence_refs)
 
     def test_runtime_closure_proof_helpers_stay_fail_closed_on_edge_inputs(
@@ -3008,6 +3021,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             ),
             7,
         )
+        self.assertEqual(runner._runtime_report_int("bad", default=11), 11)
         self.assertEqual(
             runner._portfolio_executable_max_notional(portfolio), Decimal("50000")
         )

--- a/services/torghut/tests/test_runtime_closure.py
+++ b/services/torghut/tests/test_runtime_closure.py
@@ -1316,6 +1316,14 @@ data:
                 )
             )
             self.assertEqual(delay_depth_report["model"], "latency_depth_haircut")
+            self.assertGreater(delay_depth_report["case_count"], 0)
+            self.assertEqual(
+                delay_depth_report["stress_case_count"],
+                len(delay_depth_report["daily"]),
+            )
+            self.assertIn("generated_at", delay_depth_report)
+            self.assertIn("checked_at", delay_depth_report)
+            self.assertIn("report_id", delay_depth_report)
             self.assertGreater(Decimal(delay_depth_report["delay_depth_cost_bps"]), 0)
             stress_metrics = json.loads(
                 Path(summary.stress_metrics_path).read_text(encoding="utf-8")

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -18,9 +18,14 @@ from app.models import (
     VNextDatasetSnapshot,
 )
 from app.trading.runtime_window_import import (
+    _delay_adjusted_depth_stress_blocking_reasons,
+    _observation_bool,
+    _observation_int,
+    _parse_observation_datetime,
     build_observed_runtime_buckets,
     build_regular_session_buckets,
     persist_observed_runtime_windows,
+    resolve_hypothesis_manifest,
 )
 
 
@@ -68,6 +73,54 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(len(buckets), 1)
         self.assertEqual(buckets[0].decision_alignment_ratio, Decimal("1"))
         self.assertEqual(buckets[0].avg_abs_slippage_bps, Decimal("0"))
+
+    def test_runtime_observation_parsers_handle_edge_inputs(self) -> None:
+        parsed = _parse_observation_datetime(
+            datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        )
+
+        self.assertEqual(parsed, datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc))
+        self.assertEqual(_parse_observation_datetime("not-a-date"), None)
+        self.assertEqual(_observation_bool(1), True)
+        self.assertEqual(_observation_bool(0), False)
+        self.assertEqual(_observation_bool("passed"), True)
+        self.assertEqual(_observation_bool("blocked"), False)
+        self.assertEqual(_observation_bool("unclear"), None)
+        self.assertEqual(_observation_int("-7"), 0)
+        self.assertEqual(_observation_int("bad"), 0)
+
+    def test_delay_adjusted_depth_stress_blockers_cover_failed_and_stale_proof(
+        self,
+    ) -> None:
+        _, manifest = resolve_hypothesis_manifest(
+            hypothesis_id="H-MICRO-01",
+            strategy_family="microstructure_breakout",
+        )
+        now = datetime(2026, 3, 6, 15, 30, tzinfo=timezone.utc)
+
+        failed_reasons = _delay_adjusted_depth_stress_blocking_reasons(
+            manifest=manifest,
+            runtime_payload={
+                "delay_adjusted_depth_stress_checks_total": 1,
+                "delay_adjusted_depth_stress_passed": "failed",
+                "delay_adjusted_depth_stress_checked_at": now.isoformat(),
+            },
+            now=now,
+        )
+        stale_reasons = _delay_adjusted_depth_stress_blocking_reasons(
+            manifest=manifest,
+            runtime_payload={
+                "delay_adjusted_depth_stress_report": {
+                    "case_count": "1",
+                    "passed": True,
+                    "checked_at": "2026-03-06T13:00:00Z",
+                }
+            },
+            now=now,
+        )
+
+        self.assertEqual(failed_reasons, ["delay_adjusted_depth_stress_failed"])
+        self.assertEqual(stale_reasons, ["delay_adjusted_depth_stress_stale"])
 
     def test_persist_observed_runtime_windows_creates_governance_rows(self) -> None:
         buckets = build_observed_runtime_buckets(
@@ -235,6 +288,135 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(
             decision.reason_summary, "runtime_evidence_thresholds_satisfied"
         )
+
+    def test_persist_observed_runtime_windows_blocks_h_micro_without_delay_depth_stress(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    30,
+                ),
+                (
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 30, tzinfo=timezone.utc),
+                    30,
+                ),
+            ],
+            decision_times=[
+                datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 15, 5, tzinfo=timezone.utc),
+            ],
+            execution_times=[
+                datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
+            ],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("4"),
+                    "post_cost_expectancy_bps": Decimal("12"),
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("5"),
+                    "post_cost_expectancy_bps": Decimal("12"),
+                },
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        with self.session_local() as session:
+            summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-h-micro-no-depth",
+                candidate_id="chip-paper-microbar-composite@execution-proof",
+                hypothesis_id="H-MICRO-01",
+                observed_stage="paper",
+                strategy_family="microstructure_breakout",
+                source_manifest_ref="config/trading/hypotheses/h-micro-01.json",
+                buckets=buckets,
+            )
+            session.commit()
+            decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
+
+        self.assertEqual(summary["promotion_allowed"], False)
+        self.assertIn(
+            "delay_adjusted_depth_stress_missing",
+            summary["promotion_blocking_reasons"],
+        )
+        self.assertEqual(decision.allowed, False)
+
+    def test_persist_observed_runtime_windows_allows_h_micro_with_fresh_delay_depth_stress(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    30,
+                ),
+                (
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 30, tzinfo=timezone.utc),
+                    30,
+                ),
+            ],
+            decision_times=[
+                datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 15, 5, tzinfo=timezone.utc),
+            ],
+            execution_times=[
+                datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
+            ],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("4"),
+                    "post_cost_expectancy_bps": Decimal("12"),
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("5"),
+                    "post_cost_expectancy_bps": Decimal("12"),
+                },
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        with self.session_local() as session:
+            summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-h-micro-depth",
+                candidate_id="chip-paper-microbar-composite@execution-proof",
+                hypothesis_id="H-MICRO-01",
+                observed_stage="paper",
+                strategy_family="microstructure_breakout",
+                source_manifest_ref="config/trading/hypotheses/h-micro-01.json",
+                buckets=buckets,
+                runtime_observation_payload={
+                    "delay_adjusted_depth_stress_report": {
+                        "passed": True,
+                        "case_count": 1,
+                        "generated_at": "2026-03-06T15:20:00+00:00",
+                        "artifact_ref": "proof/h-micro-delay-depth.json",
+                    }
+                },
+            )
+            session.commit()
+            decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
+
+        self.assertEqual(summary["promotion_allowed"], True)
+        self.assertEqual(summary["promotion_blocking_reasons"], [])
+        self.assertEqual(decision.allowed, True)
 
     def test_persist_observed_runtime_windows_blocks_zero_activity_evidence(
         self,


### PR DESCRIPTION
## Summary

- Added timestamped and counted delay-adjusted depth stress provenance to runtime closure reports.
- Carried delay-depth stress proof fields into the whitepaper scorecard and runtime-window import command path.
- Made H-MICRO runtime-window imports fail closed unless the required fresh delay-depth stress proof is present and passing.

## Related Issues

None

## Testing

- `uv run --frozen ruff check app/trading/runtime_window_import.py app/trading/hypotheses.py app/trading/discovery/runtime_closure.py scripts/import_hypothesis_runtime_windows.py scripts/renew_latest_empirical_promotion_jobs.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_runtime_window_import.py tests/test_hypotheses.py tests/test_runtime_closure.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen pytest tests/test_runtime_window_import.py -k 'h_micro or weak_paper_receipt or zero_activity' -q`
- `uv run --frozen pytest tests/test_hypotheses.py -k 'delay_depth_stress or candidate_dossier' -q`
- `uv run --frozen pytest tests/test_runtime_closure.py -k delay_adjusted_depth -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k runtime_closure_proof -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k runtime_window_import -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
