### PR TITLE
fix(torghut): require queue ahead depletion proof

### DIFF
--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -103,6 +103,20 @@ DELAY_DEPTH_SURVIVAL_SCORECARD_KEYS = (
     "delay_adjusted_depth_fill_survival_sample_count",
     "delay_adjusted_depth_fill_survival_rate",
     "delay_adjusted_depth_queue_ratio_p95",
+    "delay_adjusted_depth_queue_ahead_depletion_evidence_present",
+    "delay_adjusted_depth_queue_ahead_depletion_sample_count",
+    "queue_position_survival_fill_curve_evidence_present",
+    "queue_position_survival_sample_count",
+    "queue_position_survival_fill_rate",
+    "queue_position_survival_queue_ratio_p95",
+    "queue_position_survival_queue_ahead_depletion_evidence_present",
+    "queue_position_survival_queue_ahead_depletion_sample_count",
+    "queue_position_survival_adjusted_fillable_ratio",
+    "queue_position_survival_nonfill_opportunity_cost_per_day",
+    "queue_position_survival_nonfill_opportunity_cost_bps",
+    "queue_position_survival_stress_net_pnl_per_day",
+    "post_cost_net_pnl_after_queue_position_survival_fill_stress",
+    "queue_position_survival_source_marker",
 )
 FILL_SURVIVAL_SCORECARD_KEYS = (
     "order_lifecycle",
@@ -121,6 +135,14 @@ FILL_SURVIVAL_SCORECARD_KEYS = (
     "queue_touch_qty_avg",
     "queue_touch_notional_avg",
     "order_qty_to_touch_qty_ratio_p95",
+    "queue_ahead_depletion_evidence_present",
+    "queue_ahead_depletion_sample_count",
+    "queue_ahead_depletion_rate",
+    "queue_ahead_qty_p95",
+    "queue_ahead_depleted_qty_p50",
+    "queue_ahead_depleted_qty_p95",
+    "queue_ahead_depletion_time_ms_p50",
+    "queue_ahead_depletion_time_ms_p95",
     "fill_probability_by_latency_bucket",
     "fill_probability_by_latency_threshold_ms",
     "post_cost_survivorship",
@@ -256,11 +278,35 @@ def _order_lifecycle_metrics(source: Mapping[str, Any]) -> dict[str, Any]:
     else:
         evidence_present = sample_count > 0
     fill_rate = lifecycle.get("fill_survival_fill_rate") or lifecycle.get("fill_rate")
+    queue_ahead_depletion_sample_count = max(
+        _int(lifecycle.get("queue_ahead_depletion_sample_count")),
+        _int(lifecycle.get("queue_depletion_sample_count")),
+    )
+    queue_ahead_depletion_evidence_present = _bool(
+        lifecycle.get("queue_ahead_depletion_evidence_present")
+    ) or (
+        queue_ahead_depletion_sample_count > 0
+        and (
+            lifecycle.get("queue_ahead_depletion_rate") is not None
+            or lifecycle.get("queue_ahead_depleted_qty_p50") is not None
+            or lifecycle.get("queue_ahead_depletion_time_ms_p50") is not None
+        )
+    )
 
     metrics: dict[str, Any] = {
         "order_lifecycle": lifecycle,
         "fill_survival_evidence_present": evidence_present,
         "fill_survival_sample_count": sample_count,
+        "queue_ahead_depletion_evidence_present": (
+            queue_ahead_depletion_evidence_present
+        ),
+        "queue_ahead_depletion_sample_count": queue_ahead_depletion_sample_count,
+        "delay_adjusted_depth_queue_ahead_depletion_evidence_present": (
+            queue_ahead_depletion_evidence_present
+        ),
+        "delay_adjusted_depth_queue_ahead_depletion_sample_count": (
+            queue_ahead_depletion_sample_count
+        ),
     }
     if fill_rate is not None:
         metrics["fill_survival_fill_rate"] = _string(fill_rate)
@@ -284,6 +330,12 @@ def _order_lifecycle_metrics(source: Mapping[str, Any]) -> dict[str, Any]:
         "queue_touch_qty_avg",
         "queue_touch_notional_avg",
         "order_qty_to_touch_qty_ratio_p95",
+        "queue_ahead_depletion_rate",
+        "queue_ahead_qty_p95",
+        "queue_ahead_depleted_qty_p50",
+        "queue_ahead_depleted_qty_p95",
+        "queue_ahead_depletion_time_ms_p50",
+        "queue_ahead_depletion_time_ms_p95",
         "fill_probability_by_latency_bucket",
         "fill_probability_by_latency_threshold_ms",
         "post_cost_survivorship",
@@ -988,6 +1040,12 @@ def evidence_bundle_from_frontier_candidate(
                 "queue_ratio_p95": scorecard.get(
                     "delay_adjusted_depth_queue_ratio_p95"
                 ),
+                "queue_ahead_depletion_evidence_present": scorecard.get(
+                    "delay_adjusted_depth_queue_ahead_depletion_evidence_present"
+                ),
+                "queue_ahead_depletion_sample_count": scorecard.get(
+                    "delay_adjusted_depth_queue_ahead_depletion_sample_count"
+                ),
                 "net_pnl_per_day": scorecard.get(
                     "delay_adjusted_depth_stress_net_pnl_per_day"
                 ),
@@ -1151,6 +1209,33 @@ def _delay_depth_survival_blockers(scorecard: Mapping[str, Any]) -> list[str]:
         <= 0
     ):
         blockers.append("fill_survival_sample_count_zero")
+    if not (
+        _bool(scorecard.get("queue_ahead_depletion_evidence_present"))
+        or _bool(
+            scorecard.get("delay_adjusted_depth_queue_ahead_depletion_evidence_present")
+        )
+        or _bool(
+            scorecard.get(
+                "queue_position_survival_queue_ahead_depletion_evidence_present"
+            )
+        )
+    ):
+        blockers.append("queue_ahead_depletion_evidence_missing")
+    if (
+        max(
+            _int(scorecard.get("queue_ahead_depletion_sample_count")),
+            _int(
+                scorecard.get("delay_adjusted_depth_queue_ahead_depletion_sample_count")
+            ),
+            _int(
+                scorecard.get(
+                    "queue_position_survival_queue_ahead_depletion_sample_count"
+                )
+            ),
+        )
+        <= 0
+    ):
+        blockers.append("queue_ahead_depletion_sample_count_zero")
     return blockers
 
 

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -319,6 +319,13 @@ def _delay_adjusted_depth_stress_blocking_reasons(
             reasons.append("fill_survival_evidence_missing")
         if _observation_int(summary.get("fill_survival_sample_count")) <= 0:
             reasons.append("fill_survival_sample_count_zero")
+        if (
+            _observation_bool(summary.get("queue_ahead_depletion_evidence_present"))
+            is not True
+        ):
+            reasons.append("queue_ahead_depletion_evidence_missing")
+        if _observation_int(summary.get("queue_ahead_depletion_sample_count")) <= 0:
+            reasons.append("queue_ahead_depletion_sample_count_zero")
     return list(dict.fromkeys(reasons))
 
 
@@ -450,6 +457,30 @@ def _delay_adjusted_depth_stress_summary(
         )
         or _text(report.get("delay_adjusted_depth_queue_ratio_p95"))
         or _text(report.get("queue_ratio_p95")),
+        "queue_ahead_depletion_evidence_present": _observation_bool(
+            runtime_payload.get(
+                "delay_adjusted_depth_queue_ahead_depletion_evidence_present"
+            )
+            if runtime_payload.get(
+                "delay_adjusted_depth_queue_ahead_depletion_evidence_present"
+            )
+            is not None
+            else report.get(
+                "delay_adjusted_depth_queue_ahead_depletion_evidence_present",
+                report.get("queue_ahead_depletion_evidence_present"),
+            )
+        ),
+        "queue_ahead_depletion_sample_count": max(
+            _observation_int(
+                runtime_payload.get(
+                    "delay_adjusted_depth_queue_ahead_depletion_sample_count"
+                )
+            ),
+            _observation_int(
+                report.get("delay_adjusted_depth_queue_ahead_depletion_sample_count")
+            ),
+            _observation_int(report.get("queue_ahead_depletion_sample_count")),
+        ),
     }
 
 

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -1688,10 +1688,32 @@ def _nonnegative_int_metric(value: Any) -> int:
         return 0
 
 
+def _truthy_metric(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value in (None, ""):
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "pass", "passed"}
+
+
 def _order_lifecycle_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
     lifecycle = _mapping(payload.get("order_lifecycle"))
     if not lifecycle:
         return {}
+    queue_ahead_depletion_sample_count = _nonnegative_int_metric(
+        lifecycle.get("queue_ahead_depletion_sample_count")
+        or lifecycle.get("queue_depletion_sample_count")
+    )
+    queue_ahead_depletion_evidence_present = _truthy_metric(
+        lifecycle.get("queue_ahead_depletion_evidence_present")
+    ) or (
+        queue_ahead_depletion_sample_count > 0
+        and (
+            lifecycle.get("queue_ahead_depletion_rate") is not None
+            or lifecycle.get("queue_ahead_depleted_qty_p50") is not None
+            or lifecycle.get("queue_ahead_depletion_time_ms_p50") is not None
+        )
+    )
     metrics: dict[str, Any] = {
         "order_lifecycle": lifecycle,
         "fill_survival_evidence_present": bool(
@@ -1723,6 +1745,16 @@ def _order_lifecycle_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
         "order_qty_to_touch_qty_ratio_p95": str(
             lifecycle.get("order_qty_to_touch_qty_ratio_p95") or ""
         ),
+        "queue_ahead_depletion_evidence_present": (
+            queue_ahead_depletion_evidence_present
+        ),
+        "queue_ahead_depletion_sample_count": queue_ahead_depletion_sample_count,
+        "delay_adjusted_depth_queue_ahead_depletion_evidence_present": (
+            queue_ahead_depletion_evidence_present
+        ),
+        "delay_adjusted_depth_queue_ahead_depletion_sample_count": (
+            queue_ahead_depletion_sample_count
+        ),
         "fill_probability_by_latency_bucket": _mapping(
             lifecycle.get("fill_probability_by_latency_bucket")
         ),
@@ -1730,6 +1762,16 @@ def _order_lifecycle_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
             lifecycle.get("fill_probability_by_latency_threshold_ms")
         ),
     }
+    for key in (
+        "queue_ahead_depletion_rate",
+        "queue_ahead_qty_p95",
+        "queue_ahead_depleted_qty_p50",
+        "queue_ahead_depleted_qty_p95",
+        "queue_ahead_depletion_time_ms_p50",
+        "queue_ahead_depletion_time_ms_p95",
+    ):
+        if key in lifecycle:
+            metrics[key] = lifecycle[key]
     survivorship = _mapping(lifecycle.get("post_cost_survivorship"))
     if survivorship:
         metrics["post_cost_survivorship"] = survivorship
@@ -2158,6 +2200,8 @@ def _replay_stress_metrics(
     fill_survival_rate: Decimal | None = None,
     fill_survival_sample_count: int = 0,
     queue_ratio_p95: Decimal | None = None,
+    queue_ahead_depletion_evidence_present: bool = False,
+    queue_ahead_depletion_sample_count: int = 0,
 ) -> dict[str, Any]:
     participation = (
         total_filled_notional / total_liquidity_notional
@@ -2342,7 +2386,10 @@ def _replay_stress_metrics(
         if queue_ratio_p95 is not None
         else "",
         "queue_position_survival_fill_curve_evidence_present": (
-            fill_survival_sample_count > 0 and queue_ratio_p95 is not None
+            fill_survival_sample_count > 0
+            and queue_ratio_p95 is not None
+            and queue_ahead_depletion_evidence_present
+            and queue_ahead_depletion_sample_count > 0
         ),
         "queue_position_survival_sample_count": fill_survival_sample_count,
         "queue_position_survival_fill_rate": str(fill_survival_rate)
@@ -2351,6 +2398,12 @@ def _replay_stress_metrics(
         "queue_position_survival_queue_ratio_p95": str(queue_ratio_p95)
         if queue_ratio_p95 is not None
         else "",
+        "queue_position_survival_queue_ahead_depletion_evidence_present": (
+            queue_ahead_depletion_evidence_present
+        ),
+        "queue_position_survival_queue_ahead_depletion_sample_count": (
+            queue_ahead_depletion_sample_count
+        ),
         "queue_position_survival_adjusted_fillable_ratio": str(
             survival_adjusted_fillable_ratio
         ),
@@ -2474,6 +2527,12 @@ def _consistency_penalty(
             order_lifecycle_metrics.get("fill_survival_sample_count") or 0
         ),
         queue_ratio_p95=queue_ratio_p95,
+        queue_ahead_depletion_evidence_present=bool(
+            order_lifecycle_metrics.get("queue_ahead_depletion_evidence_present")
+        ),
+        queue_ahead_depletion_sample_count=int(
+            order_lifecycle_metrics.get("queue_ahead_depletion_sample_count") or 0
+        ),
     )
     conformal_tail_risk_metrics = _conformal_tail_risk_metrics(
         target_net_per_day=policy.target_net_per_day,
@@ -4966,6 +5025,17 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                                 "queue_position_survival_queue_ratio_p95"
                             )
                             or ""
+                        ),
+                        "queue_position_survival_queue_ahead_depletion_evidence_present": bool(
+                            full_window_summary.get(
+                                "queue_position_survival_queue_ahead_depletion_evidence_present"
+                            )
+                        ),
+                        "queue_position_survival_queue_ahead_depletion_sample_count": int(
+                            full_window_summary.get(
+                                "queue_position_survival_queue_ahead_depletion_sample_count"
+                            )
+                            or 0
                         ),
                         "queue_position_survival_adjusted_fillable_ratio": str(
                             full_window_summary.get(

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -271,6 +271,8 @@ class TestRuntimeWindowImport(TestCase):
                 "delay_adjusted_depth_stress_net_pnl_non_positive",
                 "fill_survival_evidence_missing",
                 "fill_survival_sample_count_zero",
+                "queue_ahead_depletion_evidence_missing",
+                "queue_ahead_depletion_sample_count_zero",
             ],
         )
 
@@ -936,6 +938,8 @@ class TestRuntimeWindowImport(TestCase):
                         "fill_survival_sample_count": 44,
                         "fill_survival_rate": "0.90",
                         "queue_ratio_p95": "0.12",
+                        "queue_ahead_depletion_evidence_present": True,
+                        "queue_ahead_depletion_sample_count": 44,
                     }
                 },
             )
@@ -965,6 +969,8 @@ class TestRuntimeWindowImport(TestCase):
                 "fill_survival_sample_count": 44,
                 "fill_survival_rate": "0.90",
                 "queue_ratio_p95": "0.12",
+                "queue_ahead_depletion_evidence_present": True,
+                "queue_ahead_depletion_sample_count": 44,
             },
         )
         self.assertEqual(decision.allowed, True)

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -3074,6 +3074,11 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             "fill_survival_sample_count": 4,
             "fill_survival_evidence_present": True,
             "order_qty_to_touch_qty_ratio_p95": "0.25",
+            "queue_ahead_depletion_evidence_present": True,
+            "queue_ahead_depletion_sample_count": 4,
+            "queue_ahead_depletion_rate": "0.50",
+            "queue_ahead_depleted_qty_p50": "25",
+            "queue_ahead_depletion_time_ms_p50": "125",
             "post_cost_survivorship": {
                 "post_cost_survival_rate": "1",
                 "gross_positive_killed_by_cost_count": 0,
@@ -3117,6 +3122,15 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(summary["queue_position_survival_sample_count"], 4)
         self.assertEqual(summary["queue_position_survival_fill_rate"], "0.5")
         self.assertEqual(summary["queue_position_survival_queue_ratio_p95"], "0.25")
+        self.assertTrue(
+            summary["queue_position_survival_queue_ahead_depletion_evidence_present"]
+        )
+        self.assertEqual(
+            summary["queue_position_survival_queue_ahead_depletion_sample_count"],
+            4,
+        )
+        self.assertTrue(summary["queue_ahead_depletion_evidence_present"])
+        self.assertEqual(summary["queue_ahead_depletion_sample_count"], 4)
         self.assertEqual(
             summary["queue_position_survival_adjusted_fillable_ratio"],
             "0.5",
@@ -3136,6 +3150,58 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 summary["post_cost_net_pnl_after_queue_position_survival_fill_stress"]
             ),
             frontier.Decimal("490"),
+        )
+
+    def test_consistency_penalty_does_not_count_l1_queue_ratio_as_queue_survival(
+        self,
+    ) -> None:
+        payload = self._payload(
+            start_date="2026-03-24",
+            end_date="2026-03-24",
+            daily_net={"2026-03-24": "1000"},
+            daily_filled_notional={"2026-03-24": "100000"},
+            daily_liquidity_notional={"2026-03-24": "1000000"},
+            decision_count=4,
+            filled_count=4,
+            wins=4,
+            losses=0,
+        )
+        payload["order_lifecycle"] = {
+            "submitted_order_count": 4,
+            "filled_order_count": 2,
+            "fill_rate": "0.5",
+            "fill_survival_sample_count": 4,
+            "fill_survival_evidence_present": True,
+            "order_qty_to_touch_qty_ratio_p95": "0.25",
+        }
+
+        _, summary = frontier._consistency_penalty(
+            full_window_payload=payload,
+            policy=frontier.FullWindowConsistencyPolicy(
+                target_net_per_day=frontier.Decimal("500"),
+                min_daily_net_pnl=frontier.Decimal("0"),
+                min_active_days=1,
+                min_active_ratio=frontier.Decimal("1"),
+                min_positive_days=1,
+                max_worst_day_loss=frontier.Decimal("250"),
+                max_negative_days=0,
+                max_drawdown=frontier.Decimal("500"),
+                max_best_day_share_of_total_pnl=frontier.Decimal("1"),
+                min_avg_filled_notional_per_day=frontier.Decimal("50000"),
+                min_avg_filled_notional_per_active_day=frontier.Decimal("50000"),
+                require_every_day_active=True,
+            ),
+        )
+
+        self.assertTrue(summary["delay_adjusted_depth_fill_survival_evidence_present"])
+        self.assertEqual(summary["delay_adjusted_depth_queue_ratio_p95"], "0.25")
+        self.assertFalse(summary["queue_position_survival_fill_curve_evidence_present"])
+        self.assertFalse(
+            summary["queue_position_survival_queue_ahead_depletion_evidence_present"]
+        )
+        self.assertEqual(
+            summary["queue_position_survival_queue_ahead_depletion_sample_count"],
+            0,
         )
 
     def test_consistency_penalty_reports_and_penalizes_capital_realism(self) -> None:

