### PR TITLE
fix(torghut): separate paper probation readiness

### DIFF
--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -173,6 +173,7 @@ _EVIDENCE_REFRESH_REASONS = {
     "feature_rows_missing",
     "hypothesis_window_evidence_missing",
     "hypothesis_window_evidence_stale",
+    "paper_probation_evidence_collection_only",
     "required_feature_set_unavailable",
     "runtime_ledger_proof_missing",
     "tca_evidence_stale",
@@ -287,6 +288,10 @@ def _ranked_candidate_dossiers(
                 "capital_stage": item.get("capital_stage"),
                 "capital_multiplier": item.get("capital_multiplier"),
                 "promotion_eligible": bool(item.get("promotion_eligible")),
+                "paper_probation_eligible": bool(item.get("paper_probation_eligible")),
+                "paper_probation_target_capital_stage": item.get(
+                    "paper_probation_target_capital_stage"
+                ),
                 "blocker_class": blocker_class,
                 "next_blocker": reason_codes[0] if reason_codes else None,
                 "reason_codes": reason_codes,
@@ -1982,6 +1987,9 @@ def summarize_hypothesis_runtime_statuses(
     promotion_eligible_total = sum(
         1 for item in statuses if bool(item.get("promotion_eligible"))
     )
+    paper_probation_eligible_total = sum(
+        1 for item in statuses if bool(item.get("paper_probation_eligible"))
+    )
     rollback_required_total = sum(
         1 for item in statuses if bool(item.get("rollback_required"))
     )
@@ -2002,6 +2010,7 @@ def summarize_hypothesis_runtime_statuses(
         "capital_stage_totals": dict(sorted(capital_stage_totals.items())),
         "capital_multiplier_by_hypothesis": capital_multiplier_by_hypothesis,
         "promotion_eligible_total": promotion_eligible_total,
+        "paper_probation_eligible_total": paper_probation_eligible_total,
         "rollback_required_total": rollback_required_total,
         "dependency_quorum": dependency_quorum.as_payload(),
     }

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -620,6 +620,7 @@ def _refresh_runtime_summary_totals(
     capital_stage_totals: dict[str, int] = {}
     capital_multiplier_by_hypothesis: dict[str, str] = {}
     promotion_eligible_total = 0
+    paper_probation_eligible_total = 0
     rollback_required_total = 0
 
     for item in runtime_items:
@@ -638,6 +639,8 @@ def _refresh_runtime_summary_totals(
 
         if bool(item.get("promotion_eligible")):
             promotion_eligible_total += 1
+        if bool(item.get("paper_probation_eligible")):
+            paper_probation_eligible_total += 1
         if bool(item.get("rollback_required")):
             rollback_required_total += 1
 
@@ -664,6 +667,7 @@ def _refresh_runtime_summary_totals(
             "capital_stage_totals": dict(sorted(capital_stage_totals.items())),
             "capital_multiplier_by_hypothesis": capital_multiplier_by_hypothesis,
             "promotion_eligible_total": promotion_eligible_total,
+            "paper_probation_eligible_total": paper_probation_eligible_total,
             "rollback_required_total": rollback_required_total,
             "items": list(runtime_items),
         }
@@ -1037,10 +1041,8 @@ def _merge_runtime_certificate_evidence(
         if capital_stage is None:
             merged.append(updated)
             continue
-        if _stage_rank(capital_stage) <= _stage_rank("shadow"):
-            if _safe_text(getattr(metric_window, "observed_stage", None)) != "paper":
-                merged.append(updated)
-                continue
+        observed_stage = _safe_text(getattr(metric_window, "observed_stage", None))
+        if observed_stage == "paper":
             issued_at = _window_evidence_issued_at(metric_window)
             candidate_id = (
                 _safe_text(metric_window.candidate_id)
@@ -1055,6 +1057,9 @@ def _merge_runtime_certificate_evidence(
             observed.update(
                 {
                     "runtime_window_certificate_readiness_applied": True,
+                    "runtime_window_paper_probation_applied": True,
+                    "paper_probation_evidence_collection_only": True,
+                    "paper_probation_target_capital_stage": capital_stage,
                     "runtime_window_prior_reasons": list(
                         cast(Sequence[object], updated.get("reasons") or [])
                     ),
@@ -1076,11 +1081,13 @@ def _merge_runtime_certificate_evidence(
             updated.update(
                 {
                     "state": "shadow",
-                    "capital_stage": capital_stage or "shadow",
+                    "capital_stage": "shadow",
                     "capital_multiplier": "0",
-                    "promotion_eligible": True,
+                    "promotion_eligible": False,
+                    "paper_probation_eligible": True,
+                    "paper_probation_target_capital_stage": capital_stage,
                     "rollback_required": False,
-                    "reasons": [],
+                    "reasons": ["paper_probation_evidence_collection_only"],
                     "informational_reasons": sorted(
                         {
                             *[
@@ -1092,6 +1099,7 @@ def _merge_runtime_certificate_evidence(
                                 if str(reason).strip()
                             ],
                             "runtime_window_certificate_readiness_applied",
+                            "runtime_window_paper_probation_applied",
                         }
                     ),
                     "promotion_decision_id": str(promotion_decision.id),
@@ -1099,6 +1107,12 @@ def _merge_runtime_certificate_evidence(
                     "observed": observed,
                 }
             )
+            merged.append(updated)
+            continue
+        if observed_stage != "live":
+            merged.append(updated)
+            continue
+        if _stage_rank(capital_stage) <= _stage_rank("shadow"):
             merged.append(updated)
             continue
 
@@ -1911,8 +1925,6 @@ def build_live_submission_gate_payload(
             continue
         if _safe_text(getattr(metric_window, "observed_stage", None)) != "paper":
             continue
-        if _certificate_capital_stage(metric_window, promotion_decision) != "shadow":
-            continue
         readiness_evidence_rows.append(row)
     if runtime_items and readiness_evidence_rows:
         runtime_items = _merge_runtime_certificate_evidence(
@@ -1923,6 +1935,9 @@ def build_live_submission_gate_payload(
         )
         summary = _refresh_runtime_summary_totals(summary, runtime_items)
     promotion_eligible_total = _safe_int(summary.get("promotion_eligible_total"))
+    paper_probation_eligible_total = _safe_int(
+        summary.get("paper_probation_eligible_total")
+    )
     active_capital_stage = resolve_active_capital_stage(summary)
     segment_summary = _segment_summary(
         state=state,
@@ -1985,6 +2000,7 @@ def build_live_submission_gate_payload(
             "autonomy_promotion_action": autonomy_promotion_action,
             "drift_live_promotion_eligible": drift_live_promotion_eligible,
             "promotion_eligible_total": promotion_eligible_total,
+            "paper_probation_eligible_total": paper_probation_eligible_total,
             "dependency_quorum_decision": dependency_decision,
             "empirical_jobs_ready": empirical_ready,
             "dspy_live_ready": dspy_live_ready,
@@ -2051,18 +2067,20 @@ def build_live_submission_gate_payload(
             item for item in evaluated_tuples if not item.get("reason_codes")
         ]
 
+    candidate_reason_codes = [
+        reason
+        for item in evaluated_tuples
+        for reason in cast(Sequence[str], item.get("reason_codes") or [])
+    ]
     if promotion_eligible_total > 0 and not valid_candidates:
         if not evaluated_tuples:
             blocked_reasons.append("promotion_certificate_missing")
             blocked_reasons.append("hypothesis_window_evidence_missing")
         else:
-            candidate_reason_codes = [
-                reason
-                for item in evaluated_tuples
-                for reason in cast(Sequence[str], item.get("reason_codes") or [])
-            ]
             blocked_reasons.extend(candidate_reason_codes)
             blocked_reasons.append("promotion_certificate_missing")
+    elif paper_probation_eligible_total > 0 and evaluated_tuples:
+        blocked_reasons.extend(candidate_reason_codes)
 
     blocked_reasons = _normalize_reason_codes(blocked_reasons)
 
@@ -2164,6 +2182,7 @@ def build_live_submission_gate_payload(
         "autonomy_promotion_action": autonomy_promotion_action,
         "drift_live_promotion_eligible": drift_live_promotion_eligible,
         "promotion_eligible_total": promotion_eligible_total,
+        "paper_probation_eligible_total": paper_probation_eligible_total,
         "dependency_quorum_decision": dependency_decision,
         "empirical_jobs_ready": empirical_ready,
         "dspy_live_ready": dspy_live_ready,

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -468,6 +468,7 @@ class TestSubmissionCouncil(TestCase):
                     "capital_stage": "shadow",
                     "capital_multiplier": "0",
                     "promotion_eligible": True,
+                    "paper_probation_eligible": True,
                     "rollback_required": False,
                     "reasons": [],
                     "informational_reasons": [],
@@ -477,6 +478,7 @@ class TestSubmissionCouncil(TestCase):
 
         self.assertEqual(refreshed["hypotheses_total"], 2)
         self.assertEqual(refreshed["promotion_eligible_total"], 1)
+        self.assertEqual(refreshed["paper_probation_eligible_total"], 1)
         self.assertEqual(refreshed["rollback_required_total"], 1)
         self.assertEqual(refreshed["reason_totals"], {"drift_checks_missing": 1})
         self.assertEqual(
@@ -580,6 +582,24 @@ class TestSubmissionCouncil(TestCase):
                     "promotion_decision": promotion(state="shadow"),
                 }
             ],
+            [
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "metric_window": metric_window(
+                        capital_stage="shadow",
+                        observed_stage="live",
+                        payload_json={
+                            "post_cost_promotion_sample_count": 42,
+                            "post_cost_basis_counts": {
+                                "realized_strategy_pnl_after_explicit_costs": 42
+                            },
+                            "post_cost_expectancy_aggregation": "runtime_ledger_notional_weighted",
+                            "runtime_ledger_notional_weighted_sample_count": 42,
+                        },
+                    ),
+                    "promotion_decision": promotion(state="shadow"),
+                }
+            ],
         ]
 
         for evidence in scenarios:
@@ -645,7 +665,7 @@ class TestSubmissionCouncil(TestCase):
                     run_id="runtime-proof-1",
                     candidate_id="cand-runtime",
                     hypothesis_id="H-CONT-01",
-                    observed_stage="paper",
+                    observed_stage="live",
                     window_started_at=now,
                     window_ended_at=now,
                     market_session_count=3,
@@ -659,6 +679,14 @@ class TestSubmissionCouncil(TestCase):
                     drift_ok=True,
                     dependency_quorum_decision="allow",
                     capital_stage="0.10x canary",
+                    payload_json={
+                        "post_cost_promotion_sample_count": 42,
+                        "post_cost_basis_counts": {
+                            "realized_strategy_pnl_after_explicit_costs": 42
+                        },
+                        "post_cost_expectancy_aggregation": "runtime_ledger_notional_weighted",
+                        "runtime_ledger_notional_weighted_sample_count": 42,
+                    },
                 )
             )
             session.add(
@@ -666,7 +694,7 @@ class TestSubmissionCouncil(TestCase):
                     run_id="runtime-proof-1",
                     candidate_id="cand-runtime",
                     hypothesis_id="H-CONT-01",
-                    promotion_target="paper",
+                    promotion_target="live",
                     state="0.10x canary",
                     allowed=True,
                     reason_summary="runtime_evidence_thresholds_satisfied",
@@ -703,6 +731,7 @@ class TestSubmissionCouncil(TestCase):
                 )
 
         self.assertEqual(result["promotion_eligible_total"], 1)
+        self.assertEqual(result["paper_probation_eligible_total"], 0)
         item = result["items"][0]
         self.assertTrue(item["promotion_eligible"])
         self.assertEqual(item["candidate_id"], "cand-runtime")
@@ -831,7 +860,10 @@ class TestSubmissionCouncil(TestCase):
                 promotion_certificate_evidence=[
                     {
                         "hypothesis_id": "H-CONT-01",
-                        "metric_window": self._metric_window(capital_stage="shadow"),
+                        "metric_window": self._metric_window(
+                            capital_stage="shadow",
+                            observed_stage="paper",
+                        ),
                         "promotion_decision": self._promotion_decision(
                             capital_stage="shadow"
                         ),
@@ -840,24 +872,30 @@ class TestSubmissionCouncil(TestCase):
                 session=session,
             )
 
-        self.assertEqual(summary["promotion_eligible_total"], 1)
+        self.assertEqual(summary["promotion_eligible_total"], 0)
+        self.assertEqual(summary["paper_probation_eligible_total"], 1)
         item = summary["items"][0]
-        self.assertTrue(item["promotion_eligible"])
+        self.assertFalse(item["promotion_eligible"])
+        self.assertTrue(item["paper_probation_eligible"])
+        self.assertEqual(item["paper_probation_target_capital_stage"], "shadow")
         self.assertEqual(item["candidate_id"], "cand-runtime-paper")
         self.assertEqual(item["state"], "shadow")
         self.assertEqual(item["capital_stage"], "shadow")
         self.assertEqual(item["capital_multiplier"], "0")
-        self.assertEqual(item["reasons"], [])
+        self.assertEqual(item["reasons"], ["paper_probation_evidence_collection_only"])
         self.assertEqual(
             item["informational_reasons"],
-            ["runtime_window_certificate_readiness_applied"],
+            [
+                "runtime_window_certificate_readiness_applied",
+                "runtime_window_paper_probation_applied",
+            ],
         )
         self.assertEqual(
             item["observed"]["runtime_window_prior_reasons"],
             ["drift_checks_missing"],
         )
         self.assertFalse(gate["allowed"])
-        self.assertNotIn(
+        self.assertIn(
             "alpha_readiness_not_promotion_eligible",
             gate["blocked_reasons"],
         )
@@ -899,8 +937,9 @@ class TestSubmissionCouncil(TestCase):
             session=session,
         )
 
-        self.assertEqual(stale_gate["promotion_eligible_total"], 1)
-        self.assertNotIn(
+        self.assertEqual(stale_gate["promotion_eligible_total"], 0)
+        self.assertEqual(stale_gate["paper_probation_eligible_total"], 1)
+        self.assertIn(
             "alpha_readiness_not_promotion_eligible",
             stale_gate["blocked_reasons"],
         )
@@ -936,8 +975,13 @@ class TestSubmissionCouncil(TestCase):
         )
 
         self.assertEqual(non_shadow_paper_gate["promotion_eligible_total"], 0)
+        self.assertEqual(non_shadow_paper_gate["paper_probation_eligible_total"], 1)
         self.assertIn(
             "alpha_readiness_not_promotion_eligible",
+            non_shadow_paper_gate["blocked_reasons"],
+        )
+        self.assertIn(
+            "promotion_certificate_not_live_runtime",
             non_shadow_paper_gate["blocked_reasons"],
         )
 

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -5901,13 +5901,17 @@ class TestTradingApi(TestCase):
                 feature_readiness={},
             )
 
-        self.assertEqual(summary["promotion_eligible_total"], 1)
-        self.assertEqual(payload["summary"]["promotion_eligible_total"], 1)
+        self.assertEqual(summary["promotion_eligible_total"], 0)
+        self.assertEqual(summary["paper_probation_eligible_total"], 1)
+        self.assertEqual(payload["summary"]["promotion_eligible_total"], 0)
+        self.assertEqual(payload["summary"]["paper_probation_eligible_total"], 1)
         item = payload["items"][0]
-        self.assertTrue(item["promotion_eligible"])
+        self.assertFalse(item["promotion_eligible"])
+        self.assertTrue(item["paper_probation_eligible"])
+        self.assertEqual(item["paper_probation_target_capital_stage"], "0.10x canary")
         self.assertEqual(item["candidate_id"], "cand-status-runtime")
-        self.assertEqual(item["capital_stage"], "0.10x canary")
-        self.assertEqual(item["reasons"], [])
+        self.assertEqual(item["capital_stage"], "shadow")
+        self.assertEqual(item["reasons"], ["paper_probation_evidence_collection_only"])
 
     def test_trading_status_exposes_rejection_and_market_context_controls(self) -> None:
         original_scheduler = getattr(app.state, "trading_scheduler", None)


### PR DESCRIPTION
## Summary

- Stop paper-observed runtime certificates from incrementing `promotion_eligible_total` or implying nonzero capital readiness.
- Surface paper certificates through explicit `paper_probation_eligible_total`, per-candidate `paper_probation_eligible`, and `paper_probation_target_capital_stage` fields.
- Keep live submission blocked for paper probation while preserving diagnostic blocker reasons for non-live and shadow-only certificate evidence.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app/trading/submission_council.py app/trading/hypotheses.py tests/test_submission_council.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/trading/submission_council.py app/trading/hypotheses.py tests/test_submission_council.py tests/test_trading_api.py`
- `uv run --frozen pytest tests/test_submission_council.py tests/test_hypotheses.py tests/test_trading_api.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

Runtime readiness summaries now distinguish paper probation from actual promotion eligibility. Consumers should use `paper_probation_eligible_total` for evidence-collection candidates and `promotion_eligible_total` only for live-observed promotion evidence.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
