### PR TITLE
fix(agents): bump chart version for extraction release

### DIFF
--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/proompteng/charts/tree/main/charts/agents
 type: application
 kubeVersion: '>=1.25.0-0'
-version: 0.9.19
+version: 0.9.20
 appVersion: '0.9.0'
 icon: https://avatars.githubusercontent.com/u/234536857
 keywords:

--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-version: 0.9.19
+version: 0.9.20
 name: agents
 displayName: Agents Control Plane
 description: Minimal Agents control plane with CRDs and native workflow runtime.


### PR DESCRIPTION
## Summary

- Bumps the Agents Helm chart version from `0.9.19` to `0.9.20`.
- Keeps `artifacthub-pkg.yml` aligned with `Chart.yaml` so the Agents chart publish job can push a new OCI package for the extraction release.

## Related Issues

None

## Testing

- `helm lint charts/agents`
- `scripts/agents/validate-agents.sh`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
