### PR TITLE
feat(torghut): hand off paper probation runtime windows

### DIFF
--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -85,6 +85,16 @@ def _parse_args() -> argparse.Namespace:
             "delay_adjusted_depth_stress_report_ref."
         ),
     )
+    parser.add_argument(
+        "--runtime-window-target-plan-ref",
+        action="append",
+        default=[],
+        help=(
+            "Repeatable path to a candidate-board/runtime-window-import-plan JSON "
+            "artifact. Explicit --runtime-window-target entries take precedence "
+            "over duplicate hypothesis_id values."
+        ),
+    )
     parser.add_argument("--runtime-window-hypothesis-id", default="H-TSMOM-01")
     parser.add_argument("--runtime-window-candidate-id", default="")
     parser.add_argument(
@@ -269,6 +279,21 @@ def _read_json_mapping(path: Path) -> dict[str, Any]:
     return _as_dict(payload)
 
 
+def _read_runtime_window_target_plan(ref: str) -> dict[str, Any]:
+    path = Path(ref.strip())
+    if not path.exists():
+        raise RuntimeError(f"runtime_window_target_plan_ref_missing:{path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise RuntimeError(f"runtime_window_target_plan_ref_invalid:{path}") from exc
+    data = _as_dict(payload)
+    if not data:
+        raise RuntimeError(f"runtime_window_target_plan_ref_invalid:{path}")
+    plan = _as_dict(data.get("runtime_window_import_plan")) or data
+    return plan
+
+
 def _runtime_family_harnesses(family_dir: str) -> dict[str, dict[str, str]]:
     root = Path(family_dir)
     if not root.exists():
@@ -363,12 +388,91 @@ def _registry_runtime_window_targets(
     return targets
 
 
+def _runtime_window_plan_targets(
+    args: argparse.Namespace,
+) -> list[RuntimeWindowImportTarget]:
+    refs = [
+        str(item).strip()
+        for item in getattr(args, "runtime_window_target_plan_ref", []) or []
+        if str(item).strip()
+    ]
+    targets: list[RuntimeWindowImportTarget] = []
+    for ref in refs:
+        plan = _read_runtime_window_target_plan(ref)
+        raw_targets = plan.get("targets")
+        if not isinstance(raw_targets, Sequence) or isinstance(
+            raw_targets, (str, bytes, bytearray)
+        ):
+            raise RuntimeError(f"runtime_window_target_plan_targets_missing:{ref}")
+        for index, raw_target in enumerate(raw_targets):
+            payload = _as_dict(raw_target)
+
+            def value(key: str, legacy_name: str) -> str:
+                return str(
+                    payload.get(key) or getattr(args, legacy_name, "") or ""
+                ).strip()
+
+            hypothesis_id = value("hypothesis_id", "runtime_window_hypothesis_id")
+            candidate_id = value("candidate_id", "runtime_window_candidate_id")
+            strategy_family = value("strategy_family", "runtime_window_strategy_family")
+            strategy_name = value("strategy_name", "runtime_window_strategy_name")
+            missing = [
+                field
+                for field, item in (
+                    ("hypothesis_id", hypothesis_id),
+                    ("candidate_id", candidate_id),
+                    ("strategy_family", strategy_family),
+                    ("strategy_name", strategy_name),
+                )
+                if not item
+            ]
+            if missing:
+                raise RuntimeError(
+                    "runtime_window_target_plan_target_invalid:"
+                    f"{ref}:{index}:{','.join(missing)}"
+                )
+            targets.append(
+                RuntimeWindowImportTarget(
+                    hypothesis_id=hypothesis_id,
+                    candidate_id=candidate_id,
+                    observed_stage=value(
+                        "observed_stage", "runtime_window_observed_stage"
+                    )
+                    or "paper",
+                    strategy_family=strategy_family,
+                    source_dsn_env=value(
+                        "source_dsn_env", "runtime_window_source_dsn_env"
+                    )
+                    or "DB_DSN",
+                    strategy_name=strategy_name,
+                    account_label=value("account_label", "runtime_window_account_label")
+                    or "TORGHUT_SIM",
+                    dataset_snapshot_ref=value(
+                        "dataset_snapshot_ref",
+                        "runtime_window_dataset_snapshot_ref",
+                    ),
+                    source_manifest_ref=value(
+                        "source_manifest_ref",
+                        "runtime_window_source_manifest_ref",
+                    ),
+                    source_kind=value("source_kind", "runtime_window_source_kind")
+                    or "paper_runtime_observed",
+                    delay_adjusted_depth_stress_report_ref=value(
+                        "delay_adjusted_depth_stress_report_ref",
+                        "runtime_window_delay_adjusted_depth_stress_report_ref",
+                    ),
+                )
+            )
+    return targets
+
+
 def _runtime_window_targets(
     args: argparse.Namespace,
 ) -> list[RuntimeWindowImportTarget]:
     specs = [str(item) for item in getattr(args, "runtime_window_target", []) or []]
+    plan_targets = _runtime_window_plan_targets(args)
     registry_targets = _registry_runtime_window_targets(args)
-    if not specs and not registry_targets:
+    if not specs and not plan_targets and not registry_targets:
         specs = [""]
     targets: list[RuntimeWindowImportTarget] = []
     for spec in specs:
@@ -415,6 +519,11 @@ def _runtime_window_targets(
             )
         )
     seen_hypothesis_ids = {target.hypothesis_id for target in targets}
+    for target in plan_targets:
+        if target.hypothesis_id in seen_hypothesis_ids:
+            continue
+        targets.append(target)
+        seen_hypothesis_ids.add(target.hypothesis_id)
     for target in registry_targets:
         if target.hypothesis_id in seen_hypothesis_ids:
             continue

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -7910,6 +7910,109 @@ def _candidate_board_portfolio_promotion_subject(
     }
 
 
+def _candidate_board_hypothesis_manifest_ref(hypothesis_id: str | None) -> str:
+    normalized = _string(hypothesis_id).lower().replace("_", "-")
+    if not normalized:
+        return ""
+    return f"config/trading/hypotheses/{normalized}.json"
+
+
+def _candidate_board_runtime_window_import_plan(
+    *,
+    rows: Sequence[Mapping[str, Any]],
+    paper_probation_candidate: Mapping[str, Any] | None,
+    promotion_subject: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    source_rows: list[Mapping[str, Any]] = []
+    if paper_probation_candidate is not None:
+        source_rows.append(paper_probation_candidate)
+
+    if promotion_subject is not None and _boolish(promotion_subject.get("target_met")):
+        portfolio_spec_ids = {
+            _string(candidate_spec_id)
+            for candidate_spec_id in cast(
+                Sequence[Any],
+                promotion_subject.get("sleeve_candidate_spec_ids") or (),
+            )
+            if _string(candidate_spec_id)
+        }
+        for row in rows:
+            if _string(row.get("candidate_spec_id")) in portfolio_spec_ids:
+                source_rows.append(row)
+
+    targets: list[dict[str, Any]] = []
+    blockers: list[dict[str, Any]] = []
+    seen_keys: set[tuple[str, str, str]] = set()
+    for row in source_rows:
+        candidate_id = _string(row.get("candidate_id"))
+        hypothesis_id = _string(row.get("hypothesis_id"))
+        strategy_family = _string(row.get("runtime_family"))
+        strategy_name = _string(row.get("runtime_strategy_name"))
+        candidate_spec_id = _string(row.get("candidate_spec_id"))
+        missing_fields = [
+            field
+            for field, value in (
+                ("candidate_id", candidate_id),
+                ("hypothesis_id", hypothesis_id),
+                ("runtime_family", strategy_family),
+                ("runtime_strategy_name", strategy_name),
+            )
+            if not value
+        ]
+        if missing_fields:
+            blockers.append(
+                {
+                    "blocker": "runtime_window_import_target_incomplete",
+                    "candidate_spec_id": candidate_spec_id,
+                    "candidate_id": candidate_id,
+                    "missing_fields": missing_fields,
+                }
+            )
+            continue
+        dedupe_key = (hypothesis_id, candidate_id, strategy_name)
+        if dedupe_key in seen_keys:
+            continue
+        seen_keys.add(dedupe_key)
+        targets.append(
+            {
+                "candidate_spec_id": candidate_spec_id,
+                "candidate_id": candidate_id,
+                "hypothesis_id": hypothesis_id,
+                "observed_stage": "paper",
+                "strategy_family": strategy_family,
+                "strategy_name": strategy_name,
+                "source_kind": "paper_runtime_observed",
+                "source_manifest_ref": _candidate_board_hypothesis_manifest_ref(
+                    hypothesis_id
+                ),
+                "dataset_snapshot_ref": _string(row.get("dataset_snapshot_id")),
+                "artifact_refs": [
+                    _string(ref)
+                    for ref in cast(
+                        Sequence[Any], row.get("replay_artifact_refs") or ()
+                    )
+                    if _string(ref)
+                ],
+                "candidate_blockers": [
+                    _string(blocker)
+                    for blocker in cast(Sequence[Any], row.get("blockers") or ())
+                    if _string(blocker)
+                ],
+                "handoff": "runtime_window_import_only",
+                "promotion_gate": "existing_runtime_governance_fail_closed",
+            }
+        )
+
+    return {
+        "schema_version": "torghut.runtime-window-import-plan.v1",
+        "status": "ready" if targets else "blocked",
+        "observed_stage": "paper",
+        "target_count": len(targets),
+        "targets": targets,
+        "blockers": blockers,
+    }
+
+
 def _candidate_board_payload(
     *,
     epoch_id: str,
@@ -7996,6 +8099,9 @@ def _candidate_board_payload(
                 "selected_for_replay": selected_for_replay,
                 "has_replay_evidence": evidence is not None,
                 "in_best_portfolio": in_best_portfolio,
+                "dataset_snapshot_id": evidence.dataset_snapshot_id
+                if evidence is not None
+                else "",
                 "status": _candidate_board_status(
                     selected_for_replay=selected_for_replay,
                     evidence=evidence,
@@ -8142,6 +8248,11 @@ def _candidate_board_payload(
         "closest_promotion_candidate": closest_promotion_candidate,
         "paper_probation_candidate": paper_probation_candidate,
         "promotion_subject": promotion_subject,
+        "runtime_window_import_plan": _candidate_board_runtime_window_import_plan(
+            rows=rows,
+            paper_probation_candidate=paper_probation_candidate,
+            promotion_subject=promotion_subject,
+        ),
         "double_oos_summary": _candidate_board_double_oos_summary(rows),
         "best_portfolio_candidate_id": _string(
             portfolio_payload.get("portfolio_candidate_id")

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -403,6 +403,160 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             "config/trading/hypotheses/h-pairs-01.json",
         )
 
+    def test_runtime_window_targets_from_candidate_board_plan(self) -> None:
+        plan_path = Path(self.tmp_dir) / "candidate-board.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "runtime_window_import_plan": {
+                        "schema_version": "torghut.runtime-window-import-plan.v1",
+                        "targets": [
+                            {
+                                "candidate_id": "cand-paper-probation",
+                                "hypothesis_id": "H-MICRO-01",
+                                "observed_stage": "paper",
+                                "strategy_family": "microstructure_breakout",
+                                "strategy_name": "microbar-volume-continuation-long-top2-chip-v1",
+                                "source_kind": "paper_runtime_observed",
+                                "source_manifest_ref": "config/trading/hypotheses/h-micro-01.json",
+                                "dataset_snapshot_ref": "snapshot-paper-probation",
+                            }
+                        ],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        args = SimpleNamespace(
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_targets_from_registry=False,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        targets = renewal._runtime_window_targets(args)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].candidate_id, "cand-paper-probation")
+        self.assertEqual(targets[0].hypothesis_id, "H-MICRO-01")
+        self.assertEqual(targets[0].observed_stage, "paper")
+        self.assertEqual(targets[0].strategy_family, "microstructure_breakout")
+        self.assertEqual(
+            targets[0].strategy_name, "microbar-volume-continuation-long-top2-chip-v1"
+        )
+        self.assertEqual(
+            targets[0].source_manifest_ref,
+            "config/trading/hypotheses/h-micro-01.json",
+        )
+        self.assertEqual(targets[0].dataset_snapshot_ref, "snapshot-paper-probation")
+
+    def test_runtime_window_target_plan_errors_are_explicit(self) -> None:
+        invalid_json_path = Path(self.tmp_dir) / "invalid-candidate-board.json"
+        invalid_json_path.write_text("{", encoding="utf-8")
+        empty_json_path = Path(self.tmp_dir) / "empty-candidate-board.json"
+        empty_json_path.write_text("[]", encoding="utf-8")
+        missing_targets_path = Path(self.tmp_dir) / "missing-targets-board.json"
+        missing_targets_path.write_text(
+            json.dumps({"runtime_window_import_plan": {"targets": "not-a-list"}}),
+            encoding="utf-8",
+        )
+        invalid_target_path = Path(self.tmp_dir) / "invalid-target-board.json"
+        invalid_target_path.write_text(
+            json.dumps(
+                {
+                    "runtime_window_import_plan": {
+                        "targets": [{"candidate_id": "cand-missing-fields"}]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        cases = (
+            (
+                Path(self.tmp_dir) / "missing-candidate-board.json",
+                "runtime_window_target_plan_ref_missing",
+            ),
+            (invalid_json_path, "runtime_window_target_plan_ref_invalid"),
+            (empty_json_path, "runtime_window_target_plan_ref_invalid"),
+            (missing_targets_path, "runtime_window_target_plan_targets_missing"),
+            (invalid_target_path, "runtime_window_target_plan_target_invalid"),
+        )
+        args = SimpleNamespace(
+            runtime_window_target=[],
+            runtime_window_targets_from_registry=False,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        for path, message in cases:
+            with self.subTest(path=path):
+                args.runtime_window_target_plan_ref = [str(path)]
+                with self.assertRaisesRegex(RuntimeError, message):
+                    renewal._runtime_window_targets(args)
+
+    def test_explicit_runtime_window_target_takes_precedence_over_plan(self) -> None:
+        plan_path = Path(self.tmp_dir) / "candidate-board.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "runtime_window_import_plan": {
+                        "targets": [
+                            {
+                                "candidate_id": "cand-from-plan",
+                                "hypothesis_id": "H-MICRO-01",
+                                "strategy_family": "microstructure_breakout",
+                                "strategy_name": "microbar-volume-continuation-long-top2-chip-v1",
+                            }
+                        ],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        args = SimpleNamespace(
+            runtime_window_target=[
+                (
+                    "hypothesis_id=H-MICRO-01,candidate_id=cand-explicit,"
+                    "strategy_family=microstructure_breakout,"
+                    "strategy_name=microbar-volume-continuation-long-top2-chip-v1"
+                )
+            ],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_targets_from_registry=False,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        targets = renewal._runtime_window_targets(args)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].candidate_id, "cand-explicit")
+
     def test_runtime_window_targets_from_registry_imports_all_hypotheses(
         self,
     ) -> None:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -5832,6 +5832,77 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             board["paper_probation_candidate"], board["closest_promotion_candidate"]
         )
+        plan = board["runtime_window_import_plan"]
+        self.assertEqual(
+            plan["schema_version"], "torghut.runtime-window-import-plan.v1"
+        )
+        self.assertEqual(plan["status"], "ready")
+        self.assertEqual(plan["target_count"], 1)
+        target = plan["targets"][0]
+        self.assertEqual(target["candidate_id"], "cand-paper-probation")
+        self.assertEqual(target["candidate_spec_id"], spec.candidate_spec_id)
+        self.assertEqual(target["hypothesis_id"], spec.hypothesis_id)
+        self.assertEqual(target["strategy_family"], spec.runtime_family)
+        self.assertEqual(target["strategy_name"], spec.runtime_strategy_name)
+        self.assertEqual(target["observed_stage"], "paper")
+        self.assertEqual(target["source_kind"], "paper_runtime_observed")
+        self.assertEqual(target["dataset_snapshot_ref"], "snapshot-paper-probation")
+        self.assertEqual(target["artifact_refs"], ["paper-probation.json"])
+        self.assertEqual(target["handoff"], "runtime_window_import_only")
+        self.assertEqual(
+            target["promotion_gate"], "existing_runtime_governance_fail_closed"
+        )
+
+    def test_candidate_board_runtime_window_plan_dedupes_and_blocks_incomplete_targets(
+        self,
+    ) -> None:
+        row = {
+            "candidate_spec_id": "spec-runtime-plan",
+            "candidate_id": "cand-runtime-plan",
+            "hypothesis_id": "H-MICRO-01",
+            "runtime_family": "microstructure_breakout",
+            "runtime_strategy_name": "microbar-volume-continuation-long-top2-chip-v1",
+            "dataset_snapshot_id": "snapshot-runtime-plan",
+            "replay_artifact_refs": ["paper-runtime-plan.json"],
+            "blockers": ["delay_adjusted_depth_tail_coverage_passed_failed"],
+        }
+
+        plan = runner._candidate_board_runtime_window_import_plan(
+            rows=(row,),
+            paper_probation_candidate=row,
+            promotion_subject={
+                "target_met": True,
+                "sleeve_candidate_spec_ids": ["spec-runtime-plan"],
+            },
+        )
+        incomplete_plan = runner._candidate_board_runtime_window_import_plan(
+            rows=(),
+            paper_probation_candidate={
+                "candidate_spec_id": "spec-incomplete",
+                "candidate_id": "",
+                "hypothesis_id": "",
+                "runtime_family": "microstructure_breakout",
+                "runtime_strategy_name": "microbar-volume-continuation-long-top2-chip-v1",
+            },
+            promotion_subject=None,
+        )
+
+        self.assertEqual(
+            runner._candidate_board_hypothesis_manifest_ref(None),
+            "",
+        )
+        self.assertEqual(plan["target_count"], 1)
+        self.assertEqual(
+            plan["targets"][0]["source_manifest_ref"],
+            "config/trading/hypotheses/h-micro-01.json",
+        )
+        self.assertEqual(plan["targets"][0]["candidate_blockers"], row["blockers"])
+        self.assertEqual(incomplete_plan["status"], "blocked")
+        self.assertEqual(incomplete_plan["target_count"], 0)
+        self.assertEqual(
+            incomplete_plan["blockers"][0]["missing_fields"],
+            ["candidate_id", "hypothesis_id"],
+        )
 
     def test_candidate_universe_symbols_default_to_chip_coverage_when_empty(
         self,


### PR DESCRIPTION
## Summary

- Add a fail-closed runtime-window import plan to Torghut profit candidate boards for paper-probation and target-met portfolio candidates.
- Preserve dataset, replay artifact, hypothesis, runtime family, and strategy-name handoff details without marking candidates promotion-ready.
- Teach the empirical renewal runner to consume candidate-board/runtime-window import plans as import targets while keeping explicit target args highest precedence.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k "candidate_board_surfaces_paper_probation_without_promotion"`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k "runtime_window_targets_from_candidate_board_plan or runtime_window_target_accepts_json_payload"`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k "candidate_board_surfaces_paper_probation_without_promotion or epoch_ledgers_persist_target_met_oracle_failed_as_paper_probation or feedback_evidence_loader_reconstructs_paper_probation_candidates"`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k "runtime_window_import" tests/test_runtime_window_import.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
