### PR TITLE
chore(torghut): promote image c54b708d

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-440-g99ba04b40
+              value: v0.571.1-454-gc54b708d7
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 99ba04b40dfd137aec682e19adcb91f8c98492b7
+              value: c54b708d7c580e384a89d60d8915401b05047cb1
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-440-g99ba04b40
+              value: v0.571.1-454-gc54b708d7
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 99ba04b40dfd137aec682e19adcb91f8c98492b7
+              value: c54b708d7c580e384a89d60d8915401b05047cb1
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -75,7 +75,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+                  value: sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-21T09:33:16Z"
+        client.knative.dev/updateTimestamp: "2026-05-21T16:20:00Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
           ports:
             - name: http1
               containerPort: 8181
@@ -499,11 +499,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-440-g99ba04b40
+              value: v0.571.1-454-gc54b708d7
             - name: TORGHUT_COMMIT
-              value: 99ba04b40dfd137aec682e19adcb91f8c98492b7
+              value: c54b708d7c580e384a89d60d8915401b05047cb1
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+              value: sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-21T09:33:16Z"
+        client.knative.dev/updateTimestamp: "2026-05-21T16:20:00Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
           ports:
             - name: http1
               containerPort: 8181
@@ -320,11 +320,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-440-g99ba04b40
+              value: v0.571.1-454-gc54b708d7
             - name: TORGHUT_COMMIT
-              value: 99ba04b40dfd137aec682e19adcb91f8c98492b7
+              value: c54b708d7c580e384a89d60d8915401b05047cb1
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+              value: sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -132,7 +132,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c6204bc71440c56a085a13221b7389ce1eedb2dc0aed760ea1a0f87a88ccb69d
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `c54b708d7c580e384a89d60d8915401b05047cb1`
- Image tag: `c54b708d`
- Image digest: `sha256:4cdd7760c48ef5a720c53c224c22789aa7eff96ba993910483b9c0153e6817fd`