### PR TITLE
fix(agents): package agent contracts deps in images

### DIFF
--- a/services/agents/Dockerfile
+++ b/services/agents/Dockerfile
@@ -183,6 +183,8 @@ RUN ln -sf /app/packages/cx-tools/dist/cx-codex-run.js /usr/local/bin/cx-codex-r
   && chmod +x /app/packages/cx-tools/dist/*.js
 
 COPY --from=agents-deps-prod /app/node_modules ./node_modules
+RUN mkdir -p /app/packages/agent-contracts/node_modules \
+  && ln -sf /app/node_modules/effect /app/packages/agent-contracts/node_modules/effect
 WORKDIR /app/services/agents
 COPY --from=agents-build /app/services/agents/package.json ./package.json
 COPY --from=agents-build /app/services/agents/src ./src
@@ -230,6 +232,8 @@ RUN ln -sf /app/packages/cx-tools/dist/cx-codex-run.js /usr/local/bin/cx-codex-r
   && chmod +x /app/packages/cx-tools/dist/*.js
 
 COPY --from=agents-deps-prod /app/node_modules ./node_modules
+RUN mkdir -p /app/packages/agent-contracts/node_modules \
+  && ln -sf /app/node_modules/effect /app/packages/agent-contracts/node_modules/effect
 WORKDIR /app/services/agents
 COPY --from=agents-build /app/services/agents/package.json ./package.json
 COPY --from=agents-build /app/services/agents/src ./src


### PR DESCRIPTION
## Summary

- Add the package-local `effect` dependency symlink expected by Bun when the final Agents images import root `@proompteng/agent-contracts`.
- Apply the fix to both `control-plane` and `controller` image targets.
- Keep the root scoped package shape intact; no export map is reintroduced.

## Related Issues

Fixes the failed `agents-build-push` image build from #7348.

## Testing

- Release-style pruned `docker buildx build --target controller --platform linux/arm64 --load` for `services/agents/Dockerfile`
- Release-style pruned `docker buildx build --target control-plane --platform linux/arm64 --load` for `services/agents/Dockerfile`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
