### PR TITLE
fix(codex): keep retryable app-server stream errors nonfatal

### DIFF
--- a/packages/codex/src/app-server-client.events.test.ts
+++ b/packages/codex/src/app-server-client.events.test.ts
@@ -24,6 +24,7 @@ class FakeChildProcess extends EventEmitter {
 }
 
 const spawnMock = spawn as unknown as {
+  mock: { calls: unknown[][] }
   mockReturnValue: (value: unknown) => void
   mockReset: () => void
 }
@@ -327,6 +328,73 @@ describe('CodexAppServerClient v2 notifications', () => {
     client.stop()
   })
 
+  it('keeps the active stream open when app-server error notifications are retryable', async () => {
+    const { child, client } = setupClient()
+    await respondToInitialize(child)
+    await client.ensureReady()
+
+    const runPromise = client.runTurnStream('hello')
+    await respondToThreadStart(child, 'thread-1')
+    await respondToTurnStart(child, 'response-turn-id')
+    const { stream } = await runPromise
+
+    writeLine(child, {
+      method: 'turn/started',
+      params: {
+        threadId: 'thread-1',
+        turn: {
+          id: 'canonical-turn-id',
+          status: 'inProgress',
+          items: [],
+          error: null,
+          startedAt: null,
+          completedAt: null,
+          durationMs: null,
+        },
+      },
+    })
+    writeLine(child, {
+      method: 'error',
+      params: {
+        error: {
+          message: 'Reconnecting... 2/5',
+          codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: null } },
+          additionalDetails: 'Stream disconnected before completion.',
+        },
+        willRetry: true,
+        threadId: 'thread-1',
+        turnId: 'canonical-turn-id',
+      },
+    })
+
+    await expect(stream.next()).resolves.toMatchObject({
+      value: {
+        type: 'error',
+        error: {
+          error: {
+            message: 'Reconnecting... 2/5',
+          },
+          willRetry: true,
+        },
+      },
+      done: false,
+    })
+
+    writeLine(child, {
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turn: { id: 'canonical-turn-id', status: 'completed', items: [], error: null },
+      },
+    })
+
+    await expect(withTimeout(stream.next(), 'retryable error stream completion')).resolves.toMatchObject({
+      done: true,
+      value: { id: 'canonical-turn-id', status: 'completed' },
+    })
+    client.stop()
+  })
+
   it('omits the CLI approval flag for structured rejection policies', async () => {
     const { child, client } = setupClient({
       approval: {
@@ -340,7 +408,7 @@ describe('CodexAppServerClient v2 notifications', () => {
       },
     })
 
-    const [binaryPath, args] = vi.mocked(spawn).mock.calls[0] ?? []
+    const [binaryPath, args] = spawnMock.mock.calls[0] ?? []
     expect(binaryPath).toBe('codex')
     expect(args).toEqual(['--sandbox', 'danger-full-access', '--model', 'gpt-5.5', 'app-server'])
 
@@ -354,7 +422,7 @@ describe('CodexAppServerClient v2 notifications', () => {
       cliConfigOverrides: ['mcp_servers={}', 'notify=[]'],
     })
 
-    const [binaryPath, args] = vi.mocked(spawn).mock.calls[0] ?? []
+    const [binaryPath, args] = spawnMock.mock.calls[0] ?? []
     expect(binaryPath).toBe('codex')
     expect(args).toEqual([
       '--sandbox',

--- a/packages/codex/src/app-server-client.ts
+++ b/packages/codex/src/app-server-client.ts
@@ -1391,19 +1391,28 @@ export class CodexAppServerClient {
       }
       case 'error': {
         const errorPayload = (notification.params as ErrorNotification) ?? { message: 'unknown error' }
+        const willRetry =
+          typeof notification.params === 'object' &&
+          notification.params !== null &&
+          (notification.params as { willRetry?: unknown }).willRetry === true
         const notificationTurnId = this.findTurnId(notification.params)
         if (notificationTurnId) this.reconcileActiveTurnId(notificationTurnId)
         const resolved = this.resolveTurnStream(notification.params)
         if (resolved) {
           resolved.stream.push({ type: 'error', error: errorPayload })
-          this.failTurnStream(resolved.turnId, streamErrorToError(errorPayload))
+          if (!willRetry) {
+            this.failTurnStream(resolved.turnId, streamErrorToError(errorPayload))
+          }
         } else {
           this.log('info', 'stream error without matching active turn (dropped)', {
             method,
             params: notification.params,
           })
         }
-        this.log('error', 'codex stream error', { method, params: notification.params })
+        this.log(willRetry ? 'warn' : 'error', willRetry ? 'codex stream retryable error' : 'codex stream error', {
+          method,
+          params: notification.params,
+        })
         break
       }
       default:


### PR DESCRIPTION
## Summary

- Keep retryable Codex app-server `error` notifications from failing the active turn stream.
- Preserve non-retryable stream errors as terminal failures.
- Add regression coverage for the reconnect notification shape seen in the live Spark AgentRun smoke.
- Replace two `vi.mocked` test helper calls with the existing typed spawn mock so the full event suite runs under Bun.

## Related Issues

None

## Testing

- `bun test packages/codex/src/app-server-client.events.test.ts -t "retryable"`
- `bun test packages/codex/src/app-server-client.events.test.ts`
- `bun test services/agents/src/runner/codex-app-server.test.ts`
- `bunx oxfmt --check packages/codex/src/app-server-client.ts packages/codex/src/app-server-client.events.test.ts`
- `bun run --filter @proompteng/codex build`
- `bun run --filter @proompteng/agents tsc`
- `bun run --filter @proompteng/codex lint:oxlint`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
