### PR TITLE
fix(torghut): enforce observed-day profit objective

### DIFF
--- a/services/torghut/app/trading/discovery/autoresearch.py
+++ b/services/torghut/app/trading/discovery/autoresearch.py
@@ -119,6 +119,7 @@ class StrategyObjective:
     require_every_day_active: bool
     min_regime_slice_pass_rate: Decimal
     stop_when_objective_met: bool
+    min_observed_trading_days: int = 0
     min_daily_net_pnl: Decimal = Decimal('0')
     min_profit_factor: Decimal = Decimal('1.50')
     max_gross_exposure_pct_equity: Decimal = Decimal('999999999')
@@ -148,6 +149,7 @@ class StrategyObjective:
             'require_every_day_active': self.require_every_day_active,
             'min_regime_slice_pass_rate': str(self.min_regime_slice_pass_rate),
             'stop_when_objective_met': self.stop_when_objective_met,
+            'min_observed_trading_days': self.min_observed_trading_days,
             'max_gross_exposure_pct_equity': str(self.max_gross_exposure_pct_equity),
             'min_cash': str(self.min_cash),
             'default_start_equity': str(self.default_start_equity),
@@ -518,6 +520,10 @@ def load_strategy_autoresearch_program(
             default='0.35',
         ),
         stop_when_objective_met=bool(objective_payload.get('stop_when_objective_met', False)),
+        min_observed_trading_days=max(
+            0,
+            int(objective_payload.get('min_observed_trading_days', 0)),
+        ),
         max_gross_exposure_pct_equity=_coerce_decimal(
             objective_payload.get('max_gross_exposure_pct_equity'),
             default='999999999',
@@ -993,6 +999,8 @@ def candidate_meets_objective(
     min_cash = _coerce_decimal(scorecard.get('min_cash') or full_window.get('min_cash'), default='0')
     trading_day_count = int(full_window.get('trading_day_count') or 0)
     active_days = int(full_window.get('active_days') or 0)
+    if objective.min_observed_trading_days > 0 and trading_day_count < objective.min_observed_trading_days:
+        return False
     start_equity = _objective_start_equity(scorecard, full_window, objective)
     total_net_pnl = _objective_total_net_pnl(
         scorecard=scorecard,

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -1380,6 +1380,7 @@ def _portfolio_oracle_policy(
         max_gross_exposure_pct_equity=objective.max_gross_exposure_pct_equity,
         min_cash=objective.min_cash,
         min_avg_filled_notional_per_day=objective.min_daily_notional,
+        min_observed_trading_days=objective.min_observed_trading_days,
         min_regime_slice_pass_rate=objective.min_regime_slice_pass_rate,
         require_shadow_parity_within_budget=True,
         require_executable_replay=True,

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -1171,6 +1171,7 @@ class TestStrategyAutoresearch(TestCase):
             program.objective.max_gross_exposure_pct_equity, Decimal("1.0")
         )
         self.assertEqual(program.objective.min_cash, Decimal("0"))
+        self.assertEqual(program.objective.min_observed_trading_days, 20)
         self.assertEqual(program.replay_budget.staged_train_screen_multiplier, 3)
 
         policy = runner._portfolio_oracle_policy(program)
@@ -1185,6 +1186,7 @@ class TestStrategyAutoresearch(TestCase):
         self.assertEqual(policy.min_total_net_pnl_to_drawdown_ratio, Decimal("3.00"))
         self.assertEqual(policy.max_gross_exposure_pct_equity, Decimal("1.0"))
         self.assertEqual(policy.min_cash, Decimal("0"))
+        self.assertEqual(policy.min_observed_trading_days, 20)
 
     def test_checked_in_500_portfolio_profit_program_includes_reversal_surfaces(
         self,
@@ -1771,6 +1773,47 @@ class TestStrategyAutoresearch(TestCase):
         weak_day = copy.deepcopy(candidate)
         weak_day["full_window"]["daily_net"]["2026-04-02"] = "299.99"
         self.assertFalse(candidate_meets_objective(weak_day, objective=objective))
+
+    def test_candidate_meets_objective_requires_configured_observed_days(
+        self,
+    ) -> None:
+        objective = StrategyObjective(
+            target_net_pnl_per_day=Decimal("500"),
+            min_active_day_ratio=Decimal("0.80"),
+            min_positive_day_ratio=Decimal("0.55"),
+            min_daily_notional=Decimal("300000"),
+            max_best_day_share=Decimal("0.35"),
+            max_worst_day_loss=Decimal("450"),
+            max_drawdown=Decimal("1000"),
+            require_every_day_active=False,
+            min_regime_slice_pass_rate=Decimal("0.40"),
+            stop_when_objective_met=False,
+            min_observed_trading_days=20,
+            max_gross_exposure_pct_equity=Decimal("1.50"),
+            min_cash=Decimal("0"),
+        )
+        candidate = {
+            "hard_vetoes": [],
+            "objective_scorecard": {
+                "net_pnl_per_day": "600",
+                "active_day_ratio": "0.90",
+                "positive_day_ratio": "0.60",
+                "avg_filled_notional_per_day": "350000",
+                "best_day_share": "0.30",
+                "worst_day_loss": "300",
+                "max_drawdown": "900",
+                "regime_slice_pass_rate": "0.45",
+                "max_gross_exposure_pct_equity": "1.25",
+                "min_cash": "2500",
+            },
+            "full_window": {"trading_day_count": 4, "active_days": 4},
+        }
+        self.assertFalse(candidate_meets_objective(candidate, objective=objective))
+
+        enough_days = copy.deepcopy(candidate)
+        enough_days["full_window"]["trading_day_count"] = 20
+        enough_days["full_window"]["active_days"] = 18
+        self.assertTrue(candidate_meets_objective(enough_days, objective=objective))
 
     def test_write_autoresearch_notebooks_outputs_ipynb_files(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Parse `objective.min_observed_trading_days` into the strategy autoresearch objective.
- Enforce the configured observed trading-day horizon before a replay candidate can mark the objective met.
- Forward the same horizon into the portfolio profit oracle so loop-level and portfolio-level proof gates agree.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen --extra dev ruff check app/trading/discovery/autoresearch.py scripts/run_strategy_autoresearch_loop.py tests/test_strategy_autoresearch.py`
- `uv run --frozen --extra dev pytest tests/test_strategy_autoresearch.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
