### PR TITLE
feat(torghut): add portfolio coverage reversal seeds

### DIFF
--- a/services/torghut/config/trading/profitability-frontier-portfolio-coverage-microbar-opening-prev-close-reversal.yaml
+++ b/services/torghut/config/trading/profitability-frontier-portfolio-coverage-microbar-opening-prev-close-reversal.yaml
@@ -1,0 +1,86 @@
+schema_version: torghut.replay-frontier-sweep.v1
+family: microbar_cross_sectional_pairs
+family_template_id: microbar_cross_sectional_pairs_v1
+strategy_name: microbar-cross-sectional-pairs-v1
+disable_other_strategies: true
+constraints:
+  holdout_target_net_per_day: '150'
+  min_active_holdout_days: 2
+  max_worst_holdout_day_loss: '350'
+  min_profit_factor: '1.0'
+  require_training_decisions: true
+  require_holdout_decisions: true
+consistency_constraints:
+  target_net_per_day: '150'
+  min_daily_net_pnl: '-350'
+  min_active_days: 2
+  min_active_ratio: '0.50'
+  min_positive_days: 2
+  max_worst_day_loss: '350'
+  max_negative_days: 2
+  max_drawdown: '900'
+  max_best_day_share_of_total_pnl: '0.55'
+  min_avg_filled_notional_per_day: '50000'
+  min_avg_filled_notional_per_active_day: '75000'
+  min_regime_slice_pass_rate: '0.45'
+  require_every_day_active: false
+  max_gross_exposure_pct_equity: '1.0'
+  min_cash: '0'
+strategy_overrides:
+  strategy_type:
+    - microbar_cross_sectional_long_v1
+  universe_type:
+    - microbar_cross_sectional_long_v1
+  universe_symbols:
+    - ['NVDA', 'AAPL', 'AMZN', 'GOOGL', 'AVGO', 'AMD', 'ORCL', 'INTC']
+  normalization_regime:
+    - market_neutral_gross_scaled
+  max_position_pct_equity:
+    - '1.0'
+  max_notional_per_trade:
+    - '30000'
+parameters:
+  entry_minute_after_open:
+    - '35'
+  entry_window_minutes:
+    - '25'
+  exit_minute_after_open:
+    - '180'
+  signal_motif:
+    - opening_window_prev_close_reversal
+  rank_feature:
+    - cross_section_opening_window_return_from_prev_close_rank
+  selection_mode:
+    - reversal
+  top_n:
+    - '2'
+  gate_feature:
+    - cross_section_positive_opening_window_return_from_prev_close_ratio
+  gate_min:
+    - '0.20'
+  gate_max:
+    - '0.85'
+  max_pair_legs:
+    - '3'
+  max_concurrent_positions:
+    - '3'
+  max_entries_per_session:
+    - '3'
+  entry_cooldown_seconds:
+    - '900'
+  long_stop_loss_bps:
+    - '5'
+  long_trailing_stop_activation_profit_bps:
+    - '5'
+  long_trailing_stop_drawdown_bps:
+    - '2'
+  max_hold_seconds:
+    - '3000'
+  max_session_negative_exit_bps:
+    - '3'
+  max_stop_loss_exits_per_session:
+    - '1'
+  stop_loss_lockout_seconds:
+    - '1800'
+  position_isolation_mode:
+    - per_strategy

