### PR TITLE
chore(torghut): promote image 1f9b187a

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-399-g6d1f12c95
+              value: v0.571.1-406-g1f9b187ac
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 6d1f12c954105608137f42b77397c224b1eab5af
+              value: 1f9b187aca5ea70d033195b2186cb32696f87696
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-399-g6d1f12c95
+              value: v0.571.1-406-g1f9b187ac
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 6d1f12c954105608137f42b77397c224b1eab5af
+              value: 1f9b187aca5ea70d033195b2186cb32696f87696
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -75,7 +75,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+                  value: sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-21T03:07:30Z"
+        client.knative.dev/updateTimestamp: "2026-05-21T03:29:54Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
           ports:
             - name: http1
               containerPort: 8181
@@ -499,11 +499,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-399-g6d1f12c95
+              value: v0.571.1-406-g1f9b187ac
             - name: TORGHUT_COMMIT
-              value: 6d1f12c954105608137f42b77397c224b1eab5af
+              value: 1f9b187aca5ea70d033195b2186cb32696f87696
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+              value: sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-21T03:07:30Z"
+        client.knative.dev/updateTimestamp: "2026-05-21T03:29:54Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
           ports:
             - name: http1
               containerPort: 8181
@@ -320,11 +320,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-399-g6d1f12c95
+              value: v0.571.1-406-g1f9b187ac
             - name: TORGHUT_COMMIT
-              value: 6d1f12c954105608137f42b77397c224b1eab5af
+              value: 1f9b187aca5ea70d033195b2186cb32696f87696
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+              value: sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -120,7 +120,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:22a9ed8110c855b84aea7122236f828fef6089c7cd27468226df792f02256380
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `1f9b187aca5ea70d033195b2186cb32696f87696`
- Image tag: `1f9b187a`
- Image digest: `sha256:d30bc64efbf34e860603c8bb8fe68c16a9ac5c25192a67527816b724bcc6c940`