### PR TITLE
fix(torghut): require truthful runtime pnl proof

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -9,16 +9,34 @@ from datetime import datetime, timezone
 from decimal import Decimal
 
 POST_COST_PNL_BASIS = "realized_strategy_pnl_after_explicit_costs"
+EXACT_REPLAY_LEDGER_SCHEMA_VERSION = "torghut.exact_replay_ledger.v1"
 
 _BPS_MULTIPLIER = Decimal("10000")
 _BUY_SIDES = frozenset({"buy", "buy_to_cover", "cover"})
 _SELL_SIDES = frozenset({"sell", "sell_short", "short"})
+_DECISION_EVENTS = frozenset({"decision", "trade_decision", "signal_decision"})
+_SUBMITTED_ORDER_EVENTS = frozenset(
+    {"order_submitted", "submitted_order", "submitted", "accepted", "new"}
+)
+_FILL_EVENTS = frozenset({"fill", "filled", "partial_fill", "partially_filled"})
+_CANCELLED_ORDER_EVENTS = frozenset({"order_cancelled", "order_canceled", "cancelled", "canceled"})
+_REJECTED_ORDER_EVENTS = frozenset({"order_rejected", "rejected"})
+_UNFILLED_ORDER_EVENTS = frozenset({"order_unfilled", "unfilled", "expired", "order_expired"})
+_LIFECYCLE_EVENTS = (
+    _DECISION_EVENTS
+    | _SUBMITTED_ORDER_EVENTS
+    | _FILL_EVENTS
+    | _CANCELLED_ORDER_EVENTS
+    | _REJECTED_ORDER_EVENTS
+    | _UNFILLED_ORDER_EVENTS
+)
 _TCA_PNL_BASES = frozenset(
     {
         "tca_shortfall_proxy",
         "tca_shortfall",
         "shortfall_proxy",
         "realized_pnl_proxy_from_tca_shortfall",
+        "execution_tca_shortfall_cost",
     }
 )
 
@@ -38,6 +56,13 @@ class RuntimeLedgerFill:
     strategy_id: str | None = None
     symbol: str | None = None
     source: str = "runtime_execution"
+    event_type: str | None = None
+    decision_id: str | None = None
+    order_id: str | None = None
+    execution_policy_hash: str | None = None
+    cost_model_hash: str | None = None
+    lineage_hash: str | None = None
+    replay_data_hash: str | None = None
 
 
 @dataclass(frozen=True)
@@ -50,6 +75,11 @@ class RuntimeLedgerBucket:
     strategy_id: str | None
     symbol: str | None
     fill_count: int
+    decision_count: int
+    submitted_order_count: int
+    cancelled_order_count: int
+    rejected_order_count: int
+    unfilled_order_count: int
     closed_trade_count: int
     open_position_count: int
     filled_notional: Decimal
@@ -58,7 +88,11 @@ class RuntimeLedgerBucket:
     net_strategy_pnl_after_costs: Decimal
     post_cost_expectancy_bps: Decimal | None
     cost_basis_counts: dict[str, int]
+    execution_policy_hash_counts: dict[str, int]
+    cost_model_hash_counts: dict[str, int]
+    lineage_hash_counts: dict[str, int]
     blockers: list[str]
+    ledger_schema_version: str = EXACT_REPLAY_LEDGER_SCHEMA_VERSION
     pnl_basis: str = POST_COST_PNL_BASIS
 
 
@@ -75,12 +109,20 @@ class _NormalizedFill:
     filled_notional: Decimal | None
     cost_amount: Decimal | None
     cost_basis: str | None
