### PR TITLE
feat(torghut): stage frontier train screening

### DIFF
--- a/services/torghut/app/trading/discovery/autoresearch.py
+++ b/services/torghut/app/trading/discovery/autoresearch.py
@@ -208,12 +208,14 @@ class ReplayBudget:
     max_candidates_per_round: int
     exploration_slots: int
     max_candidates_per_frontier_run: int
+    staged_train_screen_multiplier: int = 1
 
     def to_payload(self) -> dict[str, Any]:
         return {
             'max_candidates_per_round': self.max_candidates_per_round,
             'exploration_slots': self.exploration_slots,
             'max_candidates_per_frontier_run': self.max_candidates_per_frontier_run,
+            'staged_train_screen_multiplier': self.staged_train_screen_multiplier,
         }
 
 
@@ -587,6 +589,10 @@ def load_strategy_autoresearch_program(
         max_candidates_per_frontier_run=max(
             0,
             int(replay_budget_payload.get('max_candidates_per_frontier_run', 96)),
+        ),
+        staged_train_screen_multiplier=max(
+            1,
+            int(replay_budget_payload.get('staged_train_screen_multiplier', 1)),
         ),
     )
     runtime_closure_policy = _load_runtime_closure_policy(_mapping(payload.get('runtime_closure_policy')))

--- a/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
@@ -27,6 +27,7 @@ replay_budget:
   max_candidates_per_round: 8
   exploration_slots: 2
   max_candidates_per_frontier_run: 96
+  staged_train_screen_multiplier: 3
 runtime_closure_policy:
   enabled: true
   execute_parity_replay: true

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -254,6 +254,15 @@ def _parse_args() -> argparse.Namespace:
             "execution. 0 uses the program replay budget."
         ),
     )
+    parser.add_argument(
+        "--staged-train-screen-multiplier",
+        type=int,
+        default=0,
+        help=(
+            "Optional override for cheap train-screen candidate breadth per frontier "
+            "run. 0 uses the program replay budget."
+        ),
+    )
     parser.add_argument("--json-output", type=Path)
     return parser.parse_args()
 
@@ -591,6 +600,11 @@ def _frontier_args(
             replay_budget_max_candidates_per_frontier_run=replay_budget_max_candidates_per_frontier_run,
         )
     )
+    staged_train_screen_multiplier = (
+        max(1, int(args.staged_train_screen_multiplier))
+        if int(getattr(args, "staged_train_screen_multiplier", 0)) > 0
+        else max(1, int(program.replay_budget.staged_train_screen_multiplier))
+    )
     return argparse.Namespace(
         strategy_configmap=args.strategy_configmap.resolve(),
         sweep_config=sweep_config_path,
@@ -623,6 +637,7 @@ def _frontier_args(
         ),
         top_n=top_n,
         max_candidates_to_evaluate=max_candidates_to_evaluate,
+        staged_train_screen_multiplier=staged_train_screen_multiplier,
         json_output=json_output_path,
         symbol_prune_iterations=family_plan.symbol_prune_iterations,
         symbol_prune_candidates=family_plan.symbol_prune_candidates,
@@ -883,6 +898,7 @@ def _history_record(
     scorecard = _mapping(candidate_payload.get("objective_scorecard"))
     ranking = _mapping(candidate_payload.get("ranking"))
     replay_config = _mapping(candidate_payload.get("replay_config"))
+    staged_search = _mapping(candidate_payload.get("staged_search"))
     promotion_readiness = _promotion_readiness_payload(family_plan=family_plan)
     deployable_lower_bound = deployable_lower_bound_net_pnl_per_day(scorecard)
     return {
@@ -1026,6 +1042,16 @@ def _history_record(
         "daily_net": _mapping(full_window.get("daily_net")),
         "daily_filled_notional": _mapping(full_window.get("daily_filled_notional")),
         "pruned_symbol": _string(candidate_payload.get("pruned_symbol")),
+        "staged_search_stage": _string(staged_search.get("stage")),
+        "staged_train_screen_multiplier": int(
+            staged_search.get("train_screen_multiplier") or 1
+        ),
+        "staged_full_replay_candidate_budget": _string(
+            staged_search.get("full_replay_candidate_budget")
+        ),
+        "staged_full_replay_candidates_started": int(
+            staged_search.get("full_replay_candidates_started") or 0
+        ),
         "objective_scope": "research_only",
         "promotion_stage": promotion_readiness["stage"],
         "promotion_status": promotion_readiness["status"],
@@ -1131,6 +1157,8 @@ def _write_results_tsv(path: Path, history: list[dict[str, Any]]) -> None:
         "best_day_share",
         "max_drawdown",
         "status",
+        "staged_search_stage",
+        "staged_full_replay_candidates_started",
         "description",
     ]
     rows = ["\t".join(header)]
@@ -1147,6 +1175,10 @@ def _write_results_tsv(path: Path, history: list[dict[str, Any]]) -> None:
                     _sanitize_tsv_field(item["best_day_share"]),
                     _sanitize_tsv_field(item["max_drawdown"]),
                     _sanitize_tsv_field(item["status"]),
+                    _sanitize_tsv_field(item.get("staged_search_stage", "")),
+                    _sanitize_tsv_field(
+                        item.get("staged_full_replay_candidates_started", "")
+                    ),
                     _sanitize_tsv_field(item["mutation_label"]),
                 ]
             )

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -343,6 +343,40 @@ def _write_json_output(path: Path, payload: Mapping[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
 
+def _staged_search_budget_payload(
+    *,
+    args: argparse.Namespace,
+    candidate_budget: int,
+    full_replay_candidates_started: int = 0,
+    train_screen_only_candidates: int = 0,
+) -> dict[str, Any]:
+    train_screening_enabled = bool(getattr(args, "train_screening", True))
+    train_screen_multiplier = max(
+        1,
+        int(getattr(args, "staged_train_screen_multiplier", 1) or 1),
+    )
+    full_replay_budget = max(0, int(candidate_budget))
+    train_screen_budget = (
+        full_replay_budget * train_screen_multiplier
+        if train_screening_enabled and full_replay_budget > 0
+        else full_replay_budget
+    )
+    return {
+        "schema_version": "torghut.frontier-staged-search-budget.v1",
+        "enabled": bool(
+            train_screening_enabled
+            and train_screen_multiplier > 1
+            and full_replay_budget > 0
+        ),
+        "train_screening_enabled": train_screening_enabled,
+        "train_screen_multiplier": train_screen_multiplier,
+        "train_screen_candidate_budget": train_screen_budget,
+        "full_replay_candidate_budget": full_replay_budget,
+        "full_replay_candidates_started": max(0, int(full_replay_candidates_started)),
+        "train_screen_only_candidates": max(0, int(train_screen_only_candidates)),
+    }
+
+
 def _frontier_error_payload(exc: Exception) -> dict[str, Any]:
     message = str(exc)
     payload: dict[str, Any] = {
@@ -644,6 +678,15 @@ def _parse_args() -> argparse.Namespace:
         type=int,
         default=0,
         help="Optional cap on evaluated candidates inside one frontier run. 0 means unbounded.",
+    )
+    parser.add_argument(
+        "--staged-train-screen-multiplier",
+        type=int,
+        default=1,
+        help=(
+            "When train screening is enabled, allow this multiple of the expensive "
+            "full-replay budget to be evaluated through the cheap train screen."
+        ),
     )
     parser.add_argument(
         "--candidate-record",
@@ -4143,6 +4186,7 @@ def _build_frontier_payload(
     status: str,
     pending_candidates: int,
     replay_tape_validation: Mapping[str, Any] | None = None,
+    staged_search: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     ranked_items = _rank_scored_candidates(scored)
     return {
@@ -4189,6 +4233,7 @@ def _build_frontier_payload(
         "progress": {
             "evaluated_candidates": len(scored),
             "pending_candidates": pending_candidates,
+            "staged_search": dict(staged_search or {}),
         },
         "candidate_count": len(scored),
         "economic_shortlist": {
@@ -4524,6 +4569,18 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
             )
         candidate_index = 0
         candidate_budget = int(args.max_candidates_to_evaluate)
+        staged_search = _staged_search_budget_payload(
+            args=args,
+            candidate_budget=candidate_budget,
+        )
+        train_screen_candidate_budget = int(
+            staged_search["train_screen_candidate_budget"]
+        )
+        full_replay_candidate_budget = int(
+            staged_search["full_replay_candidate_budget"]
+        )
+        full_replay_candidates_started = 0
+        train_screen_only_candidates = 0
         initial_candidates = _iter_initial_worklist_candidates(
             parameter_grid=parameter_grid,
             override_candidates=override_candidates,
@@ -4556,7 +4613,16 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                             worklist.append(next_initial)
                 if not worklist:
                     break
-                if candidate_budget > 0 and len(scored) >= candidate_budget:
+                if (
+                    train_screen_candidate_budget > 0
+                    and len(scored) >= train_screen_candidate_budget
+                ):
+                    budget_exhausted = True
+                    break
+                if (
+                    full_replay_candidate_budget > 0
+                    and full_replay_candidates_started >= full_replay_candidate_budget
+                ):
                     budget_exhausted = True
                     break
                 worklist_item = worklist.popleft()
@@ -4623,6 +4689,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                 holdout_replay_skipped = bool(train_screen_failures)
                 full_window_replay_skipped = bool(train_screen_failures)
                 if train_screen_failures:
+                    train_screen_only_candidates += 1
                     second_oos_start = window.second_oos_start
                     second_oos_end = window.second_oos_end
                     holdout_payload = _empty_replay_payload(
@@ -4639,6 +4706,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     )
                     full_window_payload = train_payload
                 else:
+                    full_replay_candidates_started += 1
                     holdout_payload = run_replay(
                         _build_replay_config(
                             strategy_configmap_path=candidate_configmap_path,
@@ -4908,6 +4976,17 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     "second_oos_replay_skipped": bool(
                         train_screen_failures and window.second_oos_days
                     ),
+                }
+                candidate_payload["staged_search"] = {
+                    "schema_version": "torghut.frontier-candidate-staged-search.v1",
+                    "stage": (
+                        "train_screen_only" if holdout_replay_skipped else "full_replay"
+                    ),
+                    "train_screen_multiplier": int(
+                        staged_search["train_screen_multiplier"]
+                    ),
+                    "full_replay_candidate_budget": full_replay_candidate_budget,
+                    "full_replay_candidates_started": full_replay_candidates_started,
                 }
                 if worklist_item.pruned_symbol is not None:
                     candidate_payload["pruned_symbol"] = worklist_item.pruned_symbol
@@ -5615,6 +5694,12 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                         pending_candidates=len(worklist)
                         + (0 if initial_candidates_exhausted else 1),
                         replay_tape_validation=replay_tape_validation,
+                        staged_search=_staged_search_budget_payload(
+                            args=args,
+                            candidate_budget=candidate_budget,
+                            full_replay_candidates_started=full_replay_candidates_started,
+                            train_screen_only_candidates=train_screen_only_candidates,
+                        ),
                     )
                     _write_json_output(args.json_output, partial_payload)
 
@@ -5636,6 +5721,12 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         else "completed",
         pending_candidates=len(worklist) + (0 if initial_candidates_exhausted else 1),
         replay_tape_validation=replay_tape_validation,
+        staged_search=_staged_search_budget_payload(
+            args=args,
+            candidate_budget=candidate_budget,
+            full_replay_candidates_started=full_replay_candidates_started,
+            train_screen_only_candidates=train_screen_only_candidates,
+        ),
     )
     if args.json_output is not None:
         _write_json_output(args.json_output, payload)

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -116,6 +116,8 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     str(family_dir),
                     "--max-candidates-to-evaluate",
                     "12",
+                    "--staged-train-screen-multiplier",
+                    "3",
                     "--candidate-record",
                     str(root / "candidate.json"),
                     "--no-train-screening",
@@ -139,6 +141,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(args.replay_tape_manifest, root / "tape.jsonl.manifest.json")
         self.assertEqual(args.family_template_dir, family_dir)
         self.assertEqual(args.max_candidates_to_evaluate, 12)
+        self.assertEqual(args.staged_train_screen_multiplier, 3)
         self.assertEqual(args.candidate_record, [root / "candidate.json"])
         self.assertFalse(args.train_screening)
         self.assertEqual(args.min_train_screen_net_per_day, "-50")
@@ -4159,6 +4162,142 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             self.assertTrue(top["screening"]["full_window_replay_skipped"])
             self.assertIn("train_no_decisions", top["hard_vetoes"])
             self.assertIn("train_net_per_day_below_screen", top["hard_vetoes"])
+
+    def test_run_frontier_staged_train_screen_expands_cheap_stage(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = self._write_strategy_configmap(root)
+            sweep_config = root / "sweep.yaml"
+            sweep_config.write_text(
+                yaml.safe_dump(
+                    {
+                        "schema_version": "torghut.replay-frontier-sweep.v1",
+                        "family": "intraday_tsmom_consistent",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "disable_other_strategies": True,
+                        "constraints": {
+                            "holdout_target_net_per_day": "200",
+                            "min_active_holdout_days": 2,
+                            "max_worst_holdout_day_loss": "200",
+                            "min_profit_factor": "1.0",
+                        },
+                        "consistency_constraints": {
+                            "target_net_per_day": "200",
+                            "min_active_days": 2,
+                            "max_worst_day_loss": "300",
+                            "max_negative_days": 1,
+                            "max_drawdown": "400",
+                            "require_every_day_active": True,
+                        },
+                        "strategy_overrides": {
+                            "universe_symbols": [["NVDA"]],
+                        },
+                        "parameters": {
+                            "long_stop_loss_bps": ["12", "14", "16", "18"],
+                        },
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+            json_output = root / "frontier.json"
+            args = self._make_args(
+                strategy_configmap=strategy_configmap,
+                sweep_config=sweep_config,
+                json_output=json_output,
+            )
+            args.max_candidates_to_evaluate = 1
+            args.staged_train_screen_multiplier = 3
+            args.min_train_screen_net_per_day = "1"
+            recent_days = tuple(
+                date(2026, 3, 18) + timedelta(days=index) for index in range(6)
+            )
+            snapshot_receipt = SimpleNamespace(
+                snapshot_id="snap-staged",
+                is_fresh=True,
+                stale_override_used=False,
+                to_payload=lambda: {
+                    "snapshot_id": "snap-staged",
+                    "source": "ta",
+                    "window_size": "PT1S",
+                    "start_day": "2026-03-18",
+                    "end_day": "2026-03-23",
+                    "expected_last_trading_day": "2026-03-23",
+                    "is_fresh": True,
+                    "missing_days": [],
+                    "row_count": 123,
+                    "stale_override_used": False,
+                    "witnesses": [],
+                },
+            )
+            replay_calls: list[tuple[str, str]] = []
+
+            def fake_run_replay(config: object) -> dict[str, object]:
+                replay_calls.append(
+                    (
+                        str(getattr(config, "start_date")),
+                        str(getattr(config, "end_date")),
+                    )
+                )
+                if len(replay_calls) <= 2:
+                    return self._payload(
+                        start_date="2026-03-18",
+                        end_date="2026-03-20",
+                        daily_net={
+                            "2026-03-18": "0",
+                            "2026-03-19": "0",
+                            "2026-03-20": "0",
+                        },
+                        decision_count=0,
+                        filled_count=0,
+                        wins=0,
+                        losses=0,
+                    )
+                return self._payload(
+                    start_date=str(getattr(config, "start_date")),
+                    end_date=str(getattr(config, "end_date")),
+                    daily_net={
+                        "2026-03-18": "220",
+                        "2026-03-19": "230",
+                        "2026-03-20": "240",
+                    },
+                    decision_count=3,
+                    filled_count=3,
+                    wins=3,
+                    losses=0,
+                )
+
+            with (
+                patch(
+                    "scripts.search_consistent_profitability_frontier._resolve_recent_trading_days",
+                    return_value=recent_days,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt",
+                    return_value=snapshot_receipt,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot"
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.run_replay",
+                    side_effect=fake_run_replay,
+                ),
+            ):
+                payload = frontier.run_consistent_profitability_frontier(args)
+
+            staged = payload["progress"]["staged_search"]
+            self.assertEqual(payload["status"], "candidate_budget_exhausted")
+            self.assertEqual(payload["candidate_count"], 3)
+            self.assertEqual(staged["train_screen_candidate_budget"], 3)
+            self.assertEqual(staged["full_replay_candidate_budget"], 1)
+            self.assertEqual(staged["full_replay_candidates_started"], 1)
+            self.assertEqual(staged["train_screen_only_candidates"], 2)
+            self.assertEqual(
+                [item["staged_search"]["stage"] for item in payload["top"]],
+                ["full_replay", "train_screen_only", "train_screen_only"],
+            )
+            self.assertEqual(len(replay_calls), 5)
 
     def test_run_frontier_respects_candidate_budget(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -31,6 +31,7 @@ from app.trading.discovery.autoresearch_notebooks import (
 )
 from app.trading.discovery.family_templates import FamilyTemplate
 from app.trading.models import SignalEnvelope
+import scripts.search_consistent_profitability_frontier as frontier
 import scripts.run_strategy_autoresearch_loop as runner
 
 
@@ -435,6 +436,7 @@ class TestStrategyAutoresearch(TestCase):
         self.assertEqual(args.min_quote_valid_ratio, "0.90")
         self.assertEqual(args.max_coverage_spread_bps, "50")
         self.assertEqual(args.max_executable_gap_seconds, 120)
+        self.assertEqual(args.staged_train_screen_multiplier, 0)
 
     def test_parse_args_prefers_clickhouse_http_url_env(self) -> None:
         with (
@@ -483,12 +485,18 @@ class TestStrategyAutoresearch(TestCase):
         self.assertEqual(program.runtime_closure_policy.parity_window, "full_window")
         self.assertEqual(program.runtime_closure_policy.approval_window, "holdout")
         self.assertEqual(program.replay_budget.max_candidates_per_frontier_run, 96)
+        self.assertEqual(program.replay_budget.staged_train_screen_multiplier, 1)
         self.assertTrue(program.ledger_policy["append_only"])
 
     def test_frontier_args_forwards_second_oos_days(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             program_path, family_dir = self._write_program_fixture(root)
+            program_payload = yaml.safe_load(program_path.read_text(encoding="utf-8"))
+            program_payload["replay_budget"] = {"staged_train_screen_multiplier": 3}
+            program_path.write_text(
+                yaml.safe_dump(program_payload, sort_keys=False), encoding="utf-8"
+            )
             program = load_strategy_autoresearch_program(
                 program_path, family_dir=family_dir
             )
@@ -513,6 +521,7 @@ class TestStrategyAutoresearch(TestCase):
                 replay_tape_path=root / "tape.jsonl",
                 replay_tape_manifest=root / "tape.manifest.json",
                 max_candidates_per_frontier_run=0,
+                staged_train_screen_multiplier=0,
             )
 
             frontier_args = runner._frontier_args(
@@ -521,6 +530,14 @@ class TestStrategyAutoresearch(TestCase):
                 family_plan=program.families[0],
                 sweep_config_path=root / "sweep.yaml",
                 json_output_path=root / "result.json",
+            )
+            args.staged_train_screen_multiplier = 5
+            override_frontier_args = runner._frontier_args(
+                args=args,
+                program=program,
+                family_plan=program.families[0],
+                sweep_config_path=root / "sweep.yaml",
+                json_output_path=root / "override-result.json",
             )
 
         self.assertEqual(frontier_args.second_oos_days, 4)
@@ -535,6 +552,99 @@ class TestStrategyAutoresearch(TestCase):
         self.assertEqual(frontier_args.loss_repair_candidates, 1)
         self.assertEqual(frontier_args.consistency_repair_iterations, 1)
         self.assertEqual(frontier_args.consistency_repair_candidates, 2)
+        self.assertEqual(frontier_args.staged_train_screen_multiplier, 3)
+        self.assertEqual(override_frontier_args.staged_train_screen_multiplier, 5)
+
+    def test_frontier_staged_search_budget_expands_train_screen_only_stage(
+        self,
+    ) -> None:
+        payload = frontier._staged_search_budget_payload(
+            args=Namespace(train_screening=True, staged_train_screen_multiplier=3),
+            candidate_budget=96,
+            full_replay_candidates_started=12,
+            train_screen_only_candidates=40,
+        )
+
+        self.assertTrue(payload["enabled"])
+        self.assertEqual(payload["train_screen_candidate_budget"], 288)
+        self.assertEqual(payload["full_replay_candidate_budget"], 96)
+        self.assertEqual(payload["full_replay_candidates_started"], 12)
+        self.assertEqual(payload["train_screen_only_candidates"], 40)
+
+    def test_frontier_staged_search_budget_does_not_expand_without_train_screen(
+        self,
+    ) -> None:
+        payload = frontier._staged_search_budget_payload(
+            args=Namespace(train_screening=False, staged_train_screen_multiplier=3),
+            candidate_budget=96,
+        )
+
+        self.assertFalse(payload["enabled"])
+        self.assertEqual(payload["train_screen_candidate_budget"], 96)
+        self.assertEqual(payload["full_replay_candidate_budget"], 96)
+
+    def test_frontier_staged_search_budget_marks_unbounded_as_disabled(
+        self,
+    ) -> None:
+        payload = frontier._staged_search_budget_payload(
+            args=Namespace(train_screening=True, staged_train_screen_multiplier=3),
+            candidate_budget=0,
+        )
+
+        self.assertFalse(payload["enabled"])
+        self.assertEqual(payload["train_screen_candidate_budget"], 0)
+        self.assertEqual(payload["full_replay_candidate_budget"], 0)
+
+    def test_history_record_flattens_staged_search_metadata(self) -> None:
+        record = runner._history_record(
+            runner_run_id="run-1",
+            experiment_index=1,
+            family_plan=FamilyAutoresearchPlan(
+                family_template=_family_template(),
+                seed_sweep_config=Path("/tmp/example.yaml"),
+                max_iterations=1,
+                keep_top_candidates=1,
+                frontier_top_n=1,
+                force_keep_top_candidate_if_all_vetoed=True,
+                symbol_prune_iterations=0,
+                symbol_prune_candidates=1,
+                symbol_prune_min_universe_size=2,
+                loss_repair_iterations=0,
+                loss_repair_candidates=1,
+                consistency_repair_iterations=0,
+                consistency_repair_candidates=2,
+                parameter_mutations={},
+                strategy_override_mutations={},
+            ),
+            iteration=1,
+            mutation_label="seed",
+            parent_candidate_id=None,
+            sweep_config_path=Path("/tmp/sweep.yaml"),
+            result_path=Path("/tmp/result.json"),
+            candidate_payload={
+                "candidate_id": "candidate-1",
+                "hard_vetoes": [],
+                "ranking": {"pareto_tier": 1, "tie_breaker_score": "10"},
+                "objective_scorecard": {"net_pnl_per_day": "500"},
+                "full_window": {},
+                "replay_config": {},
+                "staged_search": {
+                    "stage": "full_replay",
+                    "train_screen_multiplier": 3,
+                    "full_replay_candidate_budget": 96,
+                    "full_replay_candidates_started": 7,
+                },
+            },
+            rank=1,
+            status="keep",
+            objective_met=False,
+            dataset_snapshot_id="snap-1",
+        )
+
+        self.assertEqual(record["staged_search_stage"], "full_replay")
+        self.assertEqual(record["staged_train_screen_multiplier"], 3)
+        self.assertEqual(record["staged_full_replay_candidate_budget"], "96")
+        self.assertEqual(record["staged_full_replay_candidates_started"], 7)
 
     def test_materialize_run_replay_tape_writes_bundle_and_receipt(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -1059,6 +1169,7 @@ class TestStrategyAutoresearch(TestCase):
             program.objective.max_gross_exposure_pct_equity, Decimal("1.0")
         )
         self.assertEqual(program.objective.min_cash, Decimal("0"))
+        self.assertEqual(program.replay_budget.staged_train_screen_multiplier, 3)
 
         policy = runner._portfolio_oracle_policy(program)
         self.assertEqual(policy.min_profit_factor, Decimal("1.50"))


### PR DESCRIPTION
## Summary

- Adds staged train-screen breadth to the consistent profitability frontier so cheap train-only rejects can expand candidate coverage without increasing the full replay budget.
- Wires `staged_train_screen_multiplier` through autoresearch program loading, runner CLI overrides, frontier args, frontier progress payloads, candidate payloads, history JSONL, and results TSV output.
- Enables a conservative `3x` train-screen stage for `portfolio-profit-autoresearch-500-v1` while keeping the full replay candidate budget at `96`.

## Related Issues

None

## Testing

- `uv run --frozen --extra dev ruff format --check scripts/run_strategy_autoresearch_loop.py scripts/search_consistent_profitability_frontier.py tests/test_strategy_autoresearch.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen --extra dev ruff check app/trading/discovery/autoresearch.py scripts/run_strategy_autoresearch_loop.py scripts/search_consistent_profitability_frontier.py tests/test_strategy_autoresearch.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen --extra dev pytest tests/test_strategy_autoresearch.py tests/test_search_consistent_profitability_frontier.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
