### PR TITLE
feat(torghut): emit runtime ledger import targets

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -8303,6 +8303,121 @@ def _candidate_board_hypothesis_manifest_ref(hypothesis_id: str | None) -> str:
     return f"config/trading/hypotheses/{normalized}.json"
 
 
+def _candidate_board_runtime_window_bounds(
+    scorecard: Mapping[str, Any],
+) -> tuple[str, str]:
+    for source in (
+        scorecard,
+        _mapping(scorecard.get("replay_window_spec")),
+        _mapping(scorecard.get("candidate_evaluation_key_payload")).get(
+            "replay_window_spec"
+        ),
+    ):
+        mapping = _mapping(source)
+        start = _string(
+            mapping.get("runtime_window_start")
+            or mapping.get("window_start")
+            or mapping.get("full_window_start")
+            or mapping.get("full_window_start_date")
+        )
+        end = _string(
+            mapping.get("runtime_window_end")
+            or mapping.get("window_end")
+            or mapping.get("full_window_end")
+            or mapping.get("full_window_end_date")
+        )
+        if start and end:
+            return start, end
+
+    replay_lineage = _mapping(scorecard.get("replay_lineage"))
+    windows = _mapping(replay_lineage.get("windows"))
+    for window_id in ("full_window", "holdout", "train"):
+        window = _mapping(windows.get(window_id))
+        start = _string(window.get("start_date") or window.get("window_start"))
+        end = _string(window.get("end_date") or window.get("window_end"))
+        if start and end:
+            return start, end
+    return "", ""
+
+
+def _candidate_board_runtime_ledger_refs(row: Mapping[str, Any]) -> tuple[str, ...]:
+    refs: list[str] = []
+    for key in (
+        "exact_replay_ledger_artifact_ref",
+        "runtime_ledger_artifact_ref",
+    ):
+        ref = _string(row.get(key))
+        if ref:
+            refs.append(ref)
+    for key in (
+        "exact_replay_ledger_artifact_refs",
+        "runtime_ledger_artifact_refs",
+    ):
+        raw_refs = row.get(key)
+        if isinstance(raw_refs, str):
+            ref = _string(raw_refs)
+            if ref:
+                refs.append(ref)
+            continue
+        for raw_ref in cast(Sequence[Any], raw_refs or ()):
+            ref = _string(raw_ref)
+            if ref:
+                refs.append(ref)
+    for raw_ref in cast(Sequence[Any], row.get("replay_artifact_refs") or ()):
+        ref = _string(raw_ref)
+        ref_lower = ref.lower()
+        if ref and (
+            "exact-replay-ledger" in ref_lower
+            or "runtime-ledger" in ref_lower
+            or "exact_replay_ledger" in ref_lower
+            or "runtime_ledger" in ref_lower
+        ):
+            refs.append(ref)
+    return tuple(dict.fromkeys(refs))
+
+
+def _candidate_board_runtime_import_args(target: Mapping[str, Any]) -> list[str]:
+    args = [
+        "uv",
+        "run",
+        "--frozen",
+        "python",
+        "scripts/import_hypothesis_runtime_windows.py",
+        "--run-id",
+        _string(target.get("run_id")) or "candidate-board-runtime-window-import",
+        "--candidate-id",
+        _string(target.get("candidate_id")),
+        "--hypothesis-id",
+        _string(target.get("hypothesis_id")),
+        "--observed-stage",
+        _string(target.get("observed_stage")) or "paper",
+        "--strategy-family",
+        _string(target.get("strategy_family")),
+        "--strategy-name",
+        _string(target.get("strategy_name")),
+        "--account-label",
+        _string(target.get("account_label")),
+        "--window-start",
+        _string(target.get("window_start")),
+        "--window-end",
+        _string(target.get("window_end")),
+        "--source-kind",
+        _string(target.get("source_kind")),
+        "--source-manifest-ref",
+        _string(target.get("source_manifest_ref")),
+        "--dataset-snapshot-ref",
+        _string(target.get("dataset_snapshot_ref")),
+    ]
+    for artifact_ref in cast(
+        Sequence[Any], target.get("runtime_ledger_artifact_refs") or ()
+    ):
+        ref = _string(artifact_ref)
+        if ref:
+            args.extend(["--artifact-ref", ref])
+    args.append("--json")
+    return args
+
+
 def _candidate_board_runtime_window_import_plan(
     *,
     rows: Sequence[Mapping[str, Any]],
@@ -8335,6 +8450,25 @@ def _candidate_board_runtime_window_import_plan(
         strategy_family = _string(row.get("runtime_family"))
         strategy_name = _string(row.get("runtime_strategy_name"))
         candidate_spec_id = _string(row.get("candidate_spec_id"))
+        runtime_ledger_artifact_refs = _candidate_board_runtime_ledger_refs(row)
+        exact_replay_ledger_artifact_ref = _string(
+            row.get("exact_replay_ledger_artifact_ref")
+        )
+        if not exact_replay_ledger_artifact_ref:
+            exact_replay_ledger_artifact_ref = next(
+                (ref for ref in runtime_ledger_artifact_refs if "exact" in ref.lower()),
+                "",
+            )
+        runtime_ledger_artifact_ref = _string(row.get("runtime_ledger_artifact_ref"))
+        if not runtime_ledger_artifact_ref and runtime_ledger_artifact_refs:
+            runtime_ledger_artifact_ref = runtime_ledger_artifact_refs[0]
+        window_start = _string(
+            row.get("runtime_window_start") or row.get("window_start")
+        )
+        window_end = _string(row.get("runtime_window_end") or row.get("window_end"))
+        account_label = _string(row.get("account_label"))
+        if not account_label and runtime_ledger_artifact_refs:
+            account_label = "TORGHUT_REPLAY"
         missing_fields = [
             field
             for field, value in (
@@ -8342,6 +8476,9 @@ def _candidate_board_runtime_window_import_plan(
                 ("hypothesis_id", hypothesis_id),
                 ("runtime_family", strategy_family),
                 ("runtime_strategy_name", strategy_name),
+                ("window_start", window_start),
+                ("window_end", window_end),
+                ("account_label", account_label),
             )
             if not value
         ]
@@ -8360,13 +8497,20 @@ def _candidate_board_runtime_window_import_plan(
             continue
         seen_keys.add(dedupe_key)
         target = {
+            "run_id": _string(row.get("epoch_id"))
+            or "candidate-board-runtime-window-import",
             "candidate_spec_id": candidate_spec_id,
             "candidate_id": candidate_id,
             "hypothesis_id": hypothesis_id,
             "observed_stage": "paper",
             "strategy_family": strategy_family,
             "strategy_name": strategy_name,
-            "source_kind": "paper_runtime_observed",
+            "account_label": account_label,
+            "window_start": window_start,
+            "window_end": window_end,
+            "source_kind": "simulation_exact_replay_runtime_ledger"
+            if runtime_ledger_artifact_refs
+            else "paper_runtime_observed",
             "source_manifest_ref": _candidate_board_hypothesis_manifest_ref(
                 hypothesis_id
             ),
@@ -8376,6 +8520,15 @@ def _candidate_board_runtime_window_import_plan(
                 for ref in cast(Sequence[Any], row.get("replay_artifact_refs") or ())
                 if _string(ref)
             ],
+            "runtime_ledger_artifact_refs": list(runtime_ledger_artifact_refs),
+            "runtime_ledger_artifact_ref": runtime_ledger_artifact_ref,
+            "exact_replay_ledger_artifact_ref": exact_replay_ledger_artifact_ref,
+            "runtime_ledger_artifact_row_count": int(
+                _decimal(row.get("runtime_ledger_artifact_row_count"))
+            ),
+            "runtime_ledger_artifact_fill_count": int(
+                _decimal(row.get("runtime_ledger_artifact_fill_count"))
+            ),
             "candidate_blockers": [
                 _string(blocker)
                 for blocker in cast(Sequence[Any], row.get("blockers") or ())
@@ -8417,6 +8570,16 @@ def _candidate_board_runtime_window_import_plan(
                     ],
                 }
             )
+        target["import_command_args"] = _candidate_board_runtime_import_args(target)
+        target["target_metadata"] = {
+            key: value
+            for key, value in target.items()
+            if key
+            not in {
+                "import_command_args",
+                "target_metadata",
+            }
+        }
         targets.append(target)
 
     return {
@@ -8498,8 +8661,19 @@ def _candidate_board_payload(
             evidence=evidence,
             scorecard=scorecard,
         )
+        runtime_window_start, runtime_window_end = (
+            _candidate_board_runtime_window_bounds(scorecard)
+        )
+        exact_replay_ledger_artifact_ref = _string(
+            scorecard.get("exact_replay_ledger_artifact_ref")
+        )
+        runtime_ledger_artifact_ref = _string(
+            scorecard.get("runtime_ledger_artifact_ref")
+            or exact_replay_ledger_artifact_ref
+        )
         rows.append(
             {
+                "epoch_id": epoch_id,
                 "candidate_spec_id": spec.candidate_spec_id,
                 "candidate_id": evidence.candidate_id if evidence is not None else "",
                 "hypothesis_id": spec.hypothesis_id,
@@ -8638,6 +8812,26 @@ def _candidate_board_payload(
                 "evidence_lineage": evidence_lineage,
                 "replay_window_coverage": replay_window_coverage,
                 "blockers": blockers,
+                "runtime_window_start": runtime_window_start,
+                "runtime_window_end": runtime_window_end,
+                "account_label": _string(scorecard.get("account_label"))
+                or ("TORGHUT_REPLAY" if runtime_ledger_artifact_ref else ""),
+                "exact_replay_ledger_artifact_ref": exact_replay_ledger_artifact_ref,
+                "runtime_ledger_artifact_ref": runtime_ledger_artifact_ref,
+                "runtime_ledger_artifact_row_count": _candidate_board_first_int_field(
+                    scorecard,
+                    (
+                        "runtime_ledger_artifact_row_count",
+                        "exact_replay_ledger_artifact_row_count",
+                    ),
+                ),
+                "runtime_ledger_artifact_fill_count": _candidate_board_first_int_field(
+                    scorecard,
+                    (
+                        "runtime_ledger_artifact_fill_count",
+                        "exact_replay_ledger_artifact_fill_count",
+                    ),
+                ),
                 "replay_artifact_refs": list(evidence.replay_artifact_refs)
                 if evidence is not None
                 else [],

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -6197,7 +6197,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             dataset_snapshot_id="snapshot-paper-probation",
             feature_spec_hash="hash-paper-probation",
             code_commit="commit-test",
-            replay_artifact_refs=("paper-probation.json",),
+            replay_artifact_refs=(
+                "paper-probation.json",
+                "paper-probation-exact-ledger.json",
+            ),
             objective_scorecard={
                 "net_pnl_per_day": "525",
                 "target_met": True,
@@ -6205,6 +6208,17 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "trade_decision_count": 9,
                 "orders_submitted_count": 9,
                 "trade_count": 9,
+                "exact_replay_ledger_artifact_ref": "paper-probation-exact-ledger.json",
+                "runtime_ledger_artifact_row_count": 27,
+                "runtime_ledger_artifact_fill_count": 9,
+                "replay_lineage": {
+                    "windows": {
+                        "full_window": {
+                            "start_date": "2026-05-18",
+                            "end_date": "2026-05-20",
+                        }
+                    }
+                },
                 "profit_target_oracle": {
                     "blockers": ["delay_adjusted_depth_tail_coverage_passed_failed"]
                 },
@@ -6282,9 +6296,31 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(target["strategy_family"], spec.runtime_family)
         self.assertEqual(target["strategy_name"], spec.runtime_strategy_name)
         self.assertEqual(target["observed_stage"], "paper")
-        self.assertEqual(target["source_kind"], "paper_runtime_observed")
+        self.assertEqual(
+            target["source_kind"], "simulation_exact_replay_runtime_ledger"
+        )
+        self.assertEqual(target["account_label"], "TORGHUT_REPLAY")
+        self.assertEqual(target["window_start"], "2026-05-18")
+        self.assertEqual(target["window_end"], "2026-05-20")
         self.assertEqual(target["dataset_snapshot_ref"], "snapshot-paper-probation")
-        self.assertEqual(target["artifact_refs"], ["paper-probation.json"])
+        self.assertEqual(
+            target["artifact_refs"],
+            ["paper-probation.json", "paper-probation-exact-ledger.json"],
+        )
+        self.assertEqual(
+            target["runtime_ledger_artifact_refs"],
+            ["paper-probation-exact-ledger.json"],
+        )
+        self.assertEqual(
+            target["exact_replay_ledger_artifact_ref"],
+            "paper-probation-exact-ledger.json",
+        )
+        self.assertEqual(target["runtime_ledger_artifact_row_count"], 27)
+        self.assertEqual(target["runtime_ledger_artifact_fill_count"], 9)
+        self.assertIn("--artifact-ref", target["import_command_args"])
+        self.assertIn(
+            "paper-probation-exact-ledger.json", target["import_command_args"]
+        )
         self.assertEqual(target["handoff"], "runtime_window_import_only")
         self.assertEqual(
             target["promotion_gate"], "existing_runtime_governance_fail_closed"
@@ -6485,8 +6521,32 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "runtime_family": "microstructure_breakout",
             "runtime_strategy_name": "microbar-volume-continuation-long-top2-chip-v1",
             "dataset_snapshot_id": "snapshot-runtime-plan",
-            "replay_artifact_refs": ["paper-runtime-plan.json"],
+            "replay_artifact_refs": [
+                "paper-runtime-plan.json",
+                "paper-runtime-plan-exact-replay-ledger.json",
+            ],
+            "exact_replay_ledger_artifact_ref": "paper-runtime-plan-exact-replay-ledger.json",
+            "runtime_ledger_artifact_row_count": 36,
+            "runtime_ledger_artifact_fill_count": 12,
+            "runtime_window_start": "2026-05-18T13:30:00+00:00",
+            "runtime_window_end": "2026-05-20T20:00:00+00:00",
+            "account_label": "TORGHUT_REPLAY",
             "blockers": ["delay_adjusted_depth_tail_coverage_passed_failed"],
+        }
+        fallback_row = {
+            "candidate_spec_id": "spec-runtime-plan-fallback",
+            "candidate_id": "cand-runtime-plan-fallback",
+            "hypothesis_id": "H-MICRO-02",
+            "runtime_family": "microstructure_breakout",
+            "runtime_strategy_name": "microbar-volume-continuation-long-top2-chip-v1",
+            "dataset_snapshot_id": "snapshot-runtime-plan-fallback",
+            "exact_replay_ledger_artifact_refs": "fallback-exact-replay-ledger.json",
+            "runtime_ledger_artifact_refs": [
+                "fallback-runtime-ledger.json",
+                "",
+            ],
+            "runtime_window_start": "2026-05-21T13:30:00+00:00",
+            "runtime_window_end": "2026-05-21T20:00:00+00:00",
         }
 
         plan = runner._candidate_board_runtime_window_import_plan(
@@ -6496,6 +6556,11 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "target_met": True,
                 "sleeve_candidate_spec_ids": ["spec-runtime-plan"],
             },
+        )
+        fallback_plan = runner._candidate_board_runtime_window_import_plan(
+            rows=(),
+            paper_probation_candidate=fallback_row,
+            promotion_subject=None,
         )
         incomplete_plan = runner._candidate_board_runtime_window_import_plan(
             rows=(),
@@ -6513,17 +6578,66 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             runner._candidate_board_hypothesis_manifest_ref(None),
             "",
         )
+        self.assertEqual(
+            runner._candidate_board_runtime_window_bounds(
+                {
+                    "runtime_window_start": "2026-05-01",
+                    "runtime_window_end": "2026-05-02",
+                }
+            ),
+            ("2026-05-01", "2026-05-02"),
+        )
         self.assertEqual(plan["target_count"], 1)
         self.assertEqual(
             plan["targets"][0]["source_manifest_ref"],
             "config/trading/hypotheses/h-micro-01.json",
         )
         self.assertEqual(plan["targets"][0]["candidate_blockers"], row["blockers"])
+        self.assertEqual(
+            plan["targets"][0]["runtime_ledger_artifact_refs"],
+            ["paper-runtime-plan-exact-replay-ledger.json"],
+        )
+        self.assertEqual(
+            plan["targets"][0]["window_start"], "2026-05-18T13:30:00+00:00"
+        )
+        self.assertEqual(plan["targets"][0]["window_end"], "2026-05-20T20:00:00+00:00")
+        self.assertEqual(plan["targets"][0]["account_label"], "TORGHUT_REPLAY")
+        self.assertIn(
+            "paper-runtime-plan-exact-replay-ledger.json",
+            plan["targets"][0]["import_command_args"],
+        )
+        self.assertEqual(fallback_plan["status"], "ready")
+        self.assertEqual(fallback_plan["target_count"], 1)
+        self.assertEqual(
+            fallback_plan["targets"][0]["runtime_ledger_artifact_refs"],
+            [
+                "fallback-exact-replay-ledger.json",
+                "fallback-runtime-ledger.json",
+            ],
+        )
+        self.assertEqual(
+            fallback_plan["targets"][0]["exact_replay_ledger_artifact_ref"],
+            "fallback-exact-replay-ledger.json",
+        )
+        self.assertEqual(
+            fallback_plan["targets"][0]["runtime_ledger_artifact_ref"],
+            "fallback-exact-replay-ledger.json",
+        )
+        self.assertEqual(
+            fallback_plan["targets"][0]["account_label"],
+            "TORGHUT_REPLAY",
+        )
         self.assertEqual(incomplete_plan["status"], "blocked")
         self.assertEqual(incomplete_plan["target_count"], 0)
         self.assertEqual(
             incomplete_plan["blockers"][0]["missing_fields"],
-            ["candidate_id", "hypothesis_id"],
+            [
+                "candidate_id",
+                "hypothesis_id",
+                "window_start",
+                "window_end",
+                "account_label",
+            ],
         )
 
     def test_candidate_universe_symbols_default_to_chip_coverage_when_empty(


### PR DESCRIPTION
## Summary

- Add runtime-window bounds, account label, and exact/runtime ledger refs to Torghut candidate-board rows.
- Emit CLI-ready `scripts/import_hypothesis_runtime_windows.py` argument lists for runtime-ledger artifact imports.
- Fail candidate-board runtime import plans closed when candidate, hypothesis, window, strategy, or account fields are missing.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k "runtime_window_plan or paper_probation_without_promotion"`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k "candidate_board"`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
