### PR TITLE
feat(torghut): require fill survival and runtime pnl proof

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -73,6 +73,51 @@ MARKET_IMPACT_SCORECARD_KEYS = (
     "implementation_uncertainty_scenarios",
     "implementation_uncertainty_source_markers",
 )
+DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS = (
+    "delay_adjusted_depth_stress_passed",
+    "delay_adjusted_depth_stress_model",
+    "delay_adjusted_depth_stress_ms",
+    "delay_adjusted_depth_latency_grid_ms",
+    "delay_adjusted_depth_grid_max_stress_ms",
+    "delay_adjusted_depth_liquidity_evidence_present",
+    "delay_adjusted_depth_liquidity_missing_day_count",
+    "delay_adjusted_depth_fillable_notional_per_day",
+    "delay_adjusted_depth_worst_grid_fillable_notional_per_day",
+    "delay_adjusted_depth_worst_active_day_fillable_notional",
+    "delay_adjusted_depth_p10_active_day_fillable_notional",
+    "delay_adjusted_depth_tail_coverage_passed",
+    "delay_adjusted_depth_fillable_ratio",
+    "delay_adjusted_depth_survival_adjusted_fillable_ratio",
+    "delay_adjusted_depth_unfillable_notional_per_day",
+    "delay_adjusted_depth_stress_net_pnl_per_day",
+    "delay_adjusted_depth_fill_survival_evidence_present",
+    "delay_adjusted_depth_fill_survival_sample_count",
+    "delay_adjusted_depth_fill_survival_rate",
+    "delay_adjusted_depth_queue_ratio_p95",
+)
+FILL_SURVIVAL_SCORECARD_KEYS = (
+    "order_lifecycle",
+    "fill_survival_evidence_present",
+    "fill_survival_sample_count",
+    "fill_survival_fill_rate",
+    "fill_time_ms_avg",
+    "fill_time_ms_p50",
+    "fill_time_ms_p95",
+    "pending_age_ms_p95",
+    "max_censored_pending_age_ms",
+    "spread_bps_avg_at_order",
+    "spread_bps_p95_at_order",
+    "depth_notional_min_at_order",
+    "depth_notional_avg_at_order",
+    "queue_touch_qty_avg",
+    "queue_touch_notional_avg",
+    "order_qty_to_touch_qty_ratio_p95",
+    "fill_probability_by_latency_bucket",
+    "fill_probability_by_latency_threshold_ms",
+    "post_cost_survivorship",
+    "post_cost_survival_rate",
+    "gross_positive_killed_by_cost_count",
+)
 
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:
@@ -102,6 +147,23 @@ def _decimal(value: Any) -> Decimal:
         return Decimal(str(value or "0"))
     except (InvalidOperation, ValueError):
         return Decimal("0")
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, Decimal):
+        return value != 0
+    if isinstance(value, (int, float)):
+        return value != 0
+    normalized = str(value).strip().lower()
+    if normalized in {"", "0", "false", "f", "no", "n", "off", "none", "null"}:
+        return False
+    if normalized in {"1", "true", "t", "yes", "y", "on"}:
+        return True
+    return bool(value)
 
 
 def _decimal_mapping_total(mapping: Mapping[str, Any]) -> Decimal:
@@ -462,8 +524,25 @@ def _enrich_scorecard_with_replay_stress_metrics(
         if delay_depth_total_filled_notional > 0
         else Decimal("1")
     )
+    fill_survival_sample_count = max(
+        _int(enriched.get("fill_survival_sample_count")),
+        _int(enriched.get("delay_adjusted_depth_fill_survival_sample_count")),
+    )
+    fill_survival_rate_value = enriched.get(
+        "delay_adjusted_depth_fill_survival_rate"
+    ) or enriched.get("fill_survival_fill_rate")
+    fill_survival_rate = _decimal(fill_survival_rate_value)
+    has_fill_survival_evidence = (
+        _bool(enriched.get("fill_survival_evidence_present"))
+        or _bool(enriched.get("delay_adjusted_depth_fill_survival_evidence_present"))
+    ) and fill_survival_sample_count > 0
+    survival_adjusted_fillable_ratio = delay_depth_fillable_ratio
+    if fill_survival_sample_count > 0 or has_fill_survival_evidence:
+        survival_adjusted_fillable_ratio *= max(
+            Decimal("0"), min(Decimal("1"), fill_survival_rate)
+        )
     delay_depth_net_pnl_per_day = (
-        net_pnl_per_day * delay_depth_fillable_ratio
+        net_pnl_per_day * survival_adjusted_fillable_ratio
     ) - delay_depth_cost_per_day
     if "delay_adjusted_depth_stress_model" not in enriched:
         enriched["delay_adjusted_depth_stress_model"] = "latency_depth_haircut"