--- a/services/torghut/config/trading/profitability-frontier-portfolio-coverage-microbar-overnight-gap-reversal.yaml
+++ b/services/torghut/config/trading/profitability-frontier-portfolio-coverage-microbar-overnight-gap-reversal.yaml
@@ -1,0 +1,86 @@
+schema_version: torghut.replay-frontier-sweep.v1
+family: microbar_cross_sectional_pairs
+family_template_id: microbar_cross_sectional_pairs_v1
+strategy_name: microbar-cross-sectional-pairs-v1
+disable_other_strategies: true
+constraints:
+  holdout_target_net_per_day: '150'
+  min_active_holdout_days: 2
+  max_worst_holdout_day_loss: '350'
+  min_profit_factor: '1.0'
+  require_training_decisions: true
+  require_holdout_decisions: true
+consistency_constraints:
+  target_net_per_day: '150'
+  min_daily_net_pnl: '-350'
+  min_active_days: 2
+  min_active_ratio: '0.50'
+  min_positive_days: 2
+  max_worst_day_loss: '350'
+  max_negative_days: 2
+  max_drawdown: '900'
+  max_best_day_share_of_total_pnl: '0.55'
+  min_avg_filled_notional_per_day: '50000'
+  min_avg_filled_notional_per_active_day: '75000'
+  min_regime_slice_pass_rate: '0.45'
+  require_every_day_active: false
+  max_gross_exposure_pct_equity: '1.0'
+  min_cash: '0'
+strategy_overrides:
+  strategy_type:
+    - microbar_cross_sectional_long_v1
+  universe_type:
+    - microbar_cross_sectional_long_v1
+  universe_symbols:
+    - ['NVDA', 'AAPL', 'AMZN', 'GOOGL', 'AVGO', 'AMD', 'ORCL', 'INTC']
+  normalization_regime:
+    - market_neutral_gross_scaled
+  max_position_pct_equity:
+    - '1.0'
+  max_notional_per_trade:
+    - '30000'
+parameters:
+  entry_minute_after_open:
+    - '20'
+  entry_window_minutes:
+    - '25'
+  exit_minute_after_open:
+    - '150'
+  signal_motif:
+    - overnight_gap_reversal
+  rank_feature:
+    - cross_section_prev_session_close_rank
+  selection_mode:
+    - reversal
+  top_n:
+    - '2'
+  gate_feature:
+    - cross_section_positive_opening_window_return_from_prev_close_ratio
+  gate_min:
+    - '0.20'
+  gate_max:
+    - '0.80'
+  max_pair_legs:
+    - '3'
+  max_concurrent_positions:
+    - '3'
+  max_entries_per_session:
+    - '3'
+  entry_cooldown_seconds:
+    - '900'
+  long_stop_loss_bps:
+    - '4'
+  long_trailing_stop_activation_profit_bps:
+    - '5'
+  long_trailing_stop_drawdown_bps:
+    - '2'
+  max_hold_seconds:
+    - '2700'
+  max_session_negative_exit_bps:
+    - '3'
+  max_stop_loss_exits_per_session:
+    - '1'
+  stop_loss_lockout_seconds:
+    - '1800'
+  position_isolation_mode:
+    - per_strategy

--- a/services/torghut/config/trading/profitability-frontier-portfolio-coverage-microbar-tug-of-war-reversal.yaml
+++ b/services/torghut/config/trading/profitability-frontier-portfolio-coverage-microbar-tug-of-war-reversal.yaml
@@ -1,0 +1,86 @@
+schema_version: torghut.replay-frontier-sweep.v1
+family: microbar_cross_sectional_pairs
+family_template_id: microbar_cross_sectional_pairs_v1
+strategy_name: microbar-cross-sectional-pairs-v1
+disable_other_strategies: true
+constraints:
+  holdout_target_net_per_day: '150'
+  min_active_holdout_days: 2
+  max_worst_holdout_day_loss: '350'
+  min_profit_factor: '1.0'
+  require_training_decisions: true
+  require_holdout_decisions: true
+consistency_constraints:
+  target_net_per_day: '150'
+  min_daily_net_pnl: '-350'
+  min_active_days: 2
+  min_active_ratio: '0.50'
+  min_positive_days: 2
+  max_worst_day_loss: '350'
+  max_negative_days: 2
+  max_drawdown: '900'
+  max_best_day_share_of_total_pnl: '0.55'
+  min_avg_filled_notional_per_day: '50000'
+  min_avg_filled_notional_per_active_day: '75000'
+  min_regime_slice_pass_rate: '0.45'
+  require_every_day_active: false
+  max_gross_exposure_pct_equity: '1.0'
+  min_cash: '0'
+strategy_overrides:
+  strategy_type:
+    - microbar_cross_sectional_long_v1
+  universe_type:
+    - microbar_cross_sectional_long_v1
+  universe_symbols:
+    - ['NVDA', 'AAPL', 'AMZN', 'GOOGL', 'AVGO', 'AMD', 'ORCL', 'INTC']
+  normalization_regime:
+    - market_neutral_gross_scaled
+  max_position_pct_equity:
+    - '1.0'
+  max_notional_per_trade:
+    - '30000'
+parameters:
+  entry_minute_after_open:
+    - '120'
+  entry_window_minutes:
+    - '30'
+  exit_minute_after_open:
+    - close
+  signal_motif:
+    - intraday_tug_of_war_reversal
+  rank_feature:
+    - cross_section_prev_session_close_rank
+  selection_mode:
+    - reversal
+  top_n:
+    - '2'
+  gate_feature:
+    - cross_section_positive_opening_window_return_from_prev_close_ratio
+  gate_min:
+    - '0.15'
+  gate_max:
+    - '0.85'
+  max_pair_legs:
+    - '3'
+  max_concurrent_positions:
+    - '3'
+  max_entries_per_session:
+    - '2'
+  entry_cooldown_seconds:
+    - '1800'
+  long_stop_loss_bps:
+    - '4'
+  long_trailing_stop_activation_profit_bps:
+    - '5'
+  long_trailing_stop_drawdown_bps:
+    - '2'
+  max_hold_seconds:
+    - '3600'
+  max_session_negative_exit_bps:
+    - '3'
+  max_stop_loss_exits_per_session:
+    - '1'
+  stop_loss_lockout_seconds:
+    - '2400'
+  position_isolation_mode:
+    - per_strategy

--- a/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
@@ -1012,6 +1012,145 @@ families:
       max_position_pct_equity:
         mode: explicit_values
         values: ['0.25', '0.50', '0.75', '1.0']
+  - family_template_id: microbar_cross_sectional_pairs_v1
+    seed_sweep_config: ../profitability-frontier-portfolio-coverage-microbar-overnight-gap-reversal.yaml
+    max_iterations: 2
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: false
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
+    parameter_mutations:
+      entry_minute_after_open:
+        mode: numeric_step
+        deltas: ['-10', '0', '10']
+        minimum: '0'
+        maximum: '60'
+      entry_window_minutes:
+        mode: explicit_values
+        values: ['15', '25', '45']
+      exit_minute_after_open:
+        mode: numeric_step
+        deltas: ['-30', '0', '30']
+        minimum: '60'
+        maximum: '210'
+      top_n:
+        mode: explicit_values
+        values: ['1', '2', '3']
+      gate_min:
+        mode: explicit_values
+        values: ['0.15', '0.20', '0.30']
+      gate_max:
+        mode: explicit_values
+        values: ['0.70', '0.80', '0.90']
+      max_entries_per_session:
+        mode: explicit_values
+        values: ['1', '2', '3', '4']
+      entry_cooldown_seconds:
+        mode: explicit_values
+        values: ['300', '600', '900']
+    strategy_override_mutations:
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['7500', '15000', '22500', '30000']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['0.25', '0.50', '0.75', '1.0']
+  - family_template_id: microbar_cross_sectional_pairs_v1
+    seed_sweep_config: ../profitability-frontier-portfolio-coverage-microbar-opening-prev-close-reversal.yaml
+    max_iterations: 2
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: false
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
+    parameter_mutations:
+      entry_minute_after_open:
+        mode: numeric_step
+        deltas: ['-15', '0', '15']
+        minimum: '15'
+        maximum: '90'
+      entry_window_minutes:
+        mode: explicit_values
+        values: ['15', '25', '45']
+      exit_minute_after_open:
+        mode: numeric_step
+        deltas: ['-30', '0', '30']
+        minimum: '90'
+        maximum: '240'
+      top_n:
+        mode: explicit_values
+        values: ['1', '2', '3']
+      gate_min:
+        mode: explicit_values
+        values: ['0.15', '0.20', '0.30']
+      gate_max:
+        mode: explicit_values
+        values: ['0.75', '0.85', '0.90']
+      max_entries_per_session:
+        mode: explicit_values
+        values: ['1', '2', '3', '4']
+      entry_cooldown_seconds:
+        mode: explicit_values
+        values: ['300', '600', '900']
+    strategy_override_mutations:
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['7500', '15000', '22500', '30000']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['0.25', '0.50', '0.75', '1.0']
+  - family_template_id: microbar_cross_sectional_pairs_v1
+    seed_sweep_config: ../profitability-frontier-portfolio-coverage-microbar-tug-of-war-reversal.yaml
+    max_iterations: 2
+    keep_top_candidates: 2
+    frontier_top_n: 5
+    force_keep_top_candidate_if_all_vetoed: false
+    symbol_prune_iterations: 1
+    symbol_prune_candidates: 2
+    symbol_prune_min_universe_size: 5
+    loss_repair_iterations: 1
+    loss_repair_candidates: 1
+    parameter_mutations:
+      entry_minute_after_open:
+        mode: numeric_step
+        deltas: ['-30', '0', '30']
+        minimum: '90'
+        maximum: '240'
+      entry_window_minutes:
+        mode: explicit_values
+        values: ['15', '30', '45']
+      exit_minute_after_open:
+        mode: explicit_values
+        values: ['240', '300', 'close']
+      top_n:
+        mode: explicit_values
+        values: ['1', '2', '3']
+      gate_min:
+        mode: explicit_values
+        values: ['0.10', '0.15', '0.25']
+      gate_max:
+        mode: explicit_values
+        values: ['0.75', '0.85', '0.90']
+      max_entries_per_session:
+        mode: explicit_values
+        values: ['1', '2', '3', '4']
+      entry_cooldown_seconds:
+        mode: explicit_values
+        values: ['600', '1200', '1800']
+    strategy_override_mutations:
+      max_notional_per_trade:
+        mode: explicit_values
+        values: ['7500', '15000', '22500', '30000']
+      max_position_pct_equity:
+        mode: explicit_values
+        values: ['0.25', '0.50', '0.75', '1.0']
   - family_template_id: intraday_tsmom_v2
     seed_sweep_config: ../profitability-frontier-strict-daily-tsmom.yaml
     max_iterations: 2

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -1044,8 +1044,47 @@ class TestStrategyAutoresearch(TestCase):
                 "profitability-frontier-strict-daily-microbar-prev-day-open60-short-top1.yaml",
                 "profitability-frontier-strict-daily-microbar-recent15-reversal-short.yaml",
                 "profitability-frontier-strict-daily-microbar-vwap-stretch-reversal-long-top4.yaml",
