### PR TITLE
chore(torghut-options): promote ta image 9c0d0b26

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:f0ef118e1efce0bd9e1d55b0c9fac7cbd4631661928523247659de446fdcf8a4
   imagePullPolicy: IfNotPresent
   restartNonce: 8
   flinkVersion: v2_0
@@ -86,9 +86,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 0333e762
+              value: 9c0d0b26
             - name: TORGHUT_TA_COMMIT
-              value: 0333e762a68aff7c13028d7f16582aee2877d83e
+              value: 9c0d0b26adb48601483c563d8d1b30dfb40cb32b
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut options TA image into GitOps manifests.

- Source commit: `9c0d0b26adb48601483c563d8d1b30dfb40cb32b`
- Image tag: `9c0d0b26`
- Image digest: `sha256:f0ef118e1efce0bd9e1d55b0c9fac7cbd4631661928523247659de446fdcf8a4`