### PR TITLE
fix(torghut): require runtime ledger readiness proof

### DIFF
--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -155,12 +155,15 @@ _EVIDENCE_REFRESH_REASONS = {
     "hypothesis_window_evidence_missing",
     "hypothesis_window_evidence_stale",
     "required_feature_set_unavailable",
+    "runtime_ledger_proof_missing",
     "tca_evidence_stale",
 }
 _SAMPLE_REASONS = {"sample_count_below_canary_minimum", "route_universe_empty"}
 _EDGE_OR_COST_REASONS = {
     "post_cost_expectancy_below_manifest_threshold",
     "post_cost_expectancy_non_positive",
+    "runtime_ledger_expectancy_missing",
+    "runtime_ledger_stage_not_live",
     "slippage_budget_exceeded",
 }
 _DEPENDENCY_REASONS = {
@@ -270,8 +273,17 @@ def _ranked_candidate_dossiers(
                 "observed": {
                     "tca_order_count": observed.get("tca_order_count"),
                     "avg_abs_slippage_bps": observed.get("avg_abs_slippage_bps"),
-                    "post_cost_expectancy_bps_proxy": observed.get(
-                        "post_cost_expectancy_bps_proxy"
+                    "runtime_ledger_submitted_order_count": observed.get(
+                        "runtime_ledger_submitted_order_count"
+                    ),
+                    "runtime_ledger_post_cost_expectancy_bps": observed.get(
+                        "runtime_ledger_post_cost_expectancy_bps"
+                    ),
+                    "runtime_ledger_filled_notional": observed.get(
+                        "runtime_ledger_filled_notional"
+                    ),
+                    "runtime_ledger_net_strategy_pnl_after_costs": observed.get(
+                        "runtime_ledger_net_strategy_pnl_after_costs"
                     ),
                     "feature_batch_rows_total": observed.get(
                         "feature_batch_rows_total"
@@ -290,11 +302,12 @@ def _ranked_candidate_dossiers(
             }
         )
 
-    def sort_key(dossier: Mapping[str, object]) -> tuple[int, int, int, int, str]:
+    def sort_key(dossier: Mapping[str, object]) -> tuple[int, int, int, int, int, str]:
         observed = cast(Mapping[str, object], dossier.get("observed") or {})
         return (
             _candidate_blocker_rank(str(dossier.get("blocker_class") or "other")),
             -_CAPITAL_STAGE_RANK.get(str(dossier.get("capital_stage") or "shadow"), 0),
+            -(_optional_int(observed.get("runtime_ledger_submitted_order_count")) or 0),
             -(_optional_int(observed.get("tca_order_count")) or 0),
             -int(
                 bool(dossier.get("candidate_id")) and bool(dossier.get("strategy_id"))
@@ -612,12 +625,30 @@ class _TcaReadinessInputs:
     order_count: int
     avg_abs_slippage_bps: Decimal
     avg_realized_shortfall_bps: Decimal
-    post_cost_expectancy_bps_proxy: Decimal
     last_computed_at: datetime | None
     route_filter_applied: bool
     routeable_symbols: tuple[str, ...]
     route_excluded_symbol_count: int
     route_missing_symbol_count: int
+
+
+@dataclass(frozen=True)
+class _RuntimeLedgerReadinessInputs:
+    proof_present: bool
+    observed_stage: str | None
+    fill_count: int
+    submitted_order_count: int
+    closed_trade_count: int
+    open_position_count: int
+    filled_notional: Decimal
+    net_strategy_pnl_after_costs: Decimal
+    post_cost_expectancy_bps: Decimal | None
+    bucket_started_at: datetime | None
+    bucket_ended_at: datetime | None
+    blockers: tuple[str, ...]
+    execution_policy_hash_count: int
+    cost_model_hash_count: int
+    lineage_hash_count: int
 
 
 @dataclass(frozen=True)
@@ -726,7 +757,6 @@ def _resolve_tca_readiness_inputs(
         order_count=aggregate_order_count,
         avg_abs_slippage_bps=aggregate_avg_abs_slippage,
         avg_realized_shortfall_bps=aggregate_avg_realized_shortfall,
-        post_cost_expectancy_bps_proxy=-aggregate_avg_realized_shortfall,
         last_computed_at=aggregate_last_computed_at,
         route_filter_applied=False,
         routeable_symbols=(),
@@ -774,7 +804,6 @@ def _resolve_tca_readiness_inputs(
             order_count=0,
             avg_abs_slippage_bps=aggregate_avg_abs_slippage,
             avg_realized_shortfall_bps=aggregate_avg_realized_shortfall,
-            post_cost_expectancy_bps_proxy=-aggregate_avg_realized_shortfall,
             last_computed_at=aggregate_last_computed_at,
             route_filter_applied=True,
             routeable_symbols=(),
@@ -800,13 +829,146 @@ def _resolve_tca_readiness_inputs(
         order_count=route_order_count,
         avg_abs_slippage_bps=avg_abs_slippage,
         avg_realized_shortfall_bps=avg_realized_shortfall,
-        post_cost_expectancy_bps_proxy=-avg_realized_shortfall,
         last_computed_at=_latest_tca_timestamp(routeable_rows)
         or aggregate_last_computed_at,
         route_filter_applied=True,
         routeable_symbols=routeable_symbols,
         route_excluded_symbol_count=excluded_symbol_count,
         route_missing_symbol_count=missing_symbol_count,
+    )
+
+
+def _runtime_ledger_rows_for_hypothesis(
+    runtime_ledger_summary: Mapping[str, Any] | None,
+    *,
+    hypothesis_id: str,
+) -> list[Mapping[str, Any]]:
+    if not isinstance(runtime_ledger_summary, Mapping):
+        return []
+
+    rows: list[Mapping[str, Any]] = []
+    for key in ("by_hypothesis", "hypotheses"):
+        raw_by_hypothesis = runtime_ledger_summary.get(key)
+        if isinstance(raw_by_hypothesis, Mapping):
+            by_hypothesis = cast(Mapping[str, object], raw_by_hypothesis)
+            item: object = by_hypothesis.get(hypothesis_id)
+            if isinstance(item, Mapping):
+                rows.append(cast(Mapping[str, Any], item))
+
+    for key in ("items", "runtime_ledger_buckets", "buckets"):
+        raw_rows = runtime_ledger_summary.get(key)
+        for item in _sequence(raw_rows):
+            if not isinstance(item, Mapping):
+                continue
+            row = cast(Mapping[str, Any], item)
+            if str(row.get("hypothesis_id") or "").strip() == hypothesis_id:
+                rows.append(row)
+
+    if str(runtime_ledger_summary.get("hypothesis_id") or "").strip() == hypothesis_id:
+        rows.append(runtime_ledger_summary)
+    return rows
+
+
+def _runtime_ledger_latest_row(
+    rows: Sequence[Mapping[str, Any]],
+) -> Mapping[str, Any] | None:
+    latest: Mapping[str, Any] | None = None
+    latest_at: datetime | None = None
+    for row in rows:
+        row_at = (
+            _parse_iso8601(row.get("bucket_ended_at"))
+            or _parse_iso8601(row.get("window_ended_at"))
+            or _parse_iso8601(row.get("created_at"))
+        )
+        if latest is None or (
+            row_at is not None and (latest_at is None or row_at > latest_at)
+        ):
+            latest = row
+            latest_at = row_at
+    return latest
+
+
+def _hash_count(value: object) -> int:
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[object, object], value)
+        return sum(1 for key in mapping.keys() if str(key).strip())
+    return 0
+
+
+def _runtime_ledger_blockers(row: Mapping[str, Any]) -> tuple[str, ...]:
+    raw: object = (
+        row.get("blockers")
+        or row.get("blockers_json")
+        or row.get("runtime_ledger_blockers")
+        or []
+    )
+    blockers: list[str] = []
+    for item in _sequence(raw):
+        reason = str(item).strip()
+        if reason:
+            blockers.append(reason)
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for blocker in blockers:
+        if blocker in seen:
+            continue
+        seen.add(blocker)
+        deduped.append(blocker)
+    return tuple(deduped)
+
+
+def _resolve_runtime_ledger_readiness_inputs(
+    runtime_ledger_summary: Mapping[str, Any] | None,
+    *,
+    hypothesis_id: str,
+) -> _RuntimeLedgerReadinessInputs:
+    row = _runtime_ledger_latest_row(
+        _runtime_ledger_rows_for_hypothesis(
+            runtime_ledger_summary,
+            hypothesis_id=hypothesis_id,
+        )
+    )
+    if row is None:
+        return _RuntimeLedgerReadinessInputs(
+            proof_present=False,
+            observed_stage=None,
+            fill_count=0,
+            submitted_order_count=0,
+            closed_trade_count=0,
+            open_position_count=0,
+            filled_notional=Decimal("0"),
+            net_strategy_pnl_after_costs=Decimal("0"),
+            post_cost_expectancy_bps=None,
+            bucket_started_at=None,
+            bucket_ended_at=None,
+            blockers=("runtime_ledger_proof_missing",),
+            execution_policy_hash_count=0,
+            cost_model_hash_count=0,
+            lineage_hash_count=0,
+        )
+
+    return _RuntimeLedgerReadinessInputs(
+        proof_present=True,
+        observed_stage=str(row.get("observed_stage") or "").strip() or None,
+        fill_count=max(0, _optional_int(row.get("fill_count")) or 0),
+        submitted_order_count=max(
+            0, _optional_int(row.get("submitted_order_count")) or 0
+        ),
+        closed_trade_count=max(0, _optional_int(row.get("closed_trade_count")) or 0),
+        open_position_count=max(0, _optional_int(row.get("open_position_count")) or 0),
+        filled_notional=_coerce_decimal(row.get("filled_notional")),
+        net_strategy_pnl_after_costs=_coerce_decimal(
+            row.get("net_strategy_pnl_after_costs")
+        ),
+        post_cost_expectancy_bps=_optional_decimal(row.get("post_cost_expectancy_bps")),
+        bucket_started_at=_parse_iso8601(row.get("bucket_started_at")),
+        bucket_ended_at=_parse_iso8601(row.get("bucket_ended_at")),
+        blockers=_runtime_ledger_blockers(row),
+        execution_policy_hash_count=_hash_count(
+            row.get("execution_policy_hash_counts")
+        ),
+        cost_model_hash_count=_hash_count(row.get("cost_model_hash_counts")),
+        lineage_hash_count=_hash_count(row.get("lineage_hash_counts")),
     )
 
 
@@ -1133,6 +1295,7 @@ def compile_hypothesis_runtime_statuses(
     registry: HypothesisRegistryLoadResult,
     state: object,
     tca_summary: Mapping[str, Any],
+    runtime_ledger_summary: Mapping[str, Any] | None = None,
     market_context_status: Mapping[str, Any],
     jangar_dependency_quorum: JangarDependencyQuorumStatus,
     feature_readiness: Mapping[str, Any] | None = None,
@@ -1223,6 +1386,10 @@ def compile_hypothesis_runtime_statuses(
             tca_summary,
             max_allowed_slippage_bps=manifest.max_allowed_slippage_bps,
             route_symbol_filter_enabled=route_symbol_filter_enabled,
+        )
+        runtime_ledger_inputs = _resolve_runtime_ledger_readiness_inputs(
+            runtime_ledger_summary,
+            hypothesis_id=manifest.hypothesis_id,
         )
         tca_age_minutes: int | None = None
         if tca_inputs.last_computed_at is not None:
@@ -1396,22 +1563,45 @@ def compile_hypothesis_runtime_statuses(
             if tca_inputs.route_filter_applied and not tca_inputs.routeable_symbols:
                 reasons.append("route_universe_empty")
                 rollback_required = True
-            elif tca_inputs.order_count < manifest.min_sample_count_for_live_canary:
+            elif not runtime_ledger_inputs.proof_present:
+                reasons.append("runtime_ledger_proof_missing")
+            elif runtime_ledger_inputs.observed_stage != "live":
+                reasons.append("runtime_ledger_stage_not_live")
+            elif runtime_ledger_inputs.blockers:
+                reasons.extend(runtime_ledger_inputs.blockers)
+                rollback_required = bool(
+                    {
+                        "unclosed_position",
+                        "runtime_order_lifecycle_missing",
+                        "submitted_order_lifecycle_missing",
+                    }
+                    & set(runtime_ledger_inputs.blockers)
+                )
+            elif (
+                runtime_ledger_inputs.submitted_order_count
+                < manifest.min_sample_count_for_live_canary
+            ):
                 reasons.append("sample_count_below_canary_minimum")
             elif tca_inputs.avg_abs_slippage_bps > manifest.max_allowed_slippage_bps:
                 reasons.append("slippage_budget_exceeded")
                 rollback_required = True
-            elif tca_inputs.post_cost_expectancy_bps_proxy <= Decimal("0"):
+            elif runtime_ledger_inputs.post_cost_expectancy_bps is None:
+                reasons.append("runtime_ledger_expectancy_missing")
+                rollback_required = True
+            elif runtime_ledger_inputs.post_cost_expectancy_bps <= Decimal("0"):
                 reasons.append("post_cost_expectancy_non_positive")
                 rollback_required = True
             elif (
-                tca_inputs.post_cost_expectancy_bps_proxy
+                runtime_ledger_inputs.post_cost_expectancy_bps
                 < manifest.expected_gross_edge_bps
             ):
                 reasons.append("post_cost_expectancy_below_manifest_threshold")
             else:
                 promotion_eligible = True
-                if tca_inputs.order_count >= manifest.min_sample_count_for_scale_up:
+                if (
+                    runtime_ledger_inputs.submitted_order_count
+                    >= manifest.min_sample_count_for_scale_up
+                ):
                     if (
                         tca_inputs.avg_abs_slippage_bps
                         <= manifest.max_allowed_slippage_bps * Decimal("0.60")
@@ -1465,9 +1655,41 @@ def compile_hypothesis_runtime_statuses(
             "tca_age_minutes": tca_age_minutes,
             "market_session_open": market_session_open,
             "avg_abs_slippage_bps": _decimal_to_string(tca_inputs.avg_abs_slippage_bps),
-            "post_cost_expectancy_bps_proxy": _decimal_to_string(
-                tca_inputs.post_cost_expectancy_bps_proxy
+            "runtime_ledger_proof_present": runtime_ledger_inputs.proof_present,
+            "runtime_ledger_observed_stage": runtime_ledger_inputs.observed_stage,
+            "runtime_ledger_fill_count": runtime_ledger_inputs.fill_count,
+            "runtime_ledger_submitted_order_count": runtime_ledger_inputs.submitted_order_count,
+            "runtime_ledger_closed_trade_count": runtime_ledger_inputs.closed_trade_count,
+            "runtime_ledger_open_position_count": runtime_ledger_inputs.open_position_count,
+            "runtime_ledger_filled_notional": _decimal_to_string(
+                runtime_ledger_inputs.filled_notional
             ),
+            "runtime_ledger_net_strategy_pnl_after_costs": _decimal_to_string(
+                runtime_ledger_inputs.net_strategy_pnl_after_costs
+            ),
+            "runtime_ledger_post_cost_expectancy_bps": (
+                _decimal_to_string(runtime_ledger_inputs.post_cost_expectancy_bps)
+                if runtime_ledger_inputs.post_cost_expectancy_bps is not None
+                else None
+            ),
+            "runtime_ledger_bucket_started_at": (
+                runtime_ledger_inputs.bucket_started_at.isoformat()
+                if runtime_ledger_inputs.bucket_started_at is not None
+                else None
+            ),
+            "runtime_ledger_bucket_ended_at": (
+                runtime_ledger_inputs.bucket_ended_at.isoformat()
+                if runtime_ledger_inputs.bucket_ended_at is not None
+                else None
+            ),
+            "runtime_ledger_blockers": list(runtime_ledger_inputs.blockers),
+            "runtime_ledger_execution_policy_hash_count": (
+                runtime_ledger_inputs.execution_policy_hash_count
+            ),
+            "runtime_ledger_cost_model_hash_count": (
+                runtime_ledger_inputs.cost_model_hash_count
+            ),
+            "runtime_ledger_lineage_hash_count": runtime_ledger_inputs.lineage_hash_count,
         }
         if tca_inputs.route_filter_applied:
             observed.update(
@@ -1531,6 +1753,8 @@ def compile_hypothesis_runtime_statuses(
                     "max_avg_abs_slippage_bps": _decimal_to_string(
                         manifest.max_allowed_slippage_bps
                     ),
+                    "profitability_authority": "runtime_ledger",
+                    "sample_count_source": "runtime_ledger_submitted_order_count",
                 },
                 "dependency_quorum": jangar_dependency_quorum.as_payload(),
                 "lineage_ref": {

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -26,6 +26,7 @@ from ..models import (
     StrategyHypothesis,
     StrategyHypothesisMetricWindow,
     StrategyPromotionDecision,
+    StrategyRuntimeLedgerBucket,
     TradeDecision,
     VNextDatasetSnapshot,
     VNextPromotionDecision,
@@ -456,6 +457,10 @@ def build_hypothesis_runtime_summary(
     registry = load_hypothesis_registry()
     if dependency_quorum is None:
         dependency_quorum = resolve_hypothesis_dependency_quorum(registry)
+    runtime_ledger_summary = _load_latest_runtime_ledger_summary(
+        session,
+        hypothesis_ids=[item.hypothesis_id for item in registry.items],
+    )
     items = compile_hypothesis_runtime_statuses(
         registry=registry,
         state=state,
@@ -465,6 +470,7 @@ def build_hypothesis_runtime_summary(
             session=session,
             account_label=settings.trading_account_label,
         ),
+        runtime_ledger_summary=runtime_ledger_summary,
         market_context_status=market_context_status,
         jangar_dependency_quorum=dependency_quorum,
         feature_readiness=feature_readiness,
@@ -492,6 +498,70 @@ def build_hypothesis_runtime_summary(
     )
     summary["items"] = items
     return summary
+
+
+def _runtime_ledger_bucket_payload(
+    row: StrategyRuntimeLedgerBucket,
+) -> dict[str, object]:
+    return {
+        "run_id": row.run_id,
+        "candidate_id": row.candidate_id,
+        "hypothesis_id": row.hypothesis_id,
+        "observed_stage": row.observed_stage,
+        "bucket_started_at": row.bucket_started_at.isoformat(),
+        "bucket_ended_at": row.bucket_ended_at.isoformat(),
+        "account_label": row.account_label,
+        "runtime_strategy_name": row.runtime_strategy_name,
+        "strategy_family": row.strategy_family,
+        "fill_count": row.fill_count,
+        "decision_count": row.decision_count,
+        "submitted_order_count": row.submitted_order_count,
+        "cancelled_order_count": row.cancelled_order_count,
+        "rejected_order_count": row.rejected_order_count,
+        "unfilled_order_count": row.unfilled_order_count,
+        "closed_trade_count": row.closed_trade_count,
+        "open_position_count": row.open_position_count,
+        "filled_notional": str(row.filled_notional),
+        "gross_strategy_pnl": str(row.gross_strategy_pnl),
+        "cost_amount": str(row.cost_amount),
+        "net_strategy_pnl_after_costs": str(row.net_strategy_pnl_after_costs),
+        "post_cost_expectancy_bps": str(row.post_cost_expectancy_bps)
+        if row.post_cost_expectancy_bps is not None
+        else None,
+        "ledger_schema_version": row.ledger_schema_version,
+        "pnl_basis": row.pnl_basis,
+        "execution_policy_hash_counts": row.execution_policy_hash_counts or {},
+        "cost_model_hash_counts": row.cost_model_hash_counts or {},
+        "lineage_hash_counts": row.lineage_hash_counts or {},
+        "blockers": row.blockers_json or [],
+    }
+
+
+def _load_latest_runtime_ledger_summary(
+    session: Session,
+    *,
+    hypothesis_ids: Sequence[str],
+) -> dict[str, object]:
+    normalized_ids = [
+        hypothesis_id for hypothesis_id in hypothesis_ids if hypothesis_id
+    ]
+    by_hypothesis: dict[str, dict[str, object]] = {}
+    if not normalized_ids:
+        return {"by_hypothesis": by_hypothesis}
+
+    rows = session.execute(
+        select(StrategyRuntimeLedgerBucket)
+        .where(StrategyRuntimeLedgerBucket.hypothesis_id.in_(normalized_ids))
+        .order_by(
+            StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
+            StrategyRuntimeLedgerBucket.created_at.desc(),
+        )
+    ).scalars()
+    for row in rows:
+        if row.hypothesis_id in by_hypothesis:
+            continue
+        by_hypothesis[row.hypothesis_id] = _runtime_ledger_bucket_payload(row)
+    return {"by_hypothesis": by_hypothesis}
 
 
 def _extract_runtime_summary(

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -98,6 +98,45 @@ def _hypothesis_manifest_payload(
     return payload
 
 
+def _runtime_ledger_summary(
+    *hypothesis_ids: str,
+    submitted_order_count: int = 45,
+    fill_count: int | None = None,
+    closed_trade_count: int = 12,
+    open_position_count: int = 0,
+    filled_notional: str = "100000",
+    net_strategy_pnl_after_costs: str = "80",
+    post_cost_expectancy_bps: str | None = "8",
+    observed_stage: str = "live",
+    blockers: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "by_hypothesis": {
+            hypothesis_id: {
+                "hypothesis_id": hypothesis_id,
+                "candidate_id": f"candidate-{hypothesis_id.lower()}",
+                "observed_stage": observed_stage,
+                "bucket_started_at": "2026-03-06T15:00:00+00:00",
+                "bucket_ended_at": "2026-03-06T15:55:00+00:00",
+                "fill_count": fill_count
+                if fill_count is not None
+                else submitted_order_count,
+                "submitted_order_count": submitted_order_count,
+                "closed_trade_count": closed_trade_count,
+                "open_position_count": open_position_count,
+                "filled_notional": filled_notional,
+                "net_strategy_pnl_after_costs": net_strategy_pnl_after_costs,
+                "post_cost_expectancy_bps": post_cost_expectancy_bps,
+                "execution_policy_hash_counts": {"policy-sha": 1},
+                "cost_model_hash_counts": {"cost-sha": 1},
+                "lineage_hash_counts": {"lineage-sha": 1},
+                "blockers": blockers or [],
+            }
+            for hypothesis_id in hypothesis_ids
+        }
+    }
+
+
 class _FakeHttpResponse:
     def __init__(self, payload: dict[str, object], status: int = 200) -> None:
         self.status = status
@@ -310,6 +349,11 @@ class TestHypothesisReadiness(TestCase):
                 "avg_realized_shortfall_bps": -8,
                 "last_computed_at": "2026-03-06T15:50:00+00:00",
             },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-CONT-01",
+                "H-REV-01",
+                submitted_order_count=45,
+            ),
             market_context_status={"last_freshness_seconds": 60},
             jangar_dependency_quorum=JangarDependencyQuorumStatus(
                 decision="allow",
@@ -327,6 +371,169 @@ class TestHypothesisReadiness(TestCase):
         self.assertTrue(cont["promotion_eligible"])
         self.assertEqual(rev["state"], "canary_live")
         self.assertEqual(cont["observed"]["tca_age_minutes"], 10)
+
+    def test_compile_hypothesis_runtime_statuses_requires_live_runtime_ledger_profit_authority(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        state = _state(
+            feature_rows=5,
+            drift_checks=3,
+            evidence_checks=2,
+            signal_lag_seconds=15,
+            evidence_report={
+                "ok": True,
+                "checked_at": "2026-03-06T15:45:00+00:00",
+            },
+        )
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=state,
+            tca_summary={
+                "order_count": 45,
+                "avg_abs_slippage_bps": 4,
+                "avg_realized_shortfall_bps": -8,
+                "last_computed_at": "2026-03-06T15:50:00+00:00",
+            },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-CONT-01",
+                submitted_order_count=45,
+                observed_stage="paper",
+                post_cost_expectancy_bps="8",
+            ),
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 3, 6, 16, 0, tzinfo=timezone.utc),
+        )
+
+        cont = next(item for item in statuses if item["hypothesis_id"] == "H-CONT-01")
+        self.assertFalse(cont["promotion_eligible"])
+        self.assertEqual(cont["state"], "shadow")
+        self.assertIn("runtime_ledger_stage_not_live", cont["reasons"])
+        self.assertEqual(cont["observed"]["runtime_ledger_observed_stage"], "paper")
+        self.assertNotIn("post_cost_expectancy_non_positive", cont["reasons"])
+
+    def test_compile_hypothesis_runtime_statuses_blocks_runtime_ledger_lifecycle_blockers(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        state = _state(
+            feature_rows=5,
+            drift_checks=3,
+            evidence_checks=2,
+            signal_lag_seconds=15,
+            evidence_report={
+                "ok": True,
+                "checked_at": "2026-03-06T15:45:00+00:00",
+            },
+        )
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=state,
+            tca_summary={
+                "order_count": 45,
+                "avg_abs_slippage_bps": 4,
+                "avg_realized_shortfall_bps": -8,
+                "last_computed_at": "2026-03-06T15:50:00+00:00",
+            },
+            runtime_ledger_summary={
+                "hypothesis_id": "H-CONT-01",
+                "observed_stage": "live",
+                "bucket_ended_at": "2026-03-06T15:10:00+00:00",
+                "submitted_order_count": 45,
+                "post_cost_expectancy_bps": "8",
+                "items": [
+                    "ignored",
+                    {
+                        "hypothesis_id": "H-REV-01",
+                        "observed_stage": "live",
+                    },
+                    {
+                        "hypothesis_id": "H-CONT-01",
+                        "observed_stage": "live",
+                        "bucket_ended_at": "2026-03-06T15:55:00+00:00",
+                        "submitted_order_count": 45,
+                        "closed_trade_count": 5,
+                        "post_cost_expectancy_bps": "8",
+                        "execution_policy_hash_counts": ["not-a-hash-map"],
+                        "cost_model_hash_counts": {"cost-sha": 1},
+                        "lineage_hash_counts": {"lineage-sha": 1},
+                        "blockers": [
+                            "unclosed_position",
+                            "",
+                            "unclosed_position",
+                        ],
+                    },
+                ],
+            },
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 3, 6, 16, 0, tzinfo=timezone.utc),
+        )
+
+        cont = next(item for item in statuses if item["hypothesis_id"] == "H-CONT-01")
+        self.assertFalse(cont["promotion_eligible"])
+        self.assertTrue(cont["rollback_required"])
+        self.assertEqual(cont["reasons"], ["unclosed_position"])
+        observed = cont["observed"]
+        self.assertEqual(observed["runtime_ledger_blockers"], ["unclosed_position"])
+        self.assertEqual(
+            observed["runtime_ledger_bucket_ended_at"], "2026-03-06T15:55:00+00:00"
+        )
+        self.assertEqual(observed["runtime_ledger_execution_policy_hash_count"], 0)
+        self.assertEqual(observed["runtime_ledger_cost_model_hash_count"], 1)
+        self.assertEqual(observed["runtime_ledger_lineage_hash_count"], 1)
+
+    def test_compile_hypothesis_runtime_statuses_blocks_missing_runtime_ledger_expectancy(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        state = _state(
+            feature_rows=5,
+            drift_checks=3,
+            evidence_checks=2,
+            signal_lag_seconds=15,
+            evidence_report={
+                "ok": True,
+                "checked_at": "2026-03-06T15:45:00+00:00",
+            },
+        )
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=state,
+            tca_summary={
+                "order_count": 45,
+                "avg_abs_slippage_bps": 4,
+                "avg_realized_shortfall_bps": -8,
+                "last_computed_at": "2026-03-06T15:50:00+00:00",
+            },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-CONT-01",
+                submitted_order_count=45,
+                post_cost_expectancy_bps=None,
+            ),
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 3, 6, 16, 0, tzinfo=timezone.utc),
+        )
+
+        cont = next(item for item in statuses if item["hypothesis_id"] == "H-CONT-01")
+        self.assertFalse(cont["promotion_eligible"])
+        self.assertTrue(cont["rollback_required"])
+        self.assertIn("runtime_ledger_expectancy_missing", cont["reasons"])
+        self.assertIsNone(cont["observed"]["runtime_ledger_post_cost_expectancy_bps"])
 
     def test_compile_hypothesis_runtime_statuses_blocks_h_micro_without_delay_depth_stress(
         self,
@@ -352,6 +559,11 @@ class TestHypothesisReadiness(TestCase):
                 "avg_realized_shortfall_bps": -12,
                 "last_computed_at": "2026-03-06T15:50:00+00:00",
             },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-MICRO-01",
+                submitted_order_count=80,
+                post_cost_expectancy_bps="12",
+            ),
             market_context_status={"last_freshness_seconds": 60},
             jangar_dependency_quorum=JangarDependencyQuorumStatus(
                 decision="allow",
@@ -399,6 +611,11 @@ class TestHypothesisReadiness(TestCase):
                 "avg_realized_shortfall_bps": -12,
                 "last_computed_at": "2026-03-06T15:50:00+00:00",
             },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-MICRO-01",
+                submitted_order_count=80,
+                post_cost_expectancy_bps="12",
+            ),
             market_context_status={"last_freshness_seconds": 60},
             jangar_dependency_quorum=JangarDependencyQuorumStatus(
                 decision="allow",
@@ -572,6 +789,11 @@ class TestHypothesisReadiness(TestCase):
                     },
                 ],
             },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-CONT-01",
+                submitted_order_count=90,
+                post_cost_expectancy_bps="8",
+            ),
             market_context_status={"last_freshness_seconds": 60},
             jangar_dependency_quorum=JangarDependencyQuorumStatus(
                 decision="allow",
@@ -592,7 +814,8 @@ class TestHypothesisReadiness(TestCase):
         observed = cont["observed"]
         self.assertEqual(observed["tca_order_count"], 90)
         self.assertEqual(observed["avg_abs_slippage_bps"], "6")
-        self.assertEqual(observed["post_cost_expectancy_bps_proxy"], "8")
+        self.assertEqual(observed["runtime_ledger_post_cost_expectancy_bps"], "8")
+        self.assertEqual(observed["runtime_ledger_submitted_order_count"], 90)
         self.assertEqual(observed["route_tca_symbols"], ["AAPL"])
         self.assertEqual(observed["route_tca_excluded_symbol_count"], 1)
 
@@ -695,6 +918,12 @@ class TestHypothesisReadiness(TestCase):
                     },
                 ],
             },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-CONT-01",
+                submitted_order_count=45,
+                net_strategy_pnl_after_costs="-10",
+                post_cost_expectancy_bps="-1",
+            ),
             market_context_status={"last_freshness_seconds": 60},
             jangar_dependency_quorum=JangarDependencyQuorumStatus(
                 decision="allow",
@@ -714,7 +943,7 @@ class TestHypothesisReadiness(TestCase):
         self.assertIn("post_cost_expectancy_non_positive", cont["reasons"])
         observed = cont["observed"]
         self.assertEqual(observed["avg_abs_slippage_bps"], "6")
-        self.assertEqual(observed["post_cost_expectancy_bps_proxy"], "-1")
+        self.assertEqual(observed["runtime_ledger_post_cost_expectancy_bps"], "-1")
         self.assertEqual(observed["route_tca_symbols"], ["AAPL"])
 
     def test_compile_hypothesis_runtime_statuses_blocks_stale_tca_evidence(
@@ -779,6 +1008,14 @@ class TestHypothesisReadiness(TestCase):
                 "avg_realized_shortfall_bps": -12,
                 "last_computed_at": "2026-03-06T15:00:00+00:00",
             },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-CONT-01",
+                "H-MICRO-01",
+                "H-REV-01",
+                "H-BREAKOUT-01",
+                submitted_order_count=120,
+                post_cost_expectancy_bps="12",
+            ),
             market_context_status={"last_freshness_seconds": 10_000},
             jangar_dependency_quorum=JangarDependencyQuorumStatus(
                 decision="allow",
@@ -811,7 +1048,7 @@ class TestHypothesisReadiness(TestCase):
                 message="ok",
             ),
         )
-        self.assertEqual(summary["reason_totals"]["slippage_budget_exceeded"], 4)
+        self.assertEqual(summary["reason_totals"]["slippage_budget_exceeded"], 2)
         self.assertEqual(
             summary["informational_reason_totals"]["closed_session_signal_hold"], 5
         )

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -21,12 +21,14 @@ from app.models import (
     Strategy,
     StrategyHypothesisMetricWindow,
     StrategyPromotionDecision,
+    StrategyRuntimeLedgerBucket,
     TradeDecision,
 )
 from app.trading.hypotheses import JangarDependencyQuorumStatus
 from app.trading.submission_council import (
     _QUANT_HEALTH_CACHE,
     _coerce_aware_datetime,
+    _load_latest_runtime_ledger_summary,
     _load_profit_promotion_table_counts,
     _merge_runtime_certificate_evidence,
     _metric_window_activity_reason_codes,
@@ -168,6 +170,137 @@ class TestSubmissionCouncil(TestCase):
             "status": "healthy",
             "source_url": "http://jangar.test/api/torghut/trading/control-plane/quant/health?account=paper&window=15m",
         }
+
+    def test_load_latest_runtime_ledger_summary_uses_latest_bucket_per_hypothesis(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        older = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+        newer = datetime(2026, 3, 6, 15, 30, tzinfo=timezone.utc)
+
+        with session_local() as session:
+            self.assertEqual(
+                _load_latest_runtime_ledger_summary(session, hypothesis_ids=[]),
+                {"by_hypothesis": {}},
+            )
+            session.add_all(
+                [
+                    StrategyRuntimeLedgerBucket(
+                        run_id="ledger-old",
+                        candidate_id="cand-old",
+                        hypothesis_id="H-CONT-01",
+                        observed_stage="live",
+                        bucket_started_at=older,
+                        bucket_ended_at=older,
+                        account_label="paper",
+                        runtime_strategy_name="old-runtime",
+                        strategy_family="intraday_continuation",
+                        fill_count=20,
+                        decision_count=20,
+                        submitted_order_count=20,
+                        cancelled_order_count=1,
+                        rejected_order_count=0,
+                        unfilled_order_count=0,
+                        closed_trade_count=4,
+                        open_position_count=0,
+                        filled_notional=Decimal("1000"),
+                        gross_strategy_pnl=Decimal("12"),
+                        cost_amount=Decimal("2"),
+                        net_strategy_pnl_after_costs=Decimal("10"),
+                        post_cost_expectancy_bps=Decimal("5"),
+                        ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={"old-policy": 1},
+                        cost_model_hash_counts={"old-cost": 1},
+                        lineage_hash_counts={"old-lineage": 1},
+                        blockers_json=[],
+                    ),
+                    StrategyRuntimeLedgerBucket(
+                        run_id="ledger-new",
+                        candidate_id="cand-new",
+                        hypothesis_id="H-CONT-01",
+                        observed_stage="live",
+                        bucket_started_at=newer,
+                        bucket_ended_at=newer,
+                        account_label="paper",
+                        runtime_strategy_name="new-runtime",
+                        strategy_family="intraday_continuation",
+                        fill_count=45,
+                        decision_count=45,
+                        submitted_order_count=45,
+                        cancelled_order_count=0,
+                        rejected_order_count=0,
+                        unfilled_order_count=0,
+                        closed_trade_count=8,
+                        open_position_count=0,
+                        filled_notional=Decimal("2000"),
+                        gross_strategy_pnl=Decimal("24"),
+                        cost_amount=Decimal("4"),
+                        net_strategy_pnl_after_costs=Decimal("20"),
+                        post_cost_expectancy_bps=Decimal("8"),
+                        ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={"new-policy": 1},
+                        cost_model_hash_counts={"new-cost": 1},
+                        lineage_hash_counts={"new-lineage": 1},
+                        blockers_json=[],
+                    ),
+                    StrategyRuntimeLedgerBucket(
+                        run_id="ledger-rev",
+                        candidate_id="cand-rev",
+                        hypothesis_id="H-REV-01",
+                        observed_stage="live",
+                        bucket_started_at=newer,
+                        bucket_ended_at=newer,
+                        account_label="paper",
+                        runtime_strategy_name="rev-runtime",
+                        strategy_family="mean_reversion",
+                        fill_count=40,
+                        decision_count=40,
+                        submitted_order_count=40,
+                        cancelled_order_count=0,
+                        rejected_order_count=0,
+                        unfilled_order_count=0,
+                        closed_trade_count=7,
+                        open_position_count=0,
+                        filled_notional=Decimal("1500"),
+                        gross_strategy_pnl=Decimal("12"),
+                        cost_amount=Decimal("3"),
+                        net_strategy_pnl_after_costs=Decimal("9"),
+                        post_cost_expectancy_bps=None,
+                        ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={},
+                        cost_model_hash_counts={},
+                        lineage_hash_counts={},
+                        blockers_json=[],
+                    ),
+                ]
+            )
+            session.commit()
+
+            summary = _load_latest_runtime_ledger_summary(
+                session,
+                hypothesis_ids=["", "H-CONT-01", "H-REV-01"],
+            )
+
+        by_hypothesis = summary["by_hypothesis"]
+        self.assertIsInstance(by_hypothesis, dict)
+        cont = by_hypothesis["H-CONT-01"]
+        rev = by_hypothesis["H-REV-01"]
+        self.assertEqual(cont["run_id"], "ledger-new")
+        self.assertEqual(cont["candidate_id"], "cand-new")
+        self.assertEqual(cont["submitted_order_count"], 45)
+        self.assertEqual(cont["post_cost_expectancy_bps"], "8.00000000")
+        self.assertEqual(cont["execution_policy_hash_counts"], {"new-policy": 1})
+        self.assertIsNone(rev["post_cost_expectancy_bps"])
 
     def test_metric_window_activity_rejects_tca_proxy_expectancy(self) -> None:
         metric_window = SimpleNamespace(


### PR DESCRIPTION
## Summary

- Requires live runtime ledger proof, submitted-order sample count, and post-cost expectancy before a hypothesis can pass direct live promotion readiness.
- Removes TCA shortfall-derived PnL proxy authority from hypothesis promotion gates while keeping TCA as slippage and route-quality evidence.
- Loads the latest DB-backed `StrategyRuntimeLedgerBucket` per hypothesis into submission council runtime summaries.
- Adds regression coverage for paper-stage ledger evidence failing live promotion and updates hypothesis tests to assert runtime-ledger PnL fields.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/hypotheses.py app/trading/submission_council.py tests/test_hypotheses.py`
- `uv run --frozen ruff check app/trading/hypotheses.py app/trading/submission_council.py tests/test_hypotheses.py`
- `uv run --frozen pytest tests/test_hypotheses.py tests/test_submission_council.py tests/test_trading_pipeline.py::TestTradingPipeline::test_live_submission_allows_autonomy_eligible_canary_without_static_flag tests/test_trading_pipeline.py::TestTradingPipeline::test_pipeline_llm_disabled_keeps_live_submission_operational tests/test_trading_pipeline.py::TestTradingPipeline::test_pipeline_llm_failure_fallbacks tests/test_trading_pipeline.py::TestTradingPipeline::test_pipeline_llm_dspy_live_runtime_gate_can_pass_through_with_degraded_qty tests/test_trading_pipeline.py::TestTradingPipeline::test_pipeline_llm_shadow_bootstrap_artifact_keeps_live_submission_operational tests/test_trading_pipeline.py::TestTradingPipeline::test_pipeline_llm_dspy_runtime_reduced_sell_uses_seeded_simulation_inventory -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen coverage erase`
- `uv run --frozen coverage run --source app,scripts -m pytest tests/test_hypotheses.py tests/test_submission_council.py -q`
- `uv run --frozen coverage xml --fail-under=0`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