+                "profitability-frontier-portfolio-coverage-microbar-overnight-gap-reversal.yaml",
+                "profitability-frontier-portfolio-coverage-microbar-opening-prev-close-reversal.yaml",
+                "profitability-frontier-portfolio-coverage-microbar-tug-of-war-reversal.yaml",
             }.issubset(microbar_seed_names)
         )
+        coverage_seed_payloads = {
+            plan.seed_sweep_config.name: yaml.safe_load(
+                plan.seed_sweep_config.read_text(encoding="utf-8")
+            )
+            for plan in program.families
+            if plan.seed_sweep_config.name.startswith(
+                "profitability-frontier-portfolio-coverage-microbar-"
+            )
+        }
+        self.assertEqual(
+            {
+                "overnight_gap_reversal",
+                "opening_window_prev_close_reversal",
+                "intraday_tug_of_war_reversal",
+            },
+            {
+                payload["parameters"]["signal_motif"][0]
+                for payload in coverage_seed_payloads.values()
+            },
+        )
+        for payload in coverage_seed_payloads.values():
+            self.assertFalse(
+                payload["consistency_constraints"]["require_every_day_active"]
+            )
+            self.assertEqual(
+                payload["parameters"]["gate_feature"],
+                ["cross_section_positive_opening_window_return_from_prev_close_ratio"],
+            )
+            self.assertLessEqual(
+                Decimal(payload["strategy_overrides"]["max_position_pct_equity"][0]),
+                Decimal("1.0"),
+            )
+            self.assertLessEqual(
+                Decimal(payload["strategy_overrides"]["max_notional_per_trade"][0]),
+                Decimal("30000"),
+            )
         self.assertEqual(program.promotion_policy, "research_only")
         self.assertIn("scheduler_v3_parity_replay", program.parity_requirements)
 


### PR DESCRIPTION
## Summary

- Adds three checked-in portfolio coverage seed sweeps for runtime-supported microbar prev-close/gap reversal motifs.
- Wires overnight gap reversal, opening-window prev-close reversal, and intraday tug-of-war reversal into the $500/day portfolio autoresearch program.
- Adds regression coverage that the new sleeves remain research-only, gated, capital-bounded, and do not require every day active at the single-sleeve seed level.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen --extra dev pytest tests/test_strategy_autoresearch.py -k "500_portfolio_profit_program"`
- `uv run --frozen --extra dev pytest tests/test_strategy_runtime.py -k "microbar_cross_sectional_plugins_cover_entry_exit_and_selection_modes"`
- `uv run --frozen --extra dev ruff check tests/test_strategy_autoresearch.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
