### PR TITLE
fix(agents): unblock gitops rollout

### DIFF
--- a/argocd/applications/agents/postgres-cluster.yaml
+++ b/argocd/applications/agents/postgres-cluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: agents-db
+  name: agents-db-next
   namespace: agents
   annotations:
     argocd.argoproj.io/sync-wave: "-5"
@@ -26,5 +26,5 @@ spec:
       reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "pgadmin"
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
       reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "pgadmin"
-# CNPG emits application credentials in `agents-db-app` (uri, user, password, host, port, dbname).
-# The chart and generic Memory resource consume that generated secret directly after the Agents-owned DB cutover.
+# The app-facing database secret is canonicalized as `agents-db-app`.
+# Keep the physical CNPG cluster name on the existing live cluster until a backup/restore migration can rename it without pruning data.

--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/proompteng/charts/tree/main/charts/agents
 type: application
 kubeVersion: '>=1.25.0-0'
-version: 0.9.21
+version: 0.9.22
 appVersion: '0.9.0'
 icon: https://avatars.githubusercontent.com/u/234536857
 keywords:

--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-version: 0.9.21
+version: 0.9.22
 name: agents
 displayName: Agents Control Plane
 description: Minimal Agents control plane with CRDs and native workflow runtime.


### PR DESCRIPTION
## Summary

- Bump the Agents Helm chart and Artifact Hub package version to `0.9.22` so the chart publish step can accept the changed package contents from #7346.
- Keep the GitOps CNPG resource on the existing live `agents-db-next` physical cluster for this rollout to avoid pruning the active database.
- Leave the app-facing database secret canonicalized as `agents-db-app`; the physical cluster rename needs a separate backup/restore migration.

## Related Issues

Unblocks #7346 rollout.

## Testing

- `scripts/agents/validate-agents.sh`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render.yaml`
- `rg -n "name: agents-db($|-next)|agents-db-app|version: 0.9.22" /tmp/agents-render.yaml charts/agents/Chart.yaml charts/agents/artifacthub-pkg.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None for this hotfix. The physical CNPG cluster remains `agents-db-next` until a separate data-preserving migration renames it.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
