### PR TITLE
feat(torghut): rank paper probation candidates

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -8026,6 +8026,21 @@ def _candidate_board_net_pnl(row: Mapping[str, Any]) -> Decimal:
     return _decimal(row.get("net_pnl_per_day"))
 
 
+def _candidate_board_lower_bound_net_pnl(row: Mapping[str, Any]) -> Decimal:
+    values = [
+        _decimal(row.get(key))
+        for key in (
+            "net_pnl_per_day",
+            "market_impact_stress_net_pnl_per_day",
+            "delay_adjusted_depth_stress_net_pnl_per_day",
+            "double_oos_cost_shock_net_pnl_per_day",
+            "double_oos_net_pnl_per_day",
+        )
+        if _string(row.get(key))
+    ]
+    return min(values) if values else Decimal("0")
+
+
 def _candidate_board_best_executed_candidate(
     rows: Sequence[Mapping[str, Any]],
 ) -> dict[str, Any] | None:
@@ -8067,6 +8082,80 @@ def _candidate_board_closest_promotion_candidate(
         reverse=True,
     )
     return replayed_rows[0]
+
+
+def _candidate_board_paper_probation_candidate(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    target: Decimal,
+) -> dict[str, Any] | None:
+    candidates = [
+        dict(row)
+        for row in rows
+        if bool(row.get("has_replay_evidence"))
+        and not bool(row.get("oracle_passed"))
+        and _candidate_board_activity_count(row) > 0
+        and _string(row.get("candidate_id"))
+        and _string(row.get("hypothesis_id"))
+        and _string(row.get("runtime_family"))
+        and _string(row.get("runtime_strategy_name"))
+    ]
+    if not candidates:
+        return None
+
+    def rank(row: Mapping[str, Any]) -> tuple[Any, ...]:
+        lower_bound = _candidate_board_lower_bound_net_pnl(row)
+        target_shortfall = max(target - lower_bound, Decimal("0"))
+        return (
+            lower_bound > 0,
+            _candidate_board_int_field(row, "filled_order_count") > 0,
+            _candidate_board_int_field(row, "submitted_order_count") > 0,
+            -target_shortfall,
+            lower_bound,
+            _decimal(row.get("active_day_ratio")),
+            _decimal(row.get("positive_day_ratio")),
+            -_decimal(row.get("best_day_share"), default="1"),
+            -_decimal(row.get("worst_day_loss")),
+            -_candidate_board_oracle_blocker_count(row),
+            _candidate_board_activity_count(row),
+            -_rank_sort_value(row.get("rank")),
+            _string(row.get("candidate_spec_id")),
+        )
+
+    candidates.sort(key=rank, reverse=True)
+    candidate = dict(candidates[0])
+    lower_bound = _candidate_board_lower_bound_net_pnl(candidate)
+    final_promotion_blockers = [
+        _string(blocker)
+        for blocker in cast(Sequence[Any], candidate.get("blockers") or ())
+        if _string(blocker)
+    ]
+    if not final_promotion_blockers:
+        final_promotion_blockers.append("final_promotion_requires_runtime_governance")
+    candidate.update(
+        {
+            "candidate_selection": "oracle_recommended_paper_probation",
+            "paper_probation_tier": "paper_probation",
+            "paper_probation_authorized": True,
+            "probation_allowed": True,
+            "paper_probation_authorization_scope": "evidence_collection_only",
+            "evidence_collection_stage": "paper",
+            "probation_reason": "runtime_evidence_collection_only",
+            "selection_reason": "target_met_but_oracle_blocked"
+            if bool(candidate.get("target_met"))
+            else "closest_lower_bound_economics_below_target",
+            "selected_by": "candidate_board_paper_probation_candidate",
+            "probation_lower_bound_net_pnl_per_day": str(lower_bound),
+            "probation_target_shortfall": str(max(target - lower_bound, Decimal("0"))),
+            "promotion_allowed": False,
+            "promotion_gate": "existing_runtime_governance_fail_closed",
+            "final_promotion_authorized": False,
+            "final_promotion_allowed": False,
+            "promotion_blockers": list(dict.fromkeys(final_promotion_blockers)),
+            "final_promotion_blockers": list(dict.fromkeys(final_promotion_blockers)),
+        }
+    )
+    return candidate
 
 
 def _candidate_board_status_digest(rows: Sequence[Mapping[str, Any]]) -> str:
