### PR TITLE
chore(jangar): promote image c235e9ce

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-21T03:08:41Z
+    deploy.knative.dev/rollout: 2026-05-21T06:17:00Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 80403146903325fab9da05a2597fe1b7ba7307b6
+              value: c235e9ce01da70fc1196c514b224685c6f9bed9d
             - name: JANGAR_GITOPS_REVISION
-              value: 80403146903325fab9da05a2597fe1b7ba7307b6
+              value: c235e9ce01da70fc1196c514b224685c6f9bed9d
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -367,15 +367,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26202914147"
+              value: "26208910371"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:886b593a8d0bdc163a6887123247986408cc36f9015dc3b685fb8239548bbc0d
+              value: sha256:281f72c11991ed1d02471089d198f2777169fde6e7d671a4933156a877d22674
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 80403146903325fab9da05a2597fe1b7ba7307b6
+              value: c235e9ce01da70fc1196c514b224685c6f9bed9d
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:886b593a8d0bdc163a6887123247986408cc36f9015dc3b685fb8239548bbc0d
+              value: sha256:281f72c11991ed1d02471089d198f2777169fde6e7d671a4933156a877d22674
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -38,5 +38,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: "80403146"
-    digest: sha256:886b593a8d0bdc163a6887123247986408cc36f9015dc3b685fb8239548bbc0d
+    newTag: c235e9ce
+    digest: sha256:281f72c11991ed1d02471089d198f2777169fde6e7d671a4933156a877d22674


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `c235e9ce01da70fc1196c514b224685c6f9bed9d`
- Image tag: `c235e9ce`
- Image digest: `sha256:281f72c11991ed1d02471089d198f2777169fde6e7d671a4933156a877d22674`
- Source CI run: `26208910371`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates