### PR TITLE
fix(torghut): preserve frontier ledger evidence

### DIFF
--- a/services/torghut/config/trading/families/microbar_cross_sectional_pairs_v1.yaml
+++ b/services/torghut/config/trading/families/microbar_cross_sectional_pairs_v1.yaml
@@ -47,6 +47,8 @@ default_hard_vetoes:
   required_max_best_day_share: '0.35'
   required_max_worst_day_loss: '250'
   required_max_drawdown: '700'
+  required_max_gross_exposure_pct_equity: '1.0'
+  required_min_cash: '0'
   required_min_regime_slice_pass_rate: '0'
 default_selection_objectives:
   target_net_pnl_per_day: '300'

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -629,9 +629,10 @@ def _objective_veto_policy(
         and trading_day_count > 0
         and consistency_policy.min_active_days > 0
     ):
-        required_min_active_day_ratio = Decimal(
-            consistency_policy.min_active_days
-        ) / Decimal(trading_day_count)
+        required_min_active_day_ratio = min(
+            Decimal("1"),
+            Decimal(consistency_policy.min_active_days) / Decimal(trading_day_count),
+        )
     return ObjectiveVetoPolicy(
         required_min_active_day_ratio=max(
             required_min_active_day_ratio,
@@ -1470,6 +1471,15 @@ def _payload_digest(payload: Mapping[str, Any]) -> str:
     ).hexdigest()
 
 
+def _artifact_run_dir_name(json_output: Path) -> str:
+    raw_name = json_output.stem.strip()
+    safe_name = "".join(
+        character if character.isalnum() or character in "._-" else "-"
+        for character in raw_name
+    ).strip(".-_")
+    return safe_name or "frontier-run"
+
+
 def _order_type_ablation_artifact_dir(
     *,
     args: argparse.Namespace,
@@ -1477,7 +1487,11 @@ def _order_type_ablation_artifact_dir(
 ) -> Path:
     json_output = getattr(args, "json_output", None)
     if isinstance(json_output, Path):
-        return json_output.parent / "frontier-artifacts"
+        return (
+            json_output.parent
+            / "frontier-artifacts"
+            / _artifact_run_dir_name(json_output)
+        )
     return root / "frontier-artifacts"
 
 
@@ -2095,14 +2109,21 @@ def _consistency_penalty(
             Decimal(max(0, summary.trading_day_count - len(summary.daily_net)))
             * policy.min_daily_net_pnl
         )
-    if summary.active_days < policy.min_active_days:
-        penalties += Decimal(policy.min_active_days - summary.active_days) * Decimal(
+    effective_min_active_days = min(policy.min_active_days, summary.trading_day_count)
+    if summary.active_days < effective_min_active_days:
+        penalties += Decimal(effective_min_active_days - summary.active_days) * Decimal(
             "250"
         )
     if active_ratio < policy.min_active_ratio:
         penalties += (policy.min_active_ratio - active_ratio) * Decimal("2000")
-    if positive_days < policy.min_positive_days:
-        penalties += Decimal(policy.min_positive_days - positive_days) * Decimal("350")
+    effective_min_positive_days = min(
+        policy.min_positive_days,
+        summary.trading_day_count,
+    )
+    if positive_days < effective_min_positive_days:
+        penalties += Decimal(effective_min_positive_days - positive_days) * Decimal(
+            "350"
+        )
     if (
         policy.require_every_day_active
         and summary.active_days < summary.trading_day_count

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -651,6 +651,91 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertGreaterEqual(penalties, Decimal("600"))
         self.assertEqual(summary["negative_days"], 2)
 
+    def test_consistency_penalty_caps_impossible_count_activity_gates(self) -> None:
+        penalties, summary = frontier._consistency_penalty(
+            full_window_payload=self._payload(
+                start_date="2026-04-01",
+                end_date="2026-04-03",
+                daily_net={
+                    "2026-04-01": "20",
+                    "2026-04-02": "30",
+                    "2026-04-03": "40",
+                },
+                decision_count=3,
+                filled_count=3,
+                wins=3,
+                losses=0,
+            ),
+            policy=frontier.FullWindowConsistencyPolicy(
+                target_net_per_day=Decimal("0"),
+                min_daily_net_pnl=Decimal("-1000"),
+                min_active_days=9,
+                min_active_ratio=Decimal("0"),
+                min_positive_days=9,
+                max_worst_day_loss=Decimal("1000"),
+                max_negative_days=3,
+                max_drawdown=Decimal("1000"),
+                max_best_day_share_of_total_pnl=Decimal("1"),
+                min_avg_filled_notional_per_day=Decimal("0"),
+                min_avg_filled_notional_per_active_day=Decimal("0"),
+                require_every_day_active=False,
+            ),
+        )
+
+        self.assertEqual(summary["trading_day_count"], 3)
+        self.assertEqual(summary["active_days"], 3)
+        self.assertEqual(penalties, Decimal("0"))
+
+    def test_objective_veto_policy_caps_min_active_day_ratio_at_one(self) -> None:
+        policy = frontier._objective_veto_policy(
+            consistency_policy=frontier.FullWindowConsistencyPolicy(
+                target_net_per_day=Decimal("0"),
+                min_daily_net_pnl=Decimal("-1000"),
+                min_active_days=9,
+                min_active_ratio=Decimal("0"),
+                min_positive_days=0,
+                max_worst_day_loss=Decimal("1000"),
+                max_negative_days=3,
+                max_drawdown=Decimal("1000"),
+                max_best_day_share_of_total_pnl=Decimal("1"),
+                min_avg_filled_notional_per_day=Decimal("0"),
+                min_avg_filled_notional_per_active_day=Decimal("0"),
+                require_every_day_active=False,
+            ),
+            template_defaults={},
+            trading_day_count=5,
+        )
+
+        self.assertEqual(policy.required_min_active_day_ratio, Decimal("1"))
+
+    def test_microbar_template_enforces_cash_and_gross_exposure_defaults(
+        self,
+    ) -> None:
+        template = frontier.load_family_template("microbar_cross_sectional_pairs_v1")
+        policy = frontier._objective_veto_policy(
+            consistency_policy=frontier.FullWindowConsistencyPolicy(
+                target_net_per_day=Decimal("0"),
+                min_daily_net_pnl=Decimal("-1000"),
+                min_active_days=0,
+                min_active_ratio=Decimal("0"),
+                min_positive_days=0,
+                max_worst_day_loss=Decimal("1000"),
+                max_negative_days=3,
+                max_drawdown=Decimal("1000"),
+                max_best_day_share_of_total_pnl=Decimal("1"),
+                min_avg_filled_notional_per_day=Decimal("0"),
+                min_avg_filled_notional_per_active_day=Decimal("0"),
+                require_every_day_active=False,
+                max_gross_exposure_pct_equity=Decimal("999999999"),
+                min_cash=Decimal("-999999999"),
+            ),
+            template_defaults=template.default_hard_vetoes,
+            trading_day_count=5,
+        )
+
+        self.assertEqual(policy.required_max_gross_exposure_pct_equity, Decimal("1.0"))
+        self.assertEqual(policy.required_min_cash, Decimal("0"))
+
     def test_consistency_penalty_preserves_order_type_execution_metrics(self) -> None:
         payload = self._payload(
             start_date="2026-04-01",
@@ -951,6 +1036,10 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             self.assertNotIn("execution_shortfall_evidence_present", scorecard)
             exact_ledger_ref = Path(scorecard["exact_replay_ledger_artifact_ref"])
             self.assertTrue(exact_ledger_ref.exists())
+            self.assertEqual(
+                exact_ledger_ref.parent, root / "frontier-artifacts" / "frontier"
+            )
+            self.assertEqual(artifact_ref.parent, exact_ledger_ref.parent)
             self.assertEqual(
                 payload["top"][0]["runtime_ledger_artifact_ref"],
                 str(exact_ledger_ref),


### PR DESCRIPTION
## Summary

- Stores frontier exact replay ledger and order-type ablation artifacts under a run-scoped directory derived from the JSON output name.
- Caps impossible count-based active/positive-day gates to the actual replay trading-day count while preserving ratio and every-day activity gates.
- Adds microbar family hard veto defaults for max gross exposure and minimum cash so negative-cash replay profit is blocked from promotion.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
