### PR TITLE
chore(jangar): promote image c347efe9

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-20T17:59:35Z
+    deploy.knative.dev/rollout: 2026-05-20T19:16:14Z
 spec:
   replicas: 1
   strategy:
@@ -57,11 +57,11 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_RUNTIME_IMAGE
-              value: registry.ide-newton.ts.net/lab/jangar:691cb117@sha256:716ce8b1ee6aba453aa4e6c4b7025652bd971b2900a0f5c2b2910f2fd49d6a09
+              value: registry.ide-newton.ts.net/lab/jangar:c347efe9@sha256:34aee0e27eebfffcc37156a41c4a9b2c1809b8893be655683da6c61c12e9df1c
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 691cb1170b5635abcfa157695fb61318683da274
+              value: c347efe90c715c57a8f29320e670076b6efff8d7
             - name: JANGAR_GITOPS_REVISION
-              value: 691cb1170b5635abcfa157695fb61318683da274
+              value: c347efe90c715c57a8f29320e670076b6efff8d7
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -391,15 +391,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26179849930"
+              value: "26184168149"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:716ce8b1ee6aba453aa4e6c4b7025652bd971b2900a0f5c2b2910f2fd49d6a09
+              value: sha256:34aee0e27eebfffcc37156a41c4a9b2c1809b8893be655683da6c61c12e9df1c
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 691cb1170b5635abcfa157695fb61318683da274
+              value: c347efe90c715c57a8f29320e670076b6efff8d7
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:716ce8b1ee6aba453aa4e6c4b7025652bd971b2900a0f5c2b2910f2fd49d6a09
+              value: sha256:34aee0e27eebfffcc37156a41c4a9b2c1809b8893be655683da6c61c12e9df1c
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -39,5 +39,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 691cb117
-    digest: sha256:716ce8b1ee6aba453aa4e6c4b7025652bd971b2900a0f5c2b2910f2fd49d6a09
+    newTag: c347efe9
+    digest: sha256:34aee0e27eebfffcc37156a41c4a9b2c1809b8893be655683da6c61c12e9df1c


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `c347efe90c715c57a8f29320e670076b6efff8d7`
- Image tag: `c347efe9`
- Image digest: `sha256:34aee0e27eebfffcc37156a41c4a9b2c1809b8893be655683da6c61c12e9df1c`
- Source CI run: `26184168149`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates