### PR TITLE
chore(torghut): promote image 613ef7ed

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-614-ge25ad00f0
+              value: v0.571.1-617-g613ef7ed1
             - name: TORGHUT_OPTIONS_COMMIT
-              value: e25ad00f08d4198c79890ae734a253c0937a1c9b
+              value: 613ef7ed12a908b0122ac652740fe0c982de652e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-614-ge25ad00f0
+              value: v0.571.1-617-g613ef7ed1
             - name: TORGHUT_OPTIONS_COMMIT
-              value: e25ad00f08d4198c79890ae734a253c0937a1c9b
+              value: 613ef7ed12a908b0122ac652740fe0c982de652e
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -75,7 +75,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+                  value: sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-23T01:35:57Z"
+        client.knative.dev/updateTimestamp: "2026-05-23T02:06:10Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
           ports:
             - name: http1
               containerPort: 8181
@@ -499,11 +499,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-614-ge25ad00f0
+              value: v0.571.1-617-g613ef7ed1
             - name: TORGHUT_COMMIT
-              value: e25ad00f08d4198c79890ae734a253c0937a1c9b
+              value: 613ef7ed12a908b0122ac652740fe0c982de652e
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+              value: sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-23T01:35:57Z"
+        client.knative.dev/updateTimestamp: "2026-05-23T02:06:10Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
           ports:
             - name: http1
               containerPort: 8181
@@ -320,11 +320,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-614-ge25ad00f0
+              value: v0.571.1-617-g613ef7ed1
             - name: TORGHUT_COMMIT
-              value: e25ad00f08d4198c79890ae734a253c0937a1c9b
+              value: 613ef7ed12a908b0122ac652740fe0c982de652e
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+              value: sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -132,7 +132,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:47b26fdb812b2f0b8043f6b321316b30c725c88d3b62d9b1f9689b7b39a205e7
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `613ef7ed12a908b0122ac652740fe0c982de652e`
- Image tag: `613ef7ed`
- Image digest: `sha256:6c91ec90597fa4768ed9637a54ffaa76e95c3e378f01676d930fb5faa37021da`