### PR TITLE
chore(agents): promote images 9a8523b8

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: c347efe9
-  digest: sha256:0f0843fd2caa3221a35c625ee1e519d03bfea9545de8f5861c05b8b8cffb0053
+  tag: 9a8523b8
+  digest: sha256:742c6b36421484d65625fa1a7e4a9068fab1ef25e054f3032164bcb30b83e2b9
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,26 +11,26 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: c347efe9
-    digest: sha256:9032dc57681a7144ad07c261a2f9aedba5bde9aa6c9896966df765db5b2f3b93
+    tag: 9a8523b8
+    digest: sha256:a9a09bc3632854dd927a1cc97175cbb22724c9940b7abd69653e3af76d633321
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: c347efe90c715c57a8f29320e670076b6efff8d7
-      AGENTS_GITOPS_REVISION: c347efe90c715c57a8f29320e670076b6efff8d7
-      AGENTS_SOURCE_CI_RUN_ID: "26183682572"
+      AGENTS_SOURCE_HEAD_SHA: 9a8523b800b85bee4d734f59fc97a42d31041c7b
+      AGENTS_GITOPS_REVISION: 9a8523b800b85bee4d734f59fc97a42d31041c7b
+      AGENTS_SOURCE_CI_RUN_ID: "26184529598"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:9032dc57681a7144ad07c261a2f9aedba5bde9aa6c9896966df765db5b2f3b93
-      AGENTS_SERVING_BUILD_COMMIT: c347efe90c715c57a8f29320e670076b6efff8d7
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:9032dc57681a7144ad07c261a2f9aedba5bde9aa6c9896966df765db5b2f3b93
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:a9a09bc3632854dd927a1cc97175cbb22724c9940b7abd69653e3af76d633321
+      AGENTS_SERVING_BUILD_COMMIT: 9a8523b800b85bee4d734f59fc97a42d31041c7b
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:a9a09bc3632854dd927a1cc97175cbb22724c9940b7abd69653e3af76d633321
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: c347efe9
-    digest: sha256:495f6ade79ffc7d4fe84ed66653713acdb6b93a7a3ce58f47f9bb89a3a183330
+    tag: 9a8523b8
+    digest: sha256:ec989b42cbe87bf15eed4ef84ecee3ee6dd515a8bb83517d8e11681ce6bbd649
 argocdHooks:
   enabled: true
   image:
@@ -81,8 +81,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: c347efe9
-    digest: sha256:0f0843fd2caa3221a35c625ee1e519d03bfea9545de8f5861c05b8b8cffb0053
+    tag: 9a8523b8
+    digest: sha256:742c6b36421484d65625fa1a7e4a9068fab1ef25e054f3032164bcb30b83e2b9
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `9a8523b800b85bee4d734f59fc97a42d31041c7b`
- Image tag: `9a8523b8`
- Agents build run: `26184529598`
- Promotion source: `workflow_run`