### PR TITLE
chore(torghut-options): promote ta image ff902d30

### DIFF
--- a/argocd/applications/torghut-options/ta/flinkdeployment.yaml
+++ b/argocd/applications/torghut-options/ta/flinkdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: torghut-options-ta
 spec:
-  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:e22e7fb47921db61f749006c5ebde0eb8c12c1b9f9fe24db3f8f739745f9bad2
+  image: registry.ide-newton.ts.net/lab/torghut-ta@sha256:247fd70035e2fa53b4df64a361f45da615adbde663454a78f5e6b292abc95e7b
   imagePullPolicy: IfNotPresent
   restartNonce: 8
   flinkVersion: v2_0
@@ -86,9 +86,9 @@ spec:
                   name: flink-checkpoints
                   key: AWS_SECRET_ACCESS_KEY
             - name: TORGHUT_TA_VERSION
-              value: 0333e762
+              value: ff902d30
             - name: TORGHUT_TA_COMMIT
-              value: 0333e762a68aff7c13028d7f16582aee2877d83e
+              value: ff902d30e431ab2766f4310b8ae7a4f3ccfa3015
           ports:
             - containerPort: 9249
               name: metrics


### PR DESCRIPTION
## Summary
Promote the Torghut options TA image into GitOps manifests.

- Source commit: `ff902d30e431ab2766f4310b8ae7a4f3ccfa3015`
- Image tag: `ff902d30`
- Image digest: `sha256:247fd70035e2fa53b4df64a361f45da615adbde663454a78f5e6b292abc95e7b`