### PR TITLE
fix(agents): make github issue metadata optional

### DIFF
--- a/argocd/applications/agents/codex-orchestrations.yaml
+++ b/argocd/applications/agents/codex-orchestrations.yaml
@@ -16,15 +16,15 @@ spec:
       with:
         implementation: |-
           {
-            "summary": "Codex rerun for {{repository}}#{{issueNumber}}",
+            "summary": "Codex rerun for {{repository}} on {{head}}",
             "text": "{{codexPrompt}}",
             "source": {
-              "provider": "github",
-              "externalId": "{{repository}}#{{issueNumber}}",
+              "provider": "codex",
+              "externalId": "{{repository}}:{{head}}",
               "url": "{{issueUrl}}"
             },
             "contract": {
-              "requiredKeys": ["repository", "issueNumber", "base", "head", "stage"]
+              "requiredKeys": ["repository", "base", "head", "stage"]
             },
             "metadata": {
               "stage": "implementation"
@@ -60,15 +60,15 @@ spec:
       with:
         implementation: |-
           {
-            "summary": "Codex system improvement for {{repository}}#{{issueNumber}}",
+            "summary": "Codex system improvement for {{repository}} on {{head}}",
             "text": "{{codexPrompt}}",
             "source": {
-              "provider": "github",
-              "externalId": "{{repository}}#{{issueNumber}}",
+              "provider": "codex",
+              "externalId": "{{repository}}:{{head}}",
               "url": "{{issueUrl}}"
             },
             "contract": {
-              "requiredKeys": ["repository", "issueNumber", "base", "head", "stage"]
+              "requiredKeys": ["repository", "base", "head", "stage"]
             },
             "metadata": {
               "stage": "implementation",

--- a/argocd/applications/agents/codex-versioncontrolprovider.yaml
+++ b/argocd/applications/agents/codex-versioncontrolprovider.yaml
@@ -22,7 +22,7 @@ spec:
     pullRequests: true
   defaults:
     baseBranch: main
-    branchTemplate: codex/{{issueNumber}}
+    branchTemplate: codex/{{agentRun.name}}
     branchConflictSuffixTemplate: "{{agentRun.name}}"
     commitAuthorName: "Greg Konush"
     commitAuthorEmail: 12027037+gregkonush@users.noreply.github.com

--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -181,7 +181,7 @@ annotations:
           name: codex-orchestration
         parameters:
           repository: proompteng/lab
-          issueNumber: "1234"
+          head: codex/orchestration-run
     - apiVersion: swarm.proompteng.ai/v1alpha1
       kind: Swarm
       metadata:

--- a/charts/agents/examples/agentrun-sample.yaml
+++ b/charts/agents/examples/agentrun-sample.yaml
@@ -29,7 +29,6 @@ spec:
         memory: 512Mi
   parameters:
     repository: proompteng/lab
-    issueNumber: '1234'
     base: main
     head: codex/onboarding-flow
     url: https://example.com/tasks/1234

--- a/charts/agents/examples/implementationspec-native-workflow.yaml
+++ b/charts/agents/examples/implementationspec-native-workflow.yaml
@@ -10,9 +10,6 @@ spec:
   contract:
     requiredKeys:
       - repository
-      - issueNumber
-      - issueTitle
-      - issueUrl
       - base
       - head
   summary: 'Add autoscaling support to Agents chart'

--- a/charts/agents/examples/implementationspec-sample.yaml
+++ b/charts/agents/examples/implementationspec-sample.yaml
@@ -10,15 +10,12 @@ spec:
   contract:
     requiredKeys:
       - repository
-      - issueNumber
       - base
       - head
       - url
     mappings:
       - from: linearRepo
         to: repository
-      - from: linearIssue
-        to: issueNumber
       - from: linearUrl
         to: url
   summary: 'Implement onboarding flow'

--- a/charts/agents/examples/versioncontrolprovider-github-app.yaml
+++ b/charts/agents/examples/versioncontrolprovider-github-app.yaml
@@ -24,11 +24,11 @@ spec:
     pullRequests: true
   defaults:
     baseBranch: main
-    branchTemplate: codex/{{issueNumber}}
+    branchTemplate: codex/{{agentRun.name}}
     commitAuthorName: codex
     commitAuthorEmail: codex@proompt.com
     pullRequest:
       enabled: true
       draft: false
       titleTemplate: 'Codex: {{repository}}'
-      bodyTemplate: 'Closes #{{issueNumber}}'
+      bodyTemplate: 'AgentRun: {{agentRun.name}}'

--- a/charts/agents/examples/versioncontrolprovider-github.yaml
+++ b/charts/agents/examples/versioncontrolprovider-github.yaml
@@ -23,7 +23,7 @@ spec:
     pullRequests: true
   defaults:
     baseBranch: main
-    branchTemplate: codex/{{issueNumber}}
+    branchTemplate: codex/{{agentRun.name}}
     branchConflictSuffixTemplate: '{{agentRun.name}}'
     commitAuthorName: codex
     commitAuthorEmail: codex@proompt.com
@@ -31,4 +31,4 @@ spec:
       enabled: true
       draft: false
       titleTemplate: 'Codex: {{repository}}'
-      bodyTemplate: 'Closes #{{issueNumber}}'
+      bodyTemplate: 'AgentRun: {{agentRun.name}}'

--- a/charts/agents/values.yaml
+++ b/charts/agents/values.yaml
@@ -390,14 +390,14 @@ versionControlProvider:
     pullRequests: true
   defaults:
     baseBranch: main
-    branchTemplate: codex/{{issueNumber}}
+    branchTemplate: codex/{{agentRun.name}}
     commitAuthorName: codex
     commitAuthorEmail: codex@proompt.com
     pullRequest:
       enabled: true
       draft: false
       titleTemplate: 'Codex: {{repository}}'
-      bodyTemplate: 'Closes #{{issueNumber}}'
+      bodyTemplate: 'AgentRun: {{agentRun.name}}'
 
 orchestrationController:
   enabled: true

--- a/docs/agents/agentrun-creation-guide.md
+++ b/docs/agents/agentrun-creation-guide.md
@@ -51,9 +51,6 @@ spec:
     repository: proompteng/lab
     base: main
     head: codex/agents/leader-election-implementation-20260207
-    issueNumber: '0'
-    issueTitle: Implement leader election (code + chart)
-    issueUrl: https://github.com/proompteng/lab/blob/main/docs/agents/leader-election-design.md
     stage: implementation
   runtime:
     type: workflow

--- a/docs/agents/designs/branch-naming-conflict-strategy.md
+++ b/docs/agents/designs/branch-naming-conflict-strategy.md
@@ -36,7 +36,7 @@ The following context is available to templates:
 ```
 defaults:
   baseBranch: main
-  branchTemplate: codex/{{issueNumber}}
+  branchTemplate: codex/{{agentRun.name}}
   branchConflictSuffixTemplate: "{{agentRun.name}}"
 ```
 

--- a/docs/agents/version-control-provider-design.md
+++ b/docs/agents/version-control-provider-design.md
@@ -269,14 +269,14 @@ spec:
     pullRequests: true
   defaults:
     baseBranch: main
-    branchTemplate: codex/{{issueNumber}}
+    branchTemplate: codex/{{agentRun.name}}
     commitAuthorName: codex
     commitAuthorEmail: codex@proompt.com
     pullRequest:
       enabled: true
       draft: false
       titleTemplate: 'Codex: {{repository}}'
-      bodyTemplate: 'Closes #{{issueNumber}}'
+      bodyTemplate: 'AgentRun: {{agentRun.name}}'
 ```
 
 ### Agent referencing VCS provider

--- a/services/agents/src/server/agents-controller/implementation-contract.test.ts
+++ b/services/agents/src/server/agents-controller/implementation-contract.test.ts
@@ -57,6 +57,41 @@ describe('agents controller implementation-contract module', () => {
     })
   })
 
+  it('validates repository-backed specs without github issue metadata', () => {
+    const implementation = {
+      source: {
+        provider: 'manual',
+        externalId: 'manual:task-1',
+      },
+      text: 'Implement the task from the prompt',
+      contract: {
+        requiredKeys: ['repository', 'base', 'head', 'stage'],
+      },
+    }
+
+    const parameters = {
+      repository: 'proompteng/lab',
+      base: 'main',
+      head: 'codex/no-issue-task',
+      stage: 'implementation',
+    }
+
+    const validation = validateImplementationContract(implementation, parameters)
+    expect(validation).toMatchObject({ ok: true, requiredKeys: ['repository', 'base', 'head', 'stage'] })
+
+    const context = buildEventContext(implementation, parameters)
+    expect(context.missingRequiredKeys).toEqual([])
+    expect(context.payload).toMatchObject({
+      repository: 'proompteng/lab',
+      base: 'main',
+      head: 'codex/no-issue-task',
+      stage: 'implementation',
+      prompt: 'Implement the task from the prompt',
+    })
+    expect(context.payload).not.toHaveProperty('issueNumber')
+    expect(context.payload).not.toHaveProperty('issueTitle')
+  })
+
   it('renders parameterized implementation text for prompt and issue body', () => {
     const implementation = {
       source: {

--- a/services/agents/src/server/agents-controller/index.integration.test.ts
+++ b/services/agents/src/server/agents-controller/index.integration.test.ts
@@ -4947,6 +4947,55 @@ describe('agents controller resolveVcsContext', () => {
     expect(result.ok).toBe(true)
     expect(result.context?.headBranch).toBe('codex/123-run-1')
   })
+
+  it('falls back to the AgentRun name when an issue branch template has no issue number', async () => {
+    const kube = buildKube({
+      get: vi.fn(async (resource: string) => {
+        if (resource === RESOURCE_MAP.VersionControlProvider) {
+          return buildVcsProvider({
+            spec: {
+              provider: 'github',
+              auth: { method: 'none' },
+              defaults: {
+                branchTemplate: 'codex/{{issueNumber}}',
+                branchConflictSuffixTemplate: '{{agentRun.name}}',
+              },
+            },
+          })
+        }
+        return null
+      }),
+    })
+
+    const agentRun = buildAgentRun({
+      spec: {
+        agentRef: { name: 'agent-1' },
+        implementationSpecRef: { name: 'impl-1' },
+        runtime: { type: 'job', config: {} },
+        workload: { image: defaultRunnerImage },
+        vcsRef: { name: 'vcs-1' },
+        parameters: {
+          repository: 'proompteng/lab',
+        },
+      },
+    })
+
+    const result = await __test.resolveVcsContext({
+      kube: kube as never,
+      namespace: 'agents',
+      agentRun,
+      agent: { metadata: { name: 'agent-1' }, spec: {} },
+      implementation: {},
+      parameters: {
+        repository: 'proompteng/lab',
+      },
+      allowedSecrets: [],
+      existingRuns: [],
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.context?.headBranch).toBe('codex/run-1')
+  })
 })
 describe('agents controller reconcileVersionControlProvider', () => {
   it('surfaces deprecation warnings for github token types', async () => {

--- a/services/agents/src/server/agents-controller/vcs-context.ts
+++ b/services/agents/src/server/agents-controller/vcs-context.ts
@@ -28,6 +28,13 @@ const makeName = (base: string, suffix: string) => {
     .slice(0, 63)
 }
 
+const defaultHeadBranchForRun = (runName: string) => `codex/${runName}`
+
+const isUsableRenderedBranch = (value: string) => {
+  const branch = value.trim()
+  return branch.length > 0 && !branch.split('/').some((part) => part.length === 0)
+}
+
 export type EnvVar = {
   name: string
   value?: string
@@ -410,7 +417,11 @@ export const resolveVcsContext = async ({
     event: eventContext.payload,
   }
   if (!headBranch && branchTemplate) {
-    headBranch = renderTemplate(branchTemplate, templateContext)
+    const renderedBranch = renderTemplate(branchTemplate, templateContext)
+    headBranch = isUsableRenderedBranch(renderedBranch) ? renderedBranch.trim() : defaultHeadBranchForRun(runName)
+  }
+  if (!headBranch && effectiveMode === 'read-write') {
+    headBranch = defaultHeadBranchForRun(runName)
   }
   if (headBranch && conflictSuffixTemplate) {
     const conflictRuns = existingRuns ?? []


### PR DESCRIPTION
## Summary

- Makes GitHub issue metadata optional for default Codex AgentRun and ImplementationSpec paths.
- Switches VCS branch and PR body defaults from issue-number templates to AgentRun-name templates.
- Adds controller coverage for no-issue contracts and fallback branches when old issue templates render empty.
- Updates Agents chart examples, GitOps Codex orchestrations, and docs to stop requiring issueNumber or issueTitle by default.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test src/server/agents-controller/implementation-contract.test.ts src/server/agents-controller/index.integration.test.ts`
- `bun run --cwd services/agents tsc`
- `bunx oxfmt --check services/agents/src/server/agents-controller/vcs-context.ts services/agents/src/server/agents-controller/implementation-contract.test.ts services/agents/src/server/agents-controller/index.integration.test.ts`
- `mise exec helm@3 -- helm lint charts/agents`
- `mise exec helm@3 -- helm template agents charts/agents -n agents >/tmp/agents-optional-issue-render.yaml && rg -n 'branchTemplate: codex/\{\{issueNumber\}\}|Closes #\{\{issueNumber\}\}|requiredKeys.*issueNumber|"requiredKeys": \[[^]]*"issueNumber"' /tmp/agents-optional-issue-render.yaml || true`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-argocd-optional-issue-render.yaml && rg -n 'branchTemplate: codex/\{\{issueNumber\}\}|Closes #\{\{issueNumber\}\}|requiredKeys.*issueNumber|"requiredKeys": \[[^]]*"issueNumber"' /tmp/agents-argocd-optional-issue-render.yaml || true`
- `bun run --cwd services/agents lint:oxlint:type` completed with 0 errors and existing warnings outside this change.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
