### PR TITLE
fix(agents): keep smoke image tags string typed

### DIFF
--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -52,11 +52,11 @@ describe('buildHelmArgs', () => {
       'controlPlane.image.repository=agents-ci-local',
       '--set',
       'controllers.image.repository=agents-ci-local',
-      '--set',
+      '--set-string',
       'image.tag=latest',
-      '--set',
+      '--set-string',
       'controlPlane.image.tag=latest',
-      '--set',
+      '--set-string',
       'controllers.image.tag=latest',
       '--set',
       'image.digest=',
@@ -144,6 +144,41 @@ describe('buildHelmArgs', () => {
     expect(args).toContain(
       'runner.image.digest=sha256:3333333333333333333333333333333333333333333333333333333333333333',
     )
+  })
+
+  it('passes numeric-looking published image tags as strings for Helm schema validation', () => {
+    const valuesFile = resolve(process.cwd(), 'scripts/agents/values-ci.yaml')
+    const args = buildHelmArgs({
+      releaseName: 'agents',
+      namespace: 'agents-ci',
+      valuesFile,
+      createNamespace: false,
+      controlPlaneImageRepository: 'registry.example/agents-control-plane',
+      controllersImageRepository: 'registry.example/agents-controller',
+      runnerImageRepository: 'registry.example/agents-codex-runner',
+      controlPlaneImageTag: '80403146',
+      controllersImageTag: '80403146',
+      runnerImageTag: '80403146',
+      imageDigestSet: false,
+      imageDigest: '',
+    })
+
+    expect(args).toContain('--set-string')
+    expect(
+      args.slice(
+        args.indexOf('controlPlane.image.tag=80403146') - 1,
+        args.indexOf('controlPlane.image.tag=80403146') + 1,
+      ),
+    ).toEqual(['--set-string', 'controlPlane.image.tag=80403146'])
+    expect(
+      args.slice(
+        args.indexOf('controllers.image.tag=80403146') - 1,
+        args.indexOf('controllers.image.tag=80403146') + 1,
+      ),
+    ).toEqual(['--set-string', 'controllers.image.tag=80403146'])
+    expect(
+      args.slice(args.indexOf('runner.image.tag=80403146') - 1, args.indexOf('runner.image.tag=80403146') + 1),
+    ).toEqual(['--set-string', 'runner.image.tag=80403146'])
   })
 
   it('omits image digest when the env key is unset', () => {

--- a/packages/scripts/src/agents/smoke-agents.ts
+++ b/packages/scripts/src/agents/smoke-agents.ts
@@ -242,21 +242,21 @@ export const buildHelmArgs = ({
     helmArgs.push('--set', `runner.image.repository=${runnerImageRepository}`)
   }
   if (imageTag) {
-    helmArgs.push('--set', `image.tag=${imageTag}`)
-    helmArgs.push('--set', `controlPlane.image.tag=${controlPlaneImageTag ?? imageTag}`)
-    helmArgs.push('--set', `controllers.image.tag=${controllersImageTag ?? imageTag}`)
+    helmArgs.push('--set-string', `image.tag=${imageTag}`)
+    helmArgs.push('--set-string', `controlPlane.image.tag=${controlPlaneImageTag ?? imageTag}`)
+    helmArgs.push('--set-string', `controllers.image.tag=${controllersImageTag ?? imageTag}`)
     if (runnerImageRepository) {
-      helmArgs.push('--set', `runner.image.tag=${runnerImageTag ?? imageTag}`)
+      helmArgs.push('--set-string', `runner.image.tag=${runnerImageTag ?? imageTag}`)
     }
   } else {
     if (controlPlaneImageTag) {
-      helmArgs.push('--set', `controlPlane.image.tag=${controlPlaneImageTag}`)
+      helmArgs.push('--set-string', `controlPlane.image.tag=${controlPlaneImageTag}`)
     }
     if (controllersImageTag) {
-      helmArgs.push('--set', `controllers.image.tag=${controllersImageTag}`)
+      helmArgs.push('--set-string', `controllers.image.tag=${controllersImageTag}`)
     }
     if (runnerImageTag) {
-      helmArgs.push('--set', `runner.image.tag=${runnerImageTag}`)
+      helmArgs.push('--set-string', `runner.image.tag=${runnerImageTag}`)
     }
   }
   if (imageDigestSet) {


### PR DESCRIPTION
## Summary

- Pass Agents smoke Helm image tag overrides with `--set-string` so numeric-looking published tags remain strings.
- Add regression coverage for the promoted `80403146` tag shape across control-plane, controller, and runner overrides.
- Fixes the `agents-ci` kind smoke schema failure seen on deploy commit `9f74b09f`.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bunx oxfmt --check packages/scripts/src/agents/smoke-agents.ts packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check`
- `bun run --cwd packages/scripts lint`
- `bash scripts/agents/validate-agents.sh`
- `mise exec helm@3 -- helm template agents-ci charts/agents --namespace agents-ci --values scripts/agents/values-ci.yaml --skip-crds --set-string database.url=postgresql://agents:pw@agents-ci-postgres:5432/agents?sslmode=disable --set controlPlane.image.repository=registry.ide-newton.ts.net/lab/agents-control-plane --set controllers.image.repository=registry.ide-newton.ts.net/lab/agents-controller --set runner.image.repository=registry.ide-newton.ts.net/lab/agents-codex-runner --set-string controlPlane.image.tag=80403146 --set-string controllers.image.tag=80403146 --set-string runner.image.tag=80403146 --set image.digest= --set controlPlane.image.digest=sha256:163b380b6f4e5871f43014dd00b5f4694aaf38add2fb019ccfbb826e0cea7c29 --set controllers.image.digest=sha256:51ea87132cc6fd91e0fd6b54f2a009e03d15c1f5c79107c28b7af427c7048f73 --set runner.image.digest=sha256:a5652cb08a0270b17e3333f475407a586a825c0603650b34d4065ec2b25615bb`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
