### PR TITLE
chore(symphony): promote image 7fcd117f

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-20T17:39:04Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-21T02:17:57Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "691cb117"
-    digest: sha256:3597482f9ceb9fa8bd4fa1f57e93f7ea9e5d3725ad71324e673cf5e296618473
+    newTag: "7fcd117f"
+    digest: sha256:4c2085b135bd3d5a94cdf4361aec36b558858fd19fc1666db35ae87a9f83c7e6

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-20T17:39:04Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-21T02:17:57Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "691cb117"
-    digest: sha256:3597482f9ceb9fa8bd4fa1f57e93f7ea9e5d3725ad71324e673cf5e296618473
+    newTag: "7fcd117f"
+    digest: sha256:4c2085b135bd3d5a94cdf4361aec36b558858fd19fc1666db35ae87a9f83c7e6

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-20T17:39:04Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-21T02:17:57Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "691cb117"
-    digest: sha256:3597482f9ceb9fa8bd4fa1f57e93f7ea9e5d3725ad71324e673cf5e296618473
+    newTag: "7fcd117f"
+    digest: sha256:4c2085b135bd3d5a94cdf4361aec36b558858fd19fc1666db35ae87a9f83c7e6


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `7fcd117f7835595ec4377094943d2c0e9a68e69f`
- Image tag: `7fcd117f`
- Image digest: `sha256:4c2085b135bd3d5a94cdf4361aec36b558858fd19fc1666db35ae87a9f83c7e6`