### PR TITLE
test(agents): remove jangar compatibility fixtures

### DIFF
--- a/packages/scripts/src/agents/__tests__/build-image.test.ts
+++ b/packages/scripts/src/agents/__tests__/build-image.test.ts
@@ -19,8 +19,6 @@ const envKeys = [
   'AGENTS_IMAGE_REPOSITORY',
   'AGENTS_IMAGE_TAG',
   'AGENTS_VERSION',
-  'JANGAR_BUILD_CI',
-  'JANGAR_BUILD_MINIFY',
 ]
 
 afterEach(() => {
@@ -57,16 +55,6 @@ describe('agents build-image helpers', () => {
       AGENTS_BUILD_SOURCEMAP: '0',
       AGENTS_BUILD_CI: 'true',
       AGENTS_BUILD_LOG_LEVEL: 'warn',
-    })
-  })
-
-  it('ignores legacy Jangar build env names', () => {
-    process.env.JANGAR_BUILD_MINIFY = '0'
-    process.env.JANGAR_BUILD_CI = 'true'
-
-    expect(__private.buildArgsFromEnv('v1', 'commit1')).toEqual({
-      AGENTS_VERSION: 'v1',
-      AGENTS_COMMIT: 'commit1',
     })
   })
 

--- a/packages/scripts/src/agents/__tests__/deploy-service.test.ts
+++ b/packages/scripts/src/agents/__tests__/deploy-service.test.ts
@@ -5,15 +5,7 @@ import { join } from 'node:path'
 
 import { __private } from '../deploy-service'
 
-const envKeys = [
-  'AGENTS_IMAGE_TAG',
-  'AGENTS_IMAGE_PLATFORMS',
-  'JANGAR_IMAGE_REGISTRY',
-  'JANGAR_IMAGE_REPOSITORY',
-  'JANGAR_CONTROL_PLANE_IMAGE_REPOSITORY',
-  'JANGAR_IMAGE_TAG',
-  'JANGAR_IMAGE_PLATFORMS',
-]
+const envKeys = ['AGENTS_IMAGE_TAG', 'AGENTS_IMAGE_PLATFORMS']
 
 afterEach(() => {
   for (const key of envKeys) {
@@ -54,22 +46,6 @@ describe('agents deploy-service helpers', () => {
         platforms: ['linux/arm64'],
       },
     ])
-  })
-
-  it('ignores legacy Jangar image env aliases', () => {
-    process.env.JANGAR_IMAGE_REGISTRY = 'registry.example/jangar'
-    process.env.JANGAR_IMAGE_REPOSITORY = 'lab/jangar'
-    process.env.JANGAR_CONTROL_PLANE_IMAGE_REPOSITORY = 'lab/jangar-control-plane'
-    process.env.JANGAR_IMAGE_TAG = 'jangar-tag'
-    process.env.JANGAR_IMAGE_PLATFORMS = 'linux/s390x'
-
-    const options = __private.resolveOptions()
-
-    expect(options.registry).toBe('registry.ide-newton.ts.net')
-    expect(options.repository).toBe('lab/agents-controller')
-    expect(options.controlPlaneRepository).toBe('lab/agents-control-plane')
-    expect(options.tag).not.toBe('jangar-tag')
-    expect(options.platforms).toEqual(['linux/amd64', 'linux/arm64'])
   })
 
   it('treats local Codex auth as optional for runner image builds', () => {

--- a/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
+++ b/packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts
@@ -189,7 +189,6 @@ describe('agents-ci workflow local Agents image build', () => {
     expect(workflow).toContain('agents-runner-image-smoke')
     expect(workflow).toContain('--build-arg "AGENTS_VERSION=${AGENTS_VERSION}"')
     expect(workflow).not.toContain('-f "${WORKSPACE}/services/jangar/Dockerfile"')
-    expect(workflow).not.toContain('--build-arg "JANGAR_VERSION=')
   })
 })
 

--- a/services/agents/agentctl/src/__tests__/config.test.ts
+++ b/services/agents/agentctl/src/__tests__/config.test.ts
@@ -8,27 +8,23 @@ describe('resolveConfig', () => {
     expect(warnings.length).toBeGreaterThan(0)
   })
 
-  it('ignores Jangar compatibility aliases for gRPC config', () => {
+  it('reads canonical Agents gRPC env config', () => {
     const previousServer = process.env.AGENTCTL_SERVER
     const previousAgentctlAddress = process.env.AGENTCTL_ADDRESS
     const previousAgentctlToken = process.env.AGENTCTL_TOKEN
     const previousAddress = process.env.AGENTS_GRPC_ADDRESS
-    const previousLegacyAddress = process.env.JANGAR_GRPC_ADDRESS
     const previousToken = process.env.AGENTS_GRPC_TOKEN
-    const previousLegacyToken = process.env.JANGAR_GRPC_TOKEN
     try {
       delete process.env.AGENTCTL_SERVER
       delete process.env.AGENTCTL_ADDRESS
       delete process.env.AGENTCTL_TOKEN
-      delete process.env.AGENTS_GRPC_ADDRESS
-      process.env.JANGAR_GRPC_ADDRESS = 'jangar-grpc.jangar.svc.cluster.local:50051'
-      delete process.env.AGENTS_GRPC_TOKEN
-      process.env.JANGAR_GRPC_TOKEN = 'jangar-token'
+      process.env.AGENTS_GRPC_ADDRESS = 'agents-grpc.agents.svc.cluster.local:50051'
+      process.env.AGENTS_GRPC_TOKEN = 'agents-token'
 
       const { resolved } = resolveConfig({ grpc: true }, {})
 
       expect(resolved.address).toBe('agents-grpc.agents.svc.cluster.local:50051')
-      expect(resolved.token).toBeUndefined()
+      expect(resolved.token).toBe('agents-token')
     } finally {
       if (previousServer === undefined) delete process.env.AGENTCTL_SERVER
       else process.env.AGENTCTL_SERVER = previousServer
@@ -38,12 +34,8 @@ describe('resolveConfig', () => {
       else process.env.AGENTCTL_TOKEN = previousAgentctlToken
       if (previousAddress === undefined) delete process.env.AGENTS_GRPC_ADDRESS
       else process.env.AGENTS_GRPC_ADDRESS = previousAddress
-      if (previousLegacyAddress === undefined) delete process.env.JANGAR_GRPC_ADDRESS
-      else process.env.JANGAR_GRPC_ADDRESS = previousLegacyAddress
       if (previousToken === undefined) delete process.env.AGENTS_GRPC_TOKEN
       else process.env.AGENTS_GRPC_TOKEN = previousToken
-      if (previousLegacyToken === undefined) delete process.env.JANGAR_GRPC_TOKEN
-      else process.env.JANGAR_GRPC_TOKEN = previousLegacyToken
     }
   })
 })

--- a/services/agents/src/server/__tests__/control-plane-grpc.test.ts
+++ b/services/agents/src/server/__tests__/control-plane-grpc.test.ts
@@ -82,16 +82,6 @@ describe('resolveGrpcStatus', () => {
     expect(status.message).toContain('invalid AGENTS_GRPC_ENABLED value')
   })
 
-  it('ignores legacy JANGAR_GRPC_ENABLED when only the legacy name is set', async () => {
-    const status = await withEnv({ JANGAR_GRPC_ENABLED: 'bogus' }, () => resolveGrpcStatus())
-
-    expect(status).toMatchObject({
-      enabled: false,
-      status: 'disabled',
-    })
-    expect(status.message).toBe('gRPC disabled')
-  })
-
   it('returns degraded when AGENTS_GRPC_PORT is malformed and no address override is set', async () => {
     const status = await withEnv(
       {

--- a/services/agents/src/server/__tests__/control-plane-runtime-admission.test.ts
+++ b/services/agents/src/server/__tests__/control-plane-runtime-admission.test.ts
@@ -317,7 +317,7 @@ describe('buildRuntimeAdmissionSnapshot', () => {
       natsUrl: 'nats://nats.nats.svc.cluster.local:4222',
       executionTrust: {
         status: 'degraded',
-        reason: 'requirements are degraded on jangar-control-plane: pending=5',
+        reason: 'requirements are degraded on agents-control-plane: pending=5',
         last_evaluated_at: '2026-03-21T00:30:01.000Z',
         blocking_windows: [],
         evidence_summary: ['requirements pending=5'],

--- a/services/agents/src/server/agent-resource-labels.test.ts
+++ b/services/agents/src/server/agent-resource-labels.test.ts
@@ -46,13 +46,13 @@ describe('Agents resource labels', () => {
 
     expect(
       readOrchestrationRunLabel({
-        metadata: { labels: { 'jangar.proompteng.ai/orchestration-run': 'legacy-orch' } },
+        metadata: { labels: { 'legacy.proompteng.ai/orchestration-run': 'legacy-orch' } },
       }),
     ).toBeUndefined()
 
     expect(
       readToolRunLabel({
-        metadata: { labels: { 'jangar.proompteng.ai/tool-run': 'legacy-toolrun' } },
+        metadata: { labels: { 'legacy.proompteng.ai/tool-run': 'legacy-toolrun' } },
       }),
     ).toBeUndefined()
   })

--- a/services/agents/src/server/agents-controller/index.integration.test.ts
+++ b/services/agents/src/server/agents-controller/index.integration.test.ts
@@ -219,7 +219,7 @@ const buildVcsProvider = (overrides: Record<string, unknown> = {}) => ({
 })
 
 describe('agents controller startup', () => {
-  it('uses the Agents-owned startup feature flag without the legacy Jangar gate', async () => {
+  it('uses the Agents-owned startup feature flag without a domain gate', async () => {
     const previousNodeEnv = process.env.NODE_ENV
     const previousVitest = process.env.VITEST
     process.env.NODE_ENV = 'development'

--- a/services/agents/src/server/agents-controller/runtime-config.test.ts
+++ b/services/agents/src/server/agents-controller/runtime-config.test.ts
@@ -22,20 +22,6 @@ describe('Agents controller runtime config', () => {
     expect(resolveAgentsControllerAuthSecretConfig(env)?.name).toBe('agents-auth')
   })
 
-  it('does not read legacy Jangar env names in the Agents controller', () => {
-    const env = {
-      JANGAR_AGENT_RUNNER_IMAGE: 'registry.example/jangar-runner:compat',
-      JANGAR_AGENT_RUNNER_JOB_TTL_SECONDS: '120',
-      JANGAR_AGENTRUN_ARTIFACTS_MAX: '5',
-      JANGAR_AGENTS_CONTROLLER_AUTH_SECRET_NAME: 'jangar-auth',
-    }
-
-    expect(resolveAgentRunnerDefaultsConfig(env).defaultRunnerImage).toBeNull()
-    expect(resolveAgentRunnerDefaultsConfig(env).jobTtlSeconds).toBe(600)
-    expect(resolveAgentsControllerBehaviorConfig(env).artifactsMaxEntries).toBe(50)
-    expect(resolveAgentsControllerAuthSecretConfig(env)).toBeNull()
-  })
-
   it('does not read the legacy generic AGENTS_AGENT_IMAGE runner alias', () => {
     expect(
       resolveAgentRunnerDefaultsConfig({
@@ -52,7 +38,6 @@ describe('Agents controller runtime config', () => {
         AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_RETRY_BASE_DELAY_SECONDS: '2',
         AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_RETRY_MAX_DELAY_SECONDS: '30',
         AGENTS_IMPLEMENTATION_SOURCE_WEBHOOK_RETRY_MAX_ATTEMPTS: '4',
-        JANGAR_IMPLEMENTATION_SOURCE_WEBHOOK_QUEUE_SIZE: '999',
       }),
     ).toEqual({
       namespacesRaw: 'agents,dev',
@@ -62,12 +47,7 @@ describe('Agents controller runtime config', () => {
       retryMaxAttempts: 4,
     })
 
-    expect(
-      resolveImplementationSourceWebhookConfig({
-        JANGAR_IMPLEMENTATION_SOURCE_WEBHOOK_NAMESPACES: 'jangar',
-        JANGAR_IMPLEMENTATION_SOURCE_WEBHOOK_QUEUE_SIZE: '999',
-      }),
-    ).toEqual({
+    expect(resolveImplementationSourceWebhookConfig({})).toEqual({
       namespacesRaw: null,
       queueSize: null,
       retryBaseDelaySeconds: null,

--- a/services/agents/src/server/control-plane-watch-reliability.test.ts
+++ b/services/agents/src/server/control-plane-watch-reliability.test.ts
@@ -54,20 +54,6 @@ describe('control-plane watch reliability', () => {
     expect(summary.total_restarts).toBe(2)
   })
 
-  it('ignores legacy Jangar threshold aliases', () => {
-    expect(
-      resolveControlPlaneWatchReliabilityConfig({
-        JANGAR_CONTROL_PLANE_WATCH_HEALTH_RESTART_DEGRADE_THRESHOLD: '9',
-      }).restartDegradeThreshold,
-    ).toBe(2)
-    expect(
-      resolveControlPlaneWatchReliabilityConfig({
-        AGENTS_CONTROL_PLANE_WATCH_HEALTH_RESTART_DEGRADE_THRESHOLD: '3',
-        JANGAR_CONTROL_PLANE_WATCH_HEALTH_RESTART_DEGRADE_THRESHOLD: '9',
-      }).restartDegradeThreshold,
-    ).toBe(3)
-  })
-
   it('keeps independent single-stream restarts observable without degrading status', () => {
     vi.stubEnv('AGENTS_CONTROL_PLANE_WATCH_HEALTH_RESTART_DEGRADE_THRESHOLD', '2')
     recordWatchReliabilityRestart({

--- a/services/agents/src/server/control-plane.test.ts
+++ b/services/agents/src/server/control-plane.test.ts
@@ -29,7 +29,7 @@ afterEach(() => {
 })
 
 describe('Agents control-plane runtime', () => {
-  it('serves health from the Agents runtime without Jangar route modules', async () => {
+  it('serves health from the Agents runtime without external route modules', async () => {
     process.env.AGENTS_CONTROLLER_ENABLED = '0'
     const runtime = await createAgentsControlPlaneRuntime()
 

--- a/services/agents/src/server/controller-runtime-config.test.ts
+++ b/services/agents/src/server/controller-runtime-config.test.ts
@@ -14,31 +14,12 @@ describe('Agents controller runtime config', () => {
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: 'true',
       AGENTS_CONTROL_PLANE_CACHE_NAMESPACES: 'agents,agents-system',
       AGENTS_CONTROL_PLANE_CACHE_CLUSTER: 'prod-agents',
-      JANGAR_CONTROL_PLANE_CACHE_ENABLED: 'false',
-      JANGAR_CONTROL_PLANE_CACHE_NAMESPACES: 'jangar',
-      JANGAR_CONTROL_PLANE_CACHE_CLUSTER: 'prod-jangar',
     })
 
     expect(config).toEqual({
       enabled: true,
       namespaces: ['agents', 'agents-system'],
       clusterId: 'prod-agents',
-      resyncSeconds: 60,
-      maxPendingWrites: 5000,
-    })
-  })
-
-  it('does not read legacy Jangar control-plane cache aliases', () => {
-    expect(
-      resolveControlPlaneCacheConfig({
-        JANGAR_CONTROL_PLANE_CACHE_ENABLED: 'on',
-        JANGAR_CONTROL_PLANE_CACHE_NAMESPACES: 'jangar',
-        JANGAR_CONTROL_PLANE_CACHE_CLUSTER: 'compat',
-      }),
-    ).toEqual({
-      enabled: false,
-      namespaces: ['agents'],
-      clusterId: 'default',
       resyncSeconds: 60,
       maxPendingWrites: 5000,
     })

--- a/services/agents/src/server/integrations-config.test.ts
+++ b/services/agents/src/server/integrations-config.test.ts
@@ -3,14 +3,13 @@ import { describe, expect, it } from 'vitest'
 import { resolveAgentCommsSubscriberConfig, resolveFeatureFlagsClientConfig } from './integrations-config'
 
 describe('Agents integrations config', () => {
-  it('prefers canonical AGENTS feature flag settings over JANGAR compatibility aliases', () => {
+  it('reads canonical AGENTS feature flag settings', () => {
     const config = resolveFeatureFlagsClientConfig({
       AGENTS_FEATURE_FLAGS_ENABLED: 'true',
       AGENTS_FEATURE_FLAGS_URL: 'http://agents-flags.local/',
       AGENTS_FEATURE_FLAGS_TIMEOUT_MS: '750',
       AGENTS_FEATURE_FLAGS_NAMESPACE: 'agents',
       AGENTS_FEATURE_FLAGS_ENTITY_ID: 'agents-controller',
-      JANGAR_FEATURE_FLAGS_URL: 'http://jangar-flags.local',
     })
 
     expect(config).toMatchObject({
@@ -20,24 +19,6 @@ describe('Agents integrations config', () => {
       namespaceKey: 'agents',
       entityId: 'agents-controller',
     })
-  })
-
-  it('ignores legacy JANGAR feature flag and agent comms aliases', () => {
-    const featureFlags = resolveFeatureFlagsClientConfig({
-      JANGAR_FEATURE_FLAGS_ENABLED: 'false',
-      JANGAR_FEATURE_FLAGS_URL: 'http://jangar-flags.local/',
-      JANGAR_FEATURE_FLAGS_TIMEOUT_MS: '250',
-    })
-    const agentComms = resolveAgentCommsSubscriberConfig({
-      JANGAR_AGENT_COMMS_SUBSCRIBER_DISABLED: 'true',
-      JANGAR_AGENT_COMMS_SUBJECTS: 'agents.workflow.>,workflow.>',
-    })
-
-    expect(featureFlags.enabled).toBe(true)
-    expect(featureFlags.endpoint).toBeNull()
-    expect(featureFlags.timeoutMs).toBe(500)
-    expect(agentComms.disabled).toBe(false)
-    expect(agentComms.filterSubjects).toEqual(['agentrun.>'])
   })
 
   it('rejects non-canonical agent comms subject families', () => {

--- a/services/agents/src/server/supporting-primitives-controller.test.ts
+++ b/services/agents/src/server/supporting-primitives-controller.test.ts
@@ -108,12 +108,12 @@ describe('supporting primitives controller', () => {
             {
               dispatch_kind: 'swarm_requirement_signal',
               signal_name: 'domain-material-reentry',
-              source_swarm: 'jangar-domain',
+              source_swarm: 'domain-runtime',
               target_swarm: 'runtime-workers',
               target_stage: 'implement',
               channel: 'agentrun.general.requirement',
               description: 'domain repair',
-              payload: { domain: 'jangar' },
+              payload: { domain: 'finance' },
             },
           ],
         },
@@ -181,7 +181,7 @@ describe('supporting primitives controller', () => {
     })
   })
 
-  it('renders Schedule resources into ConfigMap and CronJob without Jangar runner paths', async () => {
+  it('renders Schedule resources into ConfigMap and CronJob from the Agents runner path', async () => {
     const { kube, applied, statuses } = createKubeMock({
       'agentruns.agents.proompteng.ai:agents:template-run': {
         apiVersion: 'agents.proompteng.ai/v1alpha1',
@@ -213,7 +213,6 @@ describe('supporting primitives controller', () => {
     const cronJob = applied.find((resource) => resource.kind === 'CronJob')
     expect(configMap).toBeTruthy()
     expect(cronJob).toBeTruthy()
-    expect(JSON.stringify(configMap)).not.toContain('JANGAR')
     expect(cronJob).toMatchObject({
       spec: {
         schedule: '*/15 * * * *',

--- a/services/agents/src/server/v1/codex-runs.test.ts
+++ b/services/agents/src/server/v1/codex-runs.test.ts
@@ -97,7 +97,7 @@ describe('Codex runs v1 API', () => {
     expect(issuesResponse.status).toBe(200)
   })
 
-  it('serves run lookup APIs used by Jangar compatibility routes', async () => {
+  it('serves run lookup APIs used by compatibility routes', async () => {
     const run = { id: 'run-1', repository: 'owner/repo' }
     const store = createStore({
       getRunById: vi.fn(async () => run),


### PR DESCRIPTION
## Summary

- Removed stale `JANGAR_*` compatibility fixtures from Agents runtime, agentctl, and build/deploy tests.
- Kept canonical `AGENTS_*` coverage for controller config, gRPC config, image build args, and deploy helpers.
- Reworded leftover generic fixtures to domain-neutral terms while preserving explicit Agents/Jangar boundary guard tests.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test -- src/server/agent-resource-labels.test.ts src/server/supporting-primitives-controller.test.ts src/server/control-plane.test.ts src/server/__tests__/control-plane-runtime-admission.test.ts src/server/agents-controller/index.integration.test.ts src/server/v1/codex-runs.test.ts src/server/integrations-config.test.ts src/server/controller-runtime-config.test.ts src/server/control-plane-watch-reliability.test.ts src/server/__tests__/control-plane-grpc.test.ts src/server/agents-controller/runtime-config.test.ts`
- `bun run --cwd services/agents/agentctl test src/__tests__/config.test.ts`
- `bun test packages/scripts/src/agents/__tests__/build-image.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`
- `bunx oxfmt --check services/agents/src/server/agent-resource-labels.test.ts services/agents/src/server/supporting-primitives-controller.test.ts services/agents/src/server/control-plane.test.ts services/agents/src/server/__tests__/control-plane-runtime-admission.test.ts services/agents/src/server/agents-controller/index.integration.test.ts services/agents/src/server/v1/codex-runs.test.ts services/agents/src/server/integrations-config.test.ts services/agents/src/server/controller-runtime-config.test.ts services/agents/src/server/control-plane-watch-reliability.test.ts services/agents/src/server/__tests__/control-plane-grpc.test.ts services/agents/src/server/agents-controller/runtime-config.test.ts services/agents/agentctl/src/__tests__/config.test.ts packages/scripts/src/agents/__tests__/build-image.test.ts packages/scripts/src/agents/__tests__/deploy-service.test.ts packages/scripts/src/agents/__tests__/resolve-agents-image-mode.test.ts`
- `rg -n "JANGAR_" services/agents packages/scripts/src/agents --glob '!**/node_modules/**'`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
