### PR TITLE
chore(torghut): promote image 805fd8e6

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-525-g57d60457e
+              value: v0.571.1-528-g805fd8e60
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 57d60457e407a9fdef9d03828e75d6108d90ae7b
+              value: 805fd8e603bf4ba0649f2261db8a0253d6b47bf8
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-525-g57d60457e
+              value: v0.571.1-528-g805fd8e60
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 57d60457e407a9fdef9d03828e75d6108d90ae7b
+              value: 805fd8e603bf4ba0649f2261db8a0253d6b47bf8
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -75,7 +75,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+                  value: sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-22T08:58:55Z"
+        client.knative.dev/updateTimestamp: "2026-05-22T09:18:29Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
           ports:
             - name: http1
               containerPort: 8181
@@ -499,11 +499,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-525-g57d60457e
+              value: v0.571.1-528-g805fd8e60
             - name: TORGHUT_COMMIT
-              value: 57d60457e407a9fdef9d03828e75d6108d90ae7b
+              value: 805fd8e603bf4ba0649f2261db8a0253d6b47bf8
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+              value: sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-22T08:58:55Z"
+        client.knative.dev/updateTimestamp: "2026-05-22T09:18:29Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
           ports:
             - name: http1
               containerPort: 8181
@@ -320,11 +320,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-525-g57d60457e
+              value: v0.571.1-528-g805fd8e60
             - name: TORGHUT_COMMIT
-              value: 57d60457e407a9fdef9d03828e75d6108d90ae7b
+              value: 805fd8e603bf4ba0649f2261db8a0253d6b47bf8
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+              value: sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -132,7 +132,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:42e45ed0fd5eda532772fe702f2cc4db9ecd1ac247e1610ad8251379108b779c
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `805fd8e603bf4ba0649f2261db8a0253d6b47bf8`
- Image tag: `805fd8e6`
- Image digest: `sha256:5c82f41c565536642876e9ab51f61de67f100bb40f4b5f5c23db2330075342b1`