### PR TITLE
chore(torghut): expose replay tape preview workflow flags

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -78,6 +78,14 @@ spec:
         value: '5'
       - name: prefetchFullWindowRows
         value: 'true'
+      - name: replayTapePath
+        value: ''
+      - name: replayTapeManifest
+        value: ''
+      - name: replayTapePreviewTopK
+        value: '0'
+      - name: replayTapePreviewMinRows
+        value: '2'
       - name: allowStaleTape
         value: 'false'
       - name: persistResults
@@ -117,6 +125,10 @@ spec:
           - name: holdoutDays
           - name: secondOosDays
           - name: prefetchFullWindowRows
+          - name: replayTapePath
+          - name: replayTapeManifest
+          - name: replayTapePreviewTopK
+          - name: replayTapePreviewMinRows
           - name: allowStaleTape
           - name: persistResults
       container:
@@ -235,6 +247,16 @@ spec:
             fi
             if [ "{{inputs.parameters.prefetchFullWindowRows}}" = "true" ]; then
               SCRIPT_ARGS+=(--prefetch-full-window-rows)
+            fi
+            if [ -n "{{inputs.parameters.replayTapePath}}" ]; then
+              SCRIPT_ARGS+=(--replay-tape-path "{{inputs.parameters.replayTapePath}}")
+            fi
+            if [ -n "{{inputs.parameters.replayTapeManifest}}" ]; then
+              SCRIPT_ARGS+=(--replay-tape-manifest "{{inputs.parameters.replayTapeManifest}}")
+            fi
+            if [ "{{inputs.parameters.replayTapePreviewTopK}}" != "0" ]; then
+              SCRIPT_ARGS+=(--replay-tape-preview-top-k "{{inputs.parameters.replayTapePreviewTopK}}")
+              SCRIPT_ARGS+=(--replay-tape-preview-min-rows "{{inputs.parameters.replayTapePreviewMinRows}}")
             fi
             if [ "{{inputs.parameters.allowStaleTape}}" = "true" ]; then
               SCRIPT_ARGS+=(--allow-stale-tape)


### PR DESCRIPTION
## Summary

- Adds GitOps workflow parameters for replay tape path, replay tape manifest, preview top-k, and minimum matched rows.
- Passes replay tape preview flags into `run_whitepaper_autoresearch_profit_target.py` only when preview is explicitly enabled.
- Keeps the existing autoresearch workflow behavior unchanged by default with replay tape preview disabled.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
