### PR TITLE
feat(torghut): enable consistency repair in autoresearch

### DIFF
--- a/services/torghut/app/trading/discovery/autoresearch.py
+++ b/services/torghut/app/trading/discovery/autoresearch.py
@@ -328,6 +328,8 @@ class FamilyAutoresearchPlan:
     symbol_prune_min_universe_size: int
     loss_repair_iterations: int
     loss_repair_candidates: int
+    consistency_repair_iterations: int
+    consistency_repair_candidates: int
     parameter_mutations: Mapping[str, MutationSpace]
     strategy_override_mutations: Mapping[str, MutationSpace]
 
@@ -344,6 +346,8 @@ class FamilyAutoresearchPlan:
             'symbol_prune_min_universe_size': self.symbol_prune_min_universe_size,
             'loss_repair_iterations': self.loss_repair_iterations,
             'loss_repair_candidates': self.loss_repair_candidates,
+            'consistency_repair_iterations': self.consistency_repair_iterations,
+            'consistency_repair_candidates': self.consistency_repair_candidates,
             'parameter_mutations': {
                 key: value.to_payload() for key, value in self.parameter_mutations.items()
             },
@@ -692,6 +696,8 @@ def load_strategy_autoresearch_program(
                 symbol_prune_min_universe_size=max(1, int(family_payload.get('symbol_prune_min_universe_size', 2))),
                 loss_repair_iterations=max(0, int(family_payload.get('loss_repair_iterations', 0))),
                 loss_repair_candidates=max(1, int(family_payload.get('loss_repair_candidates', 1))),
+                consistency_repair_iterations=max(0, int(family_payload.get('consistency_repair_iterations', 0))),
+                consistency_repair_candidates=max(1, int(family_payload.get('consistency_repair_candidates', 2))),
                 parameter_mutations=parameter_mutations,
                 strategy_override_mutations=strategy_override_mutations,
             )

--- a/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
@@ -804,6 +804,8 @@ families:
     symbol_prune_min_universe_size: 4
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       max_entries_per_session:
         mode: numeric_step
@@ -835,6 +837,8 @@ families:
     symbol_prune_min_universe_size: 4
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       min_cross_section_continuation_rank:
         mode: numeric_step
@@ -866,6 +870,8 @@ families:
     symbol_prune_min_universe_size: 5
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       entry_minute_after_open:
         mode: numeric_step
@@ -904,6 +910,8 @@ families:
     symbol_prune_min_universe_size: 5
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       entry_minute_after_open:
         mode: numeric_step
@@ -942,6 +950,8 @@ families:
     symbol_prune_min_universe_size: 5
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       entry_minute_after_open:
         mode: numeric_step
@@ -980,6 +990,8 @@ families:
     symbol_prune_min_universe_size: 5
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       entry_minute_after_open:
         mode: numeric_step
@@ -1018,6 +1030,8 @@ families:
     symbol_prune_min_universe_size: 5
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       entry_minute_after_open:
         mode: numeric_step
@@ -1056,6 +1070,8 @@ families:
     symbol_prune_min_universe_size: 5
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       entry_minute_after_open:
         mode: numeric_step
@@ -1103,6 +1119,8 @@ families:
     symbol_prune_min_universe_size: 5
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       entry_minute_after_open:
         mode: numeric_step
@@ -1150,6 +1168,8 @@ families:
     symbol_prune_min_universe_size: 5
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       entry_minute_after_open:
         mode: numeric_step
@@ -1195,6 +1215,8 @@ families:
     symbol_prune_min_universe_size: 3
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       long_stop_loss_bps:
         mode: numeric_step
@@ -1226,6 +1248,8 @@ families:
     symbol_prune_min_universe_size: 5
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       exit_macd_hist_max:
         mode: numeric_step
@@ -1258,6 +1282,8 @@ families:
     symbol_prune_min_universe_size: 5
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       min_cross_section_continuation_rank:
         mode: numeric_step
