### PR TITLE
chore(agents): sync artifacthub chart version

### DIFF
--- a/charts/agents/artifacthub-pkg.yml
+++ b/charts/agents/artifacthub-pkg.yml
@@ -1,4 +1,4 @@
-version: 0.9.22
+version: 0.9.23
 name: agents
 displayName: Agents Control Plane
 description: Minimal Agents control plane with CRDs and native workflow runtime.


### PR DESCRIPTION
## Summary

- Syncs `charts/agents/artifacthub-pkg.yml` to Agents chart version `0.9.23`.
- Fixes the `agents-sync` publisher consistency check after the chart package version bump.
- Leaves runtime manifests unchanged.

## Related Issues

None

## Testing

- `mise exec helm@3 -- helm lint charts/agents`
- `mise exec helm@3 -- helm template agents charts/agents -n agents >/tmp/agents-artifacthub-0.9.23-render.yaml && rg -n 'version: 0.9.23|branchTemplate: codex/\\{\\{issueNumber\\}\\}|Closes #\\{\\{issueNumber\\}\\}|requiredKeys.*issueNumber|"requiredKeys": \\[[^]]*"issueNumber"' /tmp/agents-artifacthub-0.9.23-render.yaml charts/agents/Chart.yaml charts/agents/artifacthub-pkg.yml || true`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
