### PR TITLE
fix(torghut): branch economic frontier near misses

### DIFF
--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -103,6 +103,29 @@ _LOSS_REPAIR_STRATEGY_EXPOSURE_KEYS = (
     "max_notional_per_trade",
     "max_position_pct_equity",
 )
+_CONSISTENCY_REPAIR_TRIGGER_REASONS = frozenset(
+    {
+        "active_day_ratio_below_min",
+        "avg_daily_notional_below_min",
+        "best_day_share_above_max",
+    }
+)
+_CONSISTENCY_REPAIR_UNSAFE_REASONS = frozenset(
+    {
+        "gross_exposure_pct_equity_above_max",
+        "min_cash_below_min",
+        "negative_cash_observation_count_above_max",
+    }
+)
+_CONSISTENCY_REPAIR_ENTRY_KEYS = (
+    "max_entries_per_session",
+    "max_entries_per_day",
+)
+_CONSISTENCY_REPAIR_BREADTH_KEYS = ("top_n",)
+_CONSISTENCY_REPAIR_COOLDOWN_KEYS = (
+    "entry_cooldown_seconds",
+    "signal_cooldown_seconds",
+)
 _WorklistItem: TypeAlias = tuple[
     dict[str, Any],
     dict[str, Any],
@@ -542,6 +565,21 @@ def _parse_args() -> argparse.Namespace:
         type=int,
         default=1,
         help="How many loss/drawdown repair children to branch on per failed candidate.",
+    )
+    parser.add_argument(
+        "--consistency-repair-iterations",
+        type=int,
+        default=0,
+        help=(
+            "Generate bounded child candidates that increase activity or breadth "
+            "after positive capital-safe candidates fail consistency gates."
+        ),
+    )
+    parser.add_argument(
+        "--consistency-repair-candidates",
+        type=int,
+        default=2,
+        help="How many consistency repair children to branch on per positive near-miss.",
     )
     parser.add_argument(
         "--train-screening",
@@ -2860,6 +2898,150 @@ def _generate_loss_repair_children(
     return children
 
 
+def _positive_capital_safe_summary(full_window_summary: Mapping[str, Any]) -> bool:
+    net_per_day = _decimal_or_none(
+        full_window_summary.get("net_per_day")
+        or full_window_summary.get("net_pnl_per_day")
+    )
+    max_gross = _decimal_or_none(
+        full_window_summary.get("max_gross_exposure_pct_equity")
+    )
+    min_cash = _decimal_or_none(full_window_summary.get("min_cash"))
+    if net_per_day is None or max_gross is None or min_cash is None:
+        return False
+    if net_per_day <= 0 or max_gross > 1 or min_cash < 0:
+        return False
+    try:
+        negative_cash_count = int(
+            full_window_summary.get("negative_cash_observation_count") or 0
+        )
+    except (TypeError, ValueError):
+        negative_cash_count = 1
+    return negative_cash_count <= 0
+
+
+def _consistency_repair_trigger_reason(
+    *,
+    hard_vetoes: Sequence[Any],
+    full_window_summary: Mapping[str, Any],
+) -> str | None:
+    reasons = [str(raw_reason) for raw_reason in hard_vetoes]
+    if any(reason in _CONSISTENCY_REPAIR_UNSAFE_REASONS for reason in reasons):
+        return None
+    if not _positive_capital_safe_summary(full_window_summary):
+        return None
+    for reason in reasons:
+        if reason in _CONSISTENCY_REPAIR_TRIGGER_REASONS:
+            return reason
+    return None
+
+
+def _increment_integer_candidate_param(
+    *,
+    params: dict[str, Any],
+    strategy_params: Mapping[str, Any],
+    keys: Sequence[str],
+) -> bool:
+    for key in keys:
+        if key not in params and key not in strategy_params:
+            continue
+        current = _decimal_or_none(params.get(key, strategy_params.get(key)))
+        if current is None or current < 1:
+            continue
+        params[key] = _decimal_payload(current.to_integral_value() + 1)
+        return True
+    return False
+
+
+def _halve_positive_integer_candidate_param(
+    *,
+    params: dict[str, Any],
+    strategy_params: Mapping[str, Any],
+    keys: Sequence[str],
+) -> bool:
+    for key in keys:
+        if key not in params and key not in strategy_params:
+            continue
+        current = _decimal_or_none(params.get(key, strategy_params.get(key)))
+        if current is None or current <= 1:
+            continue
+        repaired = max(Decimal("1"), (current / Decimal("2")).quantize(Decimal("1")))
+        params[key] = _decimal_payload(repaired)
+        return True
+    return False
+
+
+def _generate_consistency_repair_children(
+    *,
+    params_candidate: Mapping[str, Any],
+    strategy_overrides: Mapping[str, Any],
+    candidate_configmap: Mapping[str, Any],
+    strategy_name: str,
+    hard_vetoes: Sequence[Any],
+    full_window_summary: Mapping[str, Any],
+    branch_count: int,
+) -> list[tuple[str, dict[str, Any], dict[str, Any]]]:
+    trigger_reason = _consistency_repair_trigger_reason(
+        hard_vetoes=hard_vetoes,
+        full_window_summary=full_window_summary,
+    )
+    if trigger_reason is None:
+        return []
+
+    _, strategy_params = _strategy_item_from_configmap(
+        configmap_payload=candidate_configmap,
+        strategy_name=strategy_name,
+    )
+    parent_key = _candidate_search_key(
+        params_candidate=params_candidate,
+        strategy_overrides=strategy_overrides,
+    )
+    children: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+    seen: set[str] = {parent_key}
+
+    def add_child(label: str, mutator: Callable[[dict[str, Any]], bool]) -> None:
+        if len(children) >= max(1, branch_count):
+            return
+        next_params = dict(params_candidate)
+        next_overrides = dict(strategy_overrides)
+        if not mutator(next_params):
+            return
+        child_key = _candidate_search_key(
+            params_candidate=next_params,
+            strategy_overrides=next_overrides,
+        )
+        if child_key in seen:
+            return
+        seen.add(child_key)
+        children.append((f"{label}:{trigger_reason}", next_params, next_overrides))
+
+    add_child(
+        "consistency_entries",
+        lambda next_params: _increment_integer_candidate_param(
+            params=next_params,
+            strategy_params=strategy_params,
+            keys=_CONSISTENCY_REPAIR_ENTRY_KEYS,
+        ),
+    )
+    add_child(
+        "consistency_breadth",
+        lambda next_params: _increment_integer_candidate_param(
+            params=next_params,
+            strategy_params=strategy_params,
+            keys=_CONSISTENCY_REPAIR_BREADTH_KEYS,
+        ),
+    )
+    add_child(
+        "consistency_cooldown",
+        lambda next_params: _halve_positive_integer_candidate_param(
+            params=next_params,
+            strategy_params=strategy_params,
+            keys=_CONSISTENCY_REPAIR_COOLDOWN_KEYS,
+        ),
+    )
+    return children
+
+
 def _rank_scored_candidates(scored: list[dict[str, Any]]) -> list[dict[str, Any]]:
     if not scored:
         return []
@@ -3497,7 +3679,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     override_candidate,
                     prune_iteration,
                     pruned_symbol,
-                    loss_repair_reason,
+                    repair_reason,
                     parent_candidate_id,
                 ) = worklist.popleft()
                 candidate_key = _candidate_search_key(
@@ -3837,8 +4019,11 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                 }
                 if pruned_symbol is not None:
                     candidate_payload["pruned_symbol"] = pruned_symbol
-                if loss_repair_reason is not None:
-                    candidate_payload["loss_repair_reason"] = loss_repair_reason
+                if repair_reason is not None:
+                    if repair_reason.startswith("consistency_"):
+                        candidate_payload["consistency_repair_reason"] = repair_reason
+                    else:
+                        candidate_payload["loss_repair_reason"] = repair_reason
                 if parent_candidate_id is not None:
                     candidate_payload["parent_candidate_id"] = parent_candidate_id
                 symbol_contributions = _symbol_contributions_from_replay_payload(
@@ -4304,6 +4489,34 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                                 prune_iteration + 1,
                                 None,
                                 repair_reason,
+                                str(candidate_payload["candidate_id"]),
+                            )
+                        )
+                if prune_iteration < max(
+                    0, int(getattr(args, "consistency_repair_iterations", 0))
+                ):
+                    for (
+                        consistency_reason,
+                        next_params,
+                        next_override,
+                    ) in _generate_consistency_repair_children(
+                        params_candidate=params_candidate,
+                        strategy_overrides=override_candidate,
+                        candidate_configmap=candidate_configmap,
+                        strategy_name=strategy_name,
+                        hard_vetoes=hard_vetoes,
+                        full_window_summary=full_window_summary,
+                        branch_count=max(
+                            1, int(getattr(args, "consistency_repair_candidates", 1))
+                        ),
+                    ):
+                        worklist.append(
+                            (
+                                next_params,
+                                next_override,
+                                prune_iteration + 1,
+                                None,
+                                consistency_reason,
                                 str(candidate_payload["candidate_id"]),
                             )
                         )

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -2973,6 +2973,153 @@ def _rank_scored_candidates(scored: list[dict[str, Any]]) -> list[dict[str, Any]
     return ranked_items
 
 
+def _safe_decimal(value: Any) -> Decimal:
+    if value in (None, ""):
+        return Decimal("0")
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return Decimal("0")
+
+
+def _candidate_metric_value(
+    item: Mapping[str, Any],
+    *,
+    scorecard_key: str,
+    full_window_key: str,
+    default: str = "0",
+) -> Any:
+    scorecard = _mapping(item.get("objective_scorecard"))
+    raw_value = scorecard.get(scorecard_key)
+    if raw_value not in (None, ""):
+        return raw_value
+    full_window = _mapping(item.get("full_window"))
+    raw_value = full_window.get(full_window_key)
+    if raw_value not in (None, ""):
+        return raw_value
+    return default
+
+
+def _build_economic_shortlist(
+    ranked_items: Sequence[Mapping[str, Any]], *, top_n: int
+) -> list[dict[str, Any]]:
+    visible_items = [
+        item
+        for item in ranked_items
+        if _safe_decimal(
+            _candidate_metric_value(
+                item,
+                scorecard_key="net_pnl_per_day",
+                full_window_key="net_per_day",
+            )
+        )
+        != Decimal("0")
+        or item.get("runtime_ledger_artifact_ref")
+        or item.get("replay_artifact_refs")
+    ]
+    visible_items.sort(
+        key=lambda item: (
+            -_safe_decimal(
+                _candidate_metric_value(
+                    item,
+                    scorecard_key="net_pnl_per_day",
+                    full_window_key="net_per_day",
+                )
+            ),
+            -_safe_decimal(
+                _candidate_metric_value(
+                    item,
+                    scorecard_key="net_pnl",
+                    full_window_key="net_pnl",
+                )
+            ),
+            str(item.get("candidate_id") or ""),
+        )
+    )
+    shortlist: list[dict[str, Any]] = []
+    for item in visible_items[: max(1, int(top_n))]:
+        ranking = _mapping(item.get("ranking"))
+        hard_vetoes = [
+            str(reason) for reason in cast(Sequence[Any], item.get("hard_vetoes") or ())
+        ]
+        shortlist.append(
+            {
+                "candidate_id": str(item.get("candidate_id") or ""),
+                "strategy_name": str(item.get("strategy_name") or ""),
+                "family": str(item.get("family") or ""),
+                "net_pnl_per_day": str(
+                    _candidate_metric_value(
+                        item,
+                        scorecard_key="net_pnl_per_day",
+                        full_window_key="net_per_day",
+                    )
+                ),
+                "net_pnl": str(
+                    _candidate_metric_value(
+                        item,
+                        scorecard_key="net_pnl",
+                        full_window_key="net_pnl",
+                    )
+                ),
+                "active_day_ratio": str(
+                    _candidate_metric_value(
+                        item,
+                        scorecard_key="active_day_ratio",
+                        full_window_key="active_ratio",
+                    )
+                ),
+                "positive_day_ratio": str(
+                    _candidate_metric_value(
+                        item,
+                        scorecard_key="positive_day_ratio",
+                        full_window_key="positive_day_ratio",
+                    )
+                ),
+                "max_drawdown": str(
+                    _candidate_metric_value(
+                        item,
+                        scorecard_key="max_drawdown",
+                        full_window_key="max_drawdown",
+                    )
+                ),
+                "worst_day_loss": str(
+                    _candidate_metric_value(
+                        item,
+                        scorecard_key="worst_day_loss",
+                        full_window_key="worst_day_loss",
+                    )
+                ),
+                "max_gross_exposure_pct_equity": str(
+                    _candidate_metric_value(
+                        item,
+                        scorecard_key="max_gross_exposure_pct_equity",
+                        full_window_key="max_gross_exposure_pct_equity",
+                    )
+                ),
+                "min_cash": str(
+                    _candidate_metric_value(
+                        item,
+                        scorecard_key="min_cash",
+                        full_window_key="min_cash",
+                    )
+                ),
+                "runtime_ledger_artifact_ref": str(
+                    item.get("runtime_ledger_artifact_ref") or ""
+                ),
+                "replay_artifact_refs": [
+                    str(ref)
+                    for ref in cast(
+                        Sequence[Any], item.get("replay_artifact_refs") or ()
+                    )
+                ],
+                "hard_vetoes": hard_vetoes,
+                "vetoed": bool(ranking.get("vetoed") or hard_vetoes),
+                "pareto_tier": ranking.get("pareto_tier"),
+            }
+        )
+    return shortlist
+
+
 def _build_frontier_payload(
     *,
     scored: list[dict[str, Any]],
@@ -3038,6 +3185,14 @@ def _build_frontier_payload(
             "pending_candidates": pending_candidates,
         },
         "candidate_count": len(scored),
+        "economic_shortlist": {
+            "schema_version": "torghut.frontier-economic-shortlist.v1",
+            "ranking_basis": "full_window_net_pnl_per_day_desc",
+            "items": _build_economic_shortlist(
+                ranked_items,
+                top_n=max(1, int(top_n)),
+            ),
+        },
         "top": ranked_items[: max(1, int(top_n))],
     }
 

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -1723,6 +1723,37 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(shortlist[0]["hard_vetoes"], ["min_cash_below_min"])
         self.assertTrue(shortlist[0]["vetoed"])
 
+    def test_economic_shortlist_metric_helpers_handle_missing_and_invalid_values(
+        self,
+    ) -> None:
+        self.assertEqual(frontier._safe_decimal(None), Decimal("0"))
+        self.assertEqual(frontier._safe_decimal("not-a-decimal"), Decimal("0"))
+        self.assertEqual(
+            frontier._candidate_metric_value(
+                {},
+                scorecard_key="net_pnl_per_day",
+                full_window_key="net_per_day",
+                default="7",
+            ),
+            "7",
+        )
+
+        shortlist = frontier._build_economic_shortlist(
+            [
+                {
+                    "candidate_id": "artifact-only",
+                    "objective_scorecard": {},
+                    "full_window": {},
+                    "ranking": {},
+                    "replay_artifact_refs": ["/tmp/artifact.json"],
+                }
+            ],
+            top_n=1,
+        )
+
+        self.assertEqual(shortlist[0]["candidate_id"], "artifact-only")
+        self.assertEqual(shortlist[0]["net_pnl_per_day"], "0")
+
     def test_generate_symbol_prune_children_removes_worst_symbols_from_universe(
         self,
     ) -> None:
@@ -1810,6 +1841,190 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         )
 
         self.assertEqual(children, [])
+
+    def test_generate_consistency_repair_children_increases_activity_and_breadth(
+        self,
+    ) -> None:
+        configmap_payload = {
+            "data": {
+                "strategies.yaml": yaml.safe_dump(
+                    {
+                        "strategies": [
+                            {
+                                "name": "microbar-cross-sectional-pairs-v1",
+                                "params": {
+                                    "max_entries_per_session": "1",
+                                    "top_n": "2",
+                                    "entry_cooldown_seconds": "300",
+                                },
+                            }
+                        ],
+                    },
+                    sort_keys=False,
+                )
+            }
+        }
+
+        children = frontier._generate_consistency_repair_children(
+            params_candidate={},
+            strategy_overrides={},
+            candidate_configmap=configmap_payload,
+            strategy_name="microbar-cross-sectional-pairs-v1",
+            hard_vetoes=[
+                "active_day_ratio_below_min",
+                "avg_daily_notional_below_min",
+                "best_day_share_above_max",
+            ],
+            full_window_summary={
+                "net_per_day": "97",
+                "max_gross_exposure_pct_equity": "0.97",
+                "min_cash": "935",
+                "negative_cash_observation_count": "0",
+            },
+            branch_count=3,
+        )
+
+        self.assertEqual(
+            children[0][0], "consistency_entries:active_day_ratio_below_min"
+        )
+        self.assertEqual(children[0][1], {"max_entries_per_session": "2"})
+        self.assertEqual(children[0][2], {})
+        self.assertEqual(
+            children[1][0], "consistency_breadth:active_day_ratio_below_min"
+        )
+        self.assertEqual(children[1][1], {"top_n": "3"})
+        self.assertEqual(
+            children[2][0], "consistency_cooldown:active_day_ratio_below_min"
+        )
+        self.assertEqual(children[2][1], {"entry_cooldown_seconds": "150"})
+
+    def test_generate_consistency_repair_children_rejects_unsafe_parent(
+        self,
+    ) -> None:
+        children = frontier._generate_consistency_repair_children(
+            params_candidate={"max_entries_per_session": "1"},
+            strategy_overrides={},
+            candidate_configmap={},
+            strategy_name="microbar-cross-sectional-pairs-v1",
+            hard_vetoes=["active_day_ratio_below_min", "min_cash_below_min"],
+            full_window_summary={
+                "net_per_day": "97",
+                "max_gross_exposure_pct_equity": "1.2",
+                "min_cash": "-1",
+            },
+            branch_count=3,
+        )
+
+        self.assertEqual(children, [])
+
+    def test_consistency_repair_helpers_reject_non_actionable_inputs(self) -> None:
+        self.assertFalse(frontier._positive_capital_safe_summary({}))
+        self.assertFalse(
+            frontier._positive_capital_safe_summary(
+                {
+                    "net_per_day": "-1",
+                    "max_gross_exposure_pct_equity": "0.9",
+                    "min_cash": "10",
+                }
+            )
+        )
+        self.assertFalse(
+            frontier._positive_capital_safe_summary(
+                {
+                    "net_per_day": "1",
+                    "max_gross_exposure_pct_equity": "0.9",
+                    "min_cash": "10",
+                    "negative_cash_observation_count": "bad",
+                }
+            )
+        )
+        self.assertIsNone(
+            frontier._consistency_repair_trigger_reason(
+                hard_vetoes=["avg_daily_notional_below_min"],
+                full_window_summary={},
+            )
+        )
+        self.assertIsNone(
+            frontier._consistency_repair_trigger_reason(
+                hard_vetoes=["profit_factor_below_min"],
+                full_window_summary={
+                    "net_per_day": "1",
+                    "max_gross_exposure_pct_equity": "0.9",
+                    "min_cash": "10",
+                },
+            )
+        )
+        self.assertFalse(
+            frontier._increment_integer_candidate_param(
+                params={},
+                strategy_params={"ignored": "1", "max_entries_per_session": "bad"},
+                keys=("missing", "max_entries_per_session"),
+            )
+        )
+        self.assertFalse(
+            frontier._halve_positive_integer_candidate_param(
+                params={},
+                strategy_params={"ignored": "1", "entry_cooldown_seconds": "1"},
+                keys=("missing", "entry_cooldown_seconds"),
+            )
+        )
+
+        self.assertEqual(
+            frontier._generate_consistency_repair_children(
+                params_candidate={},
+                strategy_overrides={},
+                candidate_configmap={},
+                strategy_name="microbar-cross-sectional-pairs-v1",
+                hard_vetoes=["active_day_ratio_below_min"],
+                full_window_summary={
+                    "net_per_day": "1",
+                    "max_gross_exposure_pct_equity": "0.9",
+                    "min_cash": "10",
+                },
+                branch_count=3,
+            ),
+            [],
+        )
+
+    def test_consistency_repair_children_are_branch_count_bounded(self) -> None:
+        configmap_payload = {
+            "data": {
+                "strategies.yaml": yaml.safe_dump(
+                    {
+                        "strategies": [
+                            {
+                                "name": "microbar-cross-sectional-pairs-v1",
+                                "params": {
+                                    "max_entries_per_session": "1",
+                                    "top_n": "2",
+                                    "entry_cooldown_seconds": "300",
+                                },
+                            }
+                        ],
+                    },
+                    sort_keys=False,
+                )
+            }
+        }
+
+        children = frontier._generate_consistency_repair_children(
+            params_candidate={},
+            strategy_overrides={},
+            candidate_configmap=configmap_payload,
+            strategy_name="microbar-cross-sectional-pairs-v1",
+            hard_vetoes=["active_day_ratio_below_min"],
+            full_window_summary={
+                "net_per_day": "97",
+                "max_gross_exposure_pct_equity": "0.97",
+                "min_cash": "935",
+            },
+            branch_count=1,
+        )
+
+        self.assertEqual(len(children), 1)
+        self.assertEqual(
+            children[0][0], "consistency_entries:active_day_ratio_below_min"
+        )
 
     def test_loss_repair_configmap_lookup_handles_invalid_shapes(self) -> None:
         invalid_payloads = [

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -1671,6 +1671,58 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             ],
         )
 
+    def test_economic_shortlist_preserves_high_pnl_vetoed_candidate(self) -> None:
+        items = [
+            {
+                "candidate_id": "clean-low",
+                "strategy_name": "strategy",
+                "family": "family",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "25",
+                    "net_pnl": "125",
+                    "active_day_ratio": "1",
+                    "positive_day_ratio": "1",
+                    "max_drawdown": "0",
+                    "worst_day_loss": "0",
+                    "max_gross_exposure_pct_equity": "0.5",
+                    "min_cash": "100",
+                },
+                "full_window": {"net_per_day": "25", "net_pnl": "125"},
+                "hard_vetoes": [],
+                "ranking": {"vetoed": False, "pareto_tier": 0},
+            },
+            {
+                "candidate_id": "vetoed-high",
+                "strategy_name": "strategy",
+                "family": "family",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "150",
+                    "net_pnl": "750",
+                    "active_day_ratio": "1",
+                    "positive_day_ratio": "0.8",
+                    "max_drawdown": "6",
+                    "worst_day_loss": "6",
+                    "max_gross_exposure_pct_equity": "1.01",
+                    "min_cash": "-15",
+                },
+                "full_window": {"net_per_day": "150", "net_pnl": "750"},
+                "runtime_ledger_artifact_ref": "/tmp/high-ledger.json",
+                "replay_artifact_refs": ["/tmp/high-ledger.json"],
+                "hard_vetoes": ["min_cash_below_min"],
+                "ranking": {"vetoed": True, "pareto_tier": 999},
+            },
+        ]
+
+        shortlist = frontier._build_economic_shortlist(items, top_n=1)
+
+        self.assertEqual(shortlist[0]["candidate_id"], "vetoed-high")
+        self.assertEqual(shortlist[0]["net_pnl_per_day"], "150")
+        self.assertEqual(
+            shortlist[0]["runtime_ledger_artifact_ref"], "/tmp/high-ledger.json"
+        )
+        self.assertEqual(shortlist[0]["hard_vetoes"], ["min_cash_below_min"])
+        self.assertTrue(shortlist[0]["vetoed"])
+
     def test_generate_symbol_prune_children_removes_worst_symbols_from_universe(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Added an `economic_shortlist` section to consistent frontier output so high-PnL vetoed candidates stay visible for operator triage.
- Added bounded consistency-repair branches for positive, capital-safe near misses that fail active-day, notional, or best-day concentration gates.
- Kept repair generation fail-closed for gross-exposure, cash, and negative-cash vetoes; the new branch does not raise notional or exposure caps.
- Added regression tests for shortlist fallbacks, invalid metric handling, consistency-repair children, branch limits, and unsafe-parent rejection.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen ruff format --check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen ruff check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -q`
- `uv run --frozen coverage erase`
- `uv run --frozen coverage run -m pytest tests/test_search_consistent_profitability_frontier.py -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `git diff --check`
- Manual evidence import: imported exact replay ledger for candidate `494798c72372ad843c0bd045` as run `rt-ledger-vwap-cushion-20260512-20260521-494798c7`; promotion remained blocked by sample count and post-cost expectancy.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
