### PR TITLE
fix(torghut): diagnose replay coverage gaps

### DIFF
--- a/services/torghut/app/trading/discovery/replay_tape.py
+++ b/services/torghut/app/trading/discovery/replay_tape.py
@@ -30,6 +30,13 @@ def _empty_row_count_by_symbol_trading_day() -> dict[str, dict[str, int]]:
     return {}
 
 
+class ReplayTapeCoverageError(ValueError):
+    def __init__(self, reason: str, *, diagnostics: Mapping[str, Any]) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.diagnostics = dict(diagnostics)
+
+
 @dataclass(frozen=True)
 class ReplayTapeManifest:
     schema_version: str
@@ -200,14 +207,27 @@ def materialize_signal_tape(
         requested_trading_days=requested_trading_days,
         observed_trading_days=observed_trading_days,
     )
+    row_count_by_trading_day: dict[str, int] = {}
+    for row in ordered_rows:
+        key = row.event_ts.astimezone(timezone.utc).date().isoformat()
+        row_count_by_trading_day[key] = row_count_by_trading_day.get(key, 0) + 1
     if require_complete_coverage and (
         missing_trading_days or missing_symbol_trading_days
     ):
-        raise ValueError(
-            _incomplete_coverage_reason(
+        reason = _incomplete_coverage_reason(
+            missing_trading_days=missing_trading_days,
+            missing_symbol_trading_days=missing_symbol_trading_days,
+        )
+        raise ReplayTapeCoverageError(
+            reason,
+            diagnostics=_coverage_error_diagnostics(
+                requested_trading_days=requested_trading_days,
+                observed_trading_days=observed_trading_days,
                 missing_trading_days=missing_trading_days,
+                row_count_by_trading_day=row_count_by_trading_day,
                 missing_symbol_trading_days=missing_symbol_trading_days,
-            )
+                row_count_by_symbol_trading_day=row_count_by_symbol_trading_day,
+            ),
         )
 
     tape_path.parent.mkdir(parents=True, exist_ok=True)
@@ -222,10 +242,6 @@ def materialize_signal_tape(
             content_hash.update(b"\n")
             handle.write(f"{line}\n")
 
-    row_count_by_trading_day: dict[str, int] = {}
-    for row in ordered_rows:
-        key = row.event_ts.astimezone(timezone.utc).date().isoformat()
-        row_count_by_trading_day[key] = row_count_by_trading_day.get(key, 0) + 1
     start_ts = datetime.combine(start_date, _REGULAR_OPEN_UTC, tzinfo=timezone.utc)
     end_ts = datetime.combine(end_date, _REGULAR_CLOSE_UTC, tzinfo=timezone.utc)
     resolved_artifact_refs = {
@@ -576,6 +592,31 @@ def _incomplete_coverage_reason(
     return "replay_tape_incomplete_coverage:" + ":".join(parts)
 
 
+def _coverage_error_diagnostics(
+    *,
+    requested_trading_days: Sequence[date],
+    observed_trading_days: Sequence[date],
+    missing_trading_days: Sequence[date],
+    row_count_by_trading_day: Mapping[str, int],
+    missing_symbol_trading_days: Sequence[str],
+    row_count_by_symbol_trading_day: Mapping[str, Mapping[str, int]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": "torghut.replay-tape-coverage-error.v1",
+        "requested_trading_days": [item.isoformat() for item in requested_trading_days],
+        "observed_executable_trading_days": [
+            item.isoformat() for item in observed_trading_days
+        ],
+        "missing_trading_days": [item.isoformat() for item in missing_trading_days],
+        "materialized_executable_rows_by_trading_day": dict(row_count_by_trading_day),
+        "missing_symbol_trading_days": list(missing_symbol_trading_days),
+        "materialized_executable_rows_by_symbol_trading_day": {
+            symbol: dict(days)
+            for symbol, days in row_count_by_symbol_trading_day.items()
+        },
+    }
+
+
 def _date_tuple(value: Any) -> tuple[date, ...]:
     if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
         return ()
@@ -671,6 +712,7 @@ __all__ = [
     "REPLAY_TAPE_MANIFEST_SCHEMA_VERSION",
     "REPLAY_TAPE_SCHEMA_VERSION",
     "ReplayTape",
+    "ReplayTapeCoverageError",
     "ReplayTapeManifest",
     "build_source_query_digest",
     "default_manifest_path",

--- a/services/torghut/scripts/materialize_replay_tape.py
+++ b/services/torghut/scripts/materialize_replay_tape.py
@@ -4,15 +4,17 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 import logging
 import os
-from datetime import date
+from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
 from app.trading.discovery.replay_tape import (
+    ReplayTapeCoverageError,
     build_source_query_digest,
     default_manifest_path,
     materialize_signal_tape,
@@ -105,6 +107,15 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--coverage-diagnostic-output",
+        type=Path,
+        help=(
+            "Optional JSON path for day-level source coverage diagnostics. When strict "
+            "materialization fails closed, this records raw TA signal, executable "
+            "quote-backed signal, and microbar row counts without relaxing the failure."
+        ),
+    )
+    parser.add_argument(
         "--log-level",
         default=os.environ.get("TORGHUT_REPLAY_LOG_LEVEL", "INFO"),
     )
@@ -145,6 +156,216 @@ def _source_query_payload(
     }
 
 
+def _business_days(start_day: date, end_day: date) -> tuple[date, ...]:
+    if start_day > end_day:
+        return ()
+    days: list[date] = []
+    current = start_day
+    while current <= end_day:
+        if current.weekday() < 5:
+            days.append(current)
+        current += timedelta(days=1)
+    return tuple(days)
+
+
+def _coverage_diagnostics_query(
+    *,
+    start_date: date,
+    end_date: date,
+    symbols: tuple[str, ...],
+) -> str:
+    start_ts = datetime.combine(start_date, time.min, tzinfo=timezone.utc)
+    end_ts = datetime.combine(
+        end_date + timedelta(days=1), time.min, tzinfo=timezone.utc
+    )
+    symbol_filter = ""
+    if symbols:
+        rendered_symbols = ", ".join(f"'{symbol}'" for symbol in symbols)
+        symbol_filter = f"\n  AND symbol IN ({rendered_symbols})"
+    start_literal = start_ts.strftime("%Y-%m-%d %H:%M:%S")
+    end_literal = end_ts.strftime("%Y-%m-%d %H:%M:%S")
+    shared_where = f"""
+WHERE source = 'ta'
+  AND window_size = 'PT1S'
+  AND event_ts >= toDateTime64('{start_literal}', 3, 'UTC')
+  AND event_ts < toDateTime64('{end_literal}', 3, 'UTC')
+  {symbol_filter}
+""".rstrip()
+    executable_where = f"""
+{shared_where}
+  AND isNotNull(imbalance_bid_px)
+  AND isNotNull(imbalance_ask_px)
+""".rstrip()
+    return f"""
+SELECT
+  toString(trading_day) AS trading_day,
+  toString(sum(raw_signal_rows)) AS raw_signal_rows,
+  toString(sum(executable_signal_rows)) AS executable_signal_rows,
+  toString(sum(microbar_rows)) AS microbar_rows,
+  toString(uniqExactIf(symbol, source_kind = 'raw_signal')) AS raw_signal_symbol_count,
+  toString(uniqExactIf(symbol, source_kind = 'executable_signal')) AS executable_signal_symbol_count,
+  toString(uniqExactIf(symbol, source_kind = 'microbar')) AS microbar_symbol_count
+FROM
+(
+  SELECT
+    toDate(event_ts, 'UTC') AS trading_day,
+    symbol,
+    'raw_signal' AS source_kind,
+    count() AS raw_signal_rows,
+    0 AS executable_signal_rows,
+    0 AS microbar_rows
+  FROM torghut.ta_signals
+  {shared_where}
+  GROUP BY trading_day, symbol
+  UNION ALL
+  SELECT
+    toDate(event_ts, 'UTC') AS trading_day,
+    symbol,
+    'executable_signal' AS source_kind,
+    0 AS raw_signal_rows,
+    count() AS executable_signal_rows,
+    0 AS microbar_rows
+  FROM torghut.ta_signals
+  {executable_where}
+  GROUP BY trading_day, symbol
+  UNION ALL
+  SELECT
+    toDate(event_ts, 'UTC') AS trading_day,
+    symbol,
+    'microbar' AS source_kind,
+    0 AS raw_signal_rows,
+    0 AS executable_signal_rows,
+    count() AS microbar_rows
+  FROM torghut.ta_microbars
+  {shared_where}
+  GROUP BY trading_day, symbol
+)
+GROUP BY trading_day
+ORDER BY trading_day
+FORMAT TSVRaw
+""".strip()
+
+
+def _parse_coverage_diagnostics(
+    raw: str,
+) -> dict[str, dict[str, int]]:
+    diagnostics: dict[str, dict[str, int]] = {}
+    reader = csv.reader(raw.splitlines(), delimiter="\t")
+    for parts in reader:
+        if len(parts) != 7:
+            continue
+        (
+            trading_day,
+            raw_signal_rows,
+            executable_signal_rows,
+            microbar_rows,
+            raw_signal_symbol_count,
+            executable_signal_symbol_count,
+            microbar_symbol_count,
+        ) = parts
+        diagnostics[str(trading_day)] = {
+            "raw_signal_rows": int(raw_signal_rows or 0),
+            "executable_signal_rows": int(executable_signal_rows or 0),
+            "microbar_rows": int(microbar_rows or 0),
+            "raw_signal_symbol_count": int(raw_signal_symbol_count or 0),
+            "executable_signal_symbol_count": int(executable_signal_symbol_count or 0),
+            "microbar_symbol_count": int(microbar_symbol_count or 0),
+        }
+    return diagnostics
+
+
+def _fetch_coverage_diagnostics(
+    *,
+    args: argparse.Namespace,
+    symbols: tuple[str, ...],
+    start_date: date,
+    end_date: date,
+) -> dict[str, Any]:
+    requested_days = tuple(
+        day.isoformat() for day in _business_days(start_date, end_date)
+    )
+    query = _coverage_diagnostics_query(
+        start_date=start_date,
+        end_date=end_date,
+        symbols=symbols,
+    )
+    raw = replay_mod._http_query(
+        url=str(args.clickhouse_http_url),
+        username=(str(args.clickhouse_username).strip() or None),
+        password=(str(args.clickhouse_password).strip() or None),
+        timeout_seconds=max(
+            1,
+            int(
+                getattr(
+                    args,
+                    "clickhouse_query_timeout_seconds",
+                    replay_mod.DEFAULT_CLICKHOUSE_QUERY_TIMEOUT_SECONDS,
+                )
+            ),
+        ),
+        query=query,
+    )
+    rows = _parse_coverage_diagnostics(raw)
+    missing_raw_signal_days = tuple(
+        day
+        for day in requested_days
+        if rows.get(day, {}).get("raw_signal_rows", 0) <= 0
+    )
+    missing_executable_signal_days = tuple(
+        day
+        for day in requested_days
+        if rows.get(day, {}).get("executable_signal_rows", 0) <= 0
+    )
+    missing_microbar_days = tuple(
+        day for day in requested_days if rows.get(day, {}).get("microbar_rows", 0) <= 0
+    )
+    return {
+        "schema_version": "torghut.replay-coverage-diagnostic.v1",
+        "query_family": "torghut.ta_replay_source_coverage",
+        "requested_trading_days": list(requested_days),
+        "symbols": list(symbols),
+        "rows_by_trading_day": rows,
+        "missing_raw_signal_days": list(missing_raw_signal_days),
+        "missing_executable_signal_days": list(missing_executable_signal_days),
+        "missing_microbar_days": list(missing_microbar_days),
+        "source_query_digest": build_source_query_digest(
+            {
+                "query_family": "torghut.ta_replay_source_coverage",
+                "start_date": start_date,
+                "end_date": end_date,
+                "symbols": list(symbols),
+            }
+        ),
+    }
+
+
+def _write_coverage_diagnostics(
+    *,
+    output_path: Path,
+    args: argparse.Namespace,
+    symbols: tuple[str, ...],
+    start_date: date,
+    end_date: date,
+    failure_reason: str | None = None,
+    materialization_diagnostics: dict[str, Any] | None = None,
+) -> None:
+    diagnostics = _fetch_coverage_diagnostics(
+        args=args,
+        symbols=symbols,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    if failure_reason:
+        diagnostics["materialization_failure_reason"] = failure_reason
+    if materialization_diagnostics is not None:
+        diagnostics["materialization_diagnostics"] = dict(materialization_diagnostics)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(diagnostics, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
 def main() -> int:
     args = _parse_args()
     logging.basicConfig(
@@ -181,18 +402,43 @@ def main() -> int:
     )
     rows = tuple(replay_mod._iter_signal_rows(config))
     manifest_path = args.manifest_output or default_manifest_path(args.output)
-    manifest = materialize_signal_tape(
-        rows=rows,
-        tape_path=Path(args.output).resolve(),
-        manifest_path=Path(manifest_path).resolve(),
-        dataset_snapshot_ref=str(args.dataset_snapshot_ref),
-        symbols=symbols,
-        start_date=start_date,
-        end_date=end_date,
-        source_query_digest=source_query_digest,
-        source_table_versions=_parse_source_table_versions(args.source_table_version),
-        require_complete_coverage=not bool(args.allow_incomplete_coverage),
-    )
+    try:
+        manifest = materialize_signal_tape(
+            rows=rows,
+            tape_path=Path(args.output).resolve(),
+            manifest_path=Path(manifest_path).resolve(),
+            dataset_snapshot_ref=str(args.dataset_snapshot_ref),
+            symbols=symbols,
+            start_date=start_date,
+            end_date=end_date,
+            source_query_digest=source_query_digest,
+            source_table_versions=_parse_source_table_versions(
+                args.source_table_version
+            ),
+            require_complete_coverage=not bool(args.allow_incomplete_coverage),
+        )
+    except ReplayTapeCoverageError as exc:
+        diagnostic_output = getattr(args, "coverage_diagnostic_output", None)
+        if diagnostic_output:
+            _write_coverage_diagnostics(
+                output_path=Path(diagnostic_output).resolve(),
+                args=args,
+                symbols=symbols,
+                start_date=start_date,
+                end_date=end_date,
+                failure_reason=str(exc),
+                materialization_diagnostics=exc.diagnostics,
+            )
+        raise
+    diagnostic_output = getattr(args, "coverage_diagnostic_output", None)
+    if diagnostic_output:
+        _write_coverage_diagnostics(
+            output_path=Path(diagnostic_output).resolve(),
+            args=args,
+            symbols=symbols,
+            start_date=start_date,
+            end_date=end_date,
+        )
     logger.info(
         "replay_tape_materialized output=%s manifest=%s rows=%s digest=%s",
         args.output,

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 from app.trading.discovery.replay_tape import (
     REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
+    ReplayTapeCoverageError,
     ReplayTapeManifest,
     build_source_query_digest,
     default_manifest_path,
@@ -405,10 +406,7 @@ class TestReplayTape(TestCase):
         self,
     ) -> None:
         with TemporaryDirectory() as tmpdir:
-            with self.assertRaisesRegex(
-                ValueError,
-                "replay_tape_incomplete_coverage:missing_symbol_days=AAPL:2026-03-27",
-            ):
+            with self.assertRaises(ReplayTapeCoverageError) as raised:
                 materialize_signal_tape(
                     rows=[
                         self._signal(day=26, seq=1, symbol="META"),
@@ -424,6 +422,20 @@ class TestReplayTape(TestCase):
                     require_complete_coverage=True,
                 )
 
+            self.assertRegex(
+                str(raised.exception),
+                "replay_tape_incomplete_coverage:missing_symbol_days=AAPL:2026-03-27",
+            )
+            self.assertEqual(
+                raised.exception.diagnostics[
+                    "materialized_executable_rows_by_trading_day"
+                ],
+                {"2026-03-26": 2, "2026-03-27": 1},
+            )
+            self.assertEqual(
+                raised.exception.diagnostics["missing_symbol_trading_days"],
+                ["AAPL:2026-03-27"],
+            )
             self.assertFalse((Path(tmpdir) / "tape.jsonl").exists())
 
     def test_source_query_digest_normalizes_dates_decimals_and_lists(self) -> None:
@@ -526,6 +538,8 @@ class TestMaterializeReplayTapeCli(TestCase):
                     str(output),
                     "--symbols",
                     " nvda, META ",
+                    "--coverage-diagnostic-output",
+                    str(output.with_suffix(".coverage.json")),
                     "--source-table-version",
                     "ta_signals=v1",
                     "--clickhouse-query-timeout-seconds",
@@ -537,6 +551,10 @@ class TestMaterializeReplayTapeCli(TestCase):
         symbols = materialize_cli._parse_symbols(str(args.symbols))
         self.assertEqual(symbols, ("NVDA", "META"))
         self.assertEqual(args.clickhouse_query_timeout_seconds, 9)
+        self.assertEqual(
+            args.coverage_diagnostic_output,
+            output.with_suffix(".coverage.json"),
+        )
         self.assertFalse(args.allow_incomplete_coverage)
         self.assertEqual(
             materialize_cli._parse_source_table_versions(args.source_table_version),
@@ -568,11 +586,60 @@ class TestMaterializeReplayTapeCli(TestCase):
         with self.assertRaisesRegex(ValueError, "source_table_version_invalid"):
             materialize_cli._parse_source_table_versions(["broken"])
 
+    def test_coverage_diagnostics_parse_day_level_counts(self) -> None:
+        diagnostics = materialize_cli._parse_coverage_diagnostics(
+            "bad\trow\n2026-03-26\t10\t5\t7\t2\t1\t2\n"
+        )
+
+        self.assertEqual(
+            diagnostics,
+            {
+                "2026-03-26": {
+                    "raw_signal_rows": 10,
+                    "executable_signal_rows": 5,
+                    "microbar_rows": 7,
+                    "raw_signal_symbol_count": 2,
+                    "executable_signal_symbol_count": 1,
+                    "microbar_symbol_count": 2,
+                },
+            },
+        )
+
+    def test_fetch_coverage_diagnostics_marks_missing_source_layers(self) -> None:
+        args = Namespace(
+            clickhouse_http_url="http://clickhouse.invalid:8123",
+            clickhouse_username="torghut",
+            clickhouse_password="secret",
+            clickhouse_query_timeout_seconds=7,
+        )
+        with patch(
+            "scripts.materialize_replay_tape.replay_mod._http_query",
+            return_value="2026-03-26\t10\t5\t7\t2\t1\t2\n",
+        ) as query:
+            diagnostics = materialize_cli._fetch_coverage_diagnostics(
+                args=args,
+                symbols=("META",),
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 27),
+            )
+
+        self.assertEqual(
+            materialize_cli._business_days(date(2026, 3, 27), date(2026, 3, 26)),
+            (),
+        )
+        query_payload = str(query.call_args.kwargs["query"])
+        self.assertIn("symbol IN ('META')", query_payload)
+        self.assertEqual(query.call_args.kwargs["timeout_seconds"], 7)
+        self.assertEqual(diagnostics["missing_raw_signal_days"], ["2026-03-27"])
+        self.assertEqual(diagnostics["missing_executable_signal_days"], ["2026-03-27"])
+        self.assertEqual(diagnostics["missing_microbar_days"], ["2026-03-27"])
+
     def test_main_materializes_manifest_from_replay_rows(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             output = root / "tape.jsonl"
             manifest_output = root / "tape.manifest.json"
+            diagnostic_output = root / "coverage.json"
             args = Namespace(
                 strategy_configmap=root / "strategy.yaml",
                 clickhouse_http_url="http://clickhouse.invalid:8123",
@@ -586,6 +653,7 @@ class TestMaterializeReplayTapeCli(TestCase):
                 dataset_snapshot_ref="snapshot-cli",
                 output=output,
                 manifest_output=manifest_output,
+                coverage_diagnostic_output=diagnostic_output,
                 source_table_version=["ta_signals=v1"],
                 allow_incomplete_coverage=False,
                 log_level="WARNING",
@@ -603,6 +671,14 @@ class TestMaterializeReplayTapeCli(TestCase):
                         self._signal(day=27, seq=2),
                     ),
                 ),
+                patch(
+                    "scripts.materialize_replay_tape._fetch_coverage_diagnostics",
+                    return_value={
+                        "schema_version": "torghut.replay-coverage-diagnostic.v1",
+                        "requested_trading_days": ["2026-03-26", "2026-03-27"],
+                        "missing_executable_signal_days": [],
+                    },
+                ),
                 redirect_stdout(stdout),
             ):
                 exit_code = materialize_cli.main()
@@ -610,6 +686,9 @@ class TestMaterializeReplayTapeCli(TestCase):
             payload = json.loads(stdout.getvalue())
             output_exists = output.exists()
             manifest_exists = manifest_output.exists()
+            diagnostic_payload = json.loads(
+                diagnostic_output.read_text(encoding="utf-8")
+            )
 
         self.assertEqual(exit_code, 0)
         self.assertTrue(output_exists)
@@ -628,6 +707,7 @@ class TestMaterializeReplayTapeCli(TestCase):
             payload["row_count_by_symbol_trading_day"],
             {"META": {"2026-03-26": 1, "2026-03-27": 1}},
         )
+        self.assertEqual(diagnostic_payload["missing_executable_signal_days"], [])
 
     def test_main_fails_closed_on_incomplete_coverage_by_default(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -647,6 +727,7 @@ class TestMaterializeReplayTapeCli(TestCase):
                 dataset_snapshot_ref="snapshot-cli",
                 output=output,
                 manifest_output=manifest_output,
+                coverage_diagnostic_output=None,
                 source_table_version=[],
                 allow_incomplete_coverage=False,
                 log_level="WARNING",
@@ -670,6 +751,83 @@ class TestMaterializeReplayTapeCli(TestCase):
             self.assertFalse(output.exists())
             self.assertFalse(manifest_output.exists())
 
+    def test_main_writes_coverage_diagnostics_when_strict_coverage_fails(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "tape.jsonl"
+            manifest_output = root / "tape.manifest.json"
+            diagnostic_output = root / "coverage.json"
+            args = Namespace(
+                strategy_configmap=root / "strategy.yaml",
+                clickhouse_http_url="http://clickhouse.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_date="2026-03-26",
+                end_date="2026-03-27",
+                chunk_minutes=0,
+                start_equity="10000",
+                symbols="meta",
+                dataset_snapshot_ref="snapshot-cli",
+                output=output,
+                manifest_output=manifest_output,
+                coverage_diagnostic_output=diagnostic_output,
+                source_table_version=[],
+                allow_incomplete_coverage=False,
+                log_level="WARNING",
+            )
+            with (
+                patch(
+                    "scripts.materialize_replay_tape._parse_args",
+                    return_value=args,
+                ),
+                patch(
+                    "scripts.materialize_replay_tape.replay_mod._iter_signal_rows",
+                    return_value=(self._signal(day=26, seq=1),),
+                ),
+                patch(
+                    "scripts.materialize_replay_tape._fetch_coverage_diagnostics",
+                    return_value={
+                        "schema_version": "torghut.replay-coverage-diagnostic.v1",
+                        "requested_trading_days": ["2026-03-26", "2026-03-27"],
+                        "rows_by_trading_day": {
+                            "2026-03-26": {
+                                "raw_signal_rows": 10,
+                                "executable_signal_rows": 1,
+                                "microbar_rows": 10,
+                            },
+                            "2026-03-27": {
+                                "raw_signal_rows": 11,
+                                "executable_signal_rows": 0,
+                                "microbar_rows": 11,
+                            },
+                        },
+                        "missing_executable_signal_days": ["2026-03-27"],
+                    },
+                ),
+            ):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "replay_tape_incomplete_coverage:missing_days=2026-03-27",
+                ):
+                    materialize_cli.main()
+
+            payload = json.loads(diagnostic_output.read_text(encoding="utf-8"))
+            self.assertEqual(
+                payload["materialization_failure_reason"],
+                "replay_tape_incomplete_coverage:missing_days=2026-03-27",
+            )
+            self.assertEqual(payload["missing_executable_signal_days"], ["2026-03-27"])
+            self.assertEqual(
+                payload["materialization_diagnostics"][
+                    "materialized_executable_rows_by_trading_day"
+                ],
+                {"2026-03-26": 1},
+            )
+            self.assertFalse(output.exists())
+            self.assertFalse(manifest_output.exists())
+
     def test_main_fails_closed_on_missing_symbol_days_by_default(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -688,6 +846,7 @@ class TestMaterializeReplayTapeCli(TestCase):
                 dataset_snapshot_ref="snapshot-cli",
                 output=output,
                 manifest_output=manifest_output,
+                coverage_diagnostic_output=None,
                 source_table_version=[],
                 allow_incomplete_coverage=False,
                 log_level="WARNING",


### PR DESCRIPTION
## Summary

- Adds a typed `ReplayTapeCoverageError` that carries materialized executable-row coverage diagnostics when strict replay-tape coverage fails.
- Adds `--coverage-diagnostic-output` to `materialize_replay_tape.py` so failed or successful materialization can persist raw TA signal, executable quote-backed signal, and microbar row counts by trading day.
- Covers the new fail-closed diagnostic path in replay-tape tests without relaxing promotion or materialization gates.

## Related Issues

None

## Testing

- `uv run --frozen --extra dev ruff format --check scripts/materialize_replay_tape.py app/trading/discovery/replay_tape.py tests/test_replay_tape.py`
- `uv run --frozen --extra dev ruff check scripts/materialize_replay_tape.py app/trading/discovery/replay_tape.py tests/test_replay_tape.py`
- `uv run --frozen --extra dev pytest tests/test_replay_tape.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Read-only live ClickHouse materialization for `2026-05-18..2026-05-22` failed closed as expected and wrote `/tmp/torghut-current-replay/replay-tape-20260518-20260522.coverage-diagnostic.json`, showing raw signals and microbars present while executable quote-backed signals were missing on `2026-05-19` and `2026-05-20`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
