### PR TITLE
fix(agents): stop synthesizing issue body metadata

### DIFF
--- a/services/agents/src/server/agents-controller/implementation-contract.test.ts
+++ b/services/agents/src/server/agents-controller/implementation-contract.test.ts
@@ -90,6 +90,44 @@ describe('agents controller implementation-contract module', () => {
     })
     expect(context.payload).not.toHaveProperty('issueNumber')
     expect(context.payload).not.toHaveProperty('issueTitle')
+    expect(context.payload).not.toHaveProperty('issueBody')
+    expect(context.metadata).not.toHaveProperty('issueNumber')
+    expect(context.metadata).not.toHaveProperty('issueTitle')
+    expect(context.metadata).not.toHaveProperty('issueBody')
+  })
+
+  it('does not synthesize github issue title or body for repository-backed specs without an issue number', () => {
+    const implementation = {
+      source: {
+        provider: 'codex',
+        externalId: 'proompteng/lab:codex/no-issue-task',
+      },
+      summary: 'Repository-backed task summary',
+      text: 'Repository-backed task body',
+      contract: {
+        requiredKeys: ['repository', 'base', 'head', 'stage'],
+      },
+    }
+
+    const context = buildEventContext(implementation, {
+      repository: 'proompteng/lab',
+      base: 'main',
+      head: 'codex/no-issue-task',
+      stage: 'implementation',
+    })
+
+    expect(context.payload).toMatchObject({
+      repository: 'proompteng/lab',
+      base: 'main',
+      head: 'codex/no-issue-task',
+      stage: 'implementation',
+      prompt: 'Repository-backed task body',
+    })
+    expect(context.payload).not.toHaveProperty('issueNumber')
+    expect(context.payload).not.toHaveProperty('issueTitle')
+    expect(context.payload).not.toHaveProperty('issueBody')
+    expect(context.metadata).not.toHaveProperty('issueTitle')
+    expect(context.metadata).not.toHaveProperty('issueBody')
   })
 
   it('renders parameterized implementation text for prompt and issue body', () => {
@@ -106,6 +144,7 @@ describe('agents controller implementation-contract module', () => {
 
     const parameters = {
       repository: 'proompteng/lab',
+      issueNumber: '123',
       datasetRef: 'artifacts/dspy/run-1/dataset-build/dspy-dataset.json',
       optimizer: 'miprov2',
       artifactPath: 'artifacts/dspy/run-1/compile',
@@ -134,6 +173,7 @@ describe('agents controller implementation-contract module', () => {
     }
 
     const parameters = {
+      issueNumber: '123',
       symbol: 'AAPL',
     }
 
@@ -141,6 +181,29 @@ describe('agents controller implementation-contract module', () => {
     expect(context.missingRequiredKeys).toEqual([])
     expect(context.payload.prompt).toBe('SCRIPT_ROOT=/root/.codex && test -f "${SCRIPT_ROOT}/run.py" && echo AAPL')
     expect(context.payload.issueBody).toBe('SCRIPT_ROOT=/root/.codex && test -f "${SCRIPT_ROOT}/run.py" && echo AAPL')
+  })
+
+  it('preserves explicit issue body metadata without requiring an issue number', () => {
+    const context = buildEventContext(
+      {
+        text: 'Prompt text',
+        contract: {
+          requiredKeys: ['repository', 'issueBody'],
+        },
+      },
+      {
+        repository: 'proompteng/lab',
+        issueBody: 'Explicit issue body',
+      },
+    )
+
+    expect(context.missingRequiredKeys).toEqual([])
+    expect(context.payload).toMatchObject({
+      repository: 'proompteng/lab',
+      prompt: 'Prompt text',
+      issueBody: 'Explicit issue body',
+    })
+    expect(context.payload).not.toHaveProperty('issueNumber')
   })
 
   it('falls back to github external id when repository metadata is missing', () => {

--- a/services/agents/src/server/agents-controller/implementation-contract.ts
+++ b/services/agents/src/server/agents-controller/implementation-contract.ts
@@ -166,9 +166,20 @@ export const createImplementationContractTools = (resolveParam: ResolveParam) =>
     const templateContext = buildTemplateContext(metadata, parameters)
     const renderedSummary = renderParameterTemplate(summary, templateContext)
     const renderedText = renderParameterTemplate(text, templateContext)
-    const issueTitle = renderParameterTemplate(resolvedIssueTitle || renderedSummary, templateContext)
-    const issueBody = renderParameterTemplate(resolvedIssueBody || renderedText, templateContext)
     const prompt = renderedText || renderedSummary
+    let issueTitle = ''
+    if (resolvedIssueTitle) {
+      issueTitle = renderParameterTemplate(resolvedIssueTitle, templateContext)
+    } else if (issueNumber) {
+      issueTitle = renderParameterTemplate(renderedSummary, templateContext)
+    }
+
+    let issueBody = ''
+    if (resolvedIssueBody) {
+      issueBody = renderParameterTemplate(resolvedIssueBody, templateContext)
+    } else if (issueNumber) {
+      issueBody = renderParameterTemplate(renderedText, templateContext)
+    }
 
     setMetadataIfMissing(metadata, 'issueTitle', issueTitle)
     setMetadataIfMissing(metadata, 'issueBody', issueBody)


### PR DESCRIPTION
## Summary

- Stops synthesizing `issueTitle` and `issueBody` from repository-backed implementation text when no issue number is present.
- Keeps legacy GitHub issue behavior when `issueNumber` exists, and preserves explicit `issueBody` metadata when provided.
- Adds regression coverage for no-issue repository-backed AgentRuns and explicit issue body compatibility.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test src/server/agents-controller/implementation-contract.test.ts src/server/agents-controller/index.integration.test.ts`
- `bun run --cwd services/agents tsc`
- `git diff --check HEAD~1..HEAD`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
