### PR TITLE
feat(torghut): add queue survival fill proof contract

### DIFF
--- a/docs/torghut/oracle/2026-05-22-torghut-profit-breakthrough-prompt.md
+++ b/docs/torghut/oracle/2026-05-22-torghut-profit-breakthrough-prompt.md
@@ -1,0 +1,35 @@
+# Torghut Profit Breakthrough Oracle Prompt - 2026-05-22
+
+Review the attached `lab` codebase archive and give a concrete implementation plan to reach honest Torghut system profitability of at least `$500/day` post-cost net PnL.
+
+Hard constraints:
+
+- No synthetic proof, fake gates, stale replay, or unverifiable backtest shortcuts.
+- Promotion proof must come from complete manifest-verified replay, live-paper evidence, runtime ledger buckets, real fills, costs, slippage, drawdown, cash, and gross-exposure evidence.
+- Close-but-not-there candidates may enter paper probation or evidence collection, but do not call them final promotion unless the runtime/replay ledger proof supports it.
+- Avoid unsafe cluster load. Prefer reusable replay tapes, local bounded searches, and clearly capped jobs.
+- Prefer production-quality changes that land through GitOps and CI.
+
+Current known state:
+
+- Best checked-in research artifact is `H-TSMOM-LIQ-01`, around `$412.64/day` on `2026-03-30..2026-04-02`, but it is explicitly blocked because it came from a previous mixed universe and lacks fresh promotion authority.
+- Microbar pairs have looked economically promising on short/incomplete tape, but they lack full-window replay and runtime ledger authority.
+- The merged proof path requires exact replay artifact refs, runtime ledger row/fill counts, and promotion-grade post-cost PnL basis before final promotion.
+- Replay materialization fails closed when requested trading-day coverage is incomplete.
+- Latest local harness tranche adds queue-position survival fill evidence from recent limit-order-book research: queue position, time-to-fill quantiles, nonfill opportunity cost, and order-lifecycle fill evidence must be present before fill-probability assumptions can support promotion.
+
+Please answer with:
+
+1. The highest-leverage code changes, with exact file paths, to unlock an order-of-magnitude faster and more reliable path to `$500/day`.
+2. The correct next candidate families or sleeves to run, including expected failure modes and the fastest honest validation command.
+3. How to use recent 2025-2026 research to improve candidate synthesis and execution realism:
+   - KANFormer queue-position survival fill probabilities.
+   - TLOB spread-aware labels and predictability decay.
+   - DiffLOB, LOBERT, and ByteGen message-level LOB simulation/counterfactual stress.
+   - Kyle-lambda/order-flow noise stress.
+   - MPC execution scheduling with opportunity-cost and schedule-deviation control.
+4. Specific harness changes that reduce false positives while still allowing close candidates into evidence collection quickly.
+5. A promotion policy that is aggressive enough to collect real proof for close candidates but cannot claim profitability without runtime-ledger evidence.
+6. Any incorrect assumptions, dead ends, or wasted work visible in the current implementation.
+
+Do not give generic quant advice. Tie recommendations to the attached codebase and name exact modules, functions, configs, and tests.

