### PR TITLE
chore(torghut): promote image ea82e80c

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-469-g0264ae4e7
+              value: v0.571.1-473-gea82e80c8
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 0264ae4e766871037d0b007add745be1a2c513b6
+              value: ea82e80c8d2acda9df3e3e5ee790f1bb7ff57f85
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-469-g0264ae4e7
+              value: v0.571.1-473-gea82e80c8
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 0264ae4e766871037d0b007add745be1a2c513b6
+              value: ea82e80c8d2acda9df3e3e5ee790f1bb7ff57f85
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -75,7 +75,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+                  value: sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-21T18:18:43Z"
+        client.knative.dev/updateTimestamp: "2026-05-21T18:37:51Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
           ports:
             - name: http1
               containerPort: 8181
@@ -499,11 +499,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-469-g0264ae4e7
+              value: v0.571.1-473-gea82e80c8
             - name: TORGHUT_COMMIT
-              value: 0264ae4e766871037d0b007add745be1a2c513b6
+              value: ea82e80c8d2acda9df3e3e5ee790f1bb7ff57f85
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+              value: sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-21T18:18:43Z"
+        client.knative.dev/updateTimestamp: "2026-05-21T18:37:51Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
           ports:
             - name: http1
               containerPort: 8181
@@ -320,11 +320,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-469-g0264ae4e7
+              value: v0.571.1-473-gea82e80c8
             - name: TORGHUT_COMMIT
-              value: 0264ae4e766871037d0b007add745be1a2c513b6
+              value: ea82e80c8d2acda9df3e3e5ee790f1bb7ff57f85
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+              value: sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -132,7 +132,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:70aa389dfe3363b8e5788b8fad2872e59c43e1cb40f6c48795158336519a407a
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `ea82e80c8d2acda9df3e3e5ee790f1bb7ff57f85`
- Image tag: `ea82e80c`
- Image digest: `sha256:e7a417890200fa0d24fdf8d58d7ff0175b5e12bc652b3e9fb827b51b8d7b387d`