### PR TITLE
fix(torghut): quarantine legacy runtime pnl basis

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -32,7 +32,6 @@ US_EQUITIES_REGULAR_OPEN = time(hour=9, minute=30)
 US_EQUITIES_REGULAR_CLOSE = time(hour=16, minute=0)
 PROMOTION_GRADE_POST_COST_BASES = frozenset(
     {
-        "realized_strategy_pnl",
         "realized_strategy_pnl_after_explicit_costs",
     }
 )

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -124,6 +124,40 @@ class TestRuntimeWindowImport(TestCase):
             {"simulation_report_net_pnl": 1},
         )
 
+    def test_build_observed_runtime_buckets_rejects_legacy_realized_pnl_basis(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    6,
+                )
+            ],
+            decision_times=[datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+            execution_times=[datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("4"),
+                    "post_cost_expectancy_bps": Decimal("50"),
+                    "post_cost_expectancy_basis": "realized_strategy_pnl",
+                    "post_cost_promotion_eligible": True,
+                }
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        self.assertEqual(buckets[0].post_cost_expectancy_bps, Decimal("0"))
+        self.assertEqual(buckets[0].post_cost_promotion_sample_count, 0)
+        self.assertEqual(
+            buckets[0].post_cost_basis_counts,
+            {"realized_strategy_pnl": 1},
+        )
+
     def test_build_observed_runtime_buckets_weights_runtime_ledger_by_notional(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Remove the legacy `realized_strategy_pnl` basis from runtime-window promotion-grade post-cost evidence.
- Keep `realized_strategy_pnl_after_explicit_costs` as the only runtime-window basis that can satisfy post-cost promotion samples.
- Add a regression test proving explicitly flagged legacy realized PnL is still quarantined and cannot set bucket expectancy.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen --extra dev ruff check app/trading/runtime_window_import.py tests/test_runtime_window_import.py`
- `uv run --frozen --extra dev pytest tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
