### PR TITLE
fix(torghut): skip empty runtime proof windows

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -606,7 +606,14 @@ def persist_observed_runtime_windows(
         if observed_stage == "paper"
         else "live_runtime_observed"
     )
-    sorted_buckets = sorted(buckets, key=lambda item: item.window_ended_at)
+    raw_buckets = sorted(buckets, key=lambda item: item.window_ended_at)
+    sorted_buckets = [
+        bucket
+        for bucket in raw_buckets
+        if bucket.decision_count > 0 or bucket.trade_count > 0 or bucket.order_count > 0
+    ]
+    raw_window_count = len(raw_buckets)
+    skipped_zero_activity_window_count = raw_window_count - len(sorted_buckets)
     inserted = len(sorted_buckets)
     total_session_samples = sum(
         bucket.market_session_count for bucket in sorted_buckets
@@ -659,7 +666,10 @@ def persist_observed_runtime_windows(
     )
     latest_observation_at = max(
         (bucket.window_ended_at for bucket in sorted_buckets),
-        default=datetime.now(timezone.utc),
+        default=max(
+            (bucket.window_ended_at for bucket in raw_buckets),
+            default=datetime.now(timezone.utc),
+        ),
     )
     promotion_blocking_reasons = list(
         dict.fromkeys(
@@ -736,7 +746,9 @@ def persist_observed_runtime_windows(
             payload_json={
                 "imported": True,
                 "observed_stage": observed_stage,
+                "raw_window_count": raw_window_count,
                 "window_count": inserted,
+                "skipped_zero_activity_window_count": skipped_zero_activity_window_count,
                 "market_session_samples": total_session_samples,
                 "decision_count": total_decision_count,
                 "trade_count": total_trade_count,
@@ -760,7 +772,9 @@ def persist_observed_runtime_windows(
             payload_json={
                 "imported": True,
                 "observed_stage": observed_stage,
+                "raw_window_count": raw_window_count,
                 "window_count": inserted,
+                "skipped_zero_activity_window_count": skipped_zero_activity_window_count,
                 "market_session_samples": total_session_samples,
                 "decision_count": total_decision_count,
                 "trade_count": total_trade_count,
@@ -781,7 +795,9 @@ def persist_observed_runtime_windows(
         "candidate_id": candidate_id,
         "hypothesis_id": hypothesis_id,
         "observed_stage": observed_stage,
+        "raw_window_count": raw_window_count,
         "window_count": inserted,
+        "skipped_zero_activity_window_count": skipped_zero_activity_window_count,
         "market_session_samples": total_session_samples,
         "decision_count": total_decision_count,
         "trade_count": total_trade_count,

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -238,6 +238,75 @@ def _query_timestamps(
     return decisions, executions, tca_rows
 
 
+def _source_activity_missing_summary(
+    *,
+    run_id: str,
+    candidate_id: str,
+    hypothesis_id: str,
+    observed_stage: str,
+    strategy_name: str,
+    strategy_names: list[str],
+    account_label: str,
+    window_start: datetime,
+    window_end: datetime,
+    source_manifest_ref: str,
+    source_kind: str,
+    dataset_snapshot_ref: str | None,
+) -> dict[str, Any]:
+    blocker = {
+        "blocker": "runtime_window_source_activity_missing",
+        "hypothesis_id": hypothesis_id,
+        "candidate_id": candidate_id or None,
+        "strategy_name": strategy_name,
+        "strategy_name_candidates": strategy_names,
+        "account_label": account_label,
+        "window_start": window_start.isoformat(),
+        "window_end": window_end.isoformat(),
+        "remediation": (
+            "Run live-paper replay or route/TCA repair until the source database contains "
+            "execution-eligible trade_decisions, executions, or TCA rows for this target "
+            "before importing promotion evidence."
+        ),
+    }
+    return {
+        "status": "skipped",
+        "proof_status": "blocked",
+        "proof_blockers": [blocker],
+        "run_id": run_id,
+        "candidate_id": candidate_id or None,
+        "hypothesis_id": hypothesis_id,
+        "observed_stage": observed_stage,
+        "window_count": 0,
+        "market_session_samples": 0,
+        "decision_count": 0,
+        "trade_count": 0,
+        "order_count": 0,
+        "avg_abs_slippage_bps": "0",
+        "avg_post_cost_expectancy_bps": "0",
+        "promotion_allowed": False,
+        "promotion_blocking_reasons": ["runtime_window_source_activity_missing"],
+        "runtime_observation": {
+            "authoritative": False,
+            "observed_stage": observed_stage,
+            "evidence_provenance": (
+                "paper_runtime_observed"
+                if observed_stage == "paper"
+                else "live_runtime_observed"
+            ),
+            "source_kind": source_kind
+            or ("simulation_paper_runtime" if observed_stage == "paper" else "live_runtime"),
+            "source_manifest_ref": source_manifest_ref or None,
+            "strategy_name": strategy_name,
+            "strategy_name_candidates": strategy_names,
+            "account_label": account_label,
+            "window_start": window_start.isoformat(),
+            "window_end": window_end.isoformat(),
+            "dataset_snapshot_ref": dataset_snapshot_ref,
+            "skip_reason": "runtime_window_source_activity_missing",
+        },
+    }
+
+
 def main() -> int:
     args = _parse_args()
     source_dsn = args.source_dsn.strip() or os.getenv(args.source_dsn_env, "").strip()
@@ -260,6 +329,29 @@ def main() -> int:
         window_start=window_start,
         window_end=window_end,
     )
+    dataset_snapshot_ref = (
+        str(getattr(args, "dataset_snapshot_ref", "") or "").strip() or None
+    )
+    if not decisions and not executions and not tca_rows:
+        summary = _source_activity_missing_summary(
+            run_id=args.run_id,
+            candidate_id=args.candidate_id.strip(),
+            hypothesis_id=args.hypothesis_id,
+            observed_stage=args.observed_stage,
+            strategy_name=args.strategy_name,
+            strategy_names=strategy_names,
+            account_label=args.account_label,
+            window_start=window_start,
+            window_end=window_end,
+            source_manifest_ref=args.source_manifest_ref.strip(),
+            source_kind=args.source_kind.strip(),
+            dataset_snapshot_ref=dataset_snapshot_ref,
+        )
+        if args.json:
+            print(json.dumps(summary, indent=2))
+        else:
+            print(summary)
+        return 0
     artifact_refs = [
         str(item).strip() for item in args.artifact_ref if str(item).strip()
     ]
@@ -305,9 +397,6 @@ def main() -> int:
     )
     source_kind = args.source_kind.strip() or (
         "simulation_paper_runtime" if args.observed_stage == "paper" else "live_runtime"
-    )
-    dataset_snapshot_ref = (
-        str(getattr(args, "dataset_snapshot_ref", "") or "").strip() or None
     )
     runtime_observation_payload = {
         "authoritative": True,

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -1026,6 +1026,12 @@ def _run_runtime_window_import_target(
         )
     result = subprocess.run(command, check=True, capture_output=True, text=True)
     payload = json.loads(result.stdout)
+    payload_proof_blockers = [
+        blocker
+        for blocker in payload.get("proof_blockers", [])
+        if isinstance(blocker, Mapping)
+    ]
+    proof_blockers.extend(payload_proof_blockers)
     return {
         "status": "ok",
         "command": " ".join(command[:2] + ["..."]),

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -288,7 +288,11 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ),
             patch(
                 "scripts.import_hypothesis_runtime_windows._query_timestamps",
-                return_value=([], [], []),
+                return_value=(
+                    [datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+                    [datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+                    [],
+                ),
             ),
             patch(
                 "scripts.import_hypothesis_runtime_windows.build_regular_session_buckets",
@@ -327,6 +331,79 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "intraday-tsmom-v1",
             ],
         )
+
+    def test_main_skips_persist_when_source_activity_is_empty(self) -> None:
+        args = SimpleNamespace(
+            run_id="run-empty",
+            candidate_id="cand-empty",
+            hypothesis_id="H-CONT-01",
+            observed_stage="paper",
+            strategy_family="",
+            source_dsn="postgresql://example",
+            source_dsn_env="DB_DSN",
+            strategy_name="intraday-tsmom-profit-v2",
+            account_label="TORGHUT_SIM",
+            window_start="2026-03-06T14:30:00Z",
+            window_end="2026-03-06T15:00:00Z",
+            bucket_minutes=30,
+            sample_minutes=5,
+            source_manifest_ref="",
+            source_kind="simulation_paper_runtime",
+            artifact_ref=[],
+            dataset_snapshot_ref="runtime-empty-snapshot",
+            dependency_quorum_decision="allow",
+            continuity_ok="true",
+            drift_ok="true",
+            json=False,
+        )
+        manifest = SimpleNamespace(
+            strategy_family="intraday_continuation",
+            strategy_id="intraday_tsmom_v1@paper",
+            max_allowed_slippage_bps=Decimal("12"),
+        )
+
+        with (
+            patch(
+                "scripts.import_hypothesis_runtime_windows._parse_args",
+                return_value=args,
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.resolve_hypothesis_manifest",
+                return_value=(
+                    SimpleNamespace(path="config/trading/hypotheses/h-cont-01.json"),
+                    manifest,
+                ),
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows._query_timestamps",
+                return_value=([], [], []),
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.build_regular_session_buckets",
+            ) as build_buckets,
+            patch(
+                "scripts.import_hypothesis_runtime_windows.persist_observed_runtime_windows",
+            ) as persist_windows,
+            patch(
+                "scripts.import_hypothesis_runtime_windows.SessionLocal",
+            ) as session_local,
+            patch("builtins.print") as print_mock,
+        ):
+            exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        build_buckets.assert_not_called()
+        persist_windows.assert_not_called()
+        session_local.assert_not_called()
+        summary = print_mock.call_args.args[0]
+        self.assertEqual(summary["status"], "skipped")
+        self.assertEqual(summary["proof_status"], "blocked")
+        self.assertEqual(summary["decision_count"], 0)
+        self.assertEqual(
+            summary["proof_blockers"][0]["blocker"],
+            "runtime_window_source_activity_missing",
+        )
+        self.assertFalse(summary["runtime_observation"]["authoritative"])
 
     def test_main_attaches_delay_adjusted_depth_report_to_runtime_payload(
         self,
@@ -382,7 +459,11 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 ),
                 patch(
                     "scripts.import_hypothesis_runtime_windows._query_timestamps",
-                    return_value=([], [], []),
+                    return_value=(
+                        [datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+                        [datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+                        [],
+                    ),
                 ),
                 patch(
                     "scripts.import_hypothesis_runtime_windows.build_regular_session_buckets",

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -289,6 +289,58 @@ class TestRuntimeWindowImport(TestCase):
             decision.reason_summary, "runtime_evidence_thresholds_satisfied"
         )
 
+    def test_persist_observed_runtime_windows_skips_idle_buckets(self) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    40,
+                ),
+                (
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 30, tzinfo=timezone.utc),
+                    40,
+                ),
+            ],
+            decision_times=[datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+            execution_times=[datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("4"),
+                    "post_cost_expectancy_bps": Decimal("8"),
+                }
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        with self.session_local() as session:
+            summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-live-skip-idle",
+                candidate_id="cand-1",
+                hypothesis_id="H-CONT-01",
+                observed_stage="live",
+                strategy_family="intraday_continuation",
+                source_manifest_ref="config/trading/hypotheses/h-cont-01.json",
+                buckets=buckets,
+            )
+            session.commit()
+            windows = session.execute(select(StrategyHypothesisMetricWindow)).scalars().all()
+            decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
+
+        self.assertEqual(summary["raw_window_count"], 2)
+        self.assertEqual(summary["window_count"], 1)
+        self.assertEqual(summary["skipped_zero_activity_window_count"], 1)
+        self.assertEqual(summary["market_session_samples"], 40)
+        self.assertEqual(len(windows), 1)
+        self.assertEqual(windows[0].decision_count, 1)
+        self.assertEqual(decision.payload_json["raw_window_count"], 2)
+        self.assertEqual(decision.payload_json["skipped_zero_activity_window_count"], 1)
+
     def test_persist_observed_runtime_windows_blocks_h_micro_without_delay_depth_stress(
         self,
     ) -> None:
@@ -491,12 +543,20 @@ class TestRuntimeWindowImport(TestCase):
             )
             session.commit()
             decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
+            windows = session.execute(select(StrategyHypothesisMetricWindow)).scalars().all()
 
-        self.assertEqual(summary["market_session_samples"], 80)
+        self.assertEqual(summary["raw_window_count"], 2)
+        self.assertEqual(summary["window_count"], 0)
+        self.assertEqual(summary["skipped_zero_activity_window_count"], 2)
+        self.assertEqual(summary["market_session_samples"], 0)
         self.assertEqual(summary["decision_count"], 0)
         self.assertEqual(summary["trade_count"], 0)
         self.assertEqual(summary["order_count"], 0)
         self.assertEqual(summary["promotion_allowed"], False)
+        self.assertIn(
+            "runtime_window_evidence_missing",
+            summary["promotion_blocking_reasons"],
+        )
         self.assertIn(
             "runtime_decision_count_zero",
             summary["promotion_blocking_reasons"],
@@ -511,6 +571,9 @@ class TestRuntimeWindowImport(TestCase):
         )
         self.assertEqual(decision.allowed, False)
         self.assertEqual(decision.payload_json["decision_count"], 0)
+        self.assertEqual(decision.payload_json["raw_window_count"], 2)
+        self.assertEqual(decision.payload_json["skipped_zero_activity_window_count"], 2)
+        self.assertEqual(windows, [])
 
     def test_persist_observed_runtime_windows_rejects_weak_paper_receipt(
         self,
@@ -582,7 +645,10 @@ class TestRuntimeWindowImport(TestCase):
             session.commit()
             decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
 
-        self.assertEqual(summary["market_session_samples"], 36)
+        self.assertEqual(summary["raw_window_count"], 3)
+        self.assertEqual(summary["window_count"], 2)
+        self.assertEqual(summary["skipped_zero_activity_window_count"], 1)
+        self.assertEqual(summary["market_session_samples"], 21)
         self.assertEqual(summary["promotion_allowed"], False)
         self.assertIn(
             "sample_count_below_canary_minimum",


### PR DESCRIPTION
## Summary

- Skip runtime-window imports before persistence when the source database has no execution-eligible decisions, executions, or TCA rows for the target.
- Exclude zero-activity buckets from persisted `StrategyHypothesisMetricWindow` proof rows while keeping promotion decisions fail-closed with explicit blocker counts.
- Surface import-level proof blockers through empirical renewal output so empty runtime evidence is visible instead of looking like fresh empirical proof.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_run_empirical_promotion_jobs.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
