### PR TITLE
fix(torghut): record frontier clickhouse preflight failures

### DIFF
--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -9,6 +9,7 @@ import hashlib
 import itertools
 import json
 import os
+import socket
 import sys
 import tempfile
 from collections import Counter, deque
@@ -17,6 +18,7 @@ from datetime import date, timedelta, timezone
 from decimal import Decimal, InvalidOperation, ROUND_CEILING
 from pathlib import Path
 from typing import Any, Callable, Iterable, Iterator, Mapping, Sequence, TypeAlias, cast
+from urllib.parse import urlparse
 from unittest.mock import patch
 
 import yaml
@@ -274,6 +276,58 @@ def _order_type_ablation_policy(
 def _write_json_output(path: Path, payload: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _frontier_error_payload(exc: Exception) -> dict[str, Any]:
+    message = str(exc)
+    payload: dict[str, Any] = {
+        "schema_version": "torghut.consistent-profitability-frontier-error.v1",
+        "status": "error",
+        "error_type": type(exc).__name__,
+        "error": message,
+    }
+    if message.startswith("clickhouse_endpoint_"):
+        payload["remediation"] = [
+            "Run the frontier harness from an in-cluster pod.",
+            "Set TA_CLICKHOUSE_URL or CLICKHOUSE_HTTP_URL to a reachable ClickHouse HTTP endpoint.",
+            "Pass --clickhouse-http-url for a local port-forward or HTTP endpoint.",
+            "Pass --replay-tape-path with a manifest-verified replay tape when ClickHouse is intentionally offline.",
+        ]
+    return payload
+
+
+def _clickhouse_host_requires_dns_preflight(url: str) -> bool:
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    return host.endswith(".svc") or host.endswith(".svc.cluster.local")
+
+
+def _clickhouse_endpoint_preflight_failure(args: argparse.Namespace) -> str:
+    if getattr(args, "replay_tape_path", None) is not None:
+        return ""
+    url = str(getattr(args, "clickhouse_http_url", "") or "").strip()
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    if not host:
+        return (
+            "clickhouse_endpoint_invalid_url:"
+            f"url={url or '<empty>'}; set TA_CLICKHOUSE_URL, CLICKHOUSE_HTTP_URL, "
+            "or pass --clickhouse-http-url to a reachable ClickHouse HTTP endpoint"
+        )
+    if not _clickhouse_host_requires_dns_preflight(url):
+        return ""
+    port = parsed.port or (443 if parsed.scheme == "https" else 8123)
+    try:
+        socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        return (
+            "clickhouse_endpoint_unreachable:"
+            f"host={host};port={port};error={exc}; "
+            "the default Kubernetes service DNS is only reachable in-cluster. "
+            "Run from a cluster pod, set TA_CLICKHOUSE_URL or CLICKHOUSE_HTTP_URL, "
+            "or pass --clickhouse-http-url to a local port-forward/HTTP endpoint."
+        )
+    return ""
 
 
 def _stable_payload_hash(payload: Any) -> str:
@@ -3641,6 +3695,10 @@ def _resolved_clickhouse_password(args: argparse.Namespace) -> str | None:
 
 
 def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str, Any]:
+    clickhouse_preflight_failure = _clickhouse_endpoint_preflight_failure(args)
+    if clickhouse_preflight_failure:
+        raise RuntimeError(clickhouse_preflight_failure)
+
     clickhouse_password = _resolved_clickhouse_password(args)
     sweep_config = _load_sweep_config(args.sweep_config.resolve())
     second_oos_day_count = max(0, int(getattr(args, "second_oos_days", 0) or 0))
@@ -4879,7 +4937,14 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
 
 def main() -> int:
     args = _parse_args()
-    payload = run_consistent_profitability_frontier(args)
+    try:
+        payload = run_consistent_profitability_frontier(args)
+    except (RuntimeError, ValueError) as exc:
+        payload = _frontier_error_payload(exc)
+        if args.json_output:
+            _write_json_output(args.json_output, payload)
+        print(str(exc), file=sys.stderr)
+        return 1
     if args.json_output:
         _write_json_output(args.json_output, payload)
     print(json.dumps(payload, indent=2, sort_keys=True))
@@ -4887,11 +4952,7 @@ def main() -> int:
 
 
 def cli_main() -> int:
-    try:
-        return main()
-    except ValueError as exc:
-        print(str(exc), file=sys.stderr)
-        return 1
+    return main()
 
 
 if __name__ == "__main__":

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -4,7 +4,7 @@ import io
 import json
 import sys
 from argparse import Namespace
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
@@ -146,6 +146,73 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(args.max_train_screen_worst_day_loss, "125")
         self.assertEqual(args.second_oos_days, 2)
         self.assertTrue(args.collect_train_gate_diagnostics)
+
+    def test_clickhouse_preflight_fails_fast_for_unresolved_in_cluster_dns(
+        self,
+    ) -> None:
+        args = Namespace(
+            replay_tape_path=None,
+            clickhouse_http_url="http://torghut-clickhouse.torghut.svc.cluster.local:8123",
+        )
+
+        with patch(
+            "scripts.search_consistent_profitability_frontier.socket.getaddrinfo",
+            side_effect=frontier.socket.gaierror("not known"),
+        ):
+            failure = frontier._clickhouse_endpoint_preflight_failure(args)
+
+        self.assertIn("clickhouse_endpoint_unreachable", failure)
+        self.assertIn("TA_CLICKHOUSE_URL", failure)
+        self.assertIn("--clickhouse-http-url", failure)
+
+    def test_clickhouse_preflight_skips_when_replay_tape_is_supplied(self) -> None:
+        args = Namespace(
+            replay_tape_path=Path("/tmp/replay-tape.jsonl"),
+            clickhouse_http_url="http://torghut-clickhouse.torghut.svc.cluster.local:8123",
+        )
+
+        with patch(
+            "scripts.search_consistent_profitability_frontier.socket.getaddrinfo",
+            side_effect=AssertionError("replay tape should bypass DNS preflight"),
+        ):
+            failure = frontier._clickhouse_endpoint_preflight_failure(args)
+
+        self.assertEqual(failure, "")
+
+    def test_main_writes_error_json_for_clickhouse_preflight_failure(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            json_output = Path(tmpdir) / "frontier.json"
+            with (
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "search_consistent_profitability_frontier.py",
+                        "--clickhouse-http-url",
+                        "http://torghut-clickhouse.torghut.svc.cluster.local:8123",
+                        "--json-output",
+                        str(json_output),
+                    ],
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.socket.getaddrinfo",
+                    side_effect=frontier.socket.gaierror("not known"),
+                ),
+                redirect_stdout(io.StringIO()),
+                redirect_stderr(io.StringIO()),
+            ):
+                code = frontier.main()
+
+            payload = json.loads(json_output.read_text(encoding="utf-8"))
+
+        self.assertEqual(code, 1)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(
+            payload["schema_version"],
+            "torghut.consistent-profitability-frontier-error.v1",
+        )
+        self.assertIn("clickhouse_endpoint_unreachable", payload["error"])
+        self.assertIn("--replay-tape-path", payload["remediation"][-1])
 
     def test_load_replay_tape_rows_validates_and_slices_rows(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Add a DNS preflight for direct consistent-profitability frontier runs using in-cluster ClickHouse service URLs.
- Persist structured error JSON when the frontier harness cannot reach ClickHouse before replay starts.
- Cover unresolved in-cluster DNS, replay-tape bypass, and CLI error artifact behavior with regression tests.

## Related Issues

None

## Testing

- `uv run --frozen --directory services/torghut pytest tests/test_search_consistent_profitability_frontier.py -k "clickhouse_preflight or error_json"`
- `uv run --frozen --directory services/torghut pytest tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen --directory services/torghut ruff check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
