### PR TITLE
fix(torghut): emit queue survival rank metric

### DIFF
--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -2361,6 +2361,9 @@ def _replay_stress_metrics(
             queue_position_nonfill_opportunity_cost_bps
         ),
         "queue_position_survival_stress_net_pnl_per_day": str(delay_depth_net_per_day),
+        "post_cost_net_pnl_after_queue_position_survival_fill_stress": str(
+            delay_depth_net_per_day
+        ),
         "queue_position_survival_source_marker": (
             "queue_position_survival_fill_probability_arxiv_2512_05734_2025"
         ),
@@ -4984,6 +4987,15 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                         ),
                         "queue_position_survival_stress_net_pnl_per_day": str(
                             full_window_summary.get(
+                                "queue_position_survival_stress_net_pnl_per_day"
+                            )
+                            or "0"
+                        ),
+                        "post_cost_net_pnl_after_queue_position_survival_fill_stress": str(
+                            full_window_summary.get(
+                                "post_cost_net_pnl_after_queue_position_survival_fill_stress"
+                            )
+                            or full_window_summary.get(
                                 "queue_position_survival_stress_net_pnl_per_day"
                             )
                             or "0"

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -610,6 +610,18 @@ class TestCandidateSpecs(TestCase):
             "60",
         )
         self.assertTrue(specs[0].hard_vetoes["required_time_to_fill_quantiles"])
+        mechanism_overlays = candidate_specs_module._mechanism_overlays_for_card(
+            cards[0]
+        )
+        queue_contract = next(
+            contract
+            for contract in mechanism_overlays["feature_contract"]["mechanism_overlays"]
+            if contract["overlay_id"] == "queue_position_survival_fill_curve"
+        )
+        self.assertEqual(
+            queue_contract["rank_metric"],
+            "post_cost_net_pnl_after_queue_position_survival_fill_stress",
+        )
         self.assertTrue(
             specs[0].promotion_contract["requires_queue_position_survival_fill_curve"]
         )

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -3131,6 +3131,12 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             frontier.Decimal(summary["queue_position_survival_stress_net_pnl_per_day"]),
             frontier.Decimal("490"),
         )
+        self.assertEqual(
+            frontier.Decimal(
+                summary["post_cost_net_pnl_after_queue_position_survival_fill_stress"]
+            ),
+            frontier.Decimal("490"),
+        )
 
     def test_consistency_penalty_reports_and_penalizes_capital_realism(self) -> None:
         payload = self._payload(


### PR DESCRIPTION
## Summary

- Adds the exact queue-position survival rank metric emitted by the frontier runner.
- Keeps the existing queue-survival stress metric as a compatibility alias.
- Adds regression coverage tying the candidate overlay rank contract to the runner output key.

## Related Issues

None

## Testing

- `uv run --frozen --extra dev ruff format app/trading/discovery/candidate_specs.py scripts/search_consistent_profitability_frontier.py tests/test_candidate_specs.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen --extra dev pytest tests/test_candidate_specs.py -k "queue_position_survival"`
- `uv run --frozen --extra dev pytest tests/test_search_consistent_profitability_frontier.py -k "fill_survival"`
- `uv run --frozen --extra dev ruff check app/trading/discovery/candidate_specs.py scripts/search_consistent_profitability_frontier.py tests/test_candidate_specs.py tests/test_search_consistent_profitability_frontier.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen --extra dev ruff format --check app/trading/discovery/candidate_specs.py scripts/search_consistent_profitability_frontier.py tests/test_candidate_specs.py tests/test_search_consistent_profitability_frontier.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
