### PR TITLE
fix(torghut): isolate washout frontier proof

### DIFF
--- a/services/torghut/config/trading/profitability-frontier-consistent-washout.yaml
+++ b/services/torghut/config/trading/profitability-frontier-consistent-washout.yaml
@@ -2,7 +2,7 @@ schema_version: torghut.replay-frontier-sweep.v1
 family: washout_rebound_consistent
 family_template_id: washout_rebound_v2
 strategy_name: washout-rebound-long-v1
-disable_other_strategies: false
+disable_other_strategies: true
 constraints:
   holdout_target_net_per_day: '300'
   min_active_holdout_days: 2
@@ -21,6 +21,8 @@ consistency_constraints:
   max_best_day_share_of_total_pnl: '0.45'
   min_avg_filled_notional_per_day: '175000'
   min_avg_filled_notional_per_active_day: '250000'
+  max_gross_exposure_pct_equity: '1.0'
+  min_cash: '0'
   require_every_day_active: false
 strategy_overrides:
   universe_symbols:

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -114,6 +114,7 @@ _CONSISTENCY_REPAIR_TRIGGER_REASONS = frozenset(
         "active_day_ratio_below_min",
         "avg_daily_notional_below_min",
         "best_day_share_above_max",
+        "second_oos_net_per_day_below_target",
     }
 )
 _CONSISTENCY_REPAIR_UNSAFE_REASONS = frozenset(

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -931,6 +931,26 @@ class TestLiveConfigManifestContract(TestCase):
                 checked_universe_sets += 1
         self.assertGreater(checked_universe_sets, 0)
 
+    def test_washout_profitability_frontier_requires_capital_safe_replay(
+        self,
+    ) -> None:
+        payload = _load_yaml_mapping(
+            "services/torghut/config/trading/profitability-frontier-consistent-washout.yaml"
+        )
+        consistency_constraints = payload.get("consistency_constraints")
+        self.assertIsInstance(consistency_constraints, Mapping)
+        constraints = cast(Mapping[str, object], consistency_constraints)
+
+        self.assertIs(payload.get("disable_other_strategies"), True)
+        self.assertLessEqual(
+            Decimal(str(constraints.get("max_gross_exposure_pct_equity"))),
+            Decimal("1.0"),
+        )
+        self.assertGreaterEqual(
+            Decimal(str(constraints.get("min_cash"))),
+            Decimal("0"),
+        )
+
     def test_candidate_records_are_not_left_on_mixed_large_cap_universes(self) -> None:
         candidates_dir = (
             _repo_root() / "services" / "torghut" / "config" / "trading" / "candidates"

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -2226,6 +2226,71 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             children[0][0], "consistency_entries:active_day_ratio_below_min"
         )
 
+    def test_consistency_repair_children_target_second_oos_shortfall(
+        self,
+    ) -> None:
+        configmap_payload = {
+            "data": {
+                "strategies.yaml": yaml.safe_dump(
+                    {
+                        "strategies": [
+                            {
+                                "name": "washout-rebound-long-v1",
+                                "params": {
+                                    "max_entries_per_session": "2",
+                                    "entry_cooldown_seconds": "600",
+                                },
+                            }
+                        ],
+                    },
+                    sort_keys=False,
+                )
+            }
+        }
+
+        children = frontier._generate_consistency_repair_children(
+            params_candidate={},
+            strategy_overrides={},
+            candidate_configmap=configmap_payload,
+            strategy_name="washout-rebound-long-v1",
+            hard_vetoes=["second_oos_net_per_day_below_target"],
+            full_window_summary={
+                "net_per_day": "515",
+                "max_gross_exposure_pct_equity": "0.95",
+                "min_cash": "2500",
+                "negative_cash_observation_count": "0",
+            },
+            branch_count=2,
+        )
+
+        self.assertEqual(
+            children[0][0],
+            "consistency_entries:second_oos_net_per_day_below_target",
+        )
+        self.assertEqual(children[0][1], {"max_entries_per_session": "3"})
+        self.assertEqual(
+            children[1][0],
+            "consistency_cooldown:second_oos_net_per_day_below_target",
+        )
+        self.assertEqual(children[1][1], {"entry_cooldown_seconds": "300"})
+
+        unsafe_children = frontier._generate_consistency_repair_children(
+            params_candidate={},
+            strategy_overrides={},
+            candidate_configmap=configmap_payload,
+            strategy_name="washout-rebound-long-v1",
+            hard_vetoes=["second_oos_net_per_day_below_target"],
+            full_window_summary={
+                "net_per_day": "515",
+                "max_gross_exposure_pct_equity": "1.2",
+                "min_cash": "-1",
+                "negative_cash_observation_count": "1",
+            },
+            branch_count=2,
+        )
+
+        self.assertEqual(unsafe_children, [])
+
     def test_loss_repair_configmap_lookup_handles_invalid_shapes(self) -> None:
         invalid_payloads = [
             {"not_data": {}},


### PR DESCRIPTION
## Summary

- Isolates the washout frontier replay by disabling other strategies in the washout sweep.
- Adds capital-safe proof constraints for washout frontier search: max gross exposure at or below 1.0x equity and nonnegative cash.
- Allows bounded consistency repair to branch on second-OOS net/day shortfalls only when the parent is already capital-safe.
- Adds regression coverage for both the second-OOS repair trigger and washout sweep proof contract.

## Related Issues

None

## Testing

- `uv run --frozen --directory services/torghut pytest tests/test_search_consistent_profitability_frontier.py -k 'consistency_repair or second_oos'`
- `uv run --frozen --directory services/torghut pytest tests/test_search_consistent_profitability_frontier.py -k 'consistency_repair or loss_repair or second_oos'`
- `uv run --frozen --directory services/torghut pytest tests/test_live_config_manifest_contract.py -k 'washout_profitability_frontier or profitability_sweep_universes'`
- `uv run --frozen --directory services/torghut pytest tests/test_live_config_manifest_contract.py -k 'washout_profitability_frontier'`
- `uv run --frozen --directory services/torghut pytest tests/test_search_consistent_profitability_frontier.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen --directory services/torghut ruff check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py tests/test_live_config_manifest_contract.py`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-kustomize-build.out`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- Bounded local ClickHouse replay against `torghut-clickhouse` with 8 candidate cap and isolated washout sweep: `/tmp/torghut-frontier-proof-20260522/washout-best-isolated-capital-safe-repair-5-3-2.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
