### PR TITLE
feat(torghut): add alpha decay stress gates

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -3398,6 +3398,74 @@ def _mechanism_overlays_for_card(card: HypothesisCard) -> dict[str, Any]:
 
     if has_any(
         (
+            "alpha decay",
+            "alpha_decay",
+            "predictability decay",
+            "predictability_decay",
+            "declined over time",
+            "market efficiency",
+            "short-run market efficiency",
+            "t-kan",
+            "tkan",
+            "temporal kolmogorov",
+            "tlob",
+            "dual attention",
+            "horizon bias",
+            "horizon_bias",
+            "spread-adjusted labels",
+            "spread adjusted labels",
+            "algorithmic activity",
+            "tight spreads",
+            "heavier trading",
+            "high-volume regimes",
+            "high volume regimes",
+        )
+    ):
+        overlay_ids.append("alpha_decay_predictability_stress")
+        overlay_contracts.append(
+            {
+                "overlay_id": "alpha_decay_predictability_stress",
+                "required_evidence": [
+                    "horizon_decay_curve",
+                    "spread_adjusted_labels",
+                    "tight_spread_regime_slices",
+                    "high_volume_regime_slices",
+                    "inference_latency",
+                    "walk_forward_replay",
+                    "route_tca",
+                ],
+                "rank_metric": "post_cost_net_pnl_after_predictability_decay_stress",
+                "evidence_policy": "short_horizon_lob_alpha_requires_decay_and_cost_stress",
+            }
+        )
+        hard_vetoes.update(
+            {
+                "required_predictability_decay_stress": True,
+                "required_horizon_decay_curve": True,
+                "required_spread_adjusted_label_replay": True,
+                "required_min_decay_stress_horizon_count": "3",
+                "required_min_tight_spread_regime_count": "20",
+                "required_min_high_volume_regime_count": "20",
+                "required_min_decay_stress_split_pass_rate": "0.60",
+                "required_max_decay_stress_best_split_share": "0.35",
+                "required_max_model_inference_latency_ms": "200",
+            }
+        )
+        promotion_contract.update(
+            {
+                "requires_predictability_decay_stress": True,
+                "requires_horizon_decay_curve": True,
+                "requires_spread_adjusted_label_replay": True,
+                "requires_tight_spread_and_high_volume_slices": True,
+                "requires_model_latency_budget": True,
+                "requires_route_tca": True,
+                "rejects_single_horizon_lob_alpha_promotion": True,
+                "rejects_classification_accuracy_without_costs": True,
+            }
+        )
+
+    if has_any(
+        (
             "nonlinear impact",
             "nonlinear_impact",
             "square-root",
@@ -4107,6 +4175,40 @@ def _family_scores_for_hypothesis(
         )
         bump(
             "microbar_cross_sectional_pairs_v1", 3, "queue_position_survival_fill_curve"
+        )
+
+    if has_any(
+        (
+            "alpha decay",
+            "alpha_decay",
+            "predictability decay",
+            "predictability_decay",
+            "declined over time",
+            "short-run market efficiency",
+            "market efficiency",
+            "t-kan",
+            "tkan",
+            "temporal kolmogorov",
+            "tlob",
+            "dual attention",
+            "horizon bias",
+            "spread-adjusted",
+            "algorithmic activity",
+            "tight spreads",
+            "heavier trading",
+            "high-volume regimes",
+        )
+    ):
+        bump(
+            "microstructure_continuation_matched_filter_v1",
+            5,
+            "alpha_decay_predictability_stress",
+        )
+        bump("intraday_tsmom_v2", 3, "alpha_decay_predictability_stress")
+        bump(
+            "microbar_cross_sectional_pairs_v1",
+            3,
+            "alpha_decay_predictability_stress",
         )
 
     if has_any(

--- a/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
@@ -540,6 +540,39 @@ research_sources:
       - claim_id: algorithmic_activity_decay_stress
         summary: Higher algorithmic activity, tighter spreads, and heavier trading can reduce short-horizon predictability.
         implication: Stress microstructure candidates by algo-intensity, tight-spread, and high-volume regimes before portfolio ranking.
+  - source_id: tkan_lob_alpha_decay_2026
+    title: 'Temporal Kolmogorov-Arnold Networks (T-KAN) for High-Frequency Limit Order Book Forecasting: Efficiency, Interpretability, and Alpha Decay'
+    url: https://arxiv.org/abs/2601.02310
+    published_at: '2026-01-05'
+    claims:
+      - claim_id: lob_alpha_decay_horizon_stress
+        claim_type: validation_requirement
+        claim_text: Limit-order-book alpha decays as the forecast horizon lengthens; single-horizon backtests are not enough to prove executable edge.
+        summary: LOB forecasting edge must survive horizon-decay checks instead of being accepted from one favorable horizon.
+        implication: Require horizon-decay curves, walk-forward replay, and post-cost route/TCA before any LOB model output supports promotion.
+        data_requirements:
+          - horizon_decay_curve
+          - forecast_horizon
+          - walk_forward_replay
+          - route_tca
+          - post_cost_net_pnl
+        asset_scope: limit_order_book_intraday
+        horizon_scope: short_horizon_returns
+        expected_direction: neutral
+      - claim_id: spread_adjusted_lob_label_cost_stress
+        claim_type: risk_constraint
+        claim_text: LOB trend labels and model latency must be evaluated after spread adjustment and under tight-spread, high-volume, algorithmic-activity regimes.
+        summary: Classification gains are not promotion evidence unless they survive spread-adjusted labels, latency budgets, and regime slices.
+        implication: Route T-KAN/TLOB-style proposals through predictability-decay stress before ranking them for paper probation.
+        data_requirements:
+          - spread_adjusted_labels
+          - inference_latency
+          - tight_spread_regime_slices
+          - high_volume_regime_slices
+          - algorithmic_activity_regime
+        asset_scope: limit_order_book_intraday
+        horizon_scope: intraday_microstructure
+        expected_direction: neutral
   - source_id: idiosyncratic_trade_imbalance_2026
     title: 'Decomposing High-Frequency Order Flow: Commonality and Idiosyncratic Trade Imbalance'
     url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6535019

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -629,6 +629,70 @@ class TestCandidateSpecs(TestCase):
             specs[0].promotion_contract["rejects_queue_position_free_fill_assumptions"]
         )
 
+    def test_alpha_decay_claim_adds_predictability_stress_contract(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-tkan-alpha-decay",
+            claims=[
+                {
+                    "claim_id": "lob-alpha-decay",
+                    "claim_type": "validation_requirement",
+                    "claim_text": (
+                        "T-KAN limit order book forecasting shows alpha decay as "
+                        "predictability declines over longer horizons and under "
+                        "spread-adjusted labels."
+                    ),
+                    "data_requirements": [
+                        "horizon_decay_curve",
+                        "spread_adjusted_labels",
+                        "tight_spread_regime_slices",
+                        "high_volume_regime_slices",
+                        "route_tca",
+                    ],
+                    "confidence": "0.78",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+
+        self.assertIn(
+            "alpha_decay_predictability_stress",
+            specs[0].parameter_space["mechanism_overlay_ids"],
+        )
+        self.assertTrue(specs[0].hard_vetoes["required_predictability_decay_stress"])
+        self.assertTrue(specs[0].hard_vetoes["required_horizon_decay_curve"])
+        self.assertEqual(
+            specs[0].hard_vetoes["required_min_decay_stress_horizon_count"],
+            "3",
+        )
+        self.assertEqual(
+            specs[0].hard_vetoes["required_max_model_inference_latency_ms"],
+            "200",
+        )
+        mechanism_overlays = candidate_specs_module._mechanism_overlays_for_card(
+            cards[0]
+        )
+        decay_contract = next(
+            contract
+            for contract in mechanism_overlays["feature_contract"]["mechanism_overlays"]
+            if contract["overlay_id"] == "alpha_decay_predictability_stress"
+        )
+        self.assertEqual(
+            decay_contract["rank_metric"],
+            "post_cost_net_pnl_after_predictability_decay_stress",
+        )
+        self.assertTrue(
+            specs[0].promotion_contract["requires_predictability_decay_stress"]
+        )
+        self.assertTrue(
+            specs[0].promotion_contract["rejects_single_horizon_lob_alpha_promotion"]
+        )
+        self.assertTrue(
+            specs[0].promotion_contract["rejects_classification_accuracy_without_costs"]
+        )
+
     def test_ohlcv_only_claim_adds_falsification_contract(self) -> None:
         cards = build_hypothesis_cards(
             source_run_id="paper-ohlcv-falsification",


### PR DESCRIPTION
## Summary

- Added a T-KAN/LOB alpha-decay research source to the $500/day portfolio autoresearch program.
- Added an alpha-decay predictability-stress mechanism overlay for short-horizon LOB/model candidates.
- Require horizon-decay curves, spread-adjusted labels, latency budgets, tight-spread/high-volume regime slices, walk-forward replay, and route/TCA before those candidates can support promotion review.

## Related Issues

None

## Testing

- `uv run --frozen --extra dev pytest tests/test_candidate_specs.py -k "alpha_decay or queue_position_survival"`
- `uv run --frozen --extra dev pytest tests/test_candidate_specs.py`
- `uv run --frozen --extra dev ruff format --check app/trading/discovery/candidate_specs.py tests/test_candidate_specs.py`
- `uv run --frozen --extra dev ruff check app/trading/discovery/candidate_specs.py tests/test_candidate_specs.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
