### PR TITLE
fix(torghut): resolve replay config from repo root

### DIFF
--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -77,6 +77,11 @@ _EXACT_REPLAY_LEDGER_ROWS_SCHEMA_VERSION = "torghut.exact_replay_ledger.rows.v1"
 _REPLAY_LEDGER_ACCOUNT_LABEL = "TORGHUT_REPLAY"
 _REPLAY_COST_BASIS = "local_replay_transaction_cost_model"
 _REPLAY_LEDGER_SOURCE = "local_intraday_tsmom_replay"
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def default_strategy_configmap_path() -> Path:
+    return _REPO_ROOT / "argocd/applications/torghut/strategy-configmap.yaml"
 
 
 def _position_key(symbol: str, strategy_id: str) -> tuple[str, str]:
@@ -468,7 +473,8 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--strategy-configmap",
-        default="argocd/applications/torghut/strategy-configmap.yaml",
+        type=Path,
+        default=default_strategy_configmap_path(),
     )
     parser.add_argument(
         "--clickhouse-http-url",

--- a/services/torghut/scripts/materialize_replay_tape.py
+++ b/services/torghut/scripts/materialize_replay_tape.py
@@ -32,7 +32,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--strategy-configmap",
         type=Path,
-        default=Path("argocd/applications/torghut/strategy-configmap.yaml"),
+        default=replay_mod.default_strategy_configmap_path(),
         help="Accepted for parity with replay CLIs; signal materialization does not inspect strategy contents.",
     )
     parser.add_argument(

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -491,7 +491,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--strategy-configmap",
         type=Path,
-        default=Path("argocd/applications/torghut/strategy-configmap.yaml"),
+        default=replay_mod.default_strategy_configmap_path(),
     )
     parser.add_argument(
         "--sweep-config",

--- a/services/torghut/scripts/search_profitability_frontier.py
+++ b/services/torghut/scripts/search_profitability_frontier.py
@@ -22,7 +22,12 @@ from app.trading.reporting import (
     ProfitabilityConstraintPolicy,
     score_replay_profitability_candidate,
 )
-from scripts.local_intraday_tsmom_replay import ReplayConfig, _http_query, run_replay
+from scripts.local_intraday_tsmom_replay import (
+    ReplayConfig,
+    _http_query,
+    default_strategy_configmap_path,
+    run_replay,
+)
 
 _SWEEP_SCHEMA_VERSION = "torghut.replay-frontier-sweep.v1"
 _REPLAY_SIGNAL_TABLE = "torghut.ta_signals"
@@ -58,7 +63,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--strategy-configmap",
         type=Path,
-        default=Path("argocd/applications/torghut/strategy-configmap.yaml"),
+        default=default_strategy_configmap_path(),
     )
     parser.add_argument(
         "--sweep-config",

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -1846,6 +1846,17 @@ class TestLocalIntradayTsmomReplay(TestCase):
         self.assertEqual(args.clickhouse_username, "env-user")
         self.assertEqual(args.clickhouse_password, "env-secret")
 
+    def test_parse_args_uses_repo_root_strategy_configmap_by_default(self) -> None:
+        with patch.object(sys, "argv", ["local_intraday_tsmom_replay.py"]):
+            args = replay_main.__globals__["_parse_args"]()
+
+        expected = (
+            Path(__file__).resolve().parents[3]
+            / "argocd/applications/torghut/strategy-configmap.yaml"
+        )
+        self.assertEqual(args.strategy_configmap, expected)
+        self.assertTrue(args.strategy_configmap.exists())
+
     def test_replay_main_enables_trace_capture_for_funnel_and_near_miss_outputs(
         self,
     ) -> None:

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -34,6 +34,32 @@ from scripts.local_intraday_tsmom_replay import (
 
 
 class TestReplayTape(TestCase):
+    def test_materialize_cli_default_strategy_configmap_is_repo_rooted(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            with patch.object(
+                sys,
+                "argv",
+                [
+                    "materialize_replay_tape.py",
+                    "--start-date",
+                    "2026-05-13",
+                    "--end-date",
+                    "2026-05-13",
+                    "--dataset-snapshot-ref",
+                    "snapshot-a",
+                    "--output",
+                    str(Path(tmpdir) / "tape.jsonl"),
+                ],
+            ):
+                args = materialize_cli._parse_args()
+
+        expected = (
+            Path(__file__).resolve().parents[3]
+            / "argocd/applications/torghut/strategy-configmap.yaml"
+        )
+        self.assertEqual(args.strategy_configmap, expected)
+        self.assertTrue(args.strategy_configmap.exists())
+
     def _signal(
         self,
         *,

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -147,6 +147,17 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(args.second_oos_days, 2)
         self.assertTrue(args.collect_train_gate_diagnostics)
 
+    def test_parse_args_uses_repo_root_strategy_configmap_by_default(self) -> None:
+        with patch.object(sys, "argv", ["prog"]):
+            args = frontier._parse_args()
+
+        expected = (
+            Path(__file__).resolve().parents[3]
+            / "argocd/applications/torghut/strategy-configmap.yaml"
+        )
+        self.assertEqual(args.strategy_configmap, expected)
+        self.assertTrue(args.strategy_configmap.exists())
+
     def test_clickhouse_preflight_fails_fast_for_unresolved_in_cluster_dns(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Resolve Torghut replay/frontier CLI default strategy-configmap paths from the repository root instead of the current working directory.
- Share the repo-rooted default from `local_intraday_tsmom_replay.py` across materialized replay tape and profitability frontier entrypoints.
- Add parser regressions covering the default path for local replay, materialized replay tape, and consistent profitability frontier CLIs.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_local_intraday_tsmom_replay.py -k 'parse_args_uses_repo_root_strategy_configmap_by_default or parse_args_prefers_ta_clickhouse_env_defaults'`
- `uv run --frozen pytest tests/test_replay_tape.py -k 'materialize_cli_default_strategy_configmap_is_repo_rooted'`
- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -k 'parse_args_uses_repo_root_strategy_configmap_by_default or parse_args_supports_harness_v2_flags'`
- `uv run --frozen ruff check scripts/local_intraday_tsmom_replay.py scripts/materialize_replay_tape.py scripts/search_consistent_profitability_frontier.py scripts/search_profitability_frontier.py tests/test_local_intraday_tsmom_replay.py tests/test_replay_tape.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen python scripts/search_consistent_profitability_frontier.py --help`
- `uv run --frozen python scripts/search_profitability_frontier.py --help`
- `uv run --frozen python scripts/materialize_replay_tape.py --help`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
