### PR TITLE
fix(torghut): require ledger proof for simulation observations

### DIFF
--- a/services/torghut/app/trading/autonomy/lane.py
+++ b/services/torghut/app/trading/autonomy/lane.py
@@ -6068,6 +6068,25 @@ def _runtime_observation_contract_payload(
     return {}
 
 
+def _runtime_observation_has_ledger_profit_proof(
+    runtime_observation_payload: Mapping[str, Any],
+) -> bool:
+    if bool(runtime_observation_payload.get('runtime_ledger_profit_proof_present')):
+        return True
+    artifact_fill_count = _decimal_or_zero(
+        runtime_observation_payload.get('runtime_ledger_artifact_fill_count')
+    )
+    artifact_row_count = _decimal_or_zero(
+        runtime_observation_payload.get('runtime_ledger_artifact_row_count')
+    )
+    artifact_tca_row_count = _decimal_or_zero(
+        runtime_observation_payload.get('runtime_ledger_artifact_tca_row_count')
+    )
+    return artifact_fill_count > 0 and (
+        artifact_row_count > 0 or artifact_tca_row_count > 0
+    )
+
+
 def _resolve_hypothesis_window_evidence(
     *,
     promotion_target: str,
@@ -6091,10 +6110,21 @@ def _resolve_hypothesis_window_evidence(
     runtime_observation_authoritative = bool(
         runtime_observation_payload.get('authoritative')
     )
+    runtime_observation_source_kind = _coerce_str(
+        runtime_observation_payload.get('source_kind')
+    )
+    runtime_observation_has_runtime_ledger_profit_proof = (
+        _runtime_observation_has_ledger_profit_proof(runtime_observation_payload)
+    )
+    simulation_observation_without_runtime_ledger_profit_proof = (
+        runtime_observation_source_kind.startswith('simulation_')
+        and not runtime_observation_has_runtime_ledger_profit_proof
+    )
     qualified_runtime_observation = (
         runtime_observation_authoritative
         and runtime_observation_stage == observed_stage
         and runtime_observation_provenance == expected_provenance
+        and not simulation_observation_without_runtime_ledger_profit_proof
     )
     if qualified_runtime_observation:
         evidence_provenance = expected_provenance
@@ -6120,7 +6150,11 @@ def _resolve_hypothesis_window_evidence(
             else 'uncalibrated'
         )
         capital_stage = 'shadow'
-        qualification_reason = 'runtime_observation_contract_missing_or_ineligible'
+        qualification_reason = (
+            'simulation_runtime_without_runtime_ledger_profit_proof'
+            if simulation_observation_without_runtime_ledger_profit_proof
+            else 'runtime_observation_contract_missing_or_ineligible'
+        )
     return (
         evidence_provenance,
         evidence_maturity,
@@ -6131,6 +6165,10 @@ def _resolve_hypothesis_window_evidence(
             'runtime_observation_authoritative': runtime_observation_authoritative,
             'runtime_observation_stage': runtime_observation_stage,
             'runtime_observation_provenance': runtime_observation_provenance,
+            'runtime_observation_source_kind': runtime_observation_source_kind,
+            'runtime_observation_has_runtime_ledger_profit_proof': (
+                runtime_observation_has_runtime_ledger_profit_proof
+            ),
             'qualified_runtime_observation': qualified_runtime_observation,
             'qualification_reason': qualification_reason,
         },

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -252,6 +252,57 @@ def _nonnegative_int(value: Any) -> int:
         return 0
 
 
+def _runtime_ledger_profit_proof_present(
+    tca_rows: list[dict[str, object]],
+) -> bool:
+    for row in tca_rows:
+        if row.get("post_cost_expectancy_basis") != POST_COST_BASIS_RUNTIME_LEDGER:
+            continue
+        bucket = row.get("runtime_ledger_bucket")
+        if not isinstance(bucket, Mapping):
+            continue
+        filled_notional = _decimal_or_none(bucket.get("filled_notional"))
+        if (
+            _nonnegative_int(bucket.get("fill_count")) <= 0
+            or filled_notional is None
+            or filled_notional <= 0
+            or bucket.get("post_cost_expectancy_bps") is None
+            or bucket.get("blockers")
+        ):
+            continue
+        return True
+    return False
+
+
+def _runtime_observation_authority_payload(
+    *,
+    source_kind: str,
+    tca_rows: list[dict[str, object]],
+) -> dict[str, object]:
+    has_runtime_ledger_profit_proof = _runtime_ledger_profit_proof_present(tca_rows)
+    if source_kind.startswith("simulation_") and not has_runtime_ledger_profit_proof:
+        return {
+            "authoritative": False,
+            "authority_reason": "simulation_runtime_without_runtime_ledger_profit_proof",
+            "promotion_authority": "blocked",
+            "runtime_ledger_profit_proof_present": False,
+        }
+    return {
+        "authoritative": True,
+        "authority_reason": (
+            "runtime_ledger_profit_proof"
+            if has_runtime_ledger_profit_proof
+            else "observed_runtime_activity"
+        ),
+        "promotion_authority": (
+            "runtime_ledger"
+            if has_runtime_ledger_profit_proof
+            else "observed_runtime_activity"
+        ),
+        "runtime_ledger_profit_proof_present": has_runtime_ledger_profit_proof,
+    }
+
+
 def _strategy_name_candidates(*values: str | None) -> list[str]:
     candidates: list[str] = []
     for value in values:
@@ -589,6 +640,11 @@ def _runtime_ledger_tca_rows_from_artifacts(
         "runtime_ledger_artifact_refs": loaded_refs,
         "runtime_ledger_ignored_artifact_refs": ignored_refs,
         "runtime_ledger_artifact_row_count": len(ledger_rows),
+        "runtime_ledger_artifact_fill_count": sum(
+            1
+            for row in ledger_rows
+            if _runtime_ledger_event_type(row) in _RUNTIME_LEDGER_FILL_EVENTS
+        ),
         "runtime_ledger_artifact_tca_row_count": len(tca_rows),
     }
     return decision_times, execution_times, tca_rows, metadata
@@ -832,6 +888,7 @@ def main() -> int:
         "runtime_ledger_artifact_refs": [],
         "runtime_ledger_ignored_artifact_refs": [],
         "runtime_ledger_artifact_row_count": 0,
+        "runtime_ledger_artifact_fill_count": 0,
         "runtime_ledger_artifact_tca_row_count": 0,
     }
     if artifact_refs:
@@ -932,7 +989,10 @@ def main() -> int:
         "simulation_paper_runtime" if args.observed_stage == "paper" else "live_runtime"
     )
     runtime_observation_payload = {
-        "authoritative": True,
+        **_runtime_observation_authority_payload(
+            source_kind=source_kind,
+            tca_rows=tca_rows,
+        ),
         "observed_stage": args.observed_stage,
         "evidence_provenance": evidence_provenance,
         "source_kind": source_kind,

--- a/services/torghut/tests/test_autonomous_lane.py
+++ b/services/torghut/tests/test_autonomous_lane.py
@@ -25,6 +25,7 @@ from app.trading.autonomy.lane import (
     _resolve_paper_patch_path,
     _resolve_gate_forecast_metrics,
     _resolve_gate_fragility_inputs,
+    _resolve_hypothesis_window_evidence,
     run_autonomous_lane,
     upsert_autonomy_no_signal_run,
 )
@@ -114,6 +115,86 @@ class TestAutonomousLane(TestCase):
         train.to_csv(train_path)
         test.to_csv(test_path)
         return train_path, test_path
+
+    def test_runtime_observation_evidence_blocks_simulation_without_ledger_profit_proof(
+        self,
+    ) -> None:
+        _, _, capital_stage, qualification = _resolve_hypothesis_window_evidence(
+            promotion_target="paper",
+            runtime_observation_payload={
+                "authoritative": True,
+                "observed_stage": "paper",
+                "evidence_provenance": "paper_runtime_observed",
+                "source_kind": "simulation_paper_runtime",
+            },
+            effective_promotion_allowed=True,
+            order_count=24,
+            min_sample_count_for_scale_up=20,
+        )
+
+        self.assertEqual(capital_stage, "shadow")
+        self.assertEqual(
+            qualification["qualification_reason"],
+            "simulation_runtime_without_runtime_ledger_profit_proof",
+        )
+        self.assertEqual(
+            qualification["runtime_observation_has_runtime_ledger_profit_proof"],
+            False,
+        )
+        self.assertFalse(qualification["qualified_runtime_observation"])
+
+    def test_runtime_observation_evidence_accepts_simulation_with_ledger_profit_proof(
+        self,
+    ) -> None:
+        provenance, maturity, capital_stage, qualification = (
+            _resolve_hypothesis_window_evidence(
+                promotion_target="paper",
+                runtime_observation_payload={
+                    "authoritative": True,
+                    "observed_stage": "paper",
+                    "evidence_provenance": "paper_runtime_observed",
+                    "source_kind": "simulation_exact_replay_runtime_ledger",
+                    "runtime_ledger_artifact_row_count": 8,
+                    "runtime_ledger_artifact_fill_count": 2,
+                },
+                effective_promotion_allowed=True,
+                order_count=24,
+                min_sample_count_for_scale_up=20,
+            )
+        )
+
+        self.assertEqual(provenance, "paper_runtime_observed")
+        self.assertEqual(maturity, "empirically_validated")
+        self.assertEqual(capital_stage, "shadow")
+        self.assertEqual(
+            qualification["runtime_observation_has_runtime_ledger_profit_proof"],
+            True,
+        )
+        self.assertTrue(qualification["qualified_runtime_observation"])
+
+    def test_runtime_observation_evidence_accepts_explicit_ledger_profit_proof_flag(
+        self,
+    ) -> None:
+        provenance, _, _, qualification = _resolve_hypothesis_window_evidence(
+            promotion_target="paper",
+            runtime_observation_payload={
+                "authoritative": True,
+                "observed_stage": "paper",
+                "evidence_provenance": "paper_runtime_observed",
+                "source_kind": "simulation_exact_replay_runtime_ledger",
+                "runtime_ledger_profit_proof_present": True,
+            },
+            effective_promotion_allowed=False,
+            order_count=0,
+            min_sample_count_for_scale_up=20,
+        )
+
+        self.assertEqual(provenance, "paper_runtime_observed")
+        self.assertEqual(
+            qualification["runtime_observation_has_runtime_ledger_profit_proof"],
+            True,
+        )
+        self.assertTrue(qualification["qualified_runtime_observation"])
 
     def test_gate_forecast_metrics_fail_closed_for_non_authoritative_router_outputs(self) -> None:
         signals = [

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -23,6 +23,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _parse_target_metadata,
     _query_timestamps,
     _runtime_ledger_event_type,
+    _runtime_ledger_profit_proof_present,
     _runtime_ledger_tca_rows_from_artifacts,
     _strategy_name_candidates,
     main,
@@ -148,6 +149,41 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             args.target_metadata_json, '{"paper_probation_authorized":true}'
         )
         self.assertEqual(args.json, True)
+
+    def test_runtime_ledger_profit_proof_rejects_malformed_bucket_payload(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _runtime_ledger_profit_proof_present(
+                [
+                    {
+                        "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+                        "runtime_ledger_bucket": "not-a-bucket",
+                    }
+                ]
+            ),
+            False,
+        )
+
+    def test_runtime_ledger_profit_proof_rejects_incomplete_bucket_payload(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _runtime_ledger_profit_proof_present(
+                [
+                    {
+                        "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+                        "runtime_ledger_bucket": {
+                            "fill_count": 0,
+                            "filled_notional": "0",
+                            "post_cost_expectancy_bps": None,
+                            "blockers": ["runtime_ledger_filled_notional_zero"],
+                        },
+                    }
+                ]
+            ),
+            False,
+        )
 
     def test_parse_target_metadata_requires_json_mapping(self) -> None:
         self.assertEqual(_parse_target_metadata(""), {})
@@ -1062,6 +1098,13 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             runtime_payload["runtime_ledger_artifact_refs"], [str(artifact_path)]
         )
         self.assertEqual(runtime_payload["runtime_ledger_artifact_row_count"], 6)
+        self.assertEqual(runtime_payload["runtime_ledger_artifact_fill_count"], 2)
+        self.assertEqual(
+            runtime_payload["authority_reason"], "runtime_ledger_profit_proof"
+        )
+        self.assertEqual(runtime_payload["promotion_authority"], "runtime_ledger")
+        self.assertEqual(runtime_payload["runtime_ledger_profit_proof_present"], True)
+        self.assertEqual(runtime_payload["authoritative"], True)
 
     def test_main_attaches_delay_adjusted_depth_report_to_runtime_payload(
         self,
@@ -1160,6 +1203,13 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             "2026-03-06T15:20:00Z",
         )
         self.assertIn(str(report_path), runtime_payload["artifact_refs"])
+        self.assertEqual(runtime_payload["authoritative"], False)
+        self.assertEqual(
+            runtime_payload["authority_reason"],
+            "simulation_runtime_without_runtime_ledger_profit_proof",
+        )
+        self.assertEqual(runtime_payload["promotion_authority"], "blocked")
+        self.assertEqual(runtime_payload["runtime_ledger_profit_proof_present"], False)
 
     def test_main_quarantines_report_runtime_pnl_when_tca_rows_are_empty(self) -> None:
         with TemporaryDirectory() as temp_dir:
@@ -1262,3 +1312,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             runtime_payload["report_post_cost_expectancy_basis"],
             POST_COST_BASIS_SIMULATION_REPORT,
         )