@@ -1295,6 +1321,8 @@ families:
     symbol_prune_min_universe_size: 5
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       min_cross_section_reversal_rank:
         mode: numeric_step
@@ -1332,6 +1360,8 @@ families:
     symbol_prune_min_universe_size: 5
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       max_entries_per_session:
         mode: numeric_step
@@ -1366,6 +1396,8 @@ families:
     symbol_prune_min_universe_size: 5
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       min_bull_rsi:
         mode: numeric_step
@@ -1398,6 +1430,8 @@ families:
     symbol_prune_min_universe_size: 3
     loss_repair_iterations: 1
     loss_repair_candidates: 1
+    consistency_repair_iterations: 1
+    consistency_repair_candidates: 2
     parameter_mutations:
       min_price_vs_session_open_bps:
         mode: numeric_step

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -477,6 +477,7 @@ def _frontier_candidate_budget(
         family_plan.keep_top_candidates,
         family_plan.symbol_prune_candidates + 1,
         family_plan.loss_repair_candidates + 1,
+        family_plan.consistency_repair_candidates + 1,
     )
     return max(minimum_budget, replay_budget_max_candidates_per_frontier_run)
 
@@ -628,6 +629,8 @@ def _frontier_args(
         symbol_prune_min_universe_size=family_plan.symbol_prune_min_universe_size,
         loss_repair_iterations=family_plan.loss_repair_iterations,
         loss_repair_candidates=family_plan.loss_repair_candidates,
+        consistency_repair_iterations=family_plan.consistency_repair_iterations,
+        consistency_repair_candidates=family_plan.consistency_repair_candidates,
     )
 
 

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -533,6 +533,8 @@ class TestStrategyAutoresearch(TestCase):
         )
         self.assertEqual(frontier_args.loss_repair_iterations, 1)
         self.assertEqual(frontier_args.loss_repair_candidates, 1)
+        self.assertEqual(frontier_args.consistency_repair_iterations, 1)
+        self.assertEqual(frontier_args.consistency_repair_candidates, 2)
 
     def test_materialize_run_replay_tape_writes_bundle_and_receipt(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -916,6 +918,8 @@ class TestStrategyAutoresearch(TestCase):
                             "symbol_prune_min_universe_size": 2,
                             "loss_repair_iterations": 1,
                             "loss_repair_candidates": 1,
+                            "consistency_repair_iterations": 1,
+                            "consistency_repair_candidates": 2,
                             "parameter_mutations": {
                                 "max_entries_per_session": {
                                     "mode": "numeric_step",
@@ -1397,6 +1401,8 @@ class TestStrategyAutoresearch(TestCase):
             symbol_prune_min_universe_size=2,
             loss_repair_iterations=1,
             loss_repair_candidates=1,
+            consistency_repair_iterations=1,
+            consistency_repair_candidates=2,
             parameter_mutations={
                 "max_entries_per_session": MutationSpace(
                     mode="numeric_step",
@@ -1467,6 +1473,8 @@ class TestStrategyAutoresearch(TestCase):
             symbol_prune_min_universe_size=2,
             loss_repair_iterations=0,
             loss_repair_candidates=1,
+            consistency_repair_iterations=0,
+            consistency_repair_candidates=2,
             parameter_mutations={
                 "entry_cooldown_seconds": MutationSpace(
                     mode="numeric_step",


### PR DESCRIPTION
## Summary

- Adds consistency-repair knobs to `FamilyAutoresearchPlan` so outer autoresearch can pass them into the inner frontier instead of silently dropping them.
- Includes consistency repair in frontier candidate budgeting to avoid truncating bounded repair children.
- Enables one consistency-repair iteration with two children in the `$500/day` portfolio autoresearch program for close capital-safe near misses.

## Related Issues

None

## Testing

- `uv run --frozen --extra dev ruff check app/trading/discovery/autoresearch.py scripts/run_strategy_autoresearch_loop.py tests/test_strategy_autoresearch.py`
- `uv run --frozen --extra dev pytest tests/test_strategy_autoresearch.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
