### PR TITLE
chore(torghut-options): promote ta image 84bf575d

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:4bed303f0fb1933782074106bcb0df2ec1821f54f9fb67242ffd06716caba09d
   imagePullPolicy: IfNotPresent
   restartNonce: 8
   flinkVersion: v2_0
@@ -86,9 +86,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 0333e762
+              value: 84bf575d
             - name: TORGHUT_TA_COMMIT
-              value: 0333e762a68aff7c13028d7f16582aee2877d83e
+              value: 84bf575dabe54f69d8646d15fa723083e505c895
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut options TA image into GitOps manifests.

- Source commit: `84bf575dabe54f69d8646d15fa723083e505c895`
- Image tag: `84bf575d`
- Image digest: `sha256:4bed303f0fb1933782074106bcb0df2ec1821f54f9fb67242ffd06716caba09d`