### PR TITLE
fix(torghut): import durable runtime ledger proof

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -26,6 +26,7 @@ from .hypotheses import (
     HypothesisRegistryLoadResult,
     load_hypothesis_registry,
 )
+from .runtime_ledger import EXACT_REPLAY_LEDGER_SCHEMA_VERSION, POST_COST_PNL_BASIS
 
 US_EQUITIES_REGULAR_TIMEZONE = "America/New_York"
 US_EQUITIES_REGULAR_OPEN = time(hour=9, minute=30)
@@ -37,6 +38,12 @@ PROMOTION_GRADE_POST_COST_BASES = frozenset(
 )
 LIVE_PROMOTION_GRADE_POST_COST_BASES = frozenset(
     {"realized_strategy_pnl_after_explicit_costs"}
+)
+RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
+    {
+        EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+        "torghut.runtime-ledger-bucket.v1",
+    }
 )
 
 
@@ -195,6 +202,63 @@ def _mapping(value: Any) -> dict[str, Any]:
     return {str(key): item for key, item in mapping.items()}
 
 
+def _hash_count(value: Any) -> int:
+    if not isinstance(value, Mapping):
+        return 0
+    mapping = cast(Mapping[object, object], value)
+    return sum(1 for key in mapping.keys() if str(key).strip())
+
+
+def _runtime_ledger_bucket_blockers(bucket: Mapping[str, Any]) -> list[str]:
+    blockers = _string_list(bucket.get("blockers"))
+    ledger_schema_version = _text(bucket.get("ledger_schema_version"))
+    pnl_basis = _text(bucket.get("pnl_basis"))
+    filled_notional = _optional_decimal(bucket.get("filled_notional"))
+    cost_amount = _optional_decimal(bucket.get("cost_amount"))
+    post_cost_expectancy = _optional_decimal(bucket.get("post_cost_expectancy_bps"))
+
+    if ledger_schema_version is None:
+        blockers.append("runtime_ledger_schema_version_missing")
+    elif ledger_schema_version not in RUNTIME_LEDGER_BUCKET_SCHEMAS:
+        blockers.append("runtime_ledger_schema_version_invalid")
+    if pnl_basis is None:
+        blockers.append("runtime_ledger_pnl_basis_missing")
+    elif pnl_basis != POST_COST_PNL_BASIS:
+        blockers.append("runtime_ledger_pnl_basis_invalid")
+    if _observation_int(bucket.get("fill_count")) <= 0:
+        blockers.append("runtime_fills_missing")
+    if _observation_int(bucket.get("decision_count")) <= 0:
+        blockers.append("runtime_decision_lifecycle_missing")
+    if _observation_int(bucket.get("submitted_order_count")) <= 0:
+        blockers.append("submitted_order_lifecycle_missing")
+    if _observation_int(bucket.get("closed_trade_count")) <= 0:
+        blockers.append("closed_round_trip_missing")
+    if bucket.get("open_position_count") is None:
+        blockers.append("runtime_ledger_open_position_count_missing")
+    elif _observation_int(bucket.get("open_position_count")) > 0:
+        blockers.append("unclosed_position")
+    if filled_notional is None or filled_notional <= 0:
+        blockers.append("filled_notional_missing")
+    if cost_amount is None or cost_amount < 0:
+        blockers.append("explicit_cost_missing")
+    if post_cost_expectancy is None:
+        blockers.append("runtime_ledger_expectancy_missing")
+    if _hash_count(bucket.get("execution_policy_hash_counts")) <= 0:
+        blockers.append("runtime_ledger_execution_policy_hash_missing")
+    if _hash_count(bucket.get("cost_model_hash_counts")) <= 0:
+        blockers.append("runtime_ledger_cost_model_hash_missing")
+    if _hash_count(bucket.get("lineage_hash_counts")) <= 0:
+        blockers.append("runtime_ledger_lineage_hash_missing")
+    return list(dict.fromkeys(blockers))
+
+
+def _runtime_ledger_bucket_payload(value: Any) -> dict[str, Any]:
+    bucket = _mapping(value)
+    if not bucket:
+        return {}
+    return {**bucket, "blockers": _runtime_ledger_bucket_blockers(bucket)}
+
+
 def _runtime_ledger_post_cost_from_rows(
     rows: Sequence[_NormalizedTcaRow],
 ) -> tuple[Decimal | None, Decimal, Decimal, int]:
@@ -207,7 +271,7 @@ def _runtime_ledger_post_cost_from_rows(
             or row.post_cost_expectancy_basis
             != "realized_strategy_pnl_after_explicit_costs"
             or not row.runtime_ledger_bucket
-            or _string_list(row.runtime_ledger_bucket.get("blockers"))
+            or _runtime_ledger_bucket_blockers(row.runtime_ledger_bucket)
         ):
             continue
         net_pnl = _optional_decimal(
@@ -656,7 +720,9 @@ def build_observed_runtime_buckets(
                     basis=basis,
                     explicit_value=row.get("post_cost_promotion_eligible"),
                 ),
-                runtime_ledger_bucket=_mapping(row.get("runtime_ledger_bucket")),
+                runtime_ledger_bucket=_runtime_ledger_bucket_payload(
+                    row.get("runtime_ledger_bucket")
+                ),
             )
         )
 
@@ -673,9 +739,24 @@ def build_observed_runtime_buckets(
             for row in normalized_tca_rows
             if bucket_start <= row.computed_at < bucket_end
         ]
-        decision_count = len(decisions)
-        trade_count = len(executions)
-        order_count = len(executions)
+        runtime_ledger_decision_count = sum(
+            _observation_int(row.runtime_ledger_bucket.get("decision_count"))
+            for row in bucket_tca
+            if row.runtime_ledger_bucket
+        )
+        runtime_ledger_trade_count = sum(
+            _observation_int(row.runtime_ledger_bucket.get("fill_count"))
+            for row in bucket_tca
+            if row.runtime_ledger_bucket
+        )
+        runtime_ledger_order_count = sum(
+            _observation_int(row.runtime_ledger_bucket.get("submitted_order_count"))
+            for row in bucket_tca
+            if row.runtime_ledger_bucket
+        )
+        decision_count = max(len(decisions), runtime_ledger_decision_count)
+        trade_count = max(len(executions), runtime_ledger_trade_count)
+        order_count = max(len(executions), runtime_ledger_order_count)
         if decision_count <= 0 and trade_count <= 0:
             decision_alignment_ratio = Decimal("1")
         elif decision_count <= 0:
@@ -776,12 +857,15 @@ def _runtime_ledger_bucket_payloads(payload: Mapping[str, Any]) -> list[dict[str
     if isinstance(raw_payloads, Sequence) and not isinstance(
         raw_payloads, (str, bytes, bytearray)
     ):
-        return [
-            _mapping(item)
-            for item in cast(Sequence[object], raw_payloads)
-            if _mapping(item)
-        ]
-    single_payload = _mapping(payload.get("runtime_ledger_bucket"))
+        payloads: list[dict[str, Any]] = []
+        for item in cast(Sequence[object], raw_payloads):
+            payload = _runtime_ledger_bucket_payload(item)
+            if payload:
+                payloads.append(payload)
+        return payloads
+    single_payload = _runtime_ledger_bucket_payload(
+        payload.get("runtime_ledger_bucket")
+    )
     return [single_payload] if single_payload else []
 
 
@@ -793,11 +877,7 @@ def _runtime_ledger_post_cost_from_observed_buckets(
     sample_count = 0
     for bucket in buckets:
         for ledger_payload in _runtime_ledger_bucket_payloads(bucket.payload_json):
-            if _text(
-                ledger_payload.get("pnl_basis")
-            ) != "realized_strategy_pnl_after_explicit_costs" or _string_list(
-                ledger_payload.get("blockers")
-            ):
+            if _runtime_ledger_bucket_blockers(ledger_payload):
                 continue
             net_pnl = _optional_decimal(
                 ledger_payload.get("net_strategy_pnl_after_costs")

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -12,8 +12,11 @@ from pathlib import Path
 from typing import Any, Mapping
 
 import psycopg
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from app.db import SessionLocal
+from app.models import StrategyRuntimeLedgerBucket
 from app.trading.runtime_ledger import (
     EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
     POST_COST_PNL_BASIS,
@@ -40,6 +43,12 @@ RUNTIME_LEDGER_ARTIFACT_SCHEMAS = frozenset(
     {
         EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
         "torghut.exact_replay_ledger.rows.v1",
+    }
+)
+RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
+    {
+        EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+        "torghut.runtime-ledger-bucket.v1",
     }
 )
 _RUNTIME_LEDGER_DECISION_EVENTS = frozenset(
@@ -213,14 +222,58 @@ def _runtime_ledger_bucket_payload(bucket: RuntimeLedgerBucket) -> dict[str, obj
     }
 
 
+def _mapping_hash_count(value: object) -> int:
+    if not isinstance(value, Mapping):
+        return 0
+    return sum(1 for key in value.keys() if str(key).strip())
+
+
+def _runtime_ledger_bucket_profit_proof_present(
+    bucket: Mapping[str, object],
+) -> bool:
+    filled_notional = _decimal_or_none(bucket.get("filled_notional"))
+    cost_amount = _decimal_or_none(bucket.get("cost_amount"))
+    post_cost_expectancy = _decimal_or_none(bucket.get("post_cost_expectancy_bps"))
+    if bucket.get("pnl_basis") != POST_COST_BASIS_RUNTIME_LEDGER:
+        return False
+    if bucket.get("ledger_schema_version") not in RUNTIME_LEDGER_BUCKET_SCHEMAS:
+        return False
+    if bucket.get("blockers"):
+        return False
+    if _nonnegative_int(bucket.get("fill_count")) <= 0:
+        return False
+    if _nonnegative_int(bucket.get("decision_count")) <= 0:
+        return False
+    if _nonnegative_int(bucket.get("submitted_order_count")) <= 0:
+        return False
+    if _nonnegative_int(bucket.get("closed_trade_count")) <= 0:
+        return False
+    if bucket.get("open_position_count") is None:
+        return False
+    if _nonnegative_int(bucket.get("open_position_count")) > 0:
+        return False
+    if filled_notional is None or filled_notional <= 0:
+        return False
+    if cost_amount is None or cost_amount < 0:
+        return False
+    if post_cost_expectancy is None:
+        return False
+    if _mapping_hash_count(bucket.get("execution_policy_hash_counts")) <= 0:
+        return False
+    if _mapping_hash_count(bucket.get("cost_model_hash_counts")) <= 0:
+        return False
+    if _mapping_hash_count(bucket.get("lineage_hash_counts")) <= 0:
+        return False
+    return True
+
+
 def _runtime_ledger_tca_row_from_bucket(
     *,
     bucket: RuntimeLedgerBucket,
     computed_at: datetime | None = None,
 ) -> dict[str, object]:
-    promotion_eligible = (
-        bucket.post_cost_expectancy_bps is not None and not bucket.blockers
-    )
+    payload = _runtime_ledger_bucket_payload(bucket)
+    promotion_eligible = _runtime_ledger_bucket_profit_proof_present(payload)
     return {
         "computed_at": computed_at
         or max(
@@ -241,7 +294,7 @@ def _runtime_ledger_tca_row_from_bucket(
         "runtime_ledger_blockers": bucket.blockers,
         "runtime_ledger_cost_basis_counts": bucket.cost_basis_counts,
         "runtime_ledger_pnl_basis": bucket.pnl_basis,
-        "runtime_ledger_bucket": _runtime_ledger_bucket_payload(bucket),
+        "runtime_ledger_bucket": payload,
     }
 
 
@@ -261,16 +314,8 @@ def _runtime_ledger_profit_proof_present(
         bucket = row.get("runtime_ledger_bucket")
         if not isinstance(bucket, Mapping):
             continue
-        filled_notional = _decimal_or_none(bucket.get("filled_notional"))
-        if (
-            _nonnegative_int(bucket.get("fill_count")) <= 0
-            or filled_notional is None
-            or filled_notional <= 0
-            or bucket.get("post_cost_expectancy_bps") is None
-            or bucket.get("blockers")
-        ):
-            continue
-        return True
+        if _runtime_ledger_bucket_profit_proof_present(bucket):
+            return True
     return False
 
 
@@ -650,6 +695,148 @@ def _runtime_ledger_tca_rows_from_artifacts(
     return decision_times, execution_times, tca_rows, metadata
 
 
+def _runtime_ledger_bucket_payload_from_row(
+    row: StrategyRuntimeLedgerBucket,
+) -> dict[str, object]:
+    return {
+        "run_id": row.run_id,
+        "candidate_id": row.candidate_id,
+        "hypothesis_id": row.hypothesis_id,
+        "observed_stage": row.observed_stage,
+        "bucket_started_at": row.bucket_started_at.isoformat(),
+        "bucket_ended_at": row.bucket_ended_at.isoformat(),
+        "account_label": row.account_label,
+        "strategy_id": row.runtime_strategy_name,
+        "runtime_strategy_name": row.runtime_strategy_name,
+        "strategy_family": row.strategy_family,
+        "fill_count": row.fill_count,
+        "decision_count": row.decision_count,
+        "submitted_order_count": row.submitted_order_count,
+        "cancelled_order_count": row.cancelled_order_count,
+        "rejected_order_count": row.rejected_order_count,
+        "unfilled_order_count": row.unfilled_order_count,
+        "closed_trade_count": row.closed_trade_count,
+        "open_position_count": row.open_position_count,
+        "filled_notional": str(row.filled_notional),
+        "gross_strategy_pnl": str(row.gross_strategy_pnl),
+        "cost_amount": str(row.cost_amount),
+        "net_strategy_pnl_after_costs": str(row.net_strategy_pnl_after_costs),
+        "post_cost_expectancy_bps": (
+            str(row.post_cost_expectancy_bps)
+            if row.post_cost_expectancy_bps is not None
+            else None
+        ),
+        "execution_policy_hash_counts": row.execution_policy_hash_counts or {},
+        "cost_model_hash_counts": row.cost_model_hash_counts or {},
+        "lineage_hash_counts": row.lineage_hash_counts or {},
+        "blockers": row.blockers_json or [],
+        "ledger_schema_version": row.ledger_schema_version,
+        "pnl_basis": row.pnl_basis,
+    }
+
+
+def _runtime_ledger_tca_row_from_payload(
+    *,
+    payload: Mapping[str, object],
+) -> dict[str, object]:
+    bucket_started_at = _parse_dt_or_none(payload.get("bucket_started_at"))
+    bucket_ended_at = _parse_dt_or_none(payload.get("bucket_ended_at"))
+    computed_at = (
+        bucket_ended_at - timedelta(microseconds=1)
+        if bucket_ended_at is not None
+        else bucket_started_at
+    )
+    filled_notional = _decimal_or_none(payload.get("filled_notional"))
+    cost_amount = _decimal_or_none(payload.get("cost_amount"))
+    return {
+        "computed_at": computed_at or datetime.now(timezone.utc),
+        "abs_slippage_bps": (
+            (cost_amount / filled_notional) * Decimal("10000")
+            if cost_amount is not None
+            and filled_notional is not None
+            and filled_notional > 0
+            else None
+        ),
+        "post_cost_expectancy_bps": _decimal_or_none(
+            payload.get("post_cost_expectancy_bps")
+        ),
+        "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+        "post_cost_promotion_eligible": _runtime_ledger_bucket_profit_proof_present(
+            payload
+        ),
+        "realized_gross_pnl": _decimal_or_none(payload.get("gross_strategy_pnl")),
+        "realized_net_pnl": _decimal_or_none(
+            payload.get("net_strategy_pnl_after_costs")
+        ),
+        "turnover_notional": filled_notional,
+        "runtime_ledger_blockers": payload.get("blockers") or [],
+        "runtime_ledger_cost_basis_counts": payload.get("cost_basis_counts") or {},
+        "runtime_ledger_pnl_basis": payload.get("pnl_basis"),
+        "runtime_ledger_bucket": dict(payload),
+    }
+
+
+def _runtime_ledger_tca_rows_from_durable_buckets(
+    *,
+    session: Session,
+    candidate_id: str | None,
+    hypothesis_id: str,
+    observed_stage: str,
+    strategy_names: list[str],
+    account_label: str,
+    window_start: datetime,
+    window_end: datetime,
+) -> tuple[list[dict[str, object]], dict[str, Any]]:
+    query = select(StrategyRuntimeLedgerBucket).where(
+        StrategyRuntimeLedgerBucket.hypothesis_id == hypothesis_id,
+        StrategyRuntimeLedgerBucket.observed_stage == observed_stage,
+        StrategyRuntimeLedgerBucket.bucket_started_at < window_end,
+        StrategyRuntimeLedgerBucket.bucket_ended_at > window_start,
+    )
+    if candidate_id:
+        query = query.where(StrategyRuntimeLedgerBucket.candidate_id == candidate_id)
+    if account_label:
+        query = query.where(StrategyRuntimeLedgerBucket.account_label == account_label)
+    if strategy_names:
+        query = query.where(
+            StrategyRuntimeLedgerBucket.runtime_strategy_name.in_(strategy_names)
+        )
+    rows = list(
+        session.execute(
+            query.order_by(
+                StrategyRuntimeLedgerBucket.bucket_ended_at.asc(),
+                StrategyRuntimeLedgerBucket.created_at.asc(),
+            ).limit(500)
+        )
+        .scalars()
+        .all()
+    )
+    payloads = [_runtime_ledger_bucket_payload_from_row(row) for row in rows]
+    tca_rows = [
+        _runtime_ledger_tca_row_from_payload(payload=payload) for payload in payloads
+    ]
+    metadata = {
+        "runtime_ledger_durable_bucket_count": len(payloads),
+        "runtime_ledger_durable_bucket_run_ids": sorted(
+            {
+                run_id
+                for payload in payloads
+                if (run_id := _text_or_none(payload.get("run_id"))) is not None
+            }
+        ),
+        "runtime_ledger_durable_bucket_fill_count": sum(
+            _nonnegative_int(payload.get("fill_count")) for payload in payloads
+        ),
+        "runtime_ledger_durable_bucket_tca_row_count": len(tca_rows),
+        "runtime_ledger_durable_bucket_profit_proof_count": sum(
+            1
+            for payload in payloads
+            if _runtime_ledger_bucket_profit_proof_present(payload)
+        ),
+    }
+    return tca_rows, metadata
+
+
 def _query_timestamps(
     *,
     dsn: str,
@@ -860,8 +1047,6 @@ def main() -> int:
         for item in getattr(args, "artifact_ref", [])
         if str(item).strip()
     ]
-    if not source_dsn and not artifact_refs:
-        raise RuntimeError("source_dsn_not_configured")
     window_start = _parse_dt(args.window_start)
     window_end = _parse_dt(args.window_end)
     _, manifest = resolve_hypothesis_manifest(
@@ -891,6 +1076,13 @@ def main() -> int:
         "runtime_ledger_artifact_fill_count": 0,
         "runtime_ledger_artifact_tca_row_count": 0,
     }
+    runtime_ledger_durable_metadata: dict[str, Any] = {
+        "runtime_ledger_durable_bucket_count": 0,
+        "runtime_ledger_durable_bucket_run_ids": [],
+        "runtime_ledger_durable_bucket_fill_count": 0,
+        "runtime_ledger_durable_bucket_tca_row_count": 0,
+        "runtime_ledger_durable_bucket_profit_proof_count": 0,
+    }
     if artifact_refs:
         bucket_ranges = build_regular_session_buckets(
             window_start=window_start,
@@ -913,6 +1105,25 @@ def main() -> int:
     if (
         not source_dsn
         and not runtime_ledger_artifact_metadata["runtime_ledger_artifact_refs"]
+    ):
+        with SessionLocal() as session:
+            durable_runtime_ledger_tca_rows, runtime_ledger_durable_metadata = (
+                _runtime_ledger_tca_rows_from_durable_buckets(
+                    session=session,
+                    candidate_id=args.candidate_id.strip() or None,
+                    hypothesis_id=args.hypothesis_id,
+                    observed_stage=args.observed_stage,
+                    strategy_names=strategy_names,
+                    account_label=args.account_label,
+                    window_start=window_start,
+                    window_end=window_end,
+                )
+            )
+        tca_rows.extend(durable_runtime_ledger_tca_rows)
+    if (
+        not source_dsn
+        and not runtime_ledger_artifact_metadata["runtime_ledger_artifact_refs"]
+        and not runtime_ledger_durable_metadata["runtime_ledger_durable_bucket_count"]
     ):
         raise RuntimeError("source_dsn_not_configured")
     dataset_snapshot_ref = (
@@ -1006,6 +1217,7 @@ def main() -> int:
         "dataset_snapshot_ref": dataset_snapshot_ref,
         "target_metadata": target_metadata,
         **runtime_ledger_artifact_metadata,
+        **runtime_ledger_durable_metadata,
         "report_post_cost_expectancy_bps": (
             str(report_post_cost_expectancy_bps)
             if report_post_cost_expectancy_bps is not None

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -9,6 +9,11 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
 
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base, StrategyRuntimeLedgerBucket
 from scripts.import_hypothesis_runtime_windows import (
     EXECUTION_ELIGIBLE_DECISION_STATUSES,
     POST_COST_BASIS_RUNTIME_LEDGER,
@@ -22,8 +27,10 @@ from scripts.import_hypothesis_runtime_windows import (
     _parse_dt_or_none,
     _parse_target_metadata,
     _query_timestamps,
+    _runtime_ledger_bucket_profit_proof_present,
     _runtime_ledger_event_type,
     _runtime_ledger_profit_proof_present,
+    _runtime_ledger_tca_rows_from_durable_buckets,
     _runtime_ledger_tca_rows_from_artifacts,
     _strategy_name_candidates,
     main,
@@ -107,6 +114,29 @@ class _FakeSession:
         self.committed = True
 
 
+def _complete_runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "fill_count": 2,
+        "decision_count": 2,
+        "submitted_order_count": 2,
+        "closed_trade_count": 1,
+        "open_position_count": 0,
+        "filled_notional": "200",
+        "gross_strategy_pnl": "1",
+        "cost_amount": "0.20",
+        "net_strategy_pnl_after_costs": "0.80",
+        "post_cost_expectancy_bps": "40",
+        "ledger_schema_version": "torghut.exact_replay_ledger.v1",
+        "pnl_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+        "execution_policy_hash_counts": {"policy-sha": 2},
+        "cost_model_hash_counts": {"cost-sha": 2},
+        "lineage_hash_counts": {"lineage-sha": 2},
+        "blockers": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
 class TestImportHypothesisRuntimeWindows(TestCase):
     def test_parse_args_accepts_dataset_snapshot_ref(self) -> None:
         with patch(
@@ -185,6 +215,165 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             False,
         )
 
+    def test_runtime_ledger_profit_proof_requires_lifecycle_and_lineage(
+        self,
+    ) -> None:
+        incomplete = _complete_runtime_ledger_bucket(lineage_hash_counts={})
+        complete = _complete_runtime_ledger_bucket()
+
+        self.assertFalse(_runtime_ledger_bucket_profit_proof_present(incomplete))
+        self.assertTrue(_runtime_ledger_bucket_profit_proof_present(complete))
+        self.assertFalse(
+            _runtime_ledger_profit_proof_present(
+                [
+                    {
+                        "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+                        "runtime_ledger_bucket": incomplete,
+                    }
+                ]
+            )
+        )
+        self.assertTrue(
+            _runtime_ledger_profit_proof_present(
+                [
+                    {
+                        "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+                        "runtime_ledger_bucket": complete,
+                    }
+                ]
+            )
+        )
+
+    def test_runtime_ledger_profit_proof_rejects_each_incomplete_proof_field(
+        self,
+    ) -> None:
+        invalid_cases = {
+            "invalid_pnl_basis": {"pnl_basis": POST_COST_BASIS_SIMULATION_REPORT},
+            "invalid_schema": {"ledger_schema_version": "torghut.loose_ledger.v0"},
+            "explicit_blocker": {"blockers": ["runtime_ledger_incomplete"]},
+            "missing_fills": {"fill_count": 0},
+            "missing_decisions": {"decision_count": 0},
+            "missing_submitted_orders": {"submitted_order_count": 0},
+            "missing_closed_trades": {"closed_trade_count": 0},
+            "missing_open_position_count": {"open_position_count": None},
+            "unclosed_position": {"open_position_count": 1},
+            "missing_filled_notional": {"filled_notional": "0"},
+            "missing_cost": {"cost_amount": None},
+            "negative_cost": {"cost_amount": "-0.01"},
+            "missing_expectancy": {"post_cost_expectancy_bps": None},
+            "missing_execution_hash": {"execution_policy_hash_counts": "bad-shape"},
+            "missing_cost_hash": {"cost_model_hash_counts": {}},
+            "missing_lineage_hash": {"lineage_hash_counts": {}},
+        }
+
+        for name, overrides in invalid_cases.items():
+            with self.subTest(name=name):
+                self.assertFalse(
+                    _runtime_ledger_bucket_profit_proof_present(
+                        _complete_runtime_ledger_bucket(**overrides)
+                    )
+                )
+
+    def test_runtime_ledger_tca_rows_from_durable_buckets_queries_matching_proof(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+
+        with session_local() as session:
+            session.add(
+                StrategyRuntimeLedgerBucket(
+                    run_id="runtime-proof-1",
+                    candidate_id="H-TSMOM-LIQ-01",
+                    hypothesis_id="H-TSMOM-LIQ-01",
+                    observed_stage="paper",
+                    bucket_started_at=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    bucket_ended_at=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    account_label="TORGHUT_SIM",
+                    runtime_strategy_name="intraday-tsmom-profit-v3",
+                    strategy_family="intraday_tsmom_consistent",
+                    fill_count=2,
+                    decision_count=2,
+                    submitted_order_count=2,
+                    cancelled_order_count=0,
+                    rejected_order_count=0,
+                    unfilled_order_count=0,
+                    closed_trade_count=1,
+                    open_position_count=0,
+                    filled_notional=Decimal("200"),
+                    gross_strategy_pnl=Decimal("1"),
+                    cost_amount=Decimal("0.20"),
+                    net_strategy_pnl_after_costs=Decimal("0.80"),
+                    post_cost_expectancy_bps=Decimal("40"),
+                    ledger_schema_version="torghut.exact_replay_ledger.v1",
+                    pnl_basis=POST_COST_BASIS_RUNTIME_LEDGER,
+                    execution_policy_hash_counts={"policy-sha": 2},
+                    cost_model_hash_counts={"cost-sha": 2},
+                    lineage_hash_counts={"lineage-sha": 2},
+                    blockers_json=[],
+                    payload_json={},
+                )
+            )
+            session.add(
+                StrategyRuntimeLedgerBucket(
+                    run_id="runtime-proof-other",
+                    candidate_id="other-candidate",
+                    hypothesis_id="H-TSMOM-LIQ-01",
+                    observed_stage="paper",
+                    bucket_started_at=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    bucket_ended_at=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    runtime_strategy_name="intraday-tsmom-profit-v3",
+                    fill_count=2,
+                    decision_count=2,
+                    submitted_order_count=2,
+                    closed_trade_count=1,
+                    open_position_count=0,
+                    filled_notional=Decimal("200"),
+                    gross_strategy_pnl=Decimal("1"),
+                    cost_amount=Decimal("0.20"),
+                    net_strategy_pnl_after_costs=Decimal("0.80"),
+                    post_cost_expectancy_bps=Decimal("40"),
+                    ledger_schema_version="torghut.exact_replay_ledger.v1",
+                    pnl_basis=POST_COST_BASIS_RUNTIME_LEDGER,
+                )
+            )
+            session.commit()
+
+            rows, metadata = _runtime_ledger_tca_rows_from_durable_buckets(
+                session=session,
+                candidate_id="H-TSMOM-LIQ-01",
+                hypothesis_id="H-TSMOM-LIQ-01",
+                observed_stage="paper",
+                strategy_names=["intraday-tsmom-profit-v3"],
+                account_label="TORGHUT_SIM",
+                window_start=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                window_end=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+            )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(metadata["runtime_ledger_durable_bucket_count"], 1)
+        self.assertEqual(
+            metadata["runtime_ledger_durable_bucket_run_ids"],
+            ["runtime-proof-1"],
+        )
+        self.assertEqual(metadata["runtime_ledger_durable_bucket_fill_count"], 2)
+        self.assertEqual(
+            metadata["runtime_ledger_durable_bucket_profit_proof_count"],
+            1,
+        )
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], True)
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["run_id"], "runtime-proof-1")
+        self.assertEqual(bucket["closed_trade_count"], 1)
+
     def test_parse_target_metadata_requires_json_mapping(self) -> None:
         self.assertEqual(_parse_target_metadata(""), {})
         self.assertEqual(
@@ -196,16 +385,66 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         with self.assertRaisesRegex(RuntimeError, "target_metadata_json_not_mapping"):
             _parse_target_metadata("[]")
 
-    def test_main_requires_source_dsn(self) -> None:
+    def test_main_requires_source_dsn_or_durable_runtime_ledger_bucket(self) -> None:
         args = SimpleNamespace(
+            run_id="run-missing-source",
+            candidate_id="cand-missing-source",
+            hypothesis_id="H-CONT-01",
+            observed_stage="paper",
+            strategy_family="",
             source_dsn="",
             source_dsn_env="TORGHUT_TEST_MISSING_DSN",
+            strategy_name="intraday-tsmom-profit-v2",
+            account_label="TORGHUT_SIM",
+            window_start="2026-03-06T14:30:00Z",
+            window_end="2026-03-06T15:00:00Z",
+            bucket_minutes=30,
+            sample_minutes=5,
+            source_manifest_ref="",
+            source_kind="",
+            artifact_ref=[],
+            delay_adjusted_depth_stress_report_ref="",
+            dataset_snapshot_ref="",
+            target_metadata_json="",
+            dependency_quorum_decision="allow",
+            continuity_ok="true",
+            drift_ok="true",
+            json=False,
+        )
+        manifest = SimpleNamespace(
+            strategy_family="intraday_continuation",
+            strategy_id="intraday_tsmom_v2@paper",
+            max_allowed_slippage_bps=Decimal("12"),
         )
 
         with (
             patch(
                 "scripts.import_hypothesis_runtime_windows._parse_args",
                 return_value=args,
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.resolve_hypothesis_manifest",
+                return_value=(
+                    SimpleNamespace(path="config/trading/hypotheses/h-cont-01.json"),
+                    manifest,
+                ),
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows._runtime_ledger_tca_rows_from_durable_buckets",
+                return_value=(
+                    [],
+                    {
+                        "runtime_ledger_durable_bucket_count": 0,
+                        "runtime_ledger_durable_bucket_run_ids": [],
+                        "runtime_ledger_durable_bucket_fill_count": 0,
+                        "runtime_ledger_durable_bucket_tca_row_count": 0,
+                        "runtime_ledger_durable_bucket_profit_proof_count": 0,
+                    },
+                ),
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.SessionLocal",
+                return_value=_FakeSession(),
             ),
             patch.dict("os.environ", {}, clear=True),
         ):
@@ -684,6 +923,23 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                         manifest,
                     ),
                 ),
+                patch(
+                    "scripts.import_hypothesis_runtime_windows._runtime_ledger_tca_rows_from_durable_buckets",
+                    return_value=(
+                        [],
+                        {
+                            "runtime_ledger_durable_bucket_count": 0,
+                            "runtime_ledger_durable_bucket_run_ids": [],
+                            "runtime_ledger_durable_bucket_fill_count": 0,
+                            "runtime_ledger_durable_bucket_tca_row_count": 0,
+                            "runtime_ledger_durable_bucket_profit_proof_count": 0,
+                        },
+                    ),
+                ),
+                patch(
+                    "scripts.import_hypothesis_runtime_windows.SessionLocal",
+                    return_value=_FakeSession(),
+                ),
                 patch.dict("os.environ", {}, clear=True),
             ):
                 with self.assertRaisesRegex(RuntimeError, "source_dsn_not_configured"):
@@ -1105,6 +1361,128 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(runtime_payload["promotion_authority"], "runtime_ledger")
         self.assertEqual(runtime_payload["runtime_ledger_profit_proof_present"], True)
         self.assertEqual(runtime_payload["authoritative"], True)
+
+    def test_main_imports_durable_runtime_ledger_bucket_without_source_dsn(
+        self,
+    ) -> None:
+        args = SimpleNamespace(
+            run_id="run-durable-ledger",
+            candidate_id="H-TSMOM-LIQ-01",
+            hypothesis_id="H-TSMOM-LIQ-01",
+            observed_stage="paper",
+            strategy_family="intraday_tsmom_consistent",
+            source_dsn="",
+            source_dsn_env="DB_DSN",
+            strategy_name="intraday-tsmom-profit-v3",
+            account_label="TORGHUT_SIM",
+            window_start="2026-03-06T14:30:00Z",
+            window_end="2026-03-06T15:00:00Z",
+            bucket_minutes=30,
+            sample_minutes=5,
+            source_manifest_ref="config/trading/hypotheses/h-tsmom-liq-01.json",
+            source_kind="paper_runtime_observed",
+            artifact_ref=[],
+            delay_adjusted_depth_stress_report_ref="",
+            dataset_snapshot_ref="durable-runtime-ledger-snapshot",
+            target_metadata_json="",
+            dependency_quorum_decision="allow",
+            continuity_ok="true",
+            drift_ok="true",
+            json=False,
+        )
+        fake_session = _FakeSession()
+        manifest = SimpleNamespace(
+            strategy_family="intraday_tsmom_consistent",
+            strategy_id="intraday_tsmom_v2@research",
+            max_allowed_slippage_bps=Decimal("6"),
+        )
+        durable_tca_row = {
+            "computed_at": datetime(2026, 3, 6, 14, 59, 59, tzinfo=timezone.utc),
+            "abs_slippage_bps": Decimal("10"),
+            "post_cost_expectancy_bps": Decimal("40"),
+            "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+            "post_cost_promotion_eligible": True,
+            "runtime_ledger_bucket": _complete_runtime_ledger_bucket(
+                run_id="runtime-proof-1",
+                candidate_id="H-TSMOM-LIQ-01",
+                hypothesis_id="H-TSMOM-LIQ-01",
+                observed_stage="paper",
+                account_label="TORGHUT_SIM",
+                strategy_id="intraday-tsmom-profit-v3",
+                bucket_started_at="2026-03-06T14:30:00+00:00",
+                bucket_ended_at="2026-03-06T15:00:00+00:00",
+            ),
+        }
+
+        with (
+            patch(
+                "scripts.import_hypothesis_runtime_windows._parse_args",
+                return_value=args,
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.resolve_hypothesis_manifest",
+                return_value=(
+                    SimpleNamespace(
+                        path="config/trading/hypotheses/h-tsmom-liq-01.json"
+                    ),
+                    manifest,
+                ),
+            ),
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "scripts.import_hypothesis_runtime_windows._query_timestamps",
+            ) as query_timestamps,
+            patch(
+                "scripts.import_hypothesis_runtime_windows._runtime_ledger_tca_rows_from_durable_buckets",
+                return_value=(
+                    [durable_tca_row],
+                    {
+                        "runtime_ledger_durable_bucket_count": 1,
+                        "runtime_ledger_durable_bucket_run_ids": ["runtime-proof-1"],
+                        "runtime_ledger_durable_bucket_fill_count": 2,
+                        "runtime_ledger_durable_bucket_tca_row_count": 1,
+                        "runtime_ledger_durable_bucket_profit_proof_count": 1,
+                    },
+                ),
+            ) as durable_buckets,
+            patch(
+                "scripts.import_hypothesis_runtime_windows.build_observed_runtime_buckets",
+                return_value=[],
+            ) as build_buckets,
+            patch(
+                "scripts.import_hypothesis_runtime_windows.persist_observed_runtime_windows",
+                return_value={"run_id": "run-durable-ledger"},
+            ) as persist_windows,
+            patch(
+                "scripts.import_hypothesis_runtime_windows.SessionLocal",
+                return_value=fake_session,
+            ),
+            patch("builtins.print"),
+        ):
+            exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        query_timestamps.assert_not_called()
+        durable_buckets.assert_called_once()
+        tca_rows = build_buckets.call_args.kwargs["tca_rows"]
+        self.assertEqual(tca_rows, [durable_tca_row])
+        runtime_payload = persist_windows.call_args.kwargs[
+            "runtime_observation_payload"
+        ]
+        self.assertEqual(runtime_payload["runtime_ledger_durable_bucket_count"], 1)
+        self.assertEqual(
+            runtime_payload["runtime_ledger_durable_bucket_run_ids"],
+            ["runtime-proof-1"],
+        )
+        self.assertEqual(
+            runtime_payload["runtime_ledger_durable_bucket_profit_proof_count"],
+            1,
+        )
+        self.assertEqual(
+            runtime_payload["authority_reason"], "runtime_ledger_profit_proof"
+        )
+        self.assertEqual(runtime_payload["promotion_authority"], "runtime_ledger")
+        self.assertEqual(runtime_payload["runtime_ledger_profit_proof_present"], True)
 
     def test_main_attaches_delay_adjusted_depth_report_to_runtime_payload(
         self,

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -24,6 +24,8 @@ from app.trading.runtime_window_import import (
     _observation_decimal,
     _observation_int,
     _parse_observation_datetime,
+    _runtime_ledger_bucket_blockers,
+    _runtime_ledger_bucket_payloads,
     build_observed_runtime_buckets,
     build_regular_session_buckets,
     persist_observed_runtime_windows,
@@ -43,6 +45,29 @@ def _simulation_report_pnl_basis() -> dict[str, object]:
         "post_cost_expectancy_basis": "simulation_report_net_pnl",
         "post_cost_promotion_eligible": True,
     }
+
+
+def _runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "fill_count": 2,
+        "decision_count": 2,
+        "submitted_order_count": 2,
+        "closed_trade_count": 1,
+        "open_position_count": 0,
+        "filled_notional": "200",
+        "gross_strategy_pnl": "1",
+        "cost_amount": "0.20",
+        "net_strategy_pnl_after_costs": "0.80",
+        "post_cost_expectancy_bps": "40",
+        "ledger_schema_version": "torghut.exact_replay_ledger.v1",
+        "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
+        "execution_policy_hash_counts": {"policy-sha": 2},
+        "cost_model_hash_counts": {"cost-sha": 2},
+        "lineage_hash_counts": {"lineage-sha": 2},
+        "blockers": [],
+    }
+    payload.update(overrides)
+    return payload
 
 
 class TestRuntimeWindowImport(TestCase):
@@ -182,22 +207,24 @@ class TestRuntimeWindowImport(TestCase):
                     "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("1"),
                     "post_cost_expectancy_bps": Decimal("100"),
-                    "runtime_ledger_bucket": {
-                        "filled_notional": "100",
-                        "net_strategy_pnl_after_costs": "1",
-                        "blockers": [],
-                    },
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        filled_notional="100",
+                        net_strategy_pnl_after_costs="1",
+                        cost_amount="0.01",
+                        post_cost_expectancy_bps="100",
+                    ),
                     **_runtime_pnl_basis(),
                 },
                 {
                     "computed_at": datetime(2026, 3, 6, 14, 41, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("1"),
                     "post_cost_expectancy_bps": Decimal("1"),
-                    "runtime_ledger_bucket": {
-                        "filled_notional": "10000",
-                        "net_strategy_pnl_after_costs": "1",
-                        "blockers": [],
-                    },
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        filled_notional="10000",
+                        net_strategy_pnl_after_costs="1",
+                        cost_amount="0.01",
+                        post_cost_expectancy_bps="1",
+                    ),
                     **_runtime_pnl_basis(),
                 },
             ],
@@ -219,6 +246,57 @@ class TestRuntimeWindowImport(TestCase):
             buckets[0].payload_json["runtime_ledger_net_strategy_pnl_after_costs"],
             "2",
         )
+
+    def test_runtime_ledger_bucket_blockers_require_complete_lifecycle_proof(
+        self,
+    ) -> None:
+        missing_blockers = _runtime_ledger_bucket_blockers({})
+
+        self.assertIn("runtime_ledger_schema_version_missing", missing_blockers)
+        self.assertIn("runtime_ledger_pnl_basis_missing", missing_blockers)
+        self.assertIn("runtime_ledger_open_position_count_missing", missing_blockers)
+
+        invalid_blockers = _runtime_ledger_bucket_blockers(
+            {
+                "ledger_schema_version": "torghut.loose_runtime_ledger.v0",
+                "pnl_basis": "simulation_report_net_pnl",
+                "fill_count": 0,
+                "decision_count": 0,
+                "submitted_order_count": 0,
+                "closed_trade_count": 0,
+                "open_position_count": 1,
+                "filled_notional": "0",
+                "cost_amount": "-0.01",
+                "post_cost_expectancy_bps": None,
+                "execution_policy_hash_counts": "not-a-map",
+                "cost_model_hash_counts": {},
+                "lineage_hash_counts": {},
+            }
+        )
+
+        self.assertIn("runtime_ledger_schema_version_invalid", invalid_blockers)
+        self.assertIn("runtime_ledger_pnl_basis_invalid", invalid_blockers)
+        self.assertIn("runtime_fills_missing", invalid_blockers)
+        self.assertIn("runtime_decision_lifecycle_missing", invalid_blockers)
+        self.assertIn("submitted_order_lifecycle_missing", invalid_blockers)
+        self.assertIn("closed_round_trip_missing", invalid_blockers)
+        self.assertIn("unclosed_position", invalid_blockers)
+        self.assertIn("filled_notional_missing", invalid_blockers)
+        self.assertIn("explicit_cost_missing", invalid_blockers)
+        self.assertIn("runtime_ledger_expectancy_missing", invalid_blockers)
+        self.assertIn("runtime_ledger_execution_policy_hash_missing", invalid_blockers)
+        self.assertIn("runtime_ledger_cost_model_hash_missing", invalid_blockers)
+        self.assertIn("runtime_ledger_lineage_hash_missing", invalid_blockers)
+
+    def test_runtime_ledger_bucket_payloads_accept_single_bucket_payload(
+        self,
+    ) -> None:
+        payloads = _runtime_ledger_bucket_payloads(
+            {"runtime_ledger_bucket": _runtime_ledger_bucket()}
+        )
+
+        self.assertEqual(len(payloads), 1)
+        self.assertEqual(payloads[0]["blockers"], [])
 
     def test_runtime_observation_parsers_handle_edge_inputs(self) -> None:
         parsed = _parse_observation_datetime(
@@ -470,24 +548,24 @@ class TestRuntimeWindowImport(TestCase):
                     "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("1"),
                     "post_cost_expectancy_bps": Decimal("100"),
-                    "runtime_ledger_bucket": {
-                        "filled_notional": "100",
-                        "net_strategy_pnl_after_costs": "1",
-                        "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
-                        "blockers": [],
-                    },
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        filled_notional="100",
+                        net_strategy_pnl_after_costs="1",
+                        cost_amount="0.01",
+                        post_cost_expectancy_bps="100",
+                    ),
                     **_runtime_pnl_basis(),
                 },
                 {
                     "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("1"),
                     "post_cost_expectancy_bps": Decimal("1"),
-                    "runtime_ledger_bucket": {
-                        "filled_notional": "10000",
-                        "net_strategy_pnl_after_costs": "1",
-                        "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
-                        "blockers": [],
-                    },
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        filled_notional="10000",
+                        net_strategy_pnl_after_costs="1",
+                        cost_amount="0.01",
+                        post_cost_expectancy_bps="1",
+                    ),
                     **_runtime_pnl_basis(),
                 },
             ],
@@ -558,24 +636,24 @@ class TestRuntimeWindowImport(TestCase):
                     "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("4"),
                     "post_cost_expectancy_bps": Decimal("8"),
-                    "runtime_ledger_bucket": {
-                        "filled_notional": "1000",
-                        "net_strategy_pnl_after_costs": "0.8",
-                        "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
-                        "blockers": [],
-                    },
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        filled_notional="1000",
+                        net_strategy_pnl_after_costs="0.8",
+                        cost_amount="0.40",
+                        post_cost_expectancy_bps="8",
+                    ),
                     **_runtime_pnl_basis(),
                 },
                 {
                     "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("5"),
                     "post_cost_expectancy_bps": Decimal("8"),
-                    "runtime_ledger_bucket": {
-                        "filled_notional": "1000",
-                        "net_strategy_pnl_after_costs": "0.8",
-                        "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
-                        "blockers": [],
-                    },
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        filled_notional="1000",
+                        net_strategy_pnl_after_costs="0.8",
+                        cost_amount="0.50",
+                        post_cost_expectancy_bps="8",
+                    ),
                     **_runtime_pnl_basis(),
                 },
             ],


### PR DESCRIPTION
## Summary

- Added a durable `StrategyRuntimeLedgerBucket` source path for runtime-window import so exact ledger proof can be imported without a source DSN or artifact file.
- Tightened runtime-ledger proof predicates to require lifecycle counts, closed trades, zero open positions, cost/notional data, schema/PnL basis, and execution/cost/lineage hashes.
- Updated runtime-window aggregation to count durable ledger bucket activity and fail closed when payloads lack promotion-grade ledger proof.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_hypotheses.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