@@ -513,6 +592,22 @@ def _enrich_scorecard_with_replay_stress_metrics(
         enriched["delay_adjusted_depth_fillable_ratio"] = str(
             delay_depth_fillable_ratio
         )
+    if "delay_adjusted_depth_survival_adjusted_fillable_ratio" not in enriched:
+        enriched["delay_adjusted_depth_survival_adjusted_fillable_ratio"] = str(
+            survival_adjusted_fillable_ratio
+        )
+    if "delay_adjusted_depth_fill_survival_sample_count" not in enriched:
+        enriched["delay_adjusted_depth_fill_survival_sample_count"] = (
+            fill_survival_sample_count
+        )
+    if "delay_adjusted_depth_fill_survival_evidence_present" not in enriched:
+        enriched["delay_adjusted_depth_fill_survival_evidence_present"] = (
+            has_fill_survival_evidence
+        )
+    if "delay_adjusted_depth_fill_survival_rate" not in enriched and _string(
+        fill_survival_rate_value
+    ):
+        enriched["delay_adjusted_depth_fill_survival_rate"] = str(fill_survival_rate)
     if "delay_adjusted_depth_unfillable_notional_per_day" not in enriched:
         enriched["delay_adjusted_depth_unfillable_notional_per_day"] = str(
             max(
@@ -534,8 +629,8 @@ def _enrich_scorecard_with_replay_stress_metrics(
         enriched["delay_adjusted_depth_stress_artifact_ref"] = result_path
     if "delay_adjusted_depth_stress_passed" not in enriched:
         enriched["delay_adjusted_depth_stress_passed"] = (
-            bool(enriched.get("delay_adjusted_depth_liquidity_evidence_present"))
-            and bool(enriched.get("delay_adjusted_depth_tail_coverage_passed"))
+            _bool(enriched.get("delay_adjusted_depth_liquidity_evidence_present"))
+            and _bool(enriched.get("delay_adjusted_depth_tail_coverage_passed"))
             and delay_depth_fillable_notional_per_day > 0
             and delay_depth_net_pnl_per_day > 0
         )
@@ -610,6 +705,13 @@ def evidence_bundle_from_frontier_candidate(
                 scorecard = {**scorecard, key: source[key]}
                 break
     for key in MARKET_IMPACT_SCORECARD_KEYS:
+        if key in scorecard:
+            continue
+        for source in (candidate, summary, full_window):
+            if key in source:
+                scorecard = {**scorecard, key: source[key]}
+                break
+    for key in (*DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS, *FILL_SURVIVAL_SCORECARD_KEYS):
         if key in scorecard:
             continue
         for source in (candidate, summary, full_window):
@@ -720,8 +822,48 @@ def evidence_bundle_from_frontier_candidate(
                 "stress_type": "delay_adjusted_depth",
                 "model": scorecard.get("delay_adjusted_depth_stress_model"),
                 "stress_ms": scorecard.get("delay_adjusted_depth_stress_ms"),
+                "latency_grid_ms": scorecard.get(
+                    "delay_adjusted_depth_latency_grid_ms"
+                ),
+                "grid_max_stress_ms": scorecard.get(
+                    "delay_adjusted_depth_grid_max_stress_ms"
+                ),
                 "fillable_notional_per_day": scorecard.get(
                     "delay_adjusted_depth_fillable_notional_per_day"
+                ),
+                "worst_grid_fillable_notional_per_day": scorecard.get(
+                    "delay_adjusted_depth_worst_grid_fillable_notional_per_day"
+                ),
+                "worst_active_day_fillable_notional": scorecard.get(
+                    "delay_adjusted_depth_worst_active_day_fillable_notional"
+                ),
+                "p10_active_day_fillable_notional": scorecard.get(
+                    "delay_adjusted_depth_p10_active_day_fillable_notional"
+                ),
+                "tail_coverage_passed": scorecard.get(
+                    "delay_adjusted_depth_tail_coverage_passed"
+                ),
+                "liquidity_missing_day_count": scorecard.get(
+                    "delay_adjusted_depth_liquidity_missing_day_count"
+                ),
+                "fillable_ratio": scorecard.get("delay_adjusted_depth_fillable_ratio"),
+                "survival_adjusted_fillable_ratio": scorecard.get(
+                    "delay_adjusted_depth_survival_adjusted_fillable_ratio"
+                ),
+                "unfillable_notional_per_day": scorecard.get(
+                    "delay_adjusted_depth_unfillable_notional_per_day"
+                ),
+                "fill_survival_evidence_present": scorecard.get(
+                    "delay_adjusted_depth_fill_survival_evidence_present"
+                ),
+                "fill_survival_sample_count": scorecard.get(
+                    "delay_adjusted_depth_fill_survival_sample_count"
+                ),
+                "fill_survival_rate": scorecard.get(
+                    "delay_adjusted_depth_fill_survival_rate"
+                ),
+                "queue_ratio_p95": scorecard.get(
+                    "delay_adjusted_depth_queue_ratio_p95"
                 ),
                 "net_pnl_per_day": scorecard.get(
                     "delay_adjusted_depth_stress_net_pnl_per_day"
@@ -830,6 +972,65 @@ def evidence_bundle_from_payload(payload: Mapping[str, Any]) -> CandidateEvidenc
     )
 
 
+def _requires_promotion_proof(bundle: CandidateEvidenceBundle) -> bool:
+    readiness = bundle.promotion_readiness
+    if _bool(readiness.get("promotable")):
+        return True
+    stage = _string(readiness.get("stage")).lower()
+    status = _string(readiness.get("status")).lower()
+    if stage and stage not in {"research_candidate", "research"}:
+        return True
+    return status in {
+        "promotion_ready",
+        "ready_for_promotion",
+        "paper_probation",
+        "paper_canary",
+        "live_canary",
+    }
+
+
+def _delay_depth_survival_blockers(scorecard: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    if not _bool(scorecard.get("delay_adjusted_depth_stress_passed")):
+        blockers.append("delay_adjusted_depth_stress_failed")
+    if not _string(scorecard.get("delay_adjusted_depth_stress_model")):
+        blockers.append("delay_adjusted_depth_stress_model_missing")
+    if _decimal(scorecard.get("delay_adjusted_depth_stress_ms")) <= 0:
+        blockers.append("delay_adjusted_depth_stress_ms_missing")
+    if not _string(scorecard.get("delay_adjusted_depth_stress_artifact_ref")):
+        blockers.append("delay_adjusted_depth_stress_artifact_missing")
+    if not _bool(scorecard.get("delay_adjusted_depth_tail_coverage_passed")):
+        blockers.append("delay_adjusted_depth_tail_coverage_missing")
+    if (
+        _decimal(scorecard.get("delay_adjusted_depth_p10_active_day_fillable_notional"))
+        <= 0
+    ):
+        blockers.append("delay_adjusted_depth_p10_fillable_non_positive")
+    if (
+        _decimal(
+            scorecard.get("delay_adjusted_depth_worst_active_day_fillable_notional")
+        )
+        <= 0
+    ):
+        blockers.append("delay_adjusted_depth_worst_fillable_non_positive")
+    if _decimal(scorecard.get("delay_adjusted_depth_stress_net_pnl_per_day")) <= 0:
+        blockers.append("delay_adjusted_depth_stress_net_pnl_non_positive")
+    if not (
+        _bool(scorecard.get("fill_survival_evidence_present"))
+        or _bool(scorecard.get("delay_adjusted_depth_fill_survival_evidence_present"))
+    ):
+        blockers.append("fill_survival_evidence_missing")
+    if (
+        max(
+            _int(scorecard.get("fill_survival_sample_count")),
+            _int(scorecard.get("delay_adjusted_depth_fill_survival_sample_count")),
+        )
+        <= 0
+    ):
+        blockers.append("fill_survival_sample_count_zero")
+    return blockers
+
+
 def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]:
     blockers: list[str] = []
     if not _string(bundle.dataset_snapshot_id):
@@ -868,6 +1069,8 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
         bundle.dataset_snapshot_id
     ):
         blockers.append("synthetic_evidence_not_promotion_proof")
+    if _requires_promotion_proof(bundle):
+        blockers.extend(_delay_depth_survival_blockers(scorecard))
     return tuple(dict.fromkeys(blockers))
 
 

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta, timezone
 from decimal import Decimal
@@ -28,6 +29,9 @@ from .hypotheses import (
 US_EQUITIES_REGULAR_TIMEZONE = "America/New_York"
 US_EQUITIES_REGULAR_OPEN = time(hour=9, minute=30)
 US_EQUITIES_REGULAR_CLOSE = time(hour=16, minute=0)
+PROMOTION_GRADE_POST_COST_BASES = frozenset(
+    {"realized_strategy_pnl", "simulation_report_net_pnl"}
+)
 
 
 @dataclass(frozen=True)
@@ -41,6 +45,8 @@ class ObservedRuntimeBucket:
     decision_alignment_ratio: Decimal
     avg_abs_slippage_bps: Decimal
     post_cost_expectancy_bps: Decimal
+    post_cost_promotion_sample_count: int
+    post_cost_basis_counts: dict[str, int]
     continuity_ok: bool
     drift_ok: bool
     dependency_quorum_decision: str
@@ -50,8 +56,10 @@ class ObservedRuntimeBucket:
 @dataclass(frozen=True)
 class _NormalizedTcaRow:
     computed_at: datetime
-    abs_slippage_bps: Decimal
-    post_cost_expectancy_bps: Decimal
+    abs_slippage_bps: Decimal | None
+    post_cost_expectancy_bps: Decimal | None
+    post_cost_expectancy_basis: str
+    post_cost_promotion_eligible: bool
 
 
 def _utc(dt: datetime) -> datetime:
@@ -60,12 +68,18 @@ def _utc(dt: datetime) -> datetime:
     return dt.astimezone(timezone.utc)
 
 
-def _decimal(value: Any, *, default: str = "0") -> Decimal:
+def _optional_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
     if isinstance(value, Decimal):
         return value
-    if value is None:
-        return Decimal(default)
-    return Decimal(str(value))
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return Decimal(text)
+    except Exception:
+        return None
 
 
 def _strategy_family_matches(
@@ -90,6 +104,24 @@ def _text(value: Any) -> str | None:
         return None
     text = str(value).strip()
     return text or None
+
+
+def _post_cost_expectancy_basis(value: Any) -> str:
+    text = _text(value)
+    if text is None:
+        return "tca_shortfall_proxy"
+    return text.lower().replace("-", "_")
+
+
+def _post_cost_basis_is_promotion_grade(
+    *,
+    basis: str,
+    explicit_value: Any,
+) -> bool:
+    parsed = _observation_bool(explicit_value)
+    if parsed is not None:
+        return parsed
+    return basis in PROMOTION_GRADE_POST_COST_BASES
 
 
 def _parse_observation_datetime(value: Any) -> datetime | None:
@@ -127,6 +159,13 @@ def _observation_int(value: Any) -> int:
         return max(0, int(Decimal(str(value))))
     except Exception:
         return 0
+
+
+def _observation_decimal(value: Any) -> Decimal:
+    try:
+        return Decimal(str(value or "0"))
+    except Exception:
+        return Decimal("0")
 
 
 def _string_list(value: Any) -> list[str]:
@@ -191,6 +230,20 @@ def _delay_adjusted_depth_stress_blocking_reasons(
         - timedelta(minutes=requirements.max_delay_adjusted_depth_stress_age_minutes)
     ):
         reasons.append("delay_adjusted_depth_stress_stale")
+    if not reasons:
+        summary = _delay_adjusted_depth_stress_summary(runtime_payload)
+        if _observation_bool(summary.get("tail_coverage_passed")) is not True:
+            reasons.append("delay_adjusted_depth_tail_coverage_missing")
+        if _observation_decimal(summary.get("p10_active_day_fillable_notional")) <= 0:
+            reasons.append("delay_adjusted_depth_p10_fillable_non_positive")
+        if _observation_decimal(summary.get("worst_active_day_fillable_notional")) <= 0:
+            reasons.append("delay_adjusted_depth_worst_fillable_non_positive")
+        if _observation_decimal(summary.get("stress_net_pnl_per_day")) <= 0:
+            reasons.append("delay_adjusted_depth_stress_net_pnl_non_positive")
+        if _observation_bool(summary.get("fill_survival_evidence_present")) is not True:
+            reasons.append("fill_survival_evidence_missing")
+        if _observation_int(summary.get("fill_survival_sample_count")) <= 0:
+            reasons.append("fill_survival_sample_count_zero")
     return list(dict.fromkeys(reasons))
 
 
@@ -219,10 +272,10 @@ def _delay_adjusted_depth_stress_summary(
         or _parse_observation_datetime(report.get("generated_at"))
         or _parse_observation_datetime(report.get("checked_at"))
     )
-    latency_grid_ms = _string_list(
-        runtime_payload.get("delay_adjusted_depth_latency_grid_ms")
-    ) or _string_list(report.get("delay_adjusted_depth_latency_grid_ms")) or _string_list(
-        report.get("latency_grid_ms")
+    latency_grid_ms = (
+        _string_list(runtime_payload.get("delay_adjusted_depth_latency_grid_ms"))
+        or _string_list(report.get("delay_adjusted_depth_latency_grid_ms"))
+        or _string_list(report.get("latency_grid_ms"))
     )
     return {
         "checks_total": check_count,
@@ -247,7 +300,9 @@ def _delay_adjusted_depth_stress_summary(
                 "delay_adjusted_depth_worst_grid_fillable_notional_per_day"
             )
         )
-        or _text(report.get("delay_adjusted_depth_worst_grid_fillable_notional_per_day"))
+        or _text(
+            report.get("delay_adjusted_depth_worst_grid_fillable_notional_per_day")
+        )
         or _text(report.get("worst_grid_fillable_notional_per_day")),
         "worst_active_day_fillable_notional": _text(
             runtime_payload.get(
@@ -270,6 +325,56 @@ def _delay_adjusted_depth_stress_summary(
                 report.get("tail_coverage_passed"),
             )
         ),
+        "fillable_ratio": _text(
+            runtime_payload.get("delay_adjusted_depth_fillable_ratio")
+        )
+        or _text(report.get("delay_adjusted_depth_fillable_ratio"))
+        or _text(report.get("fillable_ratio")),
+        "survival_adjusted_fillable_ratio": _text(
+            runtime_payload.get("delay_adjusted_depth_survival_adjusted_fillable_ratio")
+        )
+        or _text(report.get("delay_adjusted_depth_survival_adjusted_fillable_ratio"))
+        or _text(report.get("survival_adjusted_fillable_ratio")),
+        "unfillable_notional_per_day": _text(
+            runtime_payload.get("delay_adjusted_depth_unfillable_notional_per_day")
+        )
+        or _text(report.get("delay_adjusted_depth_unfillable_notional_per_day"))
+        or _text(report.get("unfillable_notional_per_day")),
+        "stress_net_pnl_per_day": _text(
+            runtime_payload.get("delay_adjusted_depth_stress_net_pnl_per_day")
+        )
+        or _text(report.get("delay_adjusted_depth_stress_net_pnl_per_day"))
+        or _text(report.get("stress_net_pnl_per_day")),
+        "fill_survival_evidence_present": _observation_bool(
+            runtime_payload.get("delay_adjusted_depth_fill_survival_evidence_present")
+            if runtime_payload.get(
+                "delay_adjusted_depth_fill_survival_evidence_present"
+            )
+            is not None
+            else report.get(
+                "delay_adjusted_depth_fill_survival_evidence_present",
+                report.get("fill_survival_evidence_present"),
+            )
+        ),
+        "fill_survival_sample_count": max(
+            _observation_int(
+                runtime_payload.get("delay_adjusted_depth_fill_survival_sample_count")
+            ),
+            _observation_int(
+                report.get("delay_adjusted_depth_fill_survival_sample_count")
+            ),
+            _observation_int(report.get("fill_survival_sample_count")),
+        ),
+        "fill_survival_rate": _text(
+            runtime_payload.get("delay_adjusted_depth_fill_survival_rate")
+        )
+        or _text(report.get("delay_adjusted_depth_fill_survival_rate"))
+        or _text(report.get("fill_survival_rate")),
+        "queue_ratio_p95": _text(
+            runtime_payload.get("delay_adjusted_depth_queue_ratio_p95")
+        )
+        or _text(report.get("delay_adjusted_depth_queue_ratio_p95"))
+        or _text(report.get("queue_ratio_p95")),
     }
 
 
@@ -304,6 +409,7 @@ def _runtime_promotion_blocking_reasons(
     total_decision_count: int,
     total_trade_count: int,
     total_order_count: int,
+    total_post_cost_promotion_sample_count: int,
     average_slippage: Decimal,
     average_post_cost: Decimal,
     latest_three_budget_ok: bool,
@@ -325,6 +431,8 @@ def _runtime_promotion_blocking_reasons(
         reasons.append("slippage_budget_exceeded")
     if not latest_three_budget_ok:
         reasons.append("recent_slippage_budget_exceeded")
+    if total_post_cost_promotion_sample_count <= 0:
+        reasons.append("post_cost_pnl_basis_missing")
     if average_post_cost <= Decimal("0"):
         reasons.append("post_cost_expectancy_non_positive")
     elif average_post_cost < manifest.expected_gross_edge_bps:
@@ -415,11 +523,21 @@ def build_observed_runtime_buckets(
         computed_at_raw = row.get("computed_at")
         if not isinstance(computed_at_raw, datetime):
             continue
+        basis = _post_cost_expectancy_basis(
+            row.get("post_cost_expectancy_basis") or row.get("post_cost_basis")
+        )
         normalized_tca_rows.append(
             _NormalizedTcaRow(
                 computed_at=_utc(computed_at_raw),
-                abs_slippage_bps=_decimal(row.get("abs_slippage_bps")),
-                post_cost_expectancy_bps=_decimal(row.get("post_cost_expectancy_bps")),
+                abs_slippage_bps=_optional_decimal(row.get("abs_slippage_bps")),
+                post_cost_expectancy_bps=_optional_decimal(
+                    row.get("post_cost_expectancy_bps")
+                ),
+                post_cost_expectancy_basis=basis,
+                post_cost_promotion_eligible=_post_cost_basis_is_promotion_grade(
+                    basis=basis,
+                    explicit_value=row.get("post_cost_promotion_eligible"),
+                ),
             )
         )
 
@@ -445,15 +563,31 @@ def build_observed_runtime_buckets(
             decision_alignment_ratio = Decimal("0")
         else:
             decision_alignment_ratio = Decimal(trade_count) / Decimal(decision_count)
-        if bucket_tca:
-            avg_abs_slippage_bps = sum(
-                row.abs_slippage_bps for row in bucket_tca
-            ) / Decimal(len(bucket_tca))
-            post_cost_expectancy_bps = sum(
-                row.post_cost_expectancy_bps for row in bucket_tca
-            ) / Decimal(len(bucket_tca))
+        slippage_values = [
+            row.abs_slippage_bps
+            for row in bucket_tca
+            if row.abs_slippage_bps is not None
+        ]
+        promotion_post_cost_values = [
+            row.post_cost_expectancy_bps
+            for row in bucket_tca
+            if row.post_cost_expectancy_bps is not None
+            and row.post_cost_promotion_eligible
+        ]
+        basis_counts = dict(
+            sorted(
+                Counter(row.post_cost_expectancy_basis for row in bucket_tca).items()
+            )
+        )
+        if slippage_values:
+            avg_abs_slippage_bps = sum(slippage_values) / Decimal(len(slippage_values))
         else:
             avg_abs_slippage_bps = Decimal("0")
+        if promotion_post_cost_values:
+            post_cost_expectancy_bps = sum(
+                promotion_post_cost_values, Decimal("0")
+            ) / Decimal(len(promotion_post_cost_values))
+        else:
             post_cost_expectancy_bps = Decimal("0")
         buckets.append(
             ObservedRuntimeBucket(
@@ -466,6 +600,8 @@ def build_observed_runtime_buckets(
                 decision_alignment_ratio=decision_alignment_ratio,
                 avg_abs_slippage_bps=avg_abs_slippage_bps,
                 post_cost_expectancy_bps=post_cost_expectancy_bps,
+                post_cost_promotion_sample_count=len(promotion_post_cost_values),
+                post_cost_basis_counts=basis_counts,
                 continuity_ok=continuity_ok,
                 drift_ok=drift_ok,
                 dependency_quorum_decision=dependency_quorum_decision,
@@ -477,6 +613,9 @@ def build_observed_runtime_buckets(
                     "trade_count": trade_count,
                     "order_count": order_count,
                     "tca_row_count": len(bucket_tca),
+                    "slippage_sample_count": len(slippage_values),
+                    "post_cost_promotion_sample_count": len(promotion_post_cost_values),
+                    "post_cost_basis_counts": basis_counts,
                 },
             )
         )
@@ -625,6 +764,13 @@ def persist_observed_runtime_windows(
     total_decision_count = sum(bucket.decision_count for bucket in sorted_buckets)
     total_trade_count = sum(bucket.trade_count for bucket in sorted_buckets)
     total_order_count = sum(bucket.order_count for bucket in sorted_buckets)
+    total_post_cost_promotion_sample_count = sum(
+        bucket.post_cost_promotion_sample_count for bucket in sorted_buckets
+    )
+    total_post_cost_basis_counter: Counter[str] = Counter()
+    for bucket in sorted_buckets:
+        total_post_cost_basis_counter.update(bucket.post_cost_basis_counts)
+    total_post_cost_basis_counts = dict(sorted(total_post_cost_basis_counter.items()))
     total_post_cost = sum(
         (
             bucket.post_cost_expectancy_bps * Decimal(bucket.market_session_count)
@@ -658,6 +804,7 @@ def persist_observed_runtime_windows(
         total_decision_count=total_decision_count,
         total_trade_count=total_trade_count,
         total_order_count=total_order_count,
+        total_post_cost_promotion_sample_count=total_post_cost_promotion_sample_count,
         average_slippage=average_slippage,
         average_post_cost=average_post_cost,
         latest_three_budget_ok=latest_three_budget_ok,
@@ -753,6 +900,8 @@ def persist_observed_runtime_windows(
                 "decision_count": total_decision_count,
                 "trade_count": total_trade_count,
                 "order_count": total_order_count,
+                "post_cost_promotion_sample_count": total_post_cost_promotion_sample_count,
+                "post_cost_basis_counts": total_post_cost_basis_counts,
                 "promotion_allowed": promotion_allowed,
                 "promotion_blocking_reasons": promotion_blocking_reasons,
                 "delay_adjusted_depth_stress": delay_depth_stress_summary,
@@ -779,6 +928,8 @@ def persist_observed_runtime_windows(
                 "decision_count": total_decision_count,
                 "trade_count": total_trade_count,
                 "order_count": total_order_count,
+                "post_cost_promotion_sample_count": total_post_cost_promotion_sample_count,
+                "post_cost_basis_counts": total_post_cost_basis_counts,
                 "avg_abs_slippage_bps": str(average_slippage),
                 "avg_post_cost_expectancy_bps": str(average_post_cost),
                 "latest_three_within_budget": latest_three_budget_ok,
@@ -802,6 +953,8 @@ def persist_observed_runtime_windows(
         "decision_count": total_decision_count,
         "trade_count": total_trade_count,
         "order_count": total_order_count,
+        "post_cost_promotion_sample_count": total_post_cost_promotion_sample_count,
+        "post_cost_basis_counts": total_post_cost_basis_counts,
         "avg_abs_slippage_bps": str(average_slippage),
         "avg_post_cost_expectancy_bps": str(average_post_cost),
         "latest_three_within_budget": latest_three_budget_ok,

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -742,6 +742,18 @@ def _metric_window_activity_reason_codes(
     expectancy_bps = _safe_decimal(metric_window.post_cost_expectancy_bps)
     if expectancy_bps is None or expectancy_bps <= 0:
         reasons.append("hypothesis_window_post_cost_expectancy_non_positive")
+    payload_raw = getattr(metric_window, "payload_json", None)
+    payload: Mapping[str, object] = (
+        cast(Mapping[str, object], payload_raw)
+        if isinstance(payload_raw, Mapping)
+        else cast(Mapping[str, object], {})
+    )
+    basis_counts: object | None = payload.get("post_cost_basis_counts")
+    if (
+        isinstance(basis_counts, Mapping)
+        and _safe_int(payload.get("post_cost_promotion_sample_count")) <= 0
+    ):
+        reasons.append("hypothesis_window_post_cost_pnl_basis_missing")
 
     avg_abs_slippage_bps = _safe_decimal(metric_window.avg_abs_slippage_bps)
     slippage_budget_bps = _safe_decimal(metric_window.slippage_budget_bps)

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -26,6 +26,9 @@ EXECUTION_ELIGIBLE_DECISION_STATUSES = (
     "filled",
     "partially_filled",
 )
+POST_COST_BASIS_REALIZED_STRATEGY_PNL = "realized_strategy_pnl"
+POST_COST_BASIS_SIMULATION_REPORT = "simulation_report_net_pnl"
+POST_COST_BASIS_TCA_PROXY = "tca_shortfall_proxy"
 
 
 def _parse_args() -> argparse.Namespace:
@@ -114,6 +117,90 @@ def _strategy_name_candidates(*values: str | None) -> list[str]:
     return candidates
 
 
+def _execution_signed_qty(*, side: Any, qty: Any) -> Decimal:
+    normalized_side = str(side or "").strip().lower()
+    quantity = _decimal_or_none(qty)
+    if quantity is None or quantity <= 0:
+        return Decimal("0")
+    if normalized_side == "buy":
+        return quantity
+    if normalized_side == "sell":
+        return -quantity
+    return Decimal("0")
+
+
+def _build_realized_strategy_pnl_rows(
+    execution_rows: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    lots_by_symbol: dict[str, list[dict[str, Decimal]]] = {}
+    realized_rows: list[dict[str, object]] = []
+    for row in execution_rows:
+        symbol = str(row.get("symbol") or "").strip().upper()
+        computed_at = row.get("computed_at")
+        price = _decimal_or_none(row.get("avg_fill_price"))
+        signed_qty = _execution_signed_qty(
+            side=row.get("side"), qty=row.get("filled_qty")
+        )
+        if not symbol or not isinstance(computed_at, datetime):
+            continue
+        if price is None or price <= 0 or signed_qty == 0:
+            continue
+        fill_qty = abs(signed_qty)
+        shortfall_notional = _decimal_or_none(row.get("shortfall_notional"))
+        if shortfall_notional is None:
+            continue
+        fill_cost_per_share = abs(shortfall_notional) / fill_qty
+        remaining = fill_qty
+        fill_sign = Decimal("1") if signed_qty > 0 else Decimal("-1")
+        lots = lots_by_symbol.setdefault(symbol, [])
+        while remaining > 0 and lots and lots[0]["signed_qty"] * fill_sign < 0:
+            lot = lots[0]
+            lot_qty = abs(lot["signed_qty"])
+            close_qty = min(remaining, lot_qty)
+            entry_price = lot["price"]
+            entry_cost = lot["cost_per_share"] * close_qty
+            exit_cost = fill_cost_per_share * close_qty
+            if lot["signed_qty"] > 0:
+                gross_pnl = (price - entry_price) * close_qty
+            else:
+                gross_pnl = (entry_price - price) * close_qty
+            net_pnl = gross_pnl - entry_cost - exit_cost
+            turnover_notional = (entry_price + price) * close_qty
+            if turnover_notional > 0:
+                realized_rows.append(
+                    {
+                        "computed_at": computed_at,
+                        "abs_slippage_bps": (
+                            (entry_cost + exit_cost) / turnover_notional
+                        )
+                        * Decimal("10000"),
+                        "post_cost_expectancy_bps": (net_pnl / turnover_notional)
+                        * Decimal("10000"),
+                        "post_cost_expectancy_basis": POST_COST_BASIS_REALIZED_STRATEGY_PNL,
+                        "post_cost_promotion_eligible": True,
+                        "realized_gross_pnl": gross_pnl,
+                        "realized_net_pnl": net_pnl,
+                        "turnover_notional": turnover_notional,
+                        "symbol": symbol,
+                    }
+                )
+            remaining -= close_qty
+            lot["signed_qty"] -= (
+                Decimal("1") if lot["signed_qty"] > 0 else Decimal("-1")
+            ) * close_qty
+            if abs(lot["signed_qty"]) <= Decimal("0"):
+                lots.pop(0)
+        if remaining > 0:
+            lots.append(
+                {
+                    "signed_qty": fill_sign * remaining,
+                    "price": price,
+                    "cost_per_share": fill_cost_per_share,
+                }
+            )
+    return realized_rows
+
+
 def _load_report_post_cost_expectancy_bps(artifact_refs: list[str]) -> Decimal | None:
     for ref in artifact_refs:
         path = Path(ref)
@@ -129,9 +216,7 @@ def _load_report_post_cost_expectancy_bps(artifact_refs: list[str]) -> Decimal |
         pnl_payload = _as_mapping(payload.get("pnl"))
         metrics_payload = _as_mapping(payload.get("metrics"))
         net_pnl = _decimal_or_none(
-            pnl_payload.get("net_pnl_estimated")
-            or metrics_payload.get("net_pnl")
-            or pnl_payload.get("gross_pnl")
+            pnl_payload.get("net_pnl_estimated") or metrics_payload.get("net_pnl")
         )
         execution_notional = _decimal_or_none(
             pnl_payload.get("execution_notional_total")
@@ -170,6 +255,7 @@ def _query_timestamps(
     decisions: list[datetime] = []
     executions: list[datetime] = []
     tca_rows: list[dict[str, object]] = []
+    execution_rows: list[dict[str, object]] = []
     with psycopg.connect(dsn) as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -195,10 +281,18 @@ def _query_timestamps(
             decisions = [row[0] for row in cur.fetchall() if row[0] is not None]
             cur.execute(
                 """
-                select d.created_at
+                select
+                    d.created_at,
+                    e.created_at,
+                    e.symbol,
+                    e.side,
+                    e.filled_qty,
+                    e.avg_fill_price,
+                    t.shortfall_notional
                 from executions e
                 join trade_decisions d on d.id = e.trade_decision_id
                 join strategies s on s.id = d.strategy_id
+                left join execution_tca_metrics t on t.execution_id = e.id
                 where s.name = any(%s)
                   and d.alpaca_account_label = %s
                   and d.created_at >= %s
@@ -207,7 +301,24 @@ def _query_timestamps(
                 """,
                 (strategy_names, account_label, window_start, window_end),
             )
-            executions = [row[0] for row in cur.fetchall() if row[0] is not None]
+            execution_rows = [
+                {
+                    "computed_at": row[0],
+                    "execution_created_at": row[1],
+                    "symbol": row[2],
+                    "side": row[3],
+                    "filled_qty": row[4],
+                    "avg_fill_price": row[5],
+                    "shortfall_notional": row[6],
+                }
+                for row in cur.fetchall()
+                if row[0] is not None
+            ]
+            executions = []
+            for row in execution_rows:
+                computed_at = row.get("computed_at")
+                if isinstance(computed_at, datetime):
+                    executions.append(computed_at)
             cur.execute(
                 """
                 select
@@ -231,10 +342,13 @@ def _query_timestamps(
                     "computed_at": row[0],
                     "abs_slippage_bps": row[1] or Decimal("0"),
                     "post_cost_expectancy_bps": row[2] or Decimal("0"),
+                    "post_cost_expectancy_basis": POST_COST_BASIS_TCA_PROXY,
+                    "post_cost_promotion_eligible": False,
                 }
                 for row in cur.fetchall()
                 if row[0] is not None
             ]
+    tca_rows.extend(_build_realized_strategy_pnl_rows(execution_rows))
     return decisions, executions, tca_rows
 
 
@@ -294,7 +408,11 @@ def _source_activity_missing_summary(
                 else "live_runtime_observed"
             ),
             "source_kind": source_kind
-            or ("simulation_paper_runtime" if observed_stage == "paper" else "live_runtime"),
+            or (
+                "simulation_paper_runtime"
+                if observed_stage == "paper"
+                else "live_runtime"
+            ),
             "source_manifest_ref": source_manifest_ref or None,
             "strategy_name": strategy_name,
             "strategy_name_candidates": strategy_names,
@@ -368,13 +486,14 @@ def main() -> int:
         report_post_cost_expectancy_bps is not None
         and args.source_kind.strip().startswith("simulation_")
     ):
-        tca_rows = [
+        tca_rows.append(
             {
-                **row,
+                "computed_at": executions[-1] if executions else window_end,
                 "post_cost_expectancy_bps": report_post_cost_expectancy_bps,
+                "post_cost_expectancy_basis": POST_COST_BASIS_SIMULATION_REPORT,
+                "post_cost_promotion_eligible": True,
             }
-            for row in tca_rows
-        ]
+        )
     bucket_ranges = build_regular_session_buckets(
         window_start=window_start,
         window_end=window_end,
@@ -414,6 +533,12 @@ def main() -> int:
         "report_post_cost_expectancy_bps": (
             str(report_post_cost_expectancy_bps)
             if report_post_cost_expectancy_bps is not None
+            else None
+        ),
+        "report_post_cost_expectancy_basis": (
+            POST_COST_BASIS_SIMULATION_REPORT
+            if report_post_cost_expectancy_bps is not None
+            and source_kind.startswith("simulation_")
             else None
         ),
     }

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -70,6 +70,8 @@ DEFAULT_START_EQUITY = Decimal("31590.02")
 DEFAULT_PROGRESS_LOG_INTERVAL_SECONDS = 15
 logger = logging.getLogger(__name__)
 _SHARED_POSITION_OWNER = "__shared__"
+_FILL_LATENCY_BUCKETS_MS = (0, 50, 150, 250, 500, 1000)
+_FILL_LATENCY_THRESHOLDS_MS = (50, 150, 250)
 
 
 def _position_key(symbol: str, strategy_id: str) -> tuple[str, str]:
@@ -927,6 +929,367 @@ def _record_fill_order_type(stats: dict[str, Any], order_type: str) -> None:
     order_type_counts[order_type] += 1
 
 
+def _order_age_ms(*, created_at: datetime, as_of: datetime) -> int:
+    return max(0, int((as_of - created_at).total_seconds() * 1000))
+
+
+def _latency_bucket(ms: int) -> str:
+    if ms <= 0:
+        return "0ms"
+    lower_bound = 1
+    for upper_bound in _FILL_LATENCY_BUCKETS_MS[1:]:
+        if ms <= upper_bound:
+            return f"{lower_bound}-{upper_bound}ms"
+        lower_bound = upper_bound + 1
+    return f">{_FILL_LATENCY_BUCKETS_MS[-1]}ms"
+
+
+def _init_order_lifecycle_stats() -> dict[str, Any]:
+    return {
+        "submitted_order_count": 0,
+        "filled_order_count": 0,
+        "pending_censored_count": 0,
+        "replaced_pending_count": 0,
+        "outcome_counts": defaultdict(int),
+        "censor_reason_counts": defaultdict(int),
+        "decision_count_by_order_type": defaultdict(int),
+        "filled_count_by_order_type": defaultdict(int),
+        "submitted_count_by_latency_bucket": defaultdict(int),
+        "filled_count_by_latency_bucket": defaultdict(int),
+        "filled_latency_ms_samples": [],
+        "pending_age_ms_samples": [],
+        "spread_bps_samples": [],
+        "depth_notional_samples": [],
+        "queue_touch_qty_samples": [],
+        "queue_touch_notional_samples": [],
+        "order_qty_to_touch_qty_ratio_samples": [],
+        "max_censored_pending_age_ms": 0,
+    }
+
+
+def _append_decimal_sample(
+    stats: dict[str, Any],
+    key: str,
+    value: Decimal | None,
+) -> None:
+    if value is None:
+        return
+    samples = stats.setdefault(key, [])
+    samples.append(value)
+
+
+def _execution_proxy_payload(
+    *,
+    decision: StrategyDecision,
+    signal: SignalEnvelope,
+) -> dict[str, Decimal]:
+    price = _extract_price(signal)
+    bid_px = _extract_bid(signal)
+    ask_px = _extract_ask(signal)
+    bid_qty = _extract_decimal_payload(signal, "imbalance_bid_sz")
+    ask_qty = _extract_decimal_payload(signal, "imbalance_ask_sz")
+    proxy: dict[str, Decimal] = {}
+    spread_bps = _signal_spread_bps(signal=signal, price=price)
+    if spread_bps is not None:
+        proxy["spread_bps"] = spread_bps
+    if (
+        bid_px is not None
+        and ask_px is not None
+        and bid_qty is not None
+        and ask_qty is not None
+        and bid_px > 0
+        and ask_px > 0
+        and bid_qty > 0
+        and ask_qty > 0
+    ):
+        proxy["depth_notional"] = (bid_px * bid_qty) + (ask_px * ask_qty)
+    normalized_action = decision.action.strip().lower()
+    touch_px = ask_px if normalized_action == "buy" else bid_px
+    touch_qty = ask_qty if normalized_action == "buy" else bid_qty
+    if touch_qty is not None and touch_qty > 0:
+        proxy["queue_touch_qty"] = touch_qty
+        proxy["order_qty_to_touch_qty_ratio"] = decision.qty / touch_qty
+        if touch_px is not None and touch_px > 0:
+            proxy["queue_touch_notional"] = touch_px * touch_qty
+    return proxy
+
+
+def _record_order_lifecycle_outcome(
+    stats: dict[str, Any],
+    *,
+    decision: StrategyDecision,
+    placement_signal: SignalEnvelope,
+    created_at: datetime,
+    resolved_at: datetime,
+    outcome: str,
+    censor_reason: str | None = None,
+) -> None:
+    age_ms = _order_age_ms(created_at=created_at, as_of=resolved_at)
+    bucket = _latency_bucket(age_ms)
+    normalized_outcome = outcome.strip().lower() or "unknown"
+    order_type = decision.order_type.strip().lower() or "unknown"
+    stats["submitted_order_count"] += 1
+    stats["outcome_counts"][normalized_outcome] += 1
+    stats["decision_count_by_order_type"][order_type] += 1
+    stats["submitted_count_by_latency_bucket"][bucket] += 1
+    if normalized_outcome == "filled":
+        stats["filled_order_count"] += 1
+        stats["filled_count_by_order_type"][order_type] += 1
+        stats["filled_count_by_latency_bucket"][bucket] += 1
+        stats["filled_latency_ms_samples"].append(age_ms)
+    else:
+        stats["pending_censored_count"] += 1
+        stats["pending_age_ms_samples"].append(age_ms)
+        stats["max_censored_pending_age_ms"] = max(
+            int(stats.get("max_censored_pending_age_ms") or 0),
+            age_ms,
+        )
+        if normalized_outcome == "replaced":
+            stats["replaced_pending_count"] += 1
+        if censor_reason:
+            stats["censor_reason_counts"][censor_reason] += 1
+
+    proxy = _execution_proxy_payload(decision=decision, signal=placement_signal)
+    _append_decimal_sample(stats, "spread_bps_samples", proxy.get("spread_bps"))
+    _append_decimal_sample(stats, "depth_notional_samples", proxy.get("depth_notional"))
+    _append_decimal_sample(
+        stats, "queue_touch_qty_samples", proxy.get("queue_touch_qty")
+    )
+    _append_decimal_sample(
+        stats,
+        "queue_touch_notional_samples",
+        proxy.get("queue_touch_notional"),
+    )
+    _append_decimal_sample(
+        stats,
+        "order_qty_to_touch_qty_ratio_samples",
+        proxy.get("order_qty_to_touch_qty_ratio"),
+    )
+
+
+def _record_order_lifecycle(
+    *,
+    order_lifecycle_stats: dict[str, Any],
+    order_lifecycle_day_stats: dict[str, dict[str, Any]],
+    order_lifecycle_symbol_stats: dict[str, dict[str, Any]],
+    decision: StrategyDecision,
+    placement_signal: SignalEnvelope,
+    created_at: datetime,
+    resolved_at: datetime,
+    outcome: str,
+    censor_reason: str | None = None,
+) -> None:
+    day_key = created_at.date().isoformat()
+    symbol_key = decision.symbol.strip().upper()
+    for stats in (
+        order_lifecycle_stats,
+        order_lifecycle_day_stats.setdefault(day_key, _init_order_lifecycle_stats()),
+        order_lifecycle_symbol_stats.setdefault(
+            symbol_key, _init_order_lifecycle_stats()
+        ),
+    ):
+        _record_order_lifecycle_outcome(
+            stats,
+            decision=decision,
+            placement_signal=placement_signal,
+            created_at=created_at,
+            resolved_at=resolved_at,
+            outcome=outcome,
+            censor_reason=censor_reason,
+        )
+
+
+def _pending_censor_time(
+    *,
+    pending: PendingOrder,
+    fallback: datetime,
+) -> datetime:
+    close_ts = datetime.combine(
+        pending.created_at.date(),
+        REGULAR_CLOSE_UTC,
+        tzinfo=timezone.utc,
+    )
+    if close_ts > pending.created_at:
+        return close_ts
+    return fallback
+
+
+def _decimal_average(values: list[Decimal]) -> Decimal | None:
+    if not values:
+        return None
+    return sum(values, Decimal("0")) / Decimal(len(values))
+
+
+def _int_average(values: list[int]) -> Decimal | None:
+    if not values:
+        return None
+    return Decimal(sum(values)) / Decimal(len(values))
+
+
+def _decimal_percentile(values: list[Decimal], percentile: Decimal) -> Decimal | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = int(Decimal(len(ordered) - 1) * percentile)
+    return ordered[index]
+
+
+def _int_percentile(values: list[int], percentile: Decimal) -> int | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = int(Decimal(len(ordered) - 1) * percentile)
+    return ordered[index]
+
+
+def _decimal_or_none(value: Decimal | None) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _fill_probability_by_latency_bucket(stats: Mapping[str, Any]) -> dict[str, Any]:
+    submitted = stats.get("submitted_count_by_latency_bucket") or {}
+    filled = stats.get("filled_count_by_latency_bucket") or {}
+    payload: dict[str, Any] = {}
+    for bucket in sorted(submitted):
+        submitted_count = int(submitted[bucket])
+        filled_count = int(filled.get(bucket, 0))
+        payload[str(bucket)] = {
+            "submitted_order_count": submitted_count,
+            "filled_order_count": filled_count,
+            "fill_rate": str(
+                Decimal(filled_count) / Decimal(submitted_count)
+                if submitted_count > 0
+                else Decimal("0")
+            ),
+        }
+    return payload
+
+
+def _fill_probability_by_latency_threshold(stats: Mapping[str, Any]) -> dict[str, Any]:
+    filled_latency = [
+        int(value) for value in stats.get("filled_latency_ms_samples") or []
+    ]
+    submitted_order_count = int(stats.get("submitted_order_count") or 0)
+    payload: dict[str, Any] = {}
+    for threshold_ms in _FILL_LATENCY_THRESHOLDS_MS:
+        filled_within_count = sum(
+            1 for value in filled_latency if value <= threshold_ms
+        )
+        payload[str(threshold_ms)] = {
+            "submitted_order_count": submitted_order_count,
+            "filled_within_count": filled_within_count,
+            "fill_rate": str(
+                Decimal(filled_within_count) / Decimal(submitted_order_count)
+                if submitted_order_count > 0
+                else Decimal("0")
+            ),
+        }
+    return payload
+
+
+def _order_lifecycle_summary(
+    stats: Mapping[str, Any],
+    *,
+    post_cost_survivorship: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    filled_latency = [
+        int(value) for value in stats.get("filled_latency_ms_samples") or []
+    ]
+    pending_age = [int(value) for value in stats.get("pending_age_ms_samples") or []]
+    spread_bps_samples = list(stats.get("spread_bps_samples") or [])
+    depth_notional_samples = list(stats.get("depth_notional_samples") or [])
+    queue_touch_qty_samples = list(stats.get("queue_touch_qty_samples") or [])
+    queue_touch_notional_samples = list(stats.get("queue_touch_notional_samples") or [])
+    touch_ratio_samples = list(stats.get("order_qty_to_touch_qty_ratio_samples") or [])
+    submitted_order_count = int(stats.get("submitted_order_count") or 0)
+    filled_order_count = int(stats.get("filled_order_count") or 0)
+    payload: dict[str, Any] = {
+        "submitted_order_count": submitted_order_count,
+        "filled_order_count": filled_order_count,
+        "pending_censored_count": int(stats.get("pending_censored_count") or 0),
+        "replaced_pending_count": int(stats.get("replaced_pending_count") or 0),
+        "fill_rate": str(
+            Decimal(filled_order_count) / Decimal(submitted_order_count)
+            if submitted_order_count > 0
+            else Decimal("0")
+        ),
+        "outcome_counts": dict(sorted((stats.get("outcome_counts") or {}).items())),
+        "censor_reason_counts": dict(
+            sorted((stats.get("censor_reason_counts") or {}).items())
+        ),
+        "decision_count_by_order_type": dict(
+            sorted((stats.get("decision_count_by_order_type") or {}).items())
+        ),
+        "filled_count_by_order_type": dict(
+            sorted((stats.get("filled_count_by_order_type") or {}).items())
+        ),
+        "fill_time_ms_avg": _decimal_or_none(_int_average(filled_latency)),
+        "fill_time_ms_p50": _int_percentile(filled_latency, Decimal("0.50")),
+        "fill_time_ms_p95": _int_percentile(filled_latency, Decimal("0.95")),
+        "pending_age_ms_avg": _decimal_or_none(_int_average(pending_age)),
+        "pending_age_ms_p95": _int_percentile(pending_age, Decimal("0.95")),
+        "max_censored_pending_age_ms": int(
+            stats.get("max_censored_pending_age_ms") or 0
+        ),
+        "fill_probability_by_latency_bucket": _fill_probability_by_latency_bucket(
+            stats
+        ),
+        "fill_probability_by_latency_threshold_ms": _fill_probability_by_latency_threshold(
+            stats
+        ),
+        "spread_bps_avg_at_order": _decimal_or_none(
+            _decimal_average(spread_bps_samples)
+        ),
+        "spread_bps_p95_at_order": _decimal_or_none(
+            _decimal_percentile(spread_bps_samples, Decimal("0.95"))
+        ),
+        "depth_notional_min_at_order": str(min(depth_notional_samples))
+        if depth_notional_samples
+        else None,
+        "depth_notional_avg_at_order": _decimal_or_none(
+            _decimal_average(depth_notional_samples)
+        ),
+        "queue_touch_qty_avg": _decimal_or_none(
+            _decimal_average(queue_touch_qty_samples)
+        ),
+        "queue_touch_notional_avg": _decimal_or_none(
+            _decimal_average(queue_touch_notional_samples)
+        ),
+        "order_qty_to_touch_qty_ratio_p95": _decimal_or_none(
+            _decimal_percentile(touch_ratio_samples, Decimal("0.95"))
+        ),
+        "fill_survival_sample_count": submitted_order_count,
+        "fill_survival_evidence_present": submitted_order_count > 0,
+    }
+    if post_cost_survivorship is not None:
+        payload["post_cost_survivorship"] = dict(post_cost_survivorship)
+    return payload
+
+
+def _post_cost_survivorship_summary(trades: list[ClosedTrade]) -> dict[str, Any]:
+    closed_trade_count = len(trades)
+    gross_positive_count = sum(1 for trade in trades if trade.gross_pnl > 0)
+    net_positive_count = sum(1 for trade in trades if trade.net_pnl > 0)
+    survived_count = sum(
+        1 for trade in trades if trade.gross_pnl > 0 and trade.net_pnl > 0
+    )
+    killed_count = sum(
+        1 for trade in trades if trade.gross_pnl > 0 and trade.net_pnl <= 0
+    )
+    return {
+        "closed_trade_count": closed_trade_count,
+        "gross_positive_count": gross_positive_count,
+        "net_positive_count": net_positive_count,
+        "gross_positive_survived_post_cost_count": survived_count,
+        "gross_positive_killed_by_cost_count": killed_count,
+        "post_cost_survival_rate": str(
+            Decimal(survived_count) / Decimal(gross_positive_count)
+            if gross_positive_count > 0
+            else Decimal("0")
+        ),
+    }
+
+
 def _decision_entry_order_type(decision: StrategyDecision) -> str:
     raw = decision.params.get("entry_order_type")
     if raw is None:
@@ -1408,7 +1771,7 @@ def _reconcile_pending_order_before_immediate_fill(
     pending_orders: dict[tuple[str, str], PendingOrder],
     created_at: datetime,
     force_position_isolation: bool = False,
-) -> None:
+) -> PendingOrder | None:
     pending_key = _position_key(
         decision.symbol,
         _decision_position_owner(
@@ -1418,7 +1781,7 @@ def _reconcile_pending_order_before_immediate_fill(
     )
     existing_pending = pending_orders.pop(pending_key, None)
     if existing_pending is None:
-        return
+        return None
     logger.info(
         "replay_pending_order_cleared_for_immediate_fill ts=%s symbol=%s existing_order_type=%s existing_limit=%s existing_exit=%s immediate_order_type=%s immediate_limit=%s immediate_exit=%s",
         created_at.isoformat(),
@@ -1430,6 +1793,7 @@ def _reconcile_pending_order_before_immediate_fill(
         decision.limit_price,
         _decision_exit_reason(decision),
     )
+    return existing_pending
 
 
 def _log_pending_order_replaced(
@@ -1748,6 +2112,9 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
     cash = config.start_equity
     day_stats: dict[str, dict[str, Any]] = {}
     funnel_stats: dict[tuple[str, str], dict[str, Any]] = {}
+    order_lifecycle_stats = _init_order_lifecycle_stats()
+    order_lifecycle_day_stats: dict[str, dict[str, Any]] = {}
+    order_lifecycle_symbol_stats: dict[str, dict[str, Any]] = {}
     trace_records: list[ReplayTraceRecord] = []
     near_misses: dict[str, list[NearMissRecord]] = {}
     all_closed_trades: list[ClosedTrade] = []
@@ -1774,6 +2141,45 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         return funnel_stats.setdefault(
             (target_day.isoformat(), symbol), _init_funnel_stats()
         )
+
+    def _record_lifecycle_outcome(
+        *,
+        pending: PendingOrder | None,
+        decision: StrategyDecision,
+        placement_signal: SignalEnvelope,
+        created_at: datetime,
+        resolved_at: datetime,
+        outcome: str,
+        censor_reason: str | None = None,
+    ) -> None:
+        _record_order_lifecycle(
+            order_lifecycle_stats=order_lifecycle_stats,
+            order_lifecycle_day_stats=order_lifecycle_day_stats,
+            order_lifecycle_symbol_stats=order_lifecycle_symbol_stats,
+            decision=pending.decision if pending is not None else decision,
+            placement_signal=pending.signal
+            if pending is not None
+            else placement_signal,
+            created_at=pending.created_at if pending is not None else created_at,
+            resolved_at=resolved_at,
+            outcome=outcome,
+            censor_reason=censor_reason,
+        )
+
+    def _censor_pending_orders(*, reason: str, fallback: datetime) -> None:
+        for pending_key in sorted(list(pending_orders)):
+            pending = pending_orders.pop(pending_key, None)
+            if pending is None:
+                continue
+            _record_lifecycle_outcome(
+                pending=pending,
+                decision=pending.decision,
+                placement_signal=pending.signal,
+                created_at=pending.created_at,
+                resolved_at=_pending_censor_time(pending=pending, fallback=fallback),
+                outcome="censored",
+                censor_reason=reason,
+            )
 
     with (
         patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
@@ -1810,7 +2216,14 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                         all_closed_trades=all_closed_trades,
                     )
                     cash = cash_ref[0]
-                pending_orders.clear()
+                _censor_pending_orders(
+                    reason="day_boundary",
+                    fallback=datetime.combine(
+                        current_day,
+                        REGULAR_CLOSE_UTC,
+                        tzinfo=timezone.utc,
+                    ),
+                )
                 completed_day_stats = _active_day_stats(current_day)
                 completed_day_equity = _record_capital_snapshot(
                     bucket=completed_day_stats,
@@ -1882,6 +2295,14 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 if fill_price is None:
                     pending_orders[pending_key] = pending
                     continue
+                _record_lifecycle_outcome(
+                    pending=pending,
+                    decision=decision,
+                    placement_signal=pending.signal,
+                    created_at=pending.created_at,
+                    resolved_at=signal.event_ts,
+                    outcome="filled",
+                )
                 cash = _apply_filled_decision(
                     decision=decision,
                     signal=signal,
@@ -2019,11 +2440,29 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                     continue
                 immediate_fill_price = _resolve_pending_fill_price(decision, signal)
                 if immediate_fill_price is not None:
-                    _reconcile_pending_order_before_immediate_fill(
+                    replaced_pending = _reconcile_pending_order_before_immediate_fill(
                         decision=decision,
                         pending_orders=pending_orders,
                         created_at=signal.event_ts,
                         force_position_isolation=config.force_position_isolation,
+                    )
+                    if replaced_pending is not None:
+                        _record_lifecycle_outcome(
+                            pending=replaced_pending,
+                            decision=replaced_pending.decision,
+                            placement_signal=replaced_pending.signal,
+                            created_at=replaced_pending.created_at,
+                            resolved_at=signal.event_ts,
+                            outcome="replaced",
+                            censor_reason="immediate_fill_replaced_pending",
+                        )
+                    _record_lifecycle_outcome(
+                        pending=None,
+                        decision=decision,
+                        placement_signal=signal,
+                        created_at=signal.event_ts,
+                        resolved_at=signal.event_ts,
+                        outcome="filled",
                     )
                     cash = _apply_filled_decision(
                         decision=decision,
@@ -2060,6 +2499,15 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                         existing=existing_pending.decision,
                         replacement=decision,
                     ):
+                        _record_lifecycle_outcome(
+                            pending=existing_pending,
+                            decision=existing_pending.decision,
+                            placement_signal=existing_pending.signal,
+                            created_at=existing_pending.created_at,
+                            resolved_at=signal.event_ts,
+                            outcome="replaced",
+                            censor_reason="pending_replaced",
+                        )
                         pending_orders[pending_key] = PendingOrder(
                             decision=decision,
                             created_at=signal.event_ts,
@@ -2134,6 +2582,15 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 all_closed_trades=all_closed_trades,
             )
             cash = cash_ref[0]
+        if current_day is not None:
+            _censor_pending_orders(
+                reason="replay_end",
+                fallback=datetime.combine(
+                    current_day,
+                    REGULAR_CLOSE_UTC,
+                    tzinfo=timezone.utc,
+                ),
+            )
         if current_day is not None:
             final_day_stats = _active_day_stats(current_day)
             final_day_equity = _record_capital_snapshot(
@@ -2270,6 +2727,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         _decimal_text(total_cost),
         _decimal_text(final_equity),
     )
+    post_cost_survivorship = _post_cost_survivorship_summary(all_closed_trades)
     return {
         "start_date": config.start_date.isoformat(),
         "end_date": config.end_date.isoformat(),
@@ -2404,6 +2862,18 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         "trace": [item.to_payload() for item in trace_records],
         "funnel": funnel_report.to_payload(),
         "near_misses": near_miss_payload,
+        "order_lifecycle": _order_lifecycle_summary(
+            order_lifecycle_stats,
+            post_cost_survivorship=post_cost_survivorship,
+        ),
+        "order_lifecycle_by_day": {
+            key: _order_lifecycle_summary(value)
+            for key, value in sorted(order_lifecycle_day_stats.items())
+        },
+        "order_lifecycle_by_symbol": {
+            key: _order_lifecycle_summary(value)
+            for key, value in sorted(order_lifecycle_symbol_stats.items())
+        },
     }
 
 

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -1193,6 +1193,72 @@ def _int_mapping(value: Any) -> dict[str, int]:
     return counts
 
 
+def _mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[Any, Any], value).items()}
+
+
+def _optional_decimal(value: Any) -> Decimal | None:
+    if value in (None, ""):
+        return None
+    return Decimal(str(value))
+
+
+def _order_lifecycle_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
+    lifecycle = _mapping(payload.get("order_lifecycle"))
+    if not lifecycle:
+        return {}
+    metrics: dict[str, Any] = {
+        "order_lifecycle": lifecycle,
+        "fill_survival_evidence_present": bool(
+            lifecycle.get("fill_survival_evidence_present")
+        ),
+        "fill_survival_sample_count": int(
+            lifecycle.get("fill_survival_sample_count")
+            or lifecycle.get("submitted_order_count")
+            or 0
+        ),
+        "fill_survival_fill_rate": str(lifecycle.get("fill_rate") or "0"),
+        "fill_time_ms_avg": str(lifecycle.get("fill_time_ms_avg") or ""),
+        "fill_time_ms_p50": lifecycle.get("fill_time_ms_p50"),
+        "fill_time_ms_p95": lifecycle.get("fill_time_ms_p95"),
+        "pending_age_ms_p95": lifecycle.get("pending_age_ms_p95"),
+        "max_censored_pending_age_ms": lifecycle.get("max_censored_pending_age_ms"),
+        "spread_bps_avg_at_order": str(lifecycle.get("spread_bps_avg_at_order") or ""),
+        "spread_bps_p95_at_order": str(lifecycle.get("spread_bps_p95_at_order") or ""),
+        "depth_notional_min_at_order": str(
+            lifecycle.get("depth_notional_min_at_order") or ""
+        ),
+        "depth_notional_avg_at_order": str(
+            lifecycle.get("depth_notional_avg_at_order") or ""
+        ),
+        "queue_touch_qty_avg": str(lifecycle.get("queue_touch_qty_avg") or ""),
+        "queue_touch_notional_avg": str(
+            lifecycle.get("queue_touch_notional_avg") or ""
+        ),
+        "order_qty_to_touch_qty_ratio_p95": str(
+            lifecycle.get("order_qty_to_touch_qty_ratio_p95") or ""
+        ),
+        "fill_probability_by_latency_bucket": _mapping(
+            lifecycle.get("fill_probability_by_latency_bucket")
+        ),
+        "fill_probability_by_latency_threshold_ms": _mapping(
+            lifecycle.get("fill_probability_by_latency_threshold_ms")
+        ),
+    }
+    survivorship = _mapping(lifecycle.get("post_cost_survivorship"))
+    if survivorship:
+        metrics["post_cost_survivorship"] = survivorship
+        metrics["post_cost_survival_rate"] = str(
+            survivorship.get("post_cost_survival_rate") or "0"
+        )
+        metrics["gross_positive_killed_by_cost_count"] = int(
+            survivorship.get("gross_positive_killed_by_cost_count") or 0
+        )
+    return metrics
+
+
 def _order_type_execution_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
     decision_counts = _int_mapping(payload.get("decision_count_by_order_type"))
     filled_counts = _int_mapping(payload.get("filled_count_by_order_type"))
@@ -1512,6 +1578,9 @@ def _replay_stress_metrics(
     avg_filled_notional_per_day: Decimal,
     total_filled_notional: Decimal,
     total_liquidity_notional: Decimal,
+    fill_survival_rate: Decimal | None = None,
+    fill_survival_sample_count: int = 0,
+    queue_ratio_p95: Decimal | None = None,
 ) -> dict[str, Any]:
     participation = (
         total_filled_notional / total_liquidity_notional
@@ -1586,7 +1655,12 @@ def _replay_stress_metrics(
         if total_filled_notional > 0
         else Decimal("1")
     )
-    delay_depth_net_per_day = (net_per_day * delay_depth_fillable_ratio) - (
+    survival_adjusted_fillable_ratio = delay_depth_fillable_ratio
+    if fill_survival_sample_count > 0 and fill_survival_rate is not None:
+        survival_adjusted_fillable_ratio *= max(
+            Decimal("0"), min(Decimal("1"), fill_survival_rate)
+        )
+    delay_depth_net_per_day = (net_per_day * survival_adjusted_fillable_ratio) - (
         delay_depth_fillable_notional_per_day * Decimal("1") / Decimal("10000")
     )
     implementation_uncertainty = _implementation_uncertainty_metrics(
@@ -1667,6 +1741,19 @@ def _replay_stress_metrics(
         ),
         "delay_adjusted_depth_tail_coverage_passed": tail_coverage_passed,
         "delay_adjusted_depth_fillable_ratio": str(delay_depth_fillable_ratio),
+        "delay_adjusted_depth_survival_adjusted_fillable_ratio": str(
+            survival_adjusted_fillable_ratio
+        ),
+        "delay_adjusted_depth_fill_survival_evidence_present": (
+            fill_survival_sample_count > 0
+        ),
+        "delay_adjusted_depth_fill_survival_sample_count": fill_survival_sample_count,
+        "delay_adjusted_depth_fill_survival_rate": str(fill_survival_rate)
+        if fill_survival_rate is not None
+        else "",
+        "delay_adjusted_depth_queue_ratio_p95": str(queue_ratio_p95)
+        if queue_ratio_p95 is not None
+        else "",
         "delay_adjusted_depth_unfillable_notional_per_day": str(
             max(
                 Decimal("0"),
@@ -1753,6 +1840,13 @@ def _consistency_penalty(
         if summary.active_days > 0
         else Decimal("0")
     )
+    order_lifecycle_metrics = _order_lifecycle_metrics(full_window_payload)
+    fill_survival_rate = _optional_decimal(
+        order_lifecycle_metrics.get("fill_survival_fill_rate")
+    )
+    queue_ratio_p95 = _optional_decimal(
+        order_lifecycle_metrics.get("order_qty_to_touch_qty_ratio_p95")
+    )
     replay_stress_metrics = _replay_stress_metrics(
         target_net_per_day=policy.target_net_per_day,
         net_per_day=summary.net_per_day,
@@ -1762,6 +1856,11 @@ def _consistency_penalty(
         avg_filled_notional_per_day=avg_filled_notional_per_day,
         total_filled_notional=total_filled_notional,
         total_liquidity_notional=total_liquidity_notional,
+        fill_survival_rate=fill_survival_rate,
+        fill_survival_sample_count=int(
+            order_lifecycle_metrics.get("fill_survival_sample_count") or 0
+        ),
+        queue_ratio_p95=queue_ratio_p95,
     )
     best_day_share_of_total_pnl = _max_best_day_share_of_total_pnl(
         daily_net=summary.daily_net,
@@ -1927,6 +2026,7 @@ def _consistency_penalty(
             },
             "daily_negative_cash_observation_count": daily_negative_cash_observations,
             **_order_type_execution_metrics(full_window_payload),
+            **order_lifecycle_metrics,
         },
     )
 
@@ -3318,6 +3418,12 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                             )
                             or "0"
                         ),
+                        "delay_adjusted_depth_worst_grid_fillable_notional_per_day": str(
+                            full_window_summary.get(
+                                "delay_adjusted_depth_worst_grid_fillable_notional_per_day"
+                            )
+                            or "0"
+                        ),
                         "delay_adjusted_depth_worst_active_day_fillable_notional": str(
                             full_window_summary.get(
                                 "delay_adjusted_depth_worst_active_day_fillable_notional"
@@ -3334,6 +3440,47 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                             full_window_summary.get(
                                 "delay_adjusted_depth_tail_coverage_passed"
                             )
+                        ),
+                        "delay_adjusted_depth_fillable_ratio": str(
+                            full_window_summary.get(
+                                "delay_adjusted_depth_fillable_ratio"
+                            )
+                            or "0"
+                        ),
+                        "delay_adjusted_depth_survival_adjusted_fillable_ratio": str(
+                            full_window_summary.get(
+                                "delay_adjusted_depth_survival_adjusted_fillable_ratio"
+                            )
+                            or "0"
+                        ),
+                        "delay_adjusted_depth_unfillable_notional_per_day": str(
+                            full_window_summary.get(
+                                "delay_adjusted_depth_unfillable_notional_per_day"
+                            )
+                            or "0"
+                        ),
+                        "delay_adjusted_depth_fill_survival_evidence_present": bool(
+                            full_window_summary.get(
+                                "delay_adjusted_depth_fill_survival_evidence_present"
+                            )
+                        ),
+                        "delay_adjusted_depth_fill_survival_sample_count": int(
+                            full_window_summary.get(
+                                "delay_adjusted_depth_fill_survival_sample_count"
+                            )
+                            or 0
+                        ),
+                        "delay_adjusted_depth_fill_survival_rate": str(
+                            full_window_summary.get(
+                                "delay_adjusted_depth_fill_survival_rate"
+                            )
+                            or ""
+                        ),
+                        "delay_adjusted_depth_queue_ratio_p95": str(
+                            full_window_summary.get(
+                                "delay_adjusted_depth_queue_ratio_p95"
+                            )
+                            or ""
                         ),
                         "delay_adjusted_depth_stress_net_pnl_per_day": str(
                             full_window_summary.get(
@@ -3408,6 +3555,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                             replay_lineage
                         ),
                         **_order_type_execution_metrics(full_window_summary),
+                        **_order_lifecycle_metrics(full_window_payload),
                     }
                 )
                 objective_scorecard_payload.update(order_type_ablation_update)

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -10,6 +10,10 @@ from unittest.mock import patch
 
 from scripts.import_hypothesis_runtime_windows import (
     EXECUTION_ELIGIBLE_DECISION_STATUSES,
+    POST_COST_BASIS_REALIZED_STRATEGY_PNL,
+    POST_COST_BASIS_SIMULATION_REPORT,
+    POST_COST_BASIS_TCA_PROXY,
+    _build_realized_strategy_pnl_rows,
     _load_json_artifact,
     _load_report_post_cost_expectancy_bps,
     _nonnegative_int,
@@ -25,7 +29,17 @@ class _FakeCursor:
         self.executed: list[tuple[str, tuple[object, ...]]] = []
         self._results = [
             [(datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),)],
-            [(datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),)],
+            [
+                (
+                    datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "AAPL",
+                    "buy",
+                    Decimal("1"),
+                    Decimal("100"),
+                    Decimal("0.01"),
+                )
+            ],
             [
                 (
                     datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
@@ -142,6 +156,20 @@ class TestImportHypothesisRuntimeWindows(TestCase):
 
         self.assertEqual(value, Decimal("3.306984755680006238084907933"))
 
+    def test_load_report_post_cost_expectancy_bps_rejects_gross_only_report(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temp_dir:
+            report_path = Path(temp_dir) / "simulation-report.json"
+            report_path.write_text(
+                '{"pnl":{"gross_pnl":"66.16","execution_notional_total":"200061.4"}}',
+                encoding="utf-8",
+            )
+
+            value = _load_report_post_cost_expectancy_bps([str(report_path)])
+
+        self.assertEqual(value, None)
+
     def test_json_artifact_and_nonnegative_int_helpers_fail_closed(self) -> None:
         with TemporaryDirectory() as temp_dir:
             missing_path = Path(temp_dir) / "missing.json"
@@ -180,6 +208,50 @@ class TestImportHypothesisRuntimeWindows(TestCase):
     def test_strategy_name_candidates_drop_blank_values(self) -> None:
         self.assertEqual(_strategy_name_candidates("", "   ", None), [])
 
+    def test_build_realized_strategy_pnl_rows_requires_costed_round_trip(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("2"),
+                    "avg_fill_price": Decimal("100"),
+                    "shortfall_notional": Decimal("0.20"),
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "shortfall_notional": Decimal("0.10"),
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 45, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("102"),
+                    "shortfall_notional": None,
+                },
+            ]
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(
+            rows[0]["post_cost_expectancy_basis"],
+            POST_COST_BASIS_REALIZED_STRATEGY_PNL,
+        )
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], True)
+        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.80"))
+        self.assertEqual(
+            rows[0]["post_cost_expectancy_bps"],
+            Decimal("39.80099502487562189054726368"),
+        )
+
     def test_query_timestamps_filters_to_execution_eligible_decisions(self) -> None:
         cursor = _FakeCursor()
         connection = _FakeConnection(cursor)
@@ -205,6 +277,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(len(tca_rows), 1)
         self.assertEqual(tca_rows[0]["abs_slippage_bps"], Decimal("1.25"))
         self.assertEqual(tca_rows[0]["post_cost_expectancy_bps"], Decimal("0.50"))
+        self.assertEqual(
+            tca_rows[0]["post_cost_expectancy_basis"], POST_COST_BASIS_TCA_PROXY
+        )
+        self.assertEqual(tca_rows[0]["post_cost_promotion_eligible"], False)
         self.assertEqual(len(cursor.executed), 3)
         decision_query, decision_params = cursor.executed[0]
         self.assertIn("s.name = any(%s)", decision_query)
@@ -219,7 +295,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         tca_query, _ = cursor.executed[2]
         execution_query, _ = cursor.executed[1]
-        self.assertIn("select d.created_at", execution_query)
+        self.assertIn("left join execution_tca_metrics", execution_query)
         self.assertIn("d.created_at >= %s", execution_query)
         self.assertIn("d.created_at < %s", execution_query)
         self.assertNotIn("e.created_at >= %s", execution_query)
@@ -453,7 +529,9 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 patch(
                     "scripts.import_hypothesis_runtime_windows.resolve_hypothesis_manifest",
                     return_value=(
-                        SimpleNamespace(path="config/trading/hypotheses/h-micro-01.json"),
+                        SimpleNamespace(
+                            path="config/trading/hypotheses/h-micro-01.json"
+                        ),
                         manifest,
                     ),
                 ),
@@ -500,3 +578,104 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             "2026-03-06T15:20:00Z",
         )
         self.assertIn(str(report_path), runtime_payload["artifact_refs"])
+
+    def test_main_uses_report_runtime_pnl_when_tca_rows_are_empty(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            report_path = Path(temp_dir) / "simulation-report.json"
+            report_path.write_text(
+                '{"pnl":{"net_pnl_estimated":"50","execution_notional_total":"10000"}}',
+                encoding="utf-8",
+            )
+            args = SimpleNamespace(
+                run_id="run-report-pnl",
+                candidate_id="cand-report-pnl",
+                hypothesis_id="H-CONT-01",
+                observed_stage="paper",
+                strategy_family="",
+                source_dsn="postgresql://example",
+                source_dsn_env="DB_DSN",
+                strategy_name="intraday-tsmom-profit-v2",
+                account_label="TORGHUT_SIM",
+                window_start="2026-03-06T14:30:00Z",
+                window_end="2026-03-06T15:00:00Z",
+                bucket_minutes=30,
+                sample_minutes=5,
+                source_manifest_ref="",
+                source_kind="simulation_paper_runtime",
+                artifact_ref=[str(report_path)],
+                delay_adjusted_depth_stress_report_ref="",
+                dataset_snapshot_ref="runtime-report-snapshot",
+                dependency_quorum_decision="allow",
+                continuity_ok="true",
+                drift_ok="true",
+                json=False,
+            )
+            fake_session = _FakeSession()
+            manifest = SimpleNamespace(
+                strategy_family="intraday_continuation",
+                strategy_id="intraday_tsmom_v1@paper",
+                max_allowed_slippage_bps=Decimal("12"),
+            )
+
+            with (
+                patch(
+                    "scripts.import_hypothesis_runtime_windows._parse_args",
+                    return_value=args,
+                ),
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.resolve_hypothesis_manifest",
+                    return_value=(
+                        SimpleNamespace(
+                            path="config/trading/hypotheses/h-cont-01.json"
+                        ),
+                        manifest,
+                    ),
+                ),
+                patch(
+                    "scripts.import_hypothesis_runtime_windows._query_timestamps",
+                    return_value=(
+                        [datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+                        [datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+                        [],
+                    ),
+                ),
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.build_regular_session_buckets",
+                    return_value=[],
+                ),
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.build_observed_runtime_buckets",
+                    return_value=[],
+                ) as build_buckets,
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.persist_observed_runtime_windows",
+                    return_value={"run_id": "run-report-pnl"},
+                ) as persist_windows,
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.SessionLocal",
+                    return_value=fake_session,
+                ),
+                patch("builtins.print"),
+            ):
+                exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        tca_rows = build_buckets.call_args.kwargs["tca_rows"]
+        self.assertEqual(
+            tca_rows,
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "post_cost_expectancy_bps": Decimal("50.000"),
+                    "post_cost_expectancy_basis": POST_COST_BASIS_SIMULATION_REPORT,
+                    "post_cost_promotion_eligible": True,
+                }
+            ],
+        )
+        runtime_payload = persist_windows.call_args.kwargs[
+            "runtime_observation_payload"
+        ]
+        self.assertEqual(
+            runtime_payload["report_post_cost_expectancy_basis"],
+            POST_COST_BASIS_SIMULATION_REPORT,
+        )

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -27,6 +27,7 @@ from scripts.local_intraday_tsmom_replay import (
     _SHARED_POSITION_OWNER,
     _apply_filled_decision,
     _apply_order_preferences,
+    _append_decimal_sample,
     _build_near_miss,
     _decision_exit_reason,
     _decision_market_order_spread_bps_max,
@@ -37,8 +38,10 @@ from scripts.local_intraday_tsmom_replay import (
     _http_query,
     _init_funnel_stats,
     _insert_near_miss,
+    _latency_bucket,
     _load_strategies,
     _parse_signal_row,
+    _pending_censor_time,
     _positions_payload,
     _quote_quality_status,
     _record_capital_snapshot,
@@ -87,6 +90,53 @@ class TestLocalIntradayTsmomReplay(TestCase):
         self.assertEqual(
             _decision_position_owner(decision, force_position_isolation=True),
             "candidate-strategy-1",
+        )
+
+    def test_order_lifecycle_helpers_cover_defensive_branches(self) -> None:
+        samples: dict[str, object] = {}
+        _append_decimal_sample(samples, "spread_bps_samples", None)
+        self.assertEqual(samples, {})
+        self.assertEqual(_latency_bucket(50), "1-50ms")
+        self.assertEqual(_latency_bucket(151), "151-250ms")
+
+        decision = StrategyDecision(
+            strategy_id="candidate-strategy-1",
+            symbol="META",
+            event_ts=datetime(2026, 3, 27, 17, 30, 3, tzinfo=timezone.utc),
+            timeframe="1Sec",
+            action="buy",
+            qty=Decimal("1"),
+            order_type="limit",
+            time_in_force="day",
+            params={},
+            limit_price=Decimal("100"),
+        )
+        signal = self._signal(bid="99.90", ask="100.00", price="99.95")
+        before_close = PendingOrder(
+            decision=decision,
+            created_at=datetime(2026, 3, 27, 17, 30, tzinfo=timezone.utc),
+            signal=signal,
+        )
+        after_close = PendingOrder(
+            decision=decision,
+            created_at=datetime(2026, 3, 27, 21, 30, tzinfo=timezone.utc),
+            signal=signal,
+        )
+        fallback = datetime(2026, 3, 27, 22, 0, tzinfo=timezone.utc)
+
+        self.assertEqual(
+            _pending_censor_time(pending=before_close, fallback=fallback),
+            datetime(2026, 3, 27, 20, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            _pending_censor_time(pending=after_close, fallback=fallback), fallback
+        )
+        self.assertIsNone(
+            _reconcile_pending_order_before_immediate_fill(
+                decision=decision,
+                pending_orders={},
+                created_at=signal.event_ts,
+            )
         )
 
     def test_kubectl_clickhouse_query_validates_target_and_reports_failure(
@@ -1877,6 +1927,8 @@ class TestLocalIntradayTsmomReplay(TestCase):
                 "price": Decimal("99.95"),
                 "imbalance_bid_px": Decimal("99.90"),
                 "imbalance_ask_px": Decimal("100.00"),
+                "imbalance_bid_sz": Decimal("60"),
+                "imbalance_ask_sz": Decimal("40"),
                 "spread": Decimal("0.10"),
             },
         )
@@ -1889,6 +1941,8 @@ class TestLocalIntradayTsmomReplay(TestCase):
                 "price": Decimal("99.45"),
                 "imbalance_bid_px": Decimal("99.40"),
                 "imbalance_ask_px": Decimal("99.50"),
+                "imbalance_bid_sz": Decimal("70"),
+                "imbalance_ask_sz": Decimal("50"),
                 "spread": Decimal("0.10"),
             },
         )
@@ -1901,6 +1955,8 @@ class TestLocalIntradayTsmomReplay(TestCase):
                 "price": Decimal("101.50"),
                 "imbalance_bid_px": Decimal("101.40"),
                 "imbalance_ask_px": Decimal("101.50"),
+                "imbalance_bid_sz": Decimal("80"),
+                "imbalance_ask_sz": Decimal("60"),
                 "spread": Decimal("0.10"),
             },
         )
@@ -2070,6 +2126,39 @@ class TestLocalIntradayTsmomReplay(TestCase):
         )
         self.assertEqual(payload["funnel"]["buckets"][0]["trading_day"], "2026-03-26")
         self.assertGreaterEqual(payload["filled_count"], 2)
+        lifecycle = payload["order_lifecycle"]
+        self.assertEqual(lifecycle["submitted_order_count"], 2)
+        self.assertEqual(lifecycle["filled_order_count"], 1)
+        self.assertEqual(lifecycle["pending_censored_count"], 1)
+        self.assertEqual(lifecycle["replaced_pending_count"], 1)
+        self.assertEqual(lifecycle["fill_time_ms_p50"], 60000)
+        self.assertEqual(
+            lifecycle["fill_probability_by_latency_bucket"][">1000ms"]["fill_rate"], "1"
+        )
+        self.assertEqual(
+            lifecycle["censor_reason_counts"],
+            {"pending_replaced": 1},
+        )
+        self.assertEqual(
+            Decimal(str(lifecycle["depth_notional_min_at_order"])),
+            Decimal("9994.00"),
+        )
+        self.assertEqual(
+            Decimal(str(lifecycle["order_qty_to_touch_qty_ratio_p95"])),
+            Decimal("0.05"),
+        )
+        self.assertEqual(
+            payload["order_lifecycle_by_day"]["2026-03-26"]["submitted_order_count"],
+            2,
+        )
+        self.assertEqual(
+            payload["order_lifecycle_by_symbol"]["AAPL"]["filled_order_count"],
+            1,
+        )
+        self.assertEqual(
+            lifecycle["post_cost_survivorship"]["closed_trade_count"],
+            1,
+        )
 
     def test_run_replay_enriches_day_two_open_with_prev_day_open45_ranks(self) -> None:
         strategy = Strategy(

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -20,6 +20,7 @@ from app.models import (
 from app.trading.runtime_window_import import (
     _delay_adjusted_depth_stress_blocking_reasons,
     _observation_bool,
+    _observation_decimal,
     _observation_int,
     _parse_observation_datetime,
     build_observed_runtime_buckets,
@@ -27,6 +28,13 @@ from app.trading.runtime_window_import import (
     persist_observed_runtime_windows,
     resolve_hypothesis_manifest,
 )
+
+
+def _runtime_pnl_basis() -> dict[str, object]:
+    return {
+        "post_cost_expectancy_basis": "realized_strategy_pnl",
+        "post_cost_promotion_eligible": True,
+    }
 
 
 class TestRuntimeWindowImport(TestCase):
@@ -73,6 +81,7 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(len(buckets), 1)
         self.assertEqual(buckets[0].decision_alignment_ratio, Decimal("1"))
         self.assertEqual(buckets[0].avg_abs_slippage_bps, Decimal("0"))
+        self.assertEqual(buckets[0].post_cost_promotion_sample_count, 0)
 
     def test_runtime_observation_parsers_handle_edge_inputs(self) -> None:
         parsed = _parse_observation_datetime(
@@ -86,6 +95,7 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(_observation_bool("passed"), True)
         self.assertEqual(_observation_bool("blocked"), False)
         self.assertEqual(_observation_bool("unclear"), None)
+        self.assertEqual(_observation_decimal("bad"), Decimal("0"))
         self.assertEqual(_observation_int("-7"), 0)
         self.assertEqual(_observation_int("bad"), 0)
 
@@ -122,6 +132,45 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(failed_reasons, ["delay_adjusted_depth_stress_failed"])
         self.assertEqual(stale_reasons, ["delay_adjusted_depth_stress_stale"])
 
+    def test_delay_adjusted_depth_stress_blockers_require_survival_detail(
+        self,
+    ) -> None:
+        _, manifest = resolve_hypothesis_manifest(
+            hypothesis_id="H-MICRO-01",
+            strategy_family="microstructure_breakout",
+        )
+        now = datetime(2026, 3, 6, 15, 30, tzinfo=timezone.utc)
+
+        reasons = _delay_adjusted_depth_stress_blocking_reasons(
+            manifest=manifest,
+            runtime_payload={
+                "delay_adjusted_depth_stress_report": {
+                    "case_count": "1",
+                    "passed": True,
+                    "checked_at": now.isoformat(),
+                    "tail_coverage_passed": "false",
+                    "p10_active_day_fillable_notional": "0",
+                    "worst_active_day_fillable_notional": "0",
+                    "stress_net_pnl_per_day": "-1",
+                    "fill_survival_evidence_present": "false",
+                    "fill_survival_sample_count": "0",
+                }
+            },
+            now=now,
+        )
+
+        self.assertEqual(
+            reasons,
+            [
+                "delay_adjusted_depth_tail_coverage_missing",
+                "delay_adjusted_depth_p10_fillable_non_positive",
+                "delay_adjusted_depth_worst_fillable_non_positive",
+                "delay_adjusted_depth_stress_net_pnl_non_positive",
+                "fill_survival_evidence_missing",
+                "fill_survival_sample_count_zero",
+            ],
+        )
+
     def test_persist_observed_runtime_windows_creates_governance_rows(self) -> None:
         buckets = build_observed_runtime_buckets(
             bucket_ranges=[
@@ -149,11 +198,13 @@ class TestRuntimeWindowImport(TestCase):
                     "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("4"),
                     "post_cost_expectancy_bps": Decimal("3"),
+                    **_runtime_pnl_basis(),
                 },
                 {
                     "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("5"),
                     "post_cost_expectancy_bps": Decimal("2"),
+                    **_runtime_pnl_basis(),
                 },
             ],
             continuity_ok=True,
@@ -246,11 +297,13 @@ class TestRuntimeWindowImport(TestCase):
                     "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("4"),
                     "post_cost_expectancy_bps": Decimal("8"),
+                    **_runtime_pnl_basis(),
                 },
                 {
                     "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("5"),
                     "post_cost_expectancy_bps": Decimal("8"),
+                    **_runtime_pnl_basis(),
                 },
             ],
             continuity_ok=True,
@@ -289,6 +342,76 @@ class TestRuntimeWindowImport(TestCase):
             decision.reason_summary, "runtime_evidence_thresholds_satisfied"
         )
 
+    def test_persist_observed_runtime_windows_blocks_tca_proxy_expectancy(self) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    40,
+                ),
+                (
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 30, tzinfo=timezone.utc),
+                    40,
+                ),
+            ],
+            decision_times=[
+                datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 15, 5, tzinfo=timezone.utc),
+            ],
+            execution_times=[
+                datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
+            ],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("4"),
+                    "post_cost_expectancy_bps": Decimal("80"),
+                    "post_cost_expectancy_basis": "tca_shortfall_proxy",
+                    "post_cost_promotion_eligible": False,
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("5"),
+                    "post_cost_expectancy_bps": Decimal("80"),
+                    "post_cost_expectancy_basis": "tca_shortfall_proxy",
+                    "post_cost_promotion_eligible": False,
+                },
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        with self.session_local() as session:
+            summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-live-tca-proxy",
+                candidate_id="cand-tca-proxy",
+                hypothesis_id="H-CONT-01",
+                observed_stage="live",
+                strategy_family="intraday_continuation",
+                source_manifest_ref="config/trading/hypotheses/h-cont-01.json",
+                buckets=buckets,
+            )
+            session.commit()
+            decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
+
+        self.assertEqual(summary["promotion_allowed"], False)
+        self.assertEqual(summary["post_cost_promotion_sample_count"], 0)
+        self.assertEqual(summary["post_cost_basis_counts"], {"tca_shortfall_proxy": 2})
+        self.assertIn(
+            "post_cost_pnl_basis_missing",
+            summary["promotion_blocking_reasons"],
+        )
+        self.assertIn(
+            "post_cost_expectancy_non_positive",
+            summary["promotion_blocking_reasons"],
+        )
+        self.assertEqual(decision.allowed, False)
+
     def test_persist_observed_runtime_windows_skips_idle_buckets(self) -> None:
         buckets = build_observed_runtime_buckets(
             bucket_ranges=[
@@ -310,6 +433,7 @@ class TestRuntimeWindowImport(TestCase):
                     "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("4"),
                     "post_cost_expectancy_bps": Decimal("8"),
+                    **_runtime_pnl_basis(),
                 }
             ],
             continuity_ok=True,
@@ -329,7 +453,9 @@ class TestRuntimeWindowImport(TestCase):
                 buckets=buckets,
             )
             session.commit()
-            windows = session.execute(select(StrategyHypothesisMetricWindow)).scalars().all()
+            windows = (
+                session.execute(select(StrategyHypothesisMetricWindow)).scalars().all()
+            )
             decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
 
         self.assertEqual(summary["raw_window_count"], 2)
@@ -370,11 +496,13 @@ class TestRuntimeWindowImport(TestCase):
                     "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("4"),
                     "post_cost_expectancy_bps": Decimal("12"),
+                    **_runtime_pnl_basis(),
                 },
                 {
                     "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("5"),
                     "post_cost_expectancy_bps": Decimal("12"),
+                    **_runtime_pnl_basis(),
                 },
             ],
             continuity_ok=True,
@@ -432,11 +560,13 @@ class TestRuntimeWindowImport(TestCase):
                     "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("4"),
                     "post_cost_expectancy_bps": Decimal("12"),
+                    **_runtime_pnl_basis(),
                 },
                 {
                     "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("5"),
                     "post_cost_expectancy_bps": Decimal("12"),
+                    **_runtime_pnl_basis(),
                 },
             ],
             continuity_ok=True,
@@ -466,6 +596,14 @@ class TestRuntimeWindowImport(TestCase):
                         "worst_active_day_fillable_notional": "350000",
                         "p10_active_day_fillable_notional": "325000",
                         "tail_coverage_passed": True,
+                        "fillable_ratio": "0.90",
+                        "survival_adjusted_fillable_ratio": "0.81",
+                        "unfillable_notional_per_day": "50000",
+                        "stress_net_pnl_per_day": "620",
+                        "fill_survival_evidence_present": True,
+                        "fill_survival_sample_count": 44,
+                        "fill_survival_rate": "0.90",
+                        "queue_ratio_p95": "0.12",
                     }
                 },
             )
@@ -487,6 +625,14 @@ class TestRuntimeWindowImport(TestCase):
                 "worst_active_day_fillable_notional": "350000",
                 "p10_active_day_fillable_notional": "325000",
                 "tail_coverage_passed": True,
+                "fillable_ratio": "0.90",
+                "survival_adjusted_fillable_ratio": "0.81",
+                "unfillable_notional_per_day": "50000",
+                "stress_net_pnl_per_day": "620",
+                "fill_survival_evidence_present": True,
+                "fill_survival_sample_count": 44,
+                "fill_survival_rate": "0.90",
+                "queue_ratio_p95": "0.12",
             },
         )
         self.assertEqual(decision.allowed, True)
@@ -543,7 +689,9 @@ class TestRuntimeWindowImport(TestCase):
             )
             session.commit()
             decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
-            windows = session.execute(select(StrategyHypothesisMetricWindow)).scalars().all()
+            windows = (
+                session.execute(select(StrategyHypothesisMetricWindow)).scalars().all()
+            )
 
         self.assertEqual(summary["raw_window_count"], 2)
         self.assertEqual(summary["window_count"], 0)
@@ -619,11 +767,13 @@ class TestRuntimeWindowImport(TestCase):
                     "computed_at": datetime(2026, 5, 6, 17, 26, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("0.24359349"),
                     "post_cost_expectancy_bps": Decimal("-0.24359349"),
+                    **_runtime_pnl_basis(),
                 },
                 {
                     "computed_at": datetime(2026, 5, 6, 17, 56, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("24.304747534"),
                     "post_cost_expectancy_bps": Decimal("24.304747534"),
+                    **_runtime_pnl_basis(),
                 },
             ],
             continuity_ok=True,

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -1634,6 +1634,63 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             frontier.Decimal("361"),
         )
 
+    def test_consistency_penalty_applies_order_lifecycle_fill_survival_to_delay_depth(
+        self,
+    ) -> None:
+        payload = self._payload(
+            start_date="2026-03-24",
+            end_date="2026-03-24",
+            daily_net={"2026-03-24": "1000"},
+            daily_filled_notional={"2026-03-24": "100000"},
+            daily_liquidity_notional={"2026-03-24": "1000000"},
+            decision_count=4,
+            filled_count=4,
+            wins=4,
+            losses=0,
+        )
+        payload["order_lifecycle"] = {
+            "submitted_order_count": 4,
+            "filled_order_count": 2,
+            "fill_rate": "0.5",
+            "fill_survival_sample_count": 4,
+            "fill_survival_evidence_present": True,
+            "order_qty_to_touch_qty_ratio_p95": "0.25",
+            "post_cost_survivorship": {
+                "post_cost_survival_rate": "1",
+                "gross_positive_killed_by_cost_count": 0,
+            },
+        }
+
+        _, summary = frontier._consistency_penalty(
+            full_window_payload=payload,
+            policy=frontier.FullWindowConsistencyPolicy(
+                target_net_per_day=frontier.Decimal("500"),
+                min_daily_net_pnl=frontier.Decimal("0"),
+                min_active_days=1,
+                min_active_ratio=frontier.Decimal("1"),
+                min_positive_days=1,
+                max_worst_day_loss=frontier.Decimal("250"),
+                max_negative_days=0,
+                max_drawdown=frontier.Decimal("500"),
+                max_best_day_share_of_total_pnl=frontier.Decimal("1"),
+                min_avg_filled_notional_per_day=frontier.Decimal("50000"),
+                min_avg_filled_notional_per_active_day=frontier.Decimal("50000"),
+                require_every_day_active=True,
+            ),
+        )
+
+        self.assertEqual(summary["fill_survival_sample_count"], 4)
+        self.assertEqual(summary["fill_survival_fill_rate"], "0.5")
+        self.assertEqual(
+            summary["delay_adjusted_depth_survival_adjusted_fillable_ratio"],
+            "0.5",
+        )
+        self.assertEqual(
+            frontier.Decimal(summary["delay_adjusted_depth_stress_net_pnl_per_day"]),
+            frontier.Decimal("490"),
+        )
+        self.assertEqual(summary["delay_adjusted_depth_queue_ratio_p95"], "0.25")
+
     def test_consistency_penalty_reports_and_penalizes_capital_realism(self) -> None:
         payload = self._payload(
             start_date="2026-03-24",

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -29,6 +29,7 @@ from app.trading.submission_council import (
     _coerce_aware_datetime,
     _load_profit_promotion_table_counts,
     _merge_runtime_certificate_evidence,
+    _metric_window_activity_reason_codes,
     _refresh_runtime_summary_totals,
     build_hypothesis_runtime_summary,
     build_live_submission_gate_payload,
@@ -159,6 +160,28 @@ class TestSubmissionCouncil(TestCase):
             "status": "healthy",
             "source_url": "http://jangar.test/api/torghut/trading/control-plane/quant/health?account=paper&window=15m",
         }
+
+    def test_metric_window_activity_rejects_tca_proxy_expectancy(self) -> None:
+        metric_window = SimpleNamespace(
+            market_session_count=3,
+            decision_count=3,
+            trade_count=3,
+            order_count=3,
+            post_cost_expectancy_bps="8.5",
+            avg_abs_slippage_bps="4.2",
+            slippage_budget_bps="12",
+            payload_json={
+                "post_cost_promotion_sample_count": 0,
+                "post_cost_basis_counts": {"tca_shortfall_proxy": 3},
+            },
+        )
+
+        reasons = _metric_window_activity_reason_codes(metric_window)
+
+        self.assertEqual(
+            reasons,
+            ["hypothesis_window_post_cost_pnl_basis_missing"],
+        )
 
     def test_refresh_runtime_summary_totals_counts_reasons_and_rollback(self) -> None:
         refreshed = _refresh_runtime_summary_totals(

--- a/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
+++ b/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
@@ -6,11 +6,13 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import app.trading.discovery.candidate_specs as candidate_specs_module
+import app.trading.discovery.evidence_bundles as evidence_bundles_module
 from app.trading.discovery.candidate_specs import (
     candidate_spec_from_payload,
     compile_candidate_specs,
 )
 from app.trading.discovery.evidence_bundles import (
+    evidence_bundle_blockers,
     evidence_bundle_from_frontier_candidate,
     evidence_bundle_from_payload,
 )
@@ -44,6 +46,13 @@ def _profile_ids_for_family(family_template_id: str) -> list[str]:
 
 
 class TestWhitepaperAutoresearchArtifacts(TestCase):
+    def test_evidence_bundle_bool_parser_handles_numeric_and_unknown_values(
+        self,
+    ) -> None:
+        self.assertEqual(evidence_bundles_module._bool(Decimal("1")), True)
+        self.assertEqual(evidence_bundles_module._bool(0), False)
+        self.assertEqual(evidence_bundles_module._bool("custom-truthy-marker"), True)
+
     def test_hypothesis_and_candidate_specs_round_trip(self) -> None:
         cards = build_hypothesis_cards(
             source_run_id="paper-2026",
@@ -456,10 +465,215 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
         )
         self.assertEqual(len(bundle.stress_metrics), 3)
         self.assertEqual(
+            bundle.stress_metrics[1]["worst_grid_fillable_notional_per_day"],
+            "350000",
+        )
+        self.assertEqual(bundle.stress_metrics[1]["fillable_ratio"], "1")
+        self.assertEqual(
             bundle.stress_metrics[2]["stress_type"], "implementation_uncertainty"
         )
         with self.assertRaisesRegex(ValueError, "evidence_bundle_schema_invalid"):
             evidence_bundle_from_payload({"schema_version": "bad"})
+
+    def test_evidence_bundle_blocks_promotion_proof_without_fill_survival(self) -> None:
+        bundle = evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-promotion-proof",
+            candidate={
+                "candidate_id": "cand-promotion-proof",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "650",
+                    "delay_adjusted_depth_stress_passed": True,
+                    "delay_adjusted_depth_stress_model": "latency_depth_haircut",
+                    "delay_adjusted_depth_stress_ms": "50",
+                    "delay_adjusted_depth_stress_artifact_ref": "/tmp/depth.json",
+                    "delay_adjusted_depth_tail_coverage_passed": True,
+                    "delay_adjusted_depth_p10_active_day_fillable_notional": "250000",
+                    "delay_adjusted_depth_worst_active_day_fillable_notional": "200000",
+                    "delay_adjusted_depth_stress_net_pnl_per_day": "540",
+                },
+                "full_window": {
+                    "net_per_day": "650",
+                    "trading_day_count": "1",
+                    "avg_filled_notional_per_day": "350000",
+                    "daily_filled_notional": {"2026-02-23": "350000"},
+                    "daily_liquidity_notional": {"2026-02-23": "900000"},
+                },
+                "promotion_readiness": {
+                    "stage": "paper_probation",
+                    "status": "promotion_ready",
+                    "promotable": True,
+                    "blockers": [],
+                },
+            },
+            dataset_snapshot_id="snap-promotion-proof",
+            result_path="/tmp/promotion-proof.json",
+        )
+
+        blockers = evidence_bundle_blockers(bundle)
+
+        self.assertIn("fill_survival_evidence_missing", blockers)
+        self.assertIn("fill_survival_sample_count_zero", blockers)
+
+    def test_evidence_bundle_parses_serialized_false_survival_booleans(self) -> None:
+        bundle = evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-serialized-false-proof",
+            candidate={
+                "candidate_id": "cand-serialized-false-proof",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "650",
+                    "delay_adjusted_depth_stress_passed": "false",
+                    "delay_adjusted_depth_stress_model": "latency_depth_haircut",
+                    "delay_adjusted_depth_stress_ms": "50",
+                    "delay_adjusted_depth_stress_artifact_ref": "/tmp/depth.json",
+                    "delay_adjusted_depth_tail_coverage_passed": "0",
+                    "delay_adjusted_depth_p10_active_day_fillable_notional": "250000",
+                    "delay_adjusted_depth_worst_active_day_fillable_notional": "200000",
+                    "delay_adjusted_depth_stress_net_pnl_per_day": "540",
+                    "fill_survival_evidence_present": "false",
+                    "fill_survival_sample_count": "12",
+                    "fill_survival_fill_rate": "0.85",
+                },
+                "full_window": {
+                    "net_per_day": "650",
+                    "trading_day_count": "1",
+                    "avg_filled_notional_per_day": "350000",
+                    "daily_filled_notional": {"2026-02-23": "350000"},
+                    "daily_liquidity_notional": {"2026-02-23": "900000"},
+                },
+                "promotion_readiness": {
+                    "stage": "paper_probation",
+                    "status": "promotion_ready",
+                    "promotable": "true",
+                    "blockers": [],
+                },
+            },
+            dataset_snapshot_id="snap-serialized-false-proof",
+            result_path="/tmp/serialized-false-proof.json",
+        )
+
+        blockers = evidence_bundle_blockers(bundle)
+
+        self.assertIn("delay_adjusted_depth_stress_failed", blockers)
+        self.assertIn("delay_adjusted_depth_tail_coverage_missing", blockers)
+        self.assertIn("fill_survival_evidence_missing", blockers)
+
+    def test_evidence_bundle_fallback_stress_uses_fill_survival_rate(self) -> None:
+        bundle = evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-survival-adjusted-fallback",
+            candidate={
+                "candidate_id": "cand-survival-adjusted-fallback",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "100",
+                    "fill_survival_evidence_present": True,
+                    "fill_survival_sample_count": 10,
+                    "fill_survival_fill_rate": "0.01",
+                },
+                "full_window": {
+                    "net_per_day": "100",
+                    "trading_day_count": "1",
+                    "avg_filled_notional_per_day": "100000",
+                    "daily_filled_notional": {"2026-02-23": "100000"},
+                    "daily_liquidity_notional": {"2026-02-23": "1000000"},
+                },
+                "promotion_readiness": {
+                    "stage": "paper_probation",
+                    "status": "promotion_ready",
+                    "promotable": True,
+                    "blockers": [],
+                },
+            },
+            dataset_snapshot_id="snap-survival-adjusted-fallback",
+            result_path="/tmp/survival-adjusted-fallback.json",
+        )
+
+        self.assertEqual(
+            bundle.objective_scorecard[
+                "delay_adjusted_depth_survival_adjusted_fillable_ratio"
+            ],
+            "0.01",
+        )
+        self.assertEqual(
+            bundle.objective_scorecard["delay_adjusted_depth_stress_net_pnl_per_day"],
+            "-9.00",
+        )
+        blockers = evidence_bundle_blockers(bundle)
+        self.assertIn("delay_adjusted_depth_stress_failed", blockers)
+        self.assertIn("delay_adjusted_depth_stress_net_pnl_non_positive", blockers)
+
+    def test_evidence_bundle_copies_fill_survival_from_full_window(
+        self,
+    ) -> None:
+        bundle = evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-stage-proof",
+            candidate={
+                "candidate_id": "cand-stage-proof",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "650",
+                    "delay_adjusted_depth_stress_passed": True,
+                    "delay_adjusted_depth_tail_coverage_passed": True,
+                    "fill_survival_evidence_present": True,
+                    "fill_survival_sample_count": 8,
+                },
+                "full_window": {
+                    "net_per_day": "650",
+                    "trading_day_count": "1",
+                    "avg_filled_notional_per_day": "350000",
+                    "daily_filled_notional": {"2026-02-23": "350000"},
+                    "daily_liquidity_notional": {"2026-02-23": "900000"},
+                    "fill_survival_fill_rate": "0.75",
+                },
+                "promotion_readiness": {
+                    "stage": "paper_probation",
+                    "status": "candidate_review",
+                    "promotable": False,
+                    "blockers": [],
+                },
+            },
+            dataset_snapshot_id="snap-stage-proof",
+            result_path="/tmp/stage-proof.json",
+        )
+
+        blockers = evidence_bundle_blockers(bundle)
+
+        self.assertEqual(bundle.objective_scorecard["fill_survival_fill_rate"], "0.75")
+        self.assertEqual(blockers, ())
+
+    def test_evidence_bundle_blocks_stage_promotion_with_missing_depth_fields(
+        self,
+    ) -> None:
+        bundle = evidence_bundles_module.CandidateEvidenceBundle(
+            schema_version=evidence_bundles_module.EVIDENCE_BUNDLE_SCHEMA_VERSION,
+            evidence_bundle_id="bundle-stage-proof",
+            candidate_id="cand-stage-proof",
+            candidate_spec_id="spec-stage-proof",
+            dataset_snapshot_id="snap-stage-proof",
+            feature_spec_hash="feature-hash",
+            code_commit="commit-sha",
+            replay_artifact_refs=(),
+            objective_scorecard={
+                "delay_adjusted_depth_stress_passed": True,
+                "delay_adjusted_depth_tail_coverage_passed": True,
+                "fill_survival_evidence_present": True,
+                "fill_survival_sample_count": 8,
+            },
+            fold_metrics=(),
+            stress_metrics=(),
+            cost_calibration={},
+            null_comparator={},
+            promotion_readiness={
+                "stage": "paper_probation",
+                "status": "candidate_review",
+                "promotable": False,
+            },
+        )
+
+        blockers = evidence_bundle_blockers(bundle)
+
+        self.assertIn("delay_adjusted_depth_stress_model_missing", blockers)
+        self.assertIn("delay_adjusted_depth_stress_ms_missing", blockers)
+        self.assertIn("delay_adjusted_depth_stress_artifact_missing", blockers)
+        self.assertIn("delay_adjusted_depth_p10_fillable_non_positive", blockers)
+        self.assertIn("delay_adjusted_depth_worst_fillable_non_positive", blockers)
 
     def test_evidence_bundle_marks_order_type_execution_artifact_without_ablation(
         self,


### PR DESCRIPTION
## Summary

- Adds replay order-lifecycle metrics for submitted, filled, censored, and replaced orders, including fill latency, queue/depth proxies, and post-cost survivorship.
- Propagates fill-survival evidence into profitability stress metrics and evidence bundles, including survival-adjusted delay/depth fillability.
- Requires promotion-grade post-cost expectancy to come from simulation report net PnL or costed closed-trade realized strategy PnL; TCA shortfall remains slippage/cost evidence and is blocked as promotion PnL.
- Tightens runtime certificate and evidence-bundle blockers so serialized false values, missing delay/depth survival, missing fill survival, and TCA-only expectancy fail closed.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/runtime_window_import.py app/trading/submission_council.py scripts/import_hypothesis_runtime_windows.py scripts/local_intraday_tsmom_replay.py scripts/search_consistent_profitability_frontier.py app/trading/discovery/evidence_bundles.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_submission_council.py tests/test_local_intraday_tsmom_replay.py tests/test_search_consistent_profitability_frontier.py tests/test_whitepaper_autoresearch_artifacts.py`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_submission_council.py tests/test_local_intraday_tsmom_replay.py tests/test_search_consistent_profitability_frontier.py tests/test_whitepaper_autoresearch_artifacts.py -q`
- `uv run --frozen ruff check app/trading/runtime_window_import.py app/trading/submission_council.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_submission_council.py tests/test_local_intraday_tsmom_replay.py tests/test_search_consistent_profitability_frontier.py tests/test_whitepaper_autoresearch_artifacts.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_submission_council.py tests/test_local_intraday_tsmom_replay.py tests/test_search_consistent_profitability_frontier.py tests/test_whitepaper_autoresearch_artifacts.py --cov --cov-branch --cov-fail-under=0 --cov-report= -q`
- `uv run --frozen coverage xml -o coverage.xml` wrote `coverage.xml`; the selected subset reports low total coverage, so this is not a standalone total-coverage gate.
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

Promotion/runtime certificate evidence generated from TCA-only shortfall no longer counts as post-cost expectancy; candidates need real net-PnL provenance before those runtime windows can promote.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
