### PR TITLE
fix(torghut): select complete replay windows

### DIFF
--- a/services/torghut/scripts/materialize_replay_tape.py
+++ b/services/torghut/scripts/materialize_replay_tape.py
@@ -11,7 +11,7 @@ import os
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from app.trading.discovery.replay_tape import (
     ReplayTapeCoverageError,
@@ -114,6 +114,22 @@ def _parse_args() -> argparse.Namespace:
             "materialization fails closed, this records raw TA signal, executable "
             "quote-backed signal, and microbar row counts without relaxing the failure."
         ),
+    )
+    parser.add_argument(
+        "--latest-complete-window-min-days",
+        type=int,
+        default=0,
+        help=(
+            "When greater than zero, first inspect source coverage and materialize the "
+            "latest consecutive sub-window with at least this many complete executable "
+            "trading days. The manifest is bound to the selected sub-window; incomplete "
+            "requested days are recorded only in diagnostics/receipt output."
+        ),
+    )
+    parser.add_argument(
+        "--latest-complete-window-receipt-output",
+        type=Path,
+        help="Optional JSON receipt path for --latest-complete-window-min-days.",
     )
     parser.add_argument(
         "--log-level",
@@ -274,6 +290,62 @@ def _parse_coverage_diagnostics(
     return diagnostics
 
 
+def _is_complete_coverage_day(
+    row: Mapping[str, Any],
+    *,
+    expected_symbol_count: int,
+) -> bool:
+    if int(row.get("raw_signal_rows") or 0) <= 0:
+        return False
+    if int(row.get("executable_signal_rows") or 0) <= 0:
+        return False
+    if int(row.get("microbar_rows") or 0) <= 0:
+        return False
+    if expected_symbol_count <= 0:
+        return True
+    return (
+        int(row.get("raw_signal_symbol_count") or 0) >= expected_symbol_count
+        and int(row.get("executable_signal_symbol_count") or 0) >= expected_symbol_count
+        and int(row.get("microbar_symbol_count") or 0) >= expected_symbol_count
+    )
+
+
+def _latest_complete_window(
+    diagnostics: Mapping[str, Any],
+    *,
+    min_days: int,
+    expected_symbol_count: int,
+) -> tuple[date, date, tuple[str, ...]]:
+    requested_days = tuple(
+        str(day) for day in diagnostics.get("requested_trading_days") or ()
+    )
+    rows_by_day = (
+        diagnostics.get("rows_by_trading_day")
+        if isinstance(diagnostics.get("rows_by_trading_day"), Mapping)
+        else {}
+    )
+    latest_run: list[str] = []
+    runs: list[tuple[str, ...]] = []
+    for day in requested_days:
+        row = rows_by_day.get(day) if isinstance(rows_by_day, Mapping) else None
+        if isinstance(row, Mapping) and _is_complete_coverage_day(
+            row,
+            expected_symbol_count=expected_symbol_count,
+        ):
+            latest_run.append(day)
+            continue
+        if latest_run:
+            runs.append(tuple(latest_run))
+            latest_run = []
+    if latest_run:
+        runs.append(tuple(latest_run))
+    eligible = tuple(run for run in runs if len(run) >= max(1, min_days))
+    if not eligible:
+        raise ValueError(f"latest_complete_replay_window_missing:min_days={min_days}")
+    selected = eligible[-1]
+    return date.fromisoformat(selected[0]), date.fromisoformat(selected[-1]), selected
+
+
 def _fetch_coverage_diagnostics(
     *,
     args: argparse.Namespace,
@@ -339,6 +411,14 @@ def _fetch_coverage_diagnostics(
     }
 
 
+def _write_diagnostics_payload(output_path: Path, payload: Mapping[str, Any]) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(dict(payload), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
 def _write_coverage_diagnostics(
     *,
     output_path: Path,
@@ -348,22 +428,71 @@ def _write_coverage_diagnostics(
     end_date: date,
     failure_reason: str | None = None,
     materialization_diagnostics: dict[str, Any] | None = None,
+    precomputed_diagnostics: Mapping[str, Any] | None = None,
 ) -> None:
-    diagnostics = _fetch_coverage_diagnostics(
-        args=args,
-        symbols=symbols,
-        start_date=start_date,
-        end_date=end_date,
+    diagnostics = dict(
+        precomputed_diagnostics
+        or _fetch_coverage_diagnostics(
+            args=args,
+            symbols=symbols,
+            start_date=start_date,
+            end_date=end_date,
+        )
     )
     if failure_reason:
         diagnostics["materialization_failure_reason"] = failure_reason
     if materialization_diagnostics is not None:
         diagnostics["materialization_diagnostics"] = dict(materialization_diagnostics)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(
-        json.dumps(diagnostics, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
+    _write_diagnostics_payload(output_path, diagnostics)
+
+
+def _select_effective_window(
+    *,
+    args: argparse.Namespace,
+    symbols: tuple[str, ...],
+    requested_start_date: date,
+    requested_end_date: date,
+) -> tuple[date, date, dict[str, Any] | None]:
+    min_days = max(0, int(getattr(args, "latest_complete_window_min_days", 0) or 0))
+    if min_days <= 0:
+        return requested_start_date, requested_end_date, None
+    diagnostics = _fetch_coverage_diagnostics(
+        args=args,
+        symbols=symbols,
+        start_date=requested_start_date,
+        end_date=requested_end_date,
     )
+    selected_start, selected_end, selected_days = _latest_complete_window(
+        diagnostics,
+        min_days=min_days,
+        expected_symbol_count=len(symbols),
+    )
+    receipt = {
+        "schema_version": "torghut.replay-latest-complete-window.v1",
+        "requested_start_date": requested_start_date.isoformat(),
+        "requested_end_date": requested_end_date.isoformat(),
+        "effective_start_date": selected_start.isoformat(),
+        "effective_end_date": selected_end.isoformat(),
+        "selected_trading_days": list(selected_days),
+        "min_days": min_days,
+        "symbols": list(symbols),
+        "source_coverage": diagnostics,
+    }
+    receipt_output = getattr(args, "latest_complete_window_receipt_output", None)
+    if receipt_output:
+        _write_diagnostics_payload(Path(receipt_output).resolve(), receipt)
+    diagnostic_output = getattr(args, "coverage_diagnostic_output", None)
+    if diagnostic_output:
+        enriched = dict(diagnostics)
+        enriched["latest_complete_window"] = {
+            "schema_version": "torghut.replay-latest-complete-window-selection.v1",
+            "effective_start_date": selected_start.isoformat(),
+            "effective_end_date": selected_end.isoformat(),
+            "selected_trading_days": list(selected_days),
+            "min_days": min_days,
+        }
+        _write_diagnostics_payload(Path(diagnostic_output).resolve(), enriched)
+    return selected_start, selected_end, receipt
 
 
 def main() -> int:
@@ -373,10 +502,20 @@ def main() -> int:
         format="%(asctime)s %(levelname)s %(message)s",
     )
     symbols = _parse_symbols(str(args.symbols or ""))
-    start_date = date.fromisoformat(str(args.start_date))
-    end_date = date.fromisoformat(str(args.end_date))
+    requested_start_date = date.fromisoformat(str(args.start_date))
+    requested_end_date = date.fromisoformat(str(args.end_date))
+    start_date, end_date, window_receipt = _select_effective_window(
+        args=args,
+        symbols=symbols,
+        requested_start_date=requested_start_date,
+        requested_end_date=requested_end_date,
+    )
     source_query_digest = build_source_query_digest(
         _source_query_payload(args=args, symbols=symbols)
+        | {
+            "effective_start_date": start_date,
+            "effective_end_date": end_date,
+        }
     )
     config = replay_mod.ReplayConfig(
         strategy_configmap_path=Path(args.strategy_configmap).resolve(),
@@ -424,14 +563,14 @@ def main() -> int:
                 output_path=Path(diagnostic_output).resolve(),
                 args=args,
                 symbols=symbols,
-                start_date=start_date,
-                end_date=end_date,
+                start_date=requested_start_date,
+                end_date=requested_end_date,
                 failure_reason=str(exc),
                 materialization_diagnostics=exc.diagnostics,
             )
         raise
     diagnostic_output = getattr(args, "coverage_diagnostic_output", None)
-    if diagnostic_output:
+    if diagnostic_output and window_receipt is None:
         _write_coverage_diagnostics(
             output_path=Path(diagnostic_output).resolve(),
             args=args,
@@ -439,6 +578,18 @@ def main() -> int:
             start_date=start_date,
             end_date=end_date,
         )
+    if window_receipt is not None:
+        manifest_payload = {
+            "dataset_snapshot_ref": manifest.dataset_snapshot_ref,
+            "row_count": manifest.row_count,
+            "content_sha256": manifest.content_sha256,
+            "manifest_path": str(Path(manifest_path).resolve()),
+            "tape_path": str(Path(args.output).resolve()),
+        }
+        window_receipt["materialized_manifest"] = manifest_payload
+        receipt_output = getattr(args, "latest_complete_window_receipt_output", None)
+        if receipt_output:
+            _write_diagnostics_payload(Path(receipt_output).resolve(), window_receipt)
     logger.info(
         "replay_tape_materialized output=%s manifest=%s rows=%s digest=%s",
         args.output,

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -540,6 +540,10 @@ class TestMaterializeReplayTapeCli(TestCase):
                     " nvda, META ",
                     "--coverage-diagnostic-output",
                     str(output.with_suffix(".coverage.json")),
+                    "--latest-complete-window-min-days",
+                    "2",
+                    "--latest-complete-window-receipt-output",
+                    str(output.with_suffix(".window.json")),
                     "--source-table-version",
                     "ta_signals=v1",
                     "--clickhouse-query-timeout-seconds",
@@ -554,6 +558,11 @@ class TestMaterializeReplayTapeCli(TestCase):
         self.assertEqual(
             args.coverage_diagnostic_output,
             output.with_suffix(".coverage.json"),
+        )
+        self.assertEqual(args.latest_complete_window_min_days, 2)
+        self.assertEqual(
+            args.latest_complete_window_receipt_output,
+            output.with_suffix(".window.json"),
         )
         self.assertFalse(args.allow_incomplete_coverage)
         self.assertEqual(
@@ -634,6 +643,73 @@ class TestMaterializeReplayTapeCli(TestCase):
         self.assertEqual(diagnostics["missing_executable_signal_days"], ["2026-03-27"])
         self.assertEqual(diagnostics["missing_microbar_days"], ["2026-03-27"])
 
+    def test_latest_complete_window_selects_latest_consecutive_complete_days(
+        self,
+    ) -> None:
+        diagnostics = {
+            "requested_trading_days": [
+                "2026-03-26",
+                "2026-03-27",
+                "2026-03-30",
+                "2026-03-31",
+            ],
+            "rows_by_trading_day": {
+                "2026-03-26": {
+                    "raw_signal_rows": 10,
+                    "executable_signal_rows": 10,
+                    "microbar_rows": 10,
+                    "raw_signal_symbol_count": 2,
+                    "executable_signal_symbol_count": 2,
+                    "microbar_symbol_count": 2,
+                },
+                "2026-03-27": {
+                    "raw_signal_rows": 10,
+                    "executable_signal_rows": 0,
+                    "microbar_rows": 10,
+                    "raw_signal_symbol_count": 2,
+                    "executable_signal_symbol_count": 0,
+                    "microbar_symbol_count": 2,
+                },
+                "2026-03-30": {
+                    "raw_signal_rows": 10,
+                    "executable_signal_rows": 10,
+                    "microbar_rows": 10,
+                    "raw_signal_symbol_count": 2,
+                    "executable_signal_symbol_count": 2,
+                    "microbar_symbol_count": 2,
+                },
+                "2026-03-31": {
+                    "raw_signal_rows": 11,
+                    "executable_signal_rows": 11,
+                    "microbar_rows": 11,
+                    "raw_signal_symbol_count": 2,
+                    "executable_signal_symbol_count": 2,
+                    "microbar_symbol_count": 2,
+                },
+            },
+        }
+
+        selected_start, selected_end, selected_days = (
+            materialize_cli._latest_complete_window(
+                diagnostics,
+                min_days=2,
+                expected_symbol_count=2,
+            )
+        )
+
+        self.assertEqual(selected_start, date(2026, 3, 30))
+        self.assertEqual(selected_end, date(2026, 3, 31))
+        self.assertEqual(selected_days, ("2026-03-30", "2026-03-31"))
+        with self.assertRaisesRegex(
+            ValueError,
+            "latest_complete_replay_window_missing:min_days=3",
+        ):
+            materialize_cli._latest_complete_window(
+                diagnostics,
+                min_days=3,
+                expected_symbol_count=2,
+            )
+
     def test_main_materializes_manifest_from_replay_rows(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -708,6 +784,129 @@ class TestMaterializeReplayTapeCli(TestCase):
             {"META": {"2026-03-26": 1, "2026-03-27": 1}},
         )
         self.assertEqual(diagnostic_payload["missing_executable_signal_days"], [])
+
+    def test_main_can_materialize_latest_complete_source_window(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            output = root / "tape.jsonl"
+            manifest_output = root / "tape.manifest.json"
+            diagnostic_output = root / "coverage.json"
+            receipt_output = root / "window.json"
+            captured_windows: list[tuple[date, date]] = []
+
+            def iter_rows(config: ReplayConfig) -> tuple[SignalEnvelope, ...]:
+                captured_windows.append((config.start_date, config.end_date))
+                return (
+                    self._signal(day=30, seq=1),
+                    self._signal(day=31, seq=2),
+                )
+
+            args = Namespace(
+                strategy_configmap=root / "strategy.yaml",
+                clickhouse_http_url="http://clickhouse.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_date="2026-03-26",
+                end_date="2026-03-31",
+                chunk_minutes=0,
+                start_equity="10000",
+                symbols="meta",
+                dataset_snapshot_ref="snapshot-cli",
+                output=output,
+                manifest_output=manifest_output,
+                coverage_diagnostic_output=diagnostic_output,
+                latest_complete_window_min_days=2,
+                latest_complete_window_receipt_output=receipt_output,
+                source_table_version=[],
+                allow_incomplete_coverage=False,
+                log_level="WARNING",
+            )
+            coverage = {
+                "schema_version": "torghut.replay-coverage-diagnostic.v1",
+                "requested_trading_days": [
+                    "2026-03-26",
+                    "2026-03-27",
+                    "2026-03-30",
+                    "2026-03-31",
+                ],
+                "rows_by_trading_day": {
+                    "2026-03-26": {
+                        "raw_signal_rows": 10,
+                        "executable_signal_rows": 10,
+                        "microbar_rows": 10,
+                        "raw_signal_symbol_count": 1,
+                        "executable_signal_symbol_count": 1,
+                        "microbar_symbol_count": 1,
+                    },
+                    "2026-03-27": {
+                        "raw_signal_rows": 10,
+                        "executable_signal_rows": 0,
+                        "microbar_rows": 10,
+                        "raw_signal_symbol_count": 1,
+                        "executable_signal_symbol_count": 0,
+                        "microbar_symbol_count": 1,
+                    },
+                    "2026-03-30": {
+                        "raw_signal_rows": 10,
+                        "executable_signal_rows": 10,
+                        "microbar_rows": 10,
+                        "raw_signal_symbol_count": 1,
+                        "executable_signal_symbol_count": 1,
+                        "microbar_symbol_count": 1,
+                    },
+                    "2026-03-31": {
+                        "raw_signal_rows": 11,
+                        "executable_signal_rows": 11,
+                        "microbar_rows": 11,
+                        "raw_signal_symbol_count": 1,
+                        "executable_signal_symbol_count": 1,
+                        "microbar_symbol_count": 1,
+                    },
+                },
+                "missing_executable_signal_days": ["2026-03-27"],
+            }
+            stdout = io.StringIO()
+            with (
+                patch(
+                    "scripts.materialize_replay_tape._parse_args",
+                    return_value=args,
+                ),
+                patch(
+                    "scripts.materialize_replay_tape._fetch_coverage_diagnostics",
+                    return_value=coverage,
+                ) as fetch,
+                patch(
+                    "scripts.materialize_replay_tape.replay_mod._iter_signal_rows",
+                    side_effect=iter_rows,
+                ),
+                redirect_stdout(stdout),
+            ):
+                exit_code = materialize_cli.main()
+
+            payload = json.loads(stdout.getvalue())
+            diagnostic_payload = json.loads(
+                diagnostic_output.read_text(encoding="utf-8")
+            )
+            receipt_payload = json.loads(receipt_output.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(captured_windows, [(date(2026, 3, 30), date(2026, 3, 31))])
+        self.assertEqual(fetch.call_count, 1)
+        self.assertEqual(payload["start_date"], "2026-03-30")
+        self.assertEqual(payload["end_date"], "2026-03-31")
+        self.assertEqual(
+            payload["requested_trading_days"], ["2026-03-30", "2026-03-31"]
+        )
+        self.assertEqual(
+            diagnostic_payload["latest_complete_window"]["selected_trading_days"],
+            ["2026-03-30", "2026-03-31"],
+        )
+        self.assertEqual(receipt_payload["requested_start_date"], "2026-03-26")
+        self.assertEqual(receipt_payload["effective_start_date"], "2026-03-30")
+        self.assertEqual(
+            receipt_payload["materialized_manifest"]["row_count"],
+            2,
+        )
 
     def test_main_fails_closed_on_incomplete_coverage_by_default(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Adds `--latest-complete-window-min-days` to `materialize_replay_tape.py` so bounded research can select the latest consecutive quote-backed executable replay sub-window instead of repeatedly failing on known historical ingestion gaps.
- Writes an explicit latest-complete-window receipt and enriches coverage diagnostics with the requested window, selected trading days, and materialized manifest refs.
- Keeps strict replay-tape coverage semantics intact: incomplete requested days are diagnostic evidence only, while the generated tape manifest is bound to the selected complete window.

## Related Issues

None

## Testing

- `uv run --frozen --extra dev ruff format --check scripts/materialize_replay_tape.py tests/test_replay_tape.py`
- `uv run --frozen --extra dev ruff check scripts/materialize_replay_tape.py tests/test_replay_tape.py`
- `uv run --frozen --extra dev pytest tests/test_replay_tape.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A, CLI replay-tape harness change.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
