### PR TITLE
chore(agents): promote images 9cf8cd69

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: e1653c49
-  digest: sha256:c588d9a9bad8e90b03880372e4d1cde55a2f95d1f60b9869f383c788665eb25f
+  tag: 9cf8cd69
+  digest: sha256:c7fb413b47038d1ead9032d35056f4e056776637691bf262f5306711db7249e5
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,26 +11,26 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: e1653c49
-    digest: sha256:ebd70e25d3dc5010fb2d0ad50fc14d74abf12ede942349761e529dc83262b91c
+    tag: 9cf8cd69
+    digest: sha256:141c9f8079eef3c47eb62b5e5e5a991ba3c9c6cd95c415bd7e718242d7d4fc4c
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: e1653c49cf2a03764a88a9775e9bf309fc3a72fc
-      AGENTS_GITOPS_REVISION: e1653c49cf2a03764a88a9775e9bf309fc3a72fc
-      AGENTS_SOURCE_CI_RUN_ID: "26245418306"
+      AGENTS_SOURCE_HEAD_SHA: 9cf8cd6954d9498ae002755949ff8389fb3d6d51
+      AGENTS_GITOPS_REVISION: 9cf8cd6954d9498ae002755949ff8389fb3d6d51
+      AGENTS_SOURCE_CI_RUN_ID: "26246295502"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:ebd70e25d3dc5010fb2d0ad50fc14d74abf12ede942349761e529dc83262b91c
-      AGENTS_SERVING_BUILD_COMMIT: e1653c49cf2a03764a88a9775e9bf309fc3a72fc
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:ebd70e25d3dc5010fb2d0ad50fc14d74abf12ede942349761e529dc83262b91c
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:141c9f8079eef3c47eb62b5e5e5a991ba3c9c6cd95c415bd7e718242d7d4fc4c
+      AGENTS_SERVING_BUILD_COMMIT: 9cf8cd6954d9498ae002755949ff8389fb3d6d51
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:141c9f8079eef3c47eb62b5e5e5a991ba3c9c6cd95c415bd7e718242d7d4fc4c
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: e1653c49
-    digest: sha256:6da0bf937787fd0c8c555420d4e03faaffebefe6f1cef7f76b6ad4f3620c7430
+    tag: 9cf8cd69
+    digest: sha256:143819c7bbf89f2988c411be72148531c7716417671d00a8872d5e0a46eaa0cf
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun
@@ -85,8 +85,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: e1653c49
-    digest: sha256:c588d9a9bad8e90b03880372e4d1cde55a2f95d1f60b9869f383c788665eb25f
+    tag: 9cf8cd69
+    digest: sha256:c7fb413b47038d1ead9032d35056f4e056776637691bf262f5306711db7249e5
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `9cf8cd6954d9498ae002755949ff8389fb3d6d51`
- Image tag: `9cf8cd69`
- Agents build run: `26246295502`
- Promotion source: `workflow_run`