### PR TITLE
feat(torghut): hydrate fill survival evidence

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -211,6 +211,71 @@ def _order_type_execution_metrics(source: Mapping[str, Any]) -> dict[str, Any]:
     return metrics
 
 
+def _order_lifecycle_metrics(source: Mapping[str, Any]) -> dict[str, Any]:
+    lifecycle = _mapping(source.get("order_lifecycle"))
+    if not lifecycle:
+        return {}
+
+    sample_count = max(
+        _int(lifecycle.get("fill_survival_sample_count")),
+        _int(lifecycle.get("submitted_order_count")),
+    )
+    if "fill_survival_evidence_present" in lifecycle:
+        evidence_present = _bool(lifecycle.get("fill_survival_evidence_present"))
+    else:
+        evidence_present = sample_count > 0
+    fill_rate = lifecycle.get("fill_survival_fill_rate") or lifecycle.get("fill_rate")
+
+    metrics: dict[str, Any] = {
+        "order_lifecycle": lifecycle,
+        "fill_survival_evidence_present": evidence_present,
+        "fill_survival_sample_count": sample_count,
+    }
+    if fill_rate is not None:
+        metrics["fill_survival_fill_rate"] = _string(fill_rate)
+        metrics["delay_adjusted_depth_fill_survival_rate"] = _string(fill_rate)
+    if sample_count > 0:
+        metrics["delay_adjusted_depth_fill_survival_sample_count"] = sample_count
+        metrics["delay_adjusted_depth_fill_survival_evidence_present"] = (
+            evidence_present
+        )
+
+    for key in (
+        "fill_time_ms_avg",
+        "fill_time_ms_p50",
+        "fill_time_ms_p95",
+        "pending_age_ms_p95",
+        "max_censored_pending_age_ms",
+        "spread_bps_avg_at_order",
+        "spread_bps_p95_at_order",
+        "depth_notional_min_at_order",
+        "depth_notional_avg_at_order",
+        "queue_touch_qty_avg",
+        "queue_touch_notional_avg",
+        "order_qty_to_touch_qty_ratio_p95",
+        "fill_probability_by_latency_bucket",
+        "fill_probability_by_latency_threshold_ms",
+        "post_cost_survivorship",
+    ):
+        if key in lifecycle:
+            metrics[key] = lifecycle[key]
+
+    queue_ratio_p95 = _string(lifecycle.get("order_qty_to_touch_qty_ratio_p95"))
+    if queue_ratio_p95:
+        metrics["delay_adjusted_depth_queue_ratio_p95"] = queue_ratio_p95
+
+    survivorship = _mapping(lifecycle.get("post_cost_survivorship"))
+    if survivorship:
+        survival_rate = _string(survivorship.get("post_cost_survival_rate"))
+        if survival_rate:
+            metrics["post_cost_survival_rate"] = survival_rate
+        metrics["gross_positive_killed_by_cost_count"] = _int(
+            survivorship.get("gross_positive_killed_by_cost_count")
+        )
+
+    return metrics
+
+
 def _order_type_ablation_metrics(source: Mapping[str, Any]) -> dict[str, Any]:
     raw_ablation = source.get("order_type_ablation")
     if not isinstance(raw_ablation, Mapping):
