### PR TITLE
feat(torghut): add replay tape preview narrowing

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -1,0 +1,380 @@
+"""Preview-only vectorized scoring over manifest-verified replay tapes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import timezone
+from decimal import Decimal
+from typing import Any, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+from app.trading.discovery.candidate_specs import CandidateSpec
+from app.trading.discovery.replay_tape import ReplayTapeManifest
+from app.trading.models import SignalEnvelope
+
+FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v1"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v1"
+
+
+@dataclass(frozen=True)
+class FastReplayPreviewRow:
+    candidate_spec_id: str
+    rank: int
+    preview_score: Decimal
+    selected: bool
+    selection_reason: str
+    matched_row_count: int
+    matched_symbol_count: int
+    requested_symbol_count: int
+    trading_day_count: int
+    signed_return_bps: Decimal
+    avg_abs_return_bps: Decimal
+    median_spread_bps: Decimal
+    activity_score: Decimal
+    coverage_score: Decimal
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION,
+            "candidate_spec_id": self.candidate_spec_id,
+            "rank": self.rank,
+            "preview_score": str(self.preview_score),
+            "selected": self.selected,
+            "selection_reason": self.selection_reason,
+            "matched_row_count": self.matched_row_count,
+            "matched_symbol_count": self.matched_symbol_count,
+            "requested_symbol_count": self.requested_symbol_count,
+            "trading_day_count": self.trading_day_count,
+            "signed_return_bps": str(self.signed_return_bps),
+            "avg_abs_return_bps": str(self.avg_abs_return_bps),
+            "median_spread_bps": str(self.median_spread_bps),
+            "activity_score": str(self.activity_score),
+            "coverage_score": str(self.coverage_score),
+        }
+
+
+@dataclass(frozen=True)
+class FastReplayPreviewResult:
+    rows: tuple[FastReplayPreviewRow, ...]
+    selected_candidate_spec_ids: tuple[str, ...]
+    requested_top_k: int
+    input_candidate_count: int
+    replay_tape_manifest: ReplayTapeManifest
+    selected_row_count: int
+
+    def to_manifest_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": FAST_REPLAY_PREVIEW_SCHEMA_VERSION,
+            "status": "preview_only",
+            "promotion_proof": False,
+            "blockers": [
+                "preview_only_not_promotion_proof",
+                "exact_replay_required",
+                "runtime_ledger_proof_required",
+            ],
+            "requested_top_k": self.requested_top_k,
+            "input_candidate_count": self.input_candidate_count,
+            "selected_candidate_spec_ids": list(self.selected_candidate_spec_ids),
+            "selected_candidate_spec_count": len(self.selected_candidate_spec_ids),
+            "selected_row_count": self.selected_row_count,
+            "replay_tape": {
+                "dataset_snapshot_ref": self.replay_tape_manifest.dataset_snapshot_ref,
+                "content_sha256": self.replay_tape_manifest.content_sha256,
+                "row_count": self.replay_tape_manifest.row_count,
+                "trading_day_count": self.replay_tape_manifest.trading_day_count,
+                "start_date": self.replay_tape_manifest.start_date.isoformat(),
+                "end_date": self.replay_tape_manifest.end_date.isoformat(),
+                "row_symbols": list(self.replay_tape_manifest.row_symbols),
+            },
+        }
+
+
+@dataclass(frozen=True)
+class _SymbolTapeStats:
+    symbol: str
+    row_count: int
+    trading_day_count: int
+    returns_bps: NDArray[np.float64]
+    median_spread_bps: float
+
+
+def build_fast_replay_preview(
+    *,
+    specs: Sequence[CandidateSpec],
+    rows: Sequence[SignalEnvelope],
+    replay_tape_manifest: ReplayTapeManifest,
+    top_k: int,
+    min_rows_per_candidate: int = 2,
+) -> FastReplayPreviewResult:
+    """Rank candidate specs with cheap tape-derived features only.
+
+    This intentionally produces a preview artifact, not replay evidence. Exact
+    scheduler replay and runtime ledger proof remain required downstream.
+    """
+
+    bounded_top_k = max(1, min(len(specs) or 1, int(top_k)))
+    symbol_stats = _build_symbol_stats(rows)
+    scored_rows: list[FastReplayPreviewRow] = []
+    for spec in specs:
+        scored_rows.append(
+            _score_candidate_spec(
+                spec=spec,
+                symbol_stats=symbol_stats,
+                min_rows_per_candidate=max(1, int(min_rows_per_candidate)),
+            )
+        )
+
+    ranked_rows = sorted(
+        scored_rows,
+        key=lambda row: (
+            row.selection_reason == "insufficient_replay_tape_rows",
+            -float(row.preview_score),
+            row.candidate_spec_id,
+        ),
+    )
+    selected_ids = {
+        row.candidate_spec_id for row in ranked_rows[:bounded_top_k] if scored_rows
+    }
+    final_rows = tuple(
+        FastReplayPreviewRow(
+            candidate_spec_id=row.candidate_spec_id,
+            rank=index,
+            preview_score=row.preview_score,
+            selected=row.candidate_spec_id in selected_ids,
+            selection_reason=(
+                "fast_replay_preview_selected"
+                if row.candidate_spec_id in selected_ids
+                else row.selection_reason
+            ),
+            matched_row_count=row.matched_row_count,
+            matched_symbol_count=row.matched_symbol_count,
+            requested_symbol_count=row.requested_symbol_count,
+            trading_day_count=row.trading_day_count,
+            signed_return_bps=row.signed_return_bps,
+            avg_abs_return_bps=row.avg_abs_return_bps,
+            median_spread_bps=row.median_spread_bps,
+            activity_score=row.activity_score,
+            coverage_score=row.coverage_score,
+        )
+        for index, row in enumerate(ranked_rows, start=1)
+    )
+    return FastReplayPreviewResult(
+        rows=final_rows,
+        selected_candidate_spec_ids=tuple(
+            row.candidate_spec_id for row in final_rows if row.selected
+        ),
+        requested_top_k=bounded_top_k,
+        input_candidate_count=len(specs),
+        replay_tape_manifest=replay_tape_manifest,
+        selected_row_count=len(rows),
+    )
+
+
+def _build_symbol_stats(
+    rows: Sequence[SignalEnvelope],
+) -> dict[str, _SymbolTapeStats]:
+    rows_by_symbol: dict[str, list[SignalEnvelope]] = {}
+    for row in rows:
+        symbol = row.symbol.strip().upper()
+        if not symbol:
+            continue
+        rows_by_symbol.setdefault(symbol, []).append(row)
+
+    stats: dict[str, _SymbolTapeStats] = {}
+    for symbol, symbol_rows in rows_by_symbol.items():
+        ordered = sorted(symbol_rows, key=lambda item: item.event_ts)
+        prices = [_extract_price(row) for row in ordered]
+        price_array = np.asarray(
+            [price for price in prices if price is not None and price > 0.0],
+            dtype=np.float64,
+        )
+        returns = (
+            np.diff(price_array) / price_array[:-1] * 10_000.0
+            if price_array.size >= 2
+            else np.asarray([], dtype=np.float64)
+        )
+        spread_values = [
+            spread
+            for row in ordered
+            if (spread := _extract_spread_bps(row)) is not None
+        ]
+        stats[symbol] = _SymbolTapeStats(
+            symbol=symbol,
+            row_count=len(ordered),
+            trading_day_count=len(
+                {row.event_ts.astimezone(timezone.utc).date() for row in ordered}
+            ),
+            returns_bps=returns,
+            median_spread_bps=float(np.median(spread_values)) if spread_values else 0.0,
+        )
+    return stats
+
+
+def _score_candidate_spec(
+    *,
+    spec: CandidateSpec,
+    symbol_stats: Mapping[str, _SymbolTapeStats],
+    min_rows_per_candidate: int,
+) -> FastReplayPreviewRow:
+    requested_symbols = _candidate_symbols(spec)
+    matched = [
+        stat for symbol in requested_symbols if (stat := symbol_stats.get(symbol))
+    ]
+    matched_row_count = sum(stat.row_count for stat in matched)
+    requested_symbol_count = len(requested_symbols)
+    matched_symbol_count = len(matched)
+    if matched_row_count < min_rows_per_candidate or not matched:
+        return FastReplayPreviewRow(
+            candidate_spec_id=spec.candidate_spec_id,
+            rank=0,
+            preview_score=Decimal("-1000000"),
+            selected=False,
+            selection_reason="insufficient_replay_tape_rows",
+            matched_row_count=matched_row_count,
+            matched_symbol_count=matched_symbol_count,
+            requested_symbol_count=requested_symbol_count,
+            trading_day_count=max(
+                (stat.trading_day_count for stat in matched), default=0
+            ),
+            signed_return_bps=Decimal("0"),
+            avg_abs_return_bps=Decimal("0"),
+            median_spread_bps=Decimal("0"),
+            activity_score=Decimal("0"),
+            coverage_score=Decimal("0"),
+        )
+
+    return_vectors = [stat.returns_bps for stat in matched if stat.returns_bps.size]
+    returns = (
+        np.concatenate(return_vectors)
+        if return_vectors
+        else np.asarray([], dtype=np.float64)
+    )
+    direction = _candidate_direction(spec)
+    signed_return_bps = float(np.mean(returns)) * direction if returns.size else 0.0
+    avg_abs_return_bps = float(np.mean(np.abs(returns))) if returns.size else 0.0
+    median_spread_bps = float(np.median([stat.median_spread_bps for stat in matched]))
+    activity_score = float(np.log1p(matched_row_count))
+    coverage_score = matched_symbol_count / max(1, requested_symbol_count)
+    preview_score = (
+        signed_return_bps
+        + avg_abs_return_bps * 0.15
+        + activity_score
+        + coverage_score * 25.0
+        - median_spread_bps * 0.05
+    )
+    return FastReplayPreviewRow(
+        candidate_spec_id=spec.candidate_spec_id,
+        rank=0,
+        preview_score=_decimal_from_float(preview_score),
+        selected=False,
+        selection_reason="fast_replay_preview_ranked",
+        matched_row_count=matched_row_count,
+        matched_symbol_count=matched_symbol_count,
+        requested_symbol_count=requested_symbol_count,
+        trading_day_count=max((stat.trading_day_count for stat in matched), default=0),
+        signed_return_bps=_decimal_from_float(signed_return_bps),
+        avg_abs_return_bps=_decimal_from_float(avg_abs_return_bps),
+        median_spread_bps=_decimal_from_float(median_spread_bps),
+        activity_score=_decimal_from_float(activity_score),
+        coverage_score=_decimal_from_float(coverage_score),
+    )
+
+
+def _candidate_symbols(spec: CandidateSpec) -> tuple[str, ...]:
+    raw = spec.strategy_overrides.get("universe_symbols")
+    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, bytearray)):
+        raw_symbols = cast(Sequence[Any], raw)
+        symbols = tuple(
+            sorted(
+                {_string(item).upper() for item in raw_symbols if _string(item).strip()}
+            )
+        )
+        if symbols:
+            return symbols
+    return (spec.runtime_strategy_name.upper(),)
+
+
+def _candidate_direction(spec: CandidateSpec) -> float:
+    params = _mapping(spec.strategy_overrides.get("params"))
+    text = " ".join(
+        item
+        for item in (
+            spec.runtime_strategy_name,
+            spec.family_template_id,
+            _string(params.get("selection_mode")),
+            _string(params.get("signal_motif")),
+            _string(params.get("rank_feature")),
+        )
+        if item
+    ).lower()
+    if any(
+        token in text for token in ("reversal", "rebound", "washout", "mean_revert")
+    ):
+        return -1.0
+    return 1.0
+
+
+def _extract_price(signal: SignalEnvelope) -> float | None:
+    payload = signal.payload
+    for key in ("price", "mid_price", "mid", "mark", "last_price", "close"):
+        value = _float_or_none(payload.get(key))
+        if value is not None and value > 0.0:
+            return value
+    bid = _float_or_none(payload.get("bid"))
+    ask = _float_or_none(payload.get("ask"))
+    if bid is not None and ask is not None and bid > 0.0 and ask > 0.0:
+        return (bid + ask) / 2.0
+    return None
+
+
+def _extract_spread_bps(signal: SignalEnvelope) -> float | None:
+    payload = signal.payload
+    explicit = _float_or_none(payload.get("spread_bps"))
+    if explicit is not None:
+        return max(0.0, explicit)
+    bid = _float_or_none(payload.get("bid"))
+    ask = _float_or_none(payload.get("ask"))
+    if bid is not None and ask is not None and bid > 0.0 and ask >= bid:
+        return (ask - bid) / ((ask + bid) / 2.0) * 10_000.0
+    spread = _float_or_none(payload.get("spread"))
+    price = _extract_price(signal)
+    if spread is not None and price is not None and price > 0.0:
+        return max(0.0, spread / price * 10_000.0)
+    return None
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not np.isfinite(parsed):
+        return None
+    return parsed
+
+
+def _decimal_from_float(value: float) -> Decimal:
+    return Decimal(str(round(float(value), 8)))
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    mapping = cast(Mapping[Any, Any], value)
+    return {str(key): item for key, item in mapping.items()}
+
+
+def _string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION",
+    "FAST_REPLAY_PREVIEW_SCHEMA_VERSION",
+    "FastReplayPreviewResult",
+    "FastReplayPreviewRow",
+    "build_fast_replay_preview",
+]

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -11,7 +11,7 @@ import signal
 import socket
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
@@ -48,6 +48,7 @@ from app.trading.discovery.evidence_bundles import (
     evidence_bundle_from_frontier_candidate,
     evidence_bundle_from_payload,
 )
+from app.trading.discovery.fast_replay import build_fast_replay_preview
 from app.trading.discovery.hypothesis_cards import HypothesisCard
 from app.trading.discovery.mlx_snapshot import build_mlx_snapshot_manifest
 from app.trading.discovery.mlx_snapshot import MlxSnapshotManifest
@@ -67,6 +68,12 @@ from app.trading.discovery.portfolio_optimizer import (
 from app.trading.discovery.profit_target_oracle import (
     ProfitTargetOraclePolicy,
     evaluate_profit_target_oracle,
+)
+from app.trading.discovery.replay_tape import (
+    load_replay_tape,
+    slice_tape_by_symbols,
+    slice_tape_by_window,
+    validate_tape_freshness,
 )
 from app.trading.discovery.runtime_closure import (
     RuntimeClosureExecutionContext,
@@ -386,6 +393,21 @@ def _parse_args() -> argparse.Namespace:
         type=Path,
         default=None,
         help="Optional manifest path for --replay-tape-path.",
+    )
+    parser.add_argument(
+        "--replay-tape-preview-top-k",
+        type=int,
+        default=0,
+        help=(
+            "Preview-only tape-vectorized narrowing budget before exact replay. "
+            "Requires --replay-tape-path and never counts as promotion proof."
+        ),
+    )
+    parser.add_argument(
+        "--replay-tape-preview-min-rows",
+        type=int,
+        default=2,
+        help="Minimum manifest-verified tape rows required to score a candidate in preview narrowing.",
     )
     parser.add_argument(
         "--collect-train-gate-diagnostics",
@@ -5688,6 +5710,142 @@ def _candidate_selection_for_direct_replay(
     }
 
 
+def _apply_fast_replay_preview_narrowing(
+    *,
+    args: argparse.Namespace,
+    output_dir: Path,
+    specs: Sequence[CandidateSpec],
+    candidate_selection: Mapping[str, Any],
+) -> tuple[list[CandidateSpec], dict[str, Any]]:
+    preview_top_k = max(0, int(getattr(args, "replay_tape_preview_top_k", 0) or 0))
+    if preview_top_k <= 0:
+        return list(specs), dict(candidate_selection)
+    if str(getattr(args, "replay_mode", "") or "") != "real":
+        raise ValueError("fast_replay_preview_requires_real_replay")
+    tape_path = getattr(args, "replay_tape_path", None)
+    if tape_path is None:
+        raise ValueError("fast_replay_preview_requires_replay_tape_path")
+
+    start_date = _fast_replay_preview_date_arg(args, "full_window_start_date")
+    end_date = _fast_replay_preview_date_arg(args, "full_window_end_date")
+    tape = load_replay_tape(
+        Path(tape_path).resolve(),
+        manifest_path=(
+            Path(args.replay_tape_manifest).resolve()
+            if getattr(args, "replay_tape_manifest", None) is not None
+            else None
+        ),
+    )
+    validation = validate_tape_freshness(
+        tape.manifest,
+        start_date=start_date,
+        end_date=end_date,
+        symbols=_candidate_universe_symbols_from_args(args),
+        allow_stale_tape=bool(getattr(args, "allow_stale_tape", False)),
+    )
+    selected_rows = slice_tape_by_symbols(
+        slice_tape_by_window(
+            tape.rows,
+            start_date=start_date,
+            end_date=end_date,
+        ),
+        symbols=_candidate_universe_symbols_from_args(args),
+    )
+    preview = build_fast_replay_preview(
+        specs=specs,
+        rows=selected_rows,
+        replay_tape_manifest=tape.manifest,
+        top_k=preview_top_k,
+        min_rows_per_candidate=max(
+            1, int(getattr(args, "replay_tape_preview_min_rows", 2) or 2)
+        ),
+    )
+    preview_scores_path = output_dir / "replay-tape-preview-scores.jsonl"
+    preview_manifest_path = output_dir / "replay-tape-preview-manifest.json"
+    _write_jsonl(preview_scores_path, [row.to_payload() for row in preview.rows])
+    preview_manifest = {
+        **preview.to_manifest_payload(),
+        "validation": validation,
+        "artifacts": {
+            "scores_jsonl": str(preview_scores_path),
+            "manifest_json": str(preview_manifest_path),
+        },
+    }
+    _write_json(preview_manifest_path, preview_manifest)
+
+    spec_by_id = {spec.candidate_spec_id: spec for spec in specs}
+    narrowed_specs = [
+        spec_by_id[candidate_spec_id]
+        for candidate_spec_id in preview.selected_candidate_spec_ids
+        if candidate_spec_id in spec_by_id
+    ]
+    if not narrowed_specs and specs:
+        narrowed_specs = [specs[0]]
+
+    selected_ids = {spec.candidate_spec_id for spec in narrowed_specs}
+    replay_order_by_spec = {
+        spec.candidate_spec_id: index
+        for index, spec in enumerate(narrowed_specs, start=1)
+    }
+    preview_row_by_spec = {
+        row.candidate_spec_id: row.to_payload() for row in preview.rows
+    }
+    original_selected_ids = _selected_candidate_spec_ids(candidate_selection)
+    updated_rows: list[dict[str, Any]] = []
+    for row in _list_of_mappings(candidate_selection.get("rows")):
+        candidate_spec_id = _string(row.get("candidate_spec_id"))
+        updated = dict(row)
+        preview_row = preview_row_by_spec.get(candidate_spec_id)
+        if preview_row is not None:
+            updated["fast_replay_preview_rank"] = preview_row["rank"]
+            updated["fast_replay_preview_score"] = preview_row["preview_score"]
+            updated["fast_replay_preview_selected"] = preview_row["selected"]
+            updated["fast_replay_preview_selection_reason"] = preview_row[
+                "selection_reason"
+            ]
+            updated["fast_replay_preview_matched_row_count"] = preview_row[
+                "matched_row_count"
+            ]
+        if candidate_spec_id in original_selected_ids:
+            updated["pre_fast_replay_preview_selected_for_replay"] = bool(
+                row.get("selected_for_replay")
+            )
+            updated["selected_for_replay"] = candidate_spec_id in selected_ids
+            updated["replay_order"] = replay_order_by_spec.get(candidate_spec_id)
+            if candidate_spec_id not in selected_ids:
+                updated["selection_reason"] = "fast_replay_preview_filtered"
+        updated_rows.append(updated)
+
+    updated_selection = {
+        **dict(candidate_selection),
+        "budget": {
+            **_mapping(candidate_selection.get("budget")),
+            "fast_replay_preview_enabled": True,
+            "fast_replay_preview_requested_top_k": preview_top_k,
+            "fast_replay_preview_selected_count": len(narrowed_specs),
+            "pre_fast_replay_preview_selected_count": len(specs),
+            "selected_count": len(narrowed_specs),
+        },
+        "selected_candidate_spec_ids": [
+            spec.candidate_spec_id for spec in narrowed_specs
+        ],
+        "rows": updated_rows,
+        "replay_tape_preview": {
+            **preview_manifest,
+            "scores_artifact": str(preview_scores_path),
+            "manifest_artifact": str(preview_manifest_path),
+        },
+    }
+    return narrowed_specs, updated_selection
+
+
+def _fast_replay_preview_date_arg(args: argparse.Namespace, key: str) -> date:
+    value = str(getattr(args, key, "") or "").strip()
+    if not value:
+        raise ValueError(f"fast_replay_preview_requires_{key}")
+    return date.fromisoformat(value)
+
+
 def _synthetic_net_for_spec(spec: CandidateSpec, *, rank: int) -> Decimal:
     family_bonus = {
         "microbar_cross_sectional_pairs_v1": Decimal("215"),
@@ -8694,6 +8852,23 @@ def run_whitepaper_autoresearch_profit_target(
             output_dir / "selected-candidate-specs.jsonl"
         ),
     }
+    try:
+        replay_candidate_specs, candidate_selection = (
+            _apply_fast_replay_preview_narrowing(
+                args=args,
+                output_dir=output_dir,
+                specs=replay_candidate_specs,
+                candidate_selection=candidate_selection,
+            )
+        )
+    except ValueError as exc:
+        return _write_failure_summary(
+            output_dir=output_dir,
+            epoch_id=epoch_id,
+            status="invalid_replay_tape_preview",
+            reason=str(exc),
+            started_at=started_at,
+        )
     _write_json(output_dir / "candidate-selection-manifest.json", candidate_selection)
     _write_jsonl(
         output_dir / "selected-candidate-specs.jsonl",
@@ -9278,6 +9453,12 @@ def run_whitepaper_autoresearch_profit_target(
             "real_replay_retry_max_frontier_candidates_per_spec": int(
                 getattr(args, "real_replay_retry_max_frontier_candidates_per_spec", 1)
                 or 1
+            ),
+            "replay_tape_preview_top_k": int(
+                getattr(args, "replay_tape_preview_top_k", 0) or 0
+            ),
+            "replay_tape_preview_min_rows": int(
+                getattr(args, "replay_tape_preview_min_rows", 2) or 2
             ),
             "source_jsonl": [str(path) for path in getattr(args, "source_jsonl", [])],
         }

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 import json
 import sys
 from argparse import Namespace
-from datetime import datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -32,7 +32,13 @@ from app.models import (
     WhitepaperDocument,
     WhitepaperDocumentVersion,
 )
+from app.trading.discovery import fast_replay
+from app.trading.discovery.replay_tape import (
+    build_source_query_digest,
+    materialize_signal_tape,
+)
 from app.trading.discovery.evidence_bundles import evidence_bundle_blockers
+from app.trading.models import SignalEnvelope
 
 _CHIP_UNIVERSE = list(runner.LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE)
 
@@ -174,6 +180,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             prefetch_full_window_rows=False,
             replay_tape_path=None,
             replay_tape_manifest=None,
+            replay_tape_preview_top_k=0,
+            replay_tape_preview_min_rows=2,
             min_daily_net_pnl=None,
             persist_results=False,
         )
@@ -3879,6 +3887,276 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         ledger_mock.assert_not_called()
         optimizer_mock.assert_not_called()
         runtime_mock.assert_not_called()
+
+    def test_replay_tape_preview_narrows_direct_specs_without_promotion_proof(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output_dir = root / "epoch"
+            specs_path = root / "candidate-specs.jsonl"
+            tape_path = root / "preview-tape.jsonl"
+            base_nvda = self._candidate_spec("spec-nvda-continuation")
+            nvda_spec = replace(
+                base_nvda,
+                strategy_overrides={
+                    **base_nvda.strategy_overrides,
+                    "universe_symbols": ["NVDA"],
+                },
+            )
+            base_aapl = self._candidate_spec("spec-aapl-continuation")
+            aapl_spec = replace(
+                base_aapl,
+                strategy_overrides={
+                    **base_aapl.strategy_overrides,
+                    "universe_symbols": ["AAPL"],
+                },
+            )
+            specs_path.write_text(
+                "\n".join(
+                    json.dumps(spec.to_payload(), sort_keys=True)
+                    for spec in (nvda_spec, aapl_spec)
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            materialize_signal_tape(
+                rows=[
+                    SignalEnvelope(
+                        event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                        symbol="NVDA",
+                        timeframe="1Sec",
+                        seq=1,
+                        source="ta",
+                        payload={"price": Decimal("100"), "spread_bps": Decimal("2")},
+                    ),
+                    SignalEnvelope(
+                        event_ts=datetime(2026, 2, 23, 15, 31, tzinfo=timezone.utc),
+                        symbol="NVDA",
+                        timeframe="1Sec",
+                        seq=2,
+                        source="ta",
+                        payload={"price": Decimal("101"), "spread_bps": Decimal("2")},
+                    ),
+                ],
+                tape_path=tape_path,
+                dataset_snapshot_ref="preview-snapshot",
+                symbols=("NVDA", "AAPL"),
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 27),
+                source_query_digest=build_source_query_digest({"query": "preview"}),
+            )
+            args = self._args(output_dir)
+            args.candidate_specs = [specs_path]
+            args.seed_recent_whitepapers = False
+            args.replay_mode = "real"
+            args.selection_only = True
+            args.replay_tape_path = tape_path
+            args.replay_tape_preview_top_k = 1
+            args.symbols = "NVDA,AAPL"
+
+            payload = runner.run_whitepaper_autoresearch_profit_target(args)
+
+            selection = json.loads(
+                (output_dir / "candidate-selection-manifest.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            selected_specs = [
+                json.loads(line)
+                for line in (output_dir / "selected-candidate-specs.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+                if line
+            ]
+            preview_scores_exists = (
+                output_dir / "replay-tape-preview-scores.jsonl"
+            ).exists()
+
+        self.assertEqual(payload["status"], "selection_only")
+        self.assertEqual(payload["replay_candidate_spec_count"], 1)
+        self.assertEqual(
+            selection["selected_candidate_spec_ids"], ["spec-nvda-continuation"]
+        )
+        self.assertEqual(
+            [spec["candidate_spec_id"] for spec in selected_specs],
+            ["spec-nvda-continuation"],
+        )
+        self.assertFalse(selection["replay_tape_preview"]["promotion_proof"])
+        self.assertIn(
+            "exact_replay_required", selection["replay_tape_preview"]["blockers"]
+        )
+        self.assertTrue(preview_scores_exists)
+        aapl_row = next(
+            row
+            for row in selection["rows"]
+            if row["candidate_spec_id"] == "spec-aapl-continuation"
+        )
+        self.assertTrue(aapl_row["pre_fast_replay_preview_selected_for_replay"])
+        self.assertFalse(aapl_row["selected_for_replay"])
+        self.assertEqual(aapl_row["selection_reason"], "fast_replay_preview_filtered")
+
+    def test_replay_tape_preview_error_paths_and_fallback_selection(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output_dir = root / "epoch"
+            tape_path = root / "preview-tape.jsonl"
+            materialize_signal_tape(
+                rows=[
+                    SignalEnvelope(
+                        event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                        symbol="NVDA",
+                        timeframe="1Sec",
+                        seq=1,
+                        source="ta",
+                        payload={"price": Decimal("100")},
+                    )
+                ],
+                tape_path=tape_path,
+                dataset_snapshot_ref="preview-snapshot",
+                symbols=("NVDA",),
+                start_date=date(2026, 2, 23),
+                end_date=date(2026, 2, 27),
+                source_query_digest=build_source_query_digest({"query": "preview"}),
+            )
+            spec = self._candidate_spec("spec-preview-fallback")
+            selection = {
+                "selected_candidate_spec_ids": [spec.candidate_spec_id],
+                "rows": [
+                    {
+                        "candidate_spec_id": spec.candidate_spec_id,
+                        "selected_for_replay": True,
+                    }
+                ],
+                "budget": {"selected_count": 1},
+            }
+            args = self._args(output_dir)
+            args.replay_tape_preview_top_k = 1
+            with self.assertRaisesRegex(
+                ValueError, "fast_replay_preview_requires_real_replay"
+            ):
+                runner._apply_fast_replay_preview_narrowing(
+                    args=args,
+                    output_dir=output_dir,
+                    specs=[spec],
+                    candidate_selection=selection,
+                )
+            args.replay_mode = "real"
+            args.replay_tape_path = None
+            with self.assertRaisesRegex(
+                ValueError, "fast_replay_preview_requires_replay_tape_path"
+            ):
+                runner._apply_fast_replay_preview_narrowing(
+                    args=args,
+                    output_dir=output_dir,
+                    specs=[spec],
+                    candidate_selection=selection,
+                )
+            args.replay_tape_path = tape_path
+            args.full_window_start_date = ""
+            with self.assertRaisesRegex(
+                ValueError, "fast_replay_preview_requires_full_window_start_date"
+            ):
+                runner._apply_fast_replay_preview_narrowing(
+                    args=args,
+                    output_dir=output_dir,
+                    specs=[spec],
+                    candidate_selection=selection,
+                )
+
+            class UnknownPreview:
+                selected_candidate_spec_ids = ("missing-spec",)
+                rows = ()
+
+                def to_manifest_payload(self) -> dict[str, object]:
+                    return {
+                        "schema_version": "torghut.fast-replay-preview.v1",
+                        "promotion_proof": False,
+                    }
+
+            args.full_window_start_date = "2026-02-23"
+            args.symbols = "NVDA"
+            with patch.object(
+                runner,
+                "build_fast_replay_preview",
+                return_value=UnknownPreview(),
+            ):
+                narrowed, updated = runner._apply_fast_replay_preview_narrowing(
+                    args=args,
+                    output_dir=output_dir,
+                    specs=[spec],
+                    candidate_selection=selection,
+                )
+
+        self.assertEqual(
+            [item.candidate_spec_id for item in narrowed], [spec.candidate_spec_id]
+        )
+        self.assertEqual(
+            updated["selected_candidate_spec_ids"], [spec.candidate_spec_id]
+        )
+
+    def test_fast_replay_preview_covers_signal_field_fallbacks(self) -> None:
+        no_universe_spec = replace(
+            self._candidate_spec("spec-no-universe"),
+            runtime_strategy_name="NVDA",
+            strategy_overrides={
+                "params": {
+                    "selection_mode": "continuation",
+                    "signal_motif": "opening_continuation",
+                }
+            },
+        )
+        self.assertEqual(fast_replay._candidate_symbols(no_universe_spec), ("NVDA",))
+        self.assertEqual(fast_replay._candidate_direction(no_universe_spec), 1.0)
+        self.assertEqual(
+            fast_replay._extract_price(
+                SignalEnvelope(
+                    event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                    symbol="NVDA",
+                    payload={"bid": Decimal("100"), "ask": Decimal("102")},
+                )
+            ),
+            101.0,
+        )
+        self.assertIsNone(
+            fast_replay._extract_price(
+                SignalEnvelope(
+                    event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                    symbol="NVDA",
+                    payload={},
+                )
+            )
+        )
+        bid_ask_spread = fast_replay._extract_spread_bps(
+            SignalEnvelope(
+                event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                symbol="NVDA",
+                payload={"bid": Decimal("100"), "ask": Decimal("101")},
+            )
+        )
+        self.assertAlmostEqual(bid_ask_spread or 0.0, 99.50248756218905)
+        self.assertEqual(
+            fast_replay._extract_spread_bps(
+                SignalEnvelope(
+                    event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                    symbol="NVDA",
+                    payload={"price": Decimal("100"), "spread": Decimal("0.05")},
+                )
+            ),
+            5.0,
+        )
+        self.assertIsNone(
+            fast_replay._extract_spread_bps(
+                SignalEnvelope(
+                    event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                    symbol="NVDA",
+                    payload={},
+                )
+            )
+        )
+        self.assertIsNone(fast_replay._float_or_none("not-a-number"))
+        self.assertIsNone(fast_replay._float_or_none(float("nan")))
+        self.assertEqual(fast_replay._mapping("not-a-mapping"), {})
 
     def test_candidate_specs_replay_skips_compiler_and_replays_selected_specs(
         self,


### PR DESCRIPTION
## Summary

- Adds a preview-only vectorized replay-tape scorer for candidate specs using manifest-verified tape rows.
- Wires optional `--replay-tape-preview-top-k` narrowing into the whitepaper autoresearch runner before exact replay.
- Persists preview manifest and score artifacts while explicitly marking them as non-promotion proof.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/discovery/fast_replay.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check app/trading/discovery/fast_replay.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k replay_tape_preview`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k "replay_tape_preview or fast_replay_preview"`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_replay_tape.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
