### PR TITLE
fix(torghut): require ledger proof for live certificates

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -142,6 +142,10 @@ def _safe_text(value: object) -> str | None:
     return text or None
 
 
+def _safe_attr_text(value: object, name: str) -> str | None:
+    return _safe_text(cast(object, getattr(value, name, None)))
+
+
 def _normalize_reason_codes(values: Sequence[object]) -> list[str]:
     normalized: list[str] = []
     seen: set[str] = set()
@@ -537,6 +541,273 @@ def _runtime_ledger_bucket_payload(
     }
 
 
+def _normalized_strategy_family(value: object) -> str | None:
+    text = _safe_text(value)
+    return text.replace("-", "_").lower() if text is not None else None
+
+
+def _runtime_ledger_hash_count(
+    payload: Mapping[str, object],
+    *,
+    payload_key: str,
+    observed: Mapping[str, object],
+    observed_key: str,
+) -> int:
+    payload_counts = payload.get(payload_key)
+    if isinstance(payload_counts, Mapping):
+        typed_counts = cast(Mapping[str, object], payload_counts)
+        total = 0
+        for raw_value in typed_counts.values():
+            count = _safe_int(raw_value)
+            if count > 0:
+                total += count
+        return total
+    return _safe_int(observed.get(observed_key))
+
+
+def _runtime_ledger_payload_from_runtime_item(
+    runtime_item: Mapping[str, object],
+) -> dict[str, object]:
+    observed_raw = runtime_item.get("observed")
+    observed = (
+        cast(Mapping[str, object], observed_raw)
+        if isinstance(observed_raw, Mapping)
+        else cast(Mapping[str, object], {})
+    )
+    if not bool(observed.get("runtime_ledger_proof_present")):
+        return {}
+    return {
+        "candidate_id": observed.get("runtime_ledger_candidate_id"),
+        "hypothesis_id": runtime_item.get("hypothesis_id"),
+        "observed_stage": observed.get("runtime_ledger_observed_stage"),
+        "runtime_strategy_name": observed.get("runtime_ledger_runtime_strategy_name"),
+        "strategy_family": observed.get("runtime_ledger_strategy_family")
+        or runtime_item.get("strategy_family"),
+        "fill_count": observed.get("runtime_ledger_fill_count"),
+        "submitted_order_count": observed.get("runtime_ledger_submitted_order_count"),
+        "closed_trade_count": observed.get("runtime_ledger_closed_trade_count"),
+        "open_position_count": observed.get("runtime_ledger_open_position_count"),
+        "filled_notional": observed.get("runtime_ledger_filled_notional"),
+        "net_strategy_pnl_after_costs": observed.get(
+            "runtime_ledger_net_strategy_pnl_after_costs"
+        ),
+        "post_cost_expectancy_bps": observed.get(
+            "runtime_ledger_post_cost_expectancy_bps"
+        ),
+        "blockers": observed.get("runtime_ledger_blockers"),
+        "ledger_schema_version": observed.get("runtime_ledger_schema_version"),
+        "pnl_basis": observed.get("runtime_ledger_pnl_basis"),
+    }
+
+
+def _certificate_runtime_ledger_payload(
+    *,
+    evidence_row: Mapping[str, object],
+    runtime_item: Mapping[str, object],
+) -> dict[str, object]:
+    payload = evidence_row.get("runtime_ledger_bucket")
+    if isinstance(payload, Mapping):
+        return dict(cast(Mapping[str, object], payload))
+    return _runtime_ledger_payload_from_runtime_item(runtime_item)
+
+
+def _certificate_runtime_ledger_reason_codes(
+    *,
+    evidence_row: Mapping[str, object],
+    runtime_item: Mapping[str, object],
+    metric_window: StrategyHypothesisMetricWindow,
+    promotion_decision: StrategyPromotionDecision,
+) -> list[str]:
+    ledger_payload = _certificate_runtime_ledger_payload(
+        evidence_row=evidence_row,
+        runtime_item=runtime_item,
+    )
+    if not ledger_payload:
+        return ["runtime_ledger_proof_missing"]
+
+    reasons: list[str] = []
+    observed_raw = runtime_item.get("observed")
+    observed = (
+        cast(Mapping[str, object], observed_raw)
+        if isinstance(observed_raw, Mapping)
+        else cast(Mapping[str, object], {})
+    )
+    ledger_hypothesis_id = _safe_text(
+        ledger_payload.get("hypothesis_id") or runtime_item.get("hypothesis_id")
+    )
+    metric_hypothesis_id = (
+        _safe_attr_text(metric_window, "hypothesis_id")
+        or _safe_text(evidence_row.get("hypothesis_id"))
+        or _safe_text(runtime_item.get("hypothesis_id"))
+    )
+    if ledger_hypothesis_id != metric_hypothesis_id:
+        reasons.append("runtime_ledger_hypothesis_mismatch")
+
+    ledger_run_id = _safe_text(ledger_payload.get("run_id"))
+    metric_run_id = _safe_attr_text(metric_window, "run_id")
+    if (
+        ledger_run_id is not None
+        and metric_run_id is not None
+        and ledger_run_id != metric_run_id
+    ):
+        reasons.append("runtime_ledger_run_id_mismatch")
+
+    certificate_candidate_id = (
+        _safe_attr_text(metric_window, "candidate_id")
+        or _safe_attr_text(promotion_decision, "candidate_id")
+        or _safe_text(runtime_item.get("candidate_id"))
+    )
+    ledger_candidate_id = _safe_text(
+        ledger_payload.get("candidate_id")
+        or observed.get("runtime_ledger_candidate_id")
+        or runtime_item.get("candidate_id")
+    )
+    if ledger_candidate_id is None:
+        reasons.append("runtime_ledger_candidate_missing")
+    elif (
+        certificate_candidate_id is not None
+        and ledger_candidate_id != certificate_candidate_id
+    ):
+        reasons.append("runtime_ledger_candidate_mismatch")
+
+    if _safe_text(ledger_payload.get("observed_stage")) != "live":
+        reasons.append("runtime_ledger_stage_not_live")
+
+    ledger_family = _normalized_strategy_family(ledger_payload.get("strategy_family"))
+    runtime_family = _normalized_strategy_family(runtime_item.get("strategy_family"))
+    if (
+        ledger_family is not None
+        and runtime_family is not None
+        and ledger_family != runtime_family
+    ):
+        reasons.append("runtime_ledger_strategy_family_mismatch")
+
+    blockers = [
+        str(reason).strip()
+        for reason in cast(Sequence[object], ledger_payload.get("blockers") or [])
+        if str(reason).strip()
+    ]
+    reasons.extend(blockers)
+
+    if (
+        _safe_text(ledger_payload.get("pnl_basis"))
+        != "realized_strategy_pnl_after_explicit_costs"
+    ):
+        reasons.append("runtime_ledger_pnl_basis_missing")
+
+    filled_notional = _safe_decimal(ledger_payload.get("filled_notional"))
+    if filled_notional is None or filled_notional <= 0:
+        reasons.append("runtime_ledger_filled_notional_missing")
+
+    expectancy_bps = _safe_decimal(ledger_payload.get("post_cost_expectancy_bps"))
+    if expectancy_bps is None:
+        reasons.append("runtime_ledger_expectancy_missing")
+    elif expectancy_bps <= 0:
+        reasons.append("post_cost_expectancy_non_positive")
+
+    if _safe_int(ledger_payload.get("closed_trade_count")) <= 0:
+        reasons.append("runtime_ledger_closed_trades_missing")
+    if _safe_int(ledger_payload.get("open_position_count")) > 0:
+        reasons.append("unclosed_position")
+
+    submitted_order_count = _safe_int(ledger_payload.get("submitted_order_count"))
+    if submitted_order_count <= 0:
+        reasons.append("runtime_order_lifecycle_missing")
+    elif submitted_order_count < _safe_int(
+        cast(object, getattr(metric_window, "order_count", None))
+    ):
+        reasons.append("runtime_ledger_submitted_order_count_mismatch")
+
+    if (
+        _runtime_ledger_hash_count(
+            ledger_payload,
+            payload_key="execution_policy_hash_counts",
+            observed=observed,
+            observed_key="runtime_ledger_execution_policy_hash_count",
+        )
+        <= 0
+    ):
+        reasons.append("runtime_ledger_execution_policy_hash_missing")
+    if (
+        _runtime_ledger_hash_count(
+            ledger_payload,
+            payload_key="cost_model_hash_counts",
+            observed=observed,
+            observed_key="runtime_ledger_cost_model_hash_count",
+        )
+        <= 0
+    ):
+        reasons.append("runtime_ledger_cost_model_hash_missing")
+    if (
+        _runtime_ledger_hash_count(
+            ledger_payload,
+            payload_key="lineage_hash_counts",
+            observed=observed,
+            observed_key="runtime_ledger_lineage_hash_count",
+        )
+        <= 0
+    ):
+        reasons.append("runtime_ledger_lineage_hash_missing")
+
+    return _normalize_reason_codes(reasons)
+
+
+def _mark_runtime_certificate_rejected(
+    updated: dict[str, object],
+    *,
+    metric_window: StrategyHypothesisMetricWindow,
+    promotion_decision: StrategyPromotionDecision,
+    reason_codes: Sequence[object],
+) -> dict[str, object]:
+    normalized_reasons = _normalize_reason_codes(reason_codes)
+    observed_raw = updated.get("observed")
+    observed = (
+        dict(cast(Mapping[str, object], observed_raw))
+        if isinstance(observed_raw, Mapping)
+        else {}
+    )
+    observed.update(
+        {
+            "runtime_window_certificate_rejected": True,
+            "runtime_window_rejection_reasons": normalized_reasons,
+            "metric_window_id": str(metric_window.id),
+            "promotion_decision_id": str(promotion_decision.id),
+            "metric_window_market_session_count": metric_window.market_session_count,
+            "metric_window_decision_count": metric_window.decision_count,
+            "metric_window_trade_count": metric_window.trade_count,
+            "metric_window_order_count": metric_window.order_count,
+            "metric_window_avg_abs_slippage_bps": metric_window.avg_abs_slippage_bps,
+            "metric_window_post_cost_expectancy_bps": (
+                metric_window.post_cost_expectancy_bps
+            ),
+        }
+    )
+    prior_reasons = [
+        str(reason).strip()
+        for reason in cast(Sequence[object], updated.get("reasons") or [])
+        if str(reason).strip()
+    ]
+    updated["reasons"] = _normalize_reason_codes([*prior_reasons, *normalized_reasons])
+    updated["informational_reasons"] = sorted(
+        {
+            *[
+                str(reason)
+                for reason in cast(
+                    Sequence[object],
+                    updated.get("informational_reasons") or [],
+                )
+                if str(reason).strip()
+            ],
+            "runtime_window_certificate_rejected",
+        }
+    )
+    updated["promotion_eligible"] = False
+    updated["promotion_decision_id"] = str(promotion_decision.id)
+    updated["metric_window_id"] = str(metric_window.id)
+    updated["observed"] = observed
+    return updated
+
+
 def _load_latest_runtime_ledger_summary(
     session: Session,
     *,
@@ -733,6 +1004,18 @@ def _load_latest_certificate_evidence(
     for row in promotion_rows:
         latest_promotions.setdefault(row.hypothesis_id, []).append(row)
 
+    latest_runtime_ledgers: dict[str, list[StrategyRuntimeLedgerBucket]] = {}
+    runtime_ledger_rows = session.execute(
+        select(StrategyRuntimeLedgerBucket)
+        .where(StrategyRuntimeLedgerBucket.hypothesis_id.in_(normalized_ids))
+        .order_by(
+            StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
+            StrategyRuntimeLedgerBucket.created_at.desc(),
+        )
+    ).scalars()
+    for row in runtime_ledger_rows:
+        latest_runtime_ledgers.setdefault(row.hypothesis_id, []).append(row)
+
     evidence: list[dict[str, object]] = []
     for hypothesis_id in normalized_ids:
         metric_window = latest_windows.get(hypothesis_id)
@@ -744,11 +1027,24 @@ def _load_latest_certificate_evidence(
             ):
                 promotion_decision = decision
                 break
+        runtime_ledger_bucket = None
+        for ledger in latest_runtime_ledgers.get(hypothesis_id, []):
+            if metric_window is not None and (
+                _safe_text(ledger.run_id) != _safe_text(metric_window.run_id)
+                or _safe_text(ledger.candidate_id)
+                != _safe_text(metric_window.candidate_id)
+                or _safe_text(ledger.observed_stage)
+                != _safe_text(metric_window.observed_stage)
+            ):
+                continue
+            runtime_ledger_bucket = _runtime_ledger_bucket_payload(ledger)
+            break
         evidence.append(
             {
                 "hypothesis_id": hypothesis_id,
                 "metric_window": metric_window,
                 "promotion_decision": promotion_decision,
+                "runtime_ledger_bucket": runtime_ledger_bucket,
             }
         )
     return evidence
@@ -945,95 +1241,22 @@ def _merge_runtime_certificate_evidence(
             promotion_decision
         )
         if decision_blockers:
-            observed = (
-                dict(cast(Mapping[str, Any], updated.get("observed")))
-                if isinstance(updated.get("observed"), Mapping)
-                else {}
+            updated = _mark_runtime_certificate_rejected(
+                updated,
+                metric_window=metric_window,
+                promotion_decision=promotion_decision,
+                reason_codes=decision_blockers,
             )
-            observed.update(
-                {
-                    "runtime_window_certificate_rejected": True,
-                    "runtime_window_rejection_reasons": decision_blockers,
-                    "metric_window_id": str(metric_window.id),
-                    "promotion_decision_id": str(promotion_decision.id),
-                    "metric_window_market_session_count": metric_window.market_session_count,
-                    "metric_window_decision_count": metric_window.decision_count,
-                    "metric_window_trade_count": metric_window.trade_count,
-                    "metric_window_order_count": metric_window.order_count,
-                    "metric_window_avg_abs_slippage_bps": metric_window.avg_abs_slippage_bps,
-                    "metric_window_post_cost_expectancy_bps": metric_window.post_cost_expectancy_bps,
-                }
-            )
-            prior_reasons = [
-                str(reason).strip()
-                for reason in cast(Sequence[object], updated.get("reasons") or [])
-                if str(reason).strip()
-            ]
-            updated["reasons"] = _normalize_reason_codes(
-                [*prior_reasons, *decision_blockers]
-            )
-            updated["informational_reasons"] = sorted(
-                {
-                    *[
-                        str(reason)
-                        for reason in cast(
-                            Sequence[object],
-                            updated.get("informational_reasons") or [],
-                        )
-                        if str(reason).strip()
-                    ],
-                    "runtime_window_certificate_rejected",
-                }
-            )
-            updated["promotion_eligible"] = False
-            updated["promotion_decision_id"] = str(promotion_decision.id)
-            updated["metric_window_id"] = str(metric_window.id)
-            updated["observed"] = observed
             merged.append(updated)
             continue
         activity_reason_codes = _metric_window_activity_reason_codes(metric_window)
         if activity_reason_codes:
-            observed = (
-                dict(cast(Mapping[str, Any], updated.get("observed")))
-                if isinstance(updated.get("observed"), Mapping)
-                else {}
+            updated = _mark_runtime_certificate_rejected(
+                updated,
+                metric_window=metric_window,
+                promotion_decision=promotion_decision,
+                reason_codes=activity_reason_codes,
             )
-            observed.update(
-                {
-                    "runtime_window_certificate_rejected": True,
-                    "runtime_window_rejection_reasons": activity_reason_codes,
-                    "metric_window_id": str(metric_window.id),
-                    "promotion_decision_id": str(promotion_decision.id),
-                    "metric_window_market_session_count": metric_window.market_session_count,
-                    "metric_window_decision_count": metric_window.decision_count,
-                    "metric_window_trade_count": metric_window.trade_count,
-                    "metric_window_order_count": metric_window.order_count,
-                    "metric_window_avg_abs_slippage_bps": metric_window.avg_abs_slippage_bps,
-                    "metric_window_post_cost_expectancy_bps": metric_window.post_cost_expectancy_bps,
-                }
-            )
-            prior_reasons = [
-                str(reason).strip()
-                for reason in cast(Sequence[object], updated.get("reasons") or [])
-                if str(reason).strip()
-            ]
-            updated["reasons"] = _normalize_reason_codes(
-                [*prior_reasons, *activity_reason_codes]
-            )
-            updated["informational_reasons"] = sorted(
-                {
-                    *[
-                        str(reason)
-                        for reason in cast(
-                            Sequence[object],
-                            updated.get("informational_reasons") or [],
-                        )
-                        if str(reason).strip()
-                    ],
-                    "runtime_window_certificate_rejected",
-                }
-            )
-            updated["observed"] = observed
             merged.append(updated)
             continue
 
@@ -1113,6 +1336,21 @@ def _merge_runtime_certificate_evidence(
             merged.append(updated)
             continue
         if _stage_rank(capital_stage) <= _stage_rank("shadow"):
+            merged.append(updated)
+            continue
+        runtime_ledger_reason_codes = _certificate_runtime_ledger_reason_codes(
+            evidence_row=row,
+            runtime_item=updated,
+            metric_window=metric_window,
+            promotion_decision=promotion_decision,
+        )
+        if runtime_ledger_reason_codes:
+            updated = _mark_runtime_certificate_rejected(
+                updated,
+                metric_window=metric_window,
+                promotion_decision=promotion_decision,
+                reason_codes=runtime_ledger_reason_codes,
+            )
             merged.append(updated)
             continue
 
@@ -1296,7 +1534,7 @@ def _evaluate_certificate_candidates(
             continue
         manifest = cast(Mapping[str, Any], manifests.get(hypothesis_id) or {})
         runtime_item = cast(
-            Mapping[str, Any], runtime_by_hypothesis.get(hypothesis_id) or {}
+            Mapping[str, object], runtime_by_hypothesis.get(hypothesis_id) or {}
         )
         metric_window = cast(
             StrategyHypothesisMetricWindow | None, row.get("metric_window")
@@ -1333,6 +1571,18 @@ def _evaluate_certificate_candidates(
             if _safe_text(metric_window.dependency_quorum_decision) != "allow":
                 reasons.append("hypothesis_window_dependency_quorum_not_allow")
             reasons.extend(_metric_window_activity_reason_codes(metric_window))
+            if (
+                _safe_text(getattr(metric_window, "observed_stage", None)) == "live"
+                and promotion_decision is not None
+            ):
+                reasons.extend(
+                    _certificate_runtime_ledger_reason_codes(
+                        evidence_row=row,
+                        runtime_item=runtime_item,
+                        metric_window=metric_window,
+                        promotion_decision=promotion_decision,
+                    )
+                )
 
         if promotion_decision is None:
             reasons.append("promotion_decision_evidence_missing")

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from types import SimpleNamespace
 from unittest import TestCase
@@ -28,6 +28,7 @@ from app.trading.hypotheses import JangarDependencyQuorumStatus
 from app.trading.submission_council import (
     _QUANT_HEALTH_CACHE,
     _coerce_aware_datetime,
+    _load_latest_certificate_evidence,
     _load_latest_runtime_ledger_summary,
     _load_profit_promotion_table_counts,
     _merge_runtime_certificate_evidence,
@@ -119,11 +120,17 @@ class TestSubmissionCouncil(TestCase):
         self,
         capital_stage: str = "0.10x canary",
         observed_stage: str | None = "live",
+        *,
+        run_id: str = "runtime-proof-1",
+        candidate_id: str = "cand-1",
+        hypothesis_id: str = "H-CONT-01",
     ) -> SimpleNamespace:
         observed_at = datetime.now(timezone.utc)
         payload = {
             "id": "window-1",
-            "candidate_id": "cand-1",
+            "run_id": run_id,
+            "candidate_id": candidate_id,
+            "hypothesis_id": hypothesis_id,
             "capital_stage": capital_stage,
             "window_ended_at": observed_at,
             "created_at": observed_at,
@@ -154,17 +161,154 @@ class TestSubmissionCouncil(TestCase):
         self,
         capital_stage: str = "0.10x canary",
         *,
+        run_id: str = "runtime-proof-1",
+        candidate_id: str = "cand-1",
+        hypothesis_id: str = "H-CONT-01",
         allowed: bool = True,
         reason_summary: str | None = None,
         payload_json: dict[str, object] | None = None,
     ) -> SimpleNamespace:
         return SimpleNamespace(
             id="promo-1",
-            candidate_id="cand-1",
+            run_id=run_id,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+            promotion_target="live",
             state=capital_stage,
             allowed=allowed,
             reason_summary=reason_summary,
             payload_json=payload_json,
+        )
+
+    def _runtime_ledger_bucket_payload(
+        self,
+        *,
+        run_id: str = "runtime-proof-1",
+        candidate_id: str = "cand-1",
+        hypothesis_id: str = "H-CONT-01",
+        observed_stage: str = "live",
+        strategy_family: str = "intraday_continuation",
+    ) -> dict[str, object]:
+        return {
+            "run_id": run_id,
+            "candidate_id": candidate_id,
+            "hypothesis_id": hypothesis_id,
+            "observed_stage": observed_stage,
+            "bucket_started_at": datetime.now(timezone.utc).isoformat(),
+            "bucket_ended_at": datetime.now(timezone.utc).isoformat(),
+            "account_label": "paper",
+            "runtime_strategy_name": "intraday-continuation-runtime",
+            "strategy_family": strategy_family,
+            "fill_count": 42,
+            "decision_count": 42,
+            "submitted_order_count": 42,
+            "cancelled_order_count": 0,
+            "rejected_order_count": 0,
+            "unfilled_order_count": 0,
+            "closed_trade_count": 6,
+            "open_position_count": 0,
+            "filled_notional": "50000",
+            "gross_strategy_pnl": "75",
+            "cost_amount": "15",
+            "net_strategy_pnl_after_costs": "60",
+            "post_cost_expectancy_bps": "12",
+            "ledger_schema_version": "torghut.runtime-ledger-bucket.v1",
+            "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
+            "execution_policy_hash_counts": {"policy": 42},
+            "cost_model_hash_counts": {"cost": 42},
+            "lineage_hash_counts": {"lineage": 42},
+            "blockers": [],
+        }
+
+    def _runtime_ledger_observed(
+        self,
+        *,
+        run_id: str = "runtime-proof-1",
+        candidate_id: str = "cand-1",
+        hypothesis_id: str = "H-CONT-01",
+        observed_stage: str = "live",
+        strategy_family: str = "intraday_continuation",
+    ) -> dict[str, object]:
+        payload = self._runtime_ledger_bucket_payload(
+            run_id=run_id,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+            observed_stage=observed_stage,
+            strategy_family=strategy_family,
+        )
+        return {
+            "runtime_ledger_proof_present": True,
+            "runtime_ledger_candidate_id": payload["candidate_id"],
+            "runtime_ledger_observed_stage": payload["observed_stage"],
+            "runtime_ledger_runtime_strategy_name": payload["runtime_strategy_name"],
+            "runtime_ledger_strategy_family": payload["strategy_family"],
+            "runtime_ledger_fill_count": payload["fill_count"],
+            "runtime_ledger_submitted_order_count": payload["submitted_order_count"],
+            "runtime_ledger_closed_trade_count": payload["closed_trade_count"],
+            "runtime_ledger_open_position_count": payload["open_position_count"],
+            "runtime_ledger_filled_notional": payload["filled_notional"],
+            "runtime_ledger_net_strategy_pnl_after_costs": payload[
+                "net_strategy_pnl_after_costs"
+            ],
+            "runtime_ledger_post_cost_expectancy_bps": payload[
+                "post_cost_expectancy_bps"
+            ],
+            "runtime_ledger_blockers": payload["blockers"],
+            "runtime_ledger_execution_policy_hash_count": 42,
+            "runtime_ledger_cost_model_hash_count": 42,
+            "runtime_ledger_lineage_hash_count": 42,
+            "runtime_ledger_schema_version": payload["ledger_schema_version"],
+            "runtime_ledger_pnl_basis": payload["pnl_basis"],
+        }
+
+    def _runtime_ledger_bucket_row(
+        self,
+        *,
+        run_id: str = "runtime-proof-1",
+        candidate_id: str = "cand-1",
+        hypothesis_id: str = "H-CONT-01",
+        observed_stage: str = "live",
+        strategy_family: str = "intraday_continuation",
+        bucket_at: datetime | None = None,
+    ) -> StrategyRuntimeLedgerBucket:
+        payload = self._runtime_ledger_bucket_payload(
+            run_id=run_id,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+            observed_stage=observed_stage,
+            strategy_family=strategy_family,
+        )
+        observed_at = bucket_at or datetime.now(timezone.utc)
+        return StrategyRuntimeLedgerBucket(
+            run_id=run_id,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+            observed_stage=observed_stage,
+            bucket_started_at=observed_at,
+            bucket_ended_at=observed_at,
+            account_label="paper",
+            runtime_strategy_name=str(payload["runtime_strategy_name"]),
+            strategy_family=strategy_family,
+            fill_count=42,
+            decision_count=42,
+            submitted_order_count=42,
+            cancelled_order_count=0,
+            rejected_order_count=0,
+            unfilled_order_count=0,
+            closed_trade_count=6,
+            open_position_count=0,
+            filled_notional=Decimal("50000"),
+            gross_strategy_pnl=Decimal("75"),
+            cost_amount=Decimal("15"),
+            net_strategy_pnl_after_costs=Decimal("60"),
+            post_cost_expectancy_bps=Decimal("12"),
+            ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+            pnl_basis="realized_strategy_pnl_after_explicit_costs",
+            execution_policy_hash_counts={"policy": 42},
+            cost_model_hash_counts={"cost": 42},
+            lineage_hash_counts={"lineage": 42},
+            blockers_json=[],
+            payload_json=payload,
         )
 
     def _healthy_quant_status(self) -> dict[str, object]:
@@ -622,6 +766,221 @@ class TestSubmissionCouncil(TestCase):
                     expected_reasons.append("promotion_decision_not_allowed")
                 self.assertEqual(result[0]["reasons"], expected_reasons)
 
+    def test_runtime_certificate_merge_blocks_live_certificate_without_runtime_ledger(
+        self,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        result = _merge_runtime_certificate_evidence(
+            [
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "candidate_id": None,
+                    "strategy_family": "intraday_continuation",
+                    "capital_stage": "shadow",
+                    "capital_multiplier": "0",
+                    "promotion_eligible": False,
+                    "rollback_required": False,
+                    "reasons": ["drift_checks_missing"],
+                    "informational_reasons": [],
+                    "observed": {},
+                }
+            ],
+            evidence=[
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "metric_window": self._metric_window(
+                        run_id="runtime-proof-missing-ledger",
+                        candidate_id="cand-runtime",
+                    ),
+                    "promotion_decision": self._promotion_decision(
+                        run_id="runtime-proof-missing-ledger",
+                        candidate_id="cand-runtime",
+                    ),
+                }
+            ],
+            now=now,
+            max_age_seconds=3600,
+        )
+
+        self.assertFalse(result[0]["promotion_eligible"])
+        self.assertEqual(result[0]["capital_stage"], "shadow")
+        self.assertEqual(
+            result[0]["reasons"],
+            ["drift_checks_missing", "runtime_ledger_proof_missing"],
+        )
+        self.assertEqual(
+            result[0]["observed"]["runtime_window_rejection_reasons"],
+            ["runtime_ledger_proof_missing"],
+        )
+
+    def test_runtime_certificate_merge_accepts_runtime_item_ledger_observed_fallback(
+        self,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        result = _merge_runtime_certificate_evidence(
+            [
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "candidate_id": "cand-1",
+                    "strategy_family": "intraday_continuation",
+                    "capital_stage": "shadow",
+                    "capital_multiplier": "0",
+                    "promotion_eligible": False,
+                    "rollback_required": False,
+                    "reasons": ["drift_checks_missing"],
+                    "informational_reasons": [],
+                    "observed": self._runtime_ledger_observed(),
+                }
+            ],
+            evidence=[
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "metric_window": self._metric_window(),
+                    "promotion_decision": self._promotion_decision(),
+                }
+            ],
+            now=now,
+            max_age_seconds=3600,
+        )
+
+        self.assertTrue(result[0]["promotion_eligible"])
+        self.assertEqual(result[0]["capital_stage"], "0.10x canary")
+        self.assertEqual(result[0]["reasons"], [])
+        self.assertTrue(result[0]["observed"]["runtime_window_certificate_applied"])
+        self.assertEqual(
+            result[0]["informational_reasons"],
+            ["runtime_window_certificate_applied"],
+        )
+
+    def test_runtime_certificate_merge_rejects_invalid_runtime_ledger_payloads(
+        self,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        base_item = {
+            "hypothesis_id": "H-CONT-01",
+            "candidate_id": None,
+            "strategy_family": "intraday_continuation",
+            "capital_stage": "shadow",
+            "capital_multiplier": "0",
+            "promotion_eligible": False,
+            "rollback_required": False,
+            "reasons": ["drift_checks_missing"],
+            "informational_reasons": [],
+            "observed": {},
+        }
+        drop = object()
+        scenarios: list[tuple[str, dict[str, object], tuple[str, ...]]] = [
+            (
+                "hypothesis mismatch",
+                {"hypothesis_id": "H-OTHER"},
+                ("runtime_ledger_hypothesis_mismatch",),
+            ),
+            (
+                "run mismatch",
+                {"run_id": "runtime-proof-other"},
+                ("runtime_ledger_run_id_mismatch",),
+            ),
+            (
+                "candidate missing",
+                {"candidate_id": drop},
+                ("runtime_ledger_candidate_missing",),
+            ),
+            (
+                "candidate mismatch",
+                {"candidate_id": "cand-other"},
+                ("runtime_ledger_candidate_mismatch",),
+            ),
+            (
+                "stage not live",
+                {"observed_stage": "paper"},
+                ("runtime_ledger_stage_not_live",),
+            ),
+            (
+                "family mismatch",
+                {"strategy_family": "mean_reversion"},
+                ("runtime_ledger_strategy_family_mismatch",),
+            ),
+            (
+                "pnl basis missing",
+                {"pnl_basis": drop},
+                ("runtime_ledger_pnl_basis_missing",),
+            ),
+            (
+                "filled notional missing",
+                {"filled_notional": "0"},
+                ("runtime_ledger_filled_notional_missing",),
+            ),
+            (
+                "expectancy missing",
+                {"post_cost_expectancy_bps": drop},
+                ("runtime_ledger_expectancy_missing",),
+            ),
+            (
+                "expectancy nonpositive",
+                {"post_cost_expectancy_bps": "0"},
+                ("post_cost_expectancy_non_positive",),
+            ),
+            (
+                "closed trades missing",
+                {"closed_trade_count": 0},
+                ("runtime_ledger_closed_trades_missing",),
+            ),
+            ("open position", {"open_position_count": 1}, ("unclosed_position",)),
+            (
+                "orders missing",
+                {"submitted_order_count": 0},
+                ("runtime_order_lifecycle_missing",),
+            ),
+            (
+                "orders below metric",
+                {"submitted_order_count": 1},
+                ("runtime_ledger_submitted_order_count_mismatch",),
+            ),
+            (
+                "hash counts missing",
+                {
+                    "execution_policy_hash_counts": drop,
+                    "cost_model_hash_counts": drop,
+                    "lineage_hash_counts": drop,
+                },
+                (
+                    "runtime_ledger_execution_policy_hash_missing",
+                    "runtime_ledger_cost_model_hash_missing",
+                    "runtime_ledger_lineage_hash_missing",
+                ),
+            ),
+        ]
+
+        for label, updates, expected_reasons in scenarios:
+            with self.subTest(label=label):
+                payload = self._runtime_ledger_bucket_payload()
+                for key, value in updates.items():
+                    if value is drop:
+                        payload.pop(key, None)
+                    else:
+                        payload[key] = value
+                result = _merge_runtime_certificate_evidence(
+                    [dict(base_item)],
+                    evidence=[
+                        {
+                            "hypothesis_id": "H-CONT-01",
+                            "metric_window": self._metric_window(),
+                            "promotion_decision": self._promotion_decision(),
+                            "runtime_ledger_bucket": payload,
+                        }
+                    ],
+                    now=now,
+                    max_age_seconds=3600,
+                )
+
+                self.assertFalse(result[0]["promotion_eligible"])
+                self.assertEqual(result[0]["capital_stage"], "shadow")
+                rejection_reasons = result[0]["observed"][
+                    "runtime_window_rejection_reasons"
+                ]
+                for reason in expected_reasons:
+                    self.assertIn(reason, rejection_reasons)
+
     def test_hypothesis_runtime_summary_uses_fresh_imported_runtime_proof(
         self,
     ) -> None:
@@ -700,6 +1059,14 @@ class TestSubmissionCouncil(TestCase):
                     reason_summary="runtime_evidence_thresholds_satisfied",
                 )
             )
+            session.add(
+                self._runtime_ledger_bucket_row(
+                    run_id="runtime-proof-1",
+                    candidate_id="cand-runtime",
+                    hypothesis_id="H-CONT-01",
+                    bucket_at=now,
+                )
+            )
             session.commit()
 
             with (
@@ -746,6 +1113,88 @@ class TestSubmissionCouncil(TestCase):
             item["informational_reasons"],
             ["runtime_window_certificate_applied"],
         )
+
+    def test_load_latest_certificate_evidence_skips_mismatched_runtime_ledger_bucket(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        now = datetime.now(timezone.utc)
+
+        with session_local() as session:
+            session.add(
+                StrategyHypothesisMetricWindow(
+                    run_id="runtime-proof-1",
+                    candidate_id="cand-runtime",
+                    hypothesis_id="H-CONT-01",
+                    observed_stage="live",
+                    window_started_at=now,
+                    window_ended_at=now,
+                    market_session_count=3,
+                    decision_count=42,
+                    trade_count=42,
+                    order_count=42,
+                    avg_abs_slippage_bps="4.2",
+                    slippage_budget_bps="12",
+                    post_cost_expectancy_bps="8.5",
+                    continuity_ok=True,
+                    drift_ok=True,
+                    dependency_quorum_decision="allow",
+                    capital_stage="0.10x canary",
+                    payload_json={
+                        "post_cost_promotion_sample_count": 42,
+                        "post_cost_basis_counts": {
+                            "realized_strategy_pnl_after_explicit_costs": 42
+                        },
+                        "post_cost_expectancy_aggregation": "runtime_ledger_notional_weighted",
+                        "runtime_ledger_notional_weighted_sample_count": 42,
+                    },
+                )
+            )
+            session.add(
+                StrategyPromotionDecision(
+                    run_id="runtime-proof-1",
+                    candidate_id="cand-runtime",
+                    hypothesis_id="H-CONT-01",
+                    promotion_target="live",
+                    state="0.10x canary",
+                    allowed=True,
+                    reason_summary="runtime_evidence_thresholds_satisfied",
+                )
+            )
+            session.add(
+                self._runtime_ledger_bucket_row(
+                    run_id="runtime-proof-wrong",
+                    candidate_id="cand-runtime",
+                    hypothesis_id="H-CONT-01",
+                    bucket_at=now + timedelta(seconds=1),
+                )
+            )
+            session.add(
+                self._runtime_ledger_bucket_row(
+                    run_id="runtime-proof-1",
+                    candidate_id="cand-runtime",
+                    hypothesis_id="H-CONT-01",
+                    bucket_at=now,
+                )
+            )
+            session.commit()
+
+            evidence = _load_latest_certificate_evidence(
+                session,
+                hypothesis_ids=["H-CONT-01"],
+            )
+
+        self.assertEqual(len(evidence), 1)
+        runtime_ledger_bucket = evidence[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(runtime_ledger_bucket, dict)
+        self.assertEqual(runtime_ledger_bucket["run_id"], "runtime-proof-1")
 
     def test_hypothesis_runtime_summary_counts_allowed_paper_runtime_readiness_without_capital_promotion(
         self,
@@ -2035,12 +2484,24 @@ class TestSubmissionCouncil(TestCase):
             ),
             hypothesis_summary={
                 "promotion_eligible_total": 1,
-                "capital_stage_totals": {"shadow": 1},
+                "capital_stage_totals": {"0.10x canary": 1},
                 "dependency_quorum": {
                     "decision": "allow",
                     "reasons": [],
                     "message": "ready",
                 },
+                "items": [
+                    {
+                        "hypothesis_id": "H-CONT-01",
+                        "candidate_id": "cand-1",
+                        "lane_id": "continuation",
+                        "strategy_family": "intraday_continuation",
+                        "promotion_eligible": True,
+                        "capital_stage": "0.10x canary",
+                        "reasons": [],
+                        "observed": self._runtime_ledger_observed(),
+                    }
+                ],
             },
             empirical_jobs_status={"ready": True, "status": "healthy"},
             quant_health_status=self._healthy_quant_status(),
@@ -2049,6 +2510,7 @@ class TestSubmissionCouncil(TestCase):
                     "hypothesis_id": "H-CONT-01",
                     "metric_window": self._metric_window(),
                     "promotion_decision": self._promotion_decision(),
+                    "runtime_ledger_bucket": self._runtime_ledger_bucket_payload(),
                 }
             ],
         )

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -23,6 +23,7 @@ from app.models import (
     StrategyHypothesis,
     StrategyHypothesisMetricWindow,
     StrategyPromotionDecision,
+    StrategyRuntimeLedgerBucket,
     TradeDecision,
     VNextDatasetSnapshot,
 )
@@ -1343,6 +1344,67 @@ class TestTradingPipeline(TestCase):
             "runtime_ledger_notional_weighted_sample_count": sample_count,
         }
 
+    def _runtime_ledger_bucket(
+        self,
+        *,
+        run_id: str = "run-1",
+        candidate_id: str = "cand-1",
+        hypothesis_id: str = "H-CONT-01",
+        observed_stage: str = "live",
+        strategy_family: str = "demo",
+        post_cost_expectancy_bps: Decimal = Decimal("2.5"),
+        bucket_at: datetime | None = None,
+    ) -> StrategyRuntimeLedgerBucket:
+        observed_at = bucket_at or datetime.now(timezone.utc)
+        return StrategyRuntimeLedgerBucket(
+            run_id=run_id,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+            observed_stage=observed_stage,
+            bucket_started_at=observed_at - timedelta(minutes=15),
+            bucket_ended_at=observed_at,
+            account_label="live",
+            runtime_strategy_name=f"runtime-{candidate_id}",
+            strategy_family=strategy_family,
+            fill_count=1,
+            decision_count=1,
+            submitted_order_count=1,
+            cancelled_order_count=0,
+            rejected_order_count=0,
+            unfilled_order_count=0,
+            closed_trade_count=1,
+            open_position_count=0,
+            filled_notional=Decimal("10000"),
+            gross_strategy_pnl=Decimal("3.0"),
+            cost_amount=Decimal("0.5"),
+            net_strategy_pnl_after_costs=Decimal("2.5"),
+            post_cost_expectancy_bps=post_cost_expectancy_bps,
+            ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+            pnl_basis="realized_strategy_pnl_after_explicit_costs",
+            execution_policy_hash_counts={"policy": 1},
+            cost_model_hash_counts={"cost": 1},
+            lineage_hash_counts={"lineage": 1},
+            blockers_json=[],
+            payload_json={
+                "run_id": run_id,
+                "candidate_id": candidate_id,
+                "hypothesis_id": hypothesis_id,
+                "observed_stage": observed_stage,
+                "strategy_family": strategy_family,
+                "submitted_order_count": 1,
+                "closed_trade_count": 1,
+                "open_position_count": 0,
+                "filled_notional": "10000",
+                "net_strategy_pnl_after_costs": "2.5",
+                "post_cost_expectancy_bps": str(post_cost_expectancy_bps),
+                "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
+                "execution_policy_hash_counts": {"policy": 1},
+                "cost_model_hash_counts": {"cost": 1},
+                "lineage_hash_counts": {"lineage": 1},
+                "blockers": [],
+            },
+        )
+
     def _seed_promotion_certificate_evidence(
         self,
         *,
@@ -1387,6 +1449,16 @@ class TestTradingPipeline(TestCase):
                     state=capital_stage,
                     allowed=True,
                     reason_summary="ready",
+                )
+            )
+            session.add(
+                self._runtime_ledger_bucket(
+                    run_id="run-1",
+                    candidate_id=candidate_id,
+                    hypothesis_id=hypothesis_id,
+                    strategy_family=strategy_family,
+                    post_cost_expectancy_bps=post_cost_expectancy_bps,
+                    bucket_at=evidence_at,
                 )
             )
             session.add(
@@ -5000,6 +5072,16 @@ class TestTradingPipeline(TestCase):
                         state="0.10x canary",
                         allowed=True,
                         reason_summary="ready",
+                    )
+                )
+                session.add(
+                    self._runtime_ledger_bucket(
+                        run_id="run-1",
+                        candidate_id="cand-1",
+                        hypothesis_id="H-CONT-01",
+                        strategy_family="live-canary-eligible",
+                        post_cost_expectancy_bps=Decimal("2.5"),
+                        bucket_at=evidence_at,
                     )
                 )
                 session.add(


### PR DESCRIPTION
## Summary

- Require live promotion certificates to have matching runtime-ledger bucket proof before they can clear blockers or mark a hypothesis promotion eligible.
- Attach the matching ledger bucket to certificate evidence loaded from the database and validate candidate, run, stage, lifecycle, PnL basis, filled notional, closed trades, open positions, and lineage/cost/policy hash presence.
- Add regression coverage for certificate-only live promotion rejection and the durable-ledger-backed allowed path.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen pytest tests/test_submission_council.py -q`
- `uv run --frozen pytest tests/test_hypotheses.py tests/test_submission_council.py -k runtime_ledger -q`
- `uv run --frozen pytest tests/test_submission_council.py tests/test_hypotheses.py -k 'runtime_ledger or certificate' -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py::TestTradingPipeline::test_live_submission_allows_autonomy_eligible_canary_without_static_flag tests/test_trading_pipeline.py::TestTradingPipeline::test_pipeline_llm_disabled_keeps_live_submission_operational tests/test_trading_pipeline.py::TestTradingPipeline::test_pipeline_llm_dspy_live_runtime_gate_can_pass_through_with_degraded_qty tests/test_trading_pipeline.py::TestTradingPipeline::test_pipeline_llm_shadow_bootstrap_artifact_keeps_live_submission_operational tests/test_trading_pipeline.py::TestTradingPipeline::test_pipeline_llm_failure_fallbacks tests/test_trading_pipeline.py::TestTradingPipeline::test_pipeline_llm_dspy_runtime_reduced_sell_uses_seeded_simulation_inventory -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
