### PR TITLE
fix(torghut): bound clickhouse replay queries

### DIFF
--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -68,6 +68,7 @@ REGULAR_OPEN_UTC = time(hour=13, minute=30)
 REGULAR_CLOSE_UTC = time(hour=20, minute=0)
 DEFAULT_CHUNK_MINUTES = 10
 DEFAULT_START_EQUITY = Decimal("31590.02")
+DEFAULT_CLICKHOUSE_QUERY_TIMEOUT_SECONDS = 30
 DEFAULT_PROGRESS_LOG_INTERVAL_SECONDS = 15
 logger = logging.getLogger(__name__)
 _SHARED_POSITION_OWNER = "__shared__"
@@ -132,6 +133,7 @@ class ReplayConfig:
     max_executable_spread_bps: Decimal = DEFAULT_MAX_EXECUTABLE_SPREAD_BPS
     max_quote_mid_jump_bps: Decimal = DEFAULT_MAX_QUOTE_MID_JUMP_BPS
     max_jump_with_wide_spread_bps: Decimal = DEFAULT_MAX_JUMP_WITH_WIDE_SPREAD_BPS
+    clickhouse_query_timeout_seconds: int = DEFAULT_CLICKHOUSE_QUERY_TIMEOUT_SECONDS
 
 
 @dataclass
@@ -500,6 +502,17 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--start-date", default="2026-03-23")
     parser.add_argument("--end-date", default="2026-03-27")
     parser.add_argument("--chunk-minutes", type=int, default=DEFAULT_CHUNK_MINUTES)
+    parser.add_argument(
+        "--clickhouse-query-timeout-seconds",
+        type=int,
+        default=int(
+            os.environ.get(
+                "TA_CLICKHOUSE_QUERY_TIMEOUT_SECONDS",
+                str(DEFAULT_CLICKHOUSE_QUERY_TIMEOUT_SECONDS),
+            )
+        ),
+        help="Per ClickHouse HTTP or kubectl query timeout. Keeps bounded refreshes from hanging.",
+    )
     parser.add_argument("--start-equity", default=str(DEFAULT_START_EQUITY))
     parser.add_argument(
         "--symbols",
@@ -624,13 +637,16 @@ def _http_query(
     username: str | None,
     password: str | None,
     query: str,
+    timeout_seconds: int = DEFAULT_CLICKHOUSE_QUERY_TIMEOUT_SECONDS,
 ) -> str:
+    timeout_seconds = max(1, int(timeout_seconds))
     if url.startswith("kubectl://"):
         return _kubectl_clickhouse_query(
             url=url,
             username=username,
             password=password,
             query=query,
+            timeout_seconds=timeout_seconds,
         )
     body = query.encode("utf-8")
     last_error: Exception | None = None
@@ -640,7 +656,7 @@ def _http_query(
             credentials = f"{username}:{password or ''}".encode("utf-8")
             req.add_header("Authorization", "Basic " + _b64(credentials))
         try:
-            with request.urlopen(req, timeout=120) as resp:
+            with request.urlopen(req, timeout=timeout_seconds) as resp:
                 return resp.read().decode("utf-8")
         except error.HTTPError as exc:
             payload = exc.read().decode("utf-8", errors="replace")
@@ -663,6 +679,7 @@ def _kubectl_clickhouse_query(
     username: str | None,
     password: str | None,
     query: str,
+    timeout_seconds: int = DEFAULT_CLICKHOUSE_QUERY_TIMEOUT_SECONDS,
 ) -> str:
     target = parse.urlparse(url)
     context = parse.unquote(target.netloc).strip()
@@ -688,7 +705,18 @@ def _kubectl_clickhouse_query(
     if password:
         command.extend(["--password", password])
     command.extend(["--query", query])
-    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=max(1, int(timeout_seconds)),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"clickhouse_kubectl_query_timeout:{max(1, int(timeout_seconds))}s"
+        ) from exc
     if result.returncode != 0:
         detail = (result.stderr or result.stdout).strip()
         raise RuntimeError(f"clickhouse_kubectl_query_failed: {detail[:400]}")
@@ -742,6 +770,7 @@ def _iter_signal_rows(config: ReplayConfig) -> Iterable[SignalEnvelope]:
                 http_url=config.clickhouse_http_url,
                 username=config.clickhouse_username,
                 password=config.clickhouse_password,
+                timeout_seconds=config.clickhouse_query_timeout_seconds,
                 chunk_start=chunk_start,
                 chunk_end=chunk_end,
                 symbols=config.symbols,
@@ -800,6 +829,7 @@ def _fetch_chunk(
     http_url: str,
     username: str | None,
     password: str | None,
+    timeout_seconds: int = DEFAULT_CLICKHOUSE_QUERY_TIMEOUT_SECONDS,
     chunk_start: datetime,
     chunk_end: datetime,
     symbols: tuple[str, ...] = (),
@@ -848,6 +878,7 @@ FORMAT TSVRaw
         url=http_url,
         username=username,
         password=password,
+        timeout_seconds=timeout_seconds,
         query=query,
     )
     reader = csv.reader(raw.splitlines(), delimiter="\t")
@@ -3518,6 +3549,16 @@ def main() -> None:
         max_executable_spread_bps=Decimal(str(args.max_executable_spread_bps)),
         max_quote_mid_jump_bps=Decimal(str(args.max_quote_mid_jump_bps)),
         max_jump_with_wide_spread_bps=Decimal(str(args.max_jump_with_wide_spread_bps)),
+        clickhouse_query_timeout_seconds=max(
+            1,
+            int(
+                getattr(
+                    args,
+                    "clickhouse_query_timeout_seconds",
+                    DEFAULT_CLICKHOUSE_QUERY_TIMEOUT_SECONDS,
+                )
+            ),
+        ),
     )
     payload = run_replay(config)
     if args.trace_output:

--- a/services/torghut/scripts/materialize_replay_tape.py
+++ b/services/torghut/scripts/materialize_replay_tape.py
@@ -61,6 +61,17 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--chunk-minutes", type=int, default=replay_mod.DEFAULT_CHUNK_MINUTES
     )
+    parser.add_argument(
+        "--clickhouse-query-timeout-seconds",
+        type=int,
+        default=int(
+            os.environ.get(
+                "TA_CLICKHOUSE_QUERY_TIMEOUT_SECONDS",
+                str(replay_mod.DEFAULT_CLICKHOUSE_QUERY_TIMEOUT_SECONDS),
+            )
+        ),
+        help="Per ClickHouse HTTP or kubectl query timeout. Keeps replay-tape materialization bounded.",
+    )
     parser.add_argument("--start-equity", default=str(replay_mod.DEFAULT_START_EQUITY))
     parser.add_argument(
         "--symbols",
@@ -154,6 +165,16 @@ def main() -> int:
         start_date=start_date,
         end_date=end_date,
         chunk_minutes=max(1, int(args.chunk_minutes)),
+        clickhouse_query_timeout_seconds=max(
+            1,
+            int(
+                getattr(
+                    args,
+                    "clickhouse_query_timeout_seconds",
+                    replay_mod.DEFAULT_CLICKHOUSE_QUERY_TIMEOUT_SECONDS,
+                )
+            ),
+        ),
         flatten_eod=True,
         start_equity=Decimal(str(args.start_equity)),
         symbols=symbols,

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from datetime import date, datetime, timezone
 from decimal import Decimal
@@ -165,6 +166,21 @@ class TestLocalIntradayTsmomReplay(TestCase):
                     query="SELECT 1",
                 )
 
+        with patch(
+            "scripts.local_intraday_tsmom_replay.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["kubectl"], timeout=2),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError, "clickhouse_kubectl_query_timeout:2s"
+            ):
+                _kubectl_clickhouse_query(
+                    url="kubectl://galactic-lan/torghut/clickhouse-0",
+                    username="torghut",
+                    password="secret",
+                    query="SELECT 1",
+                    timeout_seconds=2,
+                )
+
     def test_execution_spread_helpers_fall_back_on_invalid_payloads(self) -> None:
         decision = StrategyDecision(
             strategy_id="candidate-strategy-1",
@@ -217,11 +233,13 @@ class TestLocalIntradayTsmomReplay(TestCase):
             url: str,
             username: str | None,
             password: str | None,
+            timeout_seconds: int,
             query: str,
         ) -> str:
             self.assertEqual(url, "http://clickhouse")
             self.assertEqual(username, "reader")
             self.assertEqual(password, "secret")
+            self.assertEqual(timeout_seconds, 7)
             captured_queries.append(query)
             return "\t".join(
                 [
@@ -255,6 +273,7 @@ class TestLocalIntradayTsmomReplay(TestCase):
                 http_url="http://clickhouse",
                 username="reader",
                 password="secret",
+                timeout_seconds=7,
                 chunk_start=datetime(2026, 3, 27, 17, 0, tzinfo=timezone.utc),
                 chunk_end=datetime(2026, 3, 27, 18, 0, tzinfo=timezone.utc),
                 symbols=("META", "NVDA"),
@@ -282,11 +301,13 @@ class TestLocalIntradayTsmomReplay(TestCase):
                 url="kubectl://galactic-lan/torghut/chi-torghut-clickhouse-default-0-0-0",
                 username="torghut",
                 password="secret",
+                timeout_seconds=5,
                 query="SELECT 1 FORMAT TSVRaw",
             )
 
         self.assertEqual(output, "2026-05-18\n")
         cmd = run_mock.call_args.args[0]
+        self.assertEqual(run_mock.call_args.kwargs["timeout"], 5)
         self.assertEqual(
             cmd[:7],
             [

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -528,12 +528,15 @@ class TestMaterializeReplayTapeCli(TestCase):
                     " nvda, META ",
                     "--source-table-version",
                     "ta_signals=v1",
+                    "--clickhouse-query-timeout-seconds",
+                    "9",
                 ],
             ):
                 args = materialize_cli._parse_args()
 
         symbols = materialize_cli._parse_symbols(str(args.symbols))
         self.assertEqual(symbols, ("NVDA", "META"))
+        self.assertEqual(args.clickhouse_query_timeout_seconds, 9)
         self.assertFalse(args.allow_incomplete_coverage)
         self.assertEqual(
             materialize_cli._parse_source_table_versions(args.source_table_version),


### PR DESCRIPTION
## Summary

- Adds a configurable per-query timeout for local Torghut ClickHouse replay reads, defaulting to 30 seconds and honoring `TA_CLICKHOUSE_QUERY_TIMEOUT_SECONDS`.
- Applies the same timeout to direct HTTP reads and `kubectl://` ClickHouse transport used by replay tape materialization.
- Covers timeout propagation and kubectl timeout failures in replay and materialization tests.

## Related Issues

None

## Testing

- `uv run --frozen --extra dev pytest tests/test_local_intraday_tsmom_replay.py -k "kubectl_clickhouse_query or fetch_chunk_filters or http_query_supports"`
- `uv run --frozen --extra dev pytest tests/test_replay_tape.py -k "parse_args_and_helpers or main_materializes"`
- `uv run --frozen --extra dev ruff check scripts/local_intraday_tsmom_replay.py scripts/materialize_replay_tape.py tests/test_local_intraday_tsmom_replay.py tests/test_replay_tape.py`
- `uv run --frozen --extra dev ruff format --check scripts/local_intraday_tsmom_replay.py scripts/materialize_replay_tape.py tests/test_local_intraday_tsmom_replay.py tests/test_replay_tape.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