@@ -8264,35 +8353,65 @@ def _candidate_board_runtime_window_import_plan(
         if dedupe_key in seen_keys:
             continue
         seen_keys.add(dedupe_key)
-        targets.append(
-            {
-                "candidate_spec_id": candidate_spec_id,
-                "candidate_id": candidate_id,
-                "hypothesis_id": hypothesis_id,
-                "observed_stage": "paper",
-                "strategy_family": strategy_family,
-                "strategy_name": strategy_name,
-                "source_kind": "paper_runtime_observed",
-                "source_manifest_ref": _candidate_board_hypothesis_manifest_ref(
-                    hypothesis_id
-                ),
-                "dataset_snapshot_ref": _string(row.get("dataset_snapshot_id")),
-                "artifact_refs": [
-                    _string(ref)
-                    for ref in cast(
-                        Sequence[Any], row.get("replay_artifact_refs") or ()
-                    )
-                    if _string(ref)
-                ],
-                "candidate_blockers": [
-                    _string(blocker)
-                    for blocker in cast(Sequence[Any], row.get("blockers") or ())
-                    if _string(blocker)
-                ],
-                "handoff": "runtime_window_import_only",
-                "promotion_gate": "existing_runtime_governance_fail_closed",
-            }
-        )
+        target = {
+            "candidate_spec_id": candidate_spec_id,
+            "candidate_id": candidate_id,
+            "hypothesis_id": hypothesis_id,
+            "observed_stage": "paper",
+            "strategy_family": strategy_family,
+            "strategy_name": strategy_name,
+            "source_kind": "paper_runtime_observed",
+            "source_manifest_ref": _candidate_board_hypothesis_manifest_ref(
+                hypothesis_id
+            ),
+            "dataset_snapshot_ref": _string(row.get("dataset_snapshot_id")),
+            "artifact_refs": [
+                _string(ref)
+                for ref in cast(Sequence[Any], row.get("replay_artifact_refs") or ())
+                if _string(ref)
+            ],
+            "candidate_blockers": [
+                _string(blocker)
+                for blocker in cast(Sequence[Any], row.get("blockers") or ())
+                if _string(blocker)
+            ],
+            "handoff": "runtime_window_import_only",
+            "promotion_gate": "existing_runtime_governance_fail_closed",
+        }
+        if bool(row.get("paper_probation_authorized")):
+            target.update(
+                {
+                    "candidate_selection": _string(row.get("candidate_selection")),
+                    "paper_probation_authorized": True,
+                    "paper_probation_authorization_scope": _string(
+                        row.get("paper_probation_authorization_scope")
+                    ),
+                    "evidence_collection_stage": _string(
+                        row.get("evidence_collection_stage")
+                    ),
+                    "probation_allowed": bool(row.get("probation_allowed")),
+                    "probation_reason": _string(row.get("probation_reason")),
+                    "selection_reason": _string(row.get("selection_reason")),
+                    "selected_by": _string(row.get("selected_by")),
+                    "probation_lower_bound_net_pnl_per_day": _string(
+                        row.get("probation_lower_bound_net_pnl_per_day")
+                    ),
+                    "probation_target_shortfall": _string(
+                        row.get("probation_target_shortfall")
+                    ),
+                    "promotion_allowed": False,
+                    "final_promotion_authorized": False,
+                    "final_promotion_allowed": False,
+                    "final_promotion_blockers": [
+                        _string(blocker)
+                        for blocker in cast(
+                            Sequence[Any], row.get("final_promotion_blockers") or ()
+                        )
+                        if _string(blocker)
+                    ],
+                }
+            )
+        targets.append(target)
 
     return {
         "schema_version": "torghut.runtime-window-import-plan.v1",
@@ -8479,6 +8598,21 @@ def _candidate_board_payload(
                 "double_oos_cost_shock_net_pnl_per_day": _candidate_board_decimal_field(
                     scorecard, "double_oos_cost_shock_net_pnl_per_day"
                 ),
+                "active_day_ratio": _candidate_board_decimal_field(
+                    scorecard, "active_day_ratio"
+                ),
+                "positive_day_ratio": _candidate_board_decimal_field(
+                    scorecard, "positive_day_ratio"
+                ),
+                "best_day_share": _candidate_board_decimal_field(
+                    scorecard, "best_day_share"
+                ),
+                "worst_day_loss": _candidate_board_decimal_field(
+                    scorecard, "worst_day_loss"
+                ),
+                "avg_filled_notional_per_day": _candidate_board_decimal_field(
+                    scorecard, "avg_filled_notional_per_day"
+                ),
                 "market_impact_proof": market_impact_proof,
                 "regime_specialist_validation": regime_specialist_validation,
                 "rejected_signal_outcome_learning": rejected_signal_summary,
@@ -8501,12 +8635,9 @@ def _candidate_board_payload(
     best_research_candidate = rows[0] if rows else None
     best_executed_candidate = _candidate_board_best_executed_candidate(rows)
     closest_promotion_candidate = _candidate_board_closest_promotion_candidate(rows)
-    paper_probation_candidate = (
-        closest_promotion_candidate
-        if closest_promotion_candidate is not None
-        and bool(closest_promotion_candidate.get("target_met"))
-        and not bool(closest_promotion_candidate.get("oracle_passed"))
-        else None
+    paper_probation_candidate = _candidate_board_paper_probation_candidate(
+        rows,
+        target=target,
     )
     promotion_ready = _boolish(promotion_readiness.get("promotable"))
     promotion_subject = _candidate_board_portfolio_promotion_subject(

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -6162,7 +6162,14 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             board["closest_promotion_candidate"]["candidate_id"],
             "chip-paper-microbar-composite@execution-proof",
         )
-        self.assertIsNone(board["paper_probation_candidate"])
+        self.assertEqual(
+            board["paper_probation_candidate"]["candidate_id"],
+            "chip-paper-microbar-composite@execution-proof",
+        )
+        self.assertEqual(
+            board["paper_probation_candidate"]["selection_reason"],
+            "closest_lower_bound_economics_below_target",
+        )
         self.assertEqual(board["best_executed_candidate"]["decision_count"], 7)
         self.assertEqual(board["best_executed_candidate"]["submitted_order_count"], 7)
         self.assertEqual(board["best_executed_candidate"]["filled_order_count"], 7)
@@ -6238,8 +6245,27 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             board["paper_probation_candidate"]["candidate_id"], "cand-paper-probation"
         )
+        probation_candidate = board["paper_probation_candidate"]
         self.assertEqual(
-            board["paper_probation_candidate"], board["closest_promotion_candidate"]
+            probation_candidate["candidate_selection"],
+            "oracle_recommended_paper_probation",
+        )
+        self.assertTrue(probation_candidate["paper_probation_authorized"])
+        self.assertTrue(probation_candidate["probation_allowed"])
+        self.assertEqual(
+            probation_candidate["paper_probation_authorization_scope"],
+            "evidence_collection_only",
+        )
+        self.assertEqual(probation_candidate["evidence_collection_stage"], "paper")
+        self.assertEqual(
+            probation_candidate["selection_reason"], "target_met_but_oracle_blocked"
+        )
+        self.assertFalse(probation_candidate["promotion_allowed"])
+        self.assertFalse(probation_candidate["final_promotion_authorized"])
+        self.assertFalse(probation_candidate["final_promotion_allowed"])
+        self.assertIn(
+            "delay_adjusted_depth_tail_coverage_passed_failed",
+            probation_candidate["final_promotion_blockers"],
         )
         plan = board["runtime_window_import_plan"]
         self.assertEqual(
@@ -6261,6 +6287,130 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             target["promotion_gate"], "existing_runtime_governance_fail_closed"
         )
+        self.assertTrue(target["paper_probation_authorized"])
+        self.assertEqual(target["evidence_collection_stage"], "paper")
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_authorized"])
+        self.assertFalse(target["final_promotion_allowed"])
+        self.assertEqual(target["selection_reason"], "target_met_but_oracle_blocked")
+
+    def test_candidate_board_paper_probation_prefers_lower_bound_economics(
+        self,
+    ) -> None:
+        weak_spec = self._candidate_spec("spec-weak-probation")
+        close_spec = self._candidate_spec("spec-close-probation")
+        weak_evidence = runner.CandidateEvidenceBundle(
+            schema_version="torghut.candidate-evidence-bundle.v1",
+            evidence_bundle_id="ev-weak-probation",
+            candidate_id="cand-weak-probation",
+            candidate_spec_id=weak_spec.candidate_spec_id,
+            dataset_snapshot_id="snapshot-weak-probation",
+            feature_spec_hash="hash-weak-probation",
+            code_commit="commit-test",
+            replay_artifact_refs=("weak-probation.json",),
+            objective_scorecard={
+                "net_pnl_per_day": "125",
+                "target_met": False,
+                "oracle_passed": False,
+                "active_day_ratio": "1",
+                "positive_day_ratio": "1",
+                "best_day_share": "0.10",
+                "worst_day_loss": "0",
+                "trade_decision_count": 12,
+                "orders_submitted_count": 12,
+                "trade_count": 12,
+                "profit_target_oracle": {
+                    "blockers": ["min_daily_net_pnl_failed"],
+                },
+            },
+            fold_metrics=(),
+            stress_metrics=(),
+            cost_calibration={"status": "provisional", "source": "paper_runtime"},
+            null_comparator={},
+            promotion_readiness={},
+        )
+        close_evidence = runner.CandidateEvidenceBundle(
+            schema_version="torghut.candidate-evidence-bundle.v1",
+            evidence_bundle_id="ev-close-probation",
+            candidate_id="cand-close-probation",
+            candidate_spec_id=close_spec.candidate_spec_id,
+            dataset_snapshot_id="snapshot-close-probation",
+            feature_spec_hash="hash-close-probation",
+            code_commit="commit-test",
+            replay_artifact_refs=("close-probation.json",),
+            objective_scorecard={
+                "net_pnl_per_day": "480",
+                "market_impact_stress_net_pnl_per_day": "460",
+                "target_met": False,
+                "oracle_passed": False,
+                "active_day_ratio": "0.82",
+                "positive_day_ratio": "0.68",
+                "best_day_share": "0.32",
+                "worst_day_loss": "40",
+                "trade_decision_count": 8,
+                "orders_submitted_count": 8,
+                "trade_count": 8,
+                "profit_target_oracle": {
+                    "blockers": [
+                        "min_daily_net_pnl_failed",
+                        "delay_adjusted_depth_stress_net_pnl_per_day_failed",
+                    ],
+                },
+            },
+            fold_metrics=(),
+            stress_metrics=(),
+            cost_calibration={"status": "provisional", "source": "paper_runtime"},
+            null_comparator={},
+            promotion_readiness={},
+        )
+
+        board = runner._candidate_board_payload(
+            epoch_id="epoch-paper-probation-economics",
+            output_dir=Path("/tmp/epoch-paper-probation-economics"),
+            target=Decimal("500"),
+            candidate_specs=(weak_spec, close_spec),
+            candidate_selection={
+                "rows": [
+                    {
+                        "candidate_spec_id": weak_spec.candidate_spec_id,
+                        "selected_for_replay": True,
+                    },
+                    {
+                        "candidate_spec_id": close_spec.candidate_spec_id,
+                        "selected_for_replay": True,
+                    },
+                ]
+            },
+            pre_replay_proposal_rows=(
+                {
+                    "candidate_spec_id": weak_spec.candidate_spec_id,
+                    "rank": 1,
+                    "proposal_score": "9.0",
+                },
+                {
+                    "candidate_spec_id": close_spec.candidate_spec_id,
+                    "rank": 2,
+                    "proposal_score": "8.0",
+                },
+            ),
+            proposal_rows=(),
+            evidence_bundles=(weak_evidence, close_evidence),
+            portfolio=None,
+            promotion_readiness={"promotable": False},
+            runtime_closure={},
+        )
+
+        probation_candidate = board["paper_probation_candidate"]
+        self.assertEqual(probation_candidate["candidate_id"], "cand-close-probation")
+        self.assertEqual(
+            probation_candidate["selection_reason"],
+            "closest_lower_bound_economics_below_target",
+        )
+        self.assertEqual(
+            probation_candidate["probation_lower_bound_net_pnl_per_day"], "460"
+        )
+        self.assertEqual(probation_candidate["probation_target_shortfall"], "40")
+        self.assertFalse(probation_candidate["final_promotion_allowed"])
 
     def test_candidate_board_runtime_window_plan_dedupes_and_blocks_incomplete_targets(
         self,


### PR DESCRIPTION
## Summary

- Added a candidate-board paper-probation selector that ranks replayed, runtime-identifiable candidates by lower-bound post-cost economics, fill/order evidence, risk-shape metrics, and repairability.
- Marked paper probation as evidence collection only with explicit `promotion_allowed=false`, `final_promotion_authorized=false`, and fail-closed promotion blockers.
- Mirrored paper-probation authorization fields into runtime-window import targets so downstream handoffs can collect paper evidence without treating the candidate as finally promoted.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_candidate_board_surfaces_paper_probation_without_promotion tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_candidate_board_paper_probation_prefers_lower_bound_economics tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_candidate_board_separates_research_rank_from_executed_candidate tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_candidate_board_runtime_window_plan_dedupes_and_blocks_incomplete_targets -q`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
