### PR TITLE
fix(torghut): broaden frontier activity diagnostics

### DIFF
--- a/services/torghut/app/trading/evaluation_trace.py
+++ b/services/torghut/app/trading/evaluation_trace.py
@@ -8,21 +8,21 @@ from decimal import Decimal
 from typing import Any, Literal, Mapping, cast
 
 GateCategory = Literal[
-    'eligibility',
-    'feed_quality',
-    'structure',
-    'confirmation',
-    'risk',
-    'execution',
-    'exit',
+    "eligibility",
+    "feed_quality",
+    "structure",
+    "confirmation",
+    "risk",
+    "execution",
+    "exit",
 ]
-MissingPolicy = Literal['fail_open', 'fail_closed']
-FillStatus = Literal['none', 'pending', 'filled']
+MissingPolicy = Literal["fail_open", "fail_closed"]
+FillStatus = Literal["none", "pending", "filled"]
 
-_TRACE_SCHEMA_VERSION = 'torghut.strategy-trace.v1'
-_REPLAY_TRACE_SCHEMA_VERSION = 'torghut.replay-trace.v1'
-_REPLAY_FUNNEL_SCHEMA_VERSION = 'torghut.replay-funnel.v1'
-_SWEEP_RESULT_SCHEMA_VERSION = 'torghut.sweep-candidate-result.v1'
+_TRACE_SCHEMA_VERSION = "torghut.strategy-trace.v1"
+_REPLAY_TRACE_SCHEMA_VERSION = "torghut.replay-trace.v1"
+_REPLAY_FUNNEL_SCHEMA_VERSION = "torghut.replay-funnel.v1"
+_SWEEP_RESULT_SCHEMA_VERSION = "torghut.sweep-candidate-result.v1"
 
 
 def _empty_context() -> dict[str, Any]:
@@ -45,8 +45,7 @@ def _serialize_trace_value(value: Any) -> Any:
     if isinstance(value, dict):
         dict_value = cast(dict[Any, Any], value)
         return {
-            str(key): _serialize_trace_value(item)
-            for key, item in dict_value.items()
+            str(key): _serialize_trace_value(item) for key, item in dict_value.items()
         }
     return value
 
@@ -63,14 +62,16 @@ class ThresholdTrace:
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'metric': self.metric,
-            'comparator': self.comparator,
-            'value': _serialize_trace_value(self.value),
-            'threshold': _serialize_trace_value(self.threshold),
-            'passed': self.passed,
-            'missing_policy': self.missing_policy,
-            'distance_to_pass': (
-                str(self.distance_to_pass) if self.distance_to_pass is not None else None
+            "metric": self.metric,
+            "comparator": self.comparator,
+            "value": _serialize_trace_value(self.value),
+            "threshold": _serialize_trace_value(self.threshold),
+            "passed": self.passed,
+            "missing_policy": self.missing_policy,
+            "distance_to_pass": (
+                str(self.distance_to_pass)
+                if self.distance_to_pass is not None
+                else None
             ),
         }
 
@@ -87,21 +88,21 @@ class GateTrace:
         return tuple(item for item in self.thresholds if not item.passed)
 
     def distance_score(self) -> Decimal:
-        score = Decimal('0')
+        score = Decimal("0")
         for threshold in self.failing_thresholds():
             if threshold.distance_to_pass is None:
-                score += Decimal('1')
+                score += Decimal("1")
             else:
                 score += threshold.distance_to_pass
         return score
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'gate': self.gate,
-            'category': self.category,
-            'passed': self.passed,
-            'thresholds': [item.to_payload() for item in self.thresholds],
-            'context': _serialize_trace_value(self.context),
+            "gate": self.gate,
+            "category": self.category,
+            "passed": self.passed,
+            "thresholds": [item.to_payload() for item in self.thresholds],
+            "context": _serialize_trace_value(self.context),
         }
 
 
@@ -113,7 +114,7 @@ class StrategyTrace:
     event_ts: str
     timeframe: str
     passed: bool
-    action: Literal['buy', 'sell'] | None
+    action: Literal["buy", "sell"] | None
     rationale: tuple[str, ...] = ()
     gates: tuple[GateTrace, ...] = ()
     first_failed_gate: str | None = None
@@ -139,23 +140,23 @@ class StrategyTrace:
     def distance_score(self) -> Decimal:
         failed_gate = self.failed_gate()
         if failed_gate is None:
-            return Decimal('0')
+            return Decimal("0")
         return failed_gate.distance_score()
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'schema_version': self.schema_version,
-            'strategy_id': self.strategy_id,
-            'strategy_type': self.strategy_type,
-            'symbol': self.symbol,
-            'event_ts': self.event_ts,
-            'timeframe': self.timeframe,
-            'passed': self.passed,
-            'action': self.action,
-            'rationale': list(self.rationale),
-            'first_failed_gate': self.first_failed_gate,
-            'gates': [gate.to_payload() for gate in self.gates],
-            'context': _serialize_trace_value(self.context),
+            "schema_version": self.schema_version,
+            "strategy_id": self.strategy_id,
+            "strategy_type": self.strategy_type,
+            "symbol": self.symbol,
+            "event_ts": self.event_ts,
+            "timeframe": self.timeframe,
+            "passed": self.passed,
+            "action": self.action,
+            "rationale": list(self.rationale),
+            "first_failed_gate": self.first_failed_gate,
+            "gates": [gate.to_payload() for gate in self.gates],
+            "context": _serialize_trace_value(self.context),
         }
 
 
@@ -175,14 +176,14 @@ class ReplayTraceRecord:
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'schema_version': self.schema_version,
-            'trading_day': self.trading_day,
-            'decision_emitted': self.decision_emitted,
-            'fill_status': self.fill_status,
-            'decision_strategy_id': self.decision_strategy_id,
-            'block_reason': self.block_reason,
-            'fill_price': str(self.fill_price) if self.fill_price is not None else None,
-            'strategy_trace': self.strategy_trace.to_payload(),
+            "schema_version": self.schema_version,
+            "trading_day": self.trading_day,
+            "decision_emitted": self.decision_emitted,
+            "fill_status": self.fill_status,
+            "decision_strategy_id": self.decision_strategy_id,
+            "block_reason": self.block_reason,
+            "fill_price": str(self.fill_price) if self.fill_price is not None else None,
+            "strategy_trace": self.strategy_trace.to_payload(),
         }
 
 
@@ -197,6 +198,7 @@ class ReplayFunnelBucket:
     gate_pass_counts: dict[str, int]
     first_failed_gate_counts: dict[str, int]
     failing_threshold_counts: dict[str, int]
+    post_gate_block_reason_counts: dict[str, int]
     passed_trace_count: int
     decision_count: int
     filled_count: int