+    event_type: str
+    decision_id: str | None
+    order_id: str | None
+    execution_policy_hash: str | None
+    cost_model_hash: str | None
+    lineage_hash: str | None
+    replay_data_hash: str | None
     blockers: tuple[str, ...]
 
     @property
     def is_usable_fill(self) -> bool:
         return (
-            self.executed_at is not None
+            self.event_type in _FILL_EVENTS
+            and self.executed_at is not None
             and self.side is not None
             and self.filled_qty is not None
             and self.filled_qty > 0
@@ -116,6 +158,7 @@ def build_runtime_ledger_buckets(
     *,
     bucket_ranges: Sequence[tuple[datetime, datetime]],
     group_by: Sequence[str] = (),
+    require_order_lifecycle: bool = False,
 ) -> list[RuntimeLedgerBucket]:
     """Aggregate runtime fills into fail-closed post-cost PnL buckets.
 
@@ -148,6 +191,7 @@ def build_runtime_ledger_buckets(
                     bucket_end=bucket_end,
                     rows=bucket_rows,
                     carried_positions=positions,
+                    require_order_lifecycle=require_order_lifecycle,
                 )
             )
         return buckets
@@ -170,6 +214,7 @@ def build_runtime_ledger_buckets(
                     rows=grouped_rows[key],
                     group_by=group_by,
                     group_key=key,
+                    require_order_lifecycle=require_order_lifecycle,
                 )
             )
     return buckets
@@ -184,17 +229,43 @@ def _build_bucket(
     group_key: tuple[str | None, ...] = (),
     carried_positions: dict[tuple[str | None, str | None, str | None], _PositionState]
     | None = None,
+    require_order_lifecycle: bool = False,
 ) -> RuntimeLedgerBucket:
     blockers: list[str] = []
     for row in rows:
         blockers.extend(row.blockers)
 
+    lifecycle_rows = [row for row in rows if row.event_type in _LIFECYCLE_EVENTS]
+    decision_count = sum(1 for row in rows if row.event_type in _DECISION_EVENTS)
+    submitted_order_count = sum(
+        1 for row in rows if row.event_type in _SUBMITTED_ORDER_EVENTS
+    )
+    cancelled_order_count = sum(
+        1 for row in rows if row.event_type in _CANCELLED_ORDER_EVENTS
+    )
+    rejected_order_count = sum(
+        1 for row in rows if row.event_type in _REJECTED_ORDER_EVENTS
+    )
+    unfilled_order_count = sum(
+        1 for row in rows if row.event_type in _UNFILLED_ORDER_EVENTS
+    )
     usable_fills = [row for row in rows if row.is_usable_fill]
     if not usable_fills:
         blockers.append("runtime_fills_missing")
 
     accumulator = _LedgerAccumulator()
     cost_basis_counter: Counter[str] = Counter()
+    execution_policy_hash_counter: Counter[str] = Counter()
+    cost_model_hash_counter: Counter[str] = Counter()
+    lineage_hash_counter: Counter[str] = Counter()
+    for row in lifecycle_rows:
+        if row.execution_policy_hash is not None:
+            execution_policy_hash_counter[row.execution_policy_hash] += 1
+        if row.cost_model_hash is not None:
+            cost_model_hash_counter[row.cost_model_hash] += 1
+        if (lineage_hash := row.lineage_hash or row.replay_data_hash) is not None:
+            lineage_hash_counter[lineage_hash] += 1
+
     positions: dict[tuple[str | None, str | None, str | None], _PositionState] = (
         carried_positions if carried_positions is not None else {}
     )
@@ -221,6 +292,20 @@ def _build_bucket(
         blockers.append("unclosed_position")
     if accumulator.filled_notional <= 0:
         blockers.append("filled_notional_missing")
+    if require_order_lifecycle:
+        blockers.extend(
+            _order_lifecycle_blockers(
+                lifecycle_rows=lifecycle_rows,
+                usable_fills=usable_fills,
+                decision_count=decision_count,
+                submitted_order_count=submitted_order_count,
+                rejected_order_count=rejected_order_count,
+                unfilled_order_count=unfilled_order_count,
+                execution_policy_hash_counter=execution_policy_hash_counter,
+                cost_model_hash_counter=cost_model_hash_counter,
+                lineage_hash_counter=lineage_hash_counter,
+            )
+        )
 
     unique_blockers = _dedupe(blockers)
     post_cost_expectancy_bps: Decimal | None = None
@@ -238,6 +323,11 @@ def _build_bucket(
         strategy_id=_bucket_field("strategy_id", rows, group_by, group_key),
         symbol=_bucket_field("symbol", rows, group_by, group_key),
         fill_count=len(usable_fills),
+        decision_count=decision_count,
+        submitted_order_count=submitted_order_count,
+        cancelled_order_count=cancelled_order_count,
+        rejected_order_count=rejected_order_count,
+        unfilled_order_count=unfilled_order_count,
         closed_trade_count=accumulator.closed_trade_count,
         open_position_count=open_position_count,
         filled_notional=accumulator.filled_notional,
@@ -246,8 +336,75 @@ def _build_bucket(
         net_strategy_pnl_after_costs=accumulator.net_strategy_pnl_after_costs,
         post_cost_expectancy_bps=post_cost_expectancy_bps,
         cost_basis_counts=dict(sorted(cost_basis_counter.items())),
+        execution_policy_hash_counts=dict(sorted(execution_policy_hash_counter.items())),
+        cost_model_hash_counts=dict(sorted(cost_model_hash_counter.items())),
+        lineage_hash_counts=dict(sorted(lineage_hash_counter.items())),
         blockers=unique_blockers,
     )
+
+
+def _order_lifecycle_blockers(
+    *,
+    lifecycle_rows: Sequence[_NormalizedFill],
+    usable_fills: Sequence[_NormalizedFill],
+    decision_count: int,
+    submitted_order_count: int,
+    rejected_order_count: int,
+    unfilled_order_count: int,
+    execution_policy_hash_counter: Counter[str],
+    cost_model_hash_counter: Counter[str],
+    lineage_hash_counter: Counter[str],
+) -> list[str]:
+    blockers: list[str] = []
+    if not lifecycle_rows:
+        blockers.append("runtime_order_lifecycle_missing")
+    if decision_count <= 0:
+        blockers.append("runtime_decision_lifecycle_missing")
+    if submitted_order_count <= 0:
+        blockers.append("submitted_order_lifecycle_missing")
+    if not usable_fills:
+        blockers.append("zero_fill_runtime_ledger")
+
+    submitted_order_ids = {
+        row.order_id
+        for row in lifecycle_rows
+        if row.event_type in _SUBMITTED_ORDER_EVENTS and row.order_id is not None
+    }
+    submitted_without_decision = [
+        row
+        for row in lifecycle_rows
+        if row.event_type in _SUBMITTED_ORDER_EVENTS and row.decision_id is None
+    ]
+    if submitted_without_decision:
+        blockers.append("order_decision_linkage_missing")
+
+    fill_order_ids = {
+        row.order_id for row in usable_fills if row.order_id is not None
+    }
+    if usable_fills and len(fill_order_ids) < len(usable_fills):
+        blockers.append("fill_order_linkage_missing")
+    if fill_order_ids - submitted_order_ids:
+        blockers.append("fill_order_submission_missing")
+    if submitted_order_ids - fill_order_ids:
+        blockers.append("unfilled_order_present")
+    if rejected_order_count > 0:
+        blockers.append("rejected_order_present")
+    if unfilled_order_count > 0:
+        blockers.append("unfilled_order_present")
+
+    if any(row.execution_policy_hash is None for row in lifecycle_rows):
+        blockers.append("execution_policy_hash_missing")
+    if any(row.cost_model_hash is None for row in lifecycle_rows):
+        blockers.append("cost_model_hash_missing")
+    if any(row.lineage_hash is None and row.replay_data_hash is None for row in lifecycle_rows):
+        blockers.append("proof_lineage_hash_missing")
+    if len(execution_policy_hash_counter) > 1:
+        blockers.append("execution_policy_hash_ambiguous")
+    if len(cost_model_hash_counter) > 1:
+        blockers.append("cost_model_hash_ambiguous")
+    if len(lineage_hash_counter) > 1:
+        blockers.append("proof_lineage_hash_ambiguous")
+    return blockers
 
 
 def _apply_fill_to_position(
@@ -357,6 +514,7 @@ def _normalize_fill_row(
     )
     strategy_id = _coerce_text(_row_value(row, "strategy_id", "strategy_name"))
     symbol = _coerce_text(_row_value(row, "symbol"))
+    event_type = _coerce_event_type(row)
     side = _coerce_side(_row_value(row, "side", "action", "order_side"))
     filled_qty = _positive_decimal(_row_value(row, "filled_qty", "qty", "quantity"))
     avg_fill_price = _positive_decimal(
@@ -383,24 +541,68 @@ def _normalize_fill_row(
         )
     )
     cost_basis = _coerce_text(_row_value(row, "cost_basis", "cost_source", "fee_basis"))
+    decision_id = _coerce_text(
+        _row_value(row, "decision_id", "trade_decision_id", "decision_hash")
+    )
+    order_id = _coerce_text(
+        _row_value(
+            row,
+            "order_id",
+            "alpaca_order_id",
+            "client_order_id",
+            "execution_id",
+            "execution_correlation_id",
+        )
+    )
+    execution_policy_hash = _coerce_text(
+        _row_value(
+            row,
+            "execution_policy_hash",
+            "execution_policy_sha256",
+            "policy_hash",
+            "execution_idempotency_key",
+        )
+    )
+    cost_model_hash = _coerce_text(
+        _row_value(row, "cost_model_hash", "fee_model_hash", "cost_model_sha256")
+    )
+    lineage_hash = _coerce_text(
+        _row_value(
+            row,
+            "lineage_hash",
+            "candidate_lineage_hash",
+            "replay_lineage_hash",
+            "candidate_evaluation_key",
+        )
+    )
+    replay_data_hash = _coerce_text(
+        _row_value(
+            row,
+            "replay_data_hash",
+            "replay_tape_content_sha256",
+            "dataset_snapshot_hash",
+            "source_query_digest",
+        )
+    )
 
     blockers: list[str] = []
     if _has_tca_pnl_shortcut(row):
         blockers.append("tca_shortfall_not_runtime_pnl")
-    if executed_at is None:
+    if executed_at is None and event_type != "diagnostic":
         blockers.append("executed_at_missing")
-    if side is None:
-        blockers.append("side_missing_or_invalid")
-    if filled_qty is None:
-        blockers.append("filled_qty_missing_or_non_positive")
-    if avg_fill_price is None:
-        blockers.append("fill_price_missing")
-    if filled_notional is None:
-        blockers.append("filled_notional_missing")
-    if cost_amount is None:
-        blockers.append("explicit_cost_missing")
-    if cost_basis is None:
-        blockers.append("cost_basis_missing")
+    if event_type in _FILL_EVENTS:
+        if side is None:
+            blockers.append("side_missing_or_invalid")
+        if filled_qty is None:
+            blockers.append("filled_qty_missing_or_non_positive")
+        if avg_fill_price is None:
+            blockers.append("fill_price_missing")
+        if filled_notional is None:
+            blockers.append("filled_notional_missing")
+        if cost_amount is None:
+            blockers.append("explicit_cost_missing")
+        if cost_basis is None:
+            blockers.append("cost_basis_missing")
 
     return _NormalizedFill(
         row_index=row_index,
@@ -414,8 +616,58 @@ def _normalize_fill_row(
         filled_notional=filled_notional,
         cost_amount=cost_amount,
         cost_basis=cost_basis,
+        event_type=event_type,
+        decision_id=decision_id,
+        order_id=order_id,
+        execution_policy_hash=execution_policy_hash,
+        cost_model_hash=cost_model_hash,
+        lineage_hash=lineage_hash,
+        replay_data_hash=replay_data_hash,
         blockers=tuple(_dedupe(blockers)),
     )
+
+
+def _coerce_event_type(row: RuntimeLedgerFill | Mapping[str, object]) -> str:
+    raw = _coerce_text(
+        _row_value(
+            row,
+            "ledger_event_type",
+            "runtime_ledger_event_type",
+            "lifecycle_event",
+            "event_type",
+            "order_event_type",
+            "order_status",
+            "status",
+        )
+    )
+    if raw is not None:
+        normalized = raw.lower().replace("-", "_").replace(" ", "_")
+        aliases = {
+            "trade_decision": "decision",
+            "signal_decision": "decision",
+            "new_order": "order_submitted",
+            "submitted": "order_submitted",
+            "accepted": "order_submitted",
+            "new": "order_submitted",
+            "filled": "fill",
+            "partial_fill": "partial_fill",
+            "partially_filled": "partial_fill",
+            "canceled": "order_cancelled",
+            "cancelled": "order_cancelled",
+            "rejected": "order_rejected",
+            "expired": "order_unfilled",
+        }
+        candidate = aliases.get(normalized, normalized)
+        if candidate in _LIFECYCLE_EVENTS:
+            return candidate
+
+    if _row_value(row, "filled_qty", "qty", "quantity", "avg_fill_price", "fill_price") is not None:
+        return "fill"
+    if _row_value(row, "alpaca_order_id", "client_order_id", "order_id") is not None:
+        return "order_submitted"
+    if _row_value(row, "decision_id", "trade_decision_id", "decision_hash") is not None:
+        return "decision"
+    return "diagnostic"
 
 
 def _row_value(
@@ -436,7 +688,13 @@ def _row_value(
 
 def _has_tca_pnl_shortcut(row: RuntimeLedgerFill | Mapping[str, object]) -> bool:
     basis = _coerce_text(
-        _row_value(row, "post_cost_expectancy_basis", "post_cost_basis", "pnl_basis")
+        _row_value(
+            row,
+            "post_cost_expectancy_basis",
+            "post_cost_basis",
+            "pnl_basis",
+            "cost_basis",
+        )
     )
     if basis is not None and basis.lower().replace("-", "_") in _TCA_PNL_BASES:
         return True
@@ -558,6 +816,7 @@ def _dedupe(items: Sequence[str]) -> list[str]:
 
 
 __all__ = [
+    "EXACT_REPLAY_LEDGER_SCHEMA_VERSION",
     "POST_COST_PNL_BASIS",
     "RuntimeLedgerBucket",
     "RuntimeLedgerFill",

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -126,9 +126,12 @@ def _post_cost_basis_is_promotion_grade(
     explicit_value: Any,
 ) -> bool:
     parsed = _observation_bool(explicit_value)
-    if parsed is not None:
-        return parsed
-    return basis in PROMOTION_GRADE_POST_COST_BASES
+    basis_is_promotion_grade = basis in PROMOTION_GRADE_POST_COST_BASES
+    if parsed is False:
+        return False
+    if parsed is True:
+        return basis_is_promotion_grade
+    return basis_is_promotion_grade
 
 
 def _parse_observation_datetime(value: Any) -> datetime | None:

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -117,6 +117,33 @@ def _decimal_or_none(value: Any) -> Decimal | None:
         return None
 
 
+def _row_payloads(row: Mapping[str, object]) -> list[Mapping[str, object]]:
+    payloads: list[Mapping[str, object]] = [row]
+    for key in ("execution_audit_json", "raw_order"):
+        payload = row.get(key)
+        if isinstance(payload, Mapping):
+            payloads.append({str(item_key): item for item_key, item in payload.items()})
+    return payloads
+
+
+def _first_decimal(row: Mapping[str, object], *keys: str) -> Decimal | None:
+    for payload in _row_payloads(row):
+        for key in keys:
+            value = payload.get(key)
+            if (parsed := _decimal_or_none(value)) is not None:
+                return parsed
+    return None
+
+
+def _first_text(row: Mapping[str, object], *keys: str) -> str | None:
+    for payload in _row_payloads(row):
+        for key in keys:
+            text = str(payload.get(key) or "").strip()
+            if text:
+                return text
+    return None
+
+
 def _nonnegative_int(value: Any) -> int:
     try:
         return max(0, int(Decimal(str(value))))
@@ -158,9 +185,8 @@ def _execution_signed_qty(*, side: Any, qty: Any) -> Decimal:
 def _build_realized_strategy_pnl_rows(
     execution_rows: list[dict[str, object]],
 ) -> list[dict[str, object]]:
-    fills: list[RuntimeLedgerFill] = []
+    ledger_rows: list[RuntimeLedgerFill | dict[str, object]] = []
     event_times: list[datetime] = []
-    fallback_cost_basis = "execution_tca_shortfall_cost"
     for row in execution_rows:
         computed_at = row.get("computed_at")
         price = _decimal_or_none(row.get("avg_fill_price"))
@@ -168,22 +194,86 @@ def _build_realized_strategy_pnl_rows(
             side=row.get("side"), qty=row.get("filled_qty")
         )
         symbol = str(row.get("symbol") or "").strip().upper()
-        shortfall_notional = _decimal_or_none(row.get("shortfall_notional"))
         if not symbol or not isinstance(computed_at, datetime):
             continue
         event_times.append(computed_at)
+        decision_id = _first_text(row, "decision_id", "trade_decision_id", "decision_hash")
+        order_id = _first_text(
+            row,
+            "order_id",
+            "alpaca_order_id",
+            "client_order_id",
+            "execution_correlation_id",
+        )
+        common_ledger_fields = {
+            "executed_at": computed_at,
+            "account_label": str(row.get("account_label") or "") or None,
+            "strategy_id": str(row.get("strategy_id") or "") or None,
+            "symbol": symbol,
+            "decision_id": decision_id,
+            "order_id": order_id,
+            "execution_policy_hash": _first_text(
+                row,
+                "execution_policy_hash",
+                "execution_policy_sha256",
+                "policy_hash",
+                "execution_idempotency_key",
+            ),
+            "cost_model_hash": _first_text(
+                row, "cost_model_hash", "fee_model_hash", "cost_model_sha256"
+            ),
+            "lineage_hash": _first_text(
+                row,
+                "lineage_hash",
+                "candidate_lineage_hash",
+                "replay_lineage_hash",
+                "candidate_evaluation_key",
+            ),
+            "replay_data_hash": _first_text(
+                row,
+                "replay_data_hash",
+                "replay_tape_content_sha256",
+                "dataset_snapshot_hash",
+                "source_query_digest",
+            ),
+        }
+        if decision_id is not None:
+            ledger_rows.append({**common_ledger_fields, "event_type": "decision"})
+        if order_id is not None:
+            ledger_rows.append({**common_ledger_fields, "event_type": "order_submitted"})
         if price is None or price <= 0 or signed_qty == 0:
             continue
-        if shortfall_notional is None:
-            continue
-        cost_basis = str(row.get("cost_basis") or fallback_cost_basis).strip()
-        fills.append(
+        cost_amount = _first_decimal(
+            row,
+            "cost_amount",
+            "explicit_cost",
+            "commission",
+            "fees",
+            "fee_amount",
+            "broker_fee",
+        )
+        cost_basis = _first_text(
+            row,
+            "cost_basis",
+            "cost_source",
+            "fee_basis",
+            "commission_basis",
+            "broker_fee_basis",
+        )
+        ledger_rows.append(
             RuntimeLedgerFill(
                 executed_at=computed_at,
+                event_type="fill",
+                decision_id=decision_id,
+                order_id=order_id,
+                execution_policy_hash=common_ledger_fields["execution_policy_hash"],
+                cost_model_hash=common_ledger_fields["cost_model_hash"],
+                lineage_hash=common_ledger_fields["lineage_hash"],
+                replay_data_hash=common_ledger_fields["replay_data_hash"],
                 side=str(row.get("side") or ""),
                 filled_qty=abs(signed_qty),
                 avg_fill_price=price,
-                cost_amount=abs(shortfall_notional),
+                cost_amount=cost_amount,
                 cost_basis=cost_basis,
                 account_label=str(row.get("account_label") or "") or None,
                 strategy_id=str(row.get("strategy_id") or "") or None,
@@ -195,8 +285,12 @@ def _build_realized_strategy_pnl_rows(
     unique_times = sorted(set(event_times))
     bucket_ranges = [(unique_times[0], unique_times[-1] + timedelta(microseconds=1))]
     realized_rows: list[dict[str, object]] = []
-    for bucket in build_runtime_ledger_buckets(fills, bucket_ranges=bucket_ranges):
-        if bucket.closed_trade_count <= 0:
+    for bucket in build_runtime_ledger_buckets(
+        ledger_rows,
+        bucket_ranges=bucket_ranges,
+        require_order_lifecycle=True,
+    ):
+        if bucket.closed_trade_count <= 0 and not bucket.blockers:
             continue
         promotion_eligible = (
             bucket.post_cost_expectancy_bps is not None and not bucket.blockers
@@ -310,7 +404,15 @@ def _query_timestamps(
                     e.side,
                     e.filled_qty,
                     e.avg_fill_price,
-                    t.shortfall_notional
+                    t.shortfall_notional,
+                    e.execution_audit_json,
+                    e.raw_order,
+                    e.alpaca_account_label,
+                    s.name,
+                    d.decision_hash,
+                    e.alpaca_order_id,
+                    e.client_order_id,
+                    e.status
                 from executions e
                 join trade_decisions d on d.id = e.trade_decision_id
                 join strategies s on s.id = d.strategy_id
@@ -332,6 +434,14 @@ def _query_timestamps(
                     "filled_qty": row[4],
                     "avg_fill_price": row[5],
                     "shortfall_notional": row[6],
+                    "execution_audit_json": row[7],
+                    "raw_order": row[8],
+                    "account_label": row[9],
+                    "strategy_id": row[10],
+                    "decision_hash": row[11],
+                    "alpaca_order_id": row[12],
+                    "client_order_id": row[13],
+                    "order_status": row[14],
                 }
                 for row in cur.fetchall()
                 if row[0] is not None

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -40,6 +40,17 @@ class _FakeCursor:
                     Decimal("1"),
                     Decimal("100"),
                     Decimal("0.01"),
+                    {
+                        "cost_amount": "0.01",
+                        "cost_basis": "broker_reported_commission_and_fees",
+                    },
+                    {},
+                    "TORGHUT_SIM",
+                    "intraday_tsmom_v1@paper",
+                    "decision-sha",
+                    "alpaca-order-1",
+                    "client-order-1",
+                    "filled",
                 )
             ],
             [
@@ -237,7 +248,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "side": "buy",
                     "filled_qty": Decimal("1"),
                     "avg_fill_price": Decimal("100"),
-                    "shortfall_notional": Decimal("0.20"),
+                    "shortfall_notional": Decimal("99"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
                 },
                 {
                     "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
@@ -245,15 +263,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "side": "sell",
                     "filled_qty": Decimal("1"),
                     "avg_fill_price": Decimal("101"),
-                    "shortfall_notional": Decimal("0.10"),
-                },
-                {
-                    "computed_at": datetime(2026, 3, 6, 14, 45, tzinfo=timezone.utc),
-                    "symbol": "AAPL",
-                    "side": "sell",
-                    "filled_qty": Decimal("1"),
-                    "avg_fill_price": Decimal("102"),
-                    "shortfall_notional": None,
+                    "shortfall_notional": Decimal("99"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
                 },
             ]
         )
@@ -269,6 +286,36 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             rows[0]["post_cost_expectancy_bps"],
             Decimal("34.82587064676616915422885572"),
         )
+
+    def test_build_realized_strategy_pnl_rows_rejects_shortfall_only_costs(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "shortfall_notional": Decimal("0.20"),
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "shortfall_notional": Decimal("0.10"),
+                },
+            ]
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
+        self.assertIsNone(rows[0]["post_cost_expectancy_bps"])
+        self.assertIn("explicit_cost_missing", rows[0]["runtime_ledger_blockers"])
+        self.assertIn("cost_basis_missing", rows[0]["runtime_ledger_blockers"])
 
     def test_build_realized_strategy_pnl_rows_returns_empty_without_event_times(
         self,
@@ -310,13 +357,15 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(
             executions, [datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)]
         )
-        self.assertEqual(len(tca_rows), 1)
+        self.assertEqual(len(tca_rows), 2)
         self.assertEqual(tca_rows[0]["abs_slippage_bps"], Decimal("1.25"))
         self.assertEqual(tca_rows[0]["post_cost_expectancy_bps"], Decimal("0.50"))
         self.assertEqual(
             tca_rows[0]["post_cost_expectancy_basis"], POST_COST_BASIS_TCA_PROXY
         )
         self.assertEqual(tca_rows[0]["post_cost_promotion_eligible"], False)
+        self.assertEqual(tca_rows[1]["post_cost_promotion_eligible"], False)
+        self.assertIn("unclosed_position", tca_rows[1]["runtime_ledger_blockers"])
         self.assertEqual(len(cursor.executed), 3)
         decision_query, decision_params = cursor.executed[0]
         self.assertIn("s.name = any(%s)", decision_query)

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -5,7 +5,11 @@ from decimal import Decimal
 
 import pytest
 
-from app.trading.runtime_ledger import RuntimeLedgerFill, build_runtime_ledger_buckets
+from app.trading.runtime_ledger import (
+    EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+    RuntimeLedgerFill,
+    build_runtime_ledger_buckets,
+)
 
 
 def _ts(minutes: int = 0) -> datetime:
@@ -499,3 +503,152 @@ def test_invalid_runtime_fill_fields_fail_closed() -> None:
     assert "filled_notional_missing" in bucket.blockers
     assert "explicit_cost_missing" in bucket.blockers
     assert "runtime_fills_missing" in bucket.blockers
+
+
+def test_exact_replay_ledger_requires_order_lifecycle_and_hash_lineage() -> None:
+    common = {
+        "account_label": "paper",
+        "strategy_id": "strategy-1",
+        "symbol": "NVDA",
+        "execution_policy_hash": "policy-sha",
+        "cost_model_hash": "cost-sha",
+        "lineage_hash": "lineage-sha",
+    }
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                **common,
+                "event_type": "decision",
+                "executed_at": _ts(1),
+                "decision_id": "decision-buy",
+            },
+            {
+                **common,
+                "event_type": "order_submitted",
+                "executed_at": _ts(2),
+                "decision_id": "decision-buy",
+                "order_id": "order-buy",
+            },
+            {
+                **common,
+                "event_type": "fill",
+                "executed_at": _ts(3),
+                "order_id": "order-buy",
+                "side": "buy",
+                "filled_qty": "10",
+                "avg_fill_price": "100",
+                "cost_amount": "1",
+                "cost_basis": "broker_reported_commission_and_fees",
+            },
+            {
+                **common,
+                "event_type": "decision",
+                "executed_at": _ts(10),
+                "decision_id": "decision-sell",
+            },
+            {
+                **common,
+                "event_type": "order_submitted",
+                "executed_at": _ts(11),
+                "decision_id": "decision-sell",
+                "order_id": "order-sell",
+            },
+            {
+                **common,
+                "event_type": "fill",
+                "executed_at": _ts(12),
+                "order_id": "order-sell",
+                "side": "sell",
+                "filled_qty": "10",
+                "avg_fill_price": "110",
+                "cost_amount": "2",
+                "cost_basis": "broker_reported_commission_and_fees",
+            },
+        ],
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.blockers == []
+    assert bucket.ledger_schema_version == EXACT_REPLAY_LEDGER_SCHEMA_VERSION
+    assert bucket.decision_count == 2
+    assert bucket.submitted_order_count == 2
+    assert bucket.fill_count == 2
+    assert bucket.net_strategy_pnl_after_costs == Decimal("97")
+    assert bucket.execution_policy_hash_counts == {"policy-sha": 6}
+    assert bucket.cost_model_hash_counts == {"cost-sha": 6}
+    assert bucket.lineage_hash_counts == {"lineage-sha": 6}
+    assert bucket.post_cost_expectancy_bps is not None
+
+
+def test_exact_replay_ledger_blocks_fill_only_profit_proof() -> None:
+    bucket = build_runtime_ledger_buckets(
+        [
+            RuntimeLedgerFill(
+                executed_at=_ts(1),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="buy",
+                filled_qty=Decimal("10"),
+                avg_fill_price=Decimal("100"),
+                cost_amount=Decimal("1"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(12),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="sell",
+                filled_qty=Decimal("10"),
+                avg_fill_price=Decimal("110"),
+                cost_amount=Decimal("2"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+        ],
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.net_strategy_pnl_after_costs == Decimal("97")
+    assert bucket.post_cost_expectancy_bps is None
+    assert "runtime_decision_lifecycle_missing" in bucket.blockers
+    assert "submitted_order_lifecycle_missing" in bucket.blockers
+    assert "fill_order_linkage_missing" in bucket.blockers
+
+
+def test_exact_replay_ledger_blocks_unfilled_or_unhashed_order_lifecycle() -> None:
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                "event_type": "decision",
+                "executed_at": _ts(1),
+                "decision_id": "decision-buy",
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "execution_policy_hash": "policy-sha",
+                "lineage_hash": "lineage-sha",
+            },
+            {
+                "event_type": "order_submitted",
+                "executed_at": _ts(2),
+                "decision_id": "decision-buy",
+                "order_id": "order-buy",
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "execution_policy_hash": "policy-sha",
+                "lineage_hash": "lineage-sha",
+            },
+        ],
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.fill_count == 0
+    assert bucket.post_cost_expectancy_bps is None
+    assert "zero_fill_runtime_ledger" in bucket.blockers
+    assert "unfilled_order_present" in bucket.blockers
+    assert "cost_model_hash_missing" in bucket.blockers

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -483,6 +483,37 @@ class TestRuntimeWindowImport(TestCase):
         )
         self.assertEqual(decision.allowed, False)
 
+    def test_build_observed_runtime_buckets_cannot_upgrade_tca_basis_to_promotion_grade(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    40,
+                )
+            ],
+            decision_times=[datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+            execution_times=[datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("4"),
+                    "post_cost_expectancy_bps": Decimal("80"),
+                    "post_cost_expectancy_basis": "tca_shortfall_proxy",
+                    "post_cost_promotion_eligible": True,
+                }
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        self.assertEqual(buckets[0].post_cost_promotion_sample_count, 0)
+        self.assertEqual(buckets[0].post_cost_expectancy_bps, Decimal("0"))
+        self.assertEqual(buckets[0].post_cost_basis_counts, {"tca_shortfall_proxy": 1})
+
     def test_persist_observed_runtime_windows_skips_idle_buckets(self) -> None:
         buckets = build_observed_runtime_buckets(
             bucket_ranges=[


### PR DESCRIPTION
## Summary

- Require exact runtime ledger proof to carry decision, submitted-order, fill, cost-model, execution-policy, and lineage evidence before post-cost expectancy can become promotion-grade.
- Stop treating TCA shortfall as explicit runtime costs when importing hypothesis runtime windows.
- Prevent callers from upgrading non-promotion-grade PnL bases with `post_cost_promotion_eligible=true`.
- Add regression coverage for lifecycle-gated runtime ledgers, shortfall-only cost rejection, and TCA basis downgrade behavior.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen pytest tests/test_runtime_ledger.py tests/test_runtime_window_import.py -q`
- `uv run --frozen ruff check app/trading/runtime_ledger.py app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

Runtime window imports no longer promote shortfall-only execution evidence as `realized_strategy_pnl_after_explicit_costs`; promotion-grade runtime PnL now requires explicit cost basis and order-lifecycle lineage.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
