### PR TITLE
chore(torghut): promote image 6858939c

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-501-g1d9971922
+              value: v0.571.1-503-g6858939c6
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 1d99719220a3a553645c4558d851d9d43032b8ac
+              value: 6858939c6bf7dc86cf817df0fb1de8fa5a36454b
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-501-g1d9971922
+              value: v0.571.1-503-g6858939c6
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 1d99719220a3a553645c4558d851d9d43032b8ac
+              value: 6858939c6bf7dc86cf817df0fb1de8fa5a36454b
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -75,7 +75,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+                  value: sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-22T04:31:30Z"
+        client.knative.dev/updateTimestamp: "2026-05-22T05:24:04Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
           ports:
             - name: http1
               containerPort: 8181
@@ -499,11 +499,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-501-g1d9971922
+              value: v0.571.1-503-g6858939c6
             - name: TORGHUT_COMMIT
-              value: 1d99719220a3a553645c4558d851d9d43032b8ac
+              value: 6858939c6bf7dc86cf817df0fb1de8fa5a36454b
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+              value: sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-22T04:31:30Z"
+        client.knative.dev/updateTimestamp: "2026-05-22T05:24:04Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
           ports:
             - name: http1
               containerPort: 8181
@@ -320,11 +320,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-501-g1d9971922
+              value: v0.571.1-503-g6858939c6
             - name: TORGHUT_COMMIT
-              value: 1d99719220a3a553645c4558d851d9d43032b8ac
+              value: 6858939c6bf7dc86cf817df0fb1de8fa5a36454b
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+              value: sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -132,7 +132,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8ddf64ad631d9af9a1280f33707dc9350ce620fa61477103ea4b2b2c82110bd6
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `6858939c6bf7dc86cf817df0fb1de8fa5a36454b`
- Image tag: `6858939c`
- Image digest: `sha256:98c0dc9a4dfbde9e8123135f679f58785e6980da1feee4706d7944bbd785521e`