### PR TITLE
feat(torghut): add loss repair frontier children

### DIFF
--- a/services/torghut/app/trading/discovery/autoresearch.py
+++ b/services/torghut/app/trading/discovery/autoresearch.py
@@ -326,6 +326,8 @@ class FamilyAutoresearchPlan:
     symbol_prune_iterations: int
     symbol_prune_candidates: int
     symbol_prune_min_universe_size: int
+    loss_repair_iterations: int
+    loss_repair_candidates: int
     parameter_mutations: Mapping[str, MutationSpace]
     strategy_override_mutations: Mapping[str, MutationSpace]
 
@@ -340,6 +342,8 @@ class FamilyAutoresearchPlan:
             'symbol_prune_iterations': self.symbol_prune_iterations,
             'symbol_prune_candidates': self.symbol_prune_candidates,
             'symbol_prune_min_universe_size': self.symbol_prune_min_universe_size,
+            'loss_repair_iterations': self.loss_repair_iterations,
+            'loss_repair_candidates': self.loss_repair_candidates,
             'parameter_mutations': {
                 key: value.to_payload() for key, value in self.parameter_mutations.items()
             },
@@ -686,6 +690,8 @@ def load_strategy_autoresearch_program(
                 symbol_prune_iterations=max(0, int(family_payload.get('symbol_prune_iterations', 0))),
                 symbol_prune_candidates=max(1, int(family_payload.get('symbol_prune_candidates', 1))),
                 symbol_prune_min_universe_size=max(1, int(family_payload.get('symbol_prune_min_universe_size', 2))),
+                loss_repair_iterations=max(0, int(family_payload.get('loss_repair_iterations', 0))),
+                loss_repair_candidates=max(1, int(family_payload.get('loss_repair_candidates', 1))),
                 parameter_mutations=parameter_mutations,
                 strategy_override_mutations=strategy_override_mutations,
             )

--- a/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
@@ -769,6 +769,8 @@ families:
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 4
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
     parameter_mutations:
       max_entries_per_session:
         mode: numeric_step
@@ -798,6 +800,8 @@ families:
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 4
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
     parameter_mutations:
       min_cross_section_continuation_rank:
         mode: numeric_step
@@ -827,6 +831,8 @@ families:
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 5
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
     parameter_mutations:
       entry_minute_after_open:
         mode: numeric_step
@@ -863,6 +869,8 @@ families:
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 5
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
     parameter_mutations:
       entry_minute_after_open:
         mode: numeric_step
@@ -899,6 +907,8 @@ families:
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 5
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
     parameter_mutations:
       entry_minute_after_open:
         mode: numeric_step
@@ -935,6 +945,8 @@ families:
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 5
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
     parameter_mutations:
       entry_minute_after_open:
         mode: numeric_step
@@ -971,6 +983,8 @@ families:
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 5
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
     parameter_mutations:
       entry_minute_after_open:
         mode: numeric_step
@@ -1007,6 +1021,8 @@ families:
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 3
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
     parameter_mutations:
       long_stop_loss_bps:
         mode: numeric_step
@@ -1036,6 +1052,8 @@ families:
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 5
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
     parameter_mutations:
       exit_macd_hist_max:
         mode: numeric_step
@@ -1066,6 +1084,8 @@ families:
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 5
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
     parameter_mutations:
       min_cross_section_continuation_rank:
         mode: numeric_step
@@ -1101,6 +1121,8 @@ families:
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 5
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
     parameter_mutations:
       min_cross_section_reversal_rank:
         mode: numeric_step
@@ -1136,6 +1158,8 @@ families:
     symbol_prune_iterations: 1
     symbol_prune_candidates: 1
     symbol_prune_min_universe_size: 5
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
     parameter_mutations:
       max_entries_per_session:
         mode: numeric_step
@@ -1168,6 +1192,8 @@ families:
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 5
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
     parameter_mutations:
       min_bull_rsi:
         mode: numeric_step
@@ -1198,6 +1224,8 @@ families:
     symbol_prune_iterations: 1
     symbol_prune_candidates: 2
     symbol_prune_min_universe_size: 3
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
     parameter_mutations:
       min_price_vs_session_open_bps:
         mode: numeric_step

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -399,6 +399,7 @@ def _frontier_candidate_budget(
         family_plan.frontier_top_n,
         family_plan.keep_top_candidates,
         family_plan.symbol_prune_candidates + 1,
+        family_plan.loss_repair_candidates + 1,
     )
     return max(minimum_budget, replay_budget_max_candidates_per_frontier_run)
 
@@ -548,6 +549,8 @@ def _frontier_args(
         symbol_prune_iterations=family_plan.symbol_prune_iterations,
         symbol_prune_candidates=family_plan.symbol_prune_candidates,
         symbol_prune_min_universe_size=family_plan.symbol_prune_min_universe_size,
+        loss_repair_iterations=family_plan.loss_repair_iterations,
+        loss_repair_candidates=family_plan.loss_repair_candidates,
     )
 
 

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -14,9 +14,9 @@ import tempfile
 from collections import Counter, deque
 from dataclasses import dataclass
 from datetime import date
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any, Callable, Iterable, Iterator, Mapping, Sequence, cast
+from typing import Any, Callable, Iterable, Iterator, Mapping, Sequence, TypeAlias, cast
 from unittest.mock import patch
 
 import yaml
@@ -65,6 +65,49 @@ from scripts.search_profitability_frontier import (
 
 _LOCAL_ONLY_OVERRIDE_KEYS = frozenset({"normalization_regime"})
 _SECOND_OOS_WINDOW_ID = "second_oos"
+_LOSS_REPAIR_TRIGGER_REASONS = frozenset(
+    {
+        "train_worst_day_loss_above_screen",
+        "worst_day_loss_above_max",
+        "max_drawdown_above_max",
+        "daily_net_below_min",
+        "gross_exposure_pct_equity_above_max",
+        "min_cash_below_min",
+    }
+)
+_LOSS_REPAIR_TRIGGER_SUFFIXES = (
+    "_worst_day_loss_above_max",
+    "_max_drawdown_above_max",
+)
+_LOSS_REPAIR_BPS_FLOORS = {
+    "long_stop_loss_bps": Decimal("4"),
+    "short_stop_loss_bps": Decimal("4"),
+    "long_trailing_stop_drawdown_bps": Decimal("3"),
+    "short_trailing_stop_drawdown_bps": Decimal("3"),
+    "negative_exit_loss_bps": Decimal("4"),
+    "max_session_negative_exit_bps": Decimal("4"),
+}
+_LOSS_REPAIR_EXIT_LIMIT_KEYS = (
+    "max_stop_loss_exits_per_session",
+    "max_negative_exits_per_session",
+)
+_LOSS_REPAIR_LOCKOUT_KEYS = (
+    "stop_loss_lockout_seconds",
+    "negative_exit_lockout_seconds",
+)
+_LOSS_REPAIR_PARAM_EXPOSURE_KEYS = ("max_gross_exposure_pct_equity",)
+_LOSS_REPAIR_STRATEGY_EXPOSURE_KEYS = (
+    "max_notional_per_trade",
+    "max_position_pct_equity",
+)
+_WorklistItem: TypeAlias = tuple[
+    dict[str, Any],
+    dict[str, Any],
+    int,
+    str | None,
+    str | None,
+    str | None,
+]
 
 
 @dataclass(frozen=True)
@@ -483,6 +526,21 @@ def _parse_args() -> argparse.Namespace:
         help="Do not prune below this many symbols in the candidate universe.",
     )
     parser.add_argument(
+        "--loss-repair-iterations",
+        type=int,
+        default=0,
+        help=(
+            "Generate bounded child candidates that tighten loss controls and exposure "
+            "after drawdown or worst-day-loss vetoes."
+        ),
+    )
+    parser.add_argument(
+        "--loss-repair-candidates",
+        type=int,
+        default=1,
+        help="How many loss/drawdown repair children to branch on per failed candidate.",
+    )
+    parser.add_argument(
         "--train-screening",
         dest="train_screening",
         action="store_true",
@@ -806,12 +864,19 @@ def _iter_initial_worklist_candidates(
     parameter_grid: Mapping[str, Iterable[Any]],
     override_candidates: Iterable[Mapping[str, Any]],
     seed_candidates: Iterable[tuple[Mapping[str, Any], Mapping[str, Any]]] = (),
-) -> Iterator[tuple[dict[str, Any], dict[str, Any], int, str | None, str | None]]:
+) -> Iterator[_WorklistItem]:
     for params_candidate, override_candidate in seed_candidates:
-        yield (dict(params_candidate), dict(override_candidate), 0, None, None)
+        yield (dict(params_candidate), dict(override_candidate), 0, None, None, None)
     for override_candidate in override_candidates:
         for params_candidate in _iter_parameter_candidates(parameter_grid):
