### PR TITLE
fix(torghut): fail closed on incomplete replay tape coverage

### DIFF
--- a/services/torghut/app/trading/discovery/dataset_snapshot.py
+++ b/services/torghut/app/trading/discovery/dataset_snapshot.py
@@ -404,10 +404,13 @@ def ensure_fresh_snapshot(
 ) -> None:
     if receipt.is_fresh or allow_stale_tape:
         return
+    missing_days = ",".join(item.isoformat() for item in receipt.missing_days)
+    missing_suffix = f":missing_days={missing_days}" if missing_days else ""
     raise ValueError(
         "stale_tape:"
         f"expected_last_trading_day={receipt.expected_last_trading_day.isoformat()}:"
         f"end_day={receipt.end_day.isoformat()}"
+        f"{missing_suffix}"
     )
 
 

--- a/services/torghut/app/trading/discovery/replay_tape.py
+++ b/services/torghut/app/trading/discovery/replay_tape.py
@@ -6,8 +6,8 @@ import gzip
 import hashlib
 import json
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass
-from datetime import date, datetime, time, timezone
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, TextIO, cast
@@ -20,6 +20,14 @@ _DECIMAL_TAG = "__torghut_decimal__"
 _DATETIME_TAG = "__torghut_datetime__"
 _REGULAR_OPEN_UTC = time(hour=13, minute=30)
 _REGULAR_CLOSE_UTC = time(hour=20, minute=0)
+
+
+def _empty_row_count_by_trading_day() -> dict[str, int]:
+    return {}
+
+
+def _empty_row_count_by_symbol_trading_day() -> dict[str, dict[str, int]]:
+    return {}
 
 
 @dataclass(frozen=True)
@@ -41,6 +49,16 @@ class ReplayTapeManifest:
     artifact_refs: Mapping[str, str]
     source_table_versions: Mapping[str, str]
     created_at: datetime
+    requested_trading_days: tuple[date, ...] = ()
+    observed_trading_days: tuple[date, ...] = ()
+    missing_trading_days: tuple[date, ...] = ()
+    row_count_by_trading_day: Mapping[str, int] = field(
+        default_factory=_empty_row_count_by_trading_day
+    )
+    missing_symbol_trading_days: tuple[str, ...] = ()
+    row_count_by_symbol_trading_day: Mapping[str, Mapping[str, int]] = field(
+        default_factory=_empty_row_count_by_symbol_trading_day
+    )
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -65,6 +83,25 @@ class ReplayTapeManifest:
             "artifact_refs": dict(self.artifact_refs),
             "source_table_versions": dict(self.source_table_versions),
             "created_at": self.created_at.isoformat(),
+            "requested_trading_days": [
+                item.isoformat() for item in self.requested_trading_days
+            ],
+            "observed_trading_days": [
+                item.isoformat() for item in self.observed_trading_days
+            ],
+            "missing_trading_days": [
+                item.isoformat() for item in self.missing_trading_days
+            ],
+            "row_count_by_trading_day": dict(self.row_count_by_trading_day),
+            "missing_symbol_trading_days": list(self.missing_symbol_trading_days),
+            "row_count_by_symbol_trading_day": {
+                symbol: dict(days)
+                for symbol, days in self.row_count_by_symbol_trading_day.items()
+            },
+            "coverage_status": _coverage_status(
+                missing_trading_days=self.missing_trading_days,
+                missing_symbol_trading_days=self.missing_symbol_trading_days,
+            ),
         }
 
     @classmethod
@@ -98,6 +135,18 @@ class ReplayTapeManifest:
             artifact_refs=_string_mapping(payload.get("artifact_refs")),
             source_table_versions=_string_mapping(payload.get("source_table_versions")),
             created_at=_parse_datetime(str(payload["created_at"])),
+            requested_trading_days=_date_tuple(payload.get("requested_trading_days")),
+            observed_trading_days=_date_tuple(payload.get("observed_trading_days")),
+            missing_trading_days=_date_tuple(payload.get("missing_trading_days")),
+            row_count_by_trading_day=_int_mapping(
+                payload.get("row_count_by_trading_day")
+            ),
+            missing_symbol_trading_days=_string_tuple(
+                payload.get("missing_symbol_trading_days")
+            ),
+            row_count_by_symbol_trading_day=_nested_int_mapping(
+                payload.get("row_count_by_symbol_trading_day")
+            ),
         )
 
 
@@ -133,8 +182,34 @@ def materialize_signal_tape(
     source_table_versions: Mapping[str, str] | None = None,
     artifact_refs: Mapping[str, str] | None = None,
     created_at: datetime | None = None,
+    require_complete_coverage: bool = False,
 ) -> ReplayTapeManifest:
     ordered_rows = tuple(sorted(rows, key=_signal_sort_key))
+    normalized_symbols = _normalize_symbols(symbols)
+    event_dates = {row.event_ts.astimezone(timezone.utc).date() for row in ordered_rows}
+    event_times = tuple(row.event_ts.astimezone(timezone.utc) for row in ordered_rows)
+    requested_trading_days = _business_days(start_date, end_date)
+    observed_trading_days = tuple(sorted(event_dates))
+    missing_trading_days = tuple(
+        day for day in requested_trading_days if day not in event_dates
+    )
+    row_count_by_symbol_trading_day = _row_count_by_symbol_trading_day(ordered_rows)
+    missing_symbol_trading_days = _missing_symbol_trading_days(
+        row_count_by_symbol_trading_day=row_count_by_symbol_trading_day,
+        requested_symbols=normalized_symbols,
+        requested_trading_days=requested_trading_days,
+        observed_trading_days=observed_trading_days,
+    )
+    if require_complete_coverage and (
+        missing_trading_days or missing_symbol_trading_days
+    ):
+        raise ValueError(
+            _incomplete_coverage_reason(
+                missing_trading_days=missing_trading_days,
+                missing_symbol_trading_days=missing_symbol_trading_days,
+            )
+        )
+
     tape_path.parent.mkdir(parents=True, exist_ok=True)
     manifest_ref = manifest_path or default_manifest_path(tape_path)
     manifest_ref.parent.mkdir(parents=True, exist_ok=True)
@@ -147,8 +222,10 @@ def materialize_signal_tape(
             content_hash.update(b"\n")
             handle.write(f"{line}\n")
 
-    event_dates = {row.event_ts.astimezone(timezone.utc).date() for row in ordered_rows}
-    event_times = tuple(row.event_ts.astimezone(timezone.utc) for row in ordered_rows)
+    row_count_by_trading_day: dict[str, int] = {}
+    for row in ordered_rows:
+        key = row.event_ts.astimezone(timezone.utc).date().isoformat()
+        row_count_by_trading_day[key] = row_count_by_trading_day.get(key, 0) + 1
     start_ts = datetime.combine(start_date, _REGULAR_OPEN_UTC, tzinfo=timezone.utc)
     end_ts = datetime.combine(end_date, _REGULAR_CLOSE_UTC, tzinfo=timezone.utc)
     resolved_artifact_refs = {
@@ -158,7 +235,7 @@ def materialize_signal_tape(
     manifest = ReplayTapeManifest(
         schema_version=REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
         dataset_snapshot_ref=dataset_snapshot_ref,
-        symbols=_normalize_symbols(symbols),
+        symbols=normalized_symbols,
         row_symbols=tuple(sorted({row.symbol.upper() for row in ordered_rows})),
         start_date=start_date,
         end_date=end_date,
@@ -173,6 +250,12 @@ def materialize_signal_tape(
         artifact_refs=resolved_artifact_refs,
         source_table_versions=dict(source_table_versions or {}),
         created_at=created_at or datetime.now(timezone.utc),
+        requested_trading_days=requested_trading_days,
+        observed_trading_days=observed_trading_days,
+        missing_trading_days=missing_trading_days,
+        row_count_by_trading_day=row_count_by_trading_day,
+        missing_symbol_trading_days=missing_symbol_trading_days,
+        row_count_by_symbol_trading_day=row_count_by_symbol_trading_day,
     )
     manifest_ref.write_text(
         json.dumps(manifest.to_payload(), indent=2, sort_keys=True) + "\n",
@@ -234,6 +317,30 @@ def validate_tape_freshness(
         if missing:
             reasons.append(f"symbols_not_covered:{','.join(missing)}")
 
+    missing_trading_days = tuple(
+        day for day in manifest.missing_trading_days if start_date <= day <= end_date
+    )
+    if missing_trading_days:
+        reasons.append(
+            "trading_days_missing:"
+            + ",".join(day.isoformat() for day in missing_trading_days)
+        )
+
+    missing_symbol_trading_days = tuple(
+        entry
+        for entry in manifest.missing_symbol_trading_days
+        if _symbol_day_entry_in_window(
+            entry,
+            start_date=start_date,
+            end_date=end_date,
+            requested_symbols=requested_symbols,
+        )
+    )
+    if missing_symbol_trading_days:
+        reasons.append(
+            "symbol_trading_days_missing:" + ",".join(missing_symbol_trading_days)
+        )
+
     if reasons and not allow_stale_tape:
         raise ValueError(f"replay_tape_stale:{';'.join(reasons)}")
     return {
@@ -245,6 +352,25 @@ def validate_tape_freshness(
         "dataset_snapshot_ref": manifest.dataset_snapshot_ref,
         "row_count": manifest.row_count,
         "trading_day_count": manifest.trading_day_count,
+        "requested_trading_days": [
+            item.isoformat() for item in manifest.requested_trading_days
+        ],
+        "observed_trading_days": [
+            item.isoformat() for item in manifest.observed_trading_days
+        ],
+        "missing_trading_days": [
+            item.isoformat() for item in manifest.missing_trading_days
+        ],
+        "row_count_by_trading_day": dict(manifest.row_count_by_trading_day),
+        "missing_symbol_trading_days": list(manifest.missing_symbol_trading_days),
+        "row_count_by_symbol_trading_day": {
+            symbol: dict(days)
+            for symbol, days in manifest.row_count_by_symbol_trading_day.items()
+        },
+        "coverage_status": _coverage_status(
+            missing_trading_days=manifest.missing_trading_days,
+            missing_symbol_trading_days=manifest.missing_symbol_trading_days,
+        ),
     }
 
 
@@ -345,6 +471,123 @@ def _normalize_symbols(symbols: Sequence[str]) -> tuple[str, ...]:
     )
 
 
+def _business_days(start_day: date, end_day: date) -> tuple[date, ...]:
+    if start_day > end_day:
+        return ()
+    current = start_day
+    values: list[date] = []
+    while current <= end_day:
+        if current.weekday() < 5:
+            values.append(current)
+        current += timedelta(days=1)
+    return tuple(values)
+
+
+def _row_count_by_symbol_trading_day(
+    rows: Sequence[SignalEnvelope],
+) -> dict[str, dict[str, int]]:
+    counts: dict[str, dict[str, int]] = {}
+    for row in rows:
+        symbol = row.symbol.strip().upper()
+        if not symbol:
+            continue
+        day = row.event_ts.astimezone(timezone.utc).date().isoformat()
+        symbol_counts = counts.setdefault(symbol, {})
+        symbol_counts[day] = symbol_counts.get(day, 0) + 1
+    return counts
+
+
+def _missing_symbol_trading_days(
+    *,
+    row_count_by_symbol_trading_day: Mapping[str, Mapping[str, int]],
+    requested_symbols: Sequence[str],
+    requested_trading_days: Sequence[date],
+    observed_trading_days: Sequence[date],
+) -> tuple[str, ...]:
+    if not requested_symbols:
+        return ()
+    observed_days = set(observed_trading_days)
+    entries: list[str] = []
+    for symbol in requested_symbols:
+        symbol_counts = row_count_by_symbol_trading_day.get(symbol, {})
+        for day in requested_trading_days:
+            if day not in observed_days:
+                continue
+            if int(symbol_counts.get(day.isoformat()) or 0) <= 0:
+                entries.append(_symbol_day_entry(symbol=symbol, day=day))
+    return tuple(entries)
+
+
+def _symbol_day_entry(*, symbol: str, day: date) -> str:
+    return f"{symbol}:{day.isoformat()}"
+
+
+def _parse_symbol_day_entry(entry: str) -> tuple[str, date] | None:
+    symbol, sep, raw_day = entry.partition(":")
+    if not sep or not symbol:
+        return None
+    try:
+        parsed_day = date.fromisoformat(raw_day)
+    except ValueError:
+        return None
+    return symbol, parsed_day
+
+
+def _symbol_day_entry_in_window(
+    entry: str,
+    *,
+    start_date: date,
+    end_date: date,
+    requested_symbols: set[str],
+) -> bool:
+    parsed = _parse_symbol_day_entry(entry)
+    if parsed is None:
+        return False
+    symbol, day = parsed
+    if requested_symbols and symbol not in requested_symbols:
+        return False
+    return start_date <= day <= end_date
+
+
+def _coverage_status(
+    *,
+    missing_trading_days: Sequence[date],
+    missing_symbol_trading_days: Sequence[str],
+) -> str:
+    if missing_trading_days:
+        return "missing_days"
+    if missing_symbol_trading_days:
+        return "missing_symbol_days"
+    return "complete"
+
+
+def _incomplete_coverage_reason(
+    *,
+    missing_trading_days: Sequence[date],
+    missing_symbol_trading_days: Sequence[str],
+) -> str:
+    parts: list[str] = []
+    if missing_trading_days:
+        missing = ",".join(day.isoformat() for day in missing_trading_days)
+        parts.append(f"missing_days={missing}")
+    if missing_symbol_trading_days:
+        missing_symbols = ",".join(missing_symbol_trading_days)
+        parts.append(f"missing_symbol_days={missing_symbols}")
+    return "replay_tape_incomplete_coverage:" + ":".join(parts)
+
+
+def _date_tuple(value: Any) -> tuple[date, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return ()
+    parsed: list[date] = []
+    for item in cast(Sequence[object], value):
+        try:
+            parsed.append(date.fromisoformat(str(item)))
+        except ValueError:
+            continue
+    return tuple(parsed)
+
+
 def _string_tuple(value: Any) -> tuple[str, ...]:
     if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
         return ()
@@ -356,6 +599,27 @@ def _string_mapping(value: Any) -> Mapping[str, str]:
         return {}
     return {
         str(key): str(item)
+        for key, item in cast(Mapping[object, object], value).items()
+    }
+
+
+def _int_mapping(value: Any) -> Mapping[str, int]:
+    if not isinstance(value, Mapping):
+        return {}
+    parsed: dict[str, int] = {}
+    for key, item in cast(Mapping[object, object], value).items():
+        try:
+            parsed[str(key)] = int(str(item))
+        except (TypeError, ValueError):
+            continue
+    return parsed
+
+
+def _nested_int_mapping(value: Any) -> Mapping[str, Mapping[str, int]]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {
+        str(key): _int_mapping(item)
         for key, item in cast(Mapping[object, object], value).items()
     }
 

--- a/services/torghut/scripts/materialize_replay_tape.py
+++ b/services/torghut/scripts/materialize_replay_tape.py
@@ -86,6 +86,14 @@ def _parse_args() -> argparse.Namespace:
         help="Optional source table/version metadata, repeatable.",
     )
     parser.add_argument(
+        "--allow-incomplete-coverage",
+        action="store_true",
+        help=(
+            "Write the tape even when the requested business-day window has missing "
+            "signal rows. By default materialization fails closed."
+        ),
+    )
+    parser.add_argument(
         "--log-level",
         default=os.environ.get("TORGHUT_REPLAY_LOG_LEVEL", "INFO"),
     )
@@ -162,6 +170,7 @@ def main() -> int:
         end_date=end_date,
         source_query_digest=source_query_digest,
         source_table_versions=_parse_source_table_versions(args.source_table_version),
+        require_complete_coverage=not bool(args.allow_incomplete_coverage),
     )
     logger.info(
         "replay_tape_materialized output=%s manifest=%s rows=%s digest=%s",

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -729,6 +729,7 @@ def _maybe_materialize_run_replay_tape(
             full_window_start_date=full_window_start_date,
             full_window_end_date=full_window_end_date,
         ),
+        require_complete_coverage=not bool(getattr(args, "allow_stale_tape", False)),
     )
     signal_bundle_stats = existing_signal_bundle or write_mlx_signal_bundle(
         Path(bundle_paths["signal_rows_jsonl"]),

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -5903,6 +5903,7 @@ def _maybe_materialize_epoch_replay_tape(
         start_date=start_date,
         end_date=end_date,
         source_query_digest=source_query_digest,
+        require_complete_coverage=not bool(getattr(args, "allow_stale_tape", False)),
     )
     receipt_path = output_dir / "replay-tape-receipt.json"
     receipt = {

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -13,7 +13,7 @@ import sys
 import tempfile
 from collections import Counter, deque
 from dataclasses import dataclass
-from datetime import date, timezone
+from datetime import date, timedelta, timezone
 from decimal import Decimal, InvalidOperation, ROUND_CEILING
 from pathlib import Path
 from typing import Any, Callable, Iterable, Iterator, Mapping, Sequence, TypeAlias, cast
@@ -643,6 +643,37 @@ def _resolve_frontier_replay_windows(
         train_days=train_slice,
         holdout_days=holdout_slice,
         second_oos_days=second_slice,
+    )
+
+
+def _business_days(start_day: date, end_day: date) -> tuple[date, ...]:
+    if start_day > end_day:
+        return ()
+    current = start_day
+    values: list[date] = []
+    while current <= end_day:
+        if current.weekday() < 5:
+            values.append(current)
+        current += timedelta(days=1)
+    return tuple(values)
+
+
+def _snapshot_expected_days(
+    *,
+    window: FrontierReplayWindows,
+    full_window_start: date,
+    full_window_end: date,
+    require_full_window_coverage: bool,
+) -> tuple[date, ...]:
+    if not require_full_window_coverage:
+        return window.expected_days
+    return tuple(
+        sorted(
+            {
+                *window.expected_days,
+                *_business_days(full_window_start, full_window_end),
+            }
+        )
     )
 
 
@@ -1291,6 +1322,43 @@ def _build_replay_tape_snapshot_receipt(
                     "manifest_end_date": str(validation.get("manifest_end_date") or ""),
                     "row_count": int(validation.get("row_count") or 0),
                     "trading_day_count": int(validation.get("trading_day_count") or 0),
+                    "requested_trading_days": list(
+                        cast(
+                            Sequence[Any],
+                            validation.get("requested_trading_days") or [],
+                        )
+                    ),
+                    "observed_trading_days": list(
+                        cast(
+                            Sequence[Any],
+                            validation.get("observed_trading_days") or [],
+                        )
+                    ),
+                    "missing_trading_days": list(
+                        cast(
+                            Sequence[Any],
+                            validation.get("missing_trading_days") or [],
+                        )
+                    ),
+                    "row_count_by_trading_day": dict(
+                        cast(
+                            Mapping[str, Any],
+                            validation.get("row_count_by_trading_day") or {},
+                        )
+                    ),
+                    "missing_symbol_trading_days": list(
+                        cast(
+                            Sequence[Any],
+                            validation.get("missing_symbol_trading_days") or [],
+                        )
+                    ),
+                    "row_count_by_symbol_trading_day": dict(
+                        cast(
+                            Mapping[str, Any],
+                            validation.get("row_count_by_symbol_trading_day") or {},
+                        )
+                    ),
+                    "coverage_status": str(validation.get("coverage_status") or ""),
                     "source_table_versions": dict(
                         cast(
                             Mapping[str, Any],
@@ -3766,6 +3834,15 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         if str(args.expected_last_trading_day or "").strip()
         else (full_window_end if str(args.full_window_end_date or "").strip() else None)
     )
+    expected_snapshot_days = _snapshot_expected_days(
+        window=window,
+        full_window_start=full_window_start,
+        full_window_end=full_window_end,
+        require_full_window_coverage=bool(
+            str(args.full_window_start_date or "").strip()
+            or str(args.full_window_end_date or "").strip()
+        ),
+    )
     cached_rows: list[Any] | None = None
     replay_tape_validation: dict[str, Any] | None = None
     if loaded_replay_tape is not None:
@@ -3784,7 +3861,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
             start_day=full_window_start,
             end_day=full_window_end,
             expected_last_trading_day=expected_last_trading_day or full_window_end,
-            expected_trading_days=window.expected_days,
+            expected_trading_days=expected_snapshot_days,
             allow_stale_tape=bool(args.allow_stale_tape),
         )
     else:
@@ -3795,7 +3872,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
             start_day=full_window_start,
             end_day=full_window_end,
             expected_last_trading_day=expected_last_trading_day,
-            expected_trading_days=window.expected_days,
+            expected_trading_days=expected_snapshot_days,
             allow_stale_tape=bool(args.allow_stale_tape),
         )
     ensure_fresh_snapshot(

--- a/services/torghut/tests/test_discovery_harness_v2.py
+++ b/services/torghut/tests/test_discovery_harness_v2.py
@@ -222,7 +222,7 @@ class TestDiscoveryHarnessV2(TestCase):
             receipt.to_payload()["witnesses"][0]["payload"]["latest_observed_day"],
             "2026-04-04",
         )
-        with self.assertRaisesRegex(ValueError, "stale_tape"):
+        with self.assertRaisesRegex(ValueError, "stale_tape:.*missing_days=2026-04-07"):
             ensure_fresh_snapshot(receipt, allow_stale_tape=False)
 
     def test_dataset_snapshot_receipt_handles_empty_latest_days_and_override(

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -80,6 +80,30 @@ class TestReplayTape(TestCase):
             tape = load_replay_tape(tape_path)
 
         self.assertEqual(tape.manifest.row_count, 2)
+        self.assertEqual(
+            tape.manifest.requested_trading_days,
+            (date(2026, 3, 26), date(2026, 3, 27)),
+        )
+        self.assertEqual(
+            tape.manifest.observed_trading_days,
+            (date(2026, 3, 26), date(2026, 3, 27)),
+        )
+        self.assertEqual(tape.manifest.missing_trading_days, ())
+        self.assertEqual(
+            tape.manifest.row_count_by_trading_day,
+            {"2026-03-26": 1, "2026-03-27": 1},
+        )
+        self.assertEqual(
+            tape.manifest.missing_symbol_trading_days,
+            ("AAPL:2026-03-26", "META:2026-03-27"),
+        )
+        self.assertEqual(
+            tape.manifest.row_count_by_symbol_trading_day,
+            {
+                "AAPL": {"2026-03-27": 1},
+                "META": {"2026-03-26": 1},
+            },
+        )
         self.assertEqual([row.symbol for row in tape.rows], ["META", "AAPL"])
         self.assertEqual(tape.rows[0].payload["price"], Decimal("100.25"))
         self.assertEqual(tape.rows[0].payload["nested"]["label"], "keep-string")
@@ -164,6 +188,8 @@ class TestReplayTape(TestCase):
         self.assertEqual(manifest.artifact_refs, {})
         self.assertEqual(manifest.source_table_versions, {})
         self.assertEqual(manifest.start_ts.tzinfo, timezone.utc)
+        self.assertEqual(manifest.missing_symbol_trading_days, ())
+        self.assertEqual(manifest.row_count_by_symbol_trading_day, {})
 
     def test_load_replay_tape_rejects_digest_and_row_count_mismatches(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -259,6 +285,121 @@ class TestReplayTape(TestCase):
                 symbols=("AAPL",),
             )
 
+    def test_manifest_records_and_validates_missing_trading_days(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            manifest = materialize_signal_tape(
+                rows=[self._signal(day=27, seq=1, symbol="META")],
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-a",
+                symbols=("META",),
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 27),
+                source_query_digest=build_source_query_digest({"window": "a"}),
+            )
+
+        self.assertEqual(
+            manifest.requested_trading_days,
+            (date(2026, 3, 26), date(2026, 3, 27)),
+        )
+        self.assertEqual(manifest.observed_trading_days, (date(2026, 3, 27),))
+        self.assertEqual(manifest.missing_trading_days, (date(2026, 3, 26),))
+        self.assertEqual(manifest.to_payload()["coverage_status"], "missing_days")
+
+        with self.assertRaisesRegex(ValueError, "trading_days_missing:2026-03-26"):
+            validate_tape_freshness(
+                manifest,
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 27),
+                symbols=("META",),
+            )
+
+        receipt = validate_tape_freshness(
+            manifest,
+            start_date=date(2026, 3, 26),
+            end_date=date(2026, 3, 27),
+            symbols=("META",),
+            allow_stale_tape=True,
+        )
+        self.assertEqual(receipt["status"], "stale_override")
+        self.assertEqual(receipt["missing_trading_days"], ["2026-03-26"])
+
+    def test_manifest_records_and_validates_missing_symbol_trading_days(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            manifest = materialize_signal_tape(
+                rows=[
+                    self._signal(day=26, seq=1, symbol="META"),
+                    self._signal(day=27, seq=2, symbol="META"),
+                    self._signal(day=26, seq=3, symbol="AAPL"),
+                ],
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-a",
+                symbols=("META", "AAPL"),
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 27),
+                source_query_digest=build_source_query_digest({"window": "a"}),
+            )
+
+        self.assertEqual(manifest.missing_trading_days, ())
+        self.assertEqual(
+            manifest.missing_symbol_trading_days,
+            ("AAPL:2026-03-27",),
+        )
+        self.assertEqual(
+            manifest.to_payload()["coverage_status"], "missing_symbol_days"
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "symbol_trading_days_missing:AAPL:2026-03-27",
+        ):
+            validate_tape_freshness(
+                manifest,
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 27),
+                symbols=("META", "AAPL"),
+            )
+
+        receipt = validate_tape_freshness(
+            manifest,
+            start_date=date(2026, 3, 26),
+            end_date=date(2026, 3, 27),
+            symbols=("AAPL",),
+            allow_stale_tape=True,
+        )
+        self.assertEqual(receipt["status"], "stale_override")
+        self.assertEqual(receipt["coverage_status"], "missing_symbol_days")
+        self.assertEqual(
+            receipt["missing_symbol_trading_days"],
+            ["AAPL:2026-03-27"],
+        )
+
+    def test_materialize_tape_requires_symbol_day_coverage_when_strict(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            with self.assertRaisesRegex(
+                ValueError,
+                "replay_tape_incomplete_coverage:missing_symbol_days=AAPL:2026-03-27",
+            ):
+                materialize_signal_tape(
+                    rows=[
+                        self._signal(day=26, seq=1, symbol="META"),
+                        self._signal(day=27, seq=2, symbol="META"),
+                        self._signal(day=26, seq=3, symbol="AAPL"),
+                    ],
+                    tape_path=Path(tmpdir) / "tape.jsonl",
+                    dataset_snapshot_ref="snapshot-a",
+                    symbols=("META", "AAPL"),
+                    start_date=date(2026, 3, 26),
+                    end_date=date(2026, 3, 27),
+                    source_query_digest=build_source_query_digest({"window": "a"}),
+                    require_complete_coverage=True,
+                )
+
+            self.assertFalse((Path(tmpdir) / "tape.jsonl").exists())
+
     def test_source_query_digest_normalizes_dates_decimals_and_lists(self) -> None:
         digest = build_source_query_digest(
             {
@@ -291,7 +432,8 @@ class TestReplayTape(TestCase):
             materialize_signal_tape(
                 rows=[
                     self._signal(day=26, seq=1, symbol="META"),
-                    self._signal(day=27, seq=2, symbol="AAPL"),
+                    self._signal(day=26, seq=2, symbol="AAPL"),
+                    self._signal(day=27, seq=3, symbol="AAPL"),
                 ],
                 tape_path=tape_path,
                 dataset_snapshot_ref="snapshot-a",
@@ -320,7 +462,7 @@ class TestReplayTape(TestCase):
             ):
                 rows = list(_iter_signal_rows(config))
 
-        self.assertEqual([row.symbol for row in rows], ["AAPL"])
+        self.assertEqual([row.symbol for row in rows], ["AAPL", "AAPL"])
         self.assertEqual(rows[0].payload["price"], Decimal("100.25"))
 
 
@@ -366,6 +508,7 @@ class TestMaterializeReplayTapeCli(TestCase):
 
         symbols = materialize_cli._parse_symbols(str(args.symbols))
         self.assertEqual(symbols, ("NVDA", "META"))
+        self.assertFalse(args.allow_incomplete_coverage)
         self.assertEqual(
             materialize_cli._parse_source_table_versions(args.source_table_version),
             {"ta_signals": "v1"},
@@ -376,6 +519,23 @@ class TestMaterializeReplayTapeCli(TestCase):
             ],
             ["NVDA", "META"],
         )
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "prog",
+                "--start-date",
+                "2026-03-26",
+                "--end-date",
+                "2026-03-27",
+                "--dataset-snapshot-ref",
+                "snapshot-cli",
+                "--output",
+                str(args.output),
+                "--allow-incomplete-coverage",
+            ],
+        ):
+            self.assertTrue(materialize_cli._parse_args().allow_incomplete_coverage)
         with self.assertRaisesRegex(ValueError, "source_table_version_invalid"):
             materialize_cli._parse_source_table_versions(["broken"])
 
@@ -398,6 +558,7 @@ class TestMaterializeReplayTapeCli(TestCase):
                 output=output,
                 manifest_output=manifest_output,
                 source_table_version=["ta_signals=v1"],
+                allow_incomplete_coverage=False,
                 log_level="WARNING",
             )
             stdout = io.StringIO()
@@ -408,7 +569,10 @@ class TestMaterializeReplayTapeCli(TestCase):
                 ),
                 patch(
                     "scripts.materialize_replay_tape.replay_mod._iter_signal_rows",
-                    return_value=(self._signal(day=26, seq=1),),
+                    return_value=(
+                        self._signal(day=26, seq=1),
+                        self._signal(day=27, seq=2),
+                    ),
                 ),
                 redirect_stdout(stdout),
             ):
@@ -422,5 +586,101 @@ class TestMaterializeReplayTapeCli(TestCase):
         self.assertTrue(output_exists)
         self.assertTrue(manifest_exists)
         self.assertEqual(payload["dataset_snapshot_ref"], "snapshot-cli")
-        self.assertEqual(payload["row_count"], 1)
+        self.assertEqual(payload["row_count"], 2)
         self.assertEqual(payload["source_table_versions"], {"ta_signals": "v1"})
+        self.assertEqual(payload["observed_trading_days"], ["2026-03-26", "2026-03-27"])
+        self.assertEqual(payload["missing_trading_days"], [])
+        self.assertEqual(
+            payload["row_count_by_trading_day"],
+            {"2026-03-26": 1, "2026-03-27": 1},
+        )
+        self.assertEqual(payload["missing_symbol_trading_days"], [])
+        self.assertEqual(
+            payload["row_count_by_symbol_trading_day"],
+            {"META": {"2026-03-26": 1, "2026-03-27": 1}},
+        )
+
+    def test_main_fails_closed_on_incomplete_coverage_by_default(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "tape.jsonl"
+            manifest_output = root / "tape.manifest.json"
+            args = Namespace(
+                strategy_configmap=root / "strategy.yaml",
+                clickhouse_http_url="http://clickhouse.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_date="2026-03-26",
+                end_date="2026-03-27",
+                chunk_minutes=0,
+                start_equity="10000",
+                symbols="meta",
+                dataset_snapshot_ref="snapshot-cli",
+                output=output,
+                manifest_output=manifest_output,
+                source_table_version=[],
+                allow_incomplete_coverage=False,
+                log_level="WARNING",
+            )
+            with (
+                patch(
+                    "scripts.materialize_replay_tape._parse_args",
+                    return_value=args,
+                ),
+                patch(
+                    "scripts.materialize_replay_tape.replay_mod._iter_signal_rows",
+                    return_value=(self._signal(day=26, seq=1),),
+                ),
+            ):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "replay_tape_incomplete_coverage:missing_days=2026-03-27",
+                ):
+                    materialize_cli.main()
+
+            self.assertFalse(output.exists())
+            self.assertFalse(manifest_output.exists())
+
+    def test_main_fails_closed_on_missing_symbol_days_by_default(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "tape.jsonl"
+            manifest_output = root / "tape.manifest.json"
+            args = Namespace(
+                strategy_configmap=root / "strategy.yaml",
+                clickhouse_http_url="http://clickhouse.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_date="2026-03-26",
+                end_date="2026-03-27",
+                chunk_minutes=0,
+                start_equity="10000",
+                symbols="meta,aapl",
+                dataset_snapshot_ref="snapshot-cli",
+                output=output,
+                manifest_output=manifest_output,
+                source_table_version=[],
+                allow_incomplete_coverage=False,
+                log_level="WARNING",
+            )
+            with (
+                patch(
+                    "scripts.materialize_replay_tape._parse_args",
+                    return_value=args,
+                ),
+                patch(
+                    "scripts.materialize_replay_tape.replay_mod._iter_signal_rows",
+                    return_value=(
+                        self._signal(day=26, seq=1),
+                        self._signal(day=27, seq=2),
+                    ),
+                ),
+            ):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "replay_tape_incomplete_coverage:missing_symbol_days=AAPL:2026-03-26,AAPL:2026-03-27",
+                ):
+                    materialize_cli.main()
+
+            self.assertFalse(output.exists())
+            self.assertFalse(manifest_output.exists())

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -3928,25 +3928,30 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             materialize_signal_tape(
                 rows=[
                     SignalEnvelope(
-                        event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
-                        symbol="NVDA",
+                        event_ts=datetime(2026, 2, day, 15, 30, tzinfo=timezone.utc),
+                        symbol=symbol,
                         timeframe="1Sec",
-                        seq=1,
+                        seq=seq,
                         source="ta",
-                        payload={"price": Decimal("100"), "spread_bps": Decimal("2")},
-                    ),
-                    SignalEnvelope(
-                        event_ts=datetime(2026, 2, 23, 15, 31, tzinfo=timezone.utc),
-                        symbol="NVDA",
-                        timeframe="1Sec",
-                        seq=2,
-                        source="ta",
-                        payload={"price": Decimal("101"), "spread_bps": Decimal("2")},
-                    ),
+                        payload={
+                            "price": Decimal(price),
+                            "spread_bps": Decimal("2"),
+                        },
+                    )
+                    for seq, (day, symbol, price) in enumerate(
+                        (
+                            (23, "NVDA", "100"),
+                            (24, "NVDA", "101"),
+                            (25, "NVDA", "102"),
+                            (26, "NVDA", "103"),
+                            (27, "NVDA", "104"),
+                        ),
+                        start=1,
+                    )
                 ],
                 tape_path=tape_path,
                 dataset_snapshot_ref="preview-snapshot",
-                symbols=("NVDA", "AAPL"),
+                symbols=("NVDA",),
                 start_date=date(2026, 2, 23),
                 end_date=date(2026, 2, 27),
                 source_query_digest=build_source_query_digest({"query": "preview"}),
@@ -3958,7 +3963,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             args.selection_only = True
             args.replay_tape_path = tape_path
             args.replay_tape_preview_top_k = 1
-            args.symbols = "NVDA,AAPL"
+            args.symbols = "NVDA"
 
             payload = runner.run_whitepaper_autoresearch_profit_target(args)
 
@@ -4154,13 +4159,14 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             materialize_signal_tape(
                 rows=[
                     SignalEnvelope(
-                        event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                        event_ts=datetime(2026, 2, day, 15, 30, tzinfo=timezone.utc),
                         symbol="NVDA",
                         timeframe="1Sec",
-                        seq=1,
+                        seq=seq,
                         source="ta",
                         payload={"price": Decimal("100")},
                     )
+                    for seq, day in enumerate(range(23, 28), start=1)
                 ],
                 tape_path=tape_path,
                 dataset_snapshot_ref="preview-snapshot",

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4017,21 +4017,14 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             args.symbols = "NVDA"
             rows = [
                 SignalEnvelope(
-                    event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                    event_ts=datetime(2026, 2, day, 15, 30, tzinfo=timezone.utc),
                     symbol="NVDA",
                     timeframe="1Sec",
-                    seq=1,
+                    seq=seq,
                     source="ta",
                     payload={"price": Decimal("100"), "spread": Decimal("0.01")},
-                ),
-                SignalEnvelope(
-                    event_ts=datetime(2026, 2, 23, 15, 31, tzinfo=timezone.utc),
-                    symbol="NVDA",
-                    timeframe="1Sec",
-                    seq=2,
-                    source="ta",
-                    payload={"price": Decimal("101"), "spread": Decimal("0.01")},
-                ),
+                )
+                for seq, day in enumerate(range(23, 28), start=1)
             ]
 
             with patch.object(
@@ -4053,11 +4046,51 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 output_dir / "replay-tape.jsonl.manifest.json",
             )
             self.assertEqual(receipt["status"], "materialized")
-            self.assertEqual(receipt["row_count"], 2)
+            self.assertEqual(receipt["row_count"], 5)
             self.assertEqual(receipt["row_symbols"], ["NVDA"])
             self.assertTrue((output_dir / "replay-tape-receipt.json").exists())
             self.assertEqual(tape.manifest.dataset_snapshot_ref, "epoch-materialized")
-            self.assertEqual(tape.manifest.row_count, 2)
+            self.assertEqual(tape.manifest.row_count, 5)
+            self.assertEqual(tape.manifest.missing_trading_days, ())
+
+    def test_materialize_replay_tape_fails_closed_on_missing_days(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output_dir = root / "epoch"
+            output_dir.mkdir()
+            strategy_configmap = root / "strategy-configmap.yaml"
+            strategy_configmap.write_text("{}", encoding="utf-8")
+            args = self._args(output_dir)
+            args.strategy_configmap = strategy_configmap
+            args.replay_mode = "real"
+            args.materialize_replay_tape = True
+            args.symbols = "NVDA"
+            rows = [
+                SignalEnvelope(
+                    event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                    symbol="NVDA",
+                    timeframe="1Sec",
+                    seq=1,
+                    source="ta",
+                    payload={"price": Decimal("100"), "spread": Decimal("0.01")},
+                )
+            ]
+
+            with patch.object(
+                runner.replay_mod, "_iter_signal_rows", return_value=rows
+            ):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "replay_tape_incomplete_coverage:missing_days=2026-02-24,2026-02-25,2026-02-26,2026-02-27",
+                ):
+                    runner._maybe_materialize_epoch_replay_tape(
+                        args=args,
+                        output_dir=output_dir,
+                        epoch_id="epoch-materialized",
+                    )
+
+            self.assertFalse((output_dir / "replay-tape.jsonl").exists())
+            self.assertFalse((output_dir / "replay-tape.jsonl.manifest.json").exists())
 
     def test_materialize_replay_tape_skips_provided_tape_and_fails_closed(
         self,

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -1317,6 +1317,72 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(resolved.second_oos_days, days[6:])
         self.assertEqual(resolved.expected_days, days)
 
+    def test_explicit_full_window_replay_tape_receipt_keeps_missing_business_days(
+        self,
+    ) -> None:
+        window = frontier.FrontierReplayWindows(
+            train_days=(date(2026, 5, 18),),
+            holdout_days=(date(2026, 5, 21),),
+        )
+        expected_days = frontier._snapshot_expected_days(
+            window=window,
+            full_window_start=date(2026, 5, 18),
+            full_window_end=date(2026, 5, 21),
+            require_full_window_coverage=True,
+        )
+        rows = [
+            SignalEnvelope(
+                event_ts=datetime(2026, 5, 18, 14, 30, tzinfo=timezone.utc),
+                symbol="AMZN",
+                timeframe="1Sec",
+                seq=1,
+                source="ta",
+                payload={"price": Decimal("200")},
+            ),
+            SignalEnvelope(
+                event_ts=datetime(2026, 5, 21, 14, 30, tzinfo=timezone.utc),
+                symbol="AMZN",
+                timeframe="1Sec",
+                seq=2,
+                source="ta",
+                payload={"price": Decimal("210")},
+            ),
+        ]
+
+        receipt = frontier._build_replay_tape_snapshot_receipt(
+            validation={
+                "status": "valid",
+                "dataset_snapshot_ref": "snapshot-gap",
+                "content_sha256": "content-sha",
+                "source_query_digest": "query-sha",
+                "row_count": 2,
+                "trading_day_count": 2,
+                "source_table_versions": {},
+                "artifact_refs": {},
+            },
+            rows=rows,
+            start_day=date(2026, 5, 18),
+            end_day=date(2026, 5, 21),
+            expected_last_trading_day=date(2026, 5, 21),
+            expected_trading_days=expected_days,
+            allow_stale_tape=False,
+        )
+
+        self.assertEqual(
+            expected_days,
+            (
+                date(2026, 5, 18),
+                date(2026, 5, 19),
+                date(2026, 5, 20),
+                date(2026, 5, 21),
+            ),
+        )
+        self.assertFalse(receipt.is_fresh)
+        self.assertEqual(
+            receipt.missing_days,
+            (date(2026, 5, 19), date(2026, 5, 20)),
+        )
+
     def test_strategy_universe_symbols_reads_target_strategy_universe(self) -> None:
         configmap_payload = {
             "data": {
@@ -2716,20 +2782,35 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 json_output=json_output,
             )
             tape_path = root / "full-window-tape.jsonl"
+            tape_rows = [
+                SignalEnvelope(
+                    event_ts=datetime(2026, 3, day, 17, 30, tzinfo=timezone.utc),
+                    symbol=symbol,
+                    timeframe="1Sec",
+                    seq=seq,
+                    source="ta",
+                    payload={"price": Decimal("900.00")},
+                )
+                for seq, (day, symbol) in enumerate(
+                    (
+                        (18, "NVDA"),
+                        (18, "AMAT"),
+                        (19, "NVDA"),
+                        (19, "AMAT"),
+                        (20, "NVDA"),
+                        (20, "AMAT"),
+                        (21, "NVDA"),
+                        (21, "AMAT"),
+                        (22, "NVDA"),
+                        (22, "AMAT"),
+                        (23, "NVDA"),
+                        (23, "AMAT"),
+                    ),
+                    start=1,
+                )
+            ]
             materialize_signal_tape(
-                rows=[
-                    SignalEnvelope(
-                        event_ts=datetime(
-                            2026, 3, 18 + index, 17, 30, tzinfo=timezone.utc
-                        ),
-                        symbol="NVDA",
-                        timeframe="1Sec",
-                        seq=index + 1,
-                        source="ta",
-                        payload={"price": Decimal("900.00")},
-                    )
-                    for index in range(6)
-                ],
+                rows=tape_rows,
                 tape_path=tape_path,
                 dataset_snapshot_ref="snapshot-test",
                 symbols=("NVDA", "AMAT"),
@@ -2865,7 +2946,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 payload["dataset_snapshot_receipt"]["source"], "replay_tape"
             )
             self.assertEqual(payload["replay_tape"]["status"], "valid")
-            self.assertEqual(payload["replay_tape"]["selected_row_count"], 6)
+            self.assertEqual(payload["replay_tape"]["selected_row_count"], 12)
             self.assertEqual(top["ranking"]["method"], "pareto_frontier_v2")
             self.assertEqual(top["family_template_id"], "intraday_tsmom_v2")
 

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -1816,7 +1816,15 @@ class TestStrategyAutoresearch(TestCase):
                     source="ta",
                     timeframe="1Sec",
                     payload={"price": "180.10"},
-                )
+                ),
+                SignalEnvelope(
+                    event_ts=datetime(2026, 3, 20, 13, 31, tzinfo=UTC),
+                    symbol="NVDA",
+                    seq=2,
+                    source="ta",
+                    timeframe="1Sec",
+                    payload={"price": "900.10"},
+                ),
             ]
 
             args = Namespace(
@@ -1941,14 +1949,14 @@ class TestStrategyAutoresearch(TestCase):
                 (run_root / "mlx-snapshot-manifest.json").read_text(encoding="utf-8")
             )
             self.assertEqual(manifest["symbols"], ["AMAT", "NVDA"])
-            self.assertEqual(manifest["row_counts"]["signal_row_count"], 1)
+            self.assertEqual(manifest["row_counts"]["signal_row_count"], 2)
             self.assertEqual(
                 manifest["tape_freshness_receipts"][0]["status"],
                 "materialized",
             )
             self.assertEqual(
                 manifest["tape_freshness_receipts"][0]["row_count"],
-                1,
+                2,
             )
             self.assertEqual(
                 manifest["tensor_bundle_paths"]["signal_rows_jsonl"],

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -579,6 +579,56 @@ class TestStrategyAutoresearch(TestCase):
         self.assertTrue(tape_exists)
         self.assertTrue(manifest_exists)
 
+    def test_materialize_run_replay_tape_fails_closed_on_missing_days(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            configmap_path = root / "strategy-configmap.yaml"
+            configmap_path.write_text("apiVersion: v1\nkind: ConfigMap\n")
+            bundle_paths = runner._mlx_bundle_paths(root)
+            args = Namespace(
+                strategy_configmap=configmap_path,
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity="31590.02",
+                chunk_minutes=10,
+                progress_log_seconds=30,
+                materialize_replay_tape=True,
+                replay_tape_path=None,
+                allow_stale_tape=False,
+            )
+            signal_rows = [
+                SignalEnvelope(
+                    event_ts=datetime(2026, 3, 20, 13, 30, tzinfo=UTC),
+                    symbol="AMAT",
+                    seq=1,
+                    source="ta",
+                    timeframe="1Sec",
+                    payload={"price": "180.10"},
+                )
+            ]
+
+            with patch(
+                "scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows",
+                return_value=iter(signal_rows),
+            ):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "replay_tape_incomplete_coverage:missing_days=2026-03-23",
+                ):
+                    runner._maybe_materialize_run_replay_tape(
+                        args=args,
+                        runner_run_id="strategy-autoresearch-test",
+                        snapshot_symbols=("AMAT",),
+                        bundle_paths=bundle_paths,
+                        full_window_start_date="2026-03-20",
+                        full_window_end_date="2026-03-23",
+                        existing_signal_bundle=None,
+                    )
+
+            self.assertFalse(Path(bundle_paths["replay_tape_jsonl"]).exists())
+            self.assertFalse(Path(bundle_paths["replay_tape_manifest_json"]).exists())
+
     def test_provided_replay_tape_receipt_reads_manifest_and_handles_missing(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds replay tape manifest coverage fields for requested/observed/missing trading days, per-day row counts, missing symbol/day coverage, and per-symbol/day row counts.
- Makes replay tape materialization fail closed by default on incomplete day or symbol/day coverage, with explicit stale/incomplete overrides preserved for research-only paths.
- Threads coverage diagnostics into frontier replay-tape receipts so incomplete proof inputs are visible at the candidate ranking boundary.
- Updates Torghut replay/frontier/autoresearch tests for the stricter proof contract.

## Related Issues

None

## Testing

- `uv run --frozen --directory services/torghut ruff check app/trading/discovery/replay_tape.py scripts/search_consistent_profitability_frontier.py tests/test_replay_tape.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen --directory services/torghut python -m pytest tests/test_replay_tape.py tests/test_search_consistent_profitability_frontier.py tests/test_discovery_harness_v2.py tests/test_strategy_autoresearch.py::TestStrategyAutoresearch::test_materialize_run_replay_tape_writes_bundle_and_receipt tests/test_strategy_autoresearch.py::TestStrategyAutoresearch::test_materialize_run_replay_tape_fails_closed_on_missing_days tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_materialize_replay_tape_writes_run_artifacts_and_updates_args tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_materialize_replay_tape_fails_closed_on_missing_days -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

Replay tape materialization now fails by default when a requested trading-day or requested symbol/day slice has no signal rows. Use the existing stale/incomplete override paths only for research-only diagnostics, not promotion proof.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
