### PR TITLE
fix(torghut): require ledger-weighted live pnl windows

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -836,6 +836,21 @@ def _metric_window_activity_reason_codes(
         and _safe_int(payload.get("post_cost_promotion_sample_count")) <= 0
     ):
         reasons.append("hypothesis_window_post_cost_pnl_basis_missing")
+    observed_stage = _safe_text(getattr(metric_window, "observed_stage", None))
+    if observed_stage == "live":
+        promotion_sample_count = _safe_int(
+            payload.get("post_cost_promotion_sample_count")
+        )
+        runtime_ledger_sample_count = _safe_int(
+            payload.get("runtime_ledger_notional_weighted_sample_count")
+        )
+        aggregation = _safe_text(payload.get("post_cost_expectancy_aggregation"))
+        if (
+            promotion_sample_count <= 0
+            or runtime_ledger_sample_count < promotion_sample_count
+            or aggregation != "runtime_ledger_notional_weighted"
+        ):
+            reasons.append("runtime_ledger_pnl_basis_missing")
 
     avg_abs_slippage_bps = _safe_decimal(metric_window.avg_abs_slippage_bps)
     slippage_budget_bps = _safe_decimal(metric_window.slippage_budget_bps)

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -137,6 +137,14 @@ class TestSubmissionCouncil(TestCase):
             "continuity_ok": True,
             "drift_ok": True,
             "dependency_quorum_decision": "allow",
+            "payload_json": {
+                "post_cost_promotion_sample_count": 42,
+                "post_cost_basis_counts": {
+                    "realized_strategy_pnl_after_explicit_costs": 42
+                },
+                "post_cost_expectancy_aggregation": "runtime_ledger_notional_weighted",
+                "runtime_ledger_notional_weighted_sample_count": 42,
+            },
         }
         if observed_stage is not None:
             payload["observed_stage"] = observed_stage
@@ -358,6 +366,32 @@ class TestSubmissionCouncil(TestCase):
             reasons,
             ["hypothesis_window_post_cost_pnl_basis_missing"],
         )
+
+    def test_metric_window_activity_rejects_live_window_without_runtime_ledger_weighted_pnl(
+        self,
+    ) -> None:
+        metric_window = SimpleNamespace(
+            observed_stage="live",
+            market_session_count=3,
+            decision_count=3,
+            trade_count=3,
+            order_count=3,
+            post_cost_expectancy_bps="8.5",
+            avg_abs_slippage_bps="4.2",
+            slippage_budget_bps="12",
+            payload_json={
+                "post_cost_promotion_sample_count": 3,
+                "post_cost_basis_counts": {
+                    "realized_strategy_pnl_after_explicit_costs": 3
+                },
+                "post_cost_expectancy_aggregation": "promotion_bps_average",
+                "runtime_ledger_notional_weighted_sample_count": 2,
+            },
+        )
+
+        reasons = _metric_window_activity_reason_codes(metric_window)
+
+        self.assertEqual(reasons, ["runtime_ledger_pnl_basis_missing"])
 
     def test_merge_runtime_certificate_evidence_surfaces_blocked_import_reason(
         self,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -1330,6 +1330,19 @@ class TestTradingPipeline(TestCase):
                 }
             )
 
+    @staticmethod
+    def _runtime_ledger_weighted_window_payload(
+        *, sample_count: int = 1
+    ) -> dict[str, object]:
+        return {
+            "post_cost_promotion_sample_count": sample_count,
+            "post_cost_basis_counts": {
+                "realized_strategy_pnl_after_explicit_costs": sample_count
+            },
+            "post_cost_expectancy_aggregation": "runtime_ledger_notional_weighted",
+            "runtime_ledger_notional_weighted_sample_count": sample_count,
+        }
+
     def _seed_promotion_certificate_evidence(
         self,
         *,
@@ -1362,6 +1375,7 @@ class TestTradingPipeline(TestCase):
                     avg_abs_slippage_bps=str(avg_abs_slippage_bps),
                     slippage_budget_bps=str(slippage_budget_bps),
                     capital_stage=capital_stage,
+                    payload_json=self._runtime_ledger_weighted_window_payload(),
                 )
             )
             session.add(
@@ -4974,6 +4988,7 @@ class TestTradingPipeline(TestCase):
                         avg_abs_slippage_bps="1.0",
                         slippage_budget_bps="5.0",
                         capital_stage="0.10x canary",
+                        payload_json=self._runtime_ledger_weighted_window_payload(),
                     )
                 )
                 session.add(


### PR DESCRIPTION
## Summary

- Require live hypothesis metric windows to carry runtime-ledger notional-weighted post-cost PnL evidence before they can support promotion certificates.
- Reject live windows when promotion-grade samples are missing, under-covered by runtime-ledger samples, or aggregated with the older bps-average path.
- Keep valid live-certificate test helpers explicit about realized strategy PnL basis and ledger-weighted aggregation.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen pytest tests/test_submission_council.py -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q -k "test_live_submission_allows_autonomy_eligible_canary_without_static_flag or test_pipeline_llm_disabled_keeps_live_submission_operational or test_pipeline_llm_failure_fallbacks or test_pipeline_llm_dspy_live_runtime_gate_can_pass_through_with_degraded_qty or test_pipeline_llm_shadow_bootstrap_artifact_keeps_live_submission_operational or test_pipeline_llm_dspy_runtime_reduced_sell_uses_seeded_simulation_inventory"`
- `uv run --frozen pytest tests/test_submission_council.py tests/test_trading_pipeline.py tests/test_hypotheses.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py tests/test_trading_pipeline.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
