### PR TITLE
fix(torghut): count paper runtime proof before live gate

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -527,6 +527,67 @@ def _extract_runtime_summary(
     return hypothesis_summary, items
 
 
+def _refresh_runtime_summary_totals(
+    summary: Mapping[str, Any],
+    runtime_items: Sequence[Mapping[str, Any]],
+) -> dict[str, object]:
+    state_totals: dict[str, int] = {}
+    reason_totals: dict[str, int] = {}
+    informational_reason_totals: dict[str, int] = {}
+    capital_stage_totals: dict[str, int] = {}
+    capital_multiplier_by_hypothesis: dict[str, str] = {}
+    promotion_eligible_total = 0
+    rollback_required_total = 0
+
+    for item in runtime_items:
+        state = str(item.get("state") or "unknown")
+        state_totals[state] = state_totals.get(state, 0) + 1
+
+        capital_stage = str(item.get("capital_stage") or "shadow")
+        capital_stage_totals[capital_stage] = (
+            capital_stage_totals.get(capital_stage, 0) + 1
+        )
+
+        hypothesis_id = str(item.get("hypothesis_id") or "unknown")
+        capital_multiplier_by_hypothesis[hypothesis_id] = str(
+            item.get("capital_multiplier") or "0"
+        )
+
+        if bool(item.get("promotion_eligible")):
+            promotion_eligible_total += 1
+        if bool(item.get("rollback_required")):
+            rollback_required_total += 1
+
+        for reason in cast(Sequence[object], item.get("reasons") or []):
+            reason_code = str(reason).strip()
+            if reason_code:
+                reason_totals[reason_code] = reason_totals.get(reason_code, 0) + 1
+        for reason in cast(Sequence[object], item.get("informational_reasons") or []):
+            reason_code = str(reason).strip()
+            if reason_code:
+                informational_reason_totals[reason_code] = (
+                    informational_reason_totals.get(reason_code, 0) + 1
+                )
+
+    refreshed = dict(summary)
+    refreshed.update(
+        {
+            "hypotheses_total": len(runtime_items),
+            "state_totals": dict(sorted(state_totals.items())),
+            "reason_totals": dict(sorted(reason_totals.items())),
+            "informational_reason_totals": dict(
+                sorted(informational_reason_totals.items())
+            ),
+            "capital_stage_totals": dict(sorted(capital_stage_totals.items())),
+            "capital_multiplier_by_hypothesis": capital_multiplier_by_hypothesis,
+            "promotion_eligible_total": promotion_eligible_total,
+            "rollback_required_total": rollback_required_total,
+            "items": list(runtime_items),
+        }
+    )
+    return refreshed
+
+
 def build_submission_gate_market_context_status(state: object) -> dict[str, object]:
     return {
         "last_symbol": getattr(state, "last_market_context_symbol", None),
@@ -786,7 +847,71 @@ def _merge_runtime_certificate_evidence(
             continue
 
         capital_stage = _certificate_capital_stage(metric_window, promotion_decision)
-        if capital_stage is None or _stage_rank(capital_stage) <= _stage_rank("shadow"):
+        if capital_stage is None:
+            merged.append(updated)
+            continue
+        if _stage_rank(capital_stage) <= _stage_rank("shadow"):
+            if _safe_text(getattr(metric_window, "observed_stage", None)) != "paper":
+                merged.append(updated)
+                continue
+            issued_at = _window_evidence_issued_at(metric_window)
+            candidate_id = (
+                _safe_text(metric_window.candidate_id)
+                or _safe_text(promotion_decision.candidate_id)
+                or _safe_text(updated.get("candidate_id"))
+            )
+            observed = (
+                dict(cast(Mapping[str, Any], updated.get("observed")))
+                if isinstance(updated.get("observed"), Mapping)
+                else {}
+            )
+            observed.update(
+                {
+                    "runtime_window_certificate_readiness_applied": True,
+                    "runtime_window_prior_reasons": list(
+                        cast(Sequence[object], updated.get("reasons") or [])
+                    ),
+                    "metric_window_id": str(metric_window.id),
+                    "promotion_decision_id": str(promotion_decision.id),
+                    "metric_window_issued_at": issued_at.isoformat()
+                    if issued_at is not None
+                    else None,
+                    "metric_window_market_session_count": metric_window.market_session_count,
+                    "metric_window_decision_count": metric_window.decision_count,
+                    "metric_window_trade_count": metric_window.trade_count,
+                    "metric_window_order_count": metric_window.order_count,
+                    "metric_window_avg_abs_slippage_bps": metric_window.avg_abs_slippage_bps,
+                    "metric_window_post_cost_expectancy_bps": metric_window.post_cost_expectancy_bps,
+                }
+            )
+            if candidate_id is not None:
+                updated["candidate_id"] = candidate_id
+            updated.update(
+                {
+                    "state": "shadow",
+                    "capital_stage": capital_stage or "shadow",
+                    "capital_multiplier": "0",
+                    "promotion_eligible": True,
+                    "rollback_required": False,
+                    "reasons": [],
+                    "informational_reasons": sorted(
+                        {
+                            *[
+                                str(reason)
+                                for reason in cast(
+                                    Sequence[object],
+                                    updated.get("informational_reasons") or [],
+                                )
+                                if str(reason).strip()
+                            ],
+                            "runtime_window_certificate_readiness_applied",
+                        }
+                    ),
+                    "promotion_decision_id": str(promotion_decision.id),
+                    "metric_window_id": str(metric_window.id),
+                    "observed": observed,
+                }
+            )
             merged.append(updated)
             continue
 
@@ -1521,7 +1646,6 @@ def build_live_submission_gate_payload(
         str(dependency_quorum_payload.get("decision") or "").strip().lower()
         or "unknown"
     )
-    promotion_eligible_total = _safe_int(summary.get("promotion_eligible_total"))
     empirical_ready = (
         bool(empirical_jobs_status.get("ready"))
         if isinstance(empirical_jobs_status, Mapping)
@@ -1545,7 +1669,6 @@ def build_live_submission_gate_payload(
     drift_live_promotion_eligible = bool(
         getattr(state, "drift_live_promotion_eligible", False)
     )
-    active_capital_stage = resolve_active_capital_stage(summary)
     critical_toggle_parity = build_shadow_first_toggle_parity()
     critical_toggle_mismatches = list(
         cast(list[str], critical_toggle_parity.get("mismatches") or [])
@@ -1574,6 +1697,41 @@ def build_live_submission_gate_payload(
     )
     now = datetime.now(timezone.utc)
     registry = load_hypothesis_registry()
+    evidence_rows = (
+        [dict(item) for item in promotion_certificate_evidence]
+        if promotion_certificate_evidence is not None
+        else _load_latest_certificate_evidence(
+            session,
+            hypothesis_ids=[item.hypothesis_id for item in registry.items],
+        )
+        if session is not None
+        else []
+    )
+    readiness_evidence_rows: list[Mapping[str, object]] = []
+    for row in evidence_rows:
+        metric_window = cast(
+            StrategyHypothesisMetricWindow | None, row.get("metric_window")
+        )
+        promotion_decision = cast(
+            StrategyPromotionDecision | None, row.get("promotion_decision")
+        )
+        if metric_window is None or promotion_decision is None:
+            continue
+        if _safe_text(getattr(metric_window, "observed_stage", None)) != "paper":
+            continue
+        if _certificate_capital_stage(metric_window, promotion_decision) != "shadow":
+            continue
+        readiness_evidence_rows.append(row)
+    if runtime_items and readiness_evidence_rows:
+        runtime_items = _merge_runtime_certificate_evidence(
+            runtime_items,
+            evidence=readiness_evidence_rows,
+            now=now,
+            max_age_seconds=max_age_seconds,
+        )
+        summary = _refresh_runtime_summary_totals(summary, runtime_items)
+    promotion_eligible_total = _safe_int(summary.get("promotion_eligible_total"))
+    active_capital_stage = resolve_active_capital_stage(summary)
     segment_summary = _segment_summary(
         state=state,
         runtime_items=runtime_items,
@@ -1682,16 +1840,6 @@ def build_live_submission_gate_payload(
     if quant_required and not quant_ready:
         blocked_reasons.extend(quant_blocking_reasons or [quant_reason])
 
-    evidence_rows = (
-        [dict(item) for item in promotion_certificate_evidence]
-        if promotion_certificate_evidence is not None
-        else _load_latest_certificate_evidence(
-            session,
-            hypothesis_ids=[item.hypothesis_id for item in registry.items],
-        )
-        if session is not None
-        else []
-    )
     evaluated_tuples, valid_candidates = _evaluate_certificate_candidates(
         evidence=evidence_rows,
         segment_summary=segment_summary,

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -29,6 +29,7 @@ from app.trading.submission_council import (
     _coerce_aware_datetime,
     _load_profit_promotion_table_counts,
     _merge_runtime_certificate_evidence,
+    _refresh_runtime_summary_totals,
     build_hypothesis_runtime_summary,
     build_live_submission_gate_payload,
     load_quant_evidence_status,
@@ -111,25 +112,32 @@ class TestSubmissionCouncil(TestCase):
         )
         _QUANT_HEALTH_CACHE.clear()
 
-    def _metric_window(self, capital_stage: str = "0.10x canary") -> SimpleNamespace:
+    def _metric_window(
+        self,
+        capital_stage: str = "0.10x canary",
+        observed_stage: str | None = None,
+    ) -> SimpleNamespace:
         observed_at = datetime.now(timezone.utc)
-        return SimpleNamespace(
-            id="window-1",
-            candidate_id="cand-1",
-            capital_stage=capital_stage,
-            window_ended_at=observed_at,
-            created_at=observed_at,
-            market_session_count=3,
-            decision_count=42,
-            trade_count=42,
-            order_count=42,
-            avg_abs_slippage_bps="4.2",
-            slippage_budget_bps="12",
-            post_cost_expectancy_bps="8.5",
-            continuity_ok=True,
-            drift_ok=True,
-            dependency_quorum_decision="allow",
-        )
+        payload = {
+            "id": "window-1",
+            "candidate_id": "cand-1",
+            "capital_stage": capital_stage,
+            "window_ended_at": observed_at,
+            "created_at": observed_at,
+            "market_session_count": 3,
+            "decision_count": 42,
+            "trade_count": 42,
+            "order_count": 42,
+            "avg_abs_slippage_bps": "4.2",
+            "slippage_budget_bps": "12",
+            "post_cost_expectancy_bps": "8.5",
+            "continuity_ok": True,
+            "drift_ok": True,
+            "dependency_quorum_decision": "allow",
+        }
+        if observed_stage is not None:
+            payload["observed_stage"] = observed_stage
+        return SimpleNamespace(**payload)
 
     def _promotion_decision(
         self, capital_stage: str = "0.10x canary"
@@ -151,6 +159,48 @@ class TestSubmissionCouncil(TestCase):
             "status": "healthy",
             "source_url": "http://jangar.test/api/torghut/trading/control-plane/quant/health?account=paper&window=15m",
         }
+
+    def test_refresh_runtime_summary_totals_counts_reasons_and_rollback(self) -> None:
+        refreshed = _refresh_runtime_summary_totals(
+            {
+                "dependency_quorum": {
+                    "decision": "allow",
+                    "reasons": [],
+                    "message": "ready",
+                }
+            },
+            [
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "state": "shadow",
+                    "capital_stage": "shadow",
+                    "capital_multiplier": "0",
+                    "promotion_eligible": False,
+                    "rollback_required": True,
+                    "reasons": ["drift_checks_missing", ""],
+                    "informational_reasons": ["runtime_window_certificate_rejected"],
+                },
+                {
+                    "hypothesis_id": "H-TSMOM-01",
+                    "state": "shadow",
+                    "capital_stage": "shadow",
+                    "capital_multiplier": "0",
+                    "promotion_eligible": True,
+                    "rollback_required": False,
+                    "reasons": [],
+                    "informational_reasons": [],
+                },
+            ],
+        )
+
+        self.assertEqual(refreshed["hypotheses_total"], 2)
+        self.assertEqual(refreshed["promotion_eligible_total"], 1)
+        self.assertEqual(refreshed["rollback_required_total"], 1)
+        self.assertEqual(refreshed["reason_totals"], {"drift_checks_missing": 1})
+        self.assertEqual(
+            refreshed["informational_reason_totals"],
+            {"runtime_window_certificate_rejected": 1},
+        )
 
     def test_runtime_certificate_merge_keeps_invalid_evidence_shadow(self) -> None:
         now = datetime.now(timezone.utc)
@@ -239,6 +289,13 @@ class TestSubmissionCouncil(TestCase):
                     "hypothesis_id": "H-CONT-01",
                     "metric_window": metric_window(capital_stage="observe"),
                     "promotion_decision": promotion(state="observe"),
+                }
+            ],
+            [
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "metric_window": metric_window(capital_stage="shadow"),
+                    "promotion_decision": promotion(state="shadow"),
                 }
             ],
         ]
@@ -370,6 +427,229 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(
             item["informational_reasons"],
             ["runtime_window_certificate_applied"],
+        )
+
+    def test_hypothesis_runtime_summary_counts_allowed_paper_runtime_readiness_without_capital_promotion(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        now = datetime.now(timezone.utc)
+        settings.trading_drift_live_promotion_max_evidence_age_seconds = 3600
+        registry = SimpleNamespace(
+            loaded=True,
+            path="test-registry",
+            errors=[],
+            items=[SimpleNamespace(hypothesis_id="H-CONT-01")],
+        )
+        runtime_items = [
+            {
+                "hypothesis_id": "H-CONT-01",
+                "candidate_id": None,
+                "strategy_id": "intraday_continuation",
+                "lane_id": "continuation",
+                "strategy_family": "intraday_continuation",
+                "state": "shadow",
+                "capital_stage": "shadow",
+                "capital_multiplier": "0",
+                "promotion_eligible": False,
+                "rollback_required": False,
+                "reasons": ["drift_checks_missing"],
+                "informational_reasons": [],
+                "observed": {},
+            }
+        ]
+
+        with session_local() as session:
+            session.add(
+                StrategyHypothesisMetricWindow(
+                    run_id="runtime-paper-proof-1",
+                    candidate_id="cand-runtime-paper",
+                    hypothesis_id="H-CONT-01",
+                    observed_stage="paper",
+                    window_started_at=now,
+                    window_ended_at=now,
+                    market_session_count=3,
+                    decision_count=42,
+                    trade_count=42,
+                    order_count=42,
+                    avg_abs_slippage_bps="4.2",
+                    slippage_budget_bps="12",
+                    post_cost_expectancy_bps="8.5",
+                    continuity_ok=True,
+                    drift_ok=True,
+                    dependency_quorum_decision="allow",
+                    capital_stage="shadow",
+                )
+            )
+            session.add(
+                StrategyPromotionDecision(
+                    run_id="runtime-paper-proof-1",
+                    candidate_id="cand-runtime-paper",
+                    hypothesis_id="H-CONT-01",
+                    promotion_target="paper",
+                    state="shadow",
+                    allowed=True,
+                    reason_summary="paper_runtime_evidence_thresholds_satisfied",
+                )
+            )
+            session.commit()
+
+            with (
+                patch(
+                    "app.trading.submission_council.load_hypothesis_registry",
+                    return_value=registry,
+                ),
+                patch(
+                    "app.trading.submission_council.resolve_hypothesis_dependency_quorum",
+                    return_value=JangarDependencyQuorumStatus(
+                        decision="allow",
+                        reasons=[],
+                        message="ready",
+                    ),
+                ),
+                patch(
+                    "app.trading.submission_council.compile_hypothesis_runtime_statuses",
+                    return_value=runtime_items,
+                ),
+                patch(
+                    "app.trading.submission_council.build_tca_gate_inputs",
+                    return_value={},
+                ),
+            ):
+                summary = build_hypothesis_runtime_summary(
+                    session,
+                    state=SimpleNamespace(market_session_open=True),
+                    market_context_status={"last_freshness_seconds": 10},
+                )
+
+            gate = build_live_submission_gate_payload(
+                SimpleNamespace(
+                    last_autonomy_promotion_eligible=True,
+                    last_autonomy_promotion_action="promote",
+                    drift_live_promotion_eligible=False,
+                    last_market_context_freshness_seconds=45,
+                ),
+                hypothesis_summary=summary,
+                empirical_jobs_status={"ready": True, "status": "healthy"},
+                quant_health_status=self._healthy_quant_status(),
+                promotion_certificate_evidence=[
+                    {
+                        "hypothesis_id": "H-CONT-01",
+                        "metric_window": self._metric_window(capital_stage="shadow"),
+                        "promotion_decision": self._promotion_decision(
+                            capital_stage="shadow"
+                        ),
+                    }
+                ],
+                session=session,
+            )
+
+        self.assertEqual(summary["promotion_eligible_total"], 1)
+        item = summary["items"][0]
+        self.assertTrue(item["promotion_eligible"])
+        self.assertEqual(item["candidate_id"], "cand-runtime-paper")
+        self.assertEqual(item["state"], "shadow")
+        self.assertEqual(item["capital_stage"], "shadow")
+        self.assertEqual(item["capital_multiplier"], "0")
+        self.assertEqual(item["reasons"], [])
+        self.assertEqual(
+            item["informational_reasons"],
+            ["runtime_window_certificate_readiness_applied"],
+        )
+        self.assertEqual(
+            item["observed"]["runtime_window_prior_reasons"],
+            ["drift_checks_missing"],
+        )
+        self.assertFalse(gate["allowed"])
+        self.assertNotIn(
+            "alpha_readiness_not_promotion_eligible",
+            gate["blocked_reasons"],
+        )
+        self.assertIn("promotion_certificate_shadow_only", gate["blocked_reasons"])
+        self.assertIn("alpha_hypothesis_shadow_only", gate["blocked_reasons"])
+
+        stale_summary = dict(summary)
+        stale_summary.update(
+            {
+                "items": runtime_items,
+                "promotion_eligible_total": 0,
+                "capital_stage_totals": {"shadow": 1},
+                "reason_totals": {"drift_checks_missing": 1},
+                "informational_reason_totals": {},
+            }
+        )
+        stale_gate = build_live_submission_gate_payload(
+            SimpleNamespace(
+                last_autonomy_promotion_eligible=True,
+                last_autonomy_promotion_action="promote",
+                drift_live_promotion_eligible=False,
+                last_market_context_freshness_seconds=45,
+            ),
+            hypothesis_summary=stale_summary,
+            empirical_jobs_status={"ready": True, "status": "healthy"},
+            quant_health_status=self._healthy_quant_status(),
+            promotion_certificate_evidence=[
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "metric_window": self._metric_window(
+                        capital_stage="shadow",
+                        observed_stage="paper",
+                    ),
+                    "promotion_decision": self._promotion_decision(
+                        capital_stage="shadow"
+                    ),
+                }
+            ],
+            session=session,
+        )
+
+        self.assertEqual(stale_gate["promotion_eligible_total"], 1)
+        self.assertNotIn(
+            "alpha_readiness_not_promotion_eligible",
+            stale_gate["blocked_reasons"],
+        )
+        self.assertIn(
+            "promotion_certificate_shadow_only",
+            stale_gate["blocked_reasons"],
+        )
+        self.assertIn("alpha_hypothesis_shadow_only", stale_gate["blocked_reasons"])
+
+        non_shadow_paper_gate = build_live_submission_gate_payload(
+            SimpleNamespace(
+                last_autonomy_promotion_eligible=True,
+                last_autonomy_promotion_action="promote",
+                drift_live_promotion_eligible=False,
+                last_market_context_freshness_seconds=45,
+            ),
+            hypothesis_summary=stale_summary,
+            empirical_jobs_status={"ready": True, "status": "healthy"},
+            quant_health_status=self._healthy_quant_status(),
+            promotion_certificate_evidence=[
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "metric_window": self._metric_window(
+                        capital_stage="0.10x canary",
+                        observed_stage="paper",
+                    ),
+                    "promotion_decision": self._promotion_decision(
+                        capital_stage="0.10x canary"
+                    ),
+                }
+            ],
+            session=session,
+        )
+
+        self.assertEqual(non_shadow_paper_gate["promotion_eligible_total"], 0)
+        self.assertIn(
+            "alpha_readiness_not_promotion_eligible",
+            non_shadow_paper_gate["blocked_reasons"],
         )
 
     def test_hypothesis_runtime_summary_rejects_unmatched_promotion_decision(


### PR DESCRIPTION
## Summary

- Counts fresh, allowed paper runtime-window certificate evidence as promotion readiness before the live gate computes `promotion_eligible_total`.
- Keeps that evidence in `shadow` with `capital_multiplier=0`, so it removes the stale readiness blocker without granting live submission permission.
- Recomputes live-gate runtime summary totals from merged paper/shadow evidence and preserves existing canary/live certificate safety behavior.
- Adds regression coverage for stale summary ordering, invalid evidence, shadow-only blocking, and adjacent Torghut API/runtime import paths.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py tests/test_trading_api.py tests/test_runtime_window_import.py tests/test_run_empirical_promotion_jobs.py`
- `cd services/torghut && uv run --frozen ruff format app/trading/submission_council.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
