### PR TITLE
fix(torghut): target runtime ledger readiness proof

### DIFF
--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -17,6 +17,7 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from ..config import settings
+from .runtime_ledger import EXACT_REPLAY_LEDGER_SCHEMA_VERSION, POST_COST_PNL_BASIS
 
 HypothesisState = Literal["blocked", "shadow", "canary_live", "scaled_live"]
 CapitalStage = Literal[
@@ -143,6 +144,24 @@ _CAPITAL_STAGE_RANK = {
     "0.50x live": 3,
     "1.00x live": 4,
 }
+_KNOWN_RUNTIME_LEDGER_SCHEMA_VERSIONS = frozenset(
+    {
+        EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+        "torghut.runtime-ledger-bucket.v1",
+    }
+)
+_RUNTIME_LEDGER_PROVENANCE_REASONS = {
+    "runtime_ledger_candidate_id_mismatch",
+    "runtime_ledger_candidate_id_missing",
+    "runtime_ledger_cost_model_hash_missing",
+    "runtime_ledger_execution_policy_hash_missing",
+    "runtime_ledger_lineage_hash_missing",
+    "runtime_ledger_pnl_basis_invalid",
+    "runtime_ledger_pnl_basis_missing",
+    "runtime_ledger_schema_version_invalid",
+    "runtime_ledger_schema_version_missing",
+    "runtime_ledger_strategy_family_mismatch",
+}
 _EVIDENCE_REFRESH_REASONS = {
     "delay_adjusted_depth_stress_failed",
     "delay_adjusted_depth_stress_missing",
@@ -157,6 +176,7 @@ _EVIDENCE_REFRESH_REASONS = {
     "required_feature_set_unavailable",
     "runtime_ledger_proof_missing",
     "tca_evidence_stale",
+    *_RUNTIME_LEDGER_PROVENANCE_REASONS,
 }
 _SAMPLE_REASONS = {"sample_count_below_canary_minimum", "route_universe_empty"}
 _EDGE_OR_COST_REASONS = {
@@ -273,6 +293,12 @@ def _ranked_candidate_dossiers(
                 "observed": {
                     "tca_order_count": observed.get("tca_order_count"),
                     "avg_abs_slippage_bps": observed.get("avg_abs_slippage_bps"),
+                    "runtime_ledger_candidate_id": observed.get(
+                        "runtime_ledger_candidate_id"
+                    ),
+                    "runtime_ledger_observed_stage": observed.get(
+                        "runtime_ledger_observed_stage"
+                    ),
                     "runtime_ledger_submitted_order_count": observed.get(
                         "runtime_ledger_submitted_order_count"
                     ),
@@ -284,6 +310,12 @@ def _ranked_candidate_dossiers(
                     ),
                     "runtime_ledger_net_strategy_pnl_after_costs": observed.get(
                         "runtime_ledger_net_strategy_pnl_after_costs"
+                    ),
+                    "runtime_ledger_schema_version": observed.get(
+                        "runtime_ledger_schema_version"
+                    ),
+                    "runtime_ledger_pnl_basis": observed.get(
+                        "runtime_ledger_pnl_basis"
                     ),
                     "feature_batch_rows_total": observed.get(
                         "feature_batch_rows_total"
@@ -635,7 +667,10 @@ class _TcaReadinessInputs:
 @dataclass(frozen=True)
 class _RuntimeLedgerReadinessInputs:
     proof_present: bool
+    candidate_id: str | None
     observed_stage: str | None
+    runtime_strategy_name: str | None
+    strategy_family: str | None
     fill_count: int
     submitted_order_count: int
     closed_trade_count: int
@@ -649,6 +684,8 @@ class _RuntimeLedgerReadinessInputs:
     execution_policy_hash_count: int
     cost_model_hash_count: int
     lineage_hash_count: int
+    ledger_schema_version: str | None
+    pnl_basis: str | None
 
 
 @dataclass(frozen=True)
@@ -869,23 +906,84 @@ def _runtime_ledger_rows_for_hypothesis(
     return rows
 
 
+def _runtime_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _runtime_target_token(value: object) -> str | None:
+    text = _runtime_text(value)
+    return text.lower().replace("-", "_") if text is not None else None
+
+
+def _runtime_ledger_target_blockers(
+    row: Mapping[str, Any],
+    *,
+    candidate_id: str | None,
+    strategy_family: str | None,
+) -> tuple[str, ...]:
+    blockers: list[str] = []
+    expected_candidate_id = _runtime_text(candidate_id)
+    actual_candidate_id = _runtime_text(row.get("candidate_id"))
+    if expected_candidate_id is not None:
+        if actual_candidate_id is None:
+            blockers.append("runtime_ledger_candidate_id_missing")
+        elif actual_candidate_id != expected_candidate_id:
+            blockers.append("runtime_ledger_candidate_id_mismatch")
+
+    expected_strategy_family = _runtime_target_token(strategy_family)
+    actual_strategy_family = _runtime_target_token(row.get("strategy_family"))
+    if (
+        expected_strategy_family is not None
+        and actual_strategy_family is not None
+        and actual_strategy_family != expected_strategy_family
+    ):
+        blockers.append("runtime_ledger_strategy_family_mismatch")
+    return tuple(blockers)
+
+
+def _runtime_ledger_row_rank(
+    row: Mapping[str, Any],
+    *,
+    candidate_id: str | None,
+    strategy_family: str | None,
+) -> tuple[int, int, datetime]:
+    target_blockers = _runtime_ledger_target_blockers(
+        row,
+        candidate_id=candidate_id,
+        strategy_family=strategy_family,
+    )
+    row_at = (
+        _parse_iso8601(row.get("bucket_ended_at"))
+        or _parse_iso8601(row.get("window_ended_at"))
+        or _parse_iso8601(row.get("created_at"))
+        or datetime.min.replace(tzinfo=timezone.utc)
+    )
+    return (
+        0 if target_blockers else 1,
+        1 if _runtime_text(row.get("observed_stage")) == "live" else 0,
+        row_at,
+    )
+
+
 def _runtime_ledger_latest_row(
     rows: Sequence[Mapping[str, Any]],
+    *,
+    candidate_id: str | None,
+    strategy_family: str | None,
 ) -> Mapping[str, Any] | None:
-    latest: Mapping[str, Any] | None = None
-    latest_at: datetime | None = None
-    for row in rows:
-        row_at = (
-            _parse_iso8601(row.get("bucket_ended_at"))
-            or _parse_iso8601(row.get("window_ended_at"))
-            or _parse_iso8601(row.get("created_at"))
-        )
-        if latest is None or (
-            row_at is not None and (latest_at is None or row_at > latest_at)
-        ):
-            latest = row
-            latest_at = row_at
-    return latest
+    if not rows:
+        return None
+    return max(
+        rows,
+        key=lambda row: _runtime_ledger_row_rank(
+            row,
+            candidate_id=candidate_id,
+            strategy_family=strategy_family,
+        ),
+    )
 
 
 def _hash_count(value: object) -> int:
@@ -893,6 +991,46 @@ def _hash_count(value: object) -> int:
         mapping = cast(Mapping[object, object], value)
         return sum(1 for key in mapping.keys() if str(key).strip())
     return 0
+
+
+def _dedupe_runtime_ledger_blockers(blockers: Sequence[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for blocker in blockers:
+        reason = str(blocker).strip()
+        if not reason or reason in seen:
+            continue
+        seen.add(reason)
+        deduped.append(reason)
+    return tuple(deduped)
+
+
+def _runtime_ledger_provenance_blockers(
+    *,
+    ledger_schema_version: str | None,
+    pnl_basis: str | None,
+    execution_policy_hash_count: int,
+    cost_model_hash_count: int,
+    lineage_hash_count: int,
+) -> tuple[str, ...]:
+    blockers: list[str] = []
+    if ledger_schema_version is None:
+        blockers.append("runtime_ledger_schema_version_missing")
+    elif ledger_schema_version not in _KNOWN_RUNTIME_LEDGER_SCHEMA_VERSIONS:
+        blockers.append("runtime_ledger_schema_version_invalid")
+
+    if pnl_basis is None:
+        blockers.append("runtime_ledger_pnl_basis_missing")
+    elif pnl_basis != POST_COST_PNL_BASIS:
+        blockers.append("runtime_ledger_pnl_basis_invalid")
+
+    if execution_policy_hash_count <= 0:
+        blockers.append("runtime_ledger_execution_policy_hash_missing")
+    if cost_model_hash_count <= 0:
+        blockers.append("runtime_ledger_cost_model_hash_missing")
+    if lineage_hash_count <= 0:
+        blockers.append("runtime_ledger_lineage_hash_missing")
+    return tuple(blockers)
 
 
 def _runtime_ledger_blockers(row: Mapping[str, Any]) -> tuple[str, ...]:
@@ -920,18 +1058,23 @@ def _runtime_ledger_blockers(row: Mapping[str, Any]) -> tuple[str, ...]:
 def _resolve_runtime_ledger_readiness_inputs(
     runtime_ledger_summary: Mapping[str, Any] | None,
     *,
-    hypothesis_id: str,
+    manifest: HypothesisManifest,
 ) -> _RuntimeLedgerReadinessInputs:
     row = _runtime_ledger_latest_row(
         _runtime_ledger_rows_for_hypothesis(
             runtime_ledger_summary,
-            hypothesis_id=hypothesis_id,
-        )
+            hypothesis_id=manifest.hypothesis_id,
+        ),
+        candidate_id=manifest.candidate_id,
+        strategy_family=manifest.strategy_family,
     )
     if row is None:
         return _RuntimeLedgerReadinessInputs(
             proof_present=False,
+            candidate_id=None,
             observed_stage=None,
+            runtime_strategy_name=None,
+            strategy_family=None,
             fill_count=0,
             submitted_order_count=0,
             closed_trade_count=0,
@@ -945,11 +1088,39 @@ def _resolve_runtime_ledger_readiness_inputs(
             execution_policy_hash_count=0,
             cost_model_hash_count=0,
             lineage_hash_count=0,
+            ledger_schema_version=None,
+            pnl_basis=None,
         )
 
+    execution_policy_hash_count = _hash_count(row.get("execution_policy_hash_counts"))
+    cost_model_hash_count = _hash_count(row.get("cost_model_hash_counts"))
+    lineage_hash_count = _hash_count(row.get("lineage_hash_counts"))
+    ledger_schema_version = _runtime_text(row.get("ledger_schema_version"))
+    pnl_basis = _runtime_text(row.get("pnl_basis"))
+    blockers = _dedupe_runtime_ledger_blockers(
+        (
+            *_runtime_ledger_blockers(row),
+            *_runtime_ledger_target_blockers(
+                row,
+                candidate_id=manifest.candidate_id,
+                strategy_family=manifest.strategy_family,
+            ),
+            *_runtime_ledger_provenance_blockers(
+                ledger_schema_version=ledger_schema_version,
+                pnl_basis=pnl_basis,
+                execution_policy_hash_count=execution_policy_hash_count,
+                cost_model_hash_count=cost_model_hash_count,
+                lineage_hash_count=lineage_hash_count,
+            ),
+        )
+    )
     return _RuntimeLedgerReadinessInputs(
         proof_present=True,
-        observed_stage=str(row.get("observed_stage") or "").strip() or None,
+        candidate_id=_runtime_text(row.get("candidate_id")),
+        observed_stage=_runtime_text(row.get("observed_stage")),
+        runtime_strategy_name=_runtime_text(row.get("runtime_strategy_name"))
+        or _runtime_text(row.get("strategy_id")),
+        strategy_family=_runtime_text(row.get("strategy_family")),
         fill_count=max(0, _optional_int(row.get("fill_count")) or 0),
         submitted_order_count=max(
             0, _optional_int(row.get("submitted_order_count")) or 0
@@ -963,12 +1134,12 @@ def _resolve_runtime_ledger_readiness_inputs(
         post_cost_expectancy_bps=_optional_decimal(row.get("post_cost_expectancy_bps")),
         bucket_started_at=_parse_iso8601(row.get("bucket_started_at")),
         bucket_ended_at=_parse_iso8601(row.get("bucket_ended_at")),
-        blockers=_runtime_ledger_blockers(row),
-        execution_policy_hash_count=_hash_count(
-            row.get("execution_policy_hash_counts")
-        ),
-        cost_model_hash_count=_hash_count(row.get("cost_model_hash_counts")),
-        lineage_hash_count=_hash_count(row.get("lineage_hash_counts")),
+        blockers=blockers,
+        execution_policy_hash_count=execution_policy_hash_count,
+        cost_model_hash_count=cost_model_hash_count,
+        lineage_hash_count=lineage_hash_count,
+        ledger_schema_version=ledger_schema_version,
+        pnl_basis=pnl_basis,
     )
 
 
@@ -1389,7 +1560,7 @@ def compile_hypothesis_runtime_statuses(
         )
         runtime_ledger_inputs = _resolve_runtime_ledger_readiness_inputs(
             runtime_ledger_summary,
-            hypothesis_id=manifest.hypothesis_id,
+            manifest=manifest,
         )
         tca_age_minutes: int | None = None
         if tca_inputs.last_computed_at is not None:
@@ -1656,7 +1827,12 @@ def compile_hypothesis_runtime_statuses(
             "market_session_open": market_session_open,
             "avg_abs_slippage_bps": _decimal_to_string(tca_inputs.avg_abs_slippage_bps),
             "runtime_ledger_proof_present": runtime_ledger_inputs.proof_present,
+            "runtime_ledger_candidate_id": runtime_ledger_inputs.candidate_id,
             "runtime_ledger_observed_stage": runtime_ledger_inputs.observed_stage,
+            "runtime_ledger_runtime_strategy_name": (
+                runtime_ledger_inputs.runtime_strategy_name
+            ),
+            "runtime_ledger_strategy_family": runtime_ledger_inputs.strategy_family,
             "runtime_ledger_fill_count": runtime_ledger_inputs.fill_count,
             "runtime_ledger_submitted_order_count": runtime_ledger_inputs.submitted_order_count,
             "runtime_ledger_closed_trade_count": runtime_ledger_inputs.closed_trade_count,
@@ -1690,6 +1866,8 @@ def compile_hypothesis_runtime_statuses(
                 runtime_ledger_inputs.cost_model_hash_count
             ),
             "runtime_ledger_lineage_hash_count": runtime_ledger_inputs.lineage_hash_count,
+            "runtime_ledger_schema_version": runtime_ledger_inputs.ledger_schema_version,
+            "runtime_ledger_pnl_basis": runtime_ledger_inputs.pnl_basis,
         }
         if tca_inputs.route_filter_applied:
             observed.update(

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -547,8 +547,10 @@ def _load_latest_runtime_ledger_summary(
     ]
     by_hypothesis: dict[str, dict[str, object]] = {}
     if not normalized_ids:
-        return {"by_hypothesis": by_hypothesis}
+        return {"by_hypothesis": by_hypothesis, "runtime_ledger_buckets": []}
 
+    rows_by_hypothesis: dict[str, int] = {}
+    retained_rows: list[dict[str, object]] = []
     rows = session.execute(
         select(StrategyRuntimeLedgerBucket)
         .where(StrategyRuntimeLedgerBucket.hypothesis_id.in_(normalized_ids))
@@ -558,10 +560,21 @@ def _load_latest_runtime_ledger_summary(
         )
     ).scalars()
     for row in rows:
-        if row.hypothesis_id in by_hypothesis:
+        payload = _runtime_ledger_bucket_payload(row)
+        retained_count = rows_by_hypothesis.get(row.hypothesis_id, 0)
+        if retained_count < 8:
+            retained_rows.append(payload)
+            rows_by_hypothesis[row.hypothesis_id] = retained_count + 1
+
+        current = by_hypothesis.get(row.hypothesis_id)
+        if current is None:
+            by_hypothesis[row.hypothesis_id] = payload
             continue
-        by_hypothesis[row.hypothesis_id] = _runtime_ledger_bucket_payload(row)
-    return {"by_hypothesis": by_hypothesis}
+        current_is_live = str(current.get("observed_stage") or "").strip() == "live"
+        row_is_live = str(payload.get("observed_stage") or "").strip() == "live"
+        if row_is_live and not current_is_live:
+            by_hypothesis[row.hypothesis_id] = payload
+    return {"by_hypothesis": by_hypothesis, "runtime_ledger_buckets": retained_rows}
 
 
 def _extract_runtime_summary(

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -24,6 +24,27 @@ from app.trading.hypotheses import (
     resolve_hypothesis_dependency_quorum,
     summarize_hypothesis_runtime_statuses,
 )
+from app.trading.runtime_ledger import (
+    EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+    POST_COST_PNL_BASIS,
+)
+
+
+_MANIFEST_CANDIDATE_IDS = {
+    "H-CONT-01": "chip-paper-microbar-composite@execution-proof",
+    "H-MICRO-01": "chip-paper-microbar-composite@execution-proof",
+    "H-PAIRS-01": "spec-d74b07b2aaab8d0cfa8a4c38",
+    "H-REV-01": "chip-paper-microbar-composite@execution-proof",
+    "H-TSMOM-01": "spec-83161ae16d17828eabcc58cc",
+}
+
+_MANIFEST_STRATEGY_FAMILIES = {
+    "H-CONT-01": "intraday_continuation",
+    "H-MICRO-01": "microstructure_breakout",
+    "H-PAIRS-01": "microbar_cross_sectional_pairs",
+    "H-REV-01": "event_reversion",
+    "H-TSMOM-01": "intraday_tsmom_consistent",
+}
 
 
 def _state(
@@ -100,6 +121,7 @@ def _hypothesis_manifest_payload(
 
 def _runtime_ledger_summary(
     *hypothesis_ids: str,
+    candidate_id: str | None = None,
     submitted_order_count: int = 45,
     fill_count: int | None = None,
     closed_trade_count: int = 12,
@@ -114,10 +136,13 @@ def _runtime_ledger_summary(
         "by_hypothesis": {
             hypothesis_id: {
                 "hypothesis_id": hypothesis_id,
-                "candidate_id": f"candidate-{hypothesis_id.lower()}",
+                "candidate_id": candidate_id
+                or _MANIFEST_CANDIDATE_IDS.get(hypothesis_id)
+                or f"candidate-{hypothesis_id.lower()}",
                 "observed_stage": observed_stage,
                 "bucket_started_at": "2026-03-06T15:00:00+00:00",
                 "bucket_ended_at": "2026-03-06T15:55:00+00:00",
+                "strategy_family": _MANIFEST_STRATEGY_FAMILIES.get(hypothesis_id),
                 "fill_count": fill_count
                 if fill_count is not None
                 else submitted_order_count,
@@ -127,6 +152,8 @@ def _runtime_ledger_summary(
                 "filled_notional": filled_notional,
                 "net_strategy_pnl_after_costs": net_strategy_pnl_after_costs,
                 "post_cost_expectancy_bps": post_cost_expectancy_bps,
+                "ledger_schema_version": EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+                "pnl_basis": POST_COST_PNL_BASIS,
                 "execution_policy_hash_counts": {"policy-sha": 1},
                 "cost_model_hash_counts": {"cost-sha": 1},
                 "lineage_hash_counts": {"lineage-sha": 1},
@@ -417,6 +444,185 @@ class TestHypothesisReadiness(TestCase):
         self.assertEqual(cont["observed"]["runtime_ledger_observed_stage"], "paper")
         self.assertNotIn("post_cost_expectancy_non_positive", cont["reasons"])
 
+    def test_compile_hypothesis_runtime_statuses_prefers_target_live_bucket_over_newer_paper(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        state = _state(
+            feature_rows=5,
+            drift_checks=3,
+            evidence_checks=2,
+            signal_lag_seconds=15,
+            evidence_report={
+                "ok": True,
+                "checked_at": "2026-03-06T15:45:00+00:00",
+            },
+        )
+        candidate_id = _MANIFEST_CANDIDATE_IDS["H-CONT-01"]
+        strategy_family = _MANIFEST_STRATEGY_FAMILIES["H-CONT-01"]
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=state,
+            tca_summary={
+                "order_count": 45,
+                "avg_abs_slippage_bps": 4,
+                "avg_realized_shortfall_bps": -8,
+                "last_computed_at": "2026-03-06T15:50:00+00:00",
+            },
+            runtime_ledger_summary={
+                "by_hypothesis": {
+                    "H-CONT-01": {
+                        "hypothesis_id": "H-CONT-01",
+                        "candidate_id": candidate_id,
+                        "observed_stage": "paper",
+                        "strategy_family": strategy_family,
+                        "bucket_ended_at": "2026-03-06T15:55:00+00:00",
+                        "submitted_order_count": 45,
+                        "post_cost_expectancy_bps": "8",
+                        "ledger_schema_version": EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+                        "pnl_basis": POST_COST_PNL_BASIS,
+                        "execution_policy_hash_counts": {"policy-sha": 1},
+                        "cost_model_hash_counts": {"cost-sha": 1},
+                        "lineage_hash_counts": {"lineage-sha": 1},
+                    }
+                },
+                "runtime_ledger_buckets": [
+                    {
+                        "hypothesis_id": "H-CONT-01",
+                        "candidate_id": candidate_id,
+                        "observed_stage": "live",
+                        "strategy_family": strategy_family,
+                        "bucket_ended_at": "2026-03-06T15:30:00+00:00",
+                        "submitted_order_count": 45,
+                        "closed_trade_count": 8,
+                        "post_cost_expectancy_bps": "8",
+                        "ledger_schema_version": EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+                        "pnl_basis": POST_COST_PNL_BASIS,
+                        "execution_policy_hash_counts": {"policy-sha": 1},
+                        "cost_model_hash_counts": {"cost-sha": 1},
+                        "lineage_hash_counts": {"lineage-sha": 1},
+                    }
+                ],
+            },
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 3, 6, 16, 0, tzinfo=timezone.utc),
+        )
+
+        cont = next(item for item in statuses if item["hypothesis_id"] == "H-CONT-01")
+        self.assertTrue(cont["promotion_eligible"])
+        self.assertEqual(cont["observed"]["runtime_ledger_observed_stage"], "live")
+        self.assertEqual(
+            cont["observed"]["runtime_ledger_bucket_ended_at"],
+            "2026-03-06T15:30:00+00:00",
+        )
+
+    def test_compile_hypothesis_runtime_statuses_blocks_mismatched_runtime_ledger_candidate(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        state = _state(
+            feature_rows=5,
+            drift_checks=3,
+            evidence_checks=2,
+            signal_lag_seconds=15,
+            evidence_report={
+                "ok": True,
+                "checked_at": "2026-03-06T15:45:00+00:00",
+            },
+        )
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=state,
+            tca_summary={
+                "order_count": 45,
+                "avg_abs_slippage_bps": 4,
+                "avg_realized_shortfall_bps": -8,
+                "last_computed_at": "2026-03-06T15:50:00+00:00",
+            },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-CONT-01",
+                candidate_id="unrelated-candidate",
+                submitted_order_count=45,
+            ),
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 3, 6, 16, 0, tzinfo=timezone.utc),
+        )
+
+        cont = next(item for item in statuses if item["hypothesis_id"] == "H-CONT-01")
+        self.assertFalse(cont["promotion_eligible"])
+        self.assertIn("runtime_ledger_candidate_id_mismatch", cont["reasons"])
+        self.assertEqual(
+            cont["observed"]["runtime_ledger_candidate_id"], "unrelated-candidate"
+        )
+
+    def test_compile_hypothesis_runtime_statuses_blocks_runtime_ledger_weak_provenance(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        state = _state(
+            feature_rows=5,
+            drift_checks=3,
+            evidence_checks=2,
+            signal_lag_seconds=15,
+            evidence_report={
+                "ok": True,
+                "checked_at": "2026-03-06T15:45:00+00:00",
+            },
+        )
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=state,
+            tca_summary={
+                "order_count": 45,
+                "avg_abs_slippage_bps": 4,
+                "avg_realized_shortfall_bps": -8,
+                "last_computed_at": "2026-03-06T15:50:00+00:00",
+            },
+            runtime_ledger_summary={
+                "by_hypothesis": {
+                    "H-CONT-01": {
+                        "hypothesis_id": "H-CONT-01",
+                        "candidate_id": _MANIFEST_CANDIDATE_IDS["H-CONT-01"],
+                        "observed_stage": "live",
+                        "strategy_family": _MANIFEST_STRATEGY_FAMILIES["H-CONT-01"],
+                        "bucket_ended_at": "2026-03-06T15:55:00+00:00",
+                        "submitted_order_count": 45,
+                        "post_cost_expectancy_bps": "8",
+                        "ledger_schema_version": "unknown",
+                        "pnl_basis": "tca_shortfall_proxy",
+                        "execution_policy_hash_counts": {},
+                        "cost_model_hash_counts": {},
+                        "lineage_hash_counts": {},
+                    }
+                }
+            },
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 3, 6, 16, 0, tzinfo=timezone.utc),
+        )
+
+        cont = next(item for item in statuses if item["hypothesis_id"] == "H-CONT-01")
+        self.assertFalse(cont["promotion_eligible"])
+        self.assertIn("runtime_ledger_schema_version_invalid", cont["reasons"])
+        self.assertIn("runtime_ledger_pnl_basis_invalid", cont["reasons"])
+        self.assertIn("runtime_ledger_execution_policy_hash_missing", cont["reasons"])
+        self.assertIn("runtime_ledger_cost_model_hash_missing", cont["reasons"])
+        self.assertIn("runtime_ledger_lineage_hash_missing", cont["reasons"])
+
     def test_compile_hypothesis_runtime_statuses_blocks_runtime_ledger_lifecycle_blockers(
         self,
     ) -> None:
@@ -454,12 +660,16 @@ class TestHypothesisReadiness(TestCase):
                     },
                     {
                         "hypothesis_id": "H-CONT-01",
+                        "candidate_id": _MANIFEST_CANDIDATE_IDS["H-CONT-01"],
                         "observed_stage": "live",
+                        "strategy_family": _MANIFEST_STRATEGY_FAMILIES["H-CONT-01"],
                         "bucket_ended_at": "2026-03-06T15:55:00+00:00",
                         "submitted_order_count": 45,
                         "closed_trade_count": 5,
                         "post_cost_expectancy_bps": "8",
-                        "execution_policy_hash_counts": ["not-a-hash-map"],
+                        "ledger_schema_version": EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+                        "pnl_basis": POST_COST_PNL_BASIS,
+                        "execution_policy_hash_counts": {"policy-sha": 1},
                         "cost_model_hash_counts": {"cost-sha": 1},
                         "lineage_hash_counts": {"lineage-sha": 1},
                         "blockers": [
@@ -488,7 +698,7 @@ class TestHypothesisReadiness(TestCase):
         self.assertEqual(
             observed["runtime_ledger_bucket_ended_at"], "2026-03-06T15:55:00+00:00"
         )
-        self.assertEqual(observed["runtime_ledger_execution_policy_hash_count"], 0)
+        self.assertEqual(observed["runtime_ledger_execution_policy_hash_count"], 1)
         self.assertEqual(observed["runtime_ledger_cost_model_hash_count"], 1)
         self.assertEqual(observed["runtime_ledger_lineage_hash_count"], 1)
 

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -188,10 +188,44 @@ class TestSubmissionCouncil(TestCase):
         with session_local() as session:
             self.assertEqual(
                 _load_latest_runtime_ledger_summary(session, hypothesis_ids=[]),
-                {"by_hypothesis": {}},
+                {"by_hypothesis": {}, "runtime_ledger_buckets": []},
             )
             session.add_all(
                 [
+                    StrategyRuntimeLedgerBucket(
+                        run_id="ledger-paper-newer",
+                        candidate_id="cand-new",
+                        hypothesis_id="H-CONT-01",
+                        observed_stage="paper",
+                        bucket_started_at=datetime(
+                            2026, 3, 6, 15, 45, tzinfo=timezone.utc
+                        ),
+                        bucket_ended_at=datetime(
+                            2026, 3, 6, 15, 45, tzinfo=timezone.utc
+                        ),
+                        account_label="paper",
+                        runtime_strategy_name="paper-runtime",
+                        strategy_family="intraday_continuation",
+                        fill_count=55,
+                        decision_count=55,
+                        submitted_order_count=55,
+                        cancelled_order_count=0,
+                        rejected_order_count=0,
+                        unfilled_order_count=0,
+                        closed_trade_count=9,
+                        open_position_count=0,
+                        filled_notional=Decimal("2500"),
+                        gross_strategy_pnl=Decimal("25"),
+                        cost_amount=Decimal("4"),
+                        net_strategy_pnl_after_costs=Decimal("21"),
+                        post_cost_expectancy_bps=Decimal("9"),
+                        ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={"paper-policy": 1},
+                        cost_model_hash_counts={"paper-cost": 1},
+                        lineage_hash_counts={"paper-lineage": 1},
+                        blockers_json=[],
+                    ),
                     StrategyRuntimeLedgerBucket(
                         run_id="ledger-old",
                         candidate_id="cand-old",
@@ -301,6 +335,7 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(cont["post_cost_expectancy_bps"], "8.00000000")
         self.assertEqual(cont["execution_policy_hash_counts"], {"new-policy": 1})
         self.assertIsNone(rev["post_cost_expectancy_bps"])
+        self.assertGreaterEqual(len(summary["runtime_ledger_buckets"]), 4)
 
     def test_metric_window_activity_rejects_tca_proxy_expectancy(self) -> None:
         metric_window = SimpleNamespace(


### PR DESCRIPTION
## Summary

- Select runtime-ledger readiness proof by target candidate and live stage instead of letting the newest paper or unrelated bucket win.
- Retain recent ledger buckets in the submission summary so hypothesis readiness can choose the correct target proof.
- Block promotion readiness when runtime-ledger provenance is weak: missing or invalid PnL basis, schema, candidate, execution-policy, cost-model, or lineage hashes.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/hypotheses.py app/trading/submission_council.py tests/test_hypotheses.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/hypotheses.py app/trading/submission_council.py tests/test_hypotheses.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen pytest tests/test_hypotheses.py tests/test_submission_council.py -k 'runtime_ledger'`
- `cd services/torghut && uv run --frozen pytest tests/test_hypotheses.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_window_import.py tests/test_trading_api.py -k 'runtime_ledger or live_submission_gate or trading_status'`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
