### PR TITLE
chore(torghut-options): promote ta image d74d7d80

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:0d3257c0b8fd24020643649409fc19bd1aa579774ab3a623c1a9e5797d41ee3f
   imagePullPolicy: IfNotPresent
   restartNonce: 8
   flinkVersion: v2_0
@@ -86,9 +86,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 0333e762
+              value: d74d7d80
             - name: TORGHUT_TA_COMMIT
-              value: 0333e762a68aff7c13028d7f16582aee2877d83e
+              value: d74d7d800eb2aa47ba96cc17d79cf240ca2226f2
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut options TA image into GitOps manifests.

- Source commit: `d74d7d800eb2aa47ba96cc17d79cf240ca2226f2`
- Image tag: `d74d7d80`
- Image digest: `sha256:0d3257c0b8fd24020643649409fc19bd1aa579774ab3a623c1a9e5797d41ee3f`