@@ -720,6 +785,10 @@ def evidence_bundle_from_frontier_candidate(
                 break
     for source in (candidate, summary, full_window):
         for key, value in _order_type_execution_metrics(source).items():
+            if key not in scorecard:
+                scorecard = {**scorecard, key: value}
+    for source in (candidate, summary, full_window):
+        for key, value in _order_lifecycle_metrics(source).items():
             if key not in scorecard:
                 scorecard = {**scorecard, key: value}
     for source in (candidate, summary, full_window):

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -2131,9 +2131,16 @@ class TestLocalIntradayTsmomReplay(TestCase):
         self.assertEqual(lifecycle["filled_order_count"], 1)
         self.assertEqual(lifecycle["pending_censored_count"], 1)
         self.assertEqual(lifecycle["replaced_pending_count"], 1)
+        self.assertTrue(lifecycle["fill_survival_evidence_present"])
+        self.assertEqual(lifecycle["fill_survival_sample_count"], 2)
+        self.assertEqual(lifecycle["fill_rate"], "0.5")
         self.assertEqual(lifecycle["fill_time_ms_p50"], 60000)
         self.assertEqual(
             lifecycle["fill_probability_by_latency_bucket"][">1000ms"]["fill_rate"], "1"
+        )
+        self.assertEqual(
+            lifecycle["fill_probability_by_latency_threshold_ms"]["250"]["fill_rate"],
+            "0",
         )
         self.assertEqual(
             lifecycle["censor_reason_counts"],
@@ -2146,6 +2153,14 @@ class TestLocalIntradayTsmomReplay(TestCase):
         self.assertEqual(
             Decimal(str(lifecycle["order_qty_to_touch_qty_ratio_p95"])),
             Decimal("0.05"),
+        )
+        self.assertEqual(
+            Decimal(str(lifecycle["queue_touch_qty_avg"])),
+            Decimal("40"),
+        )
+        self.assertEqual(
+            Decimal(str(lifecycle["queue_touch_notional_avg"])),
+            Decimal("4000.00"),
         )
         self.assertEqual(
             payload["order_lifecycle_by_day"]["2026-03-26"]["submitted_order_count"],

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -2125,7 +2125,11 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         )
 
         self.assertEqual(summary["fill_survival_sample_count"], 4)
+        self.assertTrue(summary["fill_survival_evidence_present"])
         self.assertEqual(summary["fill_survival_fill_rate"], "0.5")
+        self.assertTrue(summary["delay_adjusted_depth_fill_survival_evidence_present"])
+        self.assertEqual(summary["delay_adjusted_depth_fill_survival_sample_count"], 4)
+        self.assertEqual(summary["delay_adjusted_depth_fill_survival_rate"], "0.5")
         self.assertEqual(
             summary["delay_adjusted_depth_survival_adjusted_fillable_ratio"],
             "0.5",

--- a/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
+++ b/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
@@ -514,6 +514,88 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
         self.assertIn("fill_survival_evidence_missing", blockers)
         self.assertIn("fill_survival_sample_count_zero", blockers)
 
+    def test_evidence_bundle_hydrates_fill_survival_from_order_lifecycle(
+        self,
+    ) -> None:
+        bundle = evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-lifecycle-proof",
+            candidate={
+                "candidate_id": "cand-lifecycle-proof",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "650",
+                    "delay_adjusted_depth_stress_passed": True,
+                    "delay_adjusted_depth_stress_model": "latency_depth_haircut",
+                    "delay_adjusted_depth_stress_ms": "50",
+                    "delay_adjusted_depth_stress_artifact_ref": "/tmp/depth.json",
+                    "delay_adjusted_depth_tail_coverage_passed": True,
+                    "delay_adjusted_depth_p10_active_day_fillable_notional": "250000",
+                    "delay_adjusted_depth_worst_active_day_fillable_notional": "200000",
+                    "delay_adjusted_depth_stress_net_pnl_per_day": "540",
+                },
+                "full_window": {
+                    "net_per_day": "650",
+                    "trading_day_count": "1",
+                    "avg_filled_notional_per_day": "350000",
+                    "daily_filled_notional": {"2026-02-23": "350000"},
+                    "daily_liquidity_notional": {"2026-02-23": "900000"},
+                    "order_lifecycle": {
+                        "submitted_order_count": 4,
+                        "filled_order_count": 3,
+                        "fill_rate": "0.75",
+                        "fill_survival_sample_count": 4,
+                        "order_qty_to_touch_qty_ratio_p95": "0.20",
+                        "post_cost_survivorship": {
+                            "post_cost_survival_rate": "0.50",
+                            "gross_positive_killed_by_cost_count": 1,
+                        },
+                    },
+                },
+                "promotion_readiness": {
+                    "stage": "paper_probation",
+                    "status": "promotion_ready",
+                    "promotable": True,
+                    "blockers": [],
+                },
+            },
+            dataset_snapshot_id="snap-lifecycle-proof",
+            result_path="/tmp/lifecycle-proof.json",
+        )
+
+        blockers = evidence_bundle_blockers(bundle)
+
+        self.assertNotIn("fill_survival_evidence_missing", blockers)
+        self.assertNotIn("fill_survival_sample_count_zero", blockers)
+        self.assertTrue(bundle.objective_scorecard["fill_survival_evidence_present"])
+        self.assertEqual(bundle.objective_scorecard["fill_survival_sample_count"], 4)
+        self.assertEqual(bundle.objective_scorecard["fill_survival_fill_rate"], "0.75")
+        self.assertTrue(
+            bundle.objective_scorecard[
+                "delay_adjusted_depth_fill_survival_evidence_present"
+            ]
+        )
+        self.assertEqual(
+            bundle.objective_scorecard[
+                "delay_adjusted_depth_fill_survival_sample_count"
+            ],
+            4,
+        )
+        self.assertEqual(
+            bundle.objective_scorecard["delay_adjusted_depth_fill_survival_rate"],
+            "0.75",
+        )
+        self.assertEqual(
+            bundle.objective_scorecard["delay_adjusted_depth_queue_ratio_p95"],
+            "0.20",
+        )
+        self.assertEqual(
+            bundle.objective_scorecard["post_cost_survival_rate"],
+            "0.50",
+        )
+        self.assertEqual(
+            bundle.objective_scorecard["gross_positive_killed_by_cost_count"],
+            1,
+        )
+
     def test_evidence_bundle_parses_serialized_false_survival_booleans(self) -> None:
         bundle = evidence_bundle_from_frontier_candidate(
             candidate_spec_id="spec-serialized-false-proof",


### PR DESCRIPTION
## Summary

- Hydrates candidate evidence bundles from nested replay `order_lifecycle` metrics when scorecards do not already carry fill-survival fields.
- Preserves fill-survival sample count, fill rate, queue ratio, latency buckets, and post-cost survivorship as validation evidence for delay-depth stress.
- Keeps promotion proof fail-closed: promotion-ready bundles still block when fill-survival evidence is absent, and runtime closure promotion authority is unchanged.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/discovery/evidence_bundles.py tests/test_local_intraday_tsmom_replay.py tests/test_search_consistent_profitability_frontier.py tests/test_whitepaper_autoresearch_artifacts.py`
- `uv run --frozen ruff check app/trading/discovery/evidence_bundles.py tests/test_local_intraday_tsmom_replay.py tests/test_search_consistent_profitability_frontier.py tests/test_whitepaper_autoresearch_artifacts.py`
- `uv run --frozen pytest tests/test_local_intraday_tsmom_replay.py -k 'order_lifecycle or replay_main'`
- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -k 'order_lifecycle_fill_survival'`
- `uv run --frozen pytest tests/test_whitepaper_autoresearch_artifacts.py -k 'fill_survival'`
- `uv run --frozen pytest tests/test_runtime_closure.py -k 'delay_adjusted_depth_stress'`
- `uv run --frozen pytest tests/test_local_intraday_tsmom_replay.py tests/test_search_consistent_profitability_frontier.py tests/test_whitepaper_autoresearch_artifacts.py tests/test_runtime_closure.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