-            yield (dict(params_candidate), dict(override_candidate), 0, None, None)
+            yield (
+                dict(params_candidate),
+                dict(override_candidate),
+                0,
+                None,
+                None,
+                None,
+            )
 
 
 def _candidate_symbols(
@@ -2432,6 +2497,230 @@ def _generate_symbol_prune_children(
     return children
 
 
+def _strategy_item_from_configmap(
+    *,
+    configmap_payload: Mapping[str, Any],
+    strategy_name: str,
+) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    data = configmap_payload.get("data")
+    if not isinstance(data, Mapping):
+        return {}, {}
+    strategies_yaml = data.get("strategies.yaml")
+    if not isinstance(strategies_yaml, str):
+        return {}, {}
+    catalog = yaml.safe_load(strategies_yaml)
+    if not isinstance(catalog, Mapping):
+        return {}, {}
+    strategies = catalog.get("strategies")
+    if not isinstance(strategies, list):
+        return {}, {}
+    for item in strategies:
+        if not isinstance(item, Mapping):
+            continue
+        if str(item.get("name") or "").strip() != strategy_name:
+            continue
+        params = item.get("params")
+        return item, params if isinstance(params, Mapping) else {}
+    return {}, {}
+
+
+def _decimal_or_none(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return Decimal(text)
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _decimal_payload(value: Decimal) -> str:
+    text = format(value.normalize(), "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def _tightened_bps(value: Any, *, floor: Decimal) -> str | None:
+    current = _decimal_or_none(value)
+    if current is None or current <= 0:
+        return None
+    tightened = max(floor, (current * Decimal("0.75")).quantize(Decimal("0.01")))
+    if tightened >= current:
+        return None
+    return _decimal_payload(tightened)
+
+
+def _reduced_exposure(value: Any) -> str | None:
+    current = _decimal_or_none(value)
+    if current is None or current <= 0:
+        return None
+    reduced = (current * Decimal("0.75")).quantize(Decimal("0.000001"))
+    if reduced <= 0 or reduced >= current:
+        return None
+    return _decimal_payload(reduced)
+
+
+def _loss_repair_trigger_reason(
+    *,
+    hard_vetoes: Sequence[Any],
+    full_window_summary: Mapping[str, Any],
+) -> str | None:
+    for raw_reason in hard_vetoes:
+        reason = str(raw_reason)
+        if reason in _LOSS_REPAIR_TRIGGER_REASONS:
+            return reason
+        if reason.endswith(_LOSS_REPAIR_TRIGGER_SUFFIXES):
+            return reason
+    try:
+        daily_net_below_min_count = int(
+            full_window_summary.get("daily_net_below_min_count") or 0
+        )
+    except (TypeError, ValueError):
+        daily_net_below_min_count = 0
+    if daily_net_below_min_count > 0:
+        return "daily_net_below_min"
+    return None
+
+
+def _apply_loss_control_tightening(
+    *,
+    params: dict[str, Any],
+    strategy_params: Mapping[str, Any],
+) -> bool:
+    changed = False
+    for key, floor in _LOSS_REPAIR_BPS_FLOORS.items():
+        if key not in params and key not in strategy_params:
+            continue
+        tightened = _tightened_bps(
+            params.get(key, strategy_params.get(key)), floor=floor
+        )
+        if tightened is not None:
+            params[key] = tightened
+            changed = True
+
+    for key in _LOSS_REPAIR_EXIT_LIMIT_KEYS:
+        if key not in params and key not in strategy_params:
+            continue
+        current = _decimal_or_none(params.get(key, strategy_params.get(key)))
+        if current is None or current <= 1:
+            continue
+        params[key] = "1"
+        changed = True
+
+    for key in _LOSS_REPAIR_LOCKOUT_KEYS:
+        if key not in params and key not in strategy_params:
+            continue
+        current = _decimal_or_none(params.get(key, strategy_params.get(key)))
+        if current is None or current < 0:
+            continue
+        repaired = min(
+            Decimal("14400"),
+            max(Decimal("1800"), current * Decimal("2")),
+        ).quantize(Decimal("1"))
+        if repaired > current:
+            params[key] = _decimal_payload(repaired)
+            changed = True
+    return changed
+
+
+def _apply_exposure_clamp(
+    *,
+    params: dict[str, Any],
+    overrides: dict[str, Any],
+    strategy_item: Mapping[str, Any],
+    strategy_params: Mapping[str, Any],
+) -> bool:
+    changed = False
+    for key in _LOSS_REPAIR_PARAM_EXPOSURE_KEYS:
+        if key not in params and key not in strategy_params:
+            continue
+        reduced = _reduced_exposure(params.get(key, strategy_params.get(key)))
+        if reduced is not None:
+            params[key] = reduced
+            changed = True
+
+    for key in _LOSS_REPAIR_STRATEGY_EXPOSURE_KEYS:
+        if key not in overrides and key not in strategy_item:
+            continue
+        reduced = _reduced_exposure(overrides.get(key, strategy_item.get(key)))
+        if reduced is not None:
+            overrides[key] = reduced
+            changed = True
+    return changed
+
+
+def _generate_loss_repair_children(
+    *,
+    params_candidate: Mapping[str, Any],
+    strategy_overrides: Mapping[str, Any],
+    candidate_configmap: Mapping[str, Any],
+    strategy_name: str,
+    hard_vetoes: Sequence[Any],
+    full_window_summary: Mapping[str, Any],
+    branch_count: int,
+) -> list[tuple[str, dict[str, Any], dict[str, Any]]]:
+    trigger_reason = _loss_repair_trigger_reason(
+        hard_vetoes=hard_vetoes,
+        full_window_summary=full_window_summary,
+    )
+    if trigger_reason is None:
+        return []
+
+    strategy_item, strategy_params = _strategy_item_from_configmap(
+        configmap_payload=candidate_configmap,
+        strategy_name=strategy_name,
+    )
+    parent_key = _candidate_search_key(
+        params_candidate=params_candidate,
+        strategy_overrides=strategy_overrides,
+    )
+    children: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+    seen: set[str] = {parent_key}
+
+    def add_child(label: str, *, tighten_losses: bool, clamp_exposure: bool) -> None:
+        if len(children) >= max(1, branch_count):
+            return
+        next_params = dict(params_candidate)
+        next_overrides = dict(strategy_overrides)
+        changed = False
+        if tighten_losses:
+            changed = (
+                _apply_loss_control_tightening(
+                    params=next_params,
+                    strategy_params=strategy_params,
+                )
+                or changed
+            )
+        if clamp_exposure:
+            changed = (
+                _apply_exposure_clamp(
+                    params=next_params,
+                    overrides=next_overrides,
+                    strategy_item=strategy_item,
+                    strategy_params=strategy_params,
+                )
+                or changed
+            )
+        if not changed:
+            return
+        child_key = _candidate_search_key(
+            params_candidate=next_params,
+            strategy_overrides=next_overrides,
+        )
+        if child_key in seen:
+            return
+        seen.add(child_key)
+        children.append((f"{label}:{trigger_reason}", next_params, next_overrides))
+
+    add_child("loss_controls_and_exposure", tighten_losses=True, clamp_exposure=True)
+    add_child("loss_controls", tighten_losses=True, clamp_exposure=False)
+    add_child("exposure_clamp", tighten_losses=False, clamp_exposure=True)
+    return children
+
+
 def _rank_scored_candidates(scored: list[dict[str, Any]]) -> list[dict[str, Any]]:
     if not scored:
         return []
@@ -2864,9 +3153,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
             seed_candidates=seed_candidates,
         )
         initial_candidates_exhausted = False
-        worklist: deque[
-            tuple[dict[str, Any], dict[str, Any], int, str | None, str | None]
-        ] = deque()
+        worklist: deque[_WorklistItem] = deque()
         seen_candidate_keys: set[str] = set()
         cache_context: contextlib.AbstractContextManager[None]
         cache_context = (
@@ -2892,6 +3179,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     override_candidate,
                     prune_iteration,
                     pruned_symbol,
+                    loss_repair_reason,
                     parent_candidate_id,
                 ) = worklist.popleft()
                 candidate_key = _candidate_search_key(
@@ -3190,6 +3478,8 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                 }
                 if pruned_symbol is not None:
                     candidate_payload["pruned_symbol"] = pruned_symbol
+                if loss_repair_reason is not None:
+                    candidate_payload["loss_repair_reason"] = loss_repair_reason
                 if parent_candidate_id is not None:
                     candidate_payload["parent_candidate_id"] = parent_candidate_id
                 symbol_contributions = _symbol_contributions_from_replay_payload(
@@ -3625,6 +3915,35 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                                 next_override,
                                 prune_iteration + 1,
                                 removed_symbol,
+                                None,
+                                str(candidate_payload["candidate_id"]),
+                            )
+                        )
+                if prune_iteration < max(
+                    0, int(getattr(args, "loss_repair_iterations", 0))
+                ):
+                    for (
+                        repair_reason,
+                        next_params,
+                        next_override,
+                    ) in _generate_loss_repair_children(
+                        params_candidate=params_candidate,
+                        strategy_overrides=override_candidate,
+                        candidate_configmap=candidate_configmap,
+                        strategy_name=strategy_name,
+                        hard_vetoes=hard_vetoes,
+                        full_window_summary=full_window_summary,
+                        branch_count=max(
+                            1, int(getattr(args, "loss_repair_candidates", 1))
+                        ),
+                    ):
+                        worklist.append(
+                            (
+                                next_params,
+                                next_override,
+                                prune_iteration + 1,
+                                None,
+                                repair_reason,
                                 str(candidate_payload["candidate_id"]),
                             )
                         )

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -835,6 +835,8 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             symbol_prune_iterations=0,
             symbol_prune_candidates=1,
             symbol_prune_min_universe_size=2,
+            loss_repair_iterations=0,
+            loss_repair_candidates=1,
             train_screening=True,
             min_train_screen_net_per_day="0",
             min_train_screen_active_ratio="0.50",
@@ -1299,6 +1301,233 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(children[0][1]["universe_symbols"], ["NVDA", "MSFT"])
         self.assertEqual(children[1][0], "NVDA")
         self.assertEqual(children[1][1]["universe_symbols"], ["AVGO", "MSFT"])
+
+    def test_generate_loss_repair_children_tightens_controls_and_exposure(
+        self,
+    ) -> None:
+        configmap_payload = {
+            "data": {
+                "strategies.yaml": yaml.safe_dump(
+                    {
+                        "strategies": [
+                            {
+                                "name": "intraday-tsmom-profit-v3",
+                                "max_notional_per_trade": "20000",
+                                "max_position_pct_equity": "0.50",
+                                "params": {
+                                    "long_stop_loss_bps": "12",
+                                    "long_trailing_stop_drawdown_bps": "4",
+                                    "max_session_negative_exit_bps": "12",
+                                    "max_stop_loss_exits_per_session": "2",
+                                    "stop_loss_lockout_seconds": "1200",
+                                    "negative_exit_lockout_seconds": "900",
+                                    "max_gross_exposure_pct_equity": "1.0",
+                                },
+                            }
+                        ],
+                    },
+                    sort_keys=False,
+                )
+            }
+        }
+
+        children = frontier._generate_loss_repair_children(
+            params_candidate={},
+            strategy_overrides={},
+            candidate_configmap=configmap_payload,
+            strategy_name="intraday-tsmom-profit-v3",
+            hard_vetoes=["worst_day_loss_above_max"],
+            full_window_summary={},
+            branch_count=2,
+        )
+
+        self.assertEqual(
+            children[0][0], "loss_controls_and_exposure:worst_day_loss_above_max"
+        )
+        repaired_params = children[0][1]
+        repaired_overrides = children[0][2]
+        self.assertEqual(repaired_params["long_stop_loss_bps"], "9")
+        self.assertEqual(repaired_params["long_trailing_stop_drawdown_bps"], "3")
+        self.assertEqual(repaired_params["max_session_negative_exit_bps"], "9")
+        self.assertEqual(repaired_params["max_stop_loss_exits_per_session"], "1")
+        self.assertEqual(repaired_params["stop_loss_lockout_seconds"], "2400")
+        self.assertEqual(repaired_params["negative_exit_lockout_seconds"], "1800")
+        self.assertEqual(repaired_params["max_gross_exposure_pct_equity"], "0.75")
+        self.assertEqual(repaired_overrides["max_notional_per_trade"], "15000")
+        self.assertEqual(repaired_overrides["max_position_pct_equity"], "0.375")
+
+    def test_generate_loss_repair_children_ignores_non_loss_vetoes(self) -> None:
+        children = frontier._generate_loss_repair_children(
+            params_candidate={"entry_cooldown_seconds": "300"},
+            strategy_overrides={},
+            candidate_configmap={},
+            strategy_name="intraday-tsmom-profit-v3",
+            hard_vetoes=["active_day_ratio_below_min"],
+            full_window_summary={},
+            branch_count=2,
+        )
+
+        self.assertEqual(children, [])
+
+    def test_loss_repair_configmap_lookup_handles_invalid_shapes(self) -> None:
+        invalid_payloads = [
+            {"not_data": {}},
+            {"data": {"strategies.yaml": {"not": "yaml"}}},
+            {"data": {"strategies.yaml": "[]"}},
+            {"data": {"strategies.yaml": "strategies: {}\n"}},
+            {
+                "data": {
+                    "strategies.yaml": yaml.safe_dump(
+                        {
+                            "strategies": [
+                                "not-a-strategy",
+                                {"name": "other-strategy", "params": {"stop": "1"}},
+                            ]
+                        }
+                    )
+                }
+            },
+        ]
+
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                item, params = frontier._strategy_item_from_configmap(
+                    configmap_payload=payload,
+                    strategy_name="intraday-tsmom-profit-v3",
+                )
+                self.assertEqual(item, {})
+                self.assertEqual(params, {})
+
+    def test_loss_repair_decimal_helpers_reject_invalid_or_non_reducing_values(
+        self,
+    ) -> None:
+        self.assertIsNone(frontier._decimal_or_none(None))
+        self.assertIsNone(frontier._decimal_or_none(" "))
+        self.assertIsNone(frontier._decimal_or_none("not-a-decimal"))
+        self.assertIsNone(
+            frontier._tightened_bps("0", floor=Decimal("4")),
+        )
+        self.assertIsNone(
+            frontier._tightened_bps("4", floor=Decimal("4")),
+        )
+        self.assertIsNone(frontier._reduced_exposure("0"))
+        self.assertIsNone(frontier._reduced_exposure("0.0000001"))
+
+    def test_loss_repair_trigger_reason_accepts_suffix_and_daily_summary(
+        self,
+    ) -> None:
+        self.assertEqual(
+            frontier._loss_repair_trigger_reason(
+                hard_vetoes=["second_oos_worst_day_loss_above_max"],
+                full_window_summary={},
+            ),
+            "second_oos_worst_day_loss_above_max",
+        )
+        self.assertEqual(
+            frontier._loss_repair_trigger_reason(
+                hard_vetoes=[],
+                full_window_summary={"daily_net_below_min_count": "2"},
+            ),
+            "daily_net_below_min",
+        )
+        self.assertIsNone(
+            frontier._loss_repair_trigger_reason(
+                hard_vetoes=[],
+                full_window_summary={"daily_net_below_min_count": "bad"},
+            )
+        )
+
+    def test_loss_repair_tightening_skips_absent_or_non_reducible_controls(
+        self,
+    ) -> None:
+        params = {
+            "long_stop_loss_bps": "0",
+            "max_stop_loss_exits_per_session": "1",
+            "stop_loss_lockout_seconds": "-1",
+        }
+
+        changed = frontier._apply_loss_control_tightening(
+            params=params,
+            strategy_params={},
+        )
+
+        self.assertFalse(changed)
+        self.assertEqual(
+            params,
+            {
+                "long_stop_loss_bps": "0",
+                "max_stop_loss_exits_per_session": "1",
+                "stop_loss_lockout_seconds": "-1",
+            },
+        )
+
+    def test_loss_repair_exposure_clamp_skips_absent_exposure_controls(
+        self,
+    ) -> None:
+        params: dict[str, object] = {}
+        overrides: dict[str, object] = {}
+
+        changed = frontier._apply_exposure_clamp(
+            params=params,
+            overrides=overrides,
+            strategy_item={},
+            strategy_params={},
+        )
+
+        self.assertFalse(changed)
+        self.assertEqual(params, {})
+        self.assertEqual(overrides, {})
+
+    def test_generate_loss_repair_children_drops_noop_and_duplicate_children(
+        self,
+    ) -> None:
+        noop_children = frontier._generate_loss_repair_children(
+            params_candidate={},
+            strategy_overrides={},
+            candidate_configmap={
+                "data": {
+                    "strategies.yaml": yaml.safe_dump(
+                        {"strategies": [{"name": "intraday-tsmom-profit-v3"}]}
+                    )
+                }
+            },
+            strategy_name="intraday-tsmom-profit-v3",
+            hard_vetoes=["max_drawdown_above_max"],
+            full_window_summary={},
+            branch_count=3,
+        )
+        self.assertEqual(noop_children, [])
+
+        duplicate_children = frontier._generate_loss_repair_children(
+            params_candidate={},
+            strategy_overrides={},
+            candidate_configmap={
+                "data": {
+                    "strategies.yaml": yaml.safe_dump(
+                        {
+                            "strategies": [
+                                {
+                                    "name": "intraday-tsmom-profit-v3",
+                                    "params": {"long_stop_loss_bps": "12"},
+                                }
+                            ]
+                        }
+                    )
+                }
+            },
+            strategy_name="intraday-tsmom-profit-v3",
+            hard_vetoes=["max_drawdown_above_max"],
+            full_window_summary={},
+            branch_count=3,
+        )
+
+        self.assertEqual(len(duplicate_children), 1)
+        self.assertEqual(
+            duplicate_children[0][0],
+            "loss_controls_and_exposure:max_drawdown_above_max",
+        )
+        self.assertEqual(duplicate_children[0][1], {"long_stop_loss_bps": "9"})
+        self.assertEqual(duplicate_children[0][2], {})
 
     def test_consistency_penalty_rejects_lucky_strike_and_low_notional_profile(
         self,
@@ -2578,6 +2807,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             first_overrides,
             first_iteration,
             first_pruned_symbol,
+            first_loss_repair_reason,
             first_parent_id,
         ) = next(candidates)
         (
@@ -2585,6 +2815,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             second_overrides,
             second_iteration,
             second_pruned_symbol,
+            second_loss_repair_reason,
             second_parent_id,
         ) = next(candidates)
 
@@ -2602,6 +2833,8 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(second_iteration, 0)
         self.assertIsNone(first_pruned_symbol)
         self.assertIsNone(second_pruned_symbol)
+        self.assertIsNone(first_loss_repair_reason)
+        self.assertIsNone(second_loss_repair_reason)
         self.assertIsNone(first_parent_id)
         self.assertIsNone(second_parent_id)
 

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -524,6 +524,8 @@ class TestStrategyAutoresearch(TestCase):
             frontier_args.replay_tape_manifest,
             (root / "tape.manifest.json").resolve(),
         )
+        self.assertEqual(frontier_args.loss_repair_iterations, 1)
+        self.assertEqual(frontier_args.loss_repair_candidates, 1)
 
     def test_materialize_run_replay_tape_writes_bundle_and_receipt(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -766,6 +768,8 @@ class TestStrategyAutoresearch(TestCase):
                             "symbol_prune_iterations": 1,
                             "symbol_prune_candidates": 1,
                             "symbol_prune_min_universe_size": 2,
+                            "loss_repair_iterations": 1,
+                            "loss_repair_candidates": 1,
                             "parameter_mutations": {
                                 "max_entries_per_session": {
                                     "mode": "numeric_step",
@@ -1206,6 +1210,8 @@ class TestStrategyAutoresearch(TestCase):
             symbol_prune_iterations=1,
             symbol_prune_candidates=1,
             symbol_prune_min_universe_size=2,
+            loss_repair_iterations=1,
+            loss_repair_candidates=1,
             parameter_mutations={
                 "max_entries_per_session": MutationSpace(
                     mode="numeric_step",
@@ -1274,6 +1280,8 @@ class TestStrategyAutoresearch(TestCase):
             symbol_prune_iterations=0,
             symbol_prune_candidates=1,
             symbol_prune_min_universe_size=2,
+            loss_repair_iterations=0,
+            loss_repair_candidates=1,
             parameter_mutations={
                 "entry_cooldown_seconds": MutationSpace(
                     mode="numeric_step",


### PR DESCRIPTION
## Summary

- Add bounded loss-repair child generation to the Torghut consistent-profitability frontier after drawdown, worst-day-loss, daily-net, exposure, or cash vetoes.
- Tighten existing stop-loss, trailing-stop, negative-exit, lockout, and exposure controls without increasing the evaluated-candidate cap.
- Plumb `loss_repair_iterations` and `loss_repair_candidates` through autoresearch programs and enable one bounded repair child per `$500/day` portfolio family.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -k 'generate_loss_repair_children or generate_symbol_prune_children' -q`
- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py tests/test_strategy_autoresearch.py -q`
- `uv run --frozen ruff check scripts/search_consistent_profitability_frontier.py app/trading/discovery/autoresearch.py scripts/run_strategy_autoresearch_loop.py tests/test_search_consistent_profitability_frontier.py tests/test_strategy_autoresearch.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