--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -3334,6 +3334,70 @@ def _mechanism_overlays_for_card(card: HypothesisCard) -> dict[str, Any]:
 
     if has_any(
         (
+            "kanformer",
+            "queue-position",
+            "queue position",
+            "queue_position",
+            "queue ratio",
+            "queue_ratio",
+            "time-to-fill",
+            "time to fill",
+            "time_to_fill",
+            "survival analysis",
+            "survival model",
+            "survival_fill_curve",
+            "fill survival",
+            "fill_survival",
+            "fill probability",
+            "fill probabilities",
+            "fill_probability",
+            "limit fill probability",
+            "limit_fill_probability",
+            "nonfill opportunity cost",
+            "nonfill_opportunity_cost",
+            "right-censored",
+            "right censored",
+        )
+    ):
+        overlay_ids.append("queue_position_survival_fill_curve")
+        overlay_contracts.append(
+            {
+                "overlay_id": "queue_position_survival_fill_curve",
+                "required_evidence": [
+                    "queue_position",
+                    "survival_fill_curve",
+                    "time_to_fill_quantiles",
+                    "limit_fill_probability",
+                    "nonfill_opportunity_cost",
+                    "route_tca",
+                    "live_paper_parity",
+                ],
+                "rank_metric": "post_cost_net_pnl_after_queue_position_survival_fill_stress",
+                "evidence_policy": "queue_position_fill_probability_requires_real_order_lifecycle_evidence",
+            }
+        )
+        hard_vetoes.update(
+            {
+                "required_queue_position_survival_fill_curve": True,
+                "required_min_queue_position_survival_sample_count": "60",
+                "required_max_queue_position_nonfill_opportunity_cost_bps": "8",
+                "required_time_to_fill_quantiles": True,
+                "required_order_lifecycle_fill_evidence": True,
+            }
+        )
+        promotion_contract.update(
+            {
+                "requires_queue_position_survival_fill_curve": True,
+                "requires_time_to_fill_quantiles": True,
+                "requires_nonfill_opportunity_cost": True,
+                "requires_order_lifecycle_fill_evidence": True,
+                "rejects_queue_position_free_fill_assumptions": True,
+                "execution_policy": "queue_position_survival_fill_curve",
+            }
+        )
+
+    if has_any(
+        (
             "nonlinear impact",
             "nonlinear_impact",
             "square-root",
@@ -4016,6 +4080,35 @@ def _family_scores_for_hypothesis(
             "representation_or_normalization",
         )
         bump("microbar_cross_sectional_pairs_v1", 2, "microstructure_representation")
+    if has_any(
+        (
+            "kanformer",
+            "queue-position",
+            "queue position",
+            "queue_position",
+            "time-to-fill",
+            "time to fill",
+            "time_to_fill",
+            "survival analysis",
+            "survival model",
+            "survival_fill_curve",
+            "fill survival",
+            "fill_survival",
+            "fill probability",
+            "fill probabilities",
+            "nonfill opportunity cost",
+            "nonfill_opportunity_cost",
+        )
+    ):
+        bump(
+            "microstructure_continuation_matched_filter_v1",
+            6,
+            "queue_position_survival_fill_curve",
+        )
+        bump(
+            "microbar_cross_sectional_pairs_v1", 3, "queue_position_survival_fill_curve"
+        )
+
     if has_any(
         (
             "order flow",

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -2240,6 +2240,16 @@ def _replay_stress_metrics(
     delay_depth_net_per_day = (net_per_day * survival_adjusted_fillable_ratio) - (
         delay_depth_fillable_notional_per_day * Decimal("1") / Decimal("10000")
     )
+    queue_position_nonfill_opportunity_cost_per_day = max(
+        Decimal("0"), net_per_day - delay_depth_net_per_day
+    )
+    queue_position_nonfill_opportunity_cost_bps = (
+        queue_position_nonfill_opportunity_cost_per_day
+        / avg_filled_notional_per_day
+        * Decimal("10000")
+        if avg_filled_notional_per_day > 0
+        else Decimal("0")
+    )
     implementation_uncertainty = _implementation_uncertainty_metrics(
         target_net_per_day=target_net_per_day,
         net_per_day=net_per_day,
@@ -2331,6 +2341,29 @@ def _replay_stress_metrics(
         "delay_adjusted_depth_queue_ratio_p95": str(queue_ratio_p95)
         if queue_ratio_p95 is not None
         else "",
+        "queue_position_survival_fill_curve_evidence_present": (
+            fill_survival_sample_count > 0 and queue_ratio_p95 is not None
+        ),
+        "queue_position_survival_sample_count": fill_survival_sample_count,
+        "queue_position_survival_fill_rate": str(fill_survival_rate)
+        if fill_survival_rate is not None
+        else "",
+        "queue_position_survival_queue_ratio_p95": str(queue_ratio_p95)
+        if queue_ratio_p95 is not None
+        else "",
+        "queue_position_survival_adjusted_fillable_ratio": str(
+            survival_adjusted_fillable_ratio
+        ),
+        "queue_position_survival_nonfill_opportunity_cost_per_day": str(
+            queue_position_nonfill_opportunity_cost_per_day
+        ),
+        "queue_position_survival_nonfill_opportunity_cost_bps": str(
+            queue_position_nonfill_opportunity_cost_bps
+        ),
+        "queue_position_survival_stress_net_pnl_per_day": str(delay_depth_net_per_day),
+        "queue_position_survival_source_marker": (
+            "queue_position_survival_fill_probability_arxiv_2512_05734_2025"
+        ),
         "delay_adjusted_depth_unfillable_notional_per_day": str(
             max(
                 Decimal("0"),
@@ -3590,6 +3623,11 @@ def _rank_scored_candidates(scored: list[dict[str, Any]]) -> list[dict[str, Any]
                 _nonnegative_int_metric(
                     item["objective_scorecard"].get("fill_survival_sample_count")
                 ),
+                _nonnegative_int_metric(
+                    item["objective_scorecard"].get(
+                        "queue_position_survival_sample_count"
+                    )
+                ),
             ),
             fill_survival_rate=(
                 _optional_decimal(
@@ -3599,6 +3637,9 @@ def _rank_scored_candidates(scored: list[dict[str, Any]]) -> list[dict[str, Any]
                 )
                 or _optional_decimal(
                     item["objective_scorecard"].get("fill_survival_fill_rate")
+                )
+                or _optional_decimal(
+                    item["objective_scorecard"].get("queue_position_survival_fill_rate")
                 )
                 or Decimal("0")
             ),
@@ -4615,6 +4656,9 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     _nonnegative_int_metric(
                         full_window_summary.get("fill_survival_sample_count")
                     ),
+                    _nonnegative_int_metric(
+                        full_window_summary.get("queue_position_survival_sample_count")
+                    ),
                 )
                 fill_survival_rate = (
                     _optional_decimal(
@@ -4624,6 +4668,9 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     )
                     or _optional_decimal(
                         full_window_summary.get("fill_survival_fill_rate")
+                    )
+                    or _optional_decimal(
+                        full_window_summary.get("queue_position_survival_fill_rate")
                     )
                     or Decimal("0")
                 )
@@ -4893,6 +4940,57 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                         "delay_adjusted_depth_queue_ratio_p95": str(
                             full_window_summary.get(
                                 "delay_adjusted_depth_queue_ratio_p95"
+                            )
+                            or ""
+                        ),
+                        "queue_position_survival_fill_curve_evidence_present": bool(
+                            full_window_summary.get(
+                                "queue_position_survival_fill_curve_evidence_present"
+                            )
+                        ),
+                        "queue_position_survival_sample_count": int(
+                            full_window_summary.get(
+                                "queue_position_survival_sample_count"
+                            )
+                            or 0
+                        ),
+                        "queue_position_survival_fill_rate": str(
+                            full_window_summary.get("queue_position_survival_fill_rate")
+                            or ""
+                        ),
+                        "queue_position_survival_queue_ratio_p95": str(
+                            full_window_summary.get(
+                                "queue_position_survival_queue_ratio_p95"
+                            )
+                            or ""
+                        ),
+                        "queue_position_survival_adjusted_fillable_ratio": str(
+                            full_window_summary.get(
+                                "queue_position_survival_adjusted_fillable_ratio"
+                            )
+                            or "0"
+                        ),
+                        "queue_position_survival_nonfill_opportunity_cost_per_day": str(
+                            full_window_summary.get(
+                                "queue_position_survival_nonfill_opportunity_cost_per_day"
+                            )
+                            or "0"
+                        ),
+                        "queue_position_survival_nonfill_opportunity_cost_bps": str(
+                            full_window_summary.get(
+                                "queue_position_survival_nonfill_opportunity_cost_bps"
+                            )
+                            or "0"
+                        ),
+                        "queue_position_survival_stress_net_pnl_per_day": str(
+                            full_window_summary.get(
+                                "queue_position_survival_stress_net_pnl_per_day"
+                            )
+                            or "0"
+                        ),
+                        "queue_position_survival_source_marker": str(
+                            full_window_summary.get(
+                                "queue_position_survival_source_marker"
                             )
                             or ""
                         ),

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -571,6 +571,52 @@ class TestCandidateSpecs(TestCase):
             specs[0].promotion_contract["rejects_no_delay_fill_assumptions"]
         )
 
+    def test_queue_position_survival_claim_adds_fill_curve_contract(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-kanformer-queue-survival",
+            claims=[
+                {
+                    "claim_id": "kanformer-fill-survival",
+                    "claim_type": "execution_assumption",
+                    "claim_text": (
+                        "KANFormer predicts limit order fill probabilities with "
+                        "queue-position survival analysis and time-to-fill quantiles."
+                    ),
+                    "data_requirements": [
+                        "queue_position",
+                        "survival_fill_curve",
+                        "time_to_fill_quantiles",
+                        "nonfill_opportunity_cost",
+                        "route_tca",
+                    ],
+                    "confidence": "0.80",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+
+        self.assertIn(
+            "queue_position_survival_fill_curve",
+            specs[0].parameter_space["mechanism_overlay_ids"],
+        )
+        self.assertTrue(
+            specs[0].hard_vetoes["required_queue_position_survival_fill_curve"]
+        )
+        self.assertEqual(
+            specs[0].hard_vetoes["required_min_queue_position_survival_sample_count"],
+            "60",
+        )
+        self.assertTrue(specs[0].hard_vetoes["required_time_to_fill_quantiles"])
+        self.assertTrue(
+            specs[0].promotion_contract["requires_queue_position_survival_fill_curve"]
+        )
+        self.assertTrue(
+            specs[0].promotion_contract["rejects_queue_position_free_fill_assumptions"]
+        )
+
     def test_ohlcv_only_claim_adds_falsification_contract(self) -> None:
         cards = build_hypothesis_cards(
             source_run_id="paper-ohlcv-falsification",

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -3113,6 +3113,24 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             frontier.Decimal("490"),
         )
         self.assertEqual(summary["delay_adjusted_depth_queue_ratio_p95"], "0.25")
+        self.assertTrue(summary["queue_position_survival_fill_curve_evidence_present"])
+        self.assertEqual(summary["queue_position_survival_sample_count"], 4)
+        self.assertEqual(summary["queue_position_survival_fill_rate"], "0.5")
+        self.assertEqual(summary["queue_position_survival_queue_ratio_p95"], "0.25")
+        self.assertEqual(
+            summary["queue_position_survival_adjusted_fillable_ratio"],
+            "0.5",
+        )
+        self.assertEqual(
+            frontier.Decimal(
+                summary["queue_position_survival_nonfill_opportunity_cost_bps"]
+            ),
+            frontier.Decimal("51.0"),
+        )
+        self.assertEqual(
+            frontier.Decimal(summary["queue_position_survival_stress_net_pnl_per_day"]),
+            frontier.Decimal("490"),
+        )
 
     def test_consistency_penalty_reports_and_penalizes_capital_realism(self) -> None:
         payload = self._payload(


### PR DESCRIPTION
## Summary

- Adds a queue-position survival fill-curve mechanism overlay for recent LOB fill-probability papers.
- Threads queue-position survival evidence through frontier replay summaries and objective scorecards.
- Records the Torghut profit-breakthrough oracle prompt used with the committed codebase ZIP.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen --extra dev pytest tests/test_candidate_specs.py -k "queue_position_survival or execution_delay_depth_claim"`
- `cd services/torghut && uv run --frozen --extra dev pytest tests/test_search_consistent_profitability_frontier.py -k "fill_survival"`
- `cd services/torghut && uv run --frozen --extra dev ruff format --check app/trading/discovery/candidate_specs.py scripts/search_consistent_profitability_frontier.py tests/test_candidate_specs.py tests/test_search_consistent_profitability_frontier.py`
- `cd services/torghut && uv run --frozen --extra dev ruff check app/trading/discovery/candidate_specs.py scripts/search_consistent_profitability_frontier.py tests/test_candidate_specs.py tests/test_search_consistent_profitability_frontier.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
