### PR TITLE
feat(torghut): reuse replay tapes in autoresearch

### DIFF
--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -59,6 +59,12 @@ from app.trading.discovery.promotion_contract import (
 from app.trading.discovery.portfolio_candidates import PortfolioCandidateSpec
 from app.trading.discovery.portfolio_optimizer import optimize_portfolio_candidate
 from app.trading.discovery.profit_target_oracle import ProfitTargetOraclePolicy
+from app.trading.discovery.replay_tape import (
+    ReplayTapeManifest,
+    build_source_query_digest,
+    default_manifest_path,
+    materialize_signal_tape,
+)
 from app.trading.discovery.runtime_closure import write_runtime_closure_bundle
 from app.trading.discovery.runtime_closure import RuntimeClosureExecutionContext
 import scripts.local_intraday_tsmom_replay as replay_mod
@@ -142,6 +148,26 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--expected-last-trading-day", default="")
     parser.add_argument("--allow-stale-tape", action="store_true")
     parser.add_argument("--prefetch-full-window-rows", action="store_true")
+    parser.add_argument(
+        "--replay-tape-path",
+        type=Path,
+        default=None,
+        help="Optional manifest-verified replay tape reused by each frontier run.",
+    )
+    parser.add_argument(
+        "--replay-tape-manifest",
+        type=Path,
+        default=None,
+        help="Optional manifest path for --replay-tape-path.",
+    )
+    parser.add_argument(
+        "--materialize-replay-tape",
+        action="store_true",
+        help=(
+            "Fetch the resolved full-window signal rows once, write a run-scoped "
+            "replay tape, and pass it into every exact frontier run."
+        ),
+    )
     parser.add_argument(
         "--max-frontier-runs",
         type=int,
@@ -343,6 +369,8 @@ def _snapshot_symbols(
 def _mlx_bundle_paths(run_root: Path) -> dict[str, str]:
     return {
         "signal_rows_jsonl": str(run_root / "mlx-snapshot-signals.jsonl"),
+        "replay_tape_jsonl": str(run_root / "replay-tape.jsonl"),
+        "replay_tape_manifest_json": str(run_root / "replay-tape.jsonl.manifest.json"),
         "descriptors_jsonl": str(run_root / "mlx-candidate-descriptors.jsonl"),
         "proposal_scores_jsonl": str(run_root / "mlx-proposal-scores.jsonl"),
         "history_jsonl": str(run_root / "history.jsonl"),
@@ -503,6 +531,17 @@ def _frontier_args(
         allow_stale_tape=bool(args.allow_stale_tape),
         family_template_dir=args.family_template_dir.resolve(),
         prefetch_full_window_rows=bool(args.prefetch_full_window_rows),
+        replay_tape_path=(
+            Path(replay_tape_path).resolve()
+            if (replay_tape_path := getattr(args, "replay_tape_path", None)) is not None
+            else None
+        ),
+        replay_tape_manifest=(
+            Path(replay_tape_manifest).resolve()
+            if (replay_tape_manifest := getattr(args, "replay_tape_manifest", None))
+            is not None
+            else None
+        ),
         top_n=top_n,
         max_candidates_to_evaluate=max_candidates_to_evaluate,
         json_output=json_output_path,
@@ -532,20 +571,16 @@ def _iso_date(value: str) -> date:
     return date.fromisoformat(value)
 
 
-def _maybe_write_signal_bundle(
+def _full_window_signal_config(
     *,
     args: argparse.Namespace,
     snapshot_symbols: tuple[str, ...],
-    bundle_paths: Mapping[str, str],
     full_window_start_date: str,
     full_window_end_date: str,
-    existing: MlxSignalBundleStats | None,
-) -> MlxSignalBundleStats | None:
-    if existing is not None:
-        return existing
+) -> replay_mod.ReplayConfig | None:
     if not full_window_start_date or not full_window_end_date or not snapshot_symbols:
-        return existing
-    signal_bundle_config = replay_mod.ReplayConfig(
+        return None
+    return replay_mod.ReplayConfig(
         strategy_configmap_path=args.strategy_configmap.resolve(),
         clickhouse_http_url=str(args.clickhouse_http_url),
         clickhouse_username=(str(args.clickhouse_username).strip() or None),
@@ -558,9 +593,144 @@ def _maybe_write_signal_bundle(
         symbols=snapshot_symbols,
         progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
     )
+
+
+def _replay_tape_source_query_digest(
+    *,
+    args: argparse.Namespace,
+    snapshot_symbols: tuple[str, ...],
+    full_window_start_date: str,
+    full_window_end_date: str,
+) -> str:
+    return build_source_query_digest(
+        {
+            "query_family": "torghut.autoresearch_full_window_pt1s",
+            "clickhouse_http_url": str(args.clickhouse_http_url),
+            "start_date": full_window_start_date,
+            "end_date": full_window_end_date,
+            "chunk_minutes": max(1, int(args.chunk_minutes)),
+            "symbols": list(snapshot_symbols),
+            "source": "ta",
+            "window_size": "PT1S",
+            "join": "torghut.ta_microbars",
+        }
+    )
+
+
+def _replay_tape_receipt(
+    *,
+    status: str,
+    tape_path: Path,
+    manifest_path: Path,
+    manifest: ReplayTapeManifest,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "torghut.autoresearch-replay-tape-receipt.v1",
+        "status": status,
+        "tape_path": str(tape_path),
+        "manifest_path": str(manifest_path),
+        "dataset_snapshot_ref": manifest.dataset_snapshot_ref,
+        "row_count": manifest.row_count,
+        "trading_day_count": manifest.trading_day_count,
+        "row_symbols": list(manifest.row_symbols),
+        "content_sha256": manifest.content_sha256,
+        "source_query_digest": manifest.source_query_digest,
+    }
+
+
+def _provided_replay_tape_receipt(
+    *,
+    tape_path: Path,
+    manifest_path: Path | None,
+) -> dict[str, Any] | None:
+    resolved_manifest_path = manifest_path or default_manifest_path(tape_path)
+    if not resolved_manifest_path.exists():
+        return None
+    manifest = ReplayTapeManifest.from_payload(
+        json.loads(resolved_manifest_path.read_text(encoding="utf-8"))
+    )
+    return _replay_tape_receipt(
+        status="provided",
+        tape_path=tape_path,
+        manifest_path=resolved_manifest_path,
+        manifest=manifest,
+    )
+
+
+def _maybe_write_signal_bundle(
+    *,
+    args: argparse.Namespace,
+    snapshot_symbols: tuple[str, ...],
+    bundle_paths: Mapping[str, str],
+    full_window_start_date: str,
+    full_window_end_date: str,
+    existing: MlxSignalBundleStats | None,
+) -> MlxSignalBundleStats | None:
+    if existing is not None:
+        return existing
+    signal_bundle_config = _full_window_signal_config(
+        args=args,
+        snapshot_symbols=snapshot_symbols,
+        full_window_start_date=full_window_start_date,
+        full_window_end_date=full_window_end_date,
+    )
+    if signal_bundle_config is None:
+        return existing
     return write_mlx_signal_bundle(
         Path(bundle_paths["signal_rows_jsonl"]),
         replay_mod._iter_signal_rows(signal_bundle_config),
+    )
+
+
+def _maybe_materialize_run_replay_tape(
+    *,
+    args: argparse.Namespace,
+    runner_run_id: str,
+    snapshot_symbols: tuple[str, ...],
+    bundle_paths: Mapping[str, str],
+    full_window_start_date: str,
+    full_window_end_date: str,
+    existing_signal_bundle: MlxSignalBundleStats | None,
+) -> tuple[MlxSignalBundleStats | None, dict[str, Any] | None]:
+    if not bool(getattr(args, "materialize_replay_tape", False)):
+        return existing_signal_bundle, None
+    if getattr(args, "replay_tape_path", None) is not None:
+        return existing_signal_bundle, None
+    signal_bundle_config = _full_window_signal_config(
+        args=args,
+        snapshot_symbols=snapshot_symbols,
+        full_window_start_date=full_window_start_date,
+        full_window_end_date=full_window_end_date,
+    )
+    if signal_bundle_config is None:
+        return existing_signal_bundle, None
+    rows = tuple(replay_mod._iter_signal_rows(signal_bundle_config))
+    tape_path = Path(bundle_paths["replay_tape_jsonl"])
+    manifest_path = Path(bundle_paths["replay_tape_manifest_json"])
+    manifest = materialize_signal_tape(
+        rows=rows,
+        tape_path=tape_path,
+        manifest_path=manifest_path,
+        dataset_snapshot_ref=runner_run_id,
+        symbols=snapshot_symbols,
+        start_date=_iso_date(full_window_start_date),
+        end_date=_iso_date(full_window_end_date),
+        source_query_digest=_replay_tape_source_query_digest(
+            args=args,
+            snapshot_symbols=snapshot_symbols,
+            full_window_start_date=full_window_start_date,
+            full_window_end_date=full_window_end_date,
+        ),
+    )
+    signal_bundle_stats = existing_signal_bundle or write_mlx_signal_bundle(
+        Path(bundle_paths["signal_rows_jsonl"]),
+        rows,
+    )
+    return signal_bundle_stats, _replay_tape_receipt(
+        status="materialized",
+        tape_path=tape_path,
+        manifest_path=manifest_path,
+        manifest=manifest,
     )
 
 
@@ -1384,6 +1554,24 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
     resolved_full_window_start_date = _string(args.full_window_start_date)
     resolved_full_window_end_date = _string(args.full_window_end_date)
     signal_bundle_stats: MlxSignalBundleStats | None = None
+    effective_replay_tape_path = (
+        Path(replay_tape_path).resolve()
+        if (replay_tape_path := getattr(args, "replay_tape_path", None)) is not None
+        else None
+    )
+    effective_replay_tape_manifest = (
+        Path(replay_tape_manifest).resolve()
+        if (replay_tape_manifest := getattr(args, "replay_tape_manifest", None))
+        is not None
+        else None
+    )
+    if effective_replay_tape_path is not None:
+        provided_receipt = _provided_replay_tape_receipt(
+            tape_path=effective_replay_tape_path,
+            manifest_path=effective_replay_tape_manifest,
+        )
+        if provided_receipt is not None:
+            tape_freshness_receipts.append(provided_receipt)
     closure_execution_context = RuntimeClosureExecutionContext(
         strategy_configmap_path=args.strategy_configmap.resolve(),
         clickhouse_http_url=str(args.clickhouse_http_url),
@@ -1445,6 +1633,23 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         status="running",
         closure_execution_context=closure_execution_context,
     )
+    signal_bundle_stats, materialized_replay_tape_receipt = (
+        _maybe_materialize_run_replay_tape(
+            args=args,
+            runner_run_id=runner_run_id,
+            snapshot_symbols=snapshot_symbols,
+            bundle_paths=bundle_paths,
+            full_window_start_date=resolved_full_window_start_date,
+            full_window_end_date=resolved_full_window_end_date,
+            existing_signal_bundle=signal_bundle_stats,
+        )
+    )
+    if materialized_replay_tape_receipt is not None:
+        tape_freshness_receipts.append(materialized_replay_tape_receipt)
+        effective_replay_tape_path = Path(materialized_replay_tape_receipt["tape_path"])
+        effective_replay_tape_manifest = Path(
+            materialized_replay_tape_receipt["manifest_path"]
+        )
     signal_bundle_stats = _maybe_write_signal_bundle(
         args=args,
         snapshot_symbols=snapshot_symbols,
@@ -1452,6 +1657,13 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         full_window_start_date=resolved_full_window_start_date,
         full_window_end_date=resolved_full_window_end_date,
         existing=signal_bundle_stats,
+    )
+    frontier_base_args = argparse.Namespace(
+        **{
+            **vars(args),
+            "replay_tape_path": effective_replay_tape_path,
+            "replay_tape_manifest": effective_replay_tape_manifest,
+        }
     )
     manifest = _refresh_manifest()
     _persist_run_outputs(
@@ -1560,7 +1772,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
             try:
                 frontier_payload = run_consistent_profitability_frontier(
                     _frontier_args(
-                        args=args,
+                        args=frontier_base_args,
                         program=program,
                         family_plan=current.family_plan,
                         sweep_config_path=sweep_config_path,

--- a/services/torghut/scripts/run_strategy_factory_v2.py
+++ b/services/torghut/scripts/run_strategy_factory_v2.py
@@ -110,6 +110,18 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--allow-stale-tape", action="store_true")
     parser.add_argument("--prefetch-full-window-rows", action="store_true")
     parser.add_argument(
+        "--replay-tape-path",
+        type=Path,
+        default=None,
+        help="Optional manifest-verified replay tape reused by each frontier run.",
+    )
+    parser.add_argument(
+        "--replay-tape-manifest",
+        type=Path,
+        default=None,
+        help="Optional manifest path for --replay-tape-path.",
+    )
+    parser.add_argument(
         "--collect-train-gate-diagnostics",
         action="store_true",
         help="Persist aggregate train-window gate diagnostics for each frontier candidate.",
@@ -447,6 +459,17 @@ def _frontier_args(
         allow_stale_tape=bool(args.allow_stale_tape),
         family_template_dir=args.family_template_dir,
         prefetch_full_window_rows=bool(args.prefetch_full_window_rows),
+        replay_tape_path=(
+            Path(replay_tape_path).resolve()
+            if (replay_tape_path := getattr(args, "replay_tape_path", None)) is not None
+            else None
+        ),
+        replay_tape_manifest=(
+            Path(replay_tape_manifest).resolve()
+            if (replay_tape_manifest := getattr(args, "replay_tape_manifest", None))
+            is not None
+            else None
+        ),
         collect_train_gate_diagnostics=bool(
             getattr(args, "collect_train_gate_diagnostics", False)
         ),

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -376,6 +376,18 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--allow-stale-tape", action="store_true")
     parser.add_argument("--prefetch-full-window-rows", action="store_true")
     parser.add_argument(
+        "--replay-tape-path",
+        type=Path,
+        default=None,
+        help="Optional manifest-verified replay tape reused by real frontier runs.",
+    )
+    parser.add_argument(
+        "--replay-tape-manifest",
+        type=Path,
+        default=None,
+        help="Optional manifest path for --replay-tape-path.",
+    )
+    parser.add_argument(
         "--collect-train-gate-diagnostics",
         dest="collect_train_gate_diagnostics",
         action="store_true",
@@ -1389,6 +1401,8 @@ def _clickhouse_endpoint_preflight_failure(args: argparse.Namespace) -> str:
     if str(getattr(args, "replay_mode", "") or "") != "real":
         return ""
     if bool(getattr(args, "selection_only", False)):
+        return ""
+    if getattr(args, "replay_tape_path", None) is not None:
         return ""
     url = str(getattr(args, "clickhouse_http_url", "") or "").strip()
     parsed = urlparse(url)
@@ -5889,6 +5903,8 @@ def _run_real_replay(
         expected_last_trading_day=args.expected_last_trading_day,
         allow_stale_tape=args.allow_stale_tape,
         prefetch_full_window_rows=args.prefetch_full_window_rows,
+        replay_tape_path=getattr(args, "replay_tape_path", None),
+        replay_tape_manifest=getattr(args, "replay_tape_manifest", None),
         collect_train_gate_diagnostics=bool(
             getattr(args, "collect_train_gate_diagnostics", True)
         ),

--- a/services/torghut/tests/test_run_strategy_factory_v2.py
+++ b/services/torghut/tests/test_run_strategy_factory_v2.py
@@ -223,6 +223,10 @@ class TestRunStrategyFactoryV2(TestCase):
                     "TORGHUT_CLICKHOUSE_PASSWORD",
                     "--allow-stale-tape",
                     "--prefetch-full-window-rows",
+                    "--replay-tape-path",
+                    str(seed_dir / "tape.jsonl"),
+                    "--replay-tape-manifest",
+                    str(seed_dir / "tape.manifest.json"),
                     "--no-persist-results",
                 ],
             ):
@@ -241,6 +245,8 @@ class TestRunStrategyFactoryV2(TestCase):
         self.assertEqual(parsed.clickhouse_password_env, "TORGHUT_CLICKHOUSE_PASSWORD")
         self.assertTrue(parsed.allow_stale_tape)
         self.assertTrue(parsed.prefetch_full_window_rows)
+        self.assertEqual(parsed.replay_tape_path, seed_dir / "tape.jsonl")
+        self.assertEqual(parsed.replay_tape_manifest, seed_dir / "tape.manifest.json")
         self.assertFalse(parsed.persist_results)
         self.assertEqual(runner._list_of_strings("not-a-list"), [])
         self.assertEqual(
@@ -287,6 +293,33 @@ class TestRunStrategyFactoryV2(TestCase):
 
         self.assertEqual(parsed.clickhouse_http_url, "http://127.0.0.1:8123")
         self.assertEqual(parsed.clickhouse_username, "reader")
+
+    def test_frontier_args_forwards_replay_tape_paths(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            args = self._args(
+                output_dir=root / "out",
+                strategy_configmap=root / "strategy-configmap.yaml",
+                family_template_dir=root / "families",
+                seed_sweep_dir=root / "seed",
+            )
+            args.replay_tape_path = root / "tape.jsonl"
+            args.replay_tape_manifest = root / "tape.manifest.json"
+
+            frontier_args = runner._frontier_args(
+                args=args,
+                strategy_configmap=args.strategy_configmap,
+                sweep_config=root / "compiled-sweep.yaml",
+                json_output=root / "result.json",
+            )
+
+        self.assertEqual(
+            frontier_args.replay_tape_path, (root / "tape.jsonl").resolve()
+        )
+        self.assertEqual(
+            frontier_args.replay_tape_manifest,
+            (root / "tape.manifest.json").resolve(),
+        )
 
     def test_load_source_experiment_specs_applies_filters(self) -> None:
         with Session(self.engine) as session:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -172,6 +172,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             expected_last_trading_day="",
             allow_stale_tape=False,
             prefetch_full_window_rows=False,
+            replay_tape_path=None,
+            replay_tape_manifest=None,
             min_daily_net_pnl=None,
             persist_results=False,
         )
@@ -505,6 +507,22 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         with patch(
             "scripts.run_whitepaper_autoresearch_profit_target.socket.getaddrinfo",
             side_effect=AssertionError("non-cluster endpoints are replay-checked"),
+        ):
+            failure = runner._clickhouse_endpoint_preflight_failure(args)
+
+        self.assertEqual(failure, "")
+
+    def test_clickhouse_preflight_skips_when_replay_tape_is_supplied(self) -> None:
+        args = Namespace(
+            replay_mode="real",
+            selection_only=False,
+            replay_tape_path=Path("/tmp/replay-tape.jsonl"),
+            clickhouse_http_url="http://torghut-clickhouse.torghut.svc.cluster.local:8123",
+        )
+
+        with patch(
+            "scripts.run_whitepaper_autoresearch_profit_target.socket.getaddrinfo",
+            side_effect=AssertionError("replay tape should bypass DNS preflight"),
         ):
             failure = runner._clickhouse_endpoint_preflight_failure(args)
 
@@ -7758,6 +7776,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                     "TORGHUT_CLICKHOUSE_PASSWORD",
                     "--max-total-frontier-candidates",
                     "7",
+                    "--replay-tape-path",
+                    str(Path(tmpdir) / "tape.jsonl"),
+                    "--replay-tape-manifest",
+                    str(Path(tmpdir) / "tape.manifest.json"),
                     "--selection-only",
                     "--no-persist-results",
                 ],
@@ -7782,6 +7804,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(parsed.real_replay_shard_size, 0)
         self.assertEqual(parsed.real_replay_shard_timeout_seconds, 0)
         self.assertEqual(parsed.real_replay_shard_workers, 1)
+        self.assertEqual(parsed.replay_tape_path, Path(tmpdir) / "tape.jsonl")
+        self.assertEqual(
+            parsed.replay_tape_manifest, Path(tmpdir) / "tape.manifest.json"
+        )
         self.assertTrue(parsed.selection_only)
         self.assertEqual(parsed.max_worst_day_loss, "999999999")
         self.assertEqual(parsed.max_drawdown, "999999999")
@@ -8059,11 +8085,18 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 ]
             }
             captured_symbols: list[str] = []
+            captured_replay_tapes: list[tuple[Path | None, Path | None]] = []
 
             def fake_run(
                 factory_args: Namespace, *, source_specs: object
             ) -> dict[str, object]:
                 captured_symbols.append(str(factory_args.symbols))
+                captured_replay_tapes.append(
+                    (
+                        factory_args.replay_tape_path,
+                        factory_args.replay_tape_manifest,
+                    )
+                )
                 return factory_payload
 
             with patch.object(
@@ -8079,13 +8112,20 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                     family_template_dir=Path("config/trading/families"),
                     seed_sweep_dir=Path("config/trading"),
                 )
+                args = self._args(output_dir)
+                args.replay_tape_path = output_dir / "tape.jsonl"
+                args.replay_tape_manifest = output_dir / "tape.manifest.json"
                 result = runner._run_real_replay(
-                    self._args(output_dir),
+                    args,
                     output_dir=output_dir,
                     specs=compilation.executable_specs[:1],
                 )
 
         self.assertEqual(captured_symbols, [""])
+        self.assertEqual(
+            captured_replay_tapes,
+            [(output_dir / "tape.jsonl", output_dir / "tape.manifest.json")],
+        )
         self.assertEqual(len(result.evidence_bundles), 1)
 
     def test_real_replay_passes_global_frontier_candidate_budget(self) -> None:

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -4,7 +4,7 @@ import copy
 import json
 import sys
 from argparse import Namespace
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -411,6 +411,11 @@ class TestStrategyAutoresearch(TestCase):
                 "program.yaml",
                 "--output-dir",
                 "/tmp/out",
+                "--materialize-replay-tape",
+                "--replay-tape-path",
+                "/tmp/tape.jsonl",
+                "--replay-tape-manifest",
+                "/tmp/tape.manifest.json",
             ],
         ):
             args = runner._parse_args()
@@ -420,6 +425,9 @@ class TestStrategyAutoresearch(TestCase):
             runner._REPO_ROOT / "argocd/applications/torghut/strategy-configmap.yaml",
         )
         self.assertIsNone(args.shadow_validation_artifact)
+        self.assertTrue(args.materialize_replay_tape)
+        self.assertEqual(args.replay_tape_path, Path("/tmp/tape.jsonl"))
+        self.assertEqual(args.replay_tape_manifest, Path("/tmp/tape.manifest.json"))
 
     def test_parse_args_prefers_clickhouse_http_url_env(self) -> None:
         with (
@@ -495,6 +503,8 @@ class TestStrategyAutoresearch(TestCase):
                 expected_last_trading_day="",
                 allow_stale_tape=False,
                 prefetch_full_window_rows=False,
+                replay_tape_path=root / "tape.jsonl",
+                replay_tape_manifest=root / "tape.manifest.json",
                 max_candidates_per_frontier_run=0,
             )
 
@@ -507,6 +517,143 @@ class TestStrategyAutoresearch(TestCase):
             )
 
         self.assertEqual(frontier_args.second_oos_days, 4)
+        self.assertEqual(
+            frontier_args.replay_tape_path, (root / "tape.jsonl").resolve()
+        )
+        self.assertEqual(
+            frontier_args.replay_tape_manifest,
+            (root / "tape.manifest.json").resolve(),
+        )
+
+    def test_materialize_run_replay_tape_writes_bundle_and_receipt(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            configmap_path = root / "strategy-configmap.yaml"
+            configmap_path.write_text("apiVersion: v1\nkind: ConfigMap\n")
+            bundle_paths = runner._mlx_bundle_paths(root)
+            args = Namespace(
+                strategy_configmap=configmap_path,
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity="31590.02",
+                chunk_minutes=10,
+                progress_log_seconds=30,
+                materialize_replay_tape=True,
+                replay_tape_path=None,
+            )
+            signal_rows = [
+                SignalEnvelope(
+                    event_ts=datetime(2026, 3, 20, 13, 30, tzinfo=UTC),
+                    symbol="AMAT",
+                    seq=1,
+                    source="ta",
+                    timeframe="1Sec",
+                    payload={"price": "180.10"},
+                )
+            ]
+
+            with patch(
+                "scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows",
+                return_value=iter(signal_rows),
+            ):
+                stats, receipt = runner._maybe_materialize_run_replay_tape(
+                    args=args,
+                    runner_run_id="strategy-autoresearch-test",
+                    snapshot_symbols=("AMAT",),
+                    bundle_paths=bundle_paths,
+                    full_window_start_date="2026-03-20",
+                    full_window_end_date="2026-03-20",
+                    existing_signal_bundle=None,
+                )
+            assert receipt is not None
+            tape_exists = Path(receipt["tape_path"]).exists()
+            manifest_exists = Path(receipt["manifest_path"]).exists()
+
+        assert stats is not None
+        self.assertEqual(stats.row_count, 1)
+        self.assertEqual(receipt["status"], "materialized")
+        self.assertEqual(receipt["row_count"], 1)
+        self.assertTrue(tape_exists)
+        self.assertTrue(manifest_exists)
+
+    def test_provided_replay_tape_receipt_reads_manifest_and_handles_missing(
+        self,
+    ) -> None:
+        signal_row = SignalEnvelope(
+            event_ts=datetime(2026, 3, 20, 13, 30, tzinfo=UTC),
+            symbol="AMAT",
+            seq=1,
+            source="ta",
+            timeframe="1Sec",
+            payload={"price": "180.10"},
+        )
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            tape_path = root / "provided-tape.jsonl"
+            missing_tape_path = root / "missing-tape.jsonl"
+            manifest = runner.materialize_signal_tape(
+                rows=[signal_row],
+                tape_path=tape_path,
+                dataset_snapshot_ref="provided-snapshot",
+                symbols=("AMAT",),
+                start_date=date(2026, 3, 20),
+                end_date=date(2026, 3, 20),
+                source_query_digest="digest",
+            )
+
+            missing_receipt = runner._provided_replay_tape_receipt(
+                tape_path=missing_tape_path, manifest_path=None
+            )
+            receipt = runner._provided_replay_tape_receipt(
+                tape_path=tape_path, manifest_path=None
+            )
+
+        self.assertIsNone(missing_receipt)
+        assert receipt is not None
+        self.assertEqual(receipt["status"], "provided")
+        self.assertEqual(receipt["row_count"], manifest.row_count)
+        self.assertEqual(receipt["dataset_snapshot_ref"], "provided-snapshot")
+
+    def test_materialize_run_replay_tape_skips_when_supplied_or_unresolved(
+        self,
+    ) -> None:
+        existing_stats = runner.MlxSignalBundleStats(
+            path="/tmp/existing.jsonl",
+            row_count=7,
+            symbol_count=1,
+            first_event_ts="2026-03-20T13:30:00+00:00",
+            last_event_ts="2026-03-20T13:31:00+00:00",
+        )
+        args = Namespace(
+            materialize_replay_tape=True,
+            replay_tape_path=Path("/tmp/provided-tape.jsonl"),
+        )
+
+        stats, receipt = runner._maybe_materialize_run_replay_tape(
+            args=args,
+            runner_run_id="strategy-autoresearch-test",
+            snapshot_symbols=("AMAT",),
+            bundle_paths={},
+            full_window_start_date="2026-03-20",
+            full_window_end_date="2026-03-20",
+            existing_signal_bundle=existing_stats,
+        )
+        self.assertIs(stats, existing_stats)
+        self.assertIsNone(receipt)
+
+        args.replay_tape_path = None
+        stats, receipt = runner._maybe_materialize_run_replay_tape(
+            args=args,
+            runner_run_id="strategy-autoresearch-test",
+            snapshot_symbols=("AMAT",),
+            bundle_paths={},
+            full_window_start_date="",
+            full_window_end_date="2026-03-20",
+            existing_signal_bundle=existing_stats,
+        )
+        self.assertIs(stats, existing_stats)
+        self.assertIsNone(receipt)
 
     def _write_program_fixture(self, root: Path) -> tuple[Path, Path]:
         family_dir = root / "families"
@@ -1609,11 +1756,14 @@ class TestStrategyAutoresearch(TestCase):
                 shadow_validation_artifact=None,
                 train_days=6,
                 holdout_days=3,
-                full_window_start_date="",
-                full_window_end_date="",
+                full_window_start_date="2026-03-20",
+                full_window_end_date="2026-03-20",
                 expected_last_trading_day="",
                 allow_stale_tape=False,
                 prefetch_full_window_rows=False,
+                replay_tape_path=None,
+                replay_tape_manifest=None,
+                materialize_replay_tape=True,
                 max_frontier_runs=0,
                 json_output=None,
             )
@@ -1641,6 +1791,8 @@ class TestStrategyAutoresearch(TestCase):
             self.assertTrue((run_root / "promotion_readiness.json").exists())
             self.assertTrue((run_root / "mlx-snapshot-manifest.json").exists())
             self.assertTrue((run_root / "mlx-snapshot-signals.jsonl").exists())
+            self.assertTrue((run_root / "replay-tape.jsonl").exists())
+            self.assertTrue((run_root / "replay-tape.jsonl.manifest.json").exists())
             self.assertTrue((run_root / "mlx-candidate-descriptors.jsonl").exists())
             self.assertTrue((run_root / "mlx-proposal-scores.jsonl").exists())
             summary = json.loads(
@@ -1713,6 +1865,14 @@ class TestStrategyAutoresearch(TestCase):
             self.assertEqual(manifest["symbols"], ["AMAT", "NVDA"])
             self.assertEqual(manifest["row_counts"]["signal_row_count"], 1)
             self.assertEqual(
+                manifest["tape_freshness_receipts"][0]["status"],
+                "materialized",
+            )
+            self.assertEqual(
+                manifest["tape_freshness_receipts"][0]["row_count"],
+                1,
+            )
+            self.assertEqual(
                 manifest["tensor_bundle_paths"]["signal_rows_jsonl"],
                 str(run_root / "mlx-snapshot-signals.jsonl"),
             )
@@ -1740,6 +1900,26 @@ class TestStrategyAutoresearch(TestCase):
                 ),
                 encoding="utf-8",
             )
+            signal_row = SignalEnvelope(
+                event_ts=datetime(2026, 3, 20, 13, 30, tzinfo=UTC),
+                symbol="AMAT",
+                seq=1,
+                source="ta",
+                timeframe="1Sec",
+                payload={"price": "180.10"},
+            )
+            tape_path = root / "provided-tape.jsonl"
+            manifest_path = root / "provided-tape.jsonl.manifest.json"
+            runner.materialize_signal_tape(
+                rows=[signal_row],
+                tape_path=tape_path,
+                manifest_path=manifest_path,
+                dataset_snapshot_ref="provided-snapshot",
+                symbols=("AMAT",),
+                start_date=date(2026, 3, 20),
+                end_date=date(2026, 3, 20),
+                source_query_digest="digest",
+            )
             output_dir = root / "out"
             args = Namespace(
                 program=program_path,
@@ -1761,6 +1941,9 @@ class TestStrategyAutoresearch(TestCase):
                 expected_last_trading_day="",
                 allow_stale_tape=False,
                 prefetch_full_window_rows=False,
+                replay_tape_path=tape_path,
+                replay_tape_manifest=manifest_path,
+                materialize_replay_tape=False,
                 max_frontier_runs=0,
                 json_output=None,
             )
@@ -1786,6 +1969,13 @@ class TestStrategyAutoresearch(TestCase):
             self.assertEqual(len(history_rows), 1)
             self.assertEqual(history_rows[0]["status"], "skip")
             self.assertIn("runtime_strategy_missing", history_rows[0]["hard_vetoes"])
+            snapshot_manifest = json.loads(
+                (run_root / "mlx-snapshot-manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                snapshot_manifest["tape_freshness_receipts"][0]["status"],
+                "provided",
+            )
             self.assertEqual(
                 history_rows[0]["proposal_selection_reason"], "runtime_strategy_missing"
             )


### PR DESCRIPTION
## Summary

- Adds replay tape path and manifest CLI support to the whitepaper, strategy factory, and strategy autoresearch runners.
- Lets the strategy autoresearch loop materialize a run-scoped manifest-verified replay tape once and reuse it across exact frontier runs.
- Records replay tape freshness receipts in autoresearch outputs and skips ClickHouse DNS preflight when a supplied replay tape is the replay data source.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_strategy_autoresearch.py -k 'replay_tape or frontier_args or parse_args_defaults_strategy_configmap_to_repo_root'`
- `uv run --frozen pytest tests/test_run_strategy_factory_v2.py -k 'replay_tape or frontier_args or parse_args'`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'replay_tape or runner_parse_args or clickhouse_preflight or real_replay_uses_spec_universe'`
- `uv run --frozen ruff format scripts/run_strategy_autoresearch_loop.py scripts/run_strategy_factory_v2.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_strategy_autoresearch.py tests/test_run_strategy_factory_v2.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_strategy_autoresearch_loop.py scripts/run_strategy_factory_v2.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_strategy_autoresearch.py tests/test_run_strategy_factory_v2.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_strategy_autoresearch.py`
- `uv run --frozen pytest tests/test_run_strategy_factory_v2.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
