### PR TITLE
fix(froussard): promote image for atlas env rollout

### DIFF
--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -22,7 +22,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: app
-          image: registry.ide-newton.ts.net/lab/froussard@sha256:ea09d6a274a7364b728a344f97e5d0cff9c6e8ca051252e95d4a564946e66b4b
+          image: registry.ide-newton.ts.net/lab/froussard@sha256:eabac3b26b758349e9882115ecdc07c3a8a6ae53d0398420bf6cd924328dabbd
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -69,9 +69,9 @@ spec:
             - name: OTEL_SERVICE_NAMESPACE
               value: froussard
             - name: FROUSSARD_VERSION
-              value: v0.568.2-78-g0c2b64c03
+              value: v0.571.1-491-ga931fba9e
             - name: FROUSSARD_COMMIT
-              value: 0c2b64c032d7fb1a95b9c5eb42f62e71d01b5dc5
+              value: a931fba9e5a5c0bffeeec5a3c4d81fa6db73141a
             - name: LGTM_TEMPO_TRACES_ENDPOINT
               value: http://observability-tempo-gateway.observability.svc.cluster.local:4317
             - name: LGTM_MIMIR_METRICS_ENDPOINT


### PR DESCRIPTION
## Summary

- Promotes a Froussard image built from `main` commit `a931fba9e5a5c0bffeeec5a3c4d81fa6db73141a`.
- Updates the Knative manifest image digest plus `FROUSSARD_VERSION` and `FROUSSARD_COMMIT` to match the promoted image.
- Restores compatibility with the manifest that uses `ATLAS_BASE_URL` and no retired Codex Kafka topic env vars.

## Related Issues

None

## Testing

- `bun run --cwd apps/froussard test src/__tests__/argo-manifests.test.ts`
- `bun run lint:argocd`
- `git diff --check`
- Live rollout check: `kubectl --context galactic-lan -n froussard wait ksvc/froussard --for=condition=Ready --timeout=180s`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
