### PR TITLE
chore(agents): bump chart version to 0.9.23

### DIFF
--- a/charts/agents/Chart.yaml
+++ b/charts/agents/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - https://github.com/proompteng/charts/tree/main/charts/agents
 type: application
 kubeVersion: '>=1.25.0-0'
-version: 0.9.22
+version: 0.9.23
 appVersion: '0.9.0'
 icon: https://avatars.githubusercontent.com/u/234536857
 keywords:


### PR DESCRIPTION
## Summary

- Bumps the Agents Helm chart package version from `0.9.22` to `0.9.23`.
- Unblocks chart publishing for the already-merged optional GitHub issue metadata changes.
- Leaves runtime code and rendered manifests unchanged except for the chart version.

## Related Issues

None

## Testing

- `mise exec helm@3 -- helm lint charts/agents`
- `mise exec helm@3 -- helm template agents charts/agents -n agents >/tmp/agents-chart-0.9.23-render.yaml && rg -n 'version: 0.9.23|branchTemplate: codex/\\{\\{issueNumber\\}\\}|Closes #\\{\\{issueNumber\\}\\}|requiredKeys.*issueNumber|"requiredKeys": \\[[^]]*"issueNumber"' /tmp/agents-chart-0.9.23-render.yaml charts/agents/Chart.yaml || true`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
