### PR TITLE
feat(torghut): auto-import autoresearch runtime windows

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -34,6 +34,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref intraday_tsmom_v2@research \
                     --runtime-window-import \
+                    --runtime-window-targets-from-latest-autoresearch \
                     --runtime-window-targets-from-registry \
                     --runtime-window-hypothesis-id H-TSMOM-01 \
                     --runtime-window-candidate-id spec-83161ae16d17828eabcc58cc \

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -19,7 +19,7 @@ import yaml
 from sqlalchemy import select
 
 from app.db import SessionLocal
-from app.models import VNextEmpiricalJobRun
+from app.models import AutoresearchEpoch, VNextEmpiricalJobRun
 from app.trading.empirical_jobs import (
     EMPIRICAL_JOB_TYPES,
     empirical_artifact_truthfulness_reasons,
@@ -36,6 +36,11 @@ EXECUTION_ELIGIBLE_DECISION_STATUSES = (
     "submitted",
     "filled",
     "partially_filled",
+)
+DEFAULT_AUTORESEARCH_RUNTIME_WINDOW_STATUSES = (
+    "ok",
+    "no_profit_target_candidate",
+    "selection_only",
 )
 
 
@@ -94,6 +99,28 @@ def _parse_args() -> argparse.Namespace:
             "artifact. Explicit --runtime-window-target entries take precedence "
             "over duplicate hypothesis_id values."
         ),
+    )
+    parser.add_argument(
+        "--runtime-window-targets-from-latest-autoresearch",
+        action="store_true",
+        help=(
+            "Import runtime-window targets from the latest persisted whitepaper "
+            "autoresearch candidate board before falling back to hypothesis "
+            "registry targets."
+        ),
+    )
+    parser.add_argument(
+        "--runtime-window-autoresearch-status",
+        action="append",
+        default=[],
+        help=(
+            "Repeatable autoresearch epoch status eligible for latest candidate "
+            "board import. Defaults to ok, no_profit_target_candidate, and "
+            "selection_only."
+        ),
+    )
+    parser.add_argument(
+        "--runtime-window-autoresearch-scan-limit", type=int, default=20
     )
     parser.add_argument("--runtime-window-hypothesis-id", default="H-TSMOM-01")
     parser.add_argument("--runtime-window-candidate-id", default="")
@@ -399,71 +426,138 @@ def _runtime_window_plan_targets(
     targets: list[RuntimeWindowImportTarget] = []
     for ref in refs:
         plan = _read_runtime_window_target_plan(ref)
-        raw_targets = plan.get("targets")
-        if not isinstance(raw_targets, Sequence) or isinstance(
-            raw_targets, (str, bytes, bytearray)
-        ):
-            raise RuntimeError(f"runtime_window_target_plan_targets_missing:{ref}")
-        for index, raw_target in enumerate(raw_targets):
-            payload = _as_dict(raw_target)
-
-            def value(key: str, legacy_name: str) -> str:
-                return str(
-                    payload.get(key) or getattr(args, legacy_name, "") or ""
-                ).strip()
-
-            hypothesis_id = value("hypothesis_id", "runtime_window_hypothesis_id")
-            candidate_id = value("candidate_id", "runtime_window_candidate_id")
-            strategy_family = value("strategy_family", "runtime_window_strategy_family")
-            strategy_name = value("strategy_name", "runtime_window_strategy_name")
-            missing = [
-                field
-                for field, item in (
-                    ("hypothesis_id", hypothesis_id),
-                    ("candidate_id", candidate_id),
-                    ("strategy_family", strategy_family),
-                    ("strategy_name", strategy_name),
-                )
-                if not item
-            ]
-            if missing:
-                raise RuntimeError(
-                    "runtime_window_target_plan_target_invalid:"
-                    f"{ref}:{index}:{','.join(missing)}"
-                )
-            targets.append(
-                RuntimeWindowImportTarget(
-                    hypothesis_id=hypothesis_id,
-                    candidate_id=candidate_id,
-                    observed_stage=value(
-                        "observed_stage", "runtime_window_observed_stage"
-                    )
-                    or "paper",
-                    strategy_family=strategy_family,
-                    source_dsn_env=value(
-                        "source_dsn_env", "runtime_window_source_dsn_env"
-                    )
-                    or "DB_DSN",
-                    strategy_name=strategy_name,
-                    account_label=value("account_label", "runtime_window_account_label")
-                    or "TORGHUT_SIM",
-                    dataset_snapshot_ref=value(
-                        "dataset_snapshot_ref",
-                        "runtime_window_dataset_snapshot_ref",
-                    ),
-                    source_manifest_ref=value(
-                        "source_manifest_ref",
-                        "runtime_window_source_manifest_ref",
-                    ),
-                    source_kind=value("source_kind", "runtime_window_source_kind")
-                    or "paper_runtime_observed",
-                    delay_adjusted_depth_stress_report_ref=value(
-                        "delay_adjusted_depth_stress_report_ref",
-                        "runtime_window_delay_adjusted_depth_stress_report_ref",
-                    ),
-                )
-            )
+        targets.extend(_runtime_window_targets_from_plan(plan=plan, ref=ref, args=args))
     return targets
+
+
+def _runtime_window_targets_from_plan(
+    *,
+    plan: Mapping[str, Any],
+    ref: str,
+    args: argparse.Namespace,
+) -> list[RuntimeWindowImportTarget]:
+    raw_targets = plan.get("targets")
+    if not isinstance(raw_targets, Sequence) or isinstance(
+        raw_targets, (str, bytes, bytearray)
+    ):
+        raise RuntimeError(f"runtime_window_target_plan_targets_missing:{ref}")
+    targets: list[RuntimeWindowImportTarget] = []
+    for index, raw_target in enumerate(raw_targets):
+        payload = _as_dict(raw_target)
+
+        def value(key: str, legacy_name: str) -> str:
+            return str(payload.get(key) or getattr(args, legacy_name, "") or "").strip()
+
+        hypothesis_id = value("hypothesis_id", "runtime_window_hypothesis_id")
+        candidate_id = value("candidate_id", "runtime_window_candidate_id")
+        strategy_family = value("strategy_family", "runtime_window_strategy_family")
+        strategy_name = value("strategy_name", "runtime_window_strategy_name")
+        missing = [
+            field
+            for field, item in (
+                ("hypothesis_id", hypothesis_id),
+                ("candidate_id", candidate_id),
+                ("strategy_family", strategy_family),
+                ("strategy_name", strategy_name),
+            )
+            if not item
+        ]
+        if missing:
+            raise RuntimeError(
+                "runtime_window_target_plan_target_invalid:"
+                f"{ref}:{index}:{','.join(missing)}"
+            )
+        targets.append(
+            RuntimeWindowImportTarget(
+                hypothesis_id=hypothesis_id,
+                candidate_id=candidate_id,
+                observed_stage=value("observed_stage", "runtime_window_observed_stage")
+                or "paper",
+                strategy_family=strategy_family,
+                source_dsn_env=value("source_dsn_env", "runtime_window_source_dsn_env")
+                or "DB_DSN",
+                strategy_name=strategy_name,
+                account_label=value("account_label", "runtime_window_account_label")
+                or "TORGHUT_SIM",
+                dataset_snapshot_ref=value(
+                    "dataset_snapshot_ref",
+                    "runtime_window_dataset_snapshot_ref",
+                ),
+                source_manifest_ref=value(
+                    "source_manifest_ref",
+                    "runtime_window_source_manifest_ref",
+                ),
+                source_kind=value("source_kind", "runtime_window_source_kind")
+                or "paper_runtime_observed",
+                delay_adjusted_depth_stress_report_ref=value(
+                    "delay_adjusted_depth_stress_report_ref",
+                    "runtime_window_delay_adjusted_depth_stress_report_ref",
+                ),
+            )
+        )
+    return targets
+
+
+def _runtime_window_autoresearch_statuses(args: argparse.Namespace) -> set[str]:
+    statuses = {
+        str(item).strip()
+        for item in getattr(args, "runtime_window_autoresearch_status", []) or []
+        if str(item).strip()
+    }
+    return statuses or set(DEFAULT_AUTORESEARCH_RUNTIME_WINDOW_STATUSES)
+
+
+def _runtime_window_targets_from_autoresearch_epochs(
+    *,
+    args: argparse.Namespace,
+    epochs: Sequence[Any],
+) -> list[RuntimeWindowImportTarget]:
+    eligible_statuses = _runtime_window_autoresearch_statuses(args)
+    for epoch in epochs:
+        if str(getattr(epoch, "status", "") or "").strip() not in eligible_statuses:
+            continue
+        summary = _as_dict(getattr(epoch, "summary_json", None))
+        candidate_board = _as_dict(summary.get("candidate_board"))
+        plan = _as_dict(candidate_board.get("runtime_window_import_plan"))
+        if not plan or "targets" not in plan:
+            continue
+        targets = _runtime_window_targets_from_plan(
+            plan=plan,
+            ref=f"autoresearch_epoch:{getattr(epoch, 'epoch_id', 'unknown')}",
+            args=args,
+        )
+        if targets:
+            return targets
+    return []
+
+
+def _latest_autoresearch_runtime_window_targets(
+    args: argparse.Namespace,
+) -> list[RuntimeWindowImportTarget]:
+    if not bool(
+        getattr(args, "runtime_window_targets_from_latest_autoresearch", False)
+    ):
+        return []
+    scan_limit = max(
+        1,
+        int(getattr(args, "runtime_window_autoresearch_scan_limit", 20) or 20),
+    )
+    statuses = _runtime_window_autoresearch_statuses(args)
+    with SessionLocal() as session:
+        rows = (
+            session.execute(
+                select(AutoresearchEpoch)
+                .where(AutoresearchEpoch.status.in_(statuses))
+                .order_by(
+                    AutoresearchEpoch.completed_at.desc().nulls_last(),
+                    AutoresearchEpoch.created_at.desc(),
+                )
+                .limit(scan_limit)
+            )
+            .scalars()
+            .all()
+        )
+    return _runtime_window_targets_from_autoresearch_epochs(args=args, epochs=rows)
 
 
 def _runtime_window_targets(
@@ -471,8 +565,14 @@ def _runtime_window_targets(
 ) -> list[RuntimeWindowImportTarget]:
     specs = [str(item) for item in getattr(args, "runtime_window_target", []) or []]
     plan_targets = _runtime_window_plan_targets(args)
+    autoresearch_targets = _latest_autoresearch_runtime_window_targets(args)
     registry_targets = _registry_runtime_window_targets(args)
-    if not specs and not plan_targets and not registry_targets:
+    if (
+        not specs
+        and not plan_targets
+        and not autoresearch_targets
+        and not registry_targets
+    ):
         specs = [""]
     targets: list[RuntimeWindowImportTarget] = []
     for spec in specs:
@@ -520,6 +620,11 @@ def _runtime_window_targets(
         )
     seen_hypothesis_ids = {target.hypothesis_id for target in targets}
     for target in plan_targets:
+        if target.hypothesis_id in seen_hypothesis_ids:
+            continue
+        targets.append(target)
+        seen_hypothesis_ids.add(target.hypothesis_id)
+    for target in autoresearch_targets:
         if target.hypothesis_id in seen_hypothesis_ids:
             continue
         targets.append(target)

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -710,7 +710,9 @@ class TestLiveConfigManifestContract(TestCase):
             )
         }
         clickhouse_password = cast(Mapping[str, object], env["TA_CLICKHOUSE_PASSWORD"])
-        value_from = cast(Mapping[str, object], clickhouse_password.get("valueFrom", {}))
+        value_from = cast(
+            Mapping[str, object], clickhouse_password.get("valueFrom", {})
+        )
         self.assertEqual(
             value_from.get("secretKeyRef"),
             {"name": "torghut-clickhouse-auth", "key": "torghut_password"},
@@ -810,6 +812,7 @@ class TestLiveConfigManifestContract(TestCase):
 
         args = "\n".join(str(item) for item in container.get("args", []))
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
+        self.assertIn("--runtime-window-targets-from-latest-autoresearch", args)
         self.assertIn("--runtime-window-targets-from-registry", args)
         self.assertIn("--runtime-window-hypothesis-id H-TSMOM-01", args)
         self.assertNotIn("--runtime-window-target hypothesis_id=", args)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -459,6 +459,138 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         )
         self.assertEqual(targets[0].dataset_snapshot_ref, "snapshot-paper-probation")
 
+    def test_runtime_window_targets_from_latest_autoresearch_epoch(self) -> None:
+        args = SimpleNamespace(
+            runtime_window_autoresearch_status=[],
+            runtime_window_observed_stage="paper",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+            runtime_window_delay_adjusted_depth_stress_report_ref="",
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_strategy_family="",
+            runtime_window_strategy_name="",
+        )
+        skipped_epoch = SimpleNamespace(
+            epoch_id="epoch-running",
+            status="running",
+            summary_json={
+                "candidate_board": {
+                    "runtime_window_import_plan": {
+                        "targets": [
+                            {
+                                "candidate_id": "cand-running",
+                                "hypothesis_id": "H-TSMOM-01",
+                                "strategy_family": "intraday_tsmom_consistent",
+                                "strategy_name": "intraday-tsmom-profit-v3",
+                            }
+                        ]
+                    }
+                }
+            },
+        )
+        latest_epoch = SimpleNamespace(
+            epoch_id="epoch-paper-probation",
+            status="no_profit_target_candidate",
+            summary_json={
+                "candidate_board": {
+                    "runtime_window_import_plan": {
+                        "targets": [
+                            {
+                                "candidate_id": "cand-paper-probation",
+                                "hypothesis_id": "H-MICRO-01",
+                                "strategy_family": "microstructure_breakout",
+                                "strategy_name": "microbar-volume-continuation-long-top2-chip-v1",
+                                "source_manifest_ref": "config/trading/hypotheses/h-micro-01.json",
+                                "dataset_snapshot_ref": "snapshot-paper-probation",
+                            }
+                        ]
+                    }
+                }
+            },
+        )
+
+        targets = renewal._runtime_window_targets_from_autoresearch_epochs(
+            args=args,
+            epochs=[skipped_epoch, latest_epoch],
+        )
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].candidate_id, "cand-paper-probation")
+        self.assertEqual(targets[0].hypothesis_id, "H-MICRO-01")
+        self.assertEqual(targets[0].source_dsn_env, "SIM_DB_DSN")
+        self.assertEqual(targets[0].dataset_snapshot_ref, "snapshot-paper-probation")
+
+    def test_latest_autoresearch_targets_query_uses_persisted_candidate_board(
+        self,
+    ) -> None:
+        epoch = SimpleNamespace(
+            epoch_id="epoch-latest",
+            status="ok",
+            summary_json={
+                "candidate_board": {
+                    "runtime_window_import_plan": {
+                        "targets": [
+                            {
+                                "candidate_id": "cand-latest",
+                                "hypothesis_id": "H-TSMOM-01",
+                                "strategy_family": "intraday_tsmom_consistent",
+                                "strategy_name": "intraday-tsmom-profit-v3",
+                            }
+                        ]
+                    }
+                }
+            },
+        )
+
+        class FakeResult:
+            def scalars(self) -> "FakeResult":
+                return self
+
+            def all(self) -> list[SimpleNamespace]:
+                return [epoch]
+
+        class FakeSession:
+            statement: object | None = None
+
+            def __enter__(self) -> "FakeSession":
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            def execute(self, statement: object) -> FakeResult:
+                self.statement = statement
+                return FakeResult()
+
+        fake_session = FakeSession()
+        args = SimpleNamespace(
+            runtime_window_targets_from_latest_autoresearch=True,
+            runtime_window_autoresearch_status=[],
+            runtime_window_autoresearch_scan_limit=5,
+            runtime_window_observed_stage="paper",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+            runtime_window_delay_adjusted_depth_stress_report_ref="",
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_strategy_family="",
+            runtime_window_strategy_name="",
+        )
+
+        with patch.object(renewal, "SessionLocal", return_value=fake_session):
+            targets = renewal._latest_autoresearch_runtime_window_targets(args)
+
+        self.assertIsNotNone(fake_session.statement)
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].candidate_id, "cand-latest")
+
     def test_runtime_window_target_plan_errors_are_explicit(self) -> None:
         invalid_json_path = Path(self.tmp_dir) / "invalid-candidate-board.json"
         invalid_json_path.write_text("{", encoding="utf-8")


### PR DESCRIPTION
## Summary

- Adds a renewal-path flag that reads the latest persisted whitepaper autoresearch candidate board from `autoresearch_epochs.summary_json`.
- Converts its `runtime_window_import_plan` into observed paper runtime-window targets before registry fallback targets, while keeping explicit CLI targets highest priority.
- Wires the Torghut empirical-promotion renewal CronJob to use the latest autoresearch handoff automatically.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k "runtime_window_targets_from_candidate_board_plan or runtime_window_targets_from_latest_autoresearch_epoch or latest_autoresearch_targets_query_uses_persisted_candidate_board or explicit_runtime_window_target_takes_precedence_over_plan or runtime_window_targets_from_registry_imports_all_hypotheses"`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k "empirical_promotion_renewal_imports_paper_windows_from_sim_db"`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
