### PR TITLE
chore(torghut-options): promote ta image fc9ee024

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:0d2f331a0731f83b76df75428a54311592577662124082626f86a9ff1db17ec7
   imagePullPolicy: IfNotPresent
   restartNonce: 8
   flinkVersion: v2_0
@@ -86,9 +86,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 0333e762
+              value: fc9ee024
             - name: TORGHUT_TA_COMMIT
-              value: 0333e762a68aff7c13028d7f16582aee2877d83e
+              value: fc9ee024607a008fbd672b65aa8d57538ab3bc37
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut options TA image into GitOps manifests.

- Source commit: `fc9ee024607a008fbd672b65aa8d57538ab3bc37`
- Image tag: `fc9ee024`
- Image digest: `sha256:0d2f331a0731f83b76df75428a54311592577662124082626f86a9ff1db17ec7`