### PR TITLE
chore(jangar): promote image 9f83c85d

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-21T06:17:00Z
+    deploy.knative.dev/rollout: 2026-05-21T07:08:50Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: c235e9ce01da70fc1196c514b224685c6f9bed9d
+              value: 9f83c85de2877b83cd5787bdb45c2e2c240fc414
             - name: JANGAR_GITOPS_REVISION
-              value: c235e9ce01da70fc1196c514b224685c6f9bed9d
+              value: 9f83c85de2877b83cd5787bdb45c2e2c240fc414
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -367,15 +367,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26208910371"
+              value: "26211063501"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:281f72c11991ed1d02471089d198f2777169fde6e7d671a4933156a877d22674
+              value: sha256:5479bf67c21617bcc7112cb83c32d65d0df918ff947616e00743ff94e31114da
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: c235e9ce01da70fc1196c514b224685c6f9bed9d
+              value: 9f83c85de2877b83cd5787bdb45c2e2c240fc414
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:281f72c11991ed1d02471089d198f2777169fde6e7d671a4933156a877d22674
+              value: sha256:5479bf67c21617bcc7112cb83c32d65d0df918ff947616e00743ff94e31114da
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -38,5 +38,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: c235e9ce
-    digest: sha256:281f72c11991ed1d02471089d198f2777169fde6e7d671a4933156a877d22674
+    newTag: 9f83c85d
+    digest: sha256:5479bf67c21617bcc7112cb83c32d65d0df918ff947616e00743ff94e31114da


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `9f83c85de2877b83cd5787bdb45c2e2c240fc414`
- Image tag: `9f83c85d`
- Image digest: `sha256:5479bf67c21617bcc7112cb83c32d65d0df918ff947616e00743ff94e31114da`
- Source CI run: `26211063501`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates