### PR TITLE
fix(torghut): use complete replay windows in autoresearch

### DIFF
--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -76,6 +76,9 @@ import scripts.local_intraday_tsmom_replay as replay_mod
 from scripts.search_consistent_profitability_frontier import (
     run_consistent_profitability_frontier,
 )
+from scripts.materialize_replay_tape import (
+    _select_effective_window as _select_effective_replay_tape_window,
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _CAPITAL_LIMIT_SAFETY_MULTIPLIER = Decimal("0.98")
@@ -172,6 +175,27 @@ def _parse_args() -> argparse.Namespace:
             "Fetch the resolved full-window signal rows once, write a run-scoped "
             "replay tape, and pass it into every exact frontier run."
         ),
+    )
+    parser.add_argument(
+        "--latest-complete-window-min-days",
+        type=int,
+        default=0,
+        help=(
+            "When materializing a replay tape, select the latest consecutive complete "
+            "sub-window with at least this many trading days."
+        ),
+    )
+    parser.add_argument(
+        "--latest-complete-window-receipt-output",
+        type=Path,
+        default=None,
+        help="Optional JSON receipt path for latest complete replay-window selection.",
+    )
+    parser.add_argument(
+        "--coverage-diagnostic-output",
+        type=Path,
+        default=None,
+        help="Optional JSON diagnostics path for replay source coverage.",
     )
     parser.add_argument(
         "--max-frontier-runs",
@@ -376,6 +400,12 @@ def _mlx_bundle_paths(run_root: Path) -> dict[str, str]:
         "signal_rows_jsonl": str(run_root / "mlx-snapshot-signals.jsonl"),
         "replay_tape_jsonl": str(run_root / "replay-tape.jsonl"),
         "replay_tape_manifest_json": str(run_root / "replay-tape.jsonl.manifest.json"),
+        "replay_tape_latest_complete_window_receipt_json": str(
+            run_root / "latest-complete-window-receipt.json"
+        ),
+        "replay_tape_coverage_diagnostics_json": str(
+            run_root / "replay-tape-coverage-diagnostics.json"
+        ),
         "descriptors_jsonl": str(run_root / "mlx-candidate-descriptors.jsonl"),
         "proposal_scores_jsonl": str(run_root / "mlx-proposal-scores.jsonl"),
         "history_jsonl": str(run_root / "history.jsonl"),
@@ -704,6 +734,39 @@ def _maybe_materialize_run_replay_tape(
         return existing_signal_bundle, None
     if getattr(args, "replay_tape_path", None) is not None:
         return existing_signal_bundle, None
+    requested_full_window_start_date = full_window_start_date
+    requested_full_window_end_date = full_window_end_date
+    latest_window_receipt: dict[str, Any] | None = None
+    if (
+        int(getattr(args, "latest_complete_window_min_days", 0) or 0) > 0
+        and full_window_start_date
+        and full_window_end_date
+    ):
+        window_args = argparse.Namespace(
+            **{
+                **vars(args),
+                "latest_complete_window_receipt_output": (
+                    getattr(args, "latest_complete_window_receipt_output", None)
+                    or Path(
+                        bundle_paths["replay_tape_latest_complete_window_receipt_json"]
+                    )
+                ),
+                "coverage_diagnostic_output": (
+                    getattr(args, "coverage_diagnostic_output", None)
+                    or Path(bundle_paths["replay_tape_coverage_diagnostics_json"])
+                ),
+            }
+        )
+        selected_start, selected_end, latest_window_receipt = (
+            _select_effective_replay_tape_window(
+                args=window_args,
+                symbols=snapshot_symbols,
+                requested_start_date=_iso_date(full_window_start_date),
+                requested_end_date=_iso_date(full_window_end_date),
+            )
+        )
+        full_window_start_date = selected_start.isoformat()
+        full_window_end_date = selected_end.isoformat()
     signal_bundle_config = _full_window_signal_config(
         args=args,
         snapshot_symbols=snapshot_symbols,
@@ -735,12 +798,19 @@ def _maybe_materialize_run_replay_tape(
         Path(bundle_paths["signal_rows_jsonl"]),
         rows,
     )
-    return signal_bundle_stats, _replay_tape_receipt(
+    receipt = _replay_tape_receipt(
         status="materialized",
         tape_path=tape_path,
         manifest_path=manifest_path,
         manifest=manifest,
     )
+    receipt["requested_full_window_start_date"] = requested_full_window_start_date
+    receipt["requested_full_window_end_date"] = requested_full_window_end_date
+    receipt["effective_full_window_start_date"] = full_window_start_date
+    receipt["effective_full_window_end_date"] = full_window_end_date
+    if latest_window_receipt is not None:
+        receipt["latest_complete_window"] = latest_window_receipt
+    return signal_bundle_stats, receipt
 
 
 def _history_record(
@@ -1756,6 +1826,18 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         effective_replay_tape_path = Path(materialized_replay_tape_receipt["tape_path"])
         effective_replay_tape_manifest = Path(
             materialized_replay_tape_receipt["manifest_path"]
+        )
+        resolved_full_window_start_date = (
+            _string(
+                materialized_replay_tape_receipt.get("effective_full_window_start_date")
+            )
+            or resolved_full_window_start_date
+        )
+        resolved_full_window_end_date = (
+            _string(
+                materialized_replay_tape_receipt.get("effective_full_window_end_date")
+            )
+            or resolved_full_window_end_date
         )
     signal_bundle_stats = _maybe_write_signal_bundle(
         args=args,

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -428,6 +428,9 @@ class TestStrategyAutoresearch(TestCase):
         self.assertTrue(args.materialize_replay_tape)
         self.assertEqual(args.replay_tape_path, Path("/tmp/tape.jsonl"))
         self.assertEqual(args.replay_tape_manifest, Path("/tmp/tape.manifest.json"))
+        self.assertEqual(args.latest_complete_window_min_days, 0)
+        self.assertIsNone(args.latest_complete_window_receipt_output)
+        self.assertIsNone(args.coverage_diagnostic_output)
 
     def test_parse_args_prefers_clickhouse_http_url_env(self) -> None:
         with (
@@ -578,6 +581,95 @@ class TestStrategyAutoresearch(TestCase):
         self.assertEqual(receipt["row_count"], 1)
         self.assertTrue(tape_exists)
         self.assertTrue(manifest_exists)
+
+    def test_materialize_run_replay_tape_selects_latest_complete_window(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            configmap_path = root / "strategy-configmap.yaml"
+            configmap_path.write_text("apiVersion: v1\nkind: ConfigMap\n")
+            bundle_paths = runner._mlx_bundle_paths(root)
+            args = Namespace(
+                strategy_configmap=configmap_path,
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity="31590.02",
+                chunk_minutes=10,
+                progress_log_seconds=30,
+                materialize_replay_tape=True,
+                replay_tape_path=None,
+                allow_stale_tape=False,
+                latest_complete_window_min_days=1,
+                latest_complete_window_receipt_output=None,
+                coverage_diagnostic_output=None,
+            )
+            signal_rows = [
+                SignalEnvelope(
+                    event_ts=datetime(2026, 3, 23, 13, 30, tzinfo=UTC),
+                    symbol="AMAT",
+                    seq=1,
+                    source="ta",
+                    timeframe="1Sec",
+                    payload={"price": "180.10"},
+                )
+            ]
+            latest_window_receipt = {
+                "schema_version": "torghut.replay-latest-complete-window.v1",
+                "requested_start_date": "2026-03-20",
+                "requested_end_date": "2026-03-23",
+                "effective_start_date": "2026-03-23",
+                "effective_end_date": "2026-03-23",
+                "selected_trading_days": ["2026-03-23"],
+            }
+
+            with (
+                patch(
+                    "scripts.run_strategy_autoresearch_loop._select_effective_replay_tape_window",
+                    return_value=(
+                        date(2026, 3, 23),
+                        date(2026, 3, 23),
+                        latest_window_receipt,
+                    ),
+                ) as select_window,
+                patch(
+                    "scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows",
+                    return_value=iter(signal_rows),
+                ),
+            ):
+                stats, receipt = runner._maybe_materialize_run_replay_tape(
+                    args=args,
+                    runner_run_id="strategy-autoresearch-test",
+                    snapshot_symbols=("AMAT",),
+                    bundle_paths=bundle_paths,
+                    full_window_start_date="2026-03-20",
+                    full_window_end_date="2026-03-23",
+                    existing_signal_bundle=None,
+                )
+
+            select_kwargs = select_window.call_args.kwargs
+            self.assertEqual(select_kwargs["requested_start_date"], date(2026, 3, 20))
+            self.assertEqual(select_kwargs["requested_end_date"], date(2026, 3, 23))
+            self.assertEqual(select_kwargs["symbols"], ("AMAT",))
+            self.assertEqual(
+                select_kwargs["args"].latest_complete_window_receipt_output,
+                Path(bundle_paths["replay_tape_latest_complete_window_receipt_json"]),
+            )
+            self.assertEqual(
+                select_kwargs["args"].coverage_diagnostic_output,
+                Path(bundle_paths["replay_tape_coverage_diagnostics_json"]),
+            )
+
+        assert stats is not None
+        assert receipt is not None
+        self.assertEqual(stats.row_count, 1)
+        self.assertEqual(receipt["requested_full_window_start_date"], "2026-03-20")
+        self.assertEqual(receipt["requested_full_window_end_date"], "2026-03-23")
+        self.assertEqual(receipt["effective_full_window_start_date"], "2026-03-23")
+        self.assertEqual(receipt["effective_full_window_end_date"], "2026-03-23")
+        self.assertEqual(receipt["latest_complete_window"], latest_window_receipt)
+        self.assertEqual(receipt["row_count"], 1)
 
     def test_materialize_run_replay_tape_fails_closed_on_missing_days(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Wires latest-complete replay-window selection into `run_strategy_autoresearch_loop.py` when autoresearch materializes replay tapes.
- Records requested and effective full-window dates in the replay tape receipt so later runs can audit why the selected tape window changed.
- Updates downstream frontier args to use the effective complete window after materialization.
- Adds focused tests for default CLI args and latest-complete-window materialization behavior.

## Related Issues

None

## Testing

- `uv run --frozen --extra dev ruff format scripts/run_strategy_autoresearch_loop.py tests/test_strategy_autoresearch.py`
- `uv run --frozen --extra dev ruff check scripts/run_strategy_autoresearch_loop.py tests/test_strategy_autoresearch.py`
- `uv run --frozen --extra dev pytest tests/test_strategy_autoresearch.py -q -k "parse_args_defaults_strategy_configmap_to_repo_root or materialize_run_replay_tape"`
- `uv run --frozen --extra dev pytest tests/test_strategy_autoresearch.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A - no UI changes.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
