### PR TITLE
fix(torghut): select strongest runtime proof

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -483,17 +483,21 @@ def build_hypothesis_runtime_summary(
         ),
         route_symbol_filter_enabled=settings.trading_pipeline_mode == "simple",
     )
+    max_age_seconds = max(
+        0, int(settings.trading_drift_live_promotion_max_evidence_age_seconds)
+    )
+    now = datetime.now(timezone.utc)
     evidence = _load_latest_certificate_evidence(
         session,
         hypothesis_ids=[item.hypothesis_id for item in registry.items],
+        now=now,
+        max_age_seconds=max_age_seconds,
     )
     items = _merge_runtime_certificate_evidence(
         items,
         evidence=evidence,
-        now=datetime.now(timezone.utc),
-        max_age_seconds=max(
-            0, int(settings.trading_drift_live_promotion_max_evidence_age_seconds)
-        ),
+        now=now,
+        max_age_seconds=max_age_seconds,
     )
     summary = summarize_hypothesis_runtime_statuses(
         items,
@@ -848,6 +852,116 @@ def _load_latest_runtime_ledger_summary(
     return {"by_hypothesis": by_hypothesis, "runtime_ledger_buckets": retained_rows}
 
 
+def _runtime_ledger_selection_score(payload: Mapping[str, object] | None) -> int:
+    if not isinstance(payload, Mapping):
+        return 0
+
+    score = 0
+    blockers = [
+        str(reason).strip()
+        for reason in cast(Sequence[object], payload.get("blockers") or [])
+        if str(reason).strip()
+    ]
+    if not blockers:
+        score += 1
+    if (
+        _safe_text(payload.get("pnl_basis"))
+        == "realized_strategy_pnl_after_explicit_costs"
+    ):
+        score += 1
+    if (_safe_decimal(payload.get("filled_notional")) or Decimal("0")) > 0:
+        score += 1
+    if (_safe_decimal(payload.get("post_cost_expectancy_bps")) or Decimal("0")) > 0:
+        score += 1
+    if _safe_int(payload.get("closed_trade_count")) > 0:
+        score += 1
+    if _safe_int(payload.get("open_position_count")) == 0:
+        score += 1
+    if _runtime_ledger_hash_count(
+        payload,
+        payload_key="execution_policy_hash_counts",
+        observed={},
+        observed_key="runtime_ledger_execution_policy_hash_count",
+    ) > 0:
+        score += 1
+    if _runtime_ledger_hash_count(
+        payload,
+        payload_key="cost_model_hash_counts",
+        observed={},
+        observed_key="runtime_ledger_cost_model_hash_count",
+    ) > 0:
+        score += 1
+    if _runtime_ledger_hash_count(
+        payload,
+        payload_key="lineage_hash_counts",
+        observed={},
+        observed_key="runtime_ledger_lineage_hash_count",
+    ) > 0:
+        score += 1
+    return score
+
+
+def _certificate_evidence_selection_key(
+    row: Mapping[str, object],
+    *,
+    now: datetime | None,
+    max_age_seconds: int | None,
+) -> tuple[int, int, int, int, int, int, int, Decimal, float]:
+    metric_window = cast(
+        StrategyHypothesisMetricWindow | None, row.get("metric_window")
+    )
+    promotion_decision = cast(
+        StrategyPromotionDecision | None, row.get("promotion_decision")
+    )
+    runtime_ledger_bucket = cast(
+        Mapping[str, object] | None, row.get("runtime_ledger_bucket")
+    )
+    if metric_window is None:
+        return (0, 0, 0, 0, 0, 0, 0, Decimal("0"), 0.0)
+
+    issued_at = _coerce_aware_datetime(
+        getattr(metric_window, "window_ended_at", None)
+        or getattr(metric_window, "created_at", None)
+    )
+    fresh_score = 1
+    if now is not None and max_age_seconds is not None and max_age_seconds > 0:
+        fresh_score = int(
+            issued_at is not None and issued_at >= now - timedelta(seconds=max_age_seconds)
+        )
+    observed_stage = _safe_text(getattr(metric_window, "observed_stage", None))
+    stage_score = {"live": 2, "paper": 1}.get(observed_stage or "", 0)
+    decision_score = 0
+    if promotion_decision is not None:
+        decision_score = int(
+            _safe_bool(getattr(promotion_decision, "allowed", False)) is True
+            and not _promotion_decision_blocking_reason_codes(promotion_decision)
+        )
+    activity_score = int(not _metric_window_activity_reason_codes(metric_window))
+    continuity_score = int(
+        bool(getattr(metric_window, "continuity_ok", False))
+        and bool(getattr(metric_window, "drift_ok", False))
+        and _safe_text(getattr(metric_window, "dependency_quorum_decision", None))
+        == "allow"
+    )
+    capital_rank = max(0, _stage_rank(getattr(metric_window, "capital_stage", None)))
+    sample_count = _safe_int(getattr(metric_window, "order_count", None))
+    expectancy_bps = _safe_decimal(
+        getattr(metric_window, "post_cost_expectancy_bps", None)
+    ) or Decimal("0")
+    issued_ts = issued_at.timestamp() if issued_at is not None else 0.0
+    return (
+        fresh_score,
+        stage_score,
+        decision_score,
+        activity_score,
+        continuity_score,
+        _runtime_ledger_selection_score(runtime_ledger_bucket),
+        capital_rank + sample_count,
+        expectancy_bps,
+        issued_ts,
+    )
+
+
 def _extract_runtime_summary(
     hypothesis_summary: Mapping[str, Any] | None,
 ) -> tuple[Mapping[str, Any], list[Mapping[str, Any]]]:
@@ -972,6 +1086,8 @@ def _load_latest_certificate_evidence(
     session: Session,
     *,
     hypothesis_ids: Sequence[str],
+    now: datetime | None = None,
+    max_age_seconds: int | None = None,
 ) -> list[dict[str, object]]:
     normalized_ids = [
         hypothesis_id for hypothesis_id in hypothesis_ids if hypothesis_id
@@ -979,7 +1095,7 @@ def _load_latest_certificate_evidence(
     if not normalized_ids:
         return []
 
-    latest_windows: dict[str, StrategyHypothesisMetricWindow] = {}
+    windows_by_hypothesis: dict[str, list[StrategyHypothesisMetricWindow]] = {}
     window_rows = session.execute(
         select(StrategyHypothesisMetricWindow)
         .where(StrategyHypothesisMetricWindow.hypothesis_id.in_(normalized_ids))
@@ -989,9 +1105,7 @@ def _load_latest_certificate_evidence(
         )
     ).scalars()
     for row in window_rows:
-        if row.hypothesis_id in latest_windows:
-            continue
-        latest_windows[row.hypothesis_id] = row
+        windows_by_hypothesis.setdefault(row.hypothesis_id, []).append(row)
 
     latest_promotions: dict[str, list[StrategyPromotionDecision]] = {}
     promotion_rows = session.execute(
@@ -1018,34 +1132,55 @@ def _load_latest_certificate_evidence(
 
     evidence: list[dict[str, object]] = []
     for hypothesis_id in normalized_ids:
-        metric_window = latest_windows.get(hypothesis_id)
-        promotion_decision = None
-        for decision in latest_promotions.get(hypothesis_id, []):
-            if metric_window is None or _promotion_decision_matches_metric_window(
-                decision,
-                metric_window=metric_window,
-            ):
-                promotion_decision = decision
+        candidate_rows: list[dict[str, object]] = []
+        for metric_window in windows_by_hypothesis.get(hypothesis_id, []):
+            promotion_decision = None
+            for decision in latest_promotions.get(hypothesis_id, []):
+                if _promotion_decision_matches_metric_window(
+                    decision,
+                    metric_window=metric_window,
+                ):
+                    promotion_decision = decision
+                    break
+            runtime_ledger_bucket = None
+            for ledger in latest_runtime_ledgers.get(hypothesis_id, []):
+                if (
+                    _safe_text(ledger.run_id) != _safe_text(metric_window.run_id)
+                    or _safe_text(ledger.candidate_id)
+                    != _safe_text(metric_window.candidate_id)
+                    or _safe_text(ledger.observed_stage)
+                    != _safe_text(metric_window.observed_stage)
+                ):
+                    continue
+                runtime_ledger_bucket = _runtime_ledger_bucket_payload(ledger)
                 break
-        runtime_ledger_bucket = None
-        for ledger in latest_runtime_ledgers.get(hypothesis_id, []):
-            if metric_window is not None and (
-                _safe_text(ledger.run_id) != _safe_text(metric_window.run_id)
-                or _safe_text(ledger.candidate_id)
-                != _safe_text(metric_window.candidate_id)
-                or _safe_text(ledger.observed_stage)
-                != _safe_text(metric_window.observed_stage)
-            ):
-                continue
-            runtime_ledger_bucket = _runtime_ledger_bucket_payload(ledger)
-            break
+            candidate_rows.append(
+                {
+                    "hypothesis_id": hypothesis_id,
+                    "metric_window": metric_window,
+                    "promotion_decision": promotion_decision,
+                    "runtime_ledger_bucket": runtime_ledger_bucket,
+                }
+            )
+        if not candidate_rows:
+            evidence.append(
+                {
+                    "hypothesis_id": hypothesis_id,
+                    "metric_window": None,
+                    "promotion_decision": None,
+                    "runtime_ledger_bucket": None,
+                }
+            )
+            continue
         evidence.append(
-            {
-                "hypothesis_id": hypothesis_id,
-                "metric_window": metric_window,
-                "promotion_decision": promotion_decision,
-                "runtime_ledger_bucket": runtime_ledger_bucket,
-            }
+            max(
+                candidate_rows,
+                key=lambda row: _certificate_evidence_selection_key(
+                    row,
+                    now=now,
+                    max_age_seconds=max_age_seconds,
+                ),
+            )
         )
     return evidence
 
@@ -2159,11 +2294,13 @@ def build_live_submission_gate_payload(
         else _load_latest_certificate_evidence(
             session,
             hypothesis_ids=[item.hypothesis_id for item in registry.items],
+            now=now,
+            max_age_seconds=max_age_seconds,
         )
         if session is not None
         else []
     )
-    readiness_evidence_rows: list[Mapping[str, object]] = []
+    runtime_evidence_rows: list[Mapping[str, object]] = []
     for row in evidence_rows:
         metric_window = cast(
             StrategyHypothesisMetricWindow | None, row.get("metric_window")
@@ -2173,13 +2310,17 @@ def build_live_submission_gate_payload(
         )
         if metric_window is None or promotion_decision is None:
             continue
-        if _safe_text(getattr(metric_window, "observed_stage", None)) != "paper":
+        if _safe_text(getattr(metric_window, "observed_stage", None)) not in {
+            "paper",
+            "live",
+        }:
             continue
-        readiness_evidence_rows.append(row)
-    if runtime_items and readiness_evidence_rows:
+        runtime_evidence_rows.append(row)
+    claimed_promotion_eligible_total = _safe_int(summary.get("promotion_eligible_total"))
+    if runtime_items and runtime_evidence_rows:
         runtime_items = _merge_runtime_certificate_evidence(
             runtime_items,
-            evidence=readiness_evidence_rows,
+            evidence=runtime_evidence_rows,
             now=now,
             max_age_seconds=max_age_seconds,
         )
@@ -2322,7 +2463,9 @@ def build_live_submission_gate_payload(
         for item in evaluated_tuples
         for reason in cast(Sequence[str], item.get("reason_codes") or [])
     ]
-    if promotion_eligible_total > 0 and not valid_candidates:
+    if (
+        promotion_eligible_total > 0 or claimed_promotion_eligible_total > 0
+    ) and not valid_candidates:
         if not evaluated_tuples:
             blocked_reasons.append("promotion_certificate_missing")
             blocked_reasons.append("hypothesis_window_evidence_missing")

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -19,6 +19,7 @@ from app.models import (
     AutoresearchProposalScore,
     Base,
     Strategy,
+    StrategyHypothesis,
     StrategyHypothesisMetricWindow,
     StrategyPromotionDecision,
     StrategyRuntimeLedgerBucket,
@@ -1113,6 +1114,322 @@ class TestSubmissionCouncil(TestCase):
             item["informational_reasons"],
             ["runtime_window_certificate_applied"],
         )
+
+    def test_hypothesis_runtime_summary_prefers_stronger_runtime_certificate_candidate(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        now = datetime.now(timezone.utc)
+        settings.trading_drift_live_promotion_max_evidence_age_seconds = 3600
+        registry = SimpleNamespace(
+            loaded=True,
+            path="test-registry",
+            errors=[],
+            items=[SimpleNamespace(hypothesis_id="H-CONT-01")],
+        )
+        runtime_items = [
+            {
+                "hypothesis_id": "H-CONT-01",
+                "candidate_id": None,
+                "strategy_id": "intraday_continuation",
+                "lane_id": "continuation",
+                "strategy_family": "intraday_continuation",
+                "state": "shadow",
+                "capital_stage": "shadow",
+                "capital_multiplier": "0",
+                "promotion_eligible": False,
+                "rollback_required": False,
+                "reasons": ["drift_checks_missing"],
+                "informational_reasons": [],
+                "observed": {},
+            }
+        ]
+
+        with session_local() as session:
+            session.add(
+                StrategyHypothesisMetricWindow(
+                    run_id="runtime-proof-good",
+                    candidate_id="cand-good",
+                    hypothesis_id="H-CONT-01",
+                    observed_stage="live",
+                    window_started_at=now - timedelta(minutes=15),
+                    window_ended_at=now - timedelta(minutes=5),
+                    market_session_count=3,
+                    decision_count=42,
+                    trade_count=42,
+                    order_count=42,
+                    avg_abs_slippage_bps="4.2",
+                    slippage_budget_bps="12",
+                    post_cost_expectancy_bps="8.5",
+                    continuity_ok=True,
+                    drift_ok=True,
+                    dependency_quorum_decision="allow",
+                    capital_stage="0.10x canary",
+                    payload_json={
+                        "post_cost_promotion_sample_count": 42,
+                        "post_cost_basis_counts": {
+                            "realized_strategy_pnl_after_explicit_costs": 42
+                        },
+                        "post_cost_expectancy_aggregation": "runtime_ledger_notional_weighted",
+                        "runtime_ledger_notional_weighted_sample_count": 42,
+                    },
+                )
+            )
+            session.add(
+                StrategyPromotionDecision(
+                    run_id="runtime-proof-good",
+                    candidate_id="cand-good",
+                    hypothesis_id="H-CONT-01",
+                    promotion_target="live",
+                    state="0.10x canary",
+                    allowed=True,
+                    reason_summary="runtime_evidence_thresholds_satisfied",
+                )
+            )
+            session.add(
+                self._runtime_ledger_bucket_row(
+                    run_id="runtime-proof-good",
+                    candidate_id="cand-good",
+                    hypothesis_id="H-CONT-01",
+                    bucket_at=now - timedelta(minutes=5),
+                )
+            )
+            session.add(
+                StrategyHypothesisMetricWindow(
+                    run_id="runtime-proof-blocked",
+                    candidate_id="cand-blocked-newer",
+                    hypothesis_id="H-CONT-01",
+                    observed_stage="live",
+                    window_started_at=now - timedelta(minutes=10),
+                    window_ended_at=now,
+                    market_session_count=3,
+                    decision_count=0,
+                    trade_count=0,
+                    order_count=0,
+                    avg_abs_slippage_bps="0",
+                    slippage_budget_bps="12",
+                    post_cost_expectancy_bps="0",
+                    continuity_ok=True,
+                    drift_ok=True,
+                    dependency_quorum_decision="allow",
+                    capital_stage="0.10x canary",
+                    payload_json={
+                        "post_cost_promotion_sample_count": 0,
+                        "post_cost_basis_counts": {},
+                        "post_cost_expectancy_aggregation": "no_promotion_grade_post_cost_rows",
+                        "runtime_ledger_notional_weighted_sample_count": 0,
+                    },
+                )
+            )
+            session.add(
+                StrategyPromotionDecision(
+                    run_id="runtime-proof-blocked",
+                    candidate_id="cand-blocked-newer",
+                    hypothesis_id="H-CONT-01",
+                    promotion_target="live",
+                    state="0.10x canary",
+                    allowed=False,
+                    reason_summary="runtime_decision_count_zero,runtime_order_count_zero",
+                )
+            )
+            session.commit()
+
+            with (
+                patch(
+                    "app.trading.submission_council.load_hypothesis_registry",
+                    return_value=registry,
+                ),
+                patch(
+                    "app.trading.submission_council.resolve_hypothesis_dependency_quorum",
+                    return_value=JangarDependencyQuorumStatus(
+                        decision="allow",
+                        reasons=[],
+                        message="ready",
+                    ),
+                ),
+                patch(
+                    "app.trading.submission_council.compile_hypothesis_runtime_statuses",
+                    return_value=runtime_items,
+                ),
+                patch(
+                    "app.trading.submission_council.build_tca_gate_inputs",
+                    return_value={},
+                ),
+            ):
+                result = build_hypothesis_runtime_summary(
+                    session,
+                    state=SimpleNamespace(market_session_open=True),
+                    market_context_status={"last_freshness_seconds": 10},
+                )
+
+        self.assertEqual(result["promotion_eligible_total"], 1)
+        item = result["items"][0]
+        self.assertTrue(item["promotion_eligible"])
+        self.assertEqual(item["candidate_id"], "cand-good")
+        self.assertEqual(item["capital_stage"], "0.10x canary")
+        self.assertEqual(item["reasons"], [])
+
+    def test_build_live_submission_gate_payload_rescues_stale_summary_with_session_live_runtime_evidence(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        now = datetime.now(timezone.utc)
+        settings.trading_drift_live_promotion_max_evidence_age_seconds = 3600
+
+        class _RegistryItem:
+            hypothesis_id = "H-CONT-01"
+
+            def model_dump(self, *, mode: str = "json") -> dict[str, object]:
+                return {
+                    "hypothesis_id": "H-CONT-01",
+                    "candidate_id": "cand-live",
+                    "strategy_id": "intraday_continuation",
+                    "strategy_family": "intraday_continuation",
+                    "lane_id": "continuation",
+                    "dataset_snapshot_ref": "snap-live-runtime-proof",
+                    "segment_dependencies": [],
+                }
+
+        registry = SimpleNamespace(
+            loaded=True,
+            path="test-registry",
+            errors=[],
+            items=[_RegistryItem()],
+        )
+        stale_runtime_item = {
+            "hypothesis_id": "H-CONT-01",
+            "candidate_id": None,
+            "strategy_id": "intraday_continuation",
+            "lane_id": "continuation",
+            "strategy_family": "intraday_continuation",
+            "state": "shadow",
+            "capital_stage": "shadow",
+            "capital_multiplier": "0",
+            "promotion_eligible": False,
+            "rollback_required": False,
+            "reasons": ["drift_checks_missing"],
+            "informational_reasons": [],
+            "observed": {},
+        }
+
+        with session_local() as session:
+            session.add(
+                StrategyHypothesis(
+                    hypothesis_id="H-CONT-01",
+                    lane_id="continuation",
+                    strategy_family="intraday_continuation",
+                    source_manifest_ref="config/trading/hypotheses/h-cont-01.json",
+                    active=True,
+                    payload_json={},
+                )
+            )
+            session.add(
+                StrategyHypothesisMetricWindow(
+                    run_id="runtime-proof-live",
+                    candidate_id="cand-live",
+                    hypothesis_id="H-CONT-01",
+                    observed_stage="live",
+                    window_started_at=now - timedelta(minutes=15),
+                    window_ended_at=now,
+                    market_session_count=3,
+                    decision_count=42,
+                    trade_count=42,
+                    order_count=42,
+                    avg_abs_slippage_bps="4.2",
+                    slippage_budget_bps="12",
+                    post_cost_expectancy_bps="8.5",
+                    continuity_ok=True,
+                    drift_ok=True,
+                    dependency_quorum_decision="allow",
+                    capital_stage="0.10x canary",
+                    payload_json={
+                        "post_cost_promotion_sample_count": 42,
+                        "post_cost_basis_counts": {
+                            "realized_strategy_pnl_after_explicit_costs": 42
+                        },
+                        "post_cost_expectancy_aggregation": "runtime_ledger_notional_weighted",
+                        "runtime_ledger_notional_weighted_sample_count": 42,
+                    },
+                )
+            )
+            session.add(
+                StrategyPromotionDecision(
+                    run_id="runtime-proof-live",
+                    candidate_id="cand-live",
+                    hypothesis_id="H-CONT-01",
+                    promotion_target="live",
+                    state="0.10x canary",
+                    allowed=True,
+                    reason_summary="runtime_evidence_thresholds_satisfied",
+                )
+            )
+            session.add(
+                self._runtime_ledger_bucket_row(
+                    run_id="runtime-proof-live",
+                    candidate_id="cand-live",
+                    hypothesis_id="H-CONT-01",
+                    bucket_at=now,
+                )
+            )
+            session.commit()
+
+            with patch(
+                "app.trading.submission_council.load_hypothesis_registry",
+                return_value=registry,
+            ):
+                gate = build_live_submission_gate_payload(
+                    SimpleNamespace(
+                        market_session_open=True,
+                        last_autonomy_promotion_eligible=True,
+                        last_autonomy_promotion_action="promote",
+                        drift_live_promotion_eligible=False,
+                        last_market_context_freshness_seconds=45,
+                    ),
+                    hypothesis_summary={
+                        "summary": {
+                            "promotion_eligible_total": 0,
+                            "paper_probation_eligible_total": 0,
+                            "capital_stage_totals": {"shadow": 1},
+                            "reason_totals": {"drift_checks_missing": 1},
+                            "dependency_quorum": {
+                                "decision": "allow",
+                                "reasons": [],
+                                "message": "ready",
+                            },
+                        },
+                        "items": [stale_runtime_item],
+                    },
+                    empirical_jobs_status={"ready": True, "status": "healthy"},
+                    dspy_runtime_status={"mode": "inactive"},
+                    quant_health_status=self._healthy_quant_status(),
+                    session=session,
+                    clickhouse_ta_status={
+                        "state": "current",
+                        "source_ref": "torghut.ta_signals",
+                        "signal_rows": 12,
+                        "symbol_count": 6,
+                    },
+                )
+
+        self.assertTrue(gate["allowed"])
+        self.assertEqual(gate["promotion_eligible_total"], 1)
+        self.assertEqual(gate["capital_stage"], "0.10x canary")
+        self.assertEqual(gate["evidence_tuple"]["candidate_id"], "cand-live")
+        self.assertNotIn("alpha_readiness_not_promotion_eligible", gate["blocked_reasons"])
 
     def test_load_latest_certificate_evidence_skips_mismatched_runtime_ledger_bucket(
         self,


### PR DESCRIPTION
## Summary

- Scores recent runtime-window certificate candidates by freshness, stage, allowed decision state, activity, runtime-ledger quality, capital stage, samples, and expectancy instead of keeping only the newest row per hypothesis.
- Lets the live-submission gate refresh stale runtime summary items from live DB-backed certificate evidence, while preserving rejection details when a claimed eligible item is rejected.
- Adds regression coverage for strongest-candidate selection and stale-summary rescue through live runtime-ledger evidence.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py -k 'hypothesis_runtime_summary_prefers_stronger_runtime_certificate_candidate or build_live_submission_gate_payload_rescues_stale_summary_with_session_live_runtime_evidence'`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k 'live_submission_gate'`
- `cd services/torghut && uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