+        self.assertEqual(runtime_payload["authoritative"], False)
+        self.assertEqual(
+            runtime_payload["authority_reason"],
+            "simulation_runtime_without_runtime_ledger_profit_proof",
+        )
+        self.assertEqual(runtime_payload["promotion_authority"], "blocked")
+        self.assertEqual(runtime_payload["runtime_ledger_profit_proof_present"], False)


### PR DESCRIPTION
## Summary

- Require runtime-window import payloads from simulation sources to include runtime-ledger profit proof before they are marked authoritative.
- Persist runtime-ledger artifact fill counts and explicit authority metadata on runtime observation payloads.
- Make the autonomous lane fail closed for older simulation runtime-observation payloads that claim authority without ledger fill proof.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen --extra dev ruff check scripts/import_hypothesis_runtime_windows.py app/trading/autonomy/lane.py tests/test_import_hypothesis_runtime_windows.py tests/test_autonomous_lane.py`
- `uv run --frozen --extra dev pytest tests/test_import_hypothesis_runtime_windows.py tests/test_autonomous_lane.py::TestAutonomousLane::test_runtime_observation_evidence_blocks_simulation_without_ledger_profit_proof tests/test_autonomous_lane.py::TestAutonomousLane::test_runtime_observation_evidence_accepts_simulation_with_ledger_profit_proof tests/test_autonomous_lane.py::TestAutonomousLane::test_runtime_observation_evidence_accepts_explicit_ledger_profit_proof_flag -q`
- `uv run --frozen --extra dev pytest tests/test_import_hypothesis_runtime_windows.py tests/test_autonomous_lane.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
