### PR TITLE
feat(torghut): bind candidate evaluation keys to proof context

### DIFF
--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -980,6 +980,86 @@ def _candidate_search_key(
     )
 
 
+def _candidate_evaluation_key_payload(
+    *,
+    candidate_search_key: str,
+    params_candidate: Mapping[str, Any],
+    strategy_overrides: Mapping[str, Any],
+    replay_lineage: Mapping[str, Any],
+    replay_tape_validation: Mapping[str, Any] | None,
+    window: FrontierReplayWindows,
+    full_window_start: date,
+    full_window_end: date,
+    full_window_summary: Mapping[str, Any],
+) -> dict[str, Any]:
+    validation = dict(replay_tape_validation or {})
+    payload: dict[str, Any] = {
+        "schema_version": "torghut.candidate-evaluation-key.v1",
+        "candidate_search_key": candidate_search_key,
+        "candidate_params_sha256": _stable_payload_hash(params_candidate),
+        "strategy_overrides_sha256": _stable_payload_hash(
+            {
+                str(key): value
+                for key, value in strategy_overrides.items()
+                if str(key) not in _LOCAL_ONLY_OVERRIDE_KEYS
+            }
+        ),
+        "effective_strategy_config_sha256": str(
+            replay_lineage.get("candidate_configmap_sha256") or ""
+        ),
+        "dataset_snapshot_id": str(replay_lineage.get("dataset_snapshot_id") or ""),
+        "replay_lineage_hash": str(replay_lineage.get("lineage_hash") or ""),
+        "replay_tape": {
+            "content_sha256": str(validation.get("content_sha256") or ""),
+            "dataset_snapshot_ref": str(validation.get("dataset_snapshot_ref") or ""),
+            "source_query_digest": str(validation.get("source_query_digest") or ""),
+            "selected_symbols": list(
+                cast(Sequence[Any], validation.get("selected_symbols") or ())
+            ),
+            "selected_row_count": int(validation.get("selected_row_count") or 0),
+            "validation_status": str(validation.get("status") or ""),
+        },
+        "replay_window_spec": {
+            "train_start": window.train_start.isoformat(),
+            "train_end": window.train_end.isoformat(),
+            "holdout_start": window.holdout_start.isoformat(),
+            "holdout_end": window.holdout_end.isoformat(),
+            "second_oos_start": (
+                window.second_oos_start.isoformat()
+                if window.second_oos_start is not None
+                else ""
+            ),
+            "second_oos_end": (
+                window.second_oos_end.isoformat()
+                if window.second_oos_end is not None
+                else ""
+            ),
+            "full_window_start": full_window_start.isoformat(),
+            "full_window_end": full_window_end.isoformat(),
+        },
+        "cost_model_signature": {
+            "market_impact_stress_model": str(
+                full_window_summary.get("market_impact_stress_model") or ""
+            ),
+            "market_impact_stress_cost_bps": str(
+                full_window_summary.get("market_impact_stress_cost_bps") or "0"
+            ),
+            "delay_adjusted_depth_stress_model": str(
+                full_window_summary.get("delay_adjusted_depth_stress_model") or ""
+            ),
+            "delay_adjusted_depth_stress_ms": str(
+                full_window_summary.get("delay_adjusted_depth_stress_ms") or "0"
+            ),
+            "implementation_uncertainty_model": str(
+                full_window_summary.get("implementation_uncertainty_model") or ""
+            ),
+        },
+        "proof_basis_version": "post_cost_replay_net_pnl_with_cost_stress.v1",
+    }
+    payload["candidate_evaluation_key"] = _stable_payload_hash(payload)
+    return payload
+
+
 def _resolve_prefetch_symbols(
     *,
     cli_symbols: tuple[str, ...],
@@ -1094,6 +1174,7 @@ def _load_replay_tape_rows(
     validation["manifest_path"] = str(manifest_path) if manifest_path else ""
     validation["selected_row_count"] = len(rows)
     validation["selected_symbols"] = sorted({row.symbol.upper() for row in rows})
+    validation["source_query_digest"] = tape.manifest.source_query_digest
     return list(rows), validation
 
 
@@ -3461,6 +3542,23 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     full_window_replay_skipped=full_window_replay_skipped,
                 )
                 candidate_payload["replay_lineage"] = replay_lineage
+                candidate_evaluation_key = _candidate_evaluation_key_payload(
+                    candidate_search_key=candidate_key,
+                    params_candidate=params_candidate,
+                    strategy_overrides=override_candidate,
+                    replay_lineage=replay_lineage,
+                    replay_tape_validation=replay_tape_validation,
+                    window=window,
+                    full_window_start=full_window_start,
+                    full_window_end=full_window_end,
+                    full_window_summary=full_window_summary,
+                )
+                candidate_payload["candidate_evaluation_key"] = (
+                    candidate_evaluation_key["candidate_evaluation_key"]
+                )
+                candidate_payload["candidate_evaluation_key_payload"] = (
+                    candidate_evaluation_key
+                )
                 candidate_payload["screening"] = {
                     "schema_version": "torghut.frontier-train-screen.v1",
                     "enabled": bool(getattr(args, "train_screening", True)),

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -191,6 +191,9 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(validation["status"], "valid")
         self.assertEqual(validation["selected_row_count"], 1)
         self.assertEqual(validation["selected_symbols"], ["NVDA"])
+        self.assertEqual(
+            validation["source_query_digest"], build_source_query_digest({"query": "frontier"})
+        )
         self.assertEqual(validation["manifest_path"], "")
 
     def test_clickhouse_password_env_resolution_keeps_secret_out_of_argv(self) -> None:
@@ -247,6 +250,139 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         )
 
         self.assertEqual(left, right)
+
+    def test_candidate_evaluation_key_binds_replay_and_cost_proof_context(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            candidate_configmap = root / "candidate.yaml"
+            candidate_configmap.write_text("data:\n  strategies.yaml: '{}'\n")
+            replay_payload = self._payload(
+                start_date="2026-03-18",
+                end_date="2026-03-19",
+                daily_net={"2026-03-18": "100", "2026-03-19": "150"},
+                decision_count=2,
+                filled_count=2,
+                wins=2,
+                losses=0,
+            )
+            window = frontier.FrontierReplayWindows(
+                train_days=(date(2026, 3, 18),),
+                holdout_days=(date(2026, 3, 19),),
+                second_oos_days=(),
+            )
+            lineage = frontier._candidate_replay_lineage_payload(
+                candidate_configmap_path=candidate_configmap,
+                candidate_search_key="candidate-key",
+                dataset_snapshot_id="snapshot-lineage",
+                train_payload=replay_payload,
+                holdout_payload=replay_payload,
+                full_window_payload=replay_payload,
+                second_oos_payload=None,
+                window=window,
+                full_window_start=date(2026, 3, 18),
+                full_window_end=date(2026, 3, 19),
+                holdout_replay_skipped=False,
+                full_window_replay_skipped=False,
+            )
+
+        base = frontier._candidate_evaluation_key_payload(
+            candidate_search_key="candidate-key",
+            params_candidate={"long_stop_loss_bps": "12"},
+            strategy_overrides={
+                "normalization_regime": "price_scaled",
+                "universe_symbols": ["NVDA"],
+            },
+            replay_lineage=lineage,
+            replay_tape_validation={
+                "content_sha256": "tape-sha",
+                "dataset_snapshot_ref": "snapshot-lineage",
+                "source_query_digest": "query-sha",
+                "selected_symbols": ["NVDA"],
+                "selected_row_count": 10,
+                "status": "valid",
+            },
+            window=window,
+            full_window_start=date(2026, 3, 18),
+            full_window_end=date(2026, 3, 19),
+            full_window_summary={
+                "market_impact_stress_model": "impact-v1",
+                "market_impact_stress_cost_bps": "8",
+                "delay_adjusted_depth_stress_model": "latency_depth_haircut",
+                "delay_adjusted_depth_stress_ms": "50",
+                "implementation_uncertainty_model": "interval-v1",
+            },
+        )
+        changed_tape = frontier._candidate_evaluation_key_payload(
+            candidate_search_key="candidate-key",
+            params_candidate={"long_stop_loss_bps": "12"},
+            strategy_overrides={
+                "normalization_regime": "price_scaled",
+                "universe_symbols": ["NVDA"],
+            },
+            replay_lineage=lineage,
+            replay_tape_validation={
+                "content_sha256": "different-tape-sha",
+                "dataset_snapshot_ref": "snapshot-lineage",
+                "source_query_digest": "query-sha",
+                "selected_symbols": ["NVDA"],
+                "selected_row_count": 10,
+                "status": "valid",
+            },
+            window=window,
+            full_window_start=date(2026, 3, 18),
+            full_window_end=date(2026, 3, 19),
+            full_window_summary={
+                "market_impact_stress_model": "impact-v1",
+                "market_impact_stress_cost_bps": "8",
+                "delay_adjusted_depth_stress_model": "latency_depth_haircut",
+                "delay_adjusted_depth_stress_ms": "50",
+                "implementation_uncertainty_model": "interval-v1",
+            },
+        )
+        changed_cost = frontier._candidate_evaluation_key_payload(
+            candidate_search_key="candidate-key",
+            params_candidate={"long_stop_loss_bps": "12"},
+            strategy_overrides={
+                "normalization_regime": "price_scaled",
+                "universe_symbols": ["NVDA"],
+            },
+            replay_lineage=lineage,
+            replay_tape_validation={
+                "content_sha256": "tape-sha",
+                "dataset_snapshot_ref": "snapshot-lineage",
+                "source_query_digest": "query-sha",
+                "selected_symbols": ["NVDA"],
+                "selected_row_count": 10,
+                "status": "valid",
+            },
+            window=window,
+            full_window_start=date(2026, 3, 18),
+            full_window_end=date(2026, 3, 19),
+            full_window_summary={
+                "market_impact_stress_model": "impact-v2",
+                "market_impact_stress_cost_bps": "12",
+                "delay_adjusted_depth_stress_model": "latency_depth_haircut",
+                "delay_adjusted_depth_stress_ms": "50",
+                "implementation_uncertainty_model": "interval-v1",
+            },
+        )
+
+        self.assertEqual(base["schema_version"], "torghut.candidate-evaluation-key.v1")
+        self.assertEqual(base["replay_tape"]["source_query_digest"], "query-sha")
+        self.assertEqual(
+            base["effective_strategy_config_sha256"],
+            lineage["candidate_configmap_sha256"],
+        )
+        self.assertNotEqual(
+            base["candidate_evaluation_key"],
+            changed_tape["candidate_evaluation_key"],
+        )
+        self.assertNotEqual(
+            base["candidate_evaluation_key"],
+            changed_cost["candidate_evaluation_key"],
+        )
 
     def test_parameter_grid_items_rejects_non_iterable_shapes(self) -> None:
         with self.assertRaisesRegex(ValueError, "parameter_values_not_sequence:alpha"):


### PR DESCRIPTION
## Summary

- Add `torghut.candidate-evaluation-key.v1` payloads to frontier candidates so candidate identity is bound to config SHA, replay lineage, tape content/source digest, dataset, replay windows, and cost-model signature.
- Preserve replay tape `source_query_digest` in validation payloads so proof-bound keys can distinguish different source queries.
- Add regression tests proving the evaluation key changes when replay tape content or cost-model proof context changes.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -q`
- `uv run --frozen ruff check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
