### PR TITLE
feat(torghut): add runtime ledger pnl proof

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -1,0 +1,565 @@
+"""Runtime execution ledger primitives for honest post-cost PnL proof."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+
+POST_COST_PNL_BASIS = "realized_strategy_pnl_after_explicit_costs"
+
+_BPS_MULTIPLIER = Decimal("10000")
+_BUY_SIDES = frozenset({"buy", "buy_to_cover", "cover"})
+_SELL_SIDES = frozenset({"sell", "sell_short", "short"})
+_TCA_PNL_BASES = frozenset(
+    {
+        "tca_shortfall_proxy",
+        "tca_shortfall",
+        "shortfall_proxy",
+        "realized_pnl_proxy_from_tca_shortfall",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RuntimeLedgerFill:
+    """Typed runtime fill input accepted by the DB-agnostic ledger builder."""
+
+    executed_at: datetime
+    side: str
+    filled_qty: Decimal
+    avg_fill_price: Decimal | None = None
+    filled_notional: Decimal | None = None
+    cost_amount: Decimal | None = None
+    cost_basis: str | None = None
+    account_label: str | None = None
+    strategy_id: str | None = None
+    symbol: str | None = None
+    source: str = "runtime_execution"
+
+
+@dataclass(frozen=True)
+class RuntimeLedgerBucket:
+    """Post-cost runtime PnL evidence for one time/group bucket."""
+
+    bucket_started_at: datetime
+    bucket_ended_at: datetime
+    account_label: str | None
+    strategy_id: str | None
+    symbol: str | None
+    fill_count: int
+    closed_trade_count: int
+    open_position_count: int
+    filled_notional: Decimal
+    gross_strategy_pnl: Decimal
+    cost_amount: Decimal
+    net_strategy_pnl_after_costs: Decimal
+    post_cost_expectancy_bps: Decimal | None
+    cost_basis_counts: dict[str, int]
+    blockers: list[str]
+    pnl_basis: str = POST_COST_PNL_BASIS
+
+
+@dataclass(frozen=True)
+class _NormalizedFill:
+    row_index: int
+    executed_at: datetime | None
+    account_label: str | None
+    strategy_id: str | None
+    symbol: str | None
+    side: str | None
+    filled_qty: Decimal | None
+    avg_fill_price: Decimal | None
+    filled_notional: Decimal | None
+    cost_amount: Decimal | None
+    cost_basis: str | None
+    blockers: tuple[str, ...]
+
+    @property
+    def is_usable_fill(self) -> bool:
+        return (
+            self.executed_at is not None
+            and self.side is not None
+            and self.filled_qty is not None
+            and self.filled_qty > 0
+            and self.avg_fill_price is not None
+            and self.avg_fill_price > 0
+            and self.filled_notional is not None
+            and self.filled_notional > 0
+            and self.cost_amount is not None
+            and self.cost_amount >= 0
+            and self.cost_basis is not None
+            and not self.blockers
+        )
+
+
+@dataclass
+class _PositionState:
+    qty: Decimal = Decimal("0")
+    avg_price: Decimal | None = None
+    entry_cost_remaining: Decimal = Decimal("0")
+
+
+@dataclass
+class _LedgerAccumulator:
+    filled_notional: Decimal = Decimal("0")
+    cost_amount: Decimal = Decimal("0")
+    gross_strategy_pnl: Decimal = Decimal("0")
+    net_strategy_pnl_after_costs: Decimal = Decimal("0")
+    closed_trade_count: int = 0
+
+
+def build_runtime_ledger_buckets(
+    rows: Sequence[RuntimeLedgerFill | Mapping[str, object]],
+    *,
+    bucket_ranges: Sequence[tuple[datetime, datetime]],
+    group_by: Sequence[str] = (),
+) -> list[RuntimeLedgerBucket]:
+    """Aggregate runtime fills into fail-closed post-cost PnL buckets.
+
+    Expectancy is only populated when every row in the bucket carries enough
+    runtime fill data and explicit cost data to compute realized strategy PnL
+    after costs. TCA shortfall/proxy fields are treated as blockers, not PnL.
+    """
+
+    normalized_rows = [
+        _normalize_fill_row(row, row_index=index) for index, row in enumerate(rows)
+    ]
+    normalized_ranges = [(_utc(start), _utc(end)) for start, end in bucket_ranges]
+    for start, end in normalized_ranges:
+        if end <= start:
+            raise ValueError("bucket_end_must_be_after_bucket_start")
+
+    buckets: list[RuntimeLedgerBucket] = []
+    if not group_by:
+        positions: dict[tuple[str | None, str | None, str | None], _PositionState] = {}
+        for bucket_start, bucket_end in normalized_ranges:
+            bucket_rows = [
+                row
+                for row in normalized_rows
+                if row.executed_at is not None
+                and bucket_start <= row.executed_at < bucket_end
+            ]
+            buckets.append(
+                _build_bucket(
+                    bucket_start=bucket_start,
+                    bucket_end=bucket_end,
+                    rows=bucket_rows,
+                    carried_positions=positions,
+                )
+            )
+        return buckets
+
+    for bucket_start, bucket_end in normalized_ranges:
+        bucket_rows = [
+            row
+            for row in normalized_rows
+            if row.executed_at is not None
+            and bucket_start <= row.executed_at < bucket_end
+        ]
+        grouped_rows: dict[tuple[str | None, ...], list[_NormalizedFill]] = {}
+        for row in bucket_rows:
+            grouped_rows.setdefault(_group_key(row, group_by), []).append(row)
+        for key in sorted(grouped_rows):
+            buckets.append(
+                _build_bucket(
+                    bucket_start=bucket_start,
+                    bucket_end=bucket_end,
+                    rows=grouped_rows[key],
+                    group_by=group_by,
+                    group_key=key,
+                )
+            )
+    return buckets
+
+
+def _build_bucket(
+    *,
+    bucket_start: datetime,
+    bucket_end: datetime,
+    rows: Sequence[_NormalizedFill],
+    group_by: Sequence[str] = (),
+    group_key: tuple[str | None, ...] = (),
+    carried_positions: dict[tuple[str | None, str | None, str | None], _PositionState]
+    | None = None,
+) -> RuntimeLedgerBucket:
+    blockers: list[str] = []
+    for row in rows:
+        blockers.extend(row.blockers)
+
+    usable_fills = [row for row in rows if row.is_usable_fill]
+    if not usable_fills:
+        blockers.append("runtime_fills_missing")
+
+    accumulator = _LedgerAccumulator()
+    cost_basis_counter: Counter[str] = Counter()
+    positions: dict[tuple[str | None, str | None, str | None], _PositionState] = (
+        carried_positions if carried_positions is not None else {}
+    )
+    for fill in sorted(
+        usable_fills,
+        key=lambda item: (item.executed_at or bucket_start, item.row_index),
+    ):
+        assert fill.side is not None
+        assert fill.filled_qty is not None
+        assert fill.avg_fill_price is not None
+        assert fill.filled_notional is not None
+        assert fill.cost_amount is not None
+        assert fill.cost_basis is not None
+
+        cost_basis_counter[fill.cost_basis] += 1
+        position_key = (fill.account_label, fill.strategy_id, fill.symbol)
+        state = positions.setdefault(position_key, _PositionState())
+        _apply_fill_to_position(state=state, fill=fill, accumulator=accumulator)
+
+    open_position_count = sum(1 for state in positions.values() if state.qty != 0)
+    if usable_fills and accumulator.closed_trade_count <= 0:
+        blockers.append("closed_round_trip_missing")
+    if open_position_count > 0:
+        blockers.append("unclosed_position")
+    if accumulator.filled_notional <= 0:
+        blockers.append("filled_notional_missing")
+
+    unique_blockers = _dedupe(blockers)
+    post_cost_expectancy_bps: Decimal | None = None
+    if not unique_blockers and accumulator.filled_notional > 0:
+        post_cost_expectancy_bps = (
+            accumulator.net_strategy_pnl_after_costs
+            / accumulator.filled_notional
+            * _BPS_MULTIPLIER
+        )
+
+    return RuntimeLedgerBucket(
+        bucket_started_at=bucket_start,
+        bucket_ended_at=bucket_end,
+        account_label=_bucket_field("account_label", rows, group_by, group_key),
+        strategy_id=_bucket_field("strategy_id", rows, group_by, group_key),
+        symbol=_bucket_field("symbol", rows, group_by, group_key),
+        fill_count=len(usable_fills),
+        closed_trade_count=accumulator.closed_trade_count,
+        open_position_count=open_position_count,
+        filled_notional=accumulator.filled_notional,
+        gross_strategy_pnl=accumulator.gross_strategy_pnl,
+        cost_amount=accumulator.cost_amount,
+        net_strategy_pnl_after_costs=accumulator.net_strategy_pnl_after_costs,
+        post_cost_expectancy_bps=post_cost_expectancy_bps,
+        cost_basis_counts=dict(sorted(cost_basis_counter.items())),
+        blockers=unique_blockers,
+    )
+
+
+def _apply_fill_to_position(
+    *,
+    state: _PositionState,
+    fill: _NormalizedFill,
+    accumulator: _LedgerAccumulator,
+) -> None:
+    assert fill.side is not None
+    assert fill.filled_qty is not None
+    assert fill.avg_fill_price is not None
+    assert fill.cost_amount is not None
+
+    side_sign = Decimal("1") if fill.side in _BUY_SIDES else Decimal("-1")
+    remaining_qty = fill.filled_qty
+    remaining_cost = fill.cost_amount
+
+    if state.qty == 0 or _same_direction(state.qty, side_sign):
+        _open_position(
+            state=state,
+            side_sign=side_sign,
+            qty=remaining_qty,
+            price=fill.avg_fill_price,
+            cost_amount=remaining_cost,
+        )
+        return
+
+    existing_abs_qty = abs(state.qty)
+    closing_qty = min(remaining_qty, existing_abs_qty)
+    if closing_qty > 0:
+        fill_cost_allocated = _allocate(fill.cost_amount, closing_qty, fill.filled_qty)
+        entry_cost_allocated = _allocate(
+            state.entry_cost_remaining,
+            closing_qty,
+            existing_abs_qty,
+        )
+        entry_price = state.avg_price or fill.avg_fill_price
+        if state.qty > 0:
+            gross_pnl = (fill.avg_fill_price - entry_price) * closing_qty
+        else:
+            gross_pnl = (entry_price - fill.avg_fill_price) * closing_qty
+        accumulator.filled_notional += (
+            entry_price * closing_qty + fill.avg_fill_price * closing_qty
+        )
+        accumulator.cost_amount += entry_cost_allocated + fill_cost_allocated
+        accumulator.gross_strategy_pnl += gross_pnl
+        accumulator.net_strategy_pnl_after_costs += (
+            gross_pnl - entry_cost_allocated - fill_cost_allocated
+        )
+        accumulator.closed_trade_count += 1
+
+        state.entry_cost_remaining -= entry_cost_allocated
+        state.qty += side_sign * closing_qty
+        if state.qty == 0:
+            state.avg_price = None
+            state.entry_cost_remaining = Decimal("0")
+
+        remaining_qty -= closing_qty
+        remaining_cost -= fill_cost_allocated
+
+    if remaining_qty > 0:
+        _open_position(
+            state=state,
+            side_sign=side_sign,
+            qty=remaining_qty,
+            price=fill.avg_fill_price,
+            cost_amount=remaining_cost,
+        )
+
+
+def _open_position(
+    *,
+    state: _PositionState,
+    side_sign: Decimal,
+    qty: Decimal,
+    price: Decimal,
+    cost_amount: Decimal,
+) -> None:
+    signed_qty = side_sign * qty
+    if state.qty == 0 or state.avg_price is None:
+        state.qty = signed_qty
+        state.avg_price = price
+        state.entry_cost_remaining = cost_amount
+        return
+
+    existing_abs_qty = abs(state.qty)
+    new_abs_qty = existing_abs_qty + qty
+    state.avg_price = (
+        (existing_abs_qty * state.avg_price) + (qty * price)
+    ) / new_abs_qty
+    state.qty += signed_qty
+    state.entry_cost_remaining += cost_amount
+
+
+def _normalize_fill_row(
+    row: RuntimeLedgerFill | Mapping[str, object],
+    *,
+    row_index: int,
+) -> _NormalizedFill:
+    executed_at = _coerce_datetime(
+        _row_value(
+            row, "executed_at", "filled_at", "event_ts", "created_at", "computed_at"
+        )
+    )
+    account_label = _coerce_text(
+        _row_value(row, "account_label", "alpaca_account_label")
+    )
+    strategy_id = _coerce_text(_row_value(row, "strategy_id", "strategy_name"))
+    symbol = _coerce_text(_row_value(row, "symbol"))
+    side = _coerce_side(_row_value(row, "side", "action", "order_side"))
+    filled_qty = _positive_decimal(_row_value(row, "filled_qty", "qty", "quantity"))
+    avg_fill_price = _positive_decimal(
+        _row_value(row, "avg_fill_price", "filled_avg_price", "fill_price", "price")
+    )
+    filled_notional = _positive_decimal(
+        _row_value(row, "filled_notional", "notional", "fill_notional")
+    )
+    if (
+        filled_notional is None
+        and filled_qty is not None
+        and avg_fill_price is not None
+    ):
+        filled_notional = filled_qty * avg_fill_price
+    cost_amount = _non_negative_decimal(
+        _row_value(
+            row,
+            "cost_amount",
+            "total_cost",
+            "explicit_cost",
+            "commission",
+            "fees",
+            "fee_amount",
+        )
+    )
+    cost_basis = _coerce_text(_row_value(row, "cost_basis", "cost_source", "fee_basis"))
+
+    blockers: list[str] = []
+    if _has_tca_pnl_shortcut(row):
+        blockers.append("tca_shortfall_not_runtime_pnl")
+    if executed_at is None:
+        blockers.append("executed_at_missing")
+    if side is None:
+        blockers.append("side_missing_or_invalid")
+    if filled_qty is None:
+        blockers.append("filled_qty_missing_or_non_positive")
+    if avg_fill_price is None:
+        blockers.append("fill_price_missing")
+    if filled_notional is None:
+        blockers.append("filled_notional_missing")
+    if cost_amount is None:
+        blockers.append("explicit_cost_missing")
+    if cost_basis is None:
+        blockers.append("cost_basis_missing")
+
+    return _NormalizedFill(
+        row_index=row_index,
+        executed_at=executed_at,
+        account_label=account_label,
+        strategy_id=strategy_id,
+        symbol=symbol,
+        side=side,
+        filled_qty=filled_qty,
+        avg_fill_price=avg_fill_price,
+        filled_notional=filled_notional,
+        cost_amount=cost_amount,
+        cost_basis=cost_basis,
+        blockers=tuple(_dedupe(blockers)),
+    )
+
+
+def _row_value(
+    row: RuntimeLedgerFill | Mapping[str, object],
+    *keys: str,
+) -> object | None:
+    if isinstance(row, Mapping):
+        for key in keys:
+            if key in row:
+                return row[key]
+        return None
+    for key in keys:
+        value = getattr(row, key, None)
+        if value is not None:
+            return value
+    return None
+
+
+def _has_tca_pnl_shortcut(row: RuntimeLedgerFill | Mapping[str, object]) -> bool:
+    basis = _coerce_text(
+        _row_value(row, "post_cost_expectancy_basis", "post_cost_basis", "pnl_basis")
+    )
+    if basis is not None and basis.lower().replace("-", "_") in _TCA_PNL_BASES:
+        return True
+    return (
+        _row_value(row, "post_cost_expectancy_bps") is not None
+        and _row_value(row, "shortfall_notional", "realized_pnl_proxy_notional")
+        is not None
+    )
+
+
+def _group_key(row: _NormalizedFill, group_by: Sequence[str]) -> tuple[str | None, ...]:
+    return tuple(_normalized_fill_field(row, field) for field in group_by)
+
+
+def _bucket_field(
+    field: str,
+    rows: Sequence[_NormalizedFill],
+    group_by: Sequence[str],
+    group_key: tuple[str | None, ...],
+) -> str | None:
+    if field in group_by:
+        return group_key[group_by.index(field)]
+    values = {
+        value
+        for row in rows
+        if (value := _normalized_fill_field(row, field)) is not None
+    }
+    if len(values) == 1:
+        return next(iter(values))
+    return None
+
+
+def _normalized_fill_field(row: _NormalizedFill, field: str) -> str | None:
+    if field == "account_label":
+        return row.account_label
+    if field == "strategy_id":
+        return row.strategy_id
+    if field == "symbol":
+        return row.symbol
+    return None
+
+
+def _same_direction(current_qty: Decimal, side_sign: Decimal) -> bool:
+    return (current_qty > 0 and side_sign > 0) or (current_qty < 0 and side_sign < 0)
+
+
+def _allocate(amount: Decimal, qty: Decimal, total_qty: Decimal) -> Decimal:
+    if total_qty <= 0:
+        return Decimal("0")
+    return amount * qty / total_qty
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _coerce_datetime(value: object | None) -> datetime | None:
+    if isinstance(value, datetime):
+        return _utc(value)
+    text = _coerce_text(value)
+    if text is None:
+        return None
+    try:
+        return _utc(datetime.fromisoformat(text.replace("Z", "+00:00")))
+    except ValueError:
+        return None
+
+
+def _coerce_text(value: object | None) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _coerce_side(value: object | None) -> str | None:
+    text = _coerce_text(value)
+    if text is None:
+        return None
+    normalized = text.lower().replace("-", "_")
+    if normalized in _BUY_SIDES or normalized in _SELL_SIDES:
+        return normalized
+    return None
+
+
+def _positive_decimal(value: object | None) -> Decimal | None:
+    parsed = _decimal(value)
+    if parsed is None or parsed <= 0:
+        return None
+    return parsed
+
+
+def _non_negative_decimal(value: object | None) -> Decimal | None:
+    parsed = _decimal(value)
+    if parsed is None or parsed < 0:
+        return None
+    return parsed
+
+
+def _decimal(value: object | None) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        parsed = value
+    else:
+        try:
+            parsed = Decimal(str(value).strip())
+        except Exception:
+            return None
+    if not parsed.is_finite():
+        return None
+    return parsed
+
+
+def _dedupe(items: Sequence[str]) -> list[str]:
+    return list(dict.fromkeys(items))
+
+
+__all__ = [
+    "POST_COST_PNL_BASIS",
+    "RuntimeLedgerBucket",
+    "RuntimeLedgerFill",
+    "build_runtime_ledger_buckets",
+]

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -30,7 +30,14 @@ US_EQUITIES_REGULAR_TIMEZONE = "America/New_York"
 US_EQUITIES_REGULAR_OPEN = time(hour=9, minute=30)
 US_EQUITIES_REGULAR_CLOSE = time(hour=16, minute=0)
 PROMOTION_GRADE_POST_COST_BASES = frozenset(
-    {"realized_strategy_pnl", "simulation_report_net_pnl"}
+    {
+        "realized_strategy_pnl",
+        "realized_strategy_pnl_after_explicit_costs",
+        "simulation_report_net_pnl",
+    }
+)
+LIVE_PROMOTION_GRADE_POST_COST_BASES = frozenset(
+    {"realized_strategy_pnl_after_explicit_costs"}
 )
 
 
@@ -404,12 +411,14 @@ def _capital_multiplier_for_stage(stage: str) -> str:
 
 def _runtime_promotion_blocking_reasons(
     *,
+    observed_stage: str,
     inserted: int,
     total_session_samples: int,
     total_decision_count: int,
     total_trade_count: int,
     total_order_count: int,
     total_post_cost_promotion_sample_count: int,
+    total_post_cost_basis_counts: Mapping[str, int],
     average_slippage: Decimal,
     average_post_cost: Decimal,
     latest_three_budget_ok: bool,
@@ -433,6 +442,15 @@ def _runtime_promotion_blocking_reasons(
         reasons.append("recent_slippage_budget_exceeded")
     if total_post_cost_promotion_sample_count <= 0:
         reasons.append("post_cost_pnl_basis_missing")
+    if (
+        observed_stage == "live"
+        and sum(
+            total_post_cost_basis_counts.get(basis, 0)
+            for basis in LIVE_PROMOTION_GRADE_POST_COST_BASES
+        )
+        <= 0
+    ):
+        reasons.append("runtime_ledger_pnl_basis_missing")
     if average_post_cost <= Decimal("0"):
         reasons.append("post_cost_expectancy_non_positive")
     elif average_post_cost < manifest.expected_gross_edge_bps:
@@ -799,12 +817,14 @@ def persist_observed_runtime_windows(
         else Decimal("0")
     )
     promotion_blocking_reasons = _runtime_promotion_blocking_reasons(
+        observed_stage=observed_stage,
         inserted=inserted,
         total_session_samples=total_session_samples,
         total_decision_count=total_decision_count,
         total_trade_count=total_trade_count,
         total_order_count=total_order_count,
         total_post_cost_promotion_sample_count=total_post_cost_promotion_sample_count,
+        total_post_cost_basis_counts=total_post_cost_basis_counts,
         average_slippage=average_slippage,
         average_post_cost=average_post_cost,
         latest_three_budget_ok=latest_three_budget_ok,

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Mapping
@@ -14,6 +14,11 @@ from typing import Any, Mapping
 import psycopg
 
 from app.db import SessionLocal
+from app.trading.runtime_ledger import (
+    POST_COST_PNL_BASIS,
+    RuntimeLedgerFill,
+    build_runtime_ledger_buckets,
+)
 from app.trading.runtime_window_import import (
     build_observed_runtime_buckets,
     build_regular_session_buckets,
@@ -26,7 +31,7 @@ EXECUTION_ELIGIBLE_DECISION_STATUSES = (
     "filled",
     "partially_filled",
 )
-POST_COST_BASIS_REALIZED_STRATEGY_PNL = "realized_strategy_pnl"
+POST_COST_BASIS_RUNTIME_LEDGER = POST_COST_PNL_BASIS
 POST_COST_BASIS_SIMULATION_REPORT = "simulation_report_net_pnl"
 POST_COST_BASIS_TCA_PROXY = "tca_shortfall_proxy"
 
@@ -132,72 +137,68 @@ def _execution_signed_qty(*, side: Any, qty: Any) -> Decimal:
 def _build_realized_strategy_pnl_rows(
     execution_rows: list[dict[str, object]],
 ) -> list[dict[str, object]]:
-    lots_by_symbol: dict[str, list[dict[str, Decimal]]] = {}
-    realized_rows: list[dict[str, object]] = []
+    fills: list[RuntimeLedgerFill] = []
+    event_times: list[datetime] = []
+    fallback_cost_basis = "execution_tca_shortfall_cost"
     for row in execution_rows:
-        symbol = str(row.get("symbol") or "").strip().upper()
         computed_at = row.get("computed_at")
         price = _decimal_or_none(row.get("avg_fill_price"))
         signed_qty = _execution_signed_qty(
             side=row.get("side"), qty=row.get("filled_qty")
         )
+        symbol = str(row.get("symbol") or "").strip().upper()
+        shortfall_notional = _decimal_or_none(row.get("shortfall_notional"))
         if not symbol or not isinstance(computed_at, datetime):
             continue
+        event_times.append(computed_at)
         if price is None or price <= 0 or signed_qty == 0:
             continue
-        fill_qty = abs(signed_qty)
-        shortfall_notional = _decimal_or_none(row.get("shortfall_notional"))
         if shortfall_notional is None:
             continue
-        fill_cost_per_share = abs(shortfall_notional) / fill_qty
-        remaining = fill_qty
-        fill_sign = Decimal("1") if signed_qty > 0 else Decimal("-1")
-        lots = lots_by_symbol.setdefault(symbol, [])
-        while remaining > 0 and lots and lots[0]["signed_qty"] * fill_sign < 0:
-            lot = lots[0]
-            lot_qty = abs(lot["signed_qty"])
-            close_qty = min(remaining, lot_qty)
-            entry_price = lot["price"]
-            entry_cost = lot["cost_per_share"] * close_qty
-            exit_cost = fill_cost_per_share * close_qty
-            if lot["signed_qty"] > 0:
-                gross_pnl = (price - entry_price) * close_qty
-            else:
-                gross_pnl = (entry_price - price) * close_qty
-            net_pnl = gross_pnl - entry_cost - exit_cost
-            turnover_notional = (entry_price + price) * close_qty
-            if turnover_notional > 0:
-                realized_rows.append(
-                    {
-                        "computed_at": computed_at,
-                        "abs_slippage_bps": (
-                            (entry_cost + exit_cost) / turnover_notional
-                        )
-                        * Decimal("10000"),
-                        "post_cost_expectancy_bps": (net_pnl / turnover_notional)
-                        * Decimal("10000"),
-                        "post_cost_expectancy_basis": POST_COST_BASIS_REALIZED_STRATEGY_PNL,
-                        "post_cost_promotion_eligible": True,
-                        "realized_gross_pnl": gross_pnl,
-                        "realized_net_pnl": net_pnl,
-                        "turnover_notional": turnover_notional,
-                        "symbol": symbol,
-                    }
-                )
-            remaining -= close_qty
-            lot["signed_qty"] -= (
-                Decimal("1") if lot["signed_qty"] > 0 else Decimal("-1")
-            ) * close_qty
-            if abs(lot["signed_qty"]) <= Decimal("0"):
-                lots.pop(0)
-        if remaining > 0:
-            lots.append(
-                {
-                    "signed_qty": fill_sign * remaining,
-                    "price": price,
-                    "cost_per_share": fill_cost_per_share,
-                }
+        cost_basis = str(row.get("cost_basis") or fallback_cost_basis).strip()
+        fills.append(
+            RuntimeLedgerFill(
+                executed_at=computed_at,
+                side=str(row.get("side") or ""),
+                filled_qty=abs(signed_qty),
+                avg_fill_price=price,
+                cost_amount=abs(shortfall_notional),
+                cost_basis=cost_basis,
+                account_label=str(row.get("account_label") or "") or None,
+                strategy_id=str(row.get("strategy_id") or "") or None,
+                symbol=symbol,
             )
+        )
+    if not event_times:
+        return []
+    unique_times = sorted(set(event_times))
+    bucket_ranges = [(unique_times[0], unique_times[-1] + timedelta(microseconds=1))]
+    realized_rows: list[dict[str, object]] = []
+    for bucket in build_runtime_ledger_buckets(fills, bucket_ranges=bucket_ranges):
+        if bucket.closed_trade_count <= 0:
+            continue
+        promotion_eligible = (
+            bucket.post_cost_expectancy_bps is not None and not bucket.blockers
+        )
+        realized_rows.append(
+            {
+                "computed_at": unique_times[-1],
+                "abs_slippage_bps": (
+                    (bucket.cost_amount / bucket.filled_notional) * Decimal("10000")
+                    if bucket.filled_notional > 0
+                    else None
+                ),
+                "post_cost_expectancy_bps": bucket.post_cost_expectancy_bps,
+                "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+                "post_cost_promotion_eligible": promotion_eligible,
+                "realized_gross_pnl": bucket.gross_strategy_pnl,
+                "realized_net_pnl": bucket.net_strategy_pnl_after_costs,
+                "turnover_notional": bucket.filled_notional,
+                "runtime_ledger_blockers": bucket.blockers,
+                "runtime_ledger_cost_basis_counts": bucket.cost_basis_counts,
+                "runtime_ledger_pnl_basis": bucket.pnl_basis,
+            }
+        )
     return realized_rows
 
 

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 from scripts.import_hypothesis_runtime_windows import (
     EXECUTION_ELIGIBLE_DECISION_STATUSES,
-    POST_COST_BASIS_REALIZED_STRATEGY_PNL,
+    POST_COST_BASIS_RUNTIME_LEDGER,
     POST_COST_BASIS_SIMULATION_REPORT,
     POST_COST_BASIS_TCA_PROXY,
     _build_realized_strategy_pnl_rows,
@@ -217,7 +217,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
                     "symbol": "AAPL",
                     "side": "buy",
-                    "filled_qty": Decimal("2"),
+                    "filled_qty": Decimal("1"),
                     "avg_fill_price": Decimal("100"),
                     "shortfall_notional": Decimal("0.20"),
                 },
@@ -243,14 +243,32 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(
             rows[0]["post_cost_expectancy_basis"],
-            POST_COST_BASIS_REALIZED_STRATEGY_PNL,
+            POST_COST_BASIS_RUNTIME_LEDGER,
         )
         self.assertEqual(rows[0]["post_cost_promotion_eligible"], True)
-        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.80"))
+        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.70"))
         self.assertEqual(
             rows[0]["post_cost_expectancy_bps"],
-            Decimal("39.80099502487562189054726368"),
+            Decimal("34.82587064676616915422885572"),
         )
+
+    def test_build_realized_strategy_pnl_rows_returns_empty_without_event_times(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": None,
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "shortfall_notional": Decimal("0.20"),
+                }
+            ]
+        )
+
+        self.assertEqual(rows, [])
 
     def test_query_timestamps_filters_to_execution_eligible_decisions(self) -> None:
         cursor = _FakeCursor()

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -1,0 +1,501 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from app.trading.runtime_ledger import RuntimeLedgerFill, build_runtime_ledger_buckets
+
+
+def _ts(minutes: int = 0) -> datetime:
+    return datetime(2026, 5, 21, 14, 30, tzinfo=timezone.utc) + timedelta(
+        minutes=minutes
+    )
+
+
+def _bucket(rows: list[RuntimeLedgerFill | dict[str, object]]):
+    return build_runtime_ledger_buckets(
+        rows,
+        bucket_ranges=[(_ts(), _ts(60))],
+    )[0]
+
+
+def _assert_decimal_close(actual: Decimal | None, expected: Decimal) -> None:
+    assert actual is not None
+    assert abs(actual - expected) < Decimal("0.0000000001")
+
+
+def test_closed_round_trip_pnl_uses_net_after_explicit_costs() -> None:
+    bucket = _bucket(
+        [
+            RuntimeLedgerFill(
+                executed_at=_ts(1),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="buy",
+                filled_qty=Decimal("10"),
+                avg_fill_price=Decimal("100"),
+                cost_amount=Decimal("1"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(12),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="sell",
+                filled_qty=Decimal("10"),
+                avg_fill_price=Decimal("110"),
+                cost_amount=Decimal("2"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+        ]
+    )
+
+    assert bucket.blockers == []
+    assert bucket.filled_notional == Decimal("2100")
+    assert bucket.gross_strategy_pnl == Decimal("100")
+    assert bucket.cost_amount == Decimal("3")
+    assert bucket.net_strategy_pnl_after_costs == Decimal("97")
+    assert bucket.pnl_basis == "realized_strategy_pnl_after_explicit_costs"
+    assert bucket.cost_basis_counts == {"broker_reported_commission_and_fees": 2}
+    _assert_decimal_close(
+        bucket.post_cost_expectancy_bps,
+        (Decimal("97") / Decimal("2100")) * Decimal("10000"),
+    )
+
+
+def test_partial_unclosed_positions_report_realized_pnl_but_block_expectancy() -> None:
+    bucket = _bucket(
+        [
+            {
+                "executed_at": _ts(1),
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "10",
+                "avg_fill_price": "100",
+                "cost_amount": "1.00",
+                "cost_basis": "broker_reported_commission_and_fees",
+            },
+            {
+                "executed_at": _ts(12),
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "sell",
+                "filled_qty": "4",
+                "avg_fill_price": "110",
+                "cost_amount": "1.00",
+                "cost_basis": "broker_reported_commission_and_fees",
+            },
+        ]
+    )
+
+    assert bucket.closed_trade_count == 1
+    assert bucket.open_position_count == 1
+    assert "unclosed_position" in bucket.blockers
+    assert bucket.gross_strategy_pnl == Decimal("40")
+    assert bucket.net_strategy_pnl_after_costs == Decimal("38.60")
+    assert bucket.post_cost_expectancy_bps is None
+
+
+def test_missing_price_notional_and_cost_basis_are_blockers() -> None:
+    bucket = _bucket(
+        [
+            {
+                "executed_at": _ts(1),
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "10",
+                "cost_amount": "0",
+            }
+        ]
+    )
+
+    assert "fill_price_missing" in bucket.blockers
+    assert "filled_notional_missing" in bucket.blockers
+    assert "cost_basis_missing" in bucket.blockers
+    assert bucket.filled_notional == Decimal("0")
+    assert bucket.post_cost_expectancy_bps is None
+
+
+def test_explicit_costs_are_deducted_from_gross_pnl() -> None:
+    no_cost_bucket = _bucket(
+        [
+            RuntimeLedgerFill(
+                executed_at=_ts(1),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="buy",
+                filled_qty=Decimal("10"),
+                avg_fill_price=Decimal("100"),
+                cost_amount=Decimal("0"),
+                cost_basis="broker_reported_zero_cost",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(12),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="sell",
+                filled_qty=Decimal("10"),
+                avg_fill_price=Decimal("110"),
+                cost_amount=Decimal("0"),
+                cost_basis="broker_reported_zero_cost",
+            ),
+        ]
+    )
+    cost_bucket = _bucket(
+        [
+            RuntimeLedgerFill(
+                executed_at=_ts(1),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="buy",
+                filled_qty=Decimal("10"),
+                avg_fill_price=Decimal("100"),
+                cost_amount=Decimal("7.50"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(12),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="sell",
+                filled_qty=Decimal("10"),
+                avg_fill_price=Decimal("110"),
+                cost_amount=Decimal("7.50"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+        ]
+    )
+
+    assert no_cost_bucket.gross_strategy_pnl == Decimal("100")
+    assert no_cost_bucket.net_strategy_pnl_after_costs == Decimal("100")
+    assert cost_bucket.gross_strategy_pnl == Decimal("100")
+    assert cost_bucket.net_strategy_pnl_after_costs == Decimal("85.00")
+    assert (
+        cost_bucket.post_cost_expectancy_bps != no_cost_bucket.post_cost_expectancy_bps
+    )
+
+
+def test_post_cost_expectancy_is_notional_weighted_across_closed_trips() -> None:
+    bucket = _bucket(
+        [
+            RuntimeLedgerFill(
+                executed_at=_ts(1),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="buy",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                cost_amount=Decimal("0"),
+                cost_basis="broker_reported_zero_cost",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(2),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="sell",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("101"),
+                cost_amount=Decimal("0"),
+                cost_basis="broker_reported_zero_cost",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(3),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="buy",
+                filled_qty=Decimal("10"),
+                avg_fill_price=Decimal("100"),
+                cost_amount=Decimal("0"),
+                cost_basis="broker_reported_zero_cost",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(4),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="sell",
+                filled_qty=Decimal("10"),
+                avg_fill_price=Decimal("102"),
+                cost_amount=Decimal("0"),
+                cost_basis="broker_reported_zero_cost",
+            ),
+        ]
+    )
+    arithmetic_average_bps = (
+        (Decimal("1") / Decimal("201")) * Decimal("10000")
+        + (Decimal("20") / Decimal("2020")) * Decimal("10000")
+    ) / Decimal("2")
+
+    assert bucket.filled_notional == Decimal("2221")
+    assert bucket.net_strategy_pnl_after_costs == Decimal("21")
+    _assert_decimal_close(
+        bucket.post_cost_expectancy_bps,
+        (Decimal("21") / Decimal("2221")) * Decimal("10000"),
+    )
+    assert bucket.post_cost_expectancy_bps != arithmetic_average_bps
+
+
+def test_positions_carry_across_bucket_boundaries() -> None:
+    buckets = build_runtime_ledger_buckets(
+        [
+            RuntimeLedgerFill(
+                executed_at=_ts(1),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="buy",
+                filled_qty=Decimal("10"),
+                avg_fill_price=Decimal("100"),
+                cost_amount=Decimal("1"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(35),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="sell",
+                filled_qty=Decimal("10"),
+                avg_fill_price=Decimal("110"),
+                cost_amount=Decimal("2"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+        ],
+        bucket_ranges=[(_ts(), _ts(30)), (_ts(30), _ts(60))],
+    )
+
+    assert buckets[0].closed_trade_count == 0
+    assert "unclosed_position" in buckets[0].blockers
+    assert buckets[0].post_cost_expectancy_bps is None
+    assert buckets[1].blockers == []
+    assert buckets[1].closed_trade_count == 1
+    assert buckets[1].filled_notional == Decimal("2100")
+    assert buckets[1].net_strategy_pnl_after_costs == Decimal("97")
+    _assert_decimal_close(
+        buckets[1].post_cost_expectancy_bps,
+        (Decimal("97") / Decimal("2100")) * Decimal("10000"),
+    )
+
+
+def test_tca_shortfall_rows_do_not_count_as_strategy_pnl() -> None:
+    bucket = _bucket(
+        [
+            {
+                "computed_at": _ts(5),
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "shortfall_notional": "-120.50",
+                "post_cost_expectancy_bps": "32.5",
+                "post_cost_expectancy_basis": "tca_shortfall_proxy",
+                "filled_notional": "10000",
+            }
+        ]
+    )
+
+    assert "tca_shortfall_not_runtime_pnl" in bucket.blockers
+    assert "runtime_fills_missing" in bucket.blockers
+    assert bucket.filled_notional == Decimal("0")
+    assert bucket.net_strategy_pnl_after_costs == Decimal("0")
+    assert bucket.post_cost_expectancy_bps is None
+
+
+def test_invalid_bucket_range_is_rejected_before_profit_proof() -> None:
+    naive_start = _ts().replace(tzinfo=None)
+
+    with pytest.raises(ValueError, match="bucket_end_must_be_after_bucket_start"):
+        build_runtime_ledger_buckets(
+            [],
+            bucket_ranges=[(naive_start, naive_start)],
+        )
+
+
+def test_grouped_buckets_preserve_runtime_identity_fields() -> None:
+    buckets = build_runtime_ledger_buckets(
+        [
+            RuntimeLedgerFill(
+                executed_at=_ts(1),
+                account_label="paper",
+                strategy_id="strategy-a",
+                symbol="NVDA",
+                side="buy",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                cost_amount=Decimal("0.10"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(2),
+                account_label="paper",
+                strategy_id="strategy-a",
+                symbol="NVDA",
+                side="sell",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("101"),
+                cost_amount=Decimal("0.10"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(3),
+                account_label="paper",
+                strategy_id="strategy-b",
+                symbol="AAPL",
+                side="buy",
+                filled_qty=Decimal("2"),
+                avg_fill_price=Decimal("50"),
+                cost_amount=Decimal("0"),
+                cost_basis="broker_reported_zero_cost",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(4),
+                account_label="paper",
+                strategy_id="strategy-b",
+                symbol="AAPL",
+                side="sell",
+                filled_qty=Decimal("2"),
+                avg_fill_price=Decimal("51"),
+                cost_amount=Decimal("0"),
+                cost_basis="broker_reported_zero_cost",
+            ),
+        ],
+        bucket_ranges=[(_ts(), _ts(60))],
+        group_by=("strategy_id", "symbol"),
+    )
+
+    assert [(bucket.strategy_id, bucket.symbol) for bucket in buckets] == [
+        ("strategy-a", "NVDA"),
+        ("strategy-b", "AAPL"),
+    ]
+    assert all(bucket.account_label == "paper" for bucket in buckets)
+    assert all(bucket.blockers == [] for bucket in buckets)
+    assert [bucket.net_strategy_pnl_after_costs for bucket in buckets] == [
+        Decimal("0.80"),
+        Decimal("2"),
+    ]
+
+
+def test_reversal_closes_long_then_realizes_short_pnl_after_costs() -> None:
+    bucket = _bucket(
+        [
+            RuntimeLedgerFill(
+                executed_at=_ts(1),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="buy",
+                filled_qty=Decimal("5"),
+                avg_fill_price=Decimal("100"),
+                cost_amount=Decimal("0.50"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(2),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="buy",
+                filled_qty=Decimal("5"),
+                avg_fill_price=Decimal("120"),
+                cost_amount=Decimal("0.50"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(3),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="sell",
+                filled_qty=Decimal("12"),
+                avg_fill_price=Decimal("130"),
+                cost_amount=Decimal("1.20"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(4),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="buy_to_cover",
+                filled_qty=Decimal("2"),
+                avg_fill_price=Decimal("120"),
+                cost_amount=Decimal("0.20"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+        ]
+    )
+
+    assert bucket.blockers == []
+    assert bucket.closed_trade_count == 2
+    assert bucket.open_position_count == 0
+    assert bucket.filled_notional == Decimal("2900")
+    assert bucket.gross_strategy_pnl == Decimal("220")
+    assert bucket.cost_amount == Decimal("2.40")
+    assert bucket.net_strategy_pnl_after_costs == Decimal("217.60")
+    _assert_decimal_close(
+        bucket.post_cost_expectancy_bps,
+        (Decimal("217.60") / Decimal("2900")) * Decimal("10000"),
+    )
+
+
+def test_invalid_runtime_fill_fields_fail_closed() -> None:
+    bucket = _bucket(
+        [
+            {
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "1",
+                "avg_fill_price": "100",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            },
+            {
+                "executed_at": "not-a-date",
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "1",
+                "avg_fill_price": "100",
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_zero_cost",
+            },
+            {
+                "executed_at": _ts(5),
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "hold",
+                "filled_qty": "not-a-number",
+                "avg_fill_price": "NaN",
+                "filled_notional": "Infinity",
+                "cost_amount": "Infinity",
+                "cost_basis": "broker_reported_commission_and_fees",
+            },
+        ]
+    )
+
+    assert bucket.fill_count == 0
+    assert "side_missing_or_invalid" in bucket.blockers
+    assert "filled_qty_missing_or_non_positive" in bucket.blockers
+    assert "fill_price_missing" in bucket.blockers
+    assert "filled_notional_missing" in bucket.blockers
+    assert "explicit_cost_missing" in bucket.blockers
+    assert "runtime_fills_missing" in bucket.blockers

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -32,7 +32,14 @@ from app.trading.runtime_window_import import (
 
 def _runtime_pnl_basis() -> dict[str, object]:
     return {
-        "post_cost_expectancy_basis": "realized_strategy_pnl",
+        "post_cost_expectancy_basis": "realized_strategy_pnl_after_explicit_costs",
+        "post_cost_promotion_eligible": True,
+    }
+
+
+def _simulation_report_pnl_basis() -> dict[str, object]:
+    return {
+        "post_cost_expectancy_basis": "simulation_report_net_pnl",
         "post_cost_promotion_eligible": True,
     }
 
@@ -340,6 +347,70 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(decision.allowed, True)
         self.assertEqual(
             decision.reason_summary, "runtime_evidence_thresholds_satisfied"
+        )
+
+    def test_persist_observed_runtime_windows_blocks_live_simulation_report_pnl(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    40,
+                ),
+                (
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 30, tzinfo=timezone.utc),
+                    40,
+                ),
+            ],
+            decision_times=[
+                datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 15, 5, tzinfo=timezone.utc),
+            ],
+            execution_times=[
+                datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
+            ],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("4"),
+                    "post_cost_expectancy_bps": Decimal("8"),
+                    **_simulation_report_pnl_basis(),
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("5"),
+                    "post_cost_expectancy_bps": Decimal("8"),
+                    **_simulation_report_pnl_basis(),
+                },
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        with self.session_local() as session:
+            summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-live-simulation-report-pnl",
+                candidate_id="cand-sim-report",
+                hypothesis_id="H-CONT-01",
+                observed_stage="live",
+                strategy_family="intraday_continuation",
+                source_manifest_ref="config/trading/hypotheses/h-cont-01.json",
+                buckets=buckets,
+            )
+
+        self.assertEqual(summary["promotion_allowed"], False)
+        self.assertEqual(
+            summary["post_cost_basis_counts"], {"simulation_report_net_pnl": 2}
+        )
+        self.assertIn(
+            "runtime_ledger_pnl_basis_missing",
+            summary["promotion_blocking_reasons"],
         )
 
     def test_persist_observed_runtime_windows_blocks_tca_proxy_expectancy(self) -> None:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -2174,17 +2174,16 @@ class TestTradingPipeline(TestCase):
             return _market_context_bundle(symbol=symbol), None
 
         pipeline._fetch_market_context = _fetch  # type: ignore[method-assign]
-        now = datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc)
-        pipeline.state.last_market_context_checked_at = datetime(
-            2026, 3, 26, 13, 29, 45
-        )
+        now = datetime.now(timezone.utc)
+        pipeline.state.last_market_context_checked_at = now - timedelta(seconds=15)
 
         self.assertTrue(pipeline._market_context_refresh_recent(now))
         pipeline._refresh_market_context_for_proof_floor()
         self.assertEqual(fetch_calls, [])
 
+        now = datetime.now(timezone.utc)
         pipeline.state.last_market_context_checked_at = now - timedelta(seconds=60)
-        pipeline.state.last_market_context_as_of = datetime(2026, 3, 26, 13, 29, 30)
+        pipeline.state.last_market_context_as_of = now - timedelta(seconds=30)
         pipeline.state.last_market_context_freshness_seconds = 30
         pipeline.state.market_context_alert_active = False
         pipeline._refresh_market_context_for_proof_floor()
@@ -7597,7 +7596,7 @@ class TestTradingPipeline(TestCase):
                 "0.03",
             )
             self.assertEqual(updated_decision.params.get("execution_seconds"), 180)
-            self.assertEqual(payload.get("adjusted_qty"), "5")
+            self.assertEqual(Decimal(str(payload.get("adjusted_qty"))), Decimal("5"))
         finally:
             config.settings.trading_runtime_uncertainty_degrade_qty_multipliers_by_regime = original[
                 "qty_multipliers"


### PR DESCRIPTION
## Summary

- Added a DB-agnostic Torghut runtime ledger primitive that computes realized post-cost strategy PnL from runtime fills, explicit costs, and closed round trips.
- Refactored runtime-window imports to emit `realized_strategy_pnl_after_explicit_costs` basis rows from the ledger instead of local ad hoc FIFO PnL math.
- Tightened live runtime promotion gates so simulation-report net PnL cannot satisfy live promotion proof without runtime-ledger PnL basis.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen pytest --cov --cov-branch --cov-fail-under=0 --cov-report=xml tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_trading_pipeline.py::TestTradingPipeline::test_runtime_uncertainty_gate_degrade_uses_regime_profile tests/test_trading_pipeline.py::TestTradingPipeline::test_simple_pipeline_market_context_refresh_skips_recent_or_fresh_state -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen ruff check app/trading/runtime_ledger.py app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/trading/runtime_ledger.py app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_trading_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
