### PR TITLE
feat(torghut): ingest exact runtime ledger artifacts

### DIFF
--- a/services/torghut/config/trading/hypotheses/h-tsmom-liq-01.json
+++ b/services/torghut/config/trading/hypotheses/h-tsmom-liq-01.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "torghut.hypothesis-manifest.v1",
+  "hypothesis_id": "H-TSMOM-LIQ-01",
+  "lane_id": "intraday-tsmom-liquid-open",
+  "strategy_family": "intraday_tsmom_consistent",
+  "candidate_id": "H-TSMOM-LIQ-01",
+  "strategy_id": "intraday_tsmom_v2@research",
+  "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+  "initial_state": "blocked",
+  "market_regimes": [
+    "R2",
+    "R3",
+    "R5"
+  ],
+  "required_feature_sets": [
+    "trend_strength",
+    "intraday_momentum_rank",
+    "realized_volatility",
+    "turnover",
+    "tca"
+  ],
+  "required_dependency_capabilities": [
+    "drift_governance",
+    "feature_coverage",
+    "signal_continuity"
+  ],
+  "segment_dependencies": [
+    "execution",
+    "empirical",
+    "ta-core"
+  ],
+  "expected_gross_edge_bps": "6",
+  "max_allowed_slippage_bps": "6",
+  "min_sample_count_for_live_canary": 60,
+  "min_sample_count_for_scale_up": 120,
+  "max_rolling_drawdown_bps": "1000",
+  "rollback_triggers": [
+    "required_feature_set_unavailable",
+    "drift_checks_missing",
+    "slippage_budget_exceeded",
+    "post_cost_expectancy_non_positive",
+    "runtime_window_evidence_missing"
+  ],
+  "promotion_gates": [
+    "trend_features_present",
+    "fresh_signal_continuity",
+    "evidence_continuity_recent",
+    "drift_checks_recent",
+    "positive_post_cost_expectancy",
+    "executable_replay_present",
+    "shadow_parity_within_budget"
+  ],
+  "entry_requirements": {
+    "max_signal_lag_seconds": 90,
+    "max_evidence_age_minutes": 30,
+    "min_feature_batch_rows": 1,
+    "require_feature_rows": true,
+    "require_drift_checks": true,
+    "require_evidence_continuity": true
+  }
+}

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -15,8 +15,10 @@ import psycopg
 
 from app.db import SessionLocal
 from app.trading.runtime_ledger import (
+    EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
     POST_COST_PNL_BASIS,
     RuntimeLedgerFill,
+    RuntimeLedgerBucket,
     build_runtime_ledger_buckets,
 )
 from app.trading.runtime_window_import import (
@@ -34,6 +36,18 @@ EXECUTION_ELIGIBLE_DECISION_STATUSES = (
 POST_COST_BASIS_RUNTIME_LEDGER = POST_COST_PNL_BASIS
 POST_COST_BASIS_SIMULATION_REPORT = "simulation_report_net_pnl"
 POST_COST_BASIS_TCA_PROXY = "tca_shortfall_proxy"
+RUNTIME_LEDGER_ARTIFACT_SCHEMAS = frozenset(
+    {
+        EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+        "torghut.exact_replay_ledger.rows.v1",
+    }
+)
+_RUNTIME_LEDGER_DECISION_EVENTS = frozenset(
+    {"decision", "trade_decision", "signal_decision"}
+)
+_RUNTIME_LEDGER_FILL_EVENTS = frozenset(
+    {"fill", "filled", "partial_fill", "partially_filled"}
+)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -84,6 +98,22 @@ def _parse_dt(value: str) -> datetime:
     return parsed.astimezone(timezone.utc)
 
 
+def _parse_dt_or_none(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return (
+            value.astimezone(timezone.utc)
+            if value.tzinfo
+            else value.replace(tzinfo=timezone.utc)
+        )
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return _parse_dt(text)
+    except Exception:
+        return None
+
+
 def _as_mapping(value: Any) -> dict[str, Any]:
     return (
         {str(key): item for key, item in value.items()}
@@ -117,6 +147,11 @@ def _decimal_or_none(value: Any) -> Decimal | None:
         return None
 
 
+def _text_or_none(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
 def _row_payloads(row: Mapping[str, object]) -> list[Mapping[str, object]]:
     payloads: list[Mapping[str, object]] = [row]
     for key in ("execution_audit_json", "raw_order"):
@@ -142,6 +177,72 @@ def _first_text(row: Mapping[str, object], *keys: str) -> str | None:
             if text:
                 return text
     return None
+
+
+def _runtime_ledger_bucket_payload(bucket: RuntimeLedgerBucket) -> dict[str, object]:
+    return {
+        "bucket_started_at": bucket.bucket_started_at.isoformat(),
+        "bucket_ended_at": bucket.bucket_ended_at.isoformat(),
+        "account_label": bucket.account_label,
+        "strategy_id": bucket.strategy_id,
+        "symbol": bucket.symbol,
+        "fill_count": bucket.fill_count,
+        "decision_count": bucket.decision_count,
+        "submitted_order_count": bucket.submitted_order_count,
+        "cancelled_order_count": bucket.cancelled_order_count,
+        "rejected_order_count": bucket.rejected_order_count,
+        "unfilled_order_count": bucket.unfilled_order_count,
+        "closed_trade_count": bucket.closed_trade_count,
+        "open_position_count": bucket.open_position_count,
+        "filled_notional": str(bucket.filled_notional),
+        "gross_strategy_pnl": str(bucket.gross_strategy_pnl),
+        "cost_amount": str(bucket.cost_amount),
+        "net_strategy_pnl_after_costs": str(bucket.net_strategy_pnl_after_costs),
+        "post_cost_expectancy_bps": (
+            str(bucket.post_cost_expectancy_bps)
+            if bucket.post_cost_expectancy_bps is not None
+            else None
+        ),
+        "cost_basis_counts": bucket.cost_basis_counts,
+        "execution_policy_hash_counts": bucket.execution_policy_hash_counts,
+        "cost_model_hash_counts": bucket.cost_model_hash_counts,
+        "lineage_hash_counts": bucket.lineage_hash_counts,
+        "blockers": bucket.blockers,
+        "ledger_schema_version": bucket.ledger_schema_version,
+        "pnl_basis": bucket.pnl_basis,
+    }
+
+
+def _runtime_ledger_tca_row_from_bucket(
+    *,
+    bucket: RuntimeLedgerBucket,
+    computed_at: datetime | None = None,
+) -> dict[str, object]:
+    promotion_eligible = (
+        bucket.post_cost_expectancy_bps is not None and not bucket.blockers
+    )
+    return {
+        "computed_at": computed_at
+        or max(
+            bucket.bucket_started_at,
+            bucket.bucket_ended_at - timedelta(microseconds=1),
+        ),
+        "abs_slippage_bps": (
+            (bucket.cost_amount / bucket.filled_notional) * Decimal("10000")
+            if bucket.filled_notional > 0
+            else None
+        ),
+        "post_cost_expectancy_bps": bucket.post_cost_expectancy_bps,
+        "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+        "post_cost_promotion_eligible": promotion_eligible,
+        "realized_gross_pnl": bucket.gross_strategy_pnl,
+        "realized_net_pnl": bucket.net_strategy_pnl_after_costs,
+        "turnover_notional": bucket.filled_notional,
+        "runtime_ledger_blockers": bucket.blockers,
+        "runtime_ledger_cost_basis_counts": bucket.cost_basis_counts,
+        "runtime_ledger_pnl_basis": bucket.pnl_basis,
+        "runtime_ledger_bucket": _runtime_ledger_bucket_payload(bucket),
+    }
 
 
 def _nonnegative_int(value: Any) -> int:
@@ -296,60 +397,11 @@ def _build_realized_strategy_pnl_rows(
     ):
         if bucket.closed_trade_count <= 0 and not bucket.blockers:
             continue
-        promotion_eligible = (
-            bucket.post_cost_expectancy_bps is not None and not bucket.blockers
-        )
         realized_rows.append(
-            {
-                "computed_at": unique_times[-1],
-                "abs_slippage_bps": (
-                    (bucket.cost_amount / bucket.filled_notional) * Decimal("10000")
-                    if bucket.filled_notional > 0
-                    else None
-                ),
-                "post_cost_expectancy_bps": bucket.post_cost_expectancy_bps,
-                "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
-                "post_cost_promotion_eligible": promotion_eligible,
-                "realized_gross_pnl": bucket.gross_strategy_pnl,
-                "realized_net_pnl": bucket.net_strategy_pnl_after_costs,
-                "turnover_notional": bucket.filled_notional,
-                "runtime_ledger_blockers": bucket.blockers,
-                "runtime_ledger_cost_basis_counts": bucket.cost_basis_counts,
-                "runtime_ledger_pnl_basis": bucket.pnl_basis,
-                "runtime_ledger_bucket": {
-                    "bucket_started_at": bucket.bucket_started_at.isoformat(),
-                    "bucket_ended_at": bucket.bucket_ended_at.isoformat(),
-                    "account_label": bucket.account_label,
-                    "strategy_id": bucket.strategy_id,
-                    "symbol": bucket.symbol,
-                    "fill_count": bucket.fill_count,
-                    "decision_count": bucket.decision_count,
-                    "submitted_order_count": bucket.submitted_order_count,
-                    "cancelled_order_count": bucket.cancelled_order_count,
-                    "rejected_order_count": bucket.rejected_order_count,
-                    "unfilled_order_count": bucket.unfilled_order_count,
-                    "closed_trade_count": bucket.closed_trade_count,
-                    "open_position_count": bucket.open_position_count,
-                    "filled_notional": str(bucket.filled_notional),
-                    "gross_strategy_pnl": str(bucket.gross_strategy_pnl),
-                    "cost_amount": str(bucket.cost_amount),
-                    "net_strategy_pnl_after_costs": str(
-                        bucket.net_strategy_pnl_after_costs
-                    ),
-                    "post_cost_expectancy_bps": (
-                        str(bucket.post_cost_expectancy_bps)
-                        if bucket.post_cost_expectancy_bps is not None
-                        else None
-                    ),
-                    "cost_basis_counts": bucket.cost_basis_counts,
-                    "execution_policy_hash_counts": bucket.execution_policy_hash_counts,
-                    "cost_model_hash_counts": bucket.cost_model_hash_counts,
-                    "lineage_hash_counts": bucket.lineage_hash_counts,
-                    "blockers": bucket.blockers,
-                    "ledger_schema_version": bucket.ledger_schema_version,
-                    "pnl_basis": bucket.pnl_basis,
-                },
-            }
+            _runtime_ledger_tca_row_from_bucket(
+                bucket=bucket,
+                computed_at=unique_times[-1],
+            )
         )
     return realized_rows
 
@@ -393,6 +445,153 @@ def _load_json_artifact(ref: str) -> dict[str, Any]:
     except Exception:
         return {}
     return _as_mapping(payload)
+
+
+def _runtime_ledger_artifact_schema(payload: Mapping[str, Any]) -> str | None:
+    return _text_or_none(
+        payload.get("schema_version") or payload.get("ledger_schema_version")
+    )
+
+
+def _runtime_ledger_artifact_rows(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    if _runtime_ledger_artifact_schema(payload) not in RUNTIME_LEDGER_ARTIFACT_SCHEMAS:
+        return []
+    defaults = {
+        key: value
+        for key in (
+            "account_label",
+            "strategy_id",
+            "strategy_name",
+            "execution_policy_hash",
+            "execution_policy_sha256",
+            "cost_model_hash",
+            "cost_model_sha256",
+            "lineage_hash",
+            "candidate_lineage_hash",
+            "replay_data_hash",
+            "replay_tape_content_sha256",
+            "dataset_snapshot_hash",
+            "source_query_digest",
+        )
+        if (value := payload.get(key)) is not None
+    }
+    for key in ("runtime_ledger_rows", "ledger_rows", "rows", "events"):
+        raw_rows = payload.get(key)
+        if not isinstance(raw_rows, list):
+            continue
+        rows: list[dict[str, Any]] = []
+        for raw_row in raw_rows:
+            row = _as_mapping(raw_row)
+            if row:
+                rows.append({**defaults, **row})
+        if rows:
+            return rows
+    return []
+
+
+def _runtime_ledger_event_type(row: Mapping[str, Any]) -> str:
+    raw = _text_or_none(
+        row.get("ledger_event_type")
+        or row.get("runtime_ledger_event_type")
+        or row.get("lifecycle_event")
+        or row.get("event_type")
+        or row.get("order_event_type")
+        or row.get("order_status")
+        or row.get("status")
+    )
+    if raw is None:
+        if any(row.get(key) is not None for key in ("filled_qty", "qty", "quantity")):
+            return "fill"
+        if any(row.get(key) is not None for key in ("order_id", "alpaca_order_id")):
+            return "order_submitted"
+        if any(
+            row.get(key) is not None
+            for key in ("decision_id", "trade_decision_id", "decision_hash")
+        ):
+            return "decision"
+        return "diagnostic"
+    normalized = raw.lower().replace("-", "_").replace(" ", "_")
+    return {
+        "trade_decision": "decision",
+        "signal_decision": "decision",
+        "new_order": "order_submitted",
+        "submitted": "order_submitted",
+        "accepted": "order_submitted",
+        "new": "order_submitted",
+        "filled": "fill",
+        "partially_filled": "partial_fill",
+    }.get(normalized, normalized)
+
+
+def _runtime_ledger_row_time(row: Mapping[str, Any]) -> datetime | None:
+    for key in ("executed_at", "filled_at", "event_ts", "created_at", "computed_at"):
+        if (parsed := _parse_dt_or_none(row.get(key))) is not None:
+            return parsed
+    return None
+
+
+def _runtime_ledger_activity_times(
+    rows: list[dict[str, Any]],
+) -> tuple[list[datetime], list[datetime]]:
+    decision_times: list[datetime] = []
+    execution_times: list[datetime] = []
+    for row in rows:
+        event_time = _runtime_ledger_row_time(row)
+        if event_time is None:
+            continue
+        event_type = _runtime_ledger_event_type(row)
+        if event_type in _RUNTIME_LEDGER_DECISION_EVENTS:
+            decision_times.append(event_time)
+        elif event_type in _RUNTIME_LEDGER_FILL_EVENTS:
+            execution_times.append(event_time)
+    return decision_times, execution_times
+
+
+def _runtime_ledger_tca_rows_from_artifacts(
+    *,
+    artifact_refs: list[str],
+    bucket_ranges: list[tuple[datetime, datetime, int]],
+) -> tuple[list[datetime], list[datetime], list[dict[str, object]], dict[str, Any]]:
+    ledger_rows: list[dict[str, Any]] = []
+    tca_rows: list[dict[str, object]] = []
+    loaded_refs: list[str] = []
+    ignored_refs: list[str] = []
+    for ref in artifact_refs:
+        payload = _load_json_artifact(ref)
+        if not payload:
+            continue
+        rows = _runtime_ledger_artifact_rows(payload)
+        if not rows:
+            if _runtime_ledger_artifact_schema(payload) is not None:
+                ignored_refs.append(ref)
+            continue
+        loaded_refs.append(ref)
+        ledger_rows.extend(rows)
+    decision_times, execution_times = _runtime_ledger_activity_times(ledger_rows)
+    runtime_bucket_ranges = [(start, end) for start, end, _ in bucket_ranges]
+    if ledger_rows and runtime_bucket_ranges:
+        for bucket in build_runtime_ledger_buckets(
+            ledger_rows,
+            bucket_ranges=runtime_bucket_ranges,
+            require_order_lifecycle=True,
+        ):
+            if (
+                bucket.fill_count <= 0
+                and bucket.decision_count <= 0
+                and bucket.submitted_order_count <= 0
+                and bucket.cancelled_order_count <= 0
+                and bucket.rejected_order_count <= 0
+                and bucket.unfilled_order_count <= 0
+            ):
+                continue
+            tca_rows.append(_runtime_ledger_tca_row_from_bucket(bucket=bucket))
+    metadata = {
+        "runtime_ledger_artifact_refs": loaded_refs,
+        "runtime_ledger_ignored_artifact_refs": ignored_refs,
+        "runtime_ledger_artifact_row_count": len(ledger_rows),
+        "runtime_ledger_artifact_tca_row_count": len(tca_rows),
+    }
+    return decision_times, execution_times, tca_rows, metadata
 
 
 def _query_timestamps(
@@ -600,7 +799,12 @@ def _source_activity_missing_summary(
 def main() -> int:
     args = _parse_args()
     source_dsn = args.source_dsn.strip() or os.getenv(args.source_dsn_env, "").strip()
-    if not source_dsn:
+    artifact_refs = [
+        str(item).strip()
+        for item in getattr(args, "artifact_ref", [])
+        if str(item).strip()
+    ]
+    if not source_dsn and not artifact_refs:
         raise RuntimeError("source_dsn_not_configured")
     window_start = _parse_dt(args.window_start)
     window_end = _parse_dt(args.window_end)
@@ -612,13 +816,48 @@ def main() -> int:
         args.strategy_name,
         getattr(manifest, "strategy_id", None),
     )
-    decisions, executions, tca_rows = _query_timestamps(
-        dsn=source_dsn,
-        strategy_names=strategy_names,
-        account_label=args.account_label,
-        window_start=window_start,
-        window_end=window_end,
-    )
+    decisions: list[datetime] = []
+    executions: list[datetime] = []
+    tca_rows: list[dict[str, object]] = []
+    if source_dsn:
+        decisions, executions, tca_rows = _query_timestamps(
+            dsn=source_dsn,
+            strategy_names=strategy_names,
+            account_label=args.account_label,
+            window_start=window_start,
+            window_end=window_end,
+        )
+    bucket_ranges: list[tuple[datetime, datetime, int]] = []
+    runtime_ledger_artifact_metadata: dict[str, Any] = {
+        "runtime_ledger_artifact_refs": [],
+        "runtime_ledger_ignored_artifact_refs": [],
+        "runtime_ledger_artifact_row_count": 0,
+        "runtime_ledger_artifact_tca_row_count": 0,
+    }
+    if artifact_refs:
+        bucket_ranges = build_regular_session_buckets(
+            window_start=window_start,
+            window_end=window_end,
+            bucket_minutes=args.bucket_minutes,
+            sample_minutes=args.sample_minutes,
+        )
+        (
+            runtime_ledger_decisions,
+            runtime_ledger_executions,
+            runtime_ledger_tca_rows,
+            runtime_ledger_artifact_metadata,
+        ) = _runtime_ledger_tca_rows_from_artifacts(
+            artifact_refs=artifact_refs,
+            bucket_ranges=bucket_ranges,
+        )
+        decisions.extend(runtime_ledger_decisions)
+        executions.extend(runtime_ledger_executions)
+        tca_rows.extend(runtime_ledger_tca_rows)
+    if (
+        not source_dsn
+        and not runtime_ledger_artifact_metadata["runtime_ledger_artifact_refs"]
+    ):
+        raise RuntimeError("source_dsn_not_configured")
     dataset_snapshot_ref = (
         str(getattr(args, "dataset_snapshot_ref", "") or "").strip() or None
     )
@@ -646,9 +885,6 @@ def main() -> int:
         else:
             print(summary)
         return 0
-    artifact_refs = [
-        str(item).strip() for item in args.artifact_ref if str(item).strip()
-    ]
     delay_depth_report_ref = str(
         getattr(args, "delay_adjusted_depth_stress_report_ref", "") or ""
     ).strip()
@@ -671,12 +907,13 @@ def main() -> int:
                 "promotion_blocker": "simulation_report_not_runtime_ledger_proof",
             }
         )
-    bucket_ranges = build_regular_session_buckets(
-        window_start=window_start,
-        window_end=window_end,
-        bucket_minutes=args.bucket_minutes,
-        sample_minutes=args.sample_minutes,
-    )
+    if not bucket_ranges:
+        bucket_ranges = build_regular_session_buckets(
+            window_start=window_start,
+            window_end=window_end,
+            bucket_minutes=args.bucket_minutes,
+            sample_minutes=args.sample_minutes,
+        )
     buckets = build_observed_runtime_buckets(
         bucket_ranges=bucket_ranges,
         decision_times=decisions,
@@ -708,6 +945,7 @@ def main() -> int:
         "artifact_refs": artifact_refs,
         "dataset_snapshot_ref": dataset_snapshot_ref,
         "target_metadata": target_metadata,
+        **runtime_ledger_artifact_metadata,
         "report_post_cost_expectancy_bps": (
             str(report_post_cost_expectancy_bps)
             if report_post_cost_expectancy_bps is not None

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -36,6 +36,7 @@ _MANIFEST_CANDIDATE_IDS = {
     "H-PAIRS-01": "spec-d74b07b2aaab8d0cfa8a4c38",
     "H-REV-01": "chip-paper-microbar-composite@execution-proof",
     "H-TSMOM-01": "spec-83161ae16d17828eabcc58cc",
+    "H-TSMOM-LIQ-01": "H-TSMOM-LIQ-01",
 }
 
 _MANIFEST_STRATEGY_FAMILIES = {
@@ -44,6 +45,7 @@ _MANIFEST_STRATEGY_FAMILIES = {
     "H-PAIRS-01": "microbar_cross_sectional_pairs",
     "H-REV-01": "event_reversion",
     "H-TSMOM-01": "intraday_tsmom_consistent",
+    "H-TSMOM-LIQ-01": "intraday_tsmom_consistent",
 }
 
 
@@ -443,6 +445,56 @@ class TestHypothesisReadiness(TestCase):
         self.assertIn("runtime_ledger_stage_not_live", cont["reasons"])
         self.assertEqual(cont["observed"]["runtime_ledger_observed_stage"], "paper")
         self.assertNotIn("post_cost_expectancy_non_positive", cont["reasons"])
+
+    def test_htsmom_liq_manifest_keeps_candidate_identity_but_blocks_paper_ledger(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        liq_manifest = next(
+            item for item in registry.items if item.hypothesis_id == "H-TSMOM-LIQ-01"
+        )
+        self.assertEqual(liq_manifest.candidate_id, "H-TSMOM-LIQ-01")
+        self.assertEqual(liq_manifest.strategy_family, "intraday_tsmom_consistent")
+
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=_state(
+                feature_rows=5,
+                drift_checks=3,
+                evidence_checks=2,
+                signal_lag_seconds=15,
+                evidence_report={
+                    "ok": True,
+                    "checked_at": "2026-03-06T15:45:00+00:00",
+                },
+            ),
+            tca_summary={
+                "order_count": 90,
+                "avg_abs_slippage_bps": 4,
+                "avg_realized_shortfall_bps": -8,
+                "last_computed_at": "2026-03-06T15:50:00+00:00",
+            },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-TSMOM-LIQ-01",
+                submitted_order_count=90,
+                observed_stage="paper",
+                post_cost_expectancy_bps="8",
+            ),
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 3, 6, 16, 0, tzinfo=timezone.utc),
+        )
+
+        liq = next(
+            item for item in statuses if item["hypothesis_id"] == "H-TSMOM-LIQ-01"
+        )
+        self.assertFalse(liq["promotion_eligible"])
+        self.assertIn("runtime_ledger_stage_not_live", liq["reasons"])
+        self.assertNotIn("runtime_ledger_candidate_id_mismatch", liq["reasons"])
 
     def test_compile_hypothesis_runtime_statuses_prefers_target_live_bucket_over_newer_paper(
         self,
@@ -1260,7 +1312,7 @@ class TestHypothesisReadiness(TestCase):
         )
         self.assertEqual(summary["reason_totals"]["slippage_budget_exceeded"], 2)
         self.assertEqual(
-            summary["informational_reason_totals"]["closed_session_signal_hold"], 5
+            summary["informational_reason_totals"]["closed_session_signal_hold"], 6
         )
 
     def test_compile_hypothesis_runtime_statuses_isolates_dependency_capabilities_between_hypotheses(
@@ -1441,12 +1493,12 @@ class TestHypothesisReadiness(TestCase):
             ),
         )
 
-        self.assertEqual(summary["hypotheses_total"], 5)
+        self.assertEqual(summary["hypotheses_total"], 6)
         self.assertEqual(
             summary["candidate_dossier_version"],
             "torghut.hypothesis-candidate-dossier.v1",
         )
-        self.assertEqual(len(summary["ranked_candidates"]), 5)
+        self.assertEqual(len(summary["ranked_candidates"]), 6)
         self.assertIsNotNone(summary["selected_candidate"])
         self.assertEqual(summary["selected_candidate"]["hypothesis_id"], "H-MICRO-01")
         self.assertEqual(
@@ -1457,8 +1509,8 @@ class TestHypothesisReadiness(TestCase):
             summary["selected_candidate"]["next_blocker"],
             "delay_adjusted_depth_stress_missing",
         )
-        self.assertEqual(summary["state_totals"], {"blocked": 3, "shadow": 2})
-        self.assertEqual(summary["capital_stage_totals"], {"shadow": 5})
+        self.assertEqual(summary["state_totals"], {"blocked": 4, "shadow": 2})
+        self.assertEqual(summary["capital_stage_totals"], {"shadow": 6})
         self.assertEqual(summary["promotion_eligible_total"], 0)
         self.assertEqual(summary["rollback_required_total"], 0)
         self.assertEqual(

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -19,8 +19,11 @@ from scripts.import_hypothesis_runtime_windows import (
     _load_report_post_cost_expectancy_bps,
     _nonnegative_int,
     _parse_args,
+    _parse_dt_or_none,
     _parse_target_metadata,
     _query_timestamps,
+    _runtime_ledger_event_type,
+    _runtime_ledger_tca_rows_from_artifacts,
     _strategy_name_candidates,
     main,
 )
@@ -403,6 +406,253 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 window_end=window_end,
             )
 
+    def test_runtime_ledger_artifacts_build_promotion_grade_tca_rows(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            artifact_path = Path(temp_dir) / "exact-ledger.json"
+            artifact_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "account_label": "TORGHUT_SIM",
+                        "strategy_id": "intraday-tsmom-profit-v3",
+                        "execution_policy_hash": "policy-sha",
+                        "cost_model_hash": "cost-sha",
+                        "lineage_hash": "lineage-sha",
+                        "runtime_ledger_rows": [
+                            {
+                                "event_type": "decision",
+                                "executed_at": "2026-03-06T14:35:00Z",
+                                "decision_id": "decision-buy",
+                                "order_id": "order-buy",
+                            },
+                            {
+                                "event_type": "order_submitted",
+                                "executed_at": "2026-03-06T14:35:01Z",
+                                "decision_id": "decision-buy",
+                                "order_id": "order-buy",
+                            },
+                            {
+                                "event_type": "fill",
+                                "executed_at": "2026-03-06T14:35:02Z",
+                                "decision_id": "decision-buy",
+                                "order_id": "order-buy",
+                                "symbol": "AAPL",
+                                "side": "buy",
+                                "filled_qty": "1",
+                                "avg_fill_price": "100",
+                                "cost_amount": "0.10",
+                                "cost_basis": "broker_reported_commission_and_fees",
+                            },
+                            {
+                                "event_type": "decision",
+                                "executed_at": "2026-03-06T14:40:00Z",
+                                "decision_id": "decision-sell",
+                                "order_id": "order-sell",
+                            },
+                            {
+                                "event_type": "order_submitted",
+                                "executed_at": "2026-03-06T14:40:01Z",
+                                "decision_id": "decision-sell",
+                                "order_id": "order-sell",
+                            },
+                            {
+                                "event_type": "fill",
+                                "executed_at": "2026-03-06T14:40:02Z",
+                                "decision_id": "decision-sell",
+                                "order_id": "order-sell",
+                                "symbol": "AAPL",
+                                "side": "sell",
+                                "filled_qty": "1",
+                                "avg_fill_price": "101",
+                                "cost_amount": "0.10",
+                                "cost_basis": "broker_reported_commission_and_fees",
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            decisions, executions, tca_rows, metadata = (
+                _runtime_ledger_tca_rows_from_artifacts(
+                    artifact_refs=[str(artifact_path)],
+                    bucket_ranges=[
+                        (
+                            datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                            datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                            6,
+                        )
+                    ],
+                )
+            )
+
+        self.assertEqual(
+            decisions,
+            [
+                datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+            ],
+        )
+        self.assertEqual(len(executions), 2)
+        self.assertEqual(len(tca_rows), 1)
+        self.assertEqual(
+            tca_rows[0]["post_cost_expectancy_basis"],
+            POST_COST_BASIS_RUNTIME_LEDGER,
+        )
+        self.assertEqual(tca_rows[0]["post_cost_promotion_eligible"], True)
+        ledger_bucket = tca_rows[0]["runtime_ledger_bucket"]
+        assert isinstance(ledger_bucket, dict)
+        self.assertEqual(
+            ledger_bucket["ledger_schema_version"], "torghut.exact_replay_ledger.v1"
+        )
+        self.assertEqual(ledger_bucket["pnl_basis"], POST_COST_BASIS_RUNTIME_LEDGER)
+        self.assertEqual(ledger_bucket["decision_count"], 2)
+        self.assertEqual(ledger_bucket["submitted_order_count"], 2)
+        self.assertEqual(ledger_bucket["closed_trade_count"], 1)
+        self.assertEqual(ledger_bucket["blockers"], [])
+        self.assertEqual(metadata["runtime_ledger_artifact_row_count"], 6)
+        self.assertEqual(metadata["runtime_ledger_artifact_tca_row_count"], 1)
+
+    def test_runtime_ledger_artifact_helpers_fail_closed_on_loose_rows(self) -> None:
+        aware_time = datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)
+        naive_time = datetime(2026, 3, 6, 14, 35)
+
+        self.assertEqual(_parse_dt_or_none(aware_time), aware_time)
+        self.assertEqual(_parse_dt_or_none(naive_time), aware_time)
+        self.assertEqual(_parse_dt_or_none(""), None)
+        self.assertEqual(_parse_dt_or_none("not-a-date"), None)
+        self.assertEqual(_runtime_ledger_event_type({"filled_qty": "1"}), "fill")
+        self.assertEqual(
+            _runtime_ledger_event_type({"order_id": "alpaca-order-1"}),
+            "order_submitted",
+        )
+        self.assertEqual(
+            _runtime_ledger_event_type({"decision_id": "decision-1"}),
+            "decision",
+        )
+        self.assertEqual(_runtime_ledger_event_type({}), "diagnostic")
+
+        with TemporaryDirectory() as temp_dir:
+            missing_path = Path(temp_dir) / "missing.json"
+            malformed_rows_path = Path(temp_dir) / "malformed-rows.json"
+            diagnostic_path = Path(temp_dir) / "diagnostic.json"
+            malformed_rows_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "runtime_ledger_rows": {"bad": "shape"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            diagnostic_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "runtime_ledger_rows": [
+                            {"event_type": "diagnostic"},
+                            {
+                                "event_type": "diagnostic",
+                                "executed_at": "2026-03-06T14:35:00Z",
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            decisions, executions, tca_rows, metadata = (
+                _runtime_ledger_tca_rows_from_artifacts(
+                    artifact_refs=[
+                        str(missing_path),
+                        str(malformed_rows_path),
+                        str(diagnostic_path),
+                    ],
+                    bucket_ranges=[
+                        (
+                            datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                            datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                            6,
+                        )
+                    ],
+                )
+            )
+
+        self.assertEqual(decisions, [])
+        self.assertEqual(executions, [])
+        self.assertEqual(tca_rows, [])
+        self.assertEqual(
+            metadata["runtime_ledger_artifact_refs"], [str(diagnostic_path)]
+        )
+        self.assertEqual(
+            metadata["runtime_ledger_ignored_artifact_refs"],
+            [str(malformed_rows_path)],
+        )
+        self.assertEqual(metadata["runtime_ledger_artifact_row_count"], 2)
+        self.assertEqual(metadata["runtime_ledger_artifact_tca_row_count"], 0)
+
+    def test_main_rejects_artifact_refs_without_exact_runtime_ledger_rows(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            artifact_path = Path(temp_dir) / "malformed-rows.json"
+            artifact_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "runtime_ledger_rows": {"bad": "shape"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            args = SimpleNamespace(
+                run_id="run-empty-ledger-artifact",
+                candidate_id="H-TSMOM-LIQ-01",
+                hypothesis_id="H-TSMOM-LIQ-01",
+                observed_stage="paper",
+                strategy_family="intraday_tsmom_consistent",
+                source_dsn="",
+                source_dsn_env="DB_DSN",
+                strategy_name="intraday-tsmom-profit-v3",
+                account_label="TORGHUT_SIM",
+                window_start="2026-03-06T14:30:00Z",
+                window_end="2026-03-06T15:00:00Z",
+                bucket_minutes=30,
+                sample_minutes=5,
+                source_manifest_ref="config/trading/hypotheses/h-tsmom-liq-01.json",
+                source_kind="paper_runtime_observed",
+                artifact_ref=[str(artifact_path)],
+                delay_adjusted_depth_stress_report_ref="",
+                dataset_snapshot_ref="runtime-ledger-empty-artifact-snapshot",
+                target_metadata_json="",
+                dependency_quorum_decision="allow",
+                continuity_ok="true",
+                drift_ok="true",
+                json=False,
+            )
+            manifest = SimpleNamespace(
+                strategy_family="intraday_tsmom_consistent",
+                strategy_id="intraday_tsmom_v2@research",
+                max_allowed_slippage_bps=Decimal("6"),
+            )
+
+            with (
+                patch(
+                    "scripts.import_hypothesis_runtime_windows._parse_args",
+                    return_value=args,
+                ),
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.resolve_hypothesis_manifest",
+                    return_value=(
+                        SimpleNamespace(
+                            path="config/trading/hypotheses/h-tsmom-liq-01.json"
+                        ),
+                        manifest,
+                    ),
+                ),
+                patch.dict("os.environ", {}, clear=True),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "source_dsn_not_configured"):
+                    main()
+
     def test_main_preserves_registry_manifest_fallback_when_source_manifest_ref_missing(
         self,
     ) -> None:
@@ -659,6 +909,159 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             "runtime_window_source_activity_missing",
         )
         self.assertFalse(summary["runtime_observation"]["authoritative"])
+
+    def test_main_imports_exact_runtime_ledger_artifact_without_db_activity(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temp_dir:
+            artifact_path = Path(temp_dir) / "exact-ledger.json"
+            artifact_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "account_label": "TORGHUT_SIM",
+                        "strategy_id": "intraday-tsmom-profit-v3",
+                        "execution_policy_hash": "policy-sha",
+                        "cost_model_hash": "cost-sha",
+                        "lineage_hash": "lineage-sha",
+                        "runtime_ledger_rows": [
+                            {
+                                "event_type": "decision",
+                                "executed_at": "2026-03-06T14:35:00Z",
+                                "decision_id": "decision-buy",
+                                "order_id": "order-buy",
+                            },
+                            {
+                                "event_type": "order_submitted",
+                                "executed_at": "2026-03-06T14:35:01Z",
+                                "decision_id": "decision-buy",
+                                "order_id": "order-buy",
+                            },
+                            {
+                                "event_type": "fill",
+                                "executed_at": "2026-03-06T14:35:02Z",
+                                "decision_id": "decision-buy",
+                                "order_id": "order-buy",
+                                "symbol": "AAPL",
+                                "side": "buy",
+                                "filled_qty": "1",
+                                "avg_fill_price": "100",
+                                "cost_amount": "0.10",
+                                "cost_basis": "broker_reported_commission_and_fees",
+                            },
+                            {
+                                "event_type": "decision",
+                                "executed_at": "2026-03-06T14:40:00Z",
+                                "decision_id": "decision-sell",
+                                "order_id": "order-sell",
+                            },
+                            {
+                                "event_type": "order_submitted",
+                                "executed_at": "2026-03-06T14:40:01Z",
+                                "decision_id": "decision-sell",
+                                "order_id": "order-sell",
+                            },
+                            {
+                                "event_type": "fill",
+                                "executed_at": "2026-03-06T14:40:02Z",
+                                "decision_id": "decision-sell",
+                                "order_id": "order-sell",
+                                "symbol": "AAPL",
+                                "side": "sell",
+                                "filled_qty": "1",
+                                "avg_fill_price": "101",
+                                "cost_amount": "0.10",
+                                "cost_basis": "broker_reported_commission_and_fees",
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            args = SimpleNamespace(
+                run_id="run-ledger-artifact",
+                candidate_id="H-TSMOM-LIQ-01",
+                hypothesis_id="H-TSMOM-LIQ-01",
+                observed_stage="paper",
+                strategy_family="intraday_tsmom_consistent",
+                source_dsn="",
+                source_dsn_env="DB_DSN",
+                strategy_name="intraday-tsmom-profit-v3",
+                account_label="TORGHUT_SIM",
+                window_start="2026-03-06T14:30:00Z",
+                window_end="2026-03-06T15:00:00Z",
+                bucket_minutes=30,
+                sample_minutes=5,
+                source_manifest_ref="config/trading/hypotheses/h-tsmom-liq-01.json",
+                source_kind="paper_runtime_observed",
+                artifact_ref=[str(artifact_path)],
+                delay_adjusted_depth_stress_report_ref="",
+                dataset_snapshot_ref="runtime-ledger-artifact-snapshot",
+                target_metadata_json="",
+                dependency_quorum_decision="allow",
+                continuity_ok="true",
+                drift_ok="true",
+                json=False,
+            )
+            fake_session = _FakeSession()
+            manifest = SimpleNamespace(
+                strategy_family="intraday_tsmom_consistent",
+                strategy_id="intraday_tsmom_v2@research",
+                max_allowed_slippage_bps=Decimal("6"),
+            )
+
+            with (
+                patch(
+                    "scripts.import_hypothesis_runtime_windows._parse_args",
+                    return_value=args,
+                ),
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.resolve_hypothesis_manifest",
+                    return_value=(
+                        SimpleNamespace(
+                            path="config/trading/hypotheses/h-tsmom-liq-01.json"
+                        ),
+                        manifest,
+                    ),
+                ),
+                patch.dict("os.environ", {}, clear=True),
+                patch(
+                    "scripts.import_hypothesis_runtime_windows._query_timestamps",
+                ) as query_timestamps,
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.build_observed_runtime_buckets",
+                    return_value=[],
+                ) as build_buckets,
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.persist_observed_runtime_windows",
+                    return_value={"run_id": "run-ledger-artifact"},
+                ) as persist_windows,
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.SessionLocal",
+                    return_value=fake_session,
+                ),
+                patch("builtins.print"),
+            ):
+                exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        query_timestamps.assert_not_called()
+        self.assertEqual(len(build_buckets.call_args.kwargs["decision_times"]), 2)
+        self.assertEqual(len(build_buckets.call_args.kwargs["execution_times"]), 2)
+        tca_rows = build_buckets.call_args.kwargs["tca_rows"]
+        self.assertEqual(len(tca_rows), 1)
+        self.assertEqual(
+            tca_rows[0]["post_cost_expectancy_basis"],
+            POST_COST_BASIS_RUNTIME_LEDGER,
+        )
+        self.assertEqual(tca_rows[0]["post_cost_promotion_eligible"], True)
+        runtime_payload = persist_windows.call_args.kwargs[
+            "runtime_observation_payload"
+        ]
+        self.assertEqual(
+            runtime_payload["runtime_ledger_artifact_refs"], [str(artifact_path)]
+        )
+        self.assertEqual(runtime_payload["runtime_ledger_artifact_row_count"], 6)
 
     def test_main_attaches_delay_adjusted_depth_report_to_runtime_payload(
         self,

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -800,6 +800,18 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             ),
             encoding="utf-8",
         )
+        (hypothesis_dir / "h-tsmom-liq-01.json").write_text(
+            json.dumps(
+                {
+                    "hypothesis_id": "H-TSMOM-LIQ-01",
+                    "strategy_family": "stale_family",
+                    "strategy_id": "intraday_tsmom_v2@research",
+                    "candidate_id": "H-TSMOM-LIQ-01",
+                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                }
+            ),
+            encoding="utf-8",
+        )
         (hypothesis_dir / "h-micro-01.json").write_text(
             json.dumps(
                 {
@@ -845,7 +857,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
 
         self.assertEqual(
             [target.hypothesis_id for target in targets],
-            ["H-CONT-01", "H-MICRO-01", "H-TSMOM-01"],
+            ["H-CONT-01", "H-MICRO-01", "H-TSMOM-01", "H-TSMOM-LIQ-01"],
         )
         by_id = {target.hypothesis_id: target for target in targets}
         self.assertEqual(
@@ -854,6 +866,14 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         )
         self.assertEqual(
             by_id["H-TSMOM-01"].strategy_name,
+            "intraday-tsmom-profit-v3",
+        )
+        self.assertEqual(
+            by_id["H-TSMOM-LIQ-01"].candidate_id,
+            "H-TSMOM-LIQ-01",
+        )
+        self.assertEqual(
+            by_id["H-TSMOM-LIQ-01"].strategy_name,
             "intraday-tsmom-profit-v3",
         )
         self.assertEqual(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -4154,7 +4154,7 @@ class TestTradingApi(TestCase):
         self.assertGreaterEqual(evaluation["metrics"]["total_reviews"], 1)
         hypotheses = payload["hypotheses"]
         self.assertTrue(hypotheses["registry_loaded"])
-        self.assertEqual(len(hypotheses["items"]), 5)
+        self.assertEqual(len(hypotheses["items"]), 6)
         self.assertEqual(hypotheses["dependency_quorum"]["decision"], "allow")
         self.assertEqual(
             hypotheses["dependency_quorum"]["reasons"],
@@ -4176,8 +4176,8 @@ class TestTradingApi(TestCase):
         self.assertIn("universe_fail_safe_blocked", control_plane_contract)
         self.assertIn("domain_telemetry_event_total", control_plane_contract)
         self.assertIn("domain_telemetry_dropped_total", control_plane_contract)
-        self.assertEqual(control_plane_contract["alpha_readiness_hypotheses_total"], 5)
-        self.assertEqual(control_plane_contract["alpha_readiness_blocked_total"], 3)
+        self.assertEqual(control_plane_contract["alpha_readiness_hypotheses_total"], 6)
+        self.assertEqual(control_plane_contract["alpha_readiness_blocked_total"], 4)
         self.assertEqual(control_plane_contract["alpha_readiness_shadow_total"], 2)
         self.assertIn(control_plane_contract["active_capital_stage"], {"shadow", None})
         self.assertIn("critical_toggle_parity", control_plane_contract)
@@ -6002,10 +6002,10 @@ class TestTradingApi(TestCase):
             "torghut.quant-producer.v1",
         )
         self.assertEqual(
-            payload["control_plane_contract"]["alpha_readiness_hypotheses_total"], 5
+            payload["control_plane_contract"]["alpha_readiness_hypotheses_total"], 6
         )
         self.assertEqual(
-            payload["control_plane_contract"]["alpha_readiness_blocked_total"], 3
+            payload["control_plane_contract"]["alpha_readiness_blocked_total"], 4
         )
         self.assertEqual(
             payload["control_plane_contract"]["alpha_readiness_shadow_total"], 2
@@ -6049,7 +6049,7 @@ class TestTradingApi(TestCase):
                 metrics_payload,
             )
             self.assertIn(
-                'torghut_trading_hypothesis_state_total{state="blocked"} 3',
+                'torghut_trading_hypothesis_state_total{state="blocked"} 4',
                 metrics_payload,
             )
             self.assertIn(
@@ -6057,11 +6057,11 @@ class TestTradingApi(TestCase):
                 metrics_payload,
             )
             self.assertIn(
-                'torghut_trading_hypothesis_capital_stage_total{stage="shadow"} 5',
+                'torghut_trading_hypothesis_capital_stage_total{stage="shadow"} 6',
                 metrics_payload,
             )
             self.assertIn(
-                "torghut_trading_alpha_readiness_hypotheses_total 5",
+                "torghut_trading_alpha_readiness_hypotheses_total 6",
                 metrics_payload,
             )
             self.assertIn("torghut_trading_llm_runtime_fallback_ratio", metrics_payload)


### PR DESCRIPTION
## Summary

- Add strict exact runtime-ledger artifact ingestion to the runtime-window importer, rebuilding promotion evidence from row-level lifecycle/fill data through `build_runtime_ledger_buckets`.
- Add first-class `H-TSMOM-LIQ-01` hypothesis identity so liquid TSMOM replay/runtime evidence is evaluated against the matching candidate instead of the older `H-TSMOM-01` candidate id.
- Keep paper and replay evidence blocked from final promotion unless live runtime-ledger authority clears the existing gates.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py tests/test_hypotheses.py tests/test_trading_api.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py tests/test_hypotheses.py tests/test_trading_api.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_hypotheses.py tests/test_run_empirical_promotion_jobs.py tests/test_trading_api.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