@@ -208,23 +210,30 @@ class ReplayFunnelBucket:
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'trading_day': self.trading_day,
-            'symbol': self.symbol,
-            'retained_rows': self.retained_rows,
-            'runtime_evaluable_rows': self.runtime_evaluable_rows,
-            'quote_valid_rows': self.quote_valid_rows,
-            'strategy_evaluations': self.strategy_evaluations,
-            'gate_pass_counts': dict(sorted(self.gate_pass_counts.items())),
-            'first_failed_gate_counts': dict(sorted(self.first_failed_gate_counts.items())),
-            'failing_threshold_counts': dict(sorted(self.failing_threshold_counts.items())),
-            'passed_trace_count': self.passed_trace_count,
-            'decision_count': self.decision_count,
-            'filled_count': self.filled_count,
-            'filled_notional': str(self.filled_notional),
-            'closed_trade_count': self.closed_trade_count,
-            'gross_pnl': str(self.gross_pnl),
-            'net_pnl': str(self.net_pnl),
-            'cost_total': str(self.cost_total),
+            "trading_day": self.trading_day,
+            "symbol": self.symbol,
+            "retained_rows": self.retained_rows,
+            "runtime_evaluable_rows": self.runtime_evaluable_rows,
+            "quote_valid_rows": self.quote_valid_rows,
+            "strategy_evaluations": self.strategy_evaluations,
+            "gate_pass_counts": dict(sorted(self.gate_pass_counts.items())),
+            "first_failed_gate_counts": dict(
+                sorted(self.first_failed_gate_counts.items())
+            ),
+            "failing_threshold_counts": dict(
+                sorted(self.failing_threshold_counts.items())
+            ),
+            "post_gate_block_reason_counts": dict(
+                sorted(self.post_gate_block_reason_counts.items())
+            ),
+            "passed_trace_count": self.passed_trace_count,
+            "decision_count": self.decision_count,
+            "filled_count": self.filled_count,
+            "filled_notional": str(self.filled_notional),
+            "closed_trade_count": self.closed_trade_count,
+            "gross_pnl": str(self.gross_pnl),
+            "net_pnl": str(self.net_pnl),
+            "cost_total": str(self.cost_total),
         }
 
 
@@ -237,10 +246,10 @@ class ReplayFunnelReport:
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'schema_version': self.schema_version,
-            'start_date': self.start_date,
-            'end_date': self.end_date,
-            'buckets': [bucket.to_payload() for bucket in self.buckets],
+            "schema_version": self.schema_version,
+            "start_date": self.start_date,
+            "end_date": self.end_date,
+            "buckets": [bucket.to_payload() for bucket in self.buckets],
         }
 
 
@@ -251,22 +260,22 @@ class NearMissRecord:
     strategy_id: str
     strategy_type: str
     event_ts: str
-    action: Literal['buy', 'sell'] | None
+    action: Literal["buy", "sell"] | None
     first_failed_gate: str
     distance_score: Decimal
     thresholds: tuple[ThresholdTrace, ...]
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'trading_day': self.trading_day,
-            'symbol': self.symbol,
-            'strategy_id': self.strategy_id,
-            'strategy_type': self.strategy_type,
-            'event_ts': self.event_ts,
-            'action': self.action,
-            'first_failed_gate': self.first_failed_gate,
-            'distance_score': str(self.distance_score),
-            'thresholds': [item.to_payload() for item in self.thresholds],
+            "trading_day": self.trading_day,
+            "symbol": self.symbol,
+            "strategy_id": self.strategy_id,
+            "strategy_type": self.strategy_type,
+            "event_ts": self.event_ts,
+            "action": self.action,
+            "first_failed_gate": self.first_failed_gate,
+            "distance_score": str(self.distance_score),
+            "thresholds": [item.to_payload() for item in self.thresholds],
         }
 
 
@@ -290,33 +299,35 @@ class SweepCandidateResult:
 
     def to_payload(self) -> dict[str, Any]:
         return {
-            'schema_version': self.schema_version,
-            'candidate_id': self.candidate_id,
-            'family': self.family,
-            'strategy_name': self.strategy_name,
-            'train_net_per_day': str(self.train_net_per_day),
-            'holdout_net_per_day': str(self.holdout_net_per_day),
-            'train_total_net': str(self.train_total_net),
-            'holdout_total_net': str(self.holdout_total_net),
-            'active_holdout_days': self.active_holdout_days,
-            'max_holdout_drawdown_day': str(self.max_holdout_drawdown_day),
-            'profit_factor': str(self.profit_factor) if self.profit_factor is not None else None,
-            'wins': self.wins,
-            'losses': self.losses,
-            'score': str(self.score),
-            'replay_config': _serialize_trace_value(dict(self.replay_config)),
+            "schema_version": self.schema_version,
+            "candidate_id": self.candidate_id,
+            "family": self.family,
+            "strategy_name": self.strategy_name,
+            "train_net_per_day": str(self.train_net_per_day),
+            "holdout_net_per_day": str(self.holdout_net_per_day),
+            "train_total_net": str(self.train_total_net),
+            "holdout_total_net": str(self.holdout_total_net),
+            "active_holdout_days": self.active_holdout_days,
+            "max_holdout_drawdown_day": str(self.max_holdout_drawdown_day),
+            "profit_factor": str(self.profit_factor)
+            if self.profit_factor is not None
+            else None,
+            "wins": self.wins,
+            "losses": self.losses,
+            "score": str(self.score),
+            "replay_config": _serialize_trace_value(dict(self.replay_config)),
         }
 
 
 __all__ = [
-    'FillStatus',
-    'GateCategory',
-    'GateTrace',
-    'NearMissRecord',
-    'ReplayFunnelBucket',
-    'ReplayFunnelReport',
-    'ReplayTraceRecord',
-    'StrategyTrace',
-    'SweepCandidateResult',
-    'ThresholdTrace',
+    "FillStatus",
+    "GateCategory",
+    "GateTrace",
+    "NearMissRecord",
+    "ReplayFunnelBucket",
+    "ReplayFunnelReport",
+    "ReplayTraceRecord",
+    "StrategyTrace",
+    "SweepCandidateResult",
+    "ThresholdTrace",
 ]

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -1751,6 +1751,7 @@ def _init_funnel_stats() -> dict[str, Any]:
         "gate_pass_counts": defaultdict(int),
         "first_failed_gate_counts": defaultdict(int),
         "failing_threshold_counts": defaultdict(int),
+        "post_gate_block_reason_counts": defaultdict(int),
         "passed_trace_count": 0,
         "decision_count": 0,
         "filled_count": 0,
