### PR TITLE
feat(torghut): carry paper probation handoff metadata

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -185,6 +185,34 @@ def _string_list(value: Any) -> list[str]:
     ]
 
 
+def _mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    mapping = cast(Mapping[Any, Any], value)
+    return {str(key): item for key, item in mapping.items()}
+
+
+def _paper_probation_blocking_reasons(runtime_payload: Mapping[str, Any]) -> list[str]:
+    target_metadata = _mapping(runtime_payload.get("target_metadata"))
+    if not target_metadata:
+        return []
+
+    reasons: list[str] = []
+    paper_probation_authorized = _observation_bool(
+        target_metadata.get("paper_probation_authorized")
+    )
+    evidence_collection_stage = _text(target_metadata.get("evidence_collection_stage"))
+    if paper_probation_authorized is True and evidence_collection_stage == "paper":
+        reasons.append("paper_probation_evidence_collection_only")
+    if _observation_bool(target_metadata.get("promotion_allowed")) is False:
+        reasons.append("candidate_board_promotion_not_allowed")
+    if _observation_bool(target_metadata.get("final_promotion_authorized")) is False:
+        reasons.append("final_promotion_not_authorized")
+    if _observation_bool(target_metadata.get("final_promotion_allowed")) is False:
+        reasons.append("final_promotion_not_allowed")
+    return reasons
+
+
 def _delay_adjusted_depth_stress_blocking_reasons(
     *,
     manifest: HypothesisManifest,
@@ -842,6 +870,7 @@ def persist_observed_runtime_windows(
         dict.fromkeys(
             [
                 *promotion_blocking_reasons,
+                *_paper_probation_blocking_reasons(runtime_payload),
                 *_delay_adjusted_depth_stress_blocking_reasons(
                     manifest=manifest,
                     runtime_payload=runtime_payload,

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -57,6 +57,14 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--source-kind", default="")
     parser.add_argument("--dataset-snapshot-ref", default="")
     parser.add_argument("--artifact-ref", action="append", default=[])
+    parser.add_argument(
+        "--target-metadata-json",
+        default="",
+        help=(
+            "JSON object copied from the candidate-board runtime-window target. "
+            "Used for evidence-collection-only paper probation handoffs."
+        ),
+    )
     parser.add_argument("--delay-adjusted-depth-stress-report-ref", default="")
     parser.add_argument("--dependency-quorum-decision", default="allow")
     parser.add_argument("--continuity-ok", default="true")
@@ -82,6 +90,19 @@ def _as_mapping(value: Any) -> dict[str, Any]:
         if isinstance(value, Mapping)
         else {}
     )
+
+
+def _parse_target_metadata(raw: str) -> dict[str, Any]:
+    text = str(raw or "").strip()
+    if not text:
+        return {}
+    try:
+        payload = json.loads(text)
+    except Exception as exc:
+        raise RuntimeError("target_metadata_json_invalid") from exc
+    if not isinstance(payload, Mapping):
+        raise RuntimeError("target_metadata_json_not_mapping")
+    return {str(key): value for key, value in payload.items()}
 
 
 def _decimal_or_none(value: Any) -> Decimal | None:
@@ -367,7 +388,9 @@ def _source_activity_missing_summary(
     source_manifest_ref: str,
     source_kind: str,
     dataset_snapshot_ref: str | None,
+    target_metadata: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
+    metadata = _as_mapping(target_metadata)
     blocker = {
         "blocker": "runtime_window_source_activity_missing",
         "hypothesis_id": hypothesis_id,
@@ -421,6 +444,7 @@ def _source_activity_missing_summary(
             "window_start": window_start.isoformat(),
             "window_end": window_end.isoformat(),
             "dataset_snapshot_ref": dataset_snapshot_ref,
+            "target_metadata": metadata,
             "skip_reason": "runtime_window_source_activity_missing",
         },
     }
@@ -451,6 +475,9 @@ def main() -> int:
     dataset_snapshot_ref = (
         str(getattr(args, "dataset_snapshot_ref", "") or "").strip() or None
     )
+    target_metadata = _parse_target_metadata(
+        str(getattr(args, "target_metadata_json", "") or "")
+    )
     if not decisions and not executions and not tca_rows:
         summary = _source_activity_missing_summary(
             run_id=args.run_id,
@@ -465,6 +492,7 @@ def main() -> int:
             source_manifest_ref=args.source_manifest_ref.strip(),
             source_kind=args.source_kind.strip(),
             dataset_snapshot_ref=dataset_snapshot_ref,
+            target_metadata=target_metadata,
         )
         if args.json:
             print(json.dumps(summary, indent=2))
@@ -531,6 +559,7 @@ def main() -> int:
         "window_end": window_end.isoformat(),
         "artifact_refs": artifact_refs,
         "dataset_snapshot_ref": dataset_snapshot_ref,
+        "target_metadata": target_metadata,
         "report_post_cost_expectancy_bps": (
             str(report_post_cost_expectancy_bps)
             if report_post_cost_expectancy_bps is not None

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -42,6 +42,26 @@ DEFAULT_AUTORESEARCH_RUNTIME_WINDOW_STATUSES = (
     "no_profit_target_candidate",
     "selection_only",
 )
+RUNTIME_WINDOW_TARGET_METADATA_KEYS = (
+    "candidate_spec_id",
+    "candidate_selection",
+    "paper_probation_authorized",
+    "paper_probation_authorization_scope",
+    "evidence_collection_stage",
+    "probation_allowed",
+    "probation_reason",
+    "selection_reason",
+    "selected_by",
+    "probation_lower_bound_net_pnl_per_day",
+    "probation_target_shortfall",
+    "promotion_allowed",
+    "final_promotion_authorized",
+    "final_promotion_allowed",
+    "final_promotion_blockers",
+    "candidate_blockers",
+    "handoff",
+    "promotion_gate",
+)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -267,6 +287,8 @@ class RuntimeWindowImportTarget:
     source_manifest_ref: str
     source_kind: str
     delay_adjusted_depth_stress_report_ref: str
+    artifact_refs: tuple[str, ...] = ()
+    target_metadata: Mapping[str, Any] | None = None
 
 
 def _parse_runtime_window_target_spec(spec: str) -> dict[str, str]:
@@ -493,9 +515,45 @@ def _runtime_window_targets_from_plan(
                     "delay_adjusted_depth_stress_report_ref",
                     "runtime_window_delay_adjusted_depth_stress_report_ref",
                 ),
+                artifact_refs=_runtime_window_target_artifact_refs(payload),
+                target_metadata=_runtime_window_target_metadata(payload),
             )
         )
     return targets
+
+
+def _runtime_window_target_artifact_refs(payload: Mapping[str, Any]) -> tuple[str, ...]:
+    raw_refs = payload.get("artifact_refs")
+    if not isinstance(raw_refs, Sequence) or isinstance(
+        raw_refs, (str, bytes, bytearray)
+    ):
+        return ()
+    refs: list[str] = []
+    for item in raw_refs:
+        ref = _as_text(item)
+        if ref is not None and ref not in refs:
+            refs.append(ref)
+    return tuple(refs)
+
+
+def _runtime_window_target_metadata(payload: Mapping[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    for key in RUNTIME_WINDOW_TARGET_METADATA_KEYS:
+        if key not in payload:
+            continue
+        value = payload.get(key)
+        if value is None or value == "":
+            continue
+        metadata[key] = value
+    if bool(metadata.get("paper_probation_authorized")):
+        metadata.setdefault(
+            "paper_probation_authorization_scope", "evidence_collection_only"
+        )
+        metadata.setdefault("evidence_collection_stage", "paper")
+        metadata.setdefault("promotion_allowed", False)
+        metadata.setdefault("final_promotion_authorized", False)
+        metadata.setdefault("final_promotion_allowed", False)
+    return metadata
 
 
 def _runtime_window_autoresearch_statuses(args: argparse.Namespace) -> set[str]:
@@ -1013,6 +1071,15 @@ def _run_runtime_window_import_target(
         "true",
         "--json",
     ]
+    for artifact_ref in target.artifact_refs:
+        command.extend(["--artifact-ref", artifact_ref])
+    if target.target_metadata:
+        command.extend(
+            [
+                "--target-metadata-json",
+                json.dumps(dict(target.target_metadata), sort_keys=True),
+            ]
+        )
     dataset_snapshot_ref = (
         _as_text(target.dataset_snapshot_ref)
         or _as_text(runtime_manifest.get("dataset_snapshot_ref"))
@@ -1039,8 +1106,12 @@ def _run_runtime_window_import_target(
         "window_end": _utc_iso(window_end),
         "window_selection": window_selection,
         "hypothesis_id": target.hypothesis_id,
+        "candidate_id": candidate_id,
         "strategy_name": target.strategy_name,
         "account_label": target.account_label,
+        "source_kind": target.source_kind,
+        "artifact_refs": [str(manifest_path), *target.artifact_refs],
+        "target_metadata": dict(target.target_metadata or {}),
         "proof_status": "blocked" if proof_blockers else "ok",
         "proof_blockers": proof_blockers,
         "summary": payload,

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from decimal import Decimal
+import json
 from types import SimpleNamespace
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -18,6 +19,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _load_report_post_cost_expectancy_bps,
     _nonnegative_int,
     _parse_args,
+    _parse_target_metadata,
     _query_timestamps,
     _strategy_name_candidates,
     main,
@@ -118,6 +120,8 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "torghut-runtime-window-cand-1",
                 "--artifact-ref",
                 "s3://torghut-runtime/cand-1/report.json",
+                "--target-metadata-json",
+                '{"paper_probation_authorized":true}',
                 "--json",
             ],
         ):
@@ -126,7 +130,21 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(args.run_id, "run-1")
         self.assertEqual(args.dataset_snapshot_ref, "torghut-runtime-window-cand-1")
         self.assertEqual(args.artifact_ref, ["s3://torghut-runtime/cand-1/report.json"])
+        self.assertEqual(
+            args.target_metadata_json, '{"paper_probation_authorized":true}'
+        )
         self.assertEqual(args.json, True)
+
+    def test_parse_target_metadata_requires_json_mapping(self) -> None:
+        self.assertEqual(_parse_target_metadata(""), {})
+        self.assertEqual(
+            _parse_target_metadata('{"paper_probation_authorized": true}'),
+            {"paper_probation_authorized": True},
+        )
+        with self.assertRaisesRegex(RuntimeError, "target_metadata_json_invalid"):
+            _parse_target_metadata("{")
+        with self.assertRaisesRegex(RuntimeError, "target_metadata_json_not_mapping"):
+            _parse_target_metadata("[]")
 
     def test_main_requires_source_dsn(self) -> None:
         args = SimpleNamespace(
@@ -424,6 +442,100 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "intraday-tsmom-v1@paper",
                 "intraday-tsmom-v1",
             ],
+        )
+
+    def test_main_attaches_target_metadata_to_runtime_payload(self) -> None:
+        args = SimpleNamespace(
+            run_id="run-probation",
+            candidate_id="cand-paper-probation",
+            hypothesis_id="H-MICRO-01",
+            observed_stage="paper",
+            strategy_family="microstructure_breakout",
+            source_dsn="postgresql://example",
+            source_dsn_env="DB_DSN",
+            strategy_name="microbar-volume-continuation-long-top2-chip-v1",
+            account_label="TORGHUT_SIM",
+            window_start="2026-03-06T14:30:00Z",
+            window_end="2026-03-06T15:00:00Z",
+            bucket_minutes=30,
+            sample_minutes=5,
+            source_manifest_ref="config/trading/hypotheses/h-micro-01.json",
+            source_kind="paper_runtime_observed",
+            artifact_ref=[],
+            delay_adjusted_depth_stress_report_ref="",
+            dataset_snapshot_ref="runtime-probation-snapshot",
+            target_metadata_json=json.dumps(
+                {
+                    "paper_probation_authorized": True,
+                    "evidence_collection_stage": "paper",
+                    "promotion_allowed": False,
+                    "final_promotion_authorized": False,
+                }
+            ),
+            dependency_quorum_decision="allow",
+            continuity_ok="true",
+            drift_ok="true",
+            json=False,
+        )
+        fake_session = _FakeSession()
+        manifest = SimpleNamespace(
+            strategy_family="microstructure_breakout",
+            strategy_id="microbar_volume_continuation_long_top2_chip_v1@paper",
+            max_allowed_slippage_bps=Decimal("12"),
+        )
+
+        with (
+            patch(
+                "scripts.import_hypothesis_runtime_windows._parse_args",
+                return_value=args,
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.resolve_hypothesis_manifest",
+                return_value=(
+                    SimpleNamespace(path="config/trading/hypotheses/h-micro-01.json"),
+                    manifest,
+                ),
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows._query_timestamps",
+                return_value=(
+                    [datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+                    [datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+                    [],
+                ),
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.build_regular_session_buckets",
+                return_value=[],
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.build_observed_runtime_buckets",
+                return_value=[],
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.persist_observed_runtime_windows",
+                return_value={"run_id": "run-probation"},
+            ) as persist_windows,
+            patch(
+                "scripts.import_hypothesis_runtime_windows.SessionLocal",
+                return_value=fake_session,
+            ),
+            patch("builtins.print"),
+        ):
+            exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        runtime_payload = persist_windows.call_args.kwargs[
+            "runtime_observation_payload"
+        ]
+        self.assertEqual(
+            runtime_payload["target_metadata"],
+            {
+                "paper_probation_authorized": True,
+                "evidence_collection_stage": "paper",
+                "promotion_allowed": False,
+                "final_promotion_authorized": False,
+            },
         )
 
     def test_main_skips_persist_when_source_activity_is_empty(self) -> None:

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -459,6 +459,87 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         )
         self.assertEqual(targets[0].dataset_snapshot_ref, "snapshot-paper-probation")
 
+    def test_runtime_window_targets_from_candidate_board_plan_preserve_probation_handoff(
+        self,
+    ) -> None:
+        plan_path = Path(self.tmp_dir) / "candidate-board.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "runtime_window_import_plan": {
+                        "schema_version": "torghut.runtime-window-import-plan.v1",
+                        "targets": [
+                            {
+                                "candidate_spec_id": "spec-paper",
+                                "candidate_id": "cand-paper-probation",
+                                "hypothesis_id": "H-MICRO-01",
+                                "observed_stage": "paper",
+                                "strategy_family": "microstructure_breakout",
+                                "strategy_name": "microbar-volume-continuation-long-top2-chip-v1",
+                                "source_kind": "paper_runtime_observed",
+                                "source_manifest_ref": "config/trading/hypotheses/h-micro-01.json",
+                                "dataset_snapshot_ref": "snapshot-paper-probation",
+                                "artifact_refs": [
+                                    "proof/replay-summary.json",
+                                    "proof/replay-summary.json",
+                                    "",
+                                ],
+                                "candidate_selection": "oracle_recommended_paper_probation",
+                                "paper_probation_authorized": True,
+                                "paper_probation_authorization_scope": "evidence_collection_only",
+                                "evidence_collection_stage": "paper",
+                                "probation_allowed": True,
+                                "selection_reason": "best_lower_bound_candidate",
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "final_promotion_allowed": False,
+                                "final_promotion_blockers": [
+                                    "runtime_ledger_pnl_basis_missing"
+                                ],
+                            }
+                        ],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        args = SimpleNamespace(
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_targets_from_registry=False,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        targets = renewal._runtime_window_targets(args)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].artifact_refs, ("proof/replay-summary.json",))
+        self.assertEqual(
+            targets[0].target_metadata,
+            {
+                "candidate_spec_id": "spec-paper",
+                "candidate_selection": "oracle_recommended_paper_probation",
+                "paper_probation_authorized": True,
+                "paper_probation_authorization_scope": "evidence_collection_only",
+                "evidence_collection_stage": "paper",
+                "probation_allowed": True,
+                "selection_reason": "best_lower_bound_candidate",
+                "promotion_allowed": False,
+                "final_promotion_authorized": False,
+                "final_promotion_allowed": False,
+                "final_promotion_blockers": ["runtime_ledger_pnl_basis_missing"],
+            },
+        )
+
     def test_runtime_window_targets_from_latest_autoresearch_epoch(self) -> None:
         args = SimpleNamespace(
             runtime_window_autoresearch_status=[],
@@ -891,6 +972,100 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertIn("--dataset-snapshot-ref", command)
         self.assertIn("portfolio-profit-autoresearch-500-v1", command)
         self.assertNotIn("stale-empirical-dataset", command)
+
+    def test_runtime_window_import_passes_probation_metadata_and_artifacts(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-micro-01.json"
+        hypothesis_path.write_text(
+            json.dumps(
+                {
+                    "candidate_id": "cand-paper-probation",
+                    "dataset_snapshot_ref": "snapshot-paper-probation",
+                }
+            ),
+            encoding="utf-8",
+        )
+        plan_path = self.tmp_dir / "candidate-board.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "runtime_window_import_plan": {
+                        "targets": [
+                            {
+                                "candidate_id": "cand-paper-probation",
+                                "hypothesis_id": "H-MICRO-01",
+                                "observed_stage": "paper",
+                                "strategy_family": "microstructure_breakout",
+                                "strategy_name": "microbar-volume-continuation-long-top2-chip-v1",
+                                "source_manifest_ref": str(hypothesis_path),
+                                "dataset_snapshot_ref": "snapshot-paper-probation",
+                                "artifact_refs": ["proof/replay-summary.json"],
+                                "paper_probation_authorized": True,
+                                "evidence_collection_stage": "paper",
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "final_promotion_allowed": False,
+                            }
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        completed = SimpleNamespace(
+            stdout=json.dumps({"inserted_windows": 1, "promotion_decision": "blocked"})
+        )
+        args = SimpleNamespace(
+            runtime_window_import=True,
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_targets_from_latest_autoresearch=False,
+            runtime_window_targets_from_registry=False,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_start="2026-05-18T13:30:00Z",
+            runtime_window_end="2026-05-18T20:00:00Z",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with patch.object(
+            renewal.subprocess, "run", return_value=completed
+        ) as run_mock:
+            payload = renewal._run_runtime_window_import(
+                args=args,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                now=datetime(2026, 5, 18, 21, 23, tzinfo=timezone.utc),
+            )
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertEqual(payload["candidate_id"], "cand-paper-probation")
+        self.assertEqual(payload["artifact_refs"][1:], ["proof/replay-summary.json"])
+        self.assertFalse(payload["target_metadata"]["promotion_allowed"])
+        command = run_mock.call_args.args[0]
+        self.assertIn("--artifact-ref", command)
+        self.assertIn("proof/replay-summary.json", command)
+        self.assertIn("--target-metadata-json", command)
+        metadata_json = command[command.index("--target-metadata-json") + 1]
+        metadata = json.loads(metadata_json)
+        self.assertTrue(metadata["paper_probation_authorized"])
+        self.assertEqual(metadata["evidence_collection_stage"], "paper")
+        self.assertFalse(metadata["promotion_allowed"])
+        self.assertFalse(metadata["final_promotion_authorized"])
 
     def test_runtime_window_import_runs_multiple_observed_paper_imports(self) -> None:
         manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -712,6 +712,102 @@ class TestRuntimeWindowImport(TestCase):
             summary["delay_adjusted_depth_stress"],
         )
 
+    def test_persist_observed_runtime_windows_keeps_paper_probation_evidence_only(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    30,
+                ),
+                (
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 30, tzinfo=timezone.utc),
+                    30,
+                ),
+            ],
+            decision_times=[
+                datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 15, 5, tzinfo=timezone.utc),
+            ],
+            execution_times=[
+                datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
+            ],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("4"),
+                    "post_cost_expectancy_bps": Decimal("12"),
+                    **_runtime_pnl_basis(),
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("5"),
+                    "post_cost_expectancy_bps": Decimal("12"),
+                    **_runtime_pnl_basis(),
+                },
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        with self.session_local() as session:
+            summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-h-micro-paper-probation",
+                candidate_id="cand-paper-probation",
+                hypothesis_id="H-MICRO-01",
+                observed_stage="paper",
+                strategy_family="microstructure_breakout",
+                source_manifest_ref="config/trading/hypotheses/h-micro-01.json",
+                buckets=buckets,
+                runtime_observation_payload={
+                    "target_metadata": {
+                        "paper_probation_authorized": True,
+                        "evidence_collection_stage": "paper",
+                        "promotion_allowed": False,
+                        "final_promotion_authorized": False,
+                        "final_promotion_allowed": False,
+                    },
+                    "delay_adjusted_depth_stress_report": {
+                        "passed": True,
+                        "case_count": 1,
+                        "generated_at": "2026-03-06T15:20:00+00:00",
+                        "artifact_ref": "proof/h-micro-delay-depth.json",
+                        "worst_grid_fillable_notional_per_day": "450000",
+                        "worst_active_day_fillable_notional": "350000",
+                        "p10_active_day_fillable_notional": "325000",
+                        "tail_coverage_passed": True,
+                        "stress_net_pnl_per_day": "620",
+                        "fill_survival_evidence_present": True,
+                        "fill_survival_sample_count": 44,
+                    },
+                },
+            )
+            session.commit()
+            decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
+
+        self.assertEqual(summary["promotion_allowed"], False)
+        self.assertIn(
+            "paper_probation_evidence_collection_only",
+            summary["promotion_blocking_reasons"],
+        )
+        self.assertIn(
+            "final_promotion_not_authorized",
+            summary["promotion_blocking_reasons"],
+        )
+        self.assertEqual(decision.allowed, False)
+        self.assertEqual(
+            decision.payload_json["runtime_observation"]["target_metadata"][
+                "paper_probation_authorized"
+            ],
+            True,
+        )
+
     def test_persist_observed_runtime_windows_blocks_zero_activity_evidence(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Carry candidate-board runtime-window target artifact refs and paper-probation handoff metadata into empirical promotion renewal imports.
- Persist target metadata through `import_hypothesis_runtime_windows.py` runtime observations.
- Keep paper-probation runtime-window imports evidence-only by adding explicit promotion blockers when the candidate board marks final promotion unauthorized.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py -q`
- `uv run --frozen ruff format --check scripts/renew_latest_empirical_promotion_jobs.py scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py tests/test_run_empirical_promotion_jobs.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py tests/test_run_empirical_promotion_jobs.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