--- a/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
+++ b/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
@@ -598,6 +598,11 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
                         "fill_rate": "0.75",
                         "fill_survival_sample_count": 4,
                         "order_qty_to_touch_qty_ratio_p95": "0.20",
+                        "queue_ahead_depletion_evidence_present": True,
+                        "queue_ahead_depletion_sample_count": 4,
+                        "queue_ahead_depletion_rate": "0.75",
+                        "queue_ahead_depleted_qty_p50": "18",
+                        "queue_ahead_depletion_time_ms_p50": "140",
                         "post_cost_survivorship": {
                             "post_cost_survival_rate": "0.50",
                             "gross_positive_killed_by_cost_count": 1,
@@ -641,6 +646,24 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
             bundle.objective_scorecard["delay_adjusted_depth_queue_ratio_p95"],
             "0.20",
         )
+        self.assertTrue(
+            bundle.objective_scorecard["queue_ahead_depletion_evidence_present"]
+        )
+        self.assertEqual(
+            bundle.objective_scorecard["queue_ahead_depletion_sample_count"],
+            4,
+        )
+        self.assertTrue(
+            bundle.objective_scorecard[
+                "delay_adjusted_depth_queue_ahead_depletion_evidence_present"
+            ]
+        )
+        self.assertEqual(
+            bundle.objective_scorecard[
+                "delay_adjusted_depth_queue_ahead_depletion_sample_count"
+            ],
+            4,
+        )
         self.assertEqual(
             bundle.objective_scorecard["post_cost_survival_rate"],
             "0.50",
@@ -649,6 +672,55 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
             bundle.objective_scorecard["gross_positive_killed_by_cost_count"],
             1,
         )
+
+    def test_evidence_bundle_blocks_l1_queue_ratio_without_queue_ahead_depletion(
+        self,
+    ) -> None:
+        bundle = evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-l1-proxy-proof",
+            candidate={
+                "candidate_id": "cand-l1-proxy-proof",
+                "objective_scorecard": {
+                    "net_pnl_per_day": "650",
+                    "delay_adjusted_depth_stress_passed": True,
+                    "delay_adjusted_depth_stress_model": "latency_depth_haircut",
+                    "delay_adjusted_depth_stress_ms": "50",
+                    "delay_adjusted_depth_stress_artifact_ref": "/tmp/depth.json",
+                    "delay_adjusted_depth_tail_coverage_passed": True,
+                    "delay_adjusted_depth_p10_active_day_fillable_notional": "250000",
+                    "delay_adjusted_depth_worst_active_day_fillable_notional": "200000",
+                    "delay_adjusted_depth_stress_net_pnl_per_day": "540",
+                },
+                "full_window": {
+                    "net_per_day": "650",
+                    "trading_day_count": "1",
+                    "avg_filled_notional_per_day": "350000",
+                    "daily_filled_notional": {"2026-02-23": "350000"},
+                    "daily_liquidity_notional": {"2026-02-23": "900000"},
+                    "order_lifecycle": {
+                        "submitted_order_count": 4,
+                        "filled_order_count": 3,
+                        "fill_rate": "0.75",
+                        "fill_survival_sample_count": 4,
+                        "order_qty_to_touch_qty_ratio_p95": "0.20",
+                    },
+                },
+                "promotion_readiness": {
+                    "stage": "paper_probation",
+                    "status": "promotion_ready",
+                    "promotable": True,
+                    "blockers": [],
+                },
+            },
+            dataset_snapshot_id="snap-l1-proxy-proof",
+            result_path="/tmp/l1-proxy-proof.json",
+        )
+
+        blockers = evidence_bundle_blockers(bundle)
+
+        self.assertNotIn("fill_survival_evidence_missing", blockers)
+        self.assertIn("queue_ahead_depletion_evidence_missing", blockers)
+        self.assertIn("queue_ahead_depletion_sample_count_zero", blockers)
 
     def test_evidence_bundle_parses_serialized_false_survival_booleans(self) -> None:
         bundle = evidence_bundle_from_frontier_candidate(
@@ -757,6 +829,8 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
                     "daily_filled_notional": {"2026-02-23": "350000"},
                     "daily_liquidity_notional": {"2026-02-23": "900000"},
                     "fill_survival_fill_rate": "0.75",
+                    "queue_ahead_depletion_evidence_present": True,
+                    "queue_ahead_depletion_sample_count": 8,
                 },
                 "promotion_readiness": {
                     "stage": "paper_probation",


### PR DESCRIPTION
## Summary

- Requires queue-ahead depletion evidence before queue-position survival fill curves count as promotion proof.
- Carries queue-ahead depletion metrics through frontier scorecards, evidence bundles, runtime-window import summaries, and stress metrics.
- Adds regressions proving L1 queue-ratio evidence alone no longer passes queue-survival proof gates.

## Related Issues

None

## Testing

- `uv run --frozen --extra dev ruff format app/trading/discovery/evidence_bundles.py app/trading/runtime_window_import.py scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py tests/test_whitepaper_autoresearch_artifacts.py`
- `uv run --frozen --extra dev pytest tests/test_search_consistent_profitability_frontier.py -k "fill_survival or queue_ratio"`
- `uv run --frozen --extra dev pytest tests/test_whitepaper_autoresearch_artifacts.py -k "fill_survival or queue_ahead or l1_queue"`
- `uv run --frozen --extra dev pytest tests/test_runtime_window_import.py -k "fill_survival or delay_adjusted_depth"`
- `uv run --frozen --extra dev ruff check app/trading/discovery/evidence_bundles.py app/trading/runtime_window_import.py scripts/search_consistent_profitability_frontier.py tests/test_runtime_window_import.py tests/test_search_consistent_profitability_frontier.py tests/test_whitepaper_autoresearch_artifacts.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen --extra dev ruff format --check app/trading/discovery/evidence_bundles.py app/trading/runtime_window_import.py scripts/search_consistent_profitability_frontier.py tests/test_runtime_window_import.py tests/test_search_consistent_profitability_frontier.py tests/test_whitepaper_autoresearch_artifacts.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
