### PR TITLE
fix(sag): tolerate slow health probes after restart

### DIFF
--- a/argocd/sag/deployment.yaml
+++ b/argocd/sag/deployment.yaml
@@ -76,15 +76,16 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 3
+            timeoutSeconds: 10
             failureThreshold: 6
           livenessProbe:
             httpGet:
-              path: /api/health
+              path: /
               port: http
             initialDelaySeconds: 20
-            periodSeconds: 20
-            timeoutSeconds: 3
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 6
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
## Summary

- Moves the Sag liveness probe to the lightweight root route so transient Postgres-backed health latency does not restart the pod.
- Raises Sag readiness and liveness probe timeouts to 10 seconds.
- Extends Sag liveness period and failure threshold to reduce false restarts during post-outage recovery.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/sag >/tmp/sag-kustomize.yaml`
- `rg -n "path: /$|timeoutSeconds: 10|periodSeconds: 30|failureThreshold: 6" /tmp/sag-kustomize.yaml`
- Live validation before GitOps: `kubectl --context galactic-lan -n sag rollout status deploy/sag --timeout=180s`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
