### PR TITLE
fix(torghut): preserve frontier replay config for sleeves

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -185,6 +185,28 @@ def _int_mapping(value: Any) -> dict[str, int]:
     return counts
 
 
+def _frontier_replay_config(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    return _mapping(candidate.get("replay_config"))
+
+
+def _frontier_replay_params(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    return _mapping(_frontier_replay_config(candidate).get("params"))
+
+
+def _frontier_strategy_overrides(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    return _mapping(_frontier_replay_config(candidate).get("strategy_overrides"))
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        return []
+    return [
+        normalized
+        for normalized in (_string(item) for item in cast(Sequence[Any], value))
+        if normalized
+    ]
+
+
 def _order_type_execution_metrics(source: Mapping[str, Any]) -> dict[str, Any]:
     decision_counts = _int_mapping(source.get("decision_count_by_order_type"))
     filled_counts = _int_mapping(source.get("filled_count_by_order_type"))
@@ -840,10 +862,29 @@ def evidence_bundle_from_frontier_candidate(
     )
     if hard_vetoes and "hard_vetoes" not in scorecard:
         scorecard = {**scorecard, "hard_vetoes": list(hard_vetoes)}
+    replay_params = _frontier_replay_params(candidate)
+    if replay_params and "runtime_params" not in scorecard:
+        scorecard = {**scorecard, "runtime_params": replay_params}
+    strategy_overrides = _frontier_strategy_overrides(candidate)
+    if strategy_overrides and "candidate_strategy_overrides" not in scorecard:
+        scorecard = {**scorecard, "candidate_strategy_overrides": strategy_overrides}
+    universe_symbols = _string_list(strategy_overrides.get("universe_symbols"))
+    if universe_symbols and "universe_symbols" not in scorecard:
+        scorecard = {**scorecard, "universe_symbols": universe_symbols}
+    for key in ("max_notional_per_trade", "max_position_pct_equity"):
+        if key in scorecard:
+            continue
+        value = strategy_overrides.get(key)
+        if value is not None:
+            scorecard = {**scorecard, key: value}
     if "symbol_contribution_shares" not in scorecard and "symbol" not in scorecard:
         symbol_shares = _decomposition_symbol_contribution_shares(candidate)
         if symbol_shares:
             scorecard = {**scorecard, "symbol_contribution_shares": symbol_shares}
+    runtime_identity_fallbacks = {
+        "runtime_family": _string(candidate.get("family")),
+        "runtime_strategy_name": _string(candidate.get("strategy_name")),
+    }
     for key in (
         "family_template_id",
         "runtime_family",
@@ -856,7 +897,7 @@ def evidence_bundle_from_frontier_candidate(
         "universe_key",
         "signal_key",
     ):
-        value = _string(candidate.get(key))
+        value = _string(candidate.get(key)) or runtime_identity_fallbacks.get(key, "")
         if value and key not in scorecard:
             scorecard = {**scorecard, key: value}
     replay_lineage = _mapping(candidate.get("replay_lineage"))

--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -88,6 +88,16 @@ def _scorecard_universe_symbols(bundle: CandidateEvidenceBundle) -> list[str]:
     ]
 
 
+def _scorecard_sleeve_runtime_limits(bundle: CandidateEvidenceBundle) -> dict[str, str]:
+    limits: dict[str, str] = {}
+    scorecard = _scorecard(bundle)
+    for key in ("max_notional_per_trade", "max_position_pct_equity"):
+        value = _string(scorecard.get(key))
+        if value:
+            limits[key] = value
+    return limits
+
+
 def _scorecard_signal(bundle: CandidateEvidenceBundle) -> str:
     params = _scorecard_runtime_params(bundle)
     signal = _string(params.get("signal_motif"))
@@ -1692,6 +1702,7 @@ def optimize_portfolio_candidate(
                 "signal": _scorecard_signal(bundle),
                 "params": dict(_scorecard_runtime_params(bundle)),
                 "universe_symbols": _scorecard_universe_symbols(bundle),
+                **_scorecard_sleeve_runtime_limits(bundle),
                 "expected_net_pnl_per_day": str(_net_per_day(bundle) * weight),
                 "source_expected_net_pnl_per_day": str(_net_per_day(bundle)),
                 "risk_contribution": str(_max_drawdown(bundle) * weight),

--- a/services/torghut/app/trading/discovery/runtime_closure.py
+++ b/services/torghut/app/trading/discovery/runtime_closure.py
@@ -1010,6 +1010,7 @@ def _materialized_generic_portfolio_runtime_strategies(
     candidate_id = _string(best_candidate.get("candidate_id")) or "runtime-closure"
     strategies: list[dict[str, Any]] = []
     for sleeve_index, sleeve in enumerate(sleeves, start=1):
+        sleeve_params = _mapping(sleeve.get("params"))
         runtime_family = (
             _string(sleeve.get("runtime_family"))
             or _runtime_family(best_candidate)
@@ -1032,7 +1033,11 @@ def _materialized_generic_portfolio_runtime_strategies(
         else:
             max_position_pct_equity = Decimal("10")
         max_position_pct_equity = max(max_position_pct_equity, Decimal("0.1"))
-        strategy_symbols = _list_of_strings(sleeve.get("symbols")) or symbols
+        strategy_symbols = (
+            _list_of_strings(sleeve.get("symbols"))
+            or _list_of_strings(sleeve.get("universe_symbols"))
+            or symbols
+        )
         strategies.append(
             {
                 "name": strategy_name,
@@ -1047,6 +1052,7 @@ def _materialized_generic_portfolio_runtime_strategies(
                 "max_notional_per_trade": _decimal_string(max_notional_per_trade),
                 "max_position_pct_equity": _decimal_string(max_position_pct_equity),
                 "params": {
+                    **{str(key): value for key, value in sleeve_params.items()},
                     "source_candidate_id": _string(sleeve.get("candidate_id")),
                     "candidate_spec_id": _string(sleeve.get("candidate_spec_id")),
                     "portfolio_candidate_id": candidate_id,

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -1052,6 +1052,8 @@ class TestPortfolioOptimizer(TestCase):
                         "shadow_parity_status": "within_budget",
                         "correlation_cluster": candidate_id,
                         "symbol_contribution_shares": {symbol: "1.0"},
+                        "max_notional_per_trade": "24000",
+                        "max_position_pct_equity": "0.76",
                         "runtime_params": {
                             "entry_minute_after_open": "35",
                             "entry_window_minutes": "25",
@@ -1115,6 +1117,8 @@ class TestPortfolioOptimizer(TestCase):
             "cross_section_positive_opening_window_return_from_prev_close_ratio",
         )
         self.assertEqual(first_sleeve["universe_symbols"], ["NVDA", "AVGO", "AMD"])
+        self.assertEqual(first_sleeve["max_notional_per_trade"], "24000")
+        self.assertEqual(first_sleeve["max_position_pct_equity"], "0.76")
 
     def test_portfolio_candidate_round_trips_from_optimizer_payload(self) -> None:
         daily_profiles = [

--- a/services/torghut/tests/test_runtime_closure.py
+++ b/services/torghut/tests/test_runtime_closure.py
@@ -782,6 +782,12 @@ data:
                             "weight": "0.60",
                             "expected_net_pnl_per_day": "320",
                             "correlation_cluster": "momentum",
+                            "universe_symbols": ["NVDA", "AAPL"],
+                            "max_notional_per_trade": "17500",
+                            "params": {
+                                "entry_minute_after_open": "45",
+                                "exit_minute_after_open": "240",
+                            },
                         },
                         {
                             "candidate_id": "cand-b",
@@ -817,6 +823,9 @@ data:
                 strategies[1]["strategy_type"], "momentum_pullback_consistent"
             )
             self.assertEqual(strategies[1]["params"]["candidate_spec_id"], "spec-a")
+            self.assertEqual(strategies[1]["params"]["entry_minute_after_open"], "45")
+            self.assertEqual(strategies[1]["universe_symbols"], ["NVDA", "AAPL"])
+            self.assertEqual(strategies[1]["max_notional_per_trade"], "17500")
             self.assertEqual(strategies[1]["params"]["sleeve_weight"], "0.6")
             self.assertEqual(strategies[2]["max_notional_per_trade"], "20000")
             self.assertEqual(

--- a/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
+++ b/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
@@ -475,6 +475,60 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
         with self.assertRaisesRegex(ValueError, "evidence_bundle_schema_invalid"):
             evidence_bundle_from_payload({"schema_version": "bad"})
 
+    def test_evidence_bundle_hydrates_runtime_config_from_frontier_replay_config(
+        self,
+    ) -> None:
+        bundle = evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-frontier-runtime-config",
+            candidate={
+                "candidate_id": "cand-frontier-runtime-config",
+                "family": "microbar_cross_sectional_pairs",
+                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                "family_template_id": "microbar_cross_sectional_pairs_v1",
+                "full_window": {
+                    "net_per_day": "143",
+                    "active_day_ratio": "1.0",
+                    "positive_day_ratio": "1.0",
+                    "best_day_share": "0.25",
+                    "max_drawdown": "0",
+                },
+                "replay_config": {
+                    "params": {
+                        "signal_motif": "vwap_displacement_reversal",
+                        "rank_feature": "cross_section_vwap_w5m_rank",
+                        "selection_mode": "reversal",
+                        "top_n": "2",
+                        "entry_minute_after_open": "180",
+                        "exit_minute_after_open": "240",
+                    },
+                    "strategy_overrides": {
+                        "universe_symbols": ["NVDA", "AAPL"],
+                        "max_notional_per_trade": "30642.32",
+                        "max_position_pct_equity": "0.97",
+                    },
+                },
+            },
+            dataset_snapshot_id="snap-frontier-runtime-config",
+            result_path="/tmp/frontier-runtime-config.json",
+        )
+
+        scorecard = bundle.objective_scorecard
+        self.assertEqual(
+            scorecard["runtime_params"]["signal_motif"],
+            "vwap_displacement_reversal",
+        )
+        self.assertEqual(scorecard["runtime_family"], "microbar_cross_sectional_pairs")
+        self.assertEqual(
+            scorecard["runtime_strategy_name"], "microbar-cross-sectional-pairs-v1"
+        )
+        self.assertEqual(scorecard["universe_symbols"], ["NVDA", "AAPL"])
+        self.assertEqual(scorecard["max_notional_per_trade"], "30642.32")
+        self.assertEqual(scorecard["max_position_pct_equity"], "0.97")
+        self.assertEqual(
+            scorecard["candidate_strategy_overrides"]["universe_symbols"],
+            ["NVDA", "AAPL"],
+        )
+
     def test_evidence_bundle_blocks_promotion_proof_without_fill_survival(self) -> None:
         bundle = evidence_bundle_from_frontier_candidate(
             candidate_spec_id="spec-promotion-proof",


### PR DESCRIPTION
## Summary

- Preserve frontier `replay_config.params` and `strategy_overrides` in candidate evidence bundles when candidates do not already carry runtime scorecard fields.
- Carry sleeve runtime limits through portfolio optimization so runtime closure can use the replayed notional and position sizing instead of defaults.
- Materialize generic portfolio sleeves with their preserved params and `universe_symbols` so runtime closure can replay the actual sleeve shape.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/discovery/evidence_bundles.py app/trading/discovery/portfolio_optimizer.py app/trading/discovery/runtime_closure.py tests/test_whitepaper_autoresearch_artifacts.py tests/test_portfolio_optimizer.py tests/test_runtime_closure.py`
- `uv run --frozen pytest tests/test_whitepaper_autoresearch_artifacts.py::TestWhitepaperAutoresearchArtifacts::test_evidence_bundle_hydrates_runtime_config_from_frontier_replay_config tests/test_portfolio_optimizer.py::TestPortfolioOptimizer::test_portfolio_sleeves_preserve_runtime_params_for_closure tests/test_runtime_closure.py::TestRuntimeClosure::test_materialize_candidate_configmap_supports_generic_portfolio_candidates -q`
- `uv run --frozen pytest tests/test_whitepaper_autoresearch_artifacts.py tests/test_portfolio_optimizer.py tests/test_runtime_closure.py -q`
- `uv run --frozen ruff check app/trading/discovery/evidence_bundles.py app/trading/discovery/portfolio_optimizer.py app/trading/discovery/runtime_closure.py tests/test_whitepaper_autoresearch_artifacts.py tests/test_portfolio_optimizer.py tests/test_runtime_closure.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
