### PR TITLE
chore(torghut-options): promote ta image 756a2ac8

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:f52765caa5a306fb664457fc8a1171a5d8cbe18330469e6bfc11120cb6fbd47f
   imagePullPolicy: IfNotPresent
   restartNonce: 8
   flinkVersion: v2_0
@@ -86,9 +86,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 0333e762
+              value: 756a2ac8
             - name: TORGHUT_TA_COMMIT
-              value: 0333e762a68aff7c13028d7f16582aee2877d83e
+              value: 756a2ac8ad93cc91e4cb66340e8192edc72f38d5
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut options TA image into GitOps manifests.

- Source commit: `756a2ac8ad93cc91e4cb66340e8192edc72f38d5`
- Image tag: `756a2ac8`
- Image digest: `sha256:f52765caa5a306fb664457fc8a1171a5d8cbe18330469e6bfc11120cb6fbd47f`