### PR TITLE
chore(torghut-options): promote ta image 2e7a02bb

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:6948237f0816706980c521fe9153a49b735a3a1775fb130b26cf58b40b4b314e
   imagePullPolicy: IfNotPresent
   restartNonce: 8
   flinkVersion: v2_0
@@ -86,9 +86,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 0333e762
+              value: 2e7a02bb
             - name: TORGHUT_TA_COMMIT
-              value: 0333e762a68aff7c13028d7f16582aee2877d83e
+              value: 2e7a02bbc36c7e6ee65a6dd3842d0729cc7c0dce
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut options TA image into GitOps manifests.

- Source commit: `2e7a02bbc36c7e6ee65a6dd3842d0729cc7c0dce`
- Image tag: `2e7a02bb`
- Image digest: `sha256:6948237f0816706980c521fe9153a49b735a3a1775fb130b26cf58b40b4b314e`