### PR TITLE
fix(torghut): allocate portfolio exposure by edge risk

### DIFF
--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -24,6 +24,7 @@ CONFORMAL_TAIL_RISK_ALPHA = Decimal("0.20")
 PORTFOLIO_SEARCH_BEAM_WIDTH = 256
 PORTFOLIO_WEIGHTING_EQUAL_COUNT = "equal_count"
 PORTFOLIO_WEIGHTING_GROSS_EXPOSURE_BUDGET = "gross_exposure_budget"
+PORTFOLIO_WEIGHTING_EDGE_RISK_GROSS_EXPOSURE_BUDGET = "edge_risk_gross_exposure_budget"
 PORTFOLIO_COMPOSABLE_SINGLE_SLEEVE_VETOES = frozenset(
     {
         "active_day_ratio_below_min",
@@ -918,6 +919,109 @@ def _equal_weights(selected: Sequence[CandidateEvidenceBundle]) -> tuple[Decimal
     return tuple(weight for _ in selected)
 
 
+def _gross_exposure_allocation_edge_net_per_day(
+    bundle: CandidateEvidenceBundle,
+) -> Decimal:
+    scorecard = _scorecard(bundle)
+    lower_bound = deployable_lower_bound_net_pnl_per_day(scorecard)
+    edge_candidates: list[Decimal] = [
+        _net_per_day(bundle),
+    ]
+    if lower_bound is not None:
+        edge_candidates.append(lower_bound)
+    for key in (
+        "market_impact_stress_net_pnl_per_day",
+        "delay_adjusted_depth_stress_net_pnl_per_day",
+        "delay_adjusted_depth_net_pnl_per_day",
+        "implementation_uncertainty_lower_net_pnl_per_day",
+        "double_oos_cost_shock_net_pnl_per_day",
+        "double_oos_net_pnl_per_day",
+        "conformal_tail_risk_adjusted_net_pnl_per_day",
+    ):
+        if key in scorecard:
+            edge_candidates.append(_decimal(scorecard.get(key)))
+    return min(edge_candidates, default=Decimal("0"))
+
+
+def _gross_exposure_allocation_priority(bundle: CandidateEvidenceBundle) -> Decimal:
+    edge = _gross_exposure_allocation_edge_net_per_day(bundle)
+    if edge <= 0:
+        return Decimal("0")
+    downside_risk = max(
+        _worst_day_loss(bundle),
+        _max_drawdown(bundle),
+        Decimal("1"),
+    )
+    concentration_penalty = Decimal("1") + max(
+        _best_day_share(bundle),
+        Decimal("0"),
+    )
+    quality = max(_active_ratio(bundle), Decimal("0")) * max(
+        _positive_ratio(bundle),
+        Decimal("0"),
+    )
+    if quality <= 0:
+        return Decimal("0")
+    return (edge * quality) / (downside_risk * concentration_penalty)
+
+
+def _edge_risk_gross_exposure_budget_weights(
+    exposures: Sequence[Decimal],
+    priorities: Sequence[Decimal],
+    *,
+    max_gross_exposure_pct_equity: Decimal,
+    equal_scale: Decimal,
+) -> tuple[Decimal, ...] | None:
+    positive_priorities = tuple(max(priority, Decimal("0")) for priority in priorities)
+    if (
+        not positive_priorities
+        or sum(positive_priorities, Decimal("0")) <= 0
+        or max(positive_priorities) == min(positive_priorities)
+    ):
+        return None
+
+    weights = [equal_scale * Decimal("0.50") for _ in exposures]
+    used_exposure = sum(
+        exposure * weight for exposure, weight in zip(exposures, weights, strict=True)
+    )
+    remaining_exposure = max_gross_exposure_pct_equity - used_exposure
+    active_indexes = {
+        index
+        for index, (exposure, weight, priority) in enumerate(
+            zip(exposures, weights, positive_priorities, strict=True)
+        )
+        if exposure > 0 and weight < Decimal("1") and priority > 0
+    }
+
+    while remaining_exposure > 0 and active_indexes:
+        total_priority = sum(
+            (positive_priorities[index] for index in active_indexes),
+            Decimal("0"),
+        )
+        used_this_round = Decimal("0")
+        saturated_indexes: set[int] = set()
+        for index in sorted(active_indexes):
+            desired_additional_exposure = (
+                remaining_exposure * positive_priorities[index] / total_priority
+            )
+            max_additional_exposure = exposures[index] * (Decimal("1") - weights[index])
+            additional_exposure = min(
+                desired_additional_exposure,
+                max_additional_exposure,
+            )
+            weights[index] += additional_exposure / exposures[index]
+            used_this_round += additional_exposure
+            if weights[index] >= Decimal("1"):
+                weights[index] = Decimal("1")
+                saturated_indexes.add(index)
+        remaining_exposure -= used_this_round
+        active_indexes.difference_update(saturated_indexes)
+
+    if tuple(weights) == tuple(equal_scale for _ in exposures):
+        return None
+    return tuple(weights)
+
+
 def _gross_exposure_budget_weights(
     selected: Sequence[CandidateEvidenceBundle],
     *,
@@ -934,6 +1038,15 @@ def _gross_exposure_budget_weights(
         Decimal("1"),
         policy.max_gross_exposure_pct_equity / total_exposure,
     )
+    if scale < Decimal("1"):
+        edge_risk_weights = _edge_risk_gross_exposure_budget_weights(
+            exposures,
+            tuple(_gross_exposure_allocation_priority(bundle) for bundle in selected),
+            max_gross_exposure_pct_equity=policy.max_gross_exposure_pct_equity,
+            equal_scale=scale,
+        )
+        if edge_risk_weights is not None:
+            return edge_risk_weights
     return tuple(scale for _ in selected)
 
 
@@ -955,10 +1068,16 @@ def _portfolio_weighting_mode(
     *,
     oracle_policy: ProfitTargetOraclePolicy | None = None,
 ) -> str:
-    if (
-        _gross_exposure_budget_weights(selected, oracle_policy=oracle_policy)
-        is not None
-    ):
+    weights = _gross_exposure_budget_weights(selected, oracle_policy=oracle_policy)
+    if weights is not None:
+        policy = oracle_policy or ProfitTargetOraclePolicy()
+        exposures = tuple(_max_gross_exposure_pct_equity(bundle) for bundle in selected)
+        if exposures and all(exposure > 0 for exposure in exposures):
+            total_exposure = sum(exposures, Decimal("0"))
+            if total_exposure > policy.max_gross_exposure_pct_equity:
+                equal_scale = policy.max_gross_exposure_pct_equity / total_exposure
+                if weights != tuple(equal_scale for _ in selected):
+                    return PORTFOLIO_WEIGHTING_EDGE_RISK_GROSS_EXPOSURE_BUDGET
         return PORTFOLIO_WEIGHTING_GROSS_EXPOSURE_BUDGET
     return PORTFOLIO_WEIGHTING_EQUAL_COUNT
 

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -129,6 +129,77 @@ class TestPortfolioOptimizer(TestCase):
             Decimal("0"),
         )
 
+    def test_gross_exposure_allocation_priority_rejects_bad_edge_or_quality(
+        self,
+    ) -> None:
+        def bundle(
+            candidate_id: str,
+            *,
+            net_pnl_per_day: str,
+            active_day_ratio: str = "1",
+            positive_day_ratio: str = "1",
+        ) -> CandidateEvidenceBundle:
+            return evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"spec-{candidate_id}",
+                candidate={
+                    "candidate_id": candidate_id,
+                    "objective_scorecard": {
+                        "net_pnl_per_day": net_pnl_per_day,
+                        "active_day_ratio": active_day_ratio,
+                        "positive_day_ratio": positive_day_ratio,
+                        "worst_day_loss": "10",
+                        "max_drawdown": "10",
+                        "best_day_share": "0.2",
+                    },
+                },
+                dataset_snapshot_id="snapshot-priority-zero",
+                result_path=f"/tmp/{candidate_id}.json",
+            )
+
+        self.assertEqual(
+            portfolio_optimizer_module._gross_exposure_allocation_priority(
+                bundle("negative-edge", net_pnl_per_day="-1")
+            ),
+            Decimal("0"),
+        )
+        self.assertEqual(
+            portfolio_optimizer_module._gross_exposure_allocation_priority(
+                bundle("inactive", net_pnl_per_day="100", active_day_ratio="0")
+            ),
+            Decimal("0"),
+        )
+
+    def test_edge_risk_gross_exposure_budget_weights_covers_saturation_and_noop(
+        self,
+    ) -> None:
+        saturated_weights = (
+            portfolio_optimizer_module._edge_risk_gross_exposure_budget_weights(
+                (Decimal("0.1"), Decimal("1.0")),
+                (Decimal("100"), Decimal("1")),
+                max_gross_exposure_pct_equity=Decimal("0.6"),
+                equal_scale=Decimal("0.6") / Decimal("1.1"),
+            )
+        )
+
+        self.assertIsNotNone(saturated_weights)
+        assert saturated_weights is not None
+        self.assertEqual(saturated_weights[0], Decimal("1"))
+        self.assertLess(saturated_weights[1], Decimal("0.6") / Decimal("1.1"))
+        self.assertLessEqual(
+            (Decimal("0.1") * saturated_weights[0])
+            + (Decimal("1.0") * saturated_weights[1]),
+            Decimal("0.6"),
+        )
+
+        self.assertIsNone(
+            portfolio_optimizer_module._edge_risk_gross_exposure_budget_weights(
+                (Decimal("0.25"), Decimal("0.75")),
+                (Decimal("1"), Decimal("3")),
+                max_gross_exposure_pct_equity=Decimal("0.5"),
+                equal_scale=Decimal("0.5"),
+            )
+        )
+
     def test_capital_safety_rejection_reasons_block_minimums(self) -> None:
         def bundle(
             candidate_id: str,
@@ -450,6 +521,116 @@ class TestPortfolioOptimizer(TestCase):
         )
         self.assertTrue(portfolio.objective_scorecard["target_met"])
         self.assertTrue(portfolio.objective_scorecard["oracle_passed"])
+
+    def test_portfolio_gross_exposure_budget_overweights_better_edge_risk_sleeve(
+        self,
+    ) -> None:
+        def bundle(
+            candidate_id: str,
+            symbol: str,
+            cluster: str,
+            *,
+            net_pnl_per_day: str,
+            worst_day_loss: str,
+            max_drawdown: str,
+        ) -> CandidateEvidenceBundle:
+            return evidence_bundle_from_frontier_candidate(
+                candidate_spec_id=f"spec-{candidate_id}",
+                candidate={
+                    "candidate_id": candidate_id,
+                    "runtime_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                    "family_template_id": "microbar_cross_sectional_pairs_v1",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": net_pnl_per_day,
+                        "active_day_ratio": "1.0",
+                        "positive_day_ratio": "1.0",
+                        "worst_day_loss": worst_day_loss,
+                        "max_drawdown": max_drawdown,
+                        "max_gross_exposure_pct_equity": "0.75",
+                        "min_cash": "5000",
+                        "negative_cash_observation_count": 0,
+                        "best_day_share": "0.2",
+                        "avg_filled_notional_per_day": "400000",
+                        "regime_slice_pass_rate": "0.55",
+                        "posterior_edge_lower": "0.01",
+                        "shadow_parity_status": "within_budget",
+                        "correlation_cluster": cluster,
+                        "symbol_contribution_shares": {symbol: "1.0"},
+                        **_executable_scorecard_fields(candidate_id),
+                    },
+                    "full_window": {
+                        "daily_net": {
+                            "2026-02-23": net_pnl_per_day,
+                            "2026-02-24": net_pnl_per_day,
+                            "2026-02-25": net_pnl_per_day,
+                            "2026-02-26": net_pnl_per_day,
+                            "2026-02-27": net_pnl_per_day,
+                        },
+                        "daily_filled_notional": {
+                            "2026-02-23": "400000",
+                            "2026-02-24": "400000",
+                            "2026-02-25": "400000",
+                            "2026-02-26": "400000",
+                            "2026-02-27": "400000",
+                        },
+                    },
+                },
+                dataset_snapshot_id="snapshot-edge-risk-gross-budget",
+                result_path=f"/tmp/{candidate_id}.json",
+            )
+
+        portfolio = optimize_portfolio_candidate(
+            evidence_bundles=[
+                bundle(
+                    "cand-edge-risk-strong",
+                    "AAPL",
+                    "edge-risk-strong",
+                    net_pnl_per_day="700",
+                    worst_day_loss="25",
+                    max_drawdown="40",
+                ),
+                bundle(
+                    "cand-edge-risk-weak",
+                    "AMZN",
+                    "edge-risk-weak",
+                    net_pnl_per_day="150",
+                    worst_day_loss="150",
+                    max_drawdown="300",
+                ),
+            ],
+            target_net_pnl_per_day=Decimal("500"),
+            oracle_policy=ProfitTargetOraclePolicy(
+                max_cluster_contribution_share=Decimal("0.99"),
+                max_single_symbol_contribution_share=Decimal("0.99"),
+                max_gross_exposure_pct_equity=Decimal("0.75"),
+                min_observed_trading_days=5,
+            ),
+            portfolio_size_min=2,
+            portfolio_size_max=2,
+        )
+
+        self.assertIsNotNone(portfolio)
+        assert portfolio is not None
+        weights = portfolio.capital_budget["sleeve_weights"]
+        strong_weight = Decimal(str(weights["cand-edge-risk-strong"]))
+        weak_weight = Decimal(str(weights["cand-edge-risk-weak"]))
+        self.assertEqual(
+            portfolio.objective_scorecard["portfolio_weighting_mode"],
+            "edge_risk_gross_exposure_budget",
+        )
+        self.assertGreater(strong_weight, weak_weight)
+        self.assertGreater(
+            Decimal(str(portfolio.objective_scorecard["net_pnl_per_day"])),
+            Decimal("425"),
+        )
+        self.assertLessEqual(
+            Decimal(
+                str(portfolio.objective_scorecard["max_gross_exposure_pct_equity"])
+            ),
+            Decimal("0.75"),
+        )
+        self.assertTrue(portfolio.objective_scorecard["target_met"])
 
     def test_portfolio_aggregates_market_impact_stress_into_oracle(
         self,


### PR DESCRIPTION
## Summary

- Adds an edge/risk-aware gross exposure weighting mode for constrained Torghut portfolio candidates.
- Keeps the existing gross exposure behavior when sleeves have equal allocation priority or total exposure is within policy budget.
- Records the selected sleeve weights and weighting mode in the portfolio scorecard and capital budget.

## Related Issues

None

## Testing

- `uv run --frozen --directory services/torghut ruff format app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen --directory services/torghut ruff check app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen --directory services/torghut python -m pytest tests/test_portfolio_optimizer.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
