### PR TITLE
chore(symphony): promote image c1b2639f

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-21T02:17:57Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-21T07:24:37Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "7fcd117f"
-    digest: sha256:4c2085b135bd3d5a94cdf4361aec36b558858fd19fc1666db35ae87a9f83c7e6
+    newTag: "c1b2639f"
+    digest: sha256:b65364a44c565924d3d8d3fb12672da8226c3f67dcf408eaa6b287c247ee5e65

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-21T02:17:57Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-21T07:24:37Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "7fcd117f"
-    digest: sha256:4c2085b135bd3d5a94cdf4361aec36b558858fd19fc1666db35ae87a9f83c7e6
+    newTag: "c1b2639f"
+    digest: sha256:b65364a44c565924d3d8d3fb12672da8226c3f67dcf408eaa6b287c247ee5e65

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-21T02:17:57Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-21T07:24:37Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "7fcd117f"
-    digest: sha256:4c2085b135bd3d5a94cdf4361aec36b558858fd19fc1666db35ae87a9f83c7e6
+    newTag: "c1b2639f"
+    digest: sha256:b65364a44c565924d3d8d3fb12672da8226c3f67dcf408eaa6b287c247ee5e65


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `c1b2639ffe316237c75aceda2db4956bbe724194`
- Image tag: `c1b2639f`
- Image digest: `sha256:b65364a44c565924d3d8d3fb12672da8226c3f67dcf408eaa6b287c247ee5e65`