### PR TITLE
fix(torghut): exclude partial frontier sessions

### DIFF
--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -3710,6 +3710,14 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         else None
     )
     loaded_replay_tape: ReplayTape | None = None
+    explicit_expected_last_trading_day = (
+        date.fromisoformat(str(args.expected_last_trading_day))
+        if str(args.expected_last_trading_day or "").strip()
+        else None
+    )
+    recent_day_ceiling = explicit_expected_last_trading_day
+    if recent_day_ceiling is None and str(args.full_window_end_date or "").strip():
+        recent_day_ceiling = date.fromisoformat(str(args.full_window_end_date))
     if replay_tape_path is not None:
         loaded_replay_tape = load_replay_tape(
             Path(replay_tape_path).resolve(),
@@ -3726,6 +3734,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                 + max(1, int(args.holdout_days))
                 + second_oos_day_count
             ),
+            latest_trading_day=recent_day_ceiling,
         )
     window = _resolve_frontier_replay_windows(
         recent_days,
@@ -3888,10 +3897,8 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         configmap_payload=base_configmap,
         strategy_name=strategy_name,
     )
-    expected_last_trading_day = (
-        date.fromisoformat(str(args.expected_last_trading_day))
-        if str(args.expected_last_trading_day or "").strip()
-        else (full_window_end if str(args.full_window_end_date or "").strip() else None)
+    expected_last_trading_day = explicit_expected_last_trading_day or (
+        full_window_end if str(args.full_window_end_date or "").strip() else None
     )
     expected_snapshot_days = _snapshot_expected_days(
         window=window,

--- a/services/torghut/scripts/search_profitability_frontier.py
+++ b/services/torghut/scripts/search_profitability_frontier.py
@@ -17,6 +17,7 @@ from typing import Any, Iterable, Mapping, cast
 
 import yaml
 
+from app.trading.discovery.dataset_snapshot import resolve_expected_last_trading_day
 from app.trading.reporting import (
     ProfitabilityConstraintPolicy,
     score_replay_profitability_candidate,
@@ -102,7 +103,11 @@ def _resolve_recent_trading_days(
     clickhouse_username: str | None,
     clickhouse_password: str | None,
     limit: int,
+    latest_trading_day: date | None = None,
 ) -> tuple[date, ...]:
+    resolved_latest_day = latest_trading_day or resolve_expected_last_trading_day(
+        explicit_day=None
+    )
     raw = _http_query(
         url=clickhouse_http_url,
         username=clickhouse_username,
@@ -112,6 +117,7 @@ def _resolve_recent_trading_days(
             f"FROM {_REPLAY_SIGNAL_TABLE} "
             "WHERE source = 'ta' "
             "  AND window_size = 'PT1S' "
+            f"  AND toDate(event_ts) <= toDate('{resolved_latest_day.isoformat()}') "
             "ORDER BY trading_day DESC "
             f"LIMIT {max(1, int(limit))} "
             "FORMAT TSVRaw"
@@ -120,6 +126,7 @@ def _resolve_recent_trading_days(
     values = [
         date.fromisoformat(line.strip()) for line in raw.splitlines() if line.strip()
     ]
+    values = [value for value in values if value <= resolved_latest_day]
     values.sort()
     return tuple(values)
 

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -1384,6 +1384,30 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(resolved.second_oos_days, days[6:])
         self.assertEqual(resolved.expected_days, days)
 
+    def test_recent_day_query_honors_explicit_expected_last_trading_day(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            args = self._make_args(
+                strategy_configmap=self._write_strategy_configmap(root),
+                sweep_config=self._write_sweep_config(root),
+                json_output=root / "frontier.json",
+            )
+            args.expected_last_trading_day = "2026-05-21"
+            args.second_oos_days = 2
+
+            with patch(
+                "scripts.search_consistent_profitability_frontier._resolve_recent_trading_days",
+                side_effect=RuntimeError("stop-after-recent-days"),
+            ) as resolve_recent:
+                with self.assertRaisesRegex(RuntimeError, "stop-after-recent-days"):
+                    frontier.run_consistent_profitability_frontier(args)
+
+        self.assertEqual(
+            resolve_recent.call_args.kwargs["latest_trading_day"],
+            date(2026, 5, 21),
+        )
+        self.assertEqual(resolve_recent.call_args.kwargs["limit"], 8)
+
     def test_explicit_full_window_replay_tape_receipt_keeps_missing_business_days(
         self,
     ) -> None:

--- a/services/torghut/tests/test_search_profitability_frontier.py
+++ b/services/torghut/tests/test_search_profitability_frontier.py
@@ -508,6 +508,7 @@ class TestSearchProfitabilityFrontier(TestCase):
                 clickhouse_username="torghut",
                 clickhouse_password="secret",
                 limit=2,
+                latest_trading_day=date(2026, 3, 27),
             )
 
         self.assertEqual(days, (date(2026, 3, 26), date(2026, 3, 27)))
@@ -515,6 +516,26 @@ class TestSearchProfitabilityFrontier(TestCase):
         self.assertIn("FROM torghut.ta_signals", sql)
         self.assertIn("source = 'ta'", sql)
         self.assertIn("window_size = 'PT1S'", sql)
+        self.assertIn("toDate(event_ts) <= toDate('2026-03-27')", sql)
+
+    def test_resolve_recent_trading_days_filters_partial_trading_day(self) -> None:
+        with patch(
+            "scripts.search_profitability_frontier.resolve_expected_last_trading_day",
+            return_value=date(2026, 5, 21),
+        ), patch(
+            "scripts.search_profitability_frontier._http_query",
+            return_value="2026-05-22\n2026-05-21\n2026-05-20\n",
+        ) as query:
+            days = frontier._resolve_recent_trading_days(
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                limit=3,
+            )
+
+        self.assertEqual(days, (date(2026, 5, 20), date(2026, 5, 21)))
+        sql = query.call_args.kwargs["query"]
+        self.assertIn("toDate(event_ts) <= toDate('2026-05-21')", sql)
 
     def test_load_sweep_config_rejects_non_mapping_payload(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Exclude in-progress trading sessions from default frontier recent-day discovery.
- Thread explicit `--expected-last-trading-day` / `--full-window-end-date` ceilings into the consistent frontier resolver.
- Add regression coverage for partial-day filtering and consistent frontier day ceiling propagation.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_search_profitability_frontier.py -k 'recent_trading_days'`
- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -k 'recent_day_query_honors_explicit_expected_last_trading_day or resolve_frontier_replay_windows_keeps_second_oos_independent'`
- `uv run --frozen ruff check scripts/search_profitability_frontier.py scripts/search_consistent_profitability_frontier.py tests/test_search_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Bounded live-data replay: `search_consistent_profitability_frontier.py` with strict TSMOM 4/3/2 fixed completed-day window against ClickHouse; no promotable candidate found.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
