### PR TITLE
chore(torghut): promote image 598b233f

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-457-g021eab5db
+              value: v0.571.1-460-g598b233f2
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 021eab5dba88a1d743b3280efb14dd094484b43b
+              value: 598b233f29ba38f5b1186367acff1063338763e6
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-457-g021eab5db
+              value: v0.571.1-460-g598b233f2
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 021eab5dba88a1d743b3280efb14dd094484b43b
+              value: 598b233f29ba38f5b1186367acff1063338763e6
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -75,7 +75,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+                  value: sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-21T16:36:30Z"
+        client.knative.dev/updateTimestamp: "2026-05-21T17:03:51Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
           ports:
             - name: http1
               containerPort: 8181
@@ -499,11 +499,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-457-g021eab5db
+              value: v0.571.1-460-g598b233f2
             - name: TORGHUT_COMMIT
-              value: 021eab5dba88a1d743b3280efb14dd094484b43b
+              value: 598b233f29ba38f5b1186367acff1063338763e6
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+              value: sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-21T16:36:30Z"
+        client.knative.dev/updateTimestamp: "2026-05-21T17:03:51Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
           ports:
             - name: http1
               containerPort: 8181
@@ -320,11 +320,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-457-g021eab5db
+              value: v0.571.1-460-g598b233f2
             - name: TORGHUT_COMMIT
-              value: 021eab5dba88a1d743b3280efb14dd094484b43b
+              value: 598b233f29ba38f5b1186367acff1063338763e6
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+              value: sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -132,7 +132,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b0f5c8f9ce4343eefc2e9486efa779772647e94a2f63abb22802388136accc61
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `598b233f29ba38f5b1186367acff1063338763e6`
- Image tag: `598b233f`
- Image digest: `sha256:563fdb25500e6ddaf9111a417625d0375a0cf9f642ce6d218c3622e4643c40b0`