### PR TITLE
chore(symphony): promote image 691cb117

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-19T09:12:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-20T17:39:04Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "1fa7005f"
-    digest: sha256:336214d4712a47c575976c1735239f1c120b674665d32f66879a94545d8215dc
+    newTag: "691cb117"
+    digest: sha256:3597482f9ceb9fa8bd4fa1f57e93f7ea9e5d3725ad71324e673cf5e296618473

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-19T09:12:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-20T17:39:04Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "1fa7005f"
-    digest: sha256:336214d4712a47c575976c1735239f1c120b674665d32f66879a94545d8215dc
+    newTag: "691cb117"
+    digest: sha256:3597482f9ceb9fa8bd4fa1f57e93f7ea9e5d3725ad71324e673cf5e296618473

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-19T09:12:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-20T17:39:04Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "1fa7005f"
-    digest: sha256:336214d4712a47c575976c1735239f1c120b674665d32f66879a94545d8215dc
+    newTag: "691cb117"
+    digest: sha256:3597482f9ceb9fa8bd4fa1f57e93f7ea9e5d3725ad71324e673cf5e296618473


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `691cb1170b5635abcfa157695fb61318683da274`
- Image tag: `691cb117`
- Image digest: `sha256:3597482f9ceb9fa8bd4fa1f57e93f7ea9e5d3725ad71324e673cf5e296618473`