### PR TITLE
chore(agents): bump chart release version

### DIFF
--- a/.github/workflows/agents-ci.yml
+++ b/.github/workflows/agents-ci.yml
@@ -666,7 +666,9 @@ jobs:
           AGENTS_RUNNER_IMAGE_TAG: ${{ env.BUILT_AGENTS_RUNNER_IMAGE_TAG }}
           AGENTS_RUNNER_IMAGE_DIGEST: ${{ env.BUILT_AGENTS_RUNNER_IMAGE_DIGEST }}
           AGENTCTL_BIN: services/agents/agentctl/dist/agentctl
-        run: bun run packages/scripts/src/agents/smoke-agents.ts
+        run: |
+          set -euo pipefail
+          timeout -k 30s "${AGENTS_TIMEOUT}" bun run packages/scripts/src/agents/smoke-agents.ts
 
       - name: Cleanup agents integration release
         if: always()

--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/proompteng/charts/tree/main/charts/agents
 type: application
 kubeVersion: '>=1.25.0-0'
-version: 0.9.20
+version: 0.9.21
 appVersion: '0.9.0'
 icon: https://avatars.githubusercontent.com/u/234536857
 keywords:

--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-version: 0.9.20
+version: 0.9.21
 name: agents
 displayName: Agents Control Plane
 description: Minimal Agents control plane with CRDs and native workflow runtime.

--- a/services/jangar/src/__tests__/agents-ci-workflow.test.ts
+++ b/services/jangar/src/__tests__/agents-ci-workflow.test.ts
@@ -17,5 +17,6 @@ describe('agents-ci workflow', () => {
     expect(workflow).toContain('--max-time 120')
     expect(workflow).toContain('--retry 3')
     expect(workflow).toContain('--retry-all-errors')
+    expect(workflow).toContain('timeout -k 30s "${AGENTS_TIMEOUT}" bun run packages/scripts/src/agents/smoke-agents.ts')
   })
 })


### PR DESCRIPTION
## Summary

- Bump the Agents Helm chart package version from `0.9.20` to `0.9.21`.
- Keep Artifact Hub package metadata aligned with `Chart.yaml`.
- Add an outer shell timeout around the Agents CI integration smoke so wedged smoke runs fail instead of blocking chart-release unblock PRs indefinitely.
- Unblocks post-merge Agents chart publishing after PR #7300 changed chart contents under the already-published `0.9.20` version.

## Related Issues

None

## Testing

- `bash scripts/agents/validate-agents.sh`
- `bun run --cwd services/jangar test -- src/__tests__/agents-ci-workflow.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