@@ -2036,13 +2037,19 @@ def _first_reject_reason(
 def _resolve_passed_trace_block_reason(
     *,
     strategy_id: str,
+    runtime_intent_strategy_ids: set[str],
+    runtime_suppression_reason_by_strategy_id: dict[str, str],
     raw_decision_strategy_ids: set[str],
     allocation_reject_reason_by_strategy_id: dict[str, str],
     sizing_reject_reason_by_strategy_id: dict[str, str],
     emitted_strategy_ids: set[str],
 ) -> str | None:
+    if strategy_id not in runtime_intent_strategy_ids:
+        return "engine_runtime_no_intent"
+    if strategy_id in runtime_suppression_reason_by_strategy_id:
+        return runtime_suppression_reason_by_strategy_id[strategy_id]
     if strategy_id not in raw_decision_strategy_ids:
-        return "engine_runtime_filter_rejected"
+        return "engine_runtime_intent_not_emitted"
     if strategy_id in allocation_reject_reason_by_strategy_id:
         return allocation_reject_reason_by_strategy_id[strategy_id]
     if strategy_id in sizing_reject_reason_by_strategy_id:
@@ -2756,6 +2763,17 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             raw_decision_strategy_ids = {
                 decision.strategy_id for decision in raw_decisions
             }
+            runtime_intent_strategy_ids = set(raw_decision_strategy_ids)
+            runtime_suppression_reason_by_strategy_id: dict[str, str] = {}
+            observation = getattr(telemetry, "observation", None)
+            if observation is not None:
+                runtime_intent_strategy_ids = set(observation.strategy_intents_total)
+                for raw_key in observation.strategy_intent_suppression_total:
+                    strategy_id, separator, reason = str(raw_key).partition("|")
+                    if separator and strategy_id and reason:
+                        runtime_suppression_reason_by_strategy_id.setdefault(
+                            strategy_id, reason
+                        )
             allocation_reject_reason_by_strategy_id: dict[str, str] = {}
             sizing_reject_reason_by_strategy_id: dict[str, str] = {}
             for allocation_result in allocator.allocate(
@@ -2799,11 +2817,13 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             }
             fill_status_by_strategy_id: dict[str, str] = {}
             block_reason_by_strategy_id: dict[str, str] = {}
-            if config.capture_traces:
+            if capture_runtime_traces:
                 for trace in telemetry_traces:
                     if trace.passed:
                         block_reason = _resolve_passed_trace_block_reason(
                             strategy_id=trace.strategy_id,
+                            runtime_intent_strategy_ids=runtime_intent_strategy_ids,
+                            runtime_suppression_reason_by_strategy_id=runtime_suppression_reason_by_strategy_id,
                             raw_decision_strategy_ids=raw_decision_strategy_ids,
                             allocation_reject_reason_by_strategy_id=allocation_reject_reason_by_strategy_id,
                             sizing_reject_reason_by_strategy_id=sizing_reject_reason_by_strategy_id,
@@ -2813,6 +2833,9 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                             block_reason_by_strategy_id[trace.strategy_id] = (
                                 block_reason
                             )
+                            symbol_bucket["post_gate_block_reason_counts"][
+                                block_reason
+                            ] += 1
                     elif not trace.passed and trace.first_failed_gate is not None:
                         block_reason_by_strategy_id[trace.strategy_id] = (
                             trace.first_failed_gate
@@ -3122,6 +3145,9 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 gate_pass_counts=dict(bucket["gate_pass_counts"]),
                 first_failed_gate_counts=dict(bucket["first_failed_gate_counts"]),
                 failing_threshold_counts=dict(bucket["failing_threshold_counts"]),
+                post_gate_block_reason_counts=dict(
+                    bucket["post_gate_block_reason_counts"]
+                ),
                 passed_trace_count=int(bucket["passed_trace_count"]),
                 decision_count=int(bucket["decision_count"]),
                 filled_count=int(bucket["filled_count"]),

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -136,6 +136,25 @@ _CONSISTENCY_REPAIR_COOLDOWN_KEYS = (
     "entry_cooldown_seconds",
     "signal_cooldown_seconds",
 )
+_CONSISTENCY_REPAIR_SIGNAL_THRESHOLD_KEYS = (
+    "min_cross_section_continuation_rank",
+    "min_cross_section_reversal_rank",
+    "min_cross_section_opening_window_return_rank",
+    "isolated_same_day_min_session_open_rank",
+    "isolated_same_day_min_opening_window_return_rank",
+    "isolated_same_day_min_continuation_rank",
+    "min_cross_section_continuation_breadth",
+    "min_recent_above_opening_window_close_ratio",
+    "min_recent_above_opening_range_high_ratio",
+    "min_recent_above_vwap_w5m_ratio",
+    "min_recent_microprice_bias_bps",
+    "min_recent_imbalance_pressure",
+    "min_imbalance_pressure",
+)
+_CONSISTENCY_REPAIR_RANK_STEP = Decimal("0.05")
+_CONSISTENCY_REPAIR_MIN_RANK_THRESHOLD = Decimal("0.01")
+_CONSISTENCY_REPAIR_THRESHOLD_SCALE = Decimal("0.80")
+_CONSISTENCY_REPAIR_MAX_SIGNAL_THRESHOLD_RELAXATIONS = 2
 
 
 @dataclass(frozen=True)
@@ -923,11 +942,26 @@ def _parameter_grid_items(
 
 def _parameter_exploration_priority(name: str) -> int:
     lowered = name.lower()
+    if lowered in {
+        "rank_feature",
+        "rank_count",
+        "selection_mode",
+        "signal_motif",
+        "top_n",
+    } or any(
+        token in lowered
+        for token in (
+            "entry_minute",
+            "exit_minute",
+            "entry_window",
+        )
+    ):
+        return 0
     if any(
         token in lowered
         for token in ("imbalance", "microprice", "recent_above", "spread", "quote")
     ):
-        return 0
+        return 1
     if any(
         token in lowered
         for token in (
@@ -942,17 +976,17 @@ def _parameter_exploration_priority(name: str) -> int:
             "entry_end",
         )
     ):
-        return 1
+        return 2
     if any(
         token in lowered
         for token in ("bullish_hist", "bull_rsi", "vol_floor", "vol_ceil")
     ):
-        return 2
+        return 3
     if any(
         token in lowered
         for token in ("universe_symbols", "max_notional", "position_pct")
     ):
-        return 3
+        return 4
     if any(
         token in lowered
         for token in (
@@ -964,8 +998,8 @@ def _parameter_exploration_priority(name: str) -> int:
             "max_concurrent",
         )
     ):
-        return 4
-    return 5
+        return 5
+    return 6
 
 
 def _candidate_payload_key(candidate: Mapping[str, Any]) -> str:
@@ -2919,6 +2953,7 @@ def _train_gate_diagnostics_from_replay_payload(
     first_failed_gate_counts: Counter[str] = Counter()
     failing_threshold_counts: Counter[str] = Counter()
     gate_pass_counts: Counter[str] = Counter()
+    post_gate_block_reason_counts: Counter[str] = Counter()
     for raw_bucket in buckets:
         if not isinstance(raw_bucket, Mapping):
             continue
@@ -2942,6 +2977,9 @@ def _train_gate_diagnostics_from_replay_payload(
         gate_pass_counts.update(
             _counter_from_payload(raw_bucket.get("gate_pass_counts"))
         )
+        post_gate_block_reason_counts.update(
+            _counter_from_payload(raw_bucket.get("post_gate_block_reason_counts"))
+        )
 
     near_misses = payload.get("near_misses")
     near_miss_digest = [
@@ -2961,6 +2999,9 @@ def _train_gate_diagnostics_from_replay_payload(
         "top_first_failed_gates": _top_counter_payload(first_failed_gate_counts),
         "top_failing_thresholds": _top_counter_payload(failing_threshold_counts),
         "top_gate_pass_counts": _top_counter_payload(gate_pass_counts),
+        "top_post_gate_block_reasons": _top_counter_payload(
+            post_gate_block_reason_counts
+        ),
         "near_misses": near_miss_digest,
     }
 
@@ -3364,6 +3405,37 @@ def _halve_positive_integer_candidate_param(
     return False
 
 
+def _relax_signal_threshold_candidate_param(
+    *,
+    params: dict[str, Any],
+    strategy_params: Mapping[str, Any],
+    keys: Sequence[str],
+) -> bool:
+    relaxed_count = 0
+    for key in keys:
+        if key not in params and key not in strategy_params:
+            continue
+        current = _decimal_or_none(params.get(key, strategy_params.get(key)))
+        if current is None or current <= 0:
+            continue
+        if current <= Decimal("1"):
+            repaired = max(
+                _CONSISTENCY_REPAIR_MIN_RANK_THRESHOLD,
+                (current - _CONSISTENCY_REPAIR_RANK_STEP).quantize(Decimal("0.01")),
+            )
+        else:
+            repaired = (current * _CONSISTENCY_REPAIR_THRESHOLD_SCALE).quantize(
+                Decimal("0.01")
+            )
+        if repaired >= current:
+            continue
+        params[key] = _decimal_payload(repaired)
+        relaxed_count += 1
+        if relaxed_count >= _CONSISTENCY_REPAIR_MAX_SIGNAL_THRESHOLD_RELAXATIONS:
+            break
+    return relaxed_count > 0
+
+
 def _generate_consistency_repair_children(
     *,
     params_candidate: Mapping[str, Any],
@@ -3409,11 +3481,11 @@ def _generate_consistency_repair_children(
         children.append((f"{label}:{trigger_reason}", next_params, next_overrides))
 
     add_child(
-        "consistency_entries",
-        lambda next_params: _increment_integer_candidate_param(
+        "consistency_signal_thresholds",
+        lambda next_params: _relax_signal_threshold_candidate_param(
             params=next_params,
             strategy_params=strategy_params,
-            keys=_CONSISTENCY_REPAIR_ENTRY_KEYS,
+            keys=_CONSISTENCY_REPAIR_SIGNAL_THRESHOLD_KEYS,
         ),
     )
     add_child(
@@ -3422,6 +3494,14 @@ def _generate_consistency_repair_children(
             params=next_params,
             strategy_params=strategy_params,
             keys=_CONSISTENCY_REPAIR_BREADTH_KEYS,
+        ),
+    )
+    add_child(
+        "consistency_entries",
+        lambda next_params: _increment_integer_candidate_param(
+            params=next_params,
+            strategy_params=strategy_params,
+            keys=_CONSISTENCY_REPAIR_ENTRY_KEYS,
         ),
     )
     add_child(
@@ -4118,11 +4198,19 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         with cache_context:
             budget_exhausted = False
             while True:
-                if not worklist and not initial_candidates_exhausted:
+                seed_initial_candidate = not initial_candidates_exhausted and (
+                    not worklist or len(scored) % 2 == 0
+                )
+                if seed_initial_candidate:
                     try:
-                        worklist.append(next(initial_candidates))
+                        next_initial = next(initial_candidates)
                     except StopIteration:
                         initial_candidates_exhausted = True
+                    else:
+                        if worklist:
+                            worklist.appendleft(next_initial)
+                        else:
+                            worklist.append(next_initial)
                 if not worklist:
                     break
                 if candidate_budget > 0 and len(scored) >= candidate_budget:
@@ -4224,6 +4312,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                             progress_log_interval_seconds=max(
                                 1, int(args.progress_log_seconds)
                             ),
+                            capture_trace_funnel=collect_train_gate_diagnostics,
                         )
                     )
                     second_oos_payload = None
@@ -4248,6 +4337,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                                 progress_log_interval_seconds=max(
                                     1, int(args.progress_log_seconds)
                                 ),
+                                capture_trace_funnel=collect_train_gate_diagnostics,
                             )
                         )
                     full_window_payload = run_replay(
@@ -4266,6 +4356,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                             progress_log_interval_seconds=max(
                                 1, int(args.progress_log_seconds)
                             ),
+                            capture_trace_funnel=collect_train_gate_diagnostics,
                             capture_exact_replay_ledger=True,
                         )
                     )
@@ -4967,6 +5058,22 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     candidate_payload["train_gate_diagnostics"] = (
                         _train_gate_diagnostics_from_replay_payload(train_payload)
                     )
+                    if not holdout_replay_skipped:
+                        candidate_payload["holdout_gate_diagnostics"] = (
+                            _train_gate_diagnostics_from_replay_payload(holdout_payload)
+                        )
+                    if second_oos_payload is not None:
+                        candidate_payload["second_oos_gate_diagnostics"] = (
+                            _train_gate_diagnostics_from_replay_payload(
+                                second_oos_payload
+                            )
+                        )
+                    if not full_window_replay_skipped:
+                        candidate_payload["full_window_gate_diagnostics"] = (
+                            _train_gate_diagnostics_from_replay_payload(
+                                full_window_payload
+                            )
+                        )
                 if cached_rows is not None:
                     candidate_payload["prefetched_row_count"] = len(cached_rows)
                     candidate_payload["prefetched_symbols"] = list(prefetch_symbols)

--- a/services/torghut/tests/test_evaluation_trace.py
+++ b/services/torghut/tests/test_evaluation_trace.py
@@ -19,188 +19,199 @@ from app.trading.evaluation_trace import (
 class TestEvaluationTrace(TestCase):
     def test_strategy_trace_helpers_and_payload_serialize_nested_values(self) -> None:
         failed_threshold = ThresholdTrace(
-            metric='recent_quote_invalid_ratio',
-            comparator='max_lte',
-            value=Decimal('0.22'),
-            threshold=Decimal('0.10'),
+            metric="recent_quote_invalid_ratio",
+            comparator="max_lte",
+            value=Decimal("0.22"),
+            threshold=Decimal("0.10"),
             passed=False,
-            missing_policy='fail_closed',
+            missing_policy="fail_closed",
             distance_to_pass=None,
         )
         passed_threshold = ThresholdTrace(
-            metric='recent_microprice_bias_bps_avg',
-            comparator='min_gte',
-            value=Decimal('0.45'),
-            threshold=Decimal('0.10'),
+            metric="recent_microprice_bias_bps_avg",
+            comparator="min_gte",
+            value=Decimal("0.45"),
+            threshold=Decimal("0.10"),
             passed=True,
-            missing_policy='fail_closed',
-            distance_to_pass=Decimal('0'),
+            missing_policy="fail_closed",
+            distance_to_pass=Decimal("0"),
         )
         trace = StrategyTrace(
-            strategy_id='breakout@prod',
-            strategy_type='breakout_continuation_long',
-            symbol='AAPL',
-            event_ts='2026-03-27T17:30:24+00:00',
-            timeframe='1Sec',
+            strategy_id="breakout@prod",
+            strategy_type="breakout_continuation_long",
+            symbol="AAPL",
+            event_ts="2026-03-27T17:30:24+00:00",
+            timeframe="1Sec",
             passed=False,
             action=None,
-            rationale=('near_miss',),
+            rationale=("near_miss",),
             gates=(
                 GateTrace(
-                    gate='feed_quality',
-                    category='feed_quality',
+                    gate="feed_quality",
+                    category="feed_quality",
                     passed=False,
                     thresholds=(failed_threshold, passed_threshold),
                     context={
-                        'captured_at': datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),
-                        'window_day': date(2026, 3, 27),
-                        'bands': (Decimal('0.10'), Decimal('0.20')),
-                        'flags': [True, False],
-                        'nested': {'score': Decimal('1.25')},
+                        "captured_at": datetime(
+                            2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc
+                        ),
+                        "window_day": date(2026, 3, 27),
+                        "bands": (Decimal("0.10"), Decimal("0.20")),
+                        "flags": [True, False],
+                        "nested": {"score": Decimal("1.25")},
                     },
                 ),
             ),
-            first_failed_gate='feed_quality',
-            context={'family': 'breakout'},
+            first_failed_gate="feed_quality",
+            context={"family": "breakout"},
         )
 
-        updated = trace.with_context(region='US').with_updates(action='buy')
+        updated = trace.with_context(region="US").with_updates(action="buy")
 
-        self.assertEqual(updated.action, 'buy')
+        self.assertEqual(updated.action, "buy")
         self.assertEqual(updated.failed_gate(), trace.gates[0])
-        self.assertEqual(updated.distance_score(), Decimal('1'))
+        self.assertEqual(updated.distance_score(), Decimal("1"))
 
         payload = updated.to_payload()
-        gate_payload = payload['gates'][0]
-        threshold_payload = gate_payload['thresholds'][0]
-        self.assertEqual(payload['schema_version'], 'torghut.strategy-trace.v1')
-        self.assertEqual(payload['context']['region'], 'US')
-        self.assertEqual(gate_payload['context']['captured_at'], '2026-03-27T17:30:24+00:00')
-        self.assertEqual(gate_payload['context']['window_day'], '2026-03-27')
-        self.assertEqual(gate_payload['context']['bands'], ['0.10', '0.20'])
-        self.assertEqual(gate_payload['context']['nested']['score'], '1.25')
-        self.assertEqual(threshold_payload['value'], '0.22')
-        self.assertEqual(threshold_payload['distance_to_pass'], None)
+        gate_payload = payload["gates"][0]
+        threshold_payload = gate_payload["thresholds"][0]
+        self.assertEqual(payload["schema_version"], "torghut.strategy-trace.v1")
+        self.assertEqual(payload["context"]["region"], "US")
+        self.assertEqual(
+            gate_payload["context"]["captured_at"], "2026-03-27T17:30:24+00:00"
+        )
+        self.assertEqual(gate_payload["context"]["window_day"], "2026-03-27")
+        self.assertEqual(gate_payload["context"]["bands"], ["0.10", "0.20"])
+        self.assertEqual(gate_payload["context"]["nested"]["score"], "1.25")
+        self.assertEqual(threshold_payload["value"], "0.22")
+        self.assertEqual(threshold_payload["distance_to_pass"], None)
 
     def test_trace_records_and_reports_payloads_cover_optional_paths(self) -> None:
         no_failed_gate = StrategyTrace(
-            strategy_id='late-day@prod',
-            strategy_type='late_day_continuation_long',
-            symbol='MSFT',
-            event_ts='2026-03-27T19:05:00+00:00',
-            timeframe='1Sec',
+            strategy_id="late-day@prod",
+            strategy_type="late_day_continuation_long",
+            symbol="MSFT",
+            event_ts="2026-03-27T19:05:00+00:00",
+            timeframe="1Sec",
             passed=True,
-            action='buy',
+            action="buy",
             gates=(),
         )
         missing_failed_gate = StrategyTrace(
-            strategy_id='mean-reversion@prod',
-            strategy_type='mean_reversion_rebound_long',
-            symbol='META',
-            event_ts='2026-03-27T18:15:00+00:00',
-            timeframe='1Sec',
+            strategy_id="mean-reversion@prod",
+            strategy_type="mean_reversion_rebound_long",
+            symbol="META",
+            event_ts="2026-03-27T18:15:00+00:00",
+            timeframe="1Sec",
             passed=False,
             action=None,
-            first_failed_gate='confirmation',
+            first_failed_gate="confirmation",
             gates=(),
         )
 
         self.assertIsNone(no_failed_gate.failed_gate())
-        self.assertEqual(no_failed_gate.distance_score(), Decimal('0'))
+        self.assertEqual(no_failed_gate.distance_score(), Decimal("0"))
         self.assertIsNone(missing_failed_gate.failed_gate())
-        self.assertEqual(missing_failed_gate.distance_score(), Decimal('0'))
+        self.assertEqual(missing_failed_gate.distance_score(), Decimal("0"))
 
         replay_trace = ReplayTraceRecord(
-            trading_day='2026-03-27',
+            trading_day="2026-03-27",
             strategy_trace=no_failed_gate,
             decision_emitted=True,
-            fill_status='filled',
-            decision_strategy_id='late-day@prod',
-            fill_price=Decimal('451.25'),
-        ).with_updates(block_reason='filled_same_tick')
+            fill_status="filled",
+            decision_strategy_id="late-day@prod",
+            fill_price=Decimal("451.25"),
+        ).with_updates(block_reason="filled_same_tick")
         replay_payload = replay_trace.to_payload()
-        self.assertEqual(replay_payload['schema_version'], 'torghut.replay-trace.v1')
-        self.assertEqual(replay_payload['fill_price'], '451.25')
-        self.assertEqual(replay_payload['block_reason'], 'filled_same_tick')
+        self.assertEqual(replay_payload["schema_version"], "torghut.replay-trace.v1")
+        self.assertEqual(replay_payload["fill_price"], "451.25")
+        self.assertEqual(replay_payload["block_reason"], "filled_same_tick")
 
         bucket = ReplayFunnelBucket(
-            trading_day='2026-03-27',
-            symbol='AAPL',
+            trading_day="2026-03-27",
+            symbol="AAPL",
             retained_rows=10,
             runtime_evaluable_rows=8,
             quote_valid_rows=9,
             strategy_evaluations=5,
-            gate_pass_counts={'b:confirmation': 2, 'a:eligibility': 4},
-            first_failed_gate_counts={'b:feed_quality': 3},
-            failing_threshold_counts={'b:feed_quality:spread_bps': 3},
+            gate_pass_counts={"b:confirmation": 2, "a:eligibility": 4},
+            first_failed_gate_counts={"b:feed_quality": 3},
+            failing_threshold_counts={"b:feed_quality:spread_bps": 3},
+            post_gate_block_reason_counts={"allocation_rejected": 1},
             passed_trace_count=2,
             decision_count=2,
             filled_count=1,
-            filled_notional=Decimal('451.25'),
+            filled_notional=Decimal("451.25"),
             closed_trade_count=1,
-            gross_pnl=Decimal('10.50'),
-            net_pnl=Decimal('9.75'),
-            cost_total=Decimal('0.75'),
+            gross_pnl=Decimal("10.50"),
+            net_pnl=Decimal("9.75"),
+            cost_total=Decimal("0.75"),
         )
         report = ReplayFunnelReport(
-            start_date='2026-03-24',
-            end_date='2026-03-27',
+            start_date="2026-03-24",
+            end_date="2026-03-27",
             buckets=(bucket,),
         )
         report_payload = report.to_payload()
-        self.assertEqual(report_payload['schema_version'], 'torghut.replay-funnel.v1')
+        self.assertEqual(report_payload["schema_version"], "torghut.replay-funnel.v1")
         self.assertEqual(
-            report_payload['buckets'][0]['gate_pass_counts'],
-            {'a:eligibility': 4, 'b:confirmation': 2},
+            report_payload["buckets"][0]["gate_pass_counts"],
+            {"a:eligibility": 4, "b:confirmation": 2},
         )
         self.assertEqual(
-            report_payload['buckets'][0]['first_failed_gate_counts'],
-            {'b:feed_quality': 3},
+            report_payload["buckets"][0]["first_failed_gate_counts"],
+            {"b:feed_quality": 3},
         )
-        self.assertEqual(report_payload['buckets'][0]['passed_trace_count'], 2)
+        self.assertEqual(
+            report_payload["buckets"][0]["post_gate_block_reason_counts"],
+            {"allocation_rejected": 1},
+        )
+        self.assertEqual(report_payload["buckets"][0]["passed_trace_count"], 2)
 
         near_miss = NearMissRecord(
-            trading_day='2026-03-27',
-            symbol='AAPL',
-            strategy_id='breakout@prod',
-            strategy_type='breakout_continuation_long',
-            event_ts='2026-03-27T18:00:00+00:00',
-            action='buy',
-            first_failed_gate='confirmation',
-            distance_score=Decimal('0.15'),
+            trading_day="2026-03-27",
+            symbol="AAPL",
+            strategy_id="breakout@prod",
+            strategy_type="breakout_continuation_long",
+            event_ts="2026-03-27T18:00:00+00:00",
+            action="buy",
+            first_failed_gate="confirmation",
+            distance_score=Decimal("0.15"),
             thresholds=(
                 ThresholdTrace(
-                    metric='continuation_rank',
-                    comparator='min_gte',
-                    value=Decimal('0.70'),
-                    threshold=Decimal('0.85'),
+                    metric="continuation_rank",
+                    comparator="min_gte",
+                    value=Decimal("0.70"),
+                    threshold=Decimal("0.85"),
                     passed=False,
-                    missing_policy='fail_closed',
-                    distance_to_pass=Decimal('0.15'),
+                    missing_policy="fail_closed",
+                    distance_to_pass=Decimal("0.15"),
                 ),
             ),
         )
         near_miss_payload = near_miss.to_payload()
-        self.assertEqual(near_miss_payload['distance_score'], '0.15')
-        self.assertEqual(near_miss_payload['thresholds'][0]['threshold'], '0.85')
+        self.assertEqual(near_miss_payload["distance_score"], "0.15")
+        self.assertEqual(near_miss_payload["thresholds"][0]["threshold"], "0.85")
 
         candidate = SweepCandidateResult(
-            candidate_id='candidate-1',
-            family='breakout_continuation',
-            strategy_name='breakout-continuation-long-v1',
-            train_net_per_day=Decimal('12.5'),
-            holdout_net_per_day=Decimal('51.6'),
-            train_total_net=Decimal('62.5'),
-            holdout_total_net=Decimal('258.0'),
+            candidate_id="candidate-1",
+            family="breakout_continuation",
+            strategy_name="breakout-continuation-long-v1",
+            train_net_per_day=Decimal("12.5"),
+            holdout_net_per_day=Decimal("51.6"),
+            train_total_net=Decimal("62.5"),
+            holdout_total_net=Decimal("258.0"),
             active_holdout_days=2,
-            max_holdout_drawdown_day=Decimal('0'),
+            max_holdout_drawdown_day=Decimal("0"),
             profit_factor=None,
             wins=2,
             losses=0,
-            score=Decimal('-646.6'),
-            replay_config={'params': {'rank': Decimal('0.45')}},
+            score=Decimal("-646.6"),
+            replay_config={"params": {"rank": Decimal("0.45")}},
         )
         candidate_payload = candidate.to_payload()
-        self.assertEqual(candidate_payload['schema_version'], 'torghut.sweep-candidate-result.v1')
-        self.assertEqual(candidate_payload['profit_factor'], None)
-        self.assertEqual(candidate_payload['replay_config']['params']['rank'], '0.45')
+        self.assertEqual(
+            candidate_payload["schema_version"], "torghut.sweep-candidate-result.v1"
+        )
+        self.assertEqual(candidate_payload["profit_factor"], None)
+        self.assertEqual(candidate_payload["replay_config"]["params"]["rank"], "0.45")

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -423,6 +423,8 @@ class TestLocalIntradayTsmomReplay(TestCase):
     ) -> None:
         reason = _resolve_passed_trace_block_reason(
             strategy_id="candidate-a",
+            runtime_intent_strategy_ids={"candidate-a"},
+            runtime_suppression_reason_by_strategy_id={},
             raw_decision_strategy_ids={"candidate-a"},
             allocation_reject_reason_by_strategy_id={},
             sizing_reject_reason_by_strategy_id={},
@@ -430,6 +432,53 @@ class TestLocalIntradayTsmomReplay(TestCase):
         )
 
         self.assertEqual(reason, "post_runtime_filter_rejected")
+
+    def test_resolve_passed_trace_block_reason_reports_runtime_suppression(
+        self,
+    ) -> None:
+        reason = _resolve_passed_trace_block_reason(
+            strategy_id="candidate-a",
+            runtime_intent_strategy_ids={"candidate-a"},
+            runtime_suppression_reason_by_strategy_id={
+                "candidate-a": "runtime_trade_policy_blocked"
+            },
+            raw_decision_strategy_ids=set(),
+            allocation_reject_reason_by_strategy_id={},
+            sizing_reject_reason_by_strategy_id={},
+            emitted_strategy_ids=set(),
+        )
+
+        self.assertEqual(reason, "runtime_trade_policy_blocked")
+
+    def test_resolve_passed_trace_block_reason_reports_no_runtime_intent(
+        self,
+    ) -> None:
+        reason = _resolve_passed_trace_block_reason(
+            strategy_id="candidate-a",
+            runtime_intent_strategy_ids=set(),
+            runtime_suppression_reason_by_strategy_id={},
+            raw_decision_strategy_ids=set(),
+            allocation_reject_reason_by_strategy_id={},
+            sizing_reject_reason_by_strategy_id={},
+            emitted_strategy_ids=set(),
+        )
+
+        self.assertEqual(reason, "engine_runtime_no_intent")
+
+    def test_resolve_passed_trace_block_reason_reports_intent_not_emitted(
+        self,
+    ) -> None:
+        reason = _resolve_passed_trace_block_reason(
+            strategy_id="candidate-a",
+            runtime_intent_strategy_ids={"candidate-a"},
+            runtime_suppression_reason_by_strategy_id={},
+            raw_decision_strategy_ids=set(),
+            allocation_reject_reason_by_strategy_id={},
+            sizing_reject_reason_by_strategy_id={},
+            emitted_strategy_ids=set(),
+        )
+
+        self.assertEqual(reason, "engine_runtime_intent_not_emitted")
 
     def test_apply_filled_decision_opens_position_on_same_signal(self) -> None:
         signal = self._signal(bid="523.22", ask="523.28", price="523.25")
@@ -2655,7 +2704,7 @@ class TestLocalIntradayTsmomReplay(TestCase):
             payload["trace"][0]["block_reason"], "allocator_reject_symbol_capacity"
         )
 
-    def test_run_replay_marks_passed_trace_with_engine_runtime_filter_reason(
+    def test_run_replay_marks_passed_trace_with_runtime_suppression_reason(
         self,
     ) -> None:
         strategy = Strategy(
@@ -2717,7 +2766,21 @@ class TestLocalIntradayTsmomReplay(TestCase):
                 return []
 
             def consume_runtime_telemetry(self):  # type: ignore[no-untyped-def]
-                return type("Telemetry", (), {"traces": [passed_trace]})()
+                observation = type(
+                    "Observation",
+                    (),
+                    {
+                        "strategy_intents_total": {decision_strategy_id},
+                        "strategy_intent_suppression_total": {
+                            f"{decision_strategy_id}|runtime_trade_policy_blocked": 1
+                        },
+                    },
+                )()
+                return type(
+                    "Telemetry",
+                    (),
+                    {"traces": [passed_trace], "observation": observation},
+                )()
 
         config = ReplayConfig(
             strategy_configmap_path=Path("/tmp/strategies.yaml"),
@@ -2747,7 +2810,7 @@ class TestLocalIntradayTsmomReplay(TestCase):
 
         self.assertEqual(len(payload["trace"]), 1)
         self.assertEqual(
-            payload["trace"][0]["block_reason"], "engine_runtime_filter_rejected"
+            payload["trace"][0]["block_reason"], "runtime_trade_policy_blocked"
         )
 
     def test_run_replay_serializes_real_daily_liquidity_evidence(self) -> None:

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -1813,6 +1813,9 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                         "failing_threshold_counts": {
                             "short:confirmation:imbalance_pressure": 5,
                         },
+                        "post_gate_block_reason_counts": {
+                            "raw_decision_not_emitted": 2,
+                        },
                     },
                     {
                         "retained_rows": 4,
@@ -1856,6 +1859,10 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(
             diagnostics["top_failing_thresholds"][0],
             {"key": "short:confirmation:imbalance_pressure", "count": 5},
+        )
+        self.assertEqual(
+            diagnostics["top_post_gate_block_reasons"][0],
+            {"key": "raw_decision_not_emitted", "count": 2},
         )
         self.assertEqual(
             diagnostics["near_misses"][0]["thresholds"][0]["metric"],
@@ -2191,18 +2198,93 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         )
 
         self.assertEqual(
-            children[0][0], "consistency_entries:active_day_ratio_below_min"
+            children[0][0], "consistency_breadth:active_day_ratio_below_min"
         )
-        self.assertEqual(children[0][1], {"max_entries_per_session": "2"})
+        self.assertEqual(children[0][1], {"top_n": "3"})
         self.assertEqual(children[0][2], {})
         self.assertEqual(
-            children[1][0], "consistency_breadth:active_day_ratio_below_min"
+            children[1][0], "consistency_entries:active_day_ratio_below_min"
         )
-        self.assertEqual(children[1][1], {"top_n": "3"})
+        self.assertEqual(children[1][1], {"max_entries_per_session": "2"})
         self.assertEqual(
             children[2][0], "consistency_cooldown:active_day_ratio_below_min"
         )
         self.assertEqual(children[2][1], {"entry_cooldown_seconds": "150"})
+
+    def test_generate_consistency_repair_children_relaxes_signal_thresholds_first(
+        self,
+    ) -> None:
+        configmap_payload = {
+            "data": {
+                "strategies.yaml": yaml.safe_dump(
+                    {
+                        "strategies": [
+                            {
+                                "name": "microbar-cross-sectional-pairs-v1",
+                                "params": {
+                                    "min_cross_section_continuation_rank": "0.55",
+                                    "min_cross_section_reversal_rank": "0.65",
+                                    "max_entries_per_session": "1",
+                                    "top_n": "2",
+                                },
+                            }
+                        ],
+                    },
+                    sort_keys=False,
+                )
+            }
+        }
+
+        children = frontier._generate_consistency_repair_children(
+            params_candidate={},
+            strategy_overrides={},
+            candidate_configmap=configmap_payload,
+            strategy_name="microbar-cross-sectional-pairs-v1",
+            hard_vetoes=["active_day_ratio_below_min"],
+            full_window_summary={
+                "net_per_day": "131",
+                "max_gross_exposure_pct_equity": "0.93",
+                "min_cash": "2089",
+                "negative_cash_observation_count": "0",
+            },
+            branch_count=2,
+        )
+
+        self.assertEqual(
+            children[0][0], "consistency_signal_thresholds:active_day_ratio_below_min"
+        )
+        self.assertEqual(
+            children[0][1],
+            {
+                "min_cross_section_continuation_rank": "0.5",
+                "min_cross_section_reversal_rank": "0.6",
+            },
+        )
+        self.assertEqual(
+            children[1][0], "consistency_breadth:active_day_ratio_below_min"
+        )
+        self.assertEqual(children[1][1], {"top_n": "3"})
+
+    def test_relax_signal_threshold_candidate_param_scales_absolute_thresholds(
+        self,
+    ) -> None:
+        params: dict[str, object] = {}
+
+        repaired = frontier._relax_signal_threshold_candidate_param(
+            params=params,
+            strategy_params={
+                "min_recent_microprice_bias_bps": "2.50",
+                "min_cross_section_continuation_rank": "0.01",
+            },
+            keys=(
+                "min_recent_microprice_bias_bps",
+                "min_cross_section_continuation_rank",
+            ),
+        )
+
+        self.assertTrue(repaired)
+        self.assertEqual(params["min_recent_microprice_bias_bps"], "2")
+        self.assertNotIn("min_cross_section_continuation_rank", params)
 
     def test_generate_consistency_repair_children_rejects_unsafe_parent(
         self,
@@ -2274,6 +2356,16 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 keys=("missing", "entry_cooldown_seconds"),
             )
         )
+        self.assertFalse(
+            frontier._relax_signal_threshold_candidate_param(
+                params={},
+                strategy_params={
+                    "ignored": "1",
+                    "min_cross_section_continuation_rank": "bad",
+                },
+                keys=("missing", "min_cross_section_continuation_rank"),
+            )
+        )
 
         self.assertEqual(
             frontier._generate_consistency_repair_children(
@@ -2329,7 +2421,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
 
         self.assertEqual(len(children), 1)
         self.assertEqual(
-            children[0][0], "consistency_entries:active_day_ratio_below_min"
+            children[0][0], "consistency_breadth:active_day_ratio_below_min"
         )
 
     def test_consistency_repair_children_target_second_oos_shortfall(
@@ -3270,6 +3362,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 json_output=json_output,
             )
             args.second_oos_days = 2
+            args.collect_train_gate_diagnostics = True
             recent_days = tuple(
                 date(2026, 3, 18) + timedelta(days=index) for index in range(8)
             )
@@ -3452,6 +3545,10 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 for row in payload["top"]
             }
             self.assertTrue(top_by_stop["18"]["second_oos"]["passed"])
+            self.assertEqual(
+                top_by_stop["18"]["second_oos_gate_diagnostics"]["status"],
+                "no_runtime_trace_evaluations",
+            )
             self.assertTrue(
                 top_by_stop["18"]["full_window"][
                     "market_impact_liquidity_evidence_present"
@@ -3696,6 +3793,13 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             self.assertEqual(payload["candidate_count"], 2)
             self.assertEqual(
                 payload["top"][0]["train_gate_diagnostics"]["status"], "available"
+            )
+            self.assertEqual(
+                payload["top"][0]["holdout_gate_diagnostics"]["status"], "available"
+            )
+            self.assertEqual(
+                payload["top"][0]["full_window_gate_diagnostics"]["status"],
+                "available",
             )
             persisted = json.loads(json_output.read_text(encoding="utf-8"))
             self.assertEqual(persisted["status"], "completed")
@@ -3944,6 +4048,182 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(second["min_cross_section_continuation_rank"], "0.70")
         self.assertEqual(second["long_stop_loss_bps"], "20")
         self.assertEqual(third["long_stop_loss_bps"], "24")
+
+    def test_parameter_stream_prioritizes_entry_hypotheses_before_thresholds(
+        self,
+    ) -> None:
+        self.assertEqual(frontier._parameter_exploration_priority("bullish_hist"), 3)
+        candidates = frontier._iter_parameter_candidates(
+            {
+                "min_cross_section_continuation_rank": ["0.60", "0.70"],
+                "rank_feature": [
+                    "cross_section_vwap_w5m_rank",
+                    "cross_section_session_open_rank",
+                ],
+                "top_n": ["1", "5"],
+                "signal_motif": [
+                    "vwap_close_continuation",
+                    "open_window_continuation",
+                ],
+                "entry_cooldown_seconds": ["600", "900"],
+            }
+        )
+
+        first = next(candidates)
+        second = next(candidates)
+        third = next(candidates)
+        fourth = next(candidates)
+        fifth = next(candidates)
+
+        self.assertEqual(first["rank_feature"], "cross_section_vwap_w5m_rank")
+        self.assertEqual(second["rank_feature"], "cross_section_session_open_rank")
+        self.assertEqual(third["top_n"], "5")
+        self.assertEqual(fourth["signal_motif"], "open_window_continuation")
+        self.assertEqual(fifth["min_cross_section_continuation_rank"], "0.70")
+
+    def test_run_frontier_interleaves_initial_grid_with_repair_worklist(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = self._write_strategy_configmap(root)
+            sweep_config = root / "sweep.yaml"
+            sweep_config.write_text(
+                yaml.safe_dump(
+                    {
+                        "schema_version": "torghut.replay-frontier-sweep.v1",
+                        "family": "intraday_tsmom_consistent",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "disable_other_strategies": True,
+                        "constraints": {
+                            "holdout_target_net_per_day": "1",
+                            "min_active_holdout_days": 1,
+                            "max_worst_holdout_day_loss": "200",
+                            "min_profit_factor": "1.0",
+                        },
+                        "consistency_constraints": {
+                            "target_net_per_day": "1",
+                            "min_active_days": 1,
+                            "max_worst_day_loss": "300",
+                            "max_negative_days": 1,
+                            "max_drawdown": "400",
+                            "require_every_day_active": False,
+                        },
+                        "strategy_overrides": {
+                            "universe_symbols": [["NVDA"]],
+                        },
+                        "parameters": {
+                            "long_stop_loss_bps": ["12", "18"],
+                        },
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+            args = self._make_args(
+                strategy_configmap=strategy_configmap,
+                sweep_config=sweep_config,
+                json_output=root / "frontier.json",
+            )
+            args.max_candidates_to_evaluate = 3
+            args.consistency_repair_iterations = 1
+            args.consistency_repair_candidates = 2
+            recent_days = tuple(
+                date(2026, 3, 18) + timedelta(days=index) for index in range(6)
+            )
+            snapshot_receipt = SimpleNamespace(
+                snapshot_id="snap-interleave",
+                is_fresh=True,
+                stale_override_used=False,
+                to_payload=lambda: {
+                    "snapshot_id": "snap-interleave",
+                    "source": "ta",
+                    "window_size": "PT1S",
+                    "start_day": "2026-03-18",
+                    "end_day": "2026-03-23",
+                    "expected_last_trading_day": "2026-03-23",
+                    "is_fresh": True,
+                    "missing_days": [],
+                    "row_count": 123,
+                    "stale_override_used": False,
+                    "witnesses": [],
+                },
+            )
+            full_window_stops: list[str] = []
+
+            def fake_run_replay(config: object) -> dict[str, object]:
+                configmap_path = Path(getattr(config, "strategy_configmap_path"))
+                payload = yaml.safe_load(configmap_path.read_text(encoding="utf-8"))
+                strategy = next(
+                    item
+                    for item in yaml.safe_load(payload["data"]["strategies.yaml"])[
+                        "strategies"
+                    ]
+                    if item["name"] == "intraday-tsmom-profit-v3"
+                )
+                stop = str(strategy["params"]["long_stop_loss_bps"])
+                start_date = str(getattr(config, "start_date"))
+                end_date = str(getattr(config, "end_date"))
+                if start_date == "2026-03-18" and end_date == "2026-03-23":
+                    full_window_stops.append(stop)
+                start = date.fromisoformat(start_date)
+                end = date.fromisoformat(end_date)
+                days = {
+                    (start + timedelta(days=index)).isoformat(): "100"
+                    for index in range((end - start).days + 1)
+                }
+                return self._payload(
+                    start_date=start_date,
+                    end_date=end_date,
+                    daily_net=days,
+                    decision_count=len(days),
+                    filled_count=len(days),
+                    wins=len(days),
+                    losses=0,
+                )
+
+            def fake_consistency_children(
+                **kwargs: object,
+            ) -> list[tuple[str, dict[str, str], dict[str, object]]]:
+                params = cast(dict[str, object], kwargs["params_candidate"])
+                if params.get("long_stop_loss_bps") != "12":
+                    return []
+                return [
+                    (
+                        "consistency_signal_thresholds:active_day_ratio_below_min",
+                        {"long_stop_loss_bps": "13"},
+                        {},
+                    ),
+                    (
+                        "consistency_breadth:active_day_ratio_below_min",
+                        {"long_stop_loss_bps": "14"},
+                        {},
+                    ),
+                ]
+
+            with (
+                patch(
+                    "scripts.search_consistent_profitability_frontier._resolve_recent_trading_days",
+                    return_value=recent_days,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt",
+                    return_value=snapshot_receipt,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot"
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.run_replay",
+                    side_effect=fake_run_replay,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier._generate_consistency_repair_children",
+                    side_effect=fake_consistency_children,
+                ),
+            ):
+                payload = frontier.run_consistent_profitability_frontier(args)
+
+        self.assertEqual(payload["status"], "candidate_budget_exhausted")
+        self.assertEqual(full_window_stops, ["12", "13", "18"])
 
     def test_main_symbol_pruning_promotes_pruned_universe(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Added holdout, second-OOS, and full-window gate diagnostics to the consistent profitability frontier output when trace-funnel diagnostics are enabled.
- Added replay funnel post-gate block reason counts and refined passed-trace block reasons so dead holdout days show whether the runtime emitted no intent, suppressed an exit-only sell, or hit allocation/cash gates.
- Reordered consistency repair and frontier exploration so bounded sweeps try signal-threshold relaxations and fresh entry hypotheses before repeatedly repairing one stale parent candidate.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen --extra dev pytest tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen --extra dev pytest tests/test_local_intraday_tsmom_replay.py`
- `uv run --frozen --extra dev pytest tests/test_evaluation_trace.py`
- `uv run --frozen --extra dev ruff check app/trading/evaluation_trace.py scripts/local_intraday_tsmom_replay.py scripts/search_consistent_profitability_frontier.py tests/test_evaluation_trace.py tests/test_local_intraday_tsmom_replay.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen --extra dev ruff format --check app/trading/evaluation_trace.py scripts/local_intraday_tsmom_replay.py scripts/search_consistent_profitability_frontier.py tests/test_evaluation_trace.py tests/test_local_intraday_tsmom_replay.py tests/test_search_consistent_profitability_frontier.py`
- `git diff --check`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Bounded replay artifact checked: `/tmp/torghut-hpairs-hmicro-proof-20260513-20260518/h-pairs-frontier-32-interleaved-grid-repair.json`; no promotable candidate found. Best safe top candidates remained below the 500/day goal and were vetoed by activity, notional, concentration, and tail-risk gates; raw higher-PnL candidates required over-levered or cash-negative settings.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
