### PR TITLE
fix(torghut): forward selected replay windows

### DIFF
--- a/services/torghut/scripts/materialize_replay_tape.py
+++ b/services/torghut/scripts/materialize_replay_tape.py
@@ -340,30 +340,41 @@ WHERE source = 'ta'
     return f"""
 SELECT
   toString(trading_day) AS trading_day,
-  toString(sum(raw_signal_rows)) AS raw_signal_rows,
-  toString(sum(executable_signal_rows)) AS executable_signal_rows,
-  toString(sum(quote_sane_signal_rows)) AS quote_sane_signal_rows,
-  toString(sum(spread_sane_signal_rows)) AS spread_sane_signal_rows,
-  toString(sum(microbar_rows)) AS microbar_rows,
-  toString(countIf(raw_signal_rows > 0)) AS raw_signal_symbol_count,
-  toString(countIf(executable_signal_rows > 0)) AS executable_signal_symbol_count,
-  toString(countIf(microbar_rows > 0)) AS microbar_symbol_count,
-  toString(minIf(executable_signal_rows, raw_signal_rows > 0)) AS min_executable_rows_per_symbol_day,
-  toString(minIf(spread_sane_signal_rows, raw_signal_rows > 0)) AS min_spread_sane_rows_per_symbol_day,
-  toString(if(sum(executable_signal_rows) = 0, 0, sum(spread_sane_signal_rows) / sum(executable_signal_rows))) AS quote_valid_ratio,
-  toString(minIf(if(executable_signal_rows = 0, 0, spread_sane_signal_rows / executable_signal_rows), raw_signal_rows > 0)) AS min_quote_valid_ratio_by_symbol_day,
-  toString(max(max_executable_gap_seconds)) AS max_executable_gap_seconds
+  toString(sum(raw_signal_rows_by_symbol)) AS raw_signal_rows,
+  toString(sum(executable_signal_rows_by_symbol)) AS executable_signal_rows,
+  toString(sum(quote_sane_signal_rows_by_symbol)) AS quote_sane_signal_rows,
+  toString(sum(spread_sane_signal_rows_by_symbol)) AS spread_sane_signal_rows,
+  toString(sum(microbar_rows_by_symbol)) AS microbar_rows,
+  toString(countIf(raw_signal_rows_by_symbol > 0)) AS raw_signal_symbol_count,
+  toString(countIf(executable_signal_rows_by_symbol > 0)) AS executable_signal_symbol_count,
+  toString(countIf(microbar_rows_by_symbol > 0)) AS microbar_symbol_count,
+  toString(minIf(executable_signal_rows_by_symbol, raw_signal_rows_by_symbol > 0)) AS min_executable_rows_per_symbol_day,
+  toString(minIf(spread_sane_signal_rows_by_symbol, raw_signal_rows_by_symbol > 0)) AS min_spread_sane_rows_per_symbol_day,
+  toString(if(
+    sum(executable_signal_rows_by_symbol) = 0,
+    0,
+    sum(spread_sane_signal_rows_by_symbol) / sum(executable_signal_rows_by_symbol)
+  )) AS quote_valid_ratio,
+  toString(minIf(
+    if(
+      executable_signal_rows_by_symbol = 0,
+      0,
+      spread_sane_signal_rows_by_symbol / executable_signal_rows_by_symbol
+    ),
+    raw_signal_rows_by_symbol > 0
+  )) AS min_quote_valid_ratio_by_symbol_day,
+  toString(max(max_executable_gap_seconds_by_symbol)) AS max_executable_gap_seconds
 FROM
 (
   SELECT
     trading_day,
     symbol,
-    sum(raw_signal_rows) AS raw_signal_rows,
-    sum(executable_signal_rows) AS executable_signal_rows,
-    sum(quote_sane_signal_rows) AS quote_sane_signal_rows,
-    sum(spread_sane_signal_rows) AS spread_sane_signal_rows,
-    sum(microbar_rows) AS microbar_rows,
-    max(max_executable_gap_seconds) AS max_executable_gap_seconds
+    sum(toUInt64OrZero(toString(raw_signal_rows))) AS raw_signal_rows_by_symbol,
+    sum(toUInt64OrZero(toString(executable_signal_rows))) AS executable_signal_rows_by_symbol,
+    sum(toUInt64OrZero(toString(quote_sane_signal_rows))) AS quote_sane_signal_rows_by_symbol,
+    sum(toUInt64OrZero(toString(spread_sane_signal_rows))) AS spread_sane_signal_rows_by_symbol,
+    sum(toUInt64OrZero(toString(microbar_rows))) AS microbar_rows_by_symbol,
+    max(toUInt64OrZero(toString(max_executable_gap_seconds))) AS max_executable_gap_seconds_by_symbol
   FROM
   (
     SELECT
@@ -750,18 +761,48 @@ def _select_effective_window(
         end_date=requested_end_date,
     )
     policy = _executable_day_policy(args=args)
-    selected_start, selected_end, selected_days = _latest_complete_window(
-        diagnostics,
-        min_days=min_days,
-        expected_symbol_count=len(symbols),
-        min_executable_rows_per_symbol_day=int(
-            policy["min_executable_rows_per_symbol_day"]
-        ),
-        min_quote_valid_ratio=Decimal(str(policy["min_quote_valid_ratio"])),
-        max_executable_gap_seconds=int(policy["max_executable_gap_seconds"]),
-    )
+    try:
+        selected_start, selected_end, selected_days = _latest_complete_window(
+            diagnostics,
+            min_days=min_days,
+            expected_symbol_count=len(symbols),
+            min_executable_rows_per_symbol_day=int(
+                policy["min_executable_rows_per_symbol_day"]
+            ),
+            min_quote_valid_ratio=Decimal(str(policy["min_quote_valid_ratio"])),
+            max_executable_gap_seconds=int(policy["max_executable_gap_seconds"]),
+        )
+    except ValueError as exc:
+        receipt = {
+            "schema_version": "torghut.replay-latest-complete-window.v1",
+            "status": "missing",
+            "failure_reason": str(exc),
+            "requested_start_date": requested_start_date.isoformat(),
+            "requested_end_date": requested_end_date.isoformat(),
+            "selected_trading_days": [],
+            "min_days": min_days,
+            "symbols": list(symbols),
+            "source_coverage": diagnostics,
+            "executable_day_policy": policy,
+        }
+        receipt_output = getattr(args, "latest_complete_window_receipt_output", None)
+        if receipt_output:
+            _write_diagnostics_payload(Path(receipt_output).resolve(), receipt)
+        diagnostic_output = getattr(args, "coverage_diagnostic_output", None)
+        if diagnostic_output:
+            enriched = dict(diagnostics)
+            enriched["latest_complete_window"] = {
+                "schema_version": "torghut.replay-latest-complete-window-selection.v1",
+                "status": "missing",
+                "failure_reason": str(exc),
+                "selected_trading_days": [],
+                "min_days": min_days,
+            }
+            _write_diagnostics_payload(Path(diagnostic_output).resolve(), enriched)
+        raise
     receipt = {
         "schema_version": "torghut.replay-latest-complete-window.v1",
+        "status": "selected",
         "requested_start_date": requested_start_date.isoformat(),
         "requested_end_date": requested_end_date.isoformat(),
         "effective_start_date": selected_start.isoformat(),

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -99,6 +99,13 @@ def _default_clickhouse_http_url() -> str:
     )
 
 
+def _default_clickhouse_password() -> str:
+    return os.environ.get(
+        "TA_CLICKHOUSE_PASSWORD",
+        os.environ.get("CLICKHOUSE_PASSWORD", ""),
+    )
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run an autoresearch-style strategy discovery loop and emit notebooks.",
@@ -136,7 +143,7 @@ def _parse_args() -> argparse.Namespace:
             os.environ.get("CLICKHOUSE_USERNAME", "torghut"),
         ),
     )
-    parser.add_argument("--clickhouse-password", default="")
+    parser.add_argument("--clickhouse-password", default=_default_clickhouse_password())
     parser.add_argument("--start-equity", default="31590.02")
     parser.add_argument("--chunk-minutes", type=int, default=10)
     parser.add_argument("--symbols", default="")
@@ -1927,6 +1934,13 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
     frontier_base_args = argparse.Namespace(
         **{
             **vars(args),
+            "full_window_start_date": resolved_full_window_start_date,
+            "full_window_end_date": resolved_full_window_end_date,
+            "expected_last_trading_day": (
+                resolved_full_window_end_date
+                if materialized_replay_tape_receipt is not None
+                else str(args.expected_last_trading_day)
+            ),
             "replay_tape_path": effective_replay_tape_path,
             "replay_tape_manifest": effective_replay_tape_manifest,
         }

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -685,6 +685,7 @@ class TestMaterializeReplayTapeCli(TestCase):
         )
         query_payload = str(query.call_args.kwargs["query"])
         self.assertIn("symbol IN ('META')", query_payload)
+        self.assertIn("toUInt64OrZero(toString(raw_signal_rows))", query_payload)
         self.assertEqual(query.call_args.kwargs["timeout_seconds"], 7)
         self.assertEqual(diagnostics["missing_raw_signal_days"], ["2026-03-27"])
         self.assertEqual(diagnostics["missing_executable_signal_days"], ["2026-03-27"])
@@ -945,6 +946,62 @@ class TestMaterializeReplayTapeCli(TestCase):
         self.assertEqual(
             receipt_payload["materialized_manifest"]["row_count"],
             2,
+        )
+
+    def test_latest_complete_window_failure_writes_diagnostics(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            diagnostic_output = root / "coverage.json"
+            receipt_output = root / "window.json"
+            args = Namespace(
+                coverage_diagnostic_output=diagnostic_output,
+                latest_complete_window_receipt_output=receipt_output,
+                latest_complete_window_min_days=2,
+                min_executable_rows_per_symbol_day=10,
+                min_quote_valid_ratio="0.90",
+                max_executable_gap_seconds=120,
+            )
+            coverage = {
+                "schema_version": "torghut.replay-coverage-diagnostic.v1",
+                "requested_trading_days": ["2026-03-26", "2026-03-27"],
+                "rows_by_trading_day": {
+                    "2026-03-26": self._coverage_row(
+                        raw=10,
+                        executable=0,
+                        microbar=10,
+                    ),
+                    "2026-03-27": self._coverage_row(
+                        raw=10,
+                        executable=10,
+                        microbar=10,
+                    ),
+                },
+            }
+            with patch(
+                "scripts.materialize_replay_tape._fetch_coverage_diagnostics",
+                return_value=coverage,
+            ):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "latest_complete_replay_window_missing:min_days=2",
+                ):
+                    materialize_cli._select_effective_window(
+                        args=args,
+                        symbols=("META",),
+                        requested_start_date=date(2026, 3, 26),
+                        requested_end_date=date(2026, 3, 27),
+                    )
+
+            diagnostic_payload = json.loads(
+                diagnostic_output.read_text(encoding="utf-8")
+            )
+            receipt_payload = json.loads(receipt_output.read_text(encoding="utf-8"))
+
+        self.assertEqual(receipt_payload["status"], "missing")
+        self.assertEqual(receipt_payload["selected_trading_days"], [])
+        self.assertEqual(
+            diagnostic_payload["latest_complete_window"]["failure_reason"],
+            "latest_complete_replay_window_missing:min_days=2",
         )
 
     def test_main_fails_closed_on_incomplete_coverage_by_default(self) -> None:

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -446,6 +446,7 @@ class TestStrategyAutoresearch(TestCase):
                     "TA_CLICKHOUSE_URL": "jdbc:clickhouse://clickhouse/torghut",
                     "CLICKHOUSE_HTTP_URL": "http://127.0.0.1:8123",
                     "TA_CLICKHOUSE_USERNAME": "reader",
+                    "TA_CLICKHOUSE_PASSWORD": "reader-secret",
                 },
             ),
             patch.object(
@@ -464,6 +465,7 @@ class TestStrategyAutoresearch(TestCase):
 
         self.assertEqual(args.clickhouse_http_url, "http://127.0.0.1:8123")
         self.assertEqual(args.clickhouse_username, "reader")
+        self.assertEqual(args.clickhouse_password, "reader-secret")
 
     def test_program_defaults_include_mlx_contract(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -2249,6 +2251,130 @@ class TestStrategyAutoresearch(TestCase):
             )
             self.assertEqual(promotion_readiness["candidate_id"], "mutated-1")
             self.assertFalse(promotion_readiness["promotable"])
+
+    def test_run_strategy_autoresearch_loop_forwards_selected_replay_window(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            program_path, family_dir = self._write_program_fixture(root)
+            configmap_path = root / "strategy-configmap.yaml"
+            configmap_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "ConfigMap",
+                        "data": {"strategies.yaml": "strategies: []\n"},
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+            output_dir = root / "out"
+            response = {
+                "dataset_snapshot_receipt": {"snapshot_id": "snap-selected"},
+                "window": {
+                    "full_window_start_date": "2026-03-23",
+                    "full_window_end_date": "2026-03-23",
+                },
+                "top": [],
+            }
+            signal_rows = [
+                SignalEnvelope(
+                    event_ts=datetime(2026, 3, 23, 13, 30, tzinfo=UTC),
+                    symbol="AMAT",
+                    seq=1,
+                    source="ta",
+                    timeframe="1Sec",
+                    payload={"price": "180.10"},
+                ),
+                SignalEnvelope(
+                    event_ts=datetime(2026, 3, 23, 13, 31, tzinfo=UTC),
+                    symbol="NVDA",
+                    seq=2,
+                    source="ta",
+                    timeframe="1Sec",
+                    payload={"price": "900.10"},
+                ),
+            ]
+            selected_receipt = {
+                "schema_version": "torghut.replay-latest-complete-window.v1",
+                "status": "selected",
+                "selected_trading_days": ["2026-03-23"],
+            }
+            args = Namespace(
+                program=program_path,
+                output_dir=output_dir,
+                strategy_configmap=configmap_path,
+                family_template_dir=family_dir,
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity="31590.02",
+                chunk_minutes=10,
+                symbols="",
+                progress_log_seconds=30,
+                shadow_validation_artifact=None,
+                train_days=1,
+                holdout_days=1,
+                full_window_start_date="2026-03-20",
+                full_window_end_date="2026-03-24",
+                expected_last_trading_day="",
+                allow_stale_tape=False,
+                prefetch_full_window_rows=False,
+                replay_tape_path=None,
+                replay_tape_manifest=None,
+                materialize_replay_tape=True,
+                latest_complete_window_min_days=1,
+                latest_complete_window_receipt_output=None,
+                coverage_diagnostic_output=None,
+                min_executable_rows_per_symbol_day=10,
+                min_quote_valid_ratio="0.90",
+                max_coverage_spread_bps="50",
+                max_executable_gap_seconds=120,
+                max_frontier_runs=1,
+                json_output=None,
+            )
+
+            captured_frontier_args: list[Namespace] = []
+
+            def run_frontier(frontier_args: Namespace) -> dict[str, object]:
+                captured_frontier_args.append(frontier_args)
+                return response
+
+            with (
+                patch(
+                    "scripts.run_strategy_autoresearch_loop._select_effective_replay_tape_window",
+                    return_value=(
+                        date(2026, 3, 23),
+                        date(2026, 3, 23),
+                        selected_receipt,
+                    ),
+                ),
+                patch(
+                    "scripts.run_strategy_autoresearch_loop.replay_mod._iter_signal_rows",
+                    return_value=iter(signal_rows),
+                ),
+                patch(
+                    "scripts.run_strategy_autoresearch_loop.run_consistent_profitability_frontier",
+                    side_effect=run_frontier,
+                ),
+            ):
+                payload = runner.run_strategy_autoresearch_loop(args)
+
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(len(captured_frontier_args), 1)
+        self.assertEqual(
+            captured_frontier_args[0].full_window_start_date,
+            "2026-03-23",
+        )
+        self.assertEqual(
+            captured_frontier_args[0].full_window_end_date,
+            "2026-03-23",
+        )
+        self.assertEqual(
+            captured_frontier_args[0].expected_last_trading_day, "2026-03-23"
+        )
 
     def test_run_strategy_autoresearch_loop_records_missing_runtime_strategy_as_skip(
         self,


### PR DESCRIPTION
## Summary

- Read ClickHouse passwords from `TA_CLICKHOUSE_PASSWORD` / `CLICKHOUSE_PASSWORD` in the strategy autoresearch runner.
- Harden replay coverage diagnostics so nested ClickHouse unions aggregate numeric row counters reliably.
- Persist latest-complete-window diagnostics on missing-window failures and forward the selected effective replay window into frontier runs.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen --extra dev ruff format --check scripts/run_strategy_autoresearch_loop.py scripts/materialize_replay_tape.py tests/test_strategy_autoresearch.py tests/test_replay_tape.py`
- `uv run --frozen --extra dev ruff check scripts/run_strategy_autoresearch_loop.py scripts/materialize_replay_tape.py tests/test_strategy_autoresearch.py tests/test_replay_tape.py`
- `uv run --frozen --extra dev pytest tests/test_strategy_autoresearch.py tests/test_replay_tape.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Manual bounded run: `scripts/run_strategy_autoresearch_loop.py` against the local ClickHouse port-forward with `--latest-complete-window-min-days 4`, `--max-frontier-runs 3`, and `--max-candidates-per-frontier-run 4`. It completed and produced research-only candidate `ba92c47e6378ff8af9c7ae48` at `$83.35/day` post-cost on a relaxed four-day exploratory window; not promotable.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
