### PR TITLE
fix(agents): pin spark provider to spark model

### DIFF
--- a/argocd/applications/agents/codex-spark-agentprovider.yaml
+++ b/argocd/applications/agents/codex-spark-agentprovider.yaml
@@ -7,7 +7,7 @@ spec:
   adapter:
     type: codex-app-server
     codex:
-      model: gpt-5.5
+      model: gpt-5.3-codex-spark
       effort: xhigh
       sandbox: danger-full-access
       approval: never
@@ -20,15 +20,15 @@ spec:
     CODEX_LOG_LEVEL: info
     AGENT_RUN_NAME: "{{agentRun.name}}"
     AGENT_RUN_NAMESPACE: "{{agentRun.namespace}}"
-    CODEX_MODEL: gpt-5.5
-    CODEX_MODEL_FALLBACKS: gpt-5.4,gpt-5.4-mini,gpt-5.2-codex,gpt-5-codex
+    CODEX_MODEL: gpt-5.3-codex-spark
+    CODEX_MODEL_FALLBACKS: gpt-5.5,gpt-5.4,gpt-5.4-mini,gpt-5.2-codex,gpt-5-codex
     CODEX_MAX_SESSION_ATTEMPTS: "5"
     HF_BASE_URL: https://router.huggingface.co/v1
     HF_MODEL: meta-llama/Llama-3.1-8B-Instruct:novita
   inputFiles:
     - path: /root/.codex/config.toml
       content: |-
-        model = "gpt-5.5"
+        model = "gpt-5.3-codex-spark"
         model_reasoning_summary = "none"
         model_reasoning_effort = "xhigh"
         model_verbosity = "medium"

--- a/argocd/applications/torghut/agents-domain/torghut-market-context-agentprovider.yaml
+++ b/argocd/applications/torghut/agents-domain/torghut-market-context-agentprovider.yaml
@@ -21,7 +21,7 @@ spec:
   envTemplate:
     CODEX_LOG_LEVEL: info
     NATS_URL: nats://nats.nats.svc.cluster.local:4222
-    CODEX_MARKET_CONTEXT_PROVIDER_CHAIN: codex:gpt-5.5,codex-spark:gpt-5.5
+    CODEX_MARKET_CONTEXT_PROVIDER_CHAIN: codex:gpt-5.5,codex-spark:gpt-5.3-codex-spark
     CODEX_MARKET_CONTEXT_ATTEMPT_TIMEOUT_SECONDS: "600"
     CODEX_MARKET_CONTEXT_OVERALL_TIMEOUT_SECONDS: "1200"
     CODEX_MARKET_CONTEXT_PROGRESS_TIMEOUT_SECONDS: "10"

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -505,20 +505,28 @@ describe('scheduled AgentRun templates', () => {
     const codex = objectAt(adapter, 'codex')
     const envTemplate = objectAt(objectAt(provider, 'spec'), 'envTemplate')
     const inputFiles = objectAt(objectAt(provider, 'spec'), 'inputFiles') as Record<string, unknown>[] | undefined
+    const codexConfig = (inputFiles ?? []).find(
+      (inputFile) => objectAt(inputFile, 'path') === '/root/.codex/config.toml',
+    )
 
     expect(objectAt(spec, 'binary')).toBe('/usr/local/bin/agent-runner')
     expect(objectAt(spec, 'argsTemplate')).toEqual([])
     expect(objectAt(adapter, 'type')).toBe('codex-app-server')
-    expect(objectAt(codex, 'model')).toBe('gpt-5.5')
+    expect(objectAt(codex, 'model')).toBe('gpt-5.3-codex-spark')
     expect(objectAt(codex, 'effort')).toBe('xhigh')
     expect(objectAt(codex, 'sandbox')).toBe('danger-full-access')
     expect(objectAt(codex, 'approval')).toBe('never')
     expect(objectAt(codex, 'cwd')).toBe('/workspace/lab')
     expect(objectAt(envTemplate, 'AGENT_RUN_NAME')).toBe('{{agentRun.name}}')
     expect(objectAt(envTemplate, 'AGENT_RUN_NAMESPACE')).toBe('{{agentRun.namespace}}')
-    expect(objectAt(envTemplate, 'CODEX_MODEL_FALLBACKS')).toBe('gpt-5.4,gpt-5.4-mini,gpt-5.2-codex,gpt-5-codex')
+    expect(objectAt(envTemplate, 'CODEX_MODEL')).toBe('gpt-5.3-codex-spark')
+    expect(objectAt(envTemplate, 'CODEX_MODEL_FALLBACKS')).toBe(
+      'gpt-5.5,gpt-5.4,gpt-5.4-mini,gpt-5.2-codex,gpt-5-codex',
+    )
     expect(objectAt(envTemplate, 'CODEX_MODEL_FALLBACKS')).not.toContain('gpt-5.3-codex-spark')
     expect(objectAt(envTemplate, 'CODEX_MAX_SESSION_ATTEMPTS')).toBe('5')
+    expect(objectAt(codexConfig, 'content')).toContain('model = "gpt-5.3-codex-spark"')
+    expect(objectAt(codexConfig, 'content')).not.toContain('model = "gpt-5.5"')
     expect((inputFiles ?? []).map((inputFile) => objectAt(inputFile, 'path'))).not.toContain(
       '/root/.codex/provider-codex-spark.json',
     )


### PR DESCRIPTION
## Summary

- Pin the live `codex-spark` AgentProvider adapter model to `gpt-5.3-codex-spark`.
- Align `CODEX_MODEL` and the mounted Codex config with the Spark model.
- Update the Torghut market-context provider-chain label so `codex-spark` is listed as `gpt-5.3-codex-spark`.
- Add a manifest guard test for adapter, env, and config model consistency.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "renders Codex app-server adapter metadata"`
- `scripts/agents/validate-agents.sh`
- `mise exec helm -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-render-spark.yaml`
- `mise exec helm -- kustomize build --enable-helm argocd/applications/torghut/agents-domain >/tmp/torghut-agents-domain-render-spark.yaml`
- `rg -n "codex-spark:gpt-5\.5|codex-spark.*model: gpt-5\.5|name: codex-spark[\s\S]{0,200}model: gpt-5\.5" argocd packages services docs -g '!**/node_modules/**' -g '!**/dist/**' || true`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
