### PR TITLE
feat(torghut): add manifest replay tape reuse

### DIFF
--- a/services/torghut/app/trading/discovery/replay_tape.py
+++ b/services/torghut/app/trading/discovery/replay_tape.py
@@ -1,0 +1,420 @@
+"""Manifest-verified replay tape artifacts for Torghut research replays."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime, time, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, TextIO, cast
+
+from app.trading.models import SignalEnvelope
+
+REPLAY_TAPE_SCHEMA_VERSION = "torghut.replay-tape.v1"
+REPLAY_TAPE_MANIFEST_SCHEMA_VERSION = "torghut.replay-tape-manifest.v1"
+_DECIMAL_TAG = "__torghut_decimal__"
+_DATETIME_TAG = "__torghut_datetime__"
+_REGULAR_OPEN_UTC = time(hour=13, minute=30)
+_REGULAR_CLOSE_UTC = time(hour=20, minute=0)
+
+
+@dataclass(frozen=True)
+class ReplayTapeManifest:
+    schema_version: str
+    dataset_snapshot_ref: str
+    symbols: tuple[str, ...]
+    row_symbols: tuple[str, ...]
+    start_date: date
+    end_date: date
+    start_ts: datetime
+    end_ts: datetime
+    min_event_ts: datetime | None
+    max_event_ts: datetime | None
+    trading_day_count: int
+    row_count: int
+    source_query_digest: str
+    content_sha256: str
+    artifact_refs: Mapping[str, str]
+    source_table_versions: Mapping[str, str]
+    created_at: datetime
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "dataset_snapshot_ref": self.dataset_snapshot_ref,
+            "symbols": list(self.symbols),
+            "row_symbols": list(self.row_symbols),
+            "start_date": self.start_date.isoformat(),
+            "end_date": self.end_date.isoformat(),
+            "start_ts": self.start_ts.isoformat(),
+            "end_ts": self.end_ts.isoformat(),
+            "min_event_ts": self.min_event_ts.isoformat()
+            if self.min_event_ts is not None
+            else None,
+            "max_event_ts": self.max_event_ts.isoformat()
+            if self.max_event_ts is not None
+            else None,
+            "trading_day_count": self.trading_day_count,
+            "row_count": self.row_count,
+            "source_query_digest": self.source_query_digest,
+            "content_sha256": self.content_sha256,
+            "artifact_refs": dict(self.artifact_refs),
+            "source_table_versions": dict(self.source_table_versions),
+            "created_at": self.created_at.isoformat(),
+        }
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "ReplayTapeManifest":
+        schema_version = str(payload.get("schema_version") or "")
+        if schema_version != REPLAY_TAPE_MANIFEST_SCHEMA_VERSION:
+            raise ValueError(f"replay_tape_manifest_schema_invalid:{schema_version}")
+        return cls(
+            schema_version=schema_version,
+            dataset_snapshot_ref=str(payload.get("dataset_snapshot_ref") or ""),
+            symbols=_string_tuple(payload.get("symbols")),
+            row_symbols=_string_tuple(payload.get("row_symbols")),
+            start_date=date.fromisoformat(str(payload["start_date"])),
+            end_date=date.fromisoformat(str(payload["end_date"])),
+            start_ts=_parse_datetime(str(payload["start_ts"])),
+            end_ts=_parse_datetime(str(payload["end_ts"])),
+            min_event_ts=(
+                _parse_datetime(str(payload["min_event_ts"]))
+                if payload.get("min_event_ts")
+                else None
+            ),
+            max_event_ts=(
+                _parse_datetime(str(payload["max_event_ts"]))
+                if payload.get("max_event_ts")
+                else None
+            ),
+            trading_day_count=int(payload.get("trading_day_count") or 0),
+            row_count=int(payload.get("row_count") or 0),
+            source_query_digest=str(payload.get("source_query_digest") or ""),
+            content_sha256=str(payload.get("content_sha256") or ""),
+            artifact_refs=_string_mapping(payload.get("artifact_refs")),
+            source_table_versions=_string_mapping(payload.get("source_table_versions")),
+            created_at=_parse_datetime(str(payload["created_at"])),
+        )
+
+
+@dataclass(frozen=True)
+class ReplayTape:
+    manifest: ReplayTapeManifest
+    rows: tuple[SignalEnvelope, ...]
+
+
+def default_manifest_path(tape_path: Path) -> Path:
+    return tape_path.with_name(f"{tape_path.name}.manifest.json")
+
+
+def build_source_query_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(
+        _json_ready(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def materialize_signal_tape(
+    *,
+    rows: Iterable[SignalEnvelope],
+    tape_path: Path,
+    manifest_path: Path | None = None,
+    dataset_snapshot_ref: str,
+    symbols: Sequence[str] = (),
+    start_date: date,
+    end_date: date,
+    source_query_digest: str,
+    source_table_versions: Mapping[str, str] | None = None,
+    artifact_refs: Mapping[str, str] | None = None,
+    created_at: datetime | None = None,
+) -> ReplayTapeManifest:
+    ordered_rows = tuple(sorted(rows, key=_signal_sort_key))
+    tape_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_ref = manifest_path or default_manifest_path(tape_path)
+    manifest_ref.parent.mkdir(parents=True, exist_ok=True)
+
+    content_hash = hashlib.sha256()
+    with _open_text_writer(tape_path) as handle:
+        for row in ordered_rows:
+            line = _canonical_row_json(row)
+            content_hash.update(line.encode("utf-8"))
+            content_hash.update(b"\n")
+            handle.write(f"{line}\n")
+
+    event_dates = {row.event_ts.astimezone(timezone.utc).date() for row in ordered_rows}
+    event_times = tuple(row.event_ts.astimezone(timezone.utc) for row in ordered_rows)
+    start_ts = datetime.combine(start_date, _REGULAR_OPEN_UTC, tzinfo=timezone.utc)
+    end_ts = datetime.combine(end_date, _REGULAR_CLOSE_UTC, tzinfo=timezone.utc)
+    resolved_artifact_refs = {
+        "tape_path": str(tape_path),
+        **dict(artifact_refs or {}),
+    }
+    manifest = ReplayTapeManifest(
+        schema_version=REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
+        dataset_snapshot_ref=dataset_snapshot_ref,
+        symbols=_normalize_symbols(symbols),
+        row_symbols=tuple(sorted({row.symbol.upper() for row in ordered_rows})),
+        start_date=start_date,
+        end_date=end_date,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        min_event_ts=min(event_times) if event_times else None,
+        max_event_ts=max(event_times) if event_times else None,
+        trading_day_count=len(event_dates),
+        row_count=len(ordered_rows),
+        source_query_digest=source_query_digest,
+        content_sha256=content_hash.hexdigest(),
+        artifact_refs=resolved_artifact_refs,
+        source_table_versions=dict(source_table_versions or {}),
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+    manifest_ref.write_text(
+        json.dumps(manifest.to_payload(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def load_replay_tape(
+    tape_path: Path,
+    *,
+    manifest_path: Path | None = None,
+    verify_digest: bool = True,
+) -> ReplayTape:
+    manifest_ref = manifest_path or default_manifest_path(tape_path)
+    manifest = ReplayTapeManifest.from_payload(
+        json.loads(manifest_ref.read_text(encoding="utf-8"))
+    )
+    rows: list[SignalEnvelope] = []
+    content_hash = hashlib.sha256()
+    with _open_text_reader(tape_path) as handle:
+        for line in handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            content_hash.update(stripped.encode("utf-8"))
+            content_hash.update(b"\n")
+            rows.append(signal_from_tape_payload(json.loads(stripped)))
+
+    if verify_digest and content_hash.hexdigest() != manifest.content_sha256:
+        raise ValueError("replay_tape_digest_mismatch")
+    if len(rows) != manifest.row_count:
+        raise ValueError(
+            f"replay_tape_row_count_mismatch:{len(rows)}!={manifest.row_count}"
+        )
+    rows.sort(key=_signal_sort_key)
+    return ReplayTape(manifest=manifest, rows=tuple(rows))
+
+
+def validate_tape_freshness(
+    manifest: ReplayTapeManifest,
+    *,
+    start_date: date,
+    end_date: date,
+    symbols: Sequence[str] = (),
+    allow_stale_tape: bool = False,
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    if manifest.start_date > start_date or manifest.end_date < end_date:
+        reasons.append(
+            "window_not_covered:"
+            f"{manifest.start_date.isoformat()}..{manifest.end_date.isoformat()}"
+            f"<{start_date.isoformat()}..{end_date.isoformat()}"
+        )
+
+    requested_symbols = set(_normalize_symbols(symbols))
+    if requested_symbols and manifest.symbols:
+        missing = sorted(requested_symbols - set(manifest.symbols))
+        if missing:
+            reasons.append(f"symbols_not_covered:{','.join(missing)}")
+
+    if reasons and not allow_stale_tape:
+        raise ValueError(f"replay_tape_stale:{';'.join(reasons)}")
+    return {
+        "schema_version": "torghut.replay-tape-validation.v1",
+        "status": "stale_override" if reasons else "valid",
+        "reasons": reasons,
+        "stale_override_used": bool(reasons),
+        "content_sha256": manifest.content_sha256,
+        "dataset_snapshot_ref": manifest.dataset_snapshot_ref,
+        "row_count": manifest.row_count,
+        "trading_day_count": manifest.trading_day_count,
+    }
+
+
+def slice_tape_by_window(
+    rows: Iterable[SignalEnvelope],
+    *,
+    start_date: date,
+    end_date: date,
+) -> tuple[SignalEnvelope, ...]:
+    selected = (
+        row
+        for row in rows
+        if start_date <= row.event_ts.astimezone(timezone.utc).date() <= end_date
+    )
+    return tuple(sorted(selected, key=_signal_sort_key))
+
+
+def slice_tape_by_symbols(
+    rows: Iterable[SignalEnvelope],
+    *,
+    symbols: Sequence[str] = (),
+) -> tuple[SignalEnvelope, ...]:
+    selected_symbols = set(_normalize_symbols(symbols))
+    if not selected_symbols:
+        return tuple(sorted(rows, key=_signal_sort_key))
+    selected = (row for row in rows if row.symbol.upper() in selected_symbols)
+    return tuple(sorted(selected, key=_signal_sort_key))
+
+
+def signal_to_tape_payload(signal: SignalEnvelope) -> dict[str, Any]:
+    return {
+        "schema_version": REPLAY_TAPE_SCHEMA_VERSION,
+        "event_ts": signal.event_ts.astimezone(timezone.utc).isoformat(),
+        "symbol": signal.symbol,
+        "payload": _encode_value(signal.payload),
+        "timeframe": signal.timeframe,
+        "ingest_ts": signal.ingest_ts.astimezone(timezone.utc).isoformat()
+        if signal.ingest_ts is not None
+        else None,
+        "seq": signal.seq,
+        "source": signal.source,
+    }
+
+
+def signal_from_tape_payload(payload: Mapping[str, Any]) -> SignalEnvelope:
+    schema_version = str(payload.get("schema_version") or "")
+    if schema_version != REPLAY_TAPE_SCHEMA_VERSION:
+        raise ValueError(f"replay_tape_row_schema_invalid:{schema_version}")
+    ingest_ts = payload.get("ingest_ts")
+    return SignalEnvelope(
+        event_ts=_parse_datetime(str(payload["event_ts"])),
+        symbol=str(payload["symbol"]),
+        payload=_decode_value(payload.get("payload") or {}),
+        timeframe=str(payload["timeframe"]) if payload.get("timeframe") else None,
+        ingest_ts=_parse_datetime(str(ingest_ts)) if ingest_ts else None,
+        seq=int(payload["seq"]) if payload.get("seq") is not None else None,
+        source=str(payload["source"]) if payload.get("source") else None,
+    )
+
+
+def _canonical_row_json(signal: SignalEnvelope) -> str:
+    return json.dumps(
+        signal_to_tape_payload(signal),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _signal_sort_key(signal: SignalEnvelope) -> tuple[datetime, str, int]:
+    seq = signal.seq if signal.seq is not None else 0
+    return (signal.event_ts.astimezone(timezone.utc), signal.symbol.upper(), seq)
+
+
+def _open_text_writer(path: Path) -> TextIO:
+    if path.suffix == ".gz":
+        return gzip.open(path, "wt", encoding="utf-8")
+    return path.open("w", encoding="utf-8")
+
+
+def _open_text_reader(path: Path) -> TextIO:
+    if path.suffix == ".gz":
+        return gzip.open(path, "rt", encoding="utf-8")
+    return path.open("r", encoding="utf-8")
+
+
+def _parse_datetime(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _normalize_symbols(symbols: Sequence[str]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {str(symbol).strip().upper() for symbol in symbols if str(symbol).strip()}
+        )
+    )
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return ()
+    return tuple(str(item) for item in cast(Sequence[object], value))
+
+
+def _string_mapping(value: Any) -> Mapping[str, str]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {
+        str(key): str(item)
+        for key, item in cast(Mapping[object, object], value).items()
+    }
+
+
+def _encode_value(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return {_DECIMAL_TAG: str(value)}
+    if isinstance(value, datetime):
+        return {_DATETIME_TAG: value.astimezone(timezone.utc).isoformat()}
+    if isinstance(value, Mapping):
+        return {
+            str(key): _encode_value(item)
+            for key, item in cast(Mapping[object, object], value).items()
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_encode_value(item) for item in cast(Sequence[object], value)]
+    return value
+
+
+def _decode_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[object, object], value)
+        if set(mapping) == {_DECIMAL_TAG}:
+            return Decimal(str(mapping[_DECIMAL_TAG]))
+        if set(mapping) == {_DATETIME_TAG}:
+            return _parse_datetime(str(mapping[_DATETIME_TAG]))
+        return {str(key): _decode_value(item) for key, item in mapping.items()}
+    if isinstance(value, list):
+        return [_decode_value(item) for item in cast(list[object], value)]
+    return value
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {
+            str(key): _json_ready(item)
+            for key, item in cast(Mapping[object, object], value).items()
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_json_ready(item) for item in cast(Sequence[object], value)]
+    return value
+
+
+__all__ = [
+    "REPLAY_TAPE_MANIFEST_SCHEMA_VERSION",
+    "REPLAY_TAPE_SCHEMA_VERSION",
+    "ReplayTape",
+    "ReplayTapeManifest",
+    "build_source_query_digest",
+    "default_manifest_path",
+    "load_replay_tape",
+    "materialize_signal_tape",
+    "signal_from_tape_payload",
+    "signal_to_tape_payload",
+    "slice_tape_by_symbols",
+    "slice_tape_by_window",
+    "validate_tape_freshness",
+]

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -28,6 +28,12 @@ from app.strategies.catalog import StrategyCatalogConfig, _compose_strategy_desc
 from app.config import settings
 from app.trading.costs import CostModelInputs, OrderIntent, TransactionCostModel
 from app.trading.decisions import DecisionEngine
+from app.trading.discovery.replay_tape import (
+    load_replay_tape,
+    slice_tape_by_symbols,
+    slice_tape_by_window,
+    validate_tape_freshness,
+)
 from app.trading.evaluation_trace import (
     NearMissRecord,
     ReplayFunnelBucket,
@@ -82,6 +88,9 @@ class ReplayConfig:
     flatten_eod: bool
     start_equity: Decimal
     symbols: tuple[str, ...] = ()
+    replay_tape_path: Path | None = None
+    replay_tape_manifest_path: Path | None = None
+    allow_stale_tape: bool = False
     progress_log_interval_seconds: int = DEFAULT_PROGRESS_LOG_INTERVAL_SECONDS
     capture_traces: bool = False
     capture_trace_funnel: bool = False
@@ -161,6 +170,21 @@ def _parse_args() -> argparse.Namespace:
         "--symbols",
         default="",
         help="Optional comma-separated symbol filter applied in the ClickHouse query.",
+    )
+    parser.add_argument(
+        "--replay-tape-path",
+        type=Path,
+        help="Optional manifest-verified replay tape JSONL/JSONL.GZ to use instead of ClickHouse reads.",
+    )
+    parser.add_argument(
+        "--replay-tape-manifest",
+        type=Path,
+        help="Optional replay tape manifest path. Defaults to <replay-tape-path>.manifest.json.",
+    )
+    parser.add_argument(
+        "--allow-stale-tape",
+        action="store_true",
+        help="Allow a replay tape whose manifest does not fully cover the requested date/symbol window.",
     )
     parser.add_argument(
         "--progress-log-seconds",
@@ -338,6 +362,10 @@ def _b64(raw: bytes) -> str:
 
 
 def _iter_signal_rows(config: ReplayConfig) -> Iterable[SignalEnvelope]:
+    if config.replay_tape_path is not None:
+        yield from _iter_signal_rows_from_replay_tape(config)
+        return
+
     chunk_delta = timedelta(minutes=config.chunk_minutes)
     current_day = config.start_date
     while current_day <= config.end_date:
@@ -391,6 +419,40 @@ def _iter_signal_rows(config: ReplayConfig) -> Iterable[SignalEnvelope]:
                 yield row
             chunk_start = chunk_end
         current_day += timedelta(days=1)
+
+
+def _iter_signal_rows_from_replay_tape(
+    config: ReplayConfig,
+) -> Iterable[SignalEnvelope]:
+    if config.replay_tape_path is None:
+        return
+    tape = load_replay_tape(
+        config.replay_tape_path,
+        manifest_path=config.replay_tape_manifest_path,
+    )
+    validation = validate_tape_freshness(
+        tape.manifest,
+        start_date=config.start_date,
+        end_date=config.end_date,
+        symbols=config.symbols,
+        allow_stale_tape=config.allow_stale_tape,
+    )
+    logger.info(
+        "replay_tape_loaded path=%s rows=%s validation_status=%s stale_override=%s digest=%s",
+        config.replay_tape_path,
+        tape.manifest.row_count,
+        validation["status"],
+        validation["stale_override_used"],
+        tape.manifest.content_sha256,
+    )
+    rows = slice_tape_by_window(
+        tape.rows,
+        start_date=config.start_date,
+        end_date=config.end_date,
+    )
+    rows = slice_tape_by_symbols(rows, symbols=config.symbols)
+    for row in rows:
+        yield row
 
 
 def _fetch_chunk(
@@ -2478,6 +2540,18 @@ def main() -> None:
             for symbol in str(args.symbols or "").split(",")
             if symbol.strip()
         ),
+        replay_tape_path=(
+            Path(replay_tape_path).resolve()
+            if (replay_tape_path := getattr(args, "replay_tape_path", None)) is not None
+            else None
+        ),
+        replay_tape_manifest_path=(
+            Path(replay_tape_manifest).resolve()
+            if (replay_tape_manifest := getattr(args, "replay_tape_manifest", None))
+            is not None
+            else None
+        ),
+        allow_stale_tape=bool(getattr(args, "allow_stale_tape", False)),
         progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
         capture_traces=(
             bool(getattr(args, "collect_traces", False))

--- a/services/torghut/scripts/materialize_replay_tape.py
+++ b/services/torghut/scripts/materialize_replay_tape.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Materialize a manifest-verified replay tape from ClickHouse PT1S signals."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from app.trading.discovery.replay_tape import (
+    build_source_query_digest,
+    default_manifest_path,
+    materialize_signal_tape,
+)
+import scripts.local_intraday_tsmom_replay as replay_mod
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fetch Torghut ClickHouse PT1S signal rows once and write a replay tape "
+            "that exact scheduler-v3 replays can reuse without repeated ClickHouse reads."
+        ),
+    )
+    parser.add_argument(
+        "--strategy-configmap",
+        type=Path,
+        default=Path("argocd/applications/torghut/strategy-configmap.yaml"),
+        help="Accepted for parity with replay CLIs; signal materialization does not inspect strategy contents.",
+    )
+    parser.add_argument(
+        "--clickhouse-http-url",
+        default=os.environ.get(
+            "TA_CLICKHOUSE_URL",
+            "http://torghut-clickhouse.torghut.svc.cluster.local:8123",
+        ),
+    )
+    parser.add_argument(
+        "--clickhouse-username",
+        default=os.environ.get(
+            "TA_CLICKHOUSE_USERNAME",
+            os.environ.get("CLICKHOUSE_USERNAME", "torghut"),
+        ),
+    )
+    parser.add_argument(
+        "--clickhouse-password",
+        default=os.environ.get(
+            "TA_CLICKHOUSE_PASSWORD",
+            os.environ.get("CLICKHOUSE_PASSWORD", ""),
+        ),
+    )
+    parser.add_argument("--start-date", required=True)
+    parser.add_argument("--end-date", required=True)
+    parser.add_argument(
+        "--chunk-minutes", type=int, default=replay_mod.DEFAULT_CHUNK_MINUTES
+    )
+    parser.add_argument("--start-equity", default=str(replay_mod.DEFAULT_START_EQUITY))
+    parser.add_argument(
+        "--symbols",
+        default="",
+        help="Optional comma-separated symbol filter applied in the ClickHouse query.",
+    )
+    parser.add_argument(
+        "--dataset-snapshot-ref",
+        required=True,
+        help="Dataset snapshot or research run ref this tape is bound to.",
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--manifest-output",
+        type=Path,
+        help="Manifest output path. Defaults to <output>.manifest.json.",
+    )
+    parser.add_argument(
+        "--source-table-version",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help="Optional source table/version metadata, repeatable.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default=os.environ.get("TORGHUT_REPLAY_LOG_LEVEL", "INFO"),
+    )
+    return parser.parse_args()
+
+
+def _parse_symbols(value: str) -> tuple[str, ...]:
+    return tuple(
+        symbol.strip().upper()
+        for symbol in str(value or "").split(",")
+        if symbol.strip()
+    )
+
+
+def _parse_source_table_versions(values: list[str]) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for value in values:
+        key, sep, item = str(value).partition("=")
+        if not sep or not key.strip():
+            raise ValueError(f"source_table_version_invalid:{value}")
+        parsed[key.strip()] = item.strip()
+    return parsed
+
+
+def _source_query_payload(
+    args: argparse.Namespace, symbols: tuple[str, ...]
+) -> dict[str, Any]:
+    return {
+        "query_family": "torghut.ta_signals_pt1s_with_microbars",
+        "clickhouse_http_url": str(args.clickhouse_http_url),
+        "start_date": str(args.start_date),
+        "end_date": str(args.end_date),
+        "chunk_minutes": max(1, int(args.chunk_minutes)),
+        "symbols": list(symbols),
+        "source": "ta",
+        "window_size": "PT1S",
+        "join": "torghut.ta_microbars",
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    logging.basicConfig(
+        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    symbols = _parse_symbols(str(args.symbols or ""))
+    start_date = date.fromisoformat(str(args.start_date))
+    end_date = date.fromisoformat(str(args.end_date))
+    source_query_digest = build_source_query_digest(
+        _source_query_payload(args=args, symbols=symbols)
+    )
+    config = replay_mod.ReplayConfig(
+        strategy_configmap_path=Path(args.strategy_configmap).resolve(),
+        clickhouse_http_url=str(args.clickhouse_http_url),
+        clickhouse_username=(str(args.clickhouse_username).strip() or None),
+        clickhouse_password=(str(args.clickhouse_password).strip() or None),
+        start_date=start_date,
+        end_date=end_date,
+        chunk_minutes=max(1, int(args.chunk_minutes)),
+        flatten_eod=True,
+        start_equity=Decimal(str(args.start_equity)),
+        symbols=symbols,
+    )
+    rows = tuple(replay_mod._iter_signal_rows(config))
+    manifest_path = args.manifest_output or default_manifest_path(args.output)
+    manifest = materialize_signal_tape(
+        rows=rows,
+        tape_path=Path(args.output).resolve(),
+        manifest_path=Path(manifest_path).resolve(),
+        dataset_snapshot_ref=str(args.dataset_snapshot_ref),
+        symbols=symbols,
+        start_date=start_date,
+        end_date=end_date,
+        source_query_digest=source_query_digest,
+        source_table_versions=_parse_source_table_versions(args.source_table_version),
+    )
+    logger.info(
+        "replay_tape_materialized output=%s manifest=%s rows=%s digest=%s",
+        args.output,
+        manifest_path,
+        manifest.row_count,
+        manifest.content_sha256,
+    )
+    print(json.dumps(manifest.to_payload(), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -42,6 +42,12 @@ from app.trading.discovery.objectives import (
     evaluate_vetoes,
     rank_scorecards,
 )
+from app.trading.discovery.replay_tape import (
+    load_replay_tape,
+    slice_tape_by_symbols,
+    slice_tape_by_window,
+    validate_tape_freshness,
+)
 from app.trading.reporting import (
     ProfitabilityConstraintPolicy,
     score_replay_profitability_candidate,
@@ -426,6 +432,19 @@ def _parse_args() -> argparse.Namespace:
         "--prefetch-full-window-rows",
         action="store_true",
         help="Fetch full-window replay rows once and reuse them for every candidate replay.",
+    )
+    parser.add_argument(
+        "--replay-tape-path",
+        type=Path,
+        help=(
+            "Optional manifest-verified replay tape to reuse for exact scheduler-v3 replays. "
+            "This replaces ClickHouse reads only; it does not make preview evidence promotable."
+        ),
+    )
+    parser.add_argument(
+        "--replay-tape-manifest",
+        type=Path,
+        help="Optional replay tape manifest path. Defaults to <replay-tape-path>.manifest.json.",
     )
     parser.add_argument("--top-n", type=int, default=10)
     parser.add_argument(
@@ -981,6 +1000,36 @@ def _cached_signal_rows_patch(rows: list[Any]) -> Iterator[None]:
         _cached_iter_signal_rows_factory(rows),
     ):
         yield
+
+
+def _load_replay_tape_rows(
+    *,
+    tape_path: Path,
+    manifest_path: Path | None,
+    start_date: date,
+    end_date: date,
+    symbols: tuple[str, ...],
+    allow_stale_tape: bool,
+) -> tuple[list[Any], dict[str, Any]]:
+    tape = load_replay_tape(tape_path, manifest_path=manifest_path)
+    validation = validate_tape_freshness(
+        tape.manifest,
+        start_date=start_date,
+        end_date=end_date,
+        symbols=symbols,
+        allow_stale_tape=allow_stale_tape,
+    )
+    rows = slice_tape_by_window(
+        tape.rows,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    rows = slice_tape_by_symbols(rows, symbols=symbols)
+    validation["tape_path"] = str(tape_path)
+    validation["manifest_path"] = str(manifest_path) if manifest_path else ""
+    validation["selected_row_count"] = len(rows)
+    validation["selected_symbols"] = sorted({row.symbol.upper() for row in rows})
+    return list(rows), validation
 
 
 def apply_candidate_to_configmap_with_overrides(
@@ -2388,6 +2437,7 @@ def _build_frontier_payload(
     top_n: int,
     status: str,
     pending_candidates: int,
+    replay_tape_validation: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     ranked_items = _rank_scored_candidates(scored)
     return {
@@ -2430,6 +2480,7 @@ def _build_frontier_payload(
             "method": "pareto_frontier_v2",
             "stale_override_used": dataset_snapshot_receipt.stale_override_used,
         },
+        "replay_tape": dict(replay_tape_validation or {}),
         "progress": {
             "evaluated_candidates": len(scored),
             "pending_candidates": pending_candidates,
@@ -2677,7 +2728,22 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         )
         order_type_ablation_evaluated = 0
         cached_rows: list[Any] | None = None
-        if args.prefetch_full_window_rows:
+        replay_tape_validation: dict[str, Any] | None = None
+        replay_tape_path = getattr(args, "replay_tape_path", None)
+        if replay_tape_path is not None:
+            cached_rows, replay_tape_validation = _load_replay_tape_rows(
+                tape_path=Path(replay_tape_path).resolve(),
+                manifest_path=(
+                    Path(args.replay_tape_manifest).resolve()
+                    if getattr(args, "replay_tape_manifest", None) is not None
+                    else None
+                ),
+                start_date=full_window_start,
+                end_date=full_window_end,
+                symbols=prefetch_symbols,
+                allow_stale_tape=bool(getattr(args, "allow_stale_tape", False)),
+            )
+        elif args.prefetch_full_window_rows:
             cached_rows = _prefetch_signal_rows(
                 strategy_configmap_path=args.strategy_configmap.resolve(),
                 clickhouse_http_url=str(args.clickhouse_http_url),
@@ -3431,6 +3497,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                         status="running",
                         pending_candidates=len(worklist)
                         + (0 if initial_candidates_exhausted else 1),
+                        replay_tape_validation=replay_tape_validation,
                     )
                     _write_json_output(args.json_output, partial_payload)
 
@@ -3451,6 +3518,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         if budget_exhausted and (worklist or not initial_candidates_exhausted)
         else "completed",
         pending_candidates=len(worklist) + (0 if initial_candidates_exhausted else 1),
+        replay_tape_validation=replay_tape_validation,
     )
     if args.json_output is not None:
         _write_json_output(args.json_output, payload)

--- a/services/torghut/scripts/search_profitability_frontier.py
+++ b/services/torghut/scripts/search_profitability_frontier.py
@@ -262,6 +262,9 @@ def _build_replay_config(
     symbols: tuple[str, ...],
     progress_log_interval_seconds: int,
     capture_trace_funnel: bool = False,
+    replay_tape_path: Path | None = None,
+    replay_tape_manifest_path: Path | None = None,
+    allow_stale_tape: bool = False,
 ) -> ReplayConfig:
     return ReplayConfig(
         strategy_configmap_path=strategy_configmap_path,
@@ -274,6 +277,9 @@ def _build_replay_config(
         flatten_eod=True,
         start_equity=start_equity,
         symbols=symbols,
+        replay_tape_path=replay_tape_path,
+        replay_tape_manifest_path=replay_tape_manifest_path,
+        allow_stale_tape=allow_stale_tape,
         progress_log_interval_seconds=progress_log_interval_seconds,
         capture_trace_funnel=capture_trace_funnel,
         force_position_isolation=True,

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+from argparse import Namespace
+from contextlib import redirect_stdout
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+from app.trading.discovery.replay_tape import (
+    REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
+    ReplayTapeManifest,
+    build_source_query_digest,
+    default_manifest_path,
+    load_replay_tape,
+    materialize_signal_tape,
+    signal_from_tape_payload,
+    slice_tape_by_symbols,
+    slice_tape_by_window,
+    validate_tape_freshness,
+)
+from app.trading.models import SignalEnvelope
+from scripts import materialize_replay_tape as materialize_cli
+from scripts.local_intraday_tsmom_replay import (
+    ReplayConfig,
+    _iter_signal_rows,
+    _iter_signal_rows_from_replay_tape,
+)
+
+
+class TestReplayTape(TestCase):
+    def _signal(
+        self,
+        *,
+        day: int,
+        seq: int,
+        symbol: str = "META",
+        price: str = "100.25",
+    ) -> SignalEnvelope:
+        return SignalEnvelope(
+            event_ts=datetime(2026, 3, day, 17, 30, seq, tzinfo=timezone.utc),
+            symbol=symbol,
+            timeframe="1Sec",
+            seq=seq,
+            source="ta",
+            payload={
+                "price": Decimal(price),
+                "spread": Decimal("0.02"),
+                "nested": {"bid_px": Decimal("100.24"), "label": "keep-string"},
+                "levels": [Decimal("100.24"), Decimal("100.26")],
+                "computed_at": datetime(2026, 3, day, 17, 30, tzinfo=timezone.utc),
+                "window_size": "PT1S",
+            },
+            ingest_ts=datetime(2026, 3, day, 17, 31, tzinfo=timezone.utc),
+        )
+
+    def test_materialize_load_and_slice_preserves_order_and_decimal_payloads(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            tape_path = Path(tmpdir) / "tape.jsonl"
+            materialize_signal_tape(
+                rows=[
+                    self._signal(day=27, seq=2, symbol="AAPL", price="190.10"),
+                    self._signal(day=26, seq=1, symbol="META", price="100.25"),
+                ],
+                tape_path=tape_path,
+                dataset_snapshot_ref="snapshot-a",
+                symbols=("META", "AAPL"),
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 27),
+                source_query_digest=build_source_query_digest({"window": "a"}),
+            )
+
+            tape = load_replay_tape(tape_path)
+
+        self.assertEqual(tape.manifest.row_count, 2)
+        self.assertEqual([row.symbol for row in tape.rows], ["META", "AAPL"])
+        self.assertEqual(tape.rows[0].payload["price"], Decimal("100.25"))
+        self.assertEqual(tape.rows[0].payload["nested"]["label"], "keep-string")
+        self.assertEqual(
+            tape.rows[0].payload["computed_at"],
+            datetime(2026, 3, 26, 17, 30, tzinfo=timezone.utc),
+        )
+        self.assertEqual(tape.rows[0].payload["levels"][0], Decimal("100.24"))
+        self.assertEqual(
+            [row.symbol for row in slice_tape_by_symbols(tape.rows, symbols=())],
+            ["META", "AAPL"],
+        )
+        self.assertEqual(
+            [row.symbol for row in slice_tape_by_symbols(tape.rows, symbols=("AAPL",))],
+            ["AAPL"],
+        )
+        self.assertEqual(
+            [
+                row.seq
+                for row in slice_tape_by_window(
+                    tape.rows, start_date=date(2026, 3, 27), end_date=date(2026, 3, 27)
+                )
+            ],
+            [2],
+        )
+
+    def test_manifest_digest_changes_when_source_rows_change(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            first = Path(tmpdir) / "first.jsonl"
+            second = Path(tmpdir) / "second.jsonl"
+            first_manifest = materialize_signal_tape(
+                rows=[self._signal(day=27, seq=1, price="100.25")],
+                tape_path=first,
+                dataset_snapshot_ref="snapshot-a",
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                source_query_digest=build_source_query_digest({"window": "a"}),
+            )
+            second_manifest = materialize_signal_tape(
+                rows=[self._signal(day=27, seq=1, price="100.30")],
+                tape_path=second,
+                dataset_snapshot_ref="snapshot-a",
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                source_query_digest=build_source_query_digest({"window": "a"}),
+            )
+
+        self.assertNotEqual(
+            first_manifest.content_sha256, second_manifest.content_sha256
+        )
+
+    def test_manifest_payload_rejects_wrong_schema_and_coerces_loose_metadata(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(ValueError, "replay_tape_manifest_schema_invalid"):
+            ReplayTapeManifest.from_payload({"schema_version": "old"})
+
+        manifest = ReplayTapeManifest.from_payload(
+            {
+                "schema_version": REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
+                "dataset_snapshot_ref": "snapshot-a",
+                "symbols": "META",
+                "row_symbols": b"META",
+                "start_date": "2026-03-27",
+                "end_date": "2026-03-27",
+                "start_ts": "2026-03-27T13:30:00",
+                "end_ts": "2026-03-27T20:00:00Z",
+                "min_event_ts": None,
+                "max_event_ts": None,
+                "trading_day_count": 0,
+                "row_count": 0,
+                "source_query_digest": "digest",
+                "content_sha256": "sha",
+                "artifact_refs": [],
+                "source_table_versions": [],
+                "created_at": "2026-03-27T21:00:00Z",
+            }
+        )
+
+        self.assertEqual(manifest.symbols, ())
+        self.assertEqual(manifest.row_symbols, ())
+        self.assertEqual(manifest.artifact_refs, {})
+        self.assertEqual(manifest.source_table_versions, {})
+        self.assertEqual(manifest.start_ts.tzinfo, timezone.utc)
+
+    def test_load_replay_tape_rejects_digest_and_row_count_mismatches(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            tape_path = Path(tmpdir) / "tape.jsonl"
+            manifest = materialize_signal_tape(
+                rows=[self._signal(day=27, seq=1, price="100.25")],
+                tape_path=tape_path,
+                dataset_snapshot_ref="snapshot-a",
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                source_query_digest=build_source_query_digest({"window": "a"}),
+            )
+            manifest_path = default_manifest_path(tape_path)
+            tape_path.write_text(
+                tape_path.read_text(encoding="utf-8").replace("100.25", "100.26"),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "replay_tape_digest_mismatch"):
+                load_replay_tape(tape_path, manifest_path=manifest_path)
+
+            materialize_signal_tape(
+                rows=[self._signal(day=27, seq=1, price="100.25")],
+                tape_path=tape_path,
+                dataset_snapshot_ref="snapshot-a",
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                source_query_digest=build_source_query_digest({"window": "a"}),
+            )
+            payload = manifest.to_payload()
+            payload["row_count"] = 2
+            manifest_path.write_text(
+                json.dumps(payload, sort_keys=True), encoding="utf-8"
+            )
+
+            with self.assertRaisesRegex(ValueError, "replay_tape_row_count_mismatch"):
+                load_replay_tape(tape_path, manifest_path=manifest_path)
+
+    def test_gzip_tape_round_trips_and_row_schema_fails_closed(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            tape_path = Path(tmpdir) / "tape.jsonl.gz"
+            materialize_signal_tape(
+                rows=[self._signal(day=27, seq=1, price="100.25")],
+                tape_path=tape_path,
+                dataset_snapshot_ref="snapshot-a",
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                source_query_digest=build_source_query_digest({"window": "a"}),
+            )
+
+            tape = load_replay_tape(tape_path)
+
+        self.assertEqual(tape.manifest.row_count, 1)
+        self.assertEqual(tape.rows[0].symbol, "META")
+        with self.assertRaisesRegex(ValueError, "replay_tape_row_schema_invalid"):
+            signal_from_tape_payload({"schema_version": "old"})
+
+    def test_stale_tape_fails_closed_unless_explicitly_allowed(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            manifest = materialize_signal_tape(
+                rows=[self._signal(day=27, seq=1, symbol="META")],
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-a",
+                symbols=("META",),
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                source_query_digest=build_source_query_digest({"window": "a"}),
+            )
+
+        with self.assertRaisesRegex(ValueError, "replay_tape_stale"):
+            validate_tape_freshness(
+                manifest,
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 27),
+                symbols=("META",),
+            )
+
+        receipt = validate_tape_freshness(
+            manifest,
+            start_date=date(2026, 3, 26),
+            end_date=date(2026, 3, 27),
+            symbols=("META",),
+            allow_stale_tape=True,
+        )
+        self.assertEqual(receipt["status"], "stale_override")
+        self.assertTrue(receipt["stale_override_used"])
+
+        with self.assertRaisesRegex(ValueError, "symbols_not_covered:AAPL"):
+            validate_tape_freshness(
+                manifest,
+                start_date=date(2026, 3, 27),
+                end_date=date(2026, 3, 27),
+                symbols=("AAPL",),
+            )
+
+    def test_source_query_digest_normalizes_dates_decimals_and_lists(self) -> None:
+        digest = build_source_query_digest(
+            {
+                "day": date(2026, 3, 27),
+                "threshold": Decimal("1.25"),
+                "items": [date(2026, 3, 26), Decimal("2.50")],
+            }
+        )
+
+        self.assertEqual(len(digest), 64)
+
+    def test_local_replay_tape_iterator_is_empty_without_tape_path(self) -> None:
+        config = ReplayConfig(
+            strategy_configmap_path=Path("/tmp/strategy.yaml"),
+            clickhouse_http_url="http://clickhouse.invalid:8123",
+            clickhouse_username=None,
+            clickhouse_password=None,
+            start_date=date(2026, 3, 26),
+            end_date=date(2026, 3, 27),
+            chunk_minutes=10,
+            flatten_eod=True,
+            start_equity=Decimal("10000"),
+        )
+
+        self.assertEqual(list(_iter_signal_rows_from_replay_tape(config)), [])
+
+    def test_local_replay_iter_signal_rows_reads_tape_without_clickhouse(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            tape_path = Path(tmpdir) / "tape.jsonl"
+            materialize_signal_tape(
+                rows=[
+                    self._signal(day=26, seq=1, symbol="META"),
+                    self._signal(day=27, seq=2, symbol="AAPL"),
+                ],
+                tape_path=tape_path,
+                dataset_snapshot_ref="snapshot-a",
+                symbols=("META", "AAPL"),
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 27),
+                source_query_digest=build_source_query_digest({"window": "a"}),
+            )
+            config = ReplayConfig(
+                strategy_configmap_path=Path("/tmp/strategy.yaml"),
+                clickhouse_http_url="http://clickhouse.invalid:8123",
+                clickhouse_username=None,
+                clickhouse_password=None,
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 27),
+                chunk_minutes=10,
+                flatten_eod=True,
+                start_equity=Decimal("10000"),
+                symbols=("AAPL",),
+                replay_tape_path=tape_path,
+            )
+
+            with patch(
+                "scripts.local_intraday_tsmom_replay._fetch_chunk",
+                side_effect=AssertionError("clickhouse should not be queried"),
+            ):
+                rows = list(_iter_signal_rows(config))
+
+        self.assertEqual([row.symbol for row in rows], ["AAPL"])
+        self.assertEqual(rows[0].payload["price"], Decimal("100.25"))
+
+
+class TestMaterializeReplayTapeCli(TestCase):
+    def _signal(self, *, day: int, seq: int) -> SignalEnvelope:
+        return SignalEnvelope(
+            event_ts=datetime(2026, 3, day, 17, 30, seq, tzinfo=timezone.utc),
+            symbol="META",
+            timeframe="1Sec",
+            seq=seq,
+            source="ta",
+            payload={
+                "price": Decimal("100.25"),
+                "spread": Decimal("0.02"),
+                "window_size": "PT1S",
+            },
+            ingest_ts=datetime(2026, 3, day, 17, 31, tzinfo=timezone.utc),
+        )
+
+    def test_parse_args_and_helpers_normalize_cli_inputs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "tape.jsonl"
+            with patch.object(
+                sys,
+                "argv",
+                [
+                    "prog",
+                    "--start-date",
+                    "2026-03-26",
+                    "--end-date",
+                    "2026-03-27",
+                    "--dataset-snapshot-ref",
+                    "snapshot-cli",
+                    "--output",
+                    str(output),
+                    "--symbols",
+                    " nvda, META ",
+                    "--source-table-version",
+                    "ta_signals=v1",
+                ],
+            ):
+                args = materialize_cli._parse_args()
+
+        symbols = materialize_cli._parse_symbols(str(args.symbols))
+        self.assertEqual(symbols, ("NVDA", "META"))
+        self.assertEqual(
+            materialize_cli._parse_source_table_versions(args.source_table_version),
+            {"ta_signals": "v1"},
+        )
+        self.assertEqual(
+            materialize_cli._source_query_payload(args=args, symbols=symbols)[
+                "symbols"
+            ],
+            ["NVDA", "META"],
+        )
+        with self.assertRaisesRegex(ValueError, "source_table_version_invalid"):
+            materialize_cli._parse_source_table_versions(["broken"])
+
+    def test_main_materializes_manifest_from_replay_rows(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "tape.jsonl"
+            manifest_output = root / "tape.manifest.json"
+            args = Namespace(
+                strategy_configmap=root / "strategy.yaml",
+                clickhouse_http_url="http://clickhouse.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_date="2026-03-26",
+                end_date="2026-03-27",
+                chunk_minutes=0,
+                start_equity="10000",
+                symbols="meta",
+                dataset_snapshot_ref="snapshot-cli",
+                output=output,
+                manifest_output=manifest_output,
+                source_table_version=["ta_signals=v1"],
+                log_level="WARNING",
+            )
+            stdout = io.StringIO()
+            with (
+                patch(
+                    "scripts.materialize_replay_tape._parse_args",
+                    return_value=args,
+                ),
+                patch(
+                    "scripts.materialize_replay_tape.replay_mod._iter_signal_rows",
+                    return_value=(self._signal(day=26, seq=1),),
+                ),
+                redirect_stdout(stdout),
+            ):
+                exit_code = materialize_cli.main()
+
+            payload = json.loads(stdout.getvalue())
+            output_exists = output.exists()
+            manifest_exists = manifest_output.exists()
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(output_exists)
+        self.assertTrue(manifest_exists)
+        self.assertEqual(payload["dataset_snapshot_ref"], "snapshot-cli")
+        self.assertEqual(payload["row_count"], 1)
+        self.assertEqual(payload["source_table_versions"], {"ta_signals": "v1"})

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -16,6 +16,11 @@ from types import SimpleNamespace
 
 import yaml
 
+from app.trading.discovery.replay_tape import (
+    build_source_query_digest,
+    materialize_signal_tape,
+)
+from app.trading.models import SignalEnvelope
 import scripts.search_consistent_profitability_frontier as frontier
 
 
@@ -103,6 +108,10 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     "--clickhouse-password-env",
                     "TORGHUT_CLICKHOUSE_PASSWORD",
                     "--allow-stale-tape",
+                    "--replay-tape-path",
+                    str(root / "tape.jsonl"),
+                    "--replay-tape-manifest",
+                    str(root / "tape.jsonl.manifest.json"),
                     "--family-template-dir",
                     str(family_dir),
                     "--max-candidates-to-evaluate",
@@ -126,6 +135,8 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(args.expected_last_trading_day, "2026-04-07")
         self.assertEqual(args.clickhouse_password_env, "TORGHUT_CLICKHOUSE_PASSWORD")
         self.assertTrue(args.allow_stale_tape)
+        self.assertEqual(args.replay_tape_path, root / "tape.jsonl")
+        self.assertEqual(args.replay_tape_manifest, root / "tape.jsonl.manifest.json")
         self.assertEqual(args.family_template_dir, family_dir)
         self.assertEqual(args.max_candidates_to_evaluate, 12)
         self.assertEqual(args.candidate_record, [root / "candidate.json"])
@@ -135,6 +146,52 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(args.max_train_screen_worst_day_loss, "125")
         self.assertEqual(args.second_oos_days, 2)
         self.assertTrue(args.collect_train_gate_diagnostics)
+
+    def test_load_replay_tape_rows_validates_and_slices_rows(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            tape_path = root / "frontier-tape.jsonl"
+            materialize_signal_tape(
+                rows=[
+                    SignalEnvelope(
+                        event_ts=datetime(2026, 3, 18, 17, 30, tzinfo=timezone.utc),
+                        symbol="NVDA",
+                        timeframe="1Sec",
+                        seq=1,
+                        source="ta",
+                        payload={"price": Decimal("900.00")},
+                    ),
+                    SignalEnvelope(
+                        event_ts=datetime(2026, 3, 19, 17, 30, tzinfo=timezone.utc),
+                        symbol="META",
+                        timeframe="1Sec",
+                        seq=2,
+                        source="ta",
+                        payload={"price": Decimal("500.00")},
+                    ),
+                ],
+                tape_path=tape_path,
+                dataset_snapshot_ref="snapshot-frontier",
+                symbols=("NVDA", "META"),
+                start_date=date(2026, 3, 18),
+                end_date=date(2026, 3, 19),
+                source_query_digest=build_source_query_digest({"query": "frontier"}),
+            )
+
+            rows, validation = frontier._load_replay_tape_rows(
+                tape_path=tape_path,
+                manifest_path=None,
+                start_date=date(2026, 3, 18),
+                end_date=date(2026, 3, 18),
+                symbols=("NVDA",),
+                allow_stale_tape=False,
+            )
+
+        self.assertEqual([row.symbol for row in rows], ["NVDA"])
+        self.assertEqual(validation["status"], "valid")
+        self.assertEqual(validation["selected_row_count"], 1)
+        self.assertEqual(validation["selected_symbols"], ["NVDA"])
+        self.assertEqual(validation["manifest_path"], "")
 
     def test_clickhouse_password_env_resolution_keeps_secret_out_of_argv(self) -> None:
         with patch.dict("os.environ", {"TORGHUT_CLICKHOUSE_PASSWORD": "from-env"}):
@@ -1644,6 +1701,27 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 sweep_config=sweep_config,
                 json_output=json_output,
             )
+            tape_path = root / "full-window-tape.jsonl"
+            materialize_signal_tape(
+                rows=[
+                    SignalEnvelope(
+                        event_ts=datetime(2026, 3, 18, 17, 30, tzinfo=timezone.utc),
+                        symbol="NVDA",
+                        timeframe="1Sec",
+                        seq=1,
+                        source="ta",
+                        payload={"price": Decimal("900.00")},
+                    )
+                ],
+                tape_path=tape_path,
+                dataset_snapshot_ref="snapshot-test",
+                symbols=("NVDA", "AMAT"),
+                start_date=date(2026, 3, 18),
+                end_date=date(2026, 3, 23),
+                source_query_digest=build_source_query_digest({"query": "frontier"}),
+            )
+            args.replay_tape_path = tape_path
+            args.replay_tape_manifest = None
             recent_days = tuple(
                 date(2026, 3, 18) + timedelta(days=index) for index in range(6)
             )
@@ -1790,6 +1868,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             self.assertEqual(
                 payload["dataset_snapshot_receipt"]["snapshot_id"], "snap-test"
             )
+            self.assertEqual(payload["replay_tape"]["selected_row_count"], 1)
             self.assertEqual(top["ranking"]["method"], "pareto_frontier_v2")
             self.assertEqual(top["family_template_id"], "intraday_tsmom_v2")
 


### PR DESCRIPTION
## Summary

- Adds a manifest-verified replay tape artifact for Torghut signal rows, including dataset refs, source query digests, content sha256 checks, window and symbol validation, and deterministic row slicing.
- Adds `scripts/materialize_replay_tape.py` plus `--replay-tape-path` / `--replay-tape-manifest` support for local exact replay and consistent frontier sweeps.
- Keeps promotion authority unchanged: tape reuse only replaces repeated ClickHouse reads, while exact scheduler/runtime replay still produces candidate evidence and stale tapes fail closed unless explicitly overridden.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_replay_tape.py tests/test_local_intraday_tsmom_replay.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen ruff format --check app/trading/discovery/replay_tape.py scripts/materialize_replay_tape.py scripts/local_intraday_tsmom_replay.py scripts/search_profitability_frontier.py scripts/search_consistent_profitability_frontier.py tests/test_replay_tape.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen ruff check app/trading/discovery/replay_tape.py scripts/materialize_replay_tape.py scripts/local_intraday_tsmom_replay.py scripts/search_profitability_frontier.py scripts/search_consistent_profitability_frontier.py tests/test_replay_tape.py tests/test_search_consistent_profitability_frontier.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/materialize_replay_tape.py --help`
- `uv run --frozen python scripts/local_intraday_tsmom_replay.py --help`
- `uv run --frozen python scripts/search_consistent_profitability_frontier.py --help`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
