### PR TITLE
fix(torghut): split profit candidate board roles

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -5321,6 +5321,16 @@ def _candidate_board_int_field(scorecard: Mapping[str, Any], key: str) -> int:
         return 0
 
 
+def _candidate_board_first_int_field(
+    scorecard: Mapping[str, Any], keys: Sequence[str]
+) -> int:
+    for key in keys:
+        value = _candidate_board_int_field(scorecard, key)
+        if value > 0:
+            return value
+    return 0
+
+
 def _candidate_board_blockers(
     *,
     selected_for_replay: bool,
@@ -5363,6 +5373,94 @@ def _candidate_board_status(
     if selected_for_replay:
         return "selected_pending_replay_evidence"
     return "research_ranked_not_replayed"
+
+
+def _candidate_board_activity_count(row: Mapping[str, Any]) -> int:
+    return max(
+        _candidate_board_int_field(row, "decision_count"),
+        _candidate_board_int_field(row, "submitted_order_count"),
+        _candidate_board_int_field(row, "filled_order_count"),
+        _candidate_board_int_field(row, "executable_replay_order_count"),
+    )
+
+
+def _candidate_board_oracle_blocker_count(row: Mapping[str, Any]) -> int:
+    blockers = row.get("blockers")
+    if not isinstance(blockers, Sequence) or isinstance(blockers, str):
+        return 0
+    return sum(
+        1
+        for blocker in cast(Sequence[Any], blockers)
+        if _string(blocker).endswith("_failed")
+    )
+
+
+def _candidate_board_net_pnl(row: Mapping[str, Any]) -> Decimal:
+    return _decimal(row.get("net_pnl_per_day"))
+
+
+def _candidate_board_best_executed_candidate(
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any] | None:
+    executed_rows = [
+        dict(row) for row in rows if _candidate_board_activity_count(row) > 0
+    ]
+    if not executed_rows:
+        return None
+    executed_rows.sort(
+        key=lambda row: (
+            bool(row.get("oracle_passed")),
+            bool(row.get("target_met")),
+            _candidate_board_activity_count(row),
+            _candidate_board_net_pnl(row),
+            -_rank_sort_value(row.get("rank")),
+            _string(row.get("candidate_spec_id")),
+        ),
+        reverse=True,
+    )
+    return executed_rows[0]
+
+
+def _candidate_board_closest_promotion_candidate(
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any] | None:
+    replayed_rows = [dict(row) for row in rows if bool(row.get("has_replay_evidence"))]
+    if not replayed_rows:
+        return None
+    replayed_rows.sort(
+        key=lambda row: (
+            bool(row.get("oracle_passed")),
+            bool(row.get("target_met")),
+            -_candidate_board_oracle_blocker_count(row),
+            _candidate_board_activity_count(row),
+            _candidate_board_net_pnl(row),
+            -_rank_sort_value(row.get("rank")),
+            _string(row.get("candidate_spec_id")),
+        ),
+        reverse=True,
+    )
+    return replayed_rows[0]
+
+
+def _candidate_board_status_digest(rows: Sequence[Mapping[str, Any]]) -> str:
+    digest_rows = [
+        {
+            "candidate_spec_id": _string(row.get("candidate_spec_id")),
+            "candidate_id": _string(row.get("candidate_id")),
+            "rank": _rank_sort_value(row.get("rank")),
+            "status": _string(row.get("status")),
+            "target_met": bool(row.get("target_met")),
+            "oracle_passed": bool(row.get("oracle_passed")),
+            "activity_count": _candidate_board_activity_count(row),
+            "blockers": [
+                _string(blocker)
+                for blocker in cast(Sequence[Any], row.get("blockers") or ())
+            ],
+        }
+        for row in rows
+    ]
+    encoded = json.dumps(digest_rows, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
 def _candidate_board_payload(
@@ -5439,14 +5537,53 @@ def _candidate_board_payload(
                 or _candidate_board_decimal_field(
                     scorecard, "portfolio_post_cost_net_pnl_per_day"
                 ),
+                "market_impact_stress_net_pnl_per_day": _candidate_board_decimal_field(
+                    scorecard, "market_impact_stress_net_pnl_per_day"
+                ),
+                "delay_adjusted_depth_stress_net_pnl_per_day": _candidate_board_decimal_field(
+                    scorecard, "delay_adjusted_depth_stress_net_pnl_per_day"
+                ),
                 "trading_day_count": _candidate_board_int_field(
                     scorecard, "trading_day_count"
                 ),
-                "filled_order_count": _candidate_board_int_field(
-                    scorecard, "filled_count"
+                "decision_count": _candidate_board_first_int_field(
+                    scorecard,
+                    (
+                        "decision_count",
+                        "trade_decision_count",
+                        "paper_decision_count",
+                        "runtime_decision_count",
+                    ),
                 ),
-                "decision_count": _candidate_board_int_field(
-                    scorecard, "decision_count"
+                "submitted_order_count": _candidate_board_first_int_field(
+                    scorecard,
+                    (
+                        "submitted_order_count",
+                        "order_count",
+                        "orders_submitted_count",
+                        "paper_order_count",
+                        "runtime_order_count",
+                    ),
+                ),
+                "filled_order_count": _candidate_board_first_int_field(
+                    scorecard,
+                    (
+                        "filled_count",
+                        "filled_order_count",
+                        "executions_filled_count",
+                        "execution_filled_count",
+                        "paper_filled_order_count",
+                        "trade_count",
+                        "runtime_trade_count",
+                    ),
+                ),
+                "executable_replay_order_count": _candidate_board_first_int_field(
+                    scorecard,
+                    (
+                        "executable_replay_order_count",
+                        "executable_replay_submitted_order_count",
+                        "executable_replay_orders_submitted_total",
+                    ),
                 ),
                 "blockers": blockers,
                 "replay_artifact_refs": list(evidence.replay_artifact_refs)
@@ -5462,17 +5599,28 @@ def _candidate_board_payload(
         )
     )
     best_research_candidate = rows[0] if rows else None
+    best_executed_candidate = _candidate_board_best_executed_candidate(rows)
+    closest_promotion_candidate = _candidate_board_closest_promotion_candidate(rows)
     promotion_ready = _boolish(promotion_readiness.get("promotable"))
+    promotion_candidate_found = (
+        promotion_ready
+        and portfolio_oracle_passed
+        and closest_promotion_candidate is not None
+        and bool(closest_promotion_candidate.get("oracle_passed"))
+    )
     return {
         "schema_version": "torghut.profit-candidate-board.v1",
         "epoch_id": epoch_id,
         "run_root": str(output_dir),
         "target_net_pnl_per_day": str(target),
+        "status_digest": _candidate_board_status_digest(rows),
         "current_answer": "promotion_candidate_found"
-        if promotion_ready
+        if promotion_candidate_found
         else "no_promotion_ready_candidate",
         "promotion_readiness": dict(promotion_readiness),
         "best_research_candidate": best_research_candidate,
+        "best_executed_candidate": best_executed_candidate,
+        "closest_promotion_candidate": closest_promotion_candidate,
         "best_portfolio_candidate_id": _string(
             portfolio_payload.get("portfolio_candidate_id")
         ),

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -3162,6 +3162,99 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertTrue(allowed_readiness["promotable"])
         self.assertEqual(allowed_readiness["status"], "promotion_ready")
 
+    def test_candidate_board_separates_research_rank_from_executed_candidate(
+        self,
+    ) -> None:
+        research_spec = self._candidate_spec(
+            "spec-83161ae16d17828eabcc58cc",
+            family_template_id="intraday_tsmom_v2",
+        )
+        executed_spec = self._candidate_spec(
+            "spec-hmicro-proof",
+            family_template_id="microstructure_continuation_matched_filter_v1",
+        )
+        executed_evidence = runner.CandidateEvidenceBundle(
+            schema_version="torghut.candidate-evidence-bundle.v1",
+            evidence_bundle_id="ev-hmicro-proof",
+            candidate_id="chip-paper-microbar-composite@execution-proof",
+            candidate_spec_id=executed_spec.candidate_spec_id,
+            dataset_snapshot_id="snapshot-hmicro-runtime-proof",
+            feature_spec_hash="hash-hmicro-proof",
+            code_commit="commit-test",
+            replay_artifact_refs=("paper-window.json",),
+            objective_scorecard={
+                "net_pnl_per_day": "82.50",
+                "target_met": False,
+                "oracle_passed": False,
+                "trading_day_count": 3,
+                "trade_decision_count": 7,
+                "orders_submitted_count": 7,
+                "trade_count": 7,
+                "executable_replay_submitted_order_count": 7,
+                "profit_target_oracle": {
+                    "blockers": [
+                        "portfolio_post_cost_net_pnl_per_day_failed",
+                        "min_observed_trading_days_failed",
+                    ],
+                },
+            },
+            fold_metrics=(),
+            stress_metrics=(),
+            cost_calibration={"status": "provisional", "source": "paper_runtime"},
+            null_comparator={},
+            promotion_readiness={},
+        )
+
+        board = runner._candidate_board_payload(
+            epoch_id="epoch-candidate-board-split",
+            output_dir=Path("/tmp/epoch-candidate-board-split"),
+            target=Decimal("500"),
+            candidate_specs=(research_spec, executed_spec),
+            candidate_selection={
+                "rows": [
+                    {
+                        "candidate_spec_id": executed_spec.candidate_spec_id,
+                        "selected_for_replay": True,
+                    }
+                ]
+            },
+            pre_replay_proposal_rows=(
+                {
+                    "candidate_spec_id": research_spec.candidate_spec_id,
+                    "rank": 1,
+                    "proposal_score": "2.52157822",
+                },
+                {
+                    "candidate_spec_id": executed_spec.candidate_spec_id,
+                    "rank": 2,
+                    "proposal_score": "1.4",
+                },
+            ),
+            proposal_rows=(),
+            evidence_bundles=(executed_evidence,),
+            portfolio=None,
+            promotion_readiness={"promotable": False, "blockers": ["not_ready"]},
+            runtime_closure={"status": "blocked"},
+        )
+
+        self.assertEqual(board["current_answer"], "no_promotion_ready_candidate")
+        self.assertEqual(
+            board["best_research_candidate"]["candidate_spec_id"],
+            research_spec.candidate_spec_id,
+        )
+        self.assertEqual(
+            board["best_executed_candidate"]["candidate_id"],
+            "chip-paper-microbar-composite@execution-proof",
+        )
+        self.assertEqual(
+            board["closest_promotion_candidate"]["candidate_id"],
+            "chip-paper-microbar-composite@execution-proof",
+        )
+        self.assertEqual(board["best_executed_candidate"]["decision_count"], 7)
+        self.assertEqual(board["best_executed_candidate"]["submitted_order_count"], 7)
+        self.assertEqual(board["best_executed_candidate"]["filled_order_count"], 7)
+        self.assertRegex(board["status_digest"], r"^[0-9a-f]{64}$")
+
     def test_candidate_universe_symbols_default_to_chip_coverage_when_empty(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Split Torghut profit candidate board output into best research, best executed, and closest promotion candidate fields.
- Add activity aliases for decisions, submitted orders, fills, and executable replay orders so real paper/runtime proof is visible in the generated board.
- Add a stable candidate-board status digest and keep `promotion_candidate_found` fail-closed unless promotion readiness, portfolio oracle pass, and candidate oracle pass agree.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'candidate_board' -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'candidate_board or seed_recent_whitepapers_runs_end_to_end_and_writes_artifacts' -q`
- `uv run --frozen pytest tests/test_profit_target_oracle.py -q`
- `uv run --frozen ruff format scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
