### PR TITLE
chore(agents): promote images c1b2639f

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: 6596a2fb
-  digest: sha256:7b3311995bebd4d325df56a09271edd98d3e006c9e95629b9bcd2fbb76660998
+  tag: c1b2639f
+  digest: sha256:c8e66b5f297d4467127f044ac64ae88692b68d291591e2f8aabf611e0dcbe40c
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,26 +11,26 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: 6596a2fb
-    digest: sha256:db8f1a5e69758ba8870cc73b6fd0e2fa0201645c08c42e32510b3226c0d7b522
+    tag: c1b2639f
+    digest: sha256:274b09f84ff85416aadb71a115b45ebea63834b687ee4ba061bfde57e2f1c869
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: 6596a2fb634dac9a7b06d8ec447055a1a3f81722
-      AGENTS_GITOPS_REVISION: 6596a2fb634dac9a7b06d8ec447055a1a3f81722
-      AGENTS_SOURCE_CI_RUN_ID: "26210454035"
+      AGENTS_SOURCE_HEAD_SHA: c1b2639ffe316237c75aceda2db4956bbe724194
+      AGENTS_GITOPS_REVISION: c1b2639ffe316237c75aceda2db4956bbe724194
+      AGENTS_SOURCE_CI_RUN_ID: "26211452960"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:db8f1a5e69758ba8870cc73b6fd0e2fa0201645c08c42e32510b3226c0d7b522
-      AGENTS_SERVING_BUILD_COMMIT: 6596a2fb634dac9a7b06d8ec447055a1a3f81722
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:db8f1a5e69758ba8870cc73b6fd0e2fa0201645c08c42e32510b3226c0d7b522
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:274b09f84ff85416aadb71a115b45ebea63834b687ee4ba061bfde57e2f1c869
+      AGENTS_SERVING_BUILD_COMMIT: c1b2639ffe316237c75aceda2db4956bbe724194
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:274b09f84ff85416aadb71a115b45ebea63834b687ee4ba061bfde57e2f1c869
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: 6596a2fb
-    digest: sha256:8e0370c1cd2d66da6a2c9ef48d0d0d951786bd4987585cd0f338b9fcdb869f7d
+    tag: c1b2639f
+    digest: sha256:4727c0998827b605051cbc602881c0628587310ae55b63d30d10148b6907b7fc
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun
@@ -85,8 +85,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: 6596a2fb
-    digest: sha256:7b3311995bebd4d325df56a09271edd98d3e006c9e95629b9bcd2fbb76660998
+    tag: c1b2639f
+    digest: sha256:c8e66b5f297d4467127f044ac64ae88692b68d291591e2f8aabf611e0dcbe40c
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `c1b2639ffe316237c75aceda2db4956bbe724194`
- Image tag: `c1b2639f`
- Agents build run: `26211452960`
- Promotion source: `manual_dispatch`