### PR TITLE
fix(torghut): require ledger proof for paper probation

### DIFF
--- a/services/torghut/app/trading/discovery/profit_target_oracle.py
+++ b/services/torghut/app/trading/discovery/profit_target_oracle.py
@@ -84,6 +84,11 @@ class ProfitTargetOraclePolicy:
     min_implementation_uncertainty_model_count: int = 2
     require_conformal_tail_risk: bool = False
     min_conformal_tail_risk_sample_count: int = 0
+    require_predictability_decay_stress: bool = False
+    min_predictability_decay_stress_horizon_count: int = 3
+    min_tight_spread_regime_count: int = 20
+    min_predictability_decay_stress_split_pass_rate: Decimal = Decimal("0.60")
+    max_predictability_decay_stress_best_split_share: Decimal = Decimal("0.35")
     require_double_oos: bool = True
     min_double_oos_independent_window_count: int = 2
     min_double_oos_pass_rate: Decimal = Decimal("1.00")
@@ -185,6 +190,15 @@ class ProfitTargetOraclePolicy:
             "min_implementation_uncertainty_model_count": self.min_implementation_uncertainty_model_count,
             "require_conformal_tail_risk": self.require_conformal_tail_risk,
             "min_conformal_tail_risk_sample_count": self.min_conformal_tail_risk_sample_count,
+            "require_predictability_decay_stress": self.require_predictability_decay_stress,
+            "min_predictability_decay_stress_horizon_count": self.min_predictability_decay_stress_horizon_count,
+            "min_tight_spread_regime_count": self.min_tight_spread_regime_count,
+            "min_predictability_decay_stress_split_pass_rate": str(
+                self.min_predictability_decay_stress_split_pass_rate
+            ),
+            "max_predictability_decay_stress_best_split_share": str(
+                self.max_predictability_decay_stress_best_split_share
+            ),
             "require_double_oos": self.require_double_oos,
             "min_double_oos_independent_window_count": self.min_double_oos_independent_window_count,
             "min_double_oos_pass_rate": str(self.min_double_oos_pass_rate),
@@ -397,6 +411,28 @@ def _requires_conformal_tail_risk(
         }
         & overlay_ids
     )
+
+
+def _requires_predictability_decay_stress(
+    scorecard: Mapping[str, Any], policy: ProfitTargetOraclePolicy
+) -> bool:
+    if policy.require_predictability_decay_stress:
+        return True
+    if _boolish(
+        scorecard.get("predictability_decay_stress_required")
+        or scorecard.get("requires_predictability_decay_stress")
+        or scorecard.get("requires_horizon_decay_curve")
+        or scorecard.get("requires_spread_adjusted_label_replay")
+    ):
+        return True
+    overlay_ids = set(
+        _string_sequence(
+            scorecard.get("mechanism_overlay_ids")
+            or scorecard.get("mechanism_overlays")
+            or scorecard.get("overlay_ids")
+        )
+    )
+    return "alpha_decay_predictability_stress" in overlay_ids
 
 
 def _start_equity(
@@ -1413,6 +1449,151 @@ def evaluate_profit_target_oracle(
                 "source_marker": "regime_weighted_conformal_var_arxiv_2602_03903_2026",
                 "passed": conformal_tail_risk_adjusted_net >= target_net_pnl_per_day
                 if require_conformal_tail_risk
+                else True,
+            },
+        )
+    )
+    require_predictability_decay_stress = _requires_predictability_decay_stress(
+        scorecard, policy
+    )
+    predictability_decay_stress_artifact_refs = _artifact_refs(
+        scorecard,
+        "predictability_decay_stress_artifact_ref",
+        "predictability_decay_stress_artifact_refs",
+        "alpha_decay_stress_artifact_ref",
+    )
+    predictability_decay_stress_artifact_present = bool(
+        predictability_decay_stress_artifact_refs
+    )
+    predictability_decay_stress_passed = _boolish(
+        scorecard.get("predictability_decay_stress_passed")
+        or scorecard.get("alpha_decay_stress_passed")
+    )
+    horizon_decay_curve_present = _boolish(
+        scorecard.get("horizon_decay_curve_present")
+        or scorecard.get("predictability_horizon_decay_curve_present")
+    )
+    spread_adjusted_label_replay_present = _boolish(
+        scorecard.get("spread_adjusted_label_replay_present")
+        or scorecard.get("spread_adjusted_labels_present")
+    )
+    predictability_decay_horizon_count = _nonnegative_int(
+        scorecard.get("predictability_decay_stress_horizon_count")
+        or scorecard.get("horizon_decay_curve_horizon_count")
+    )
+    tight_spread_regime_count = _nonnegative_int(
+        scorecard.get("tight_spread_regime_slice_count")
+        or scorecard.get("tight_spread_regime_count")
+    )
+    predictability_decay_split_pass_rate = _decimal(
+        scorecard.get("predictability_decay_stress_split_pass_rate")
+        or scorecard.get("decay_stress_split_pass_rate")
+    )
+    predictability_decay_best_split_share = _decimal(
+        scorecard.get("predictability_decay_stress_best_split_share")
+        or scorecard.get("decay_stress_best_split_share"),
+        default="1",
+    )
+    predictability_decay_stress_net_pnl = _decimal(
+        scorecard.get("post_cost_net_pnl_after_predictability_decay_stress")
+        or scorecard.get("predictability_decay_stress_net_pnl_per_day")
+    )
+    checks.extend(
+        (
+            {
+                "metric": "predictability_decay_stress_passed",
+                "observed": str(predictability_decay_stress_passed).lower(),
+                "operator": "eq",
+                "threshold": "true",
+                "source_marker": "tkan_lob_alpha_decay_arxiv_2601_02310_2026",
+                "passed": predictability_decay_stress_passed
+                if require_predictability_decay_stress
+                else True,
+            },
+            {
+                "metric": "predictability_decay_stress_artifact_present",
+                "observed": str(predictability_decay_stress_artifact_present).lower(),
+                "operator": "eq",
+                "threshold": "true",
+                "source_marker": "tkan_lob_alpha_decay_arxiv_2601_02310_2026",
+                "passed": predictability_decay_stress_artifact_present
+                if require_predictability_decay_stress
+                else True,
+            },
+            {
+                "metric": "horizon_decay_curve_present",
+                "observed": str(horizon_decay_curve_present).lower(),
+                "operator": "eq",
+                "threshold": "true",
+                "source_marker": "tkan_lob_alpha_decay_arxiv_2601_02310_2026",
+                "passed": horizon_decay_curve_present
+                if require_predictability_decay_stress
+                else True,
+            },
+            {
+                "metric": "spread_adjusted_label_replay_present",
+                "observed": str(spread_adjusted_label_replay_present).lower(),
+                "operator": "eq",
+                "threshold": "true",
+                "source_marker": "tkan_lob_alpha_decay_arxiv_2601_02310_2026",
+                "passed": spread_adjusted_label_replay_present
+                if require_predictability_decay_stress
+                else True,
+            },
+            _numeric_check(
+                metric="predictability_decay_stress_horizon_count",
+                observed=Decimal(predictability_decay_horizon_count),
+                operator="gte",
+                threshold=Decimal(
+                    max(0, policy.min_predictability_decay_stress_horizon_count)
+                )
+                if require_predictability_decay_stress
+                else Decimal("0"),
+            ),
+            _numeric_check(
+                metric="tight_spread_regime_slice_count",
+                observed=Decimal(tight_spread_regime_count),
+                operator="gte",
+                threshold=Decimal(max(0, policy.min_tight_spread_regime_count))
+                if require_predictability_decay_stress
+                else Decimal("0"),
+            ),
+            {
+                **_numeric_check(
+                    metric="predictability_decay_stress_split_pass_rate",
+                    observed=predictability_decay_split_pass_rate,
+                    operator="gte",
+                    threshold=policy.min_predictability_decay_stress_split_pass_rate,
+                ),
+                "source_marker": "tkan_lob_alpha_decay_arxiv_2601_02310_2026",
+                "passed": predictability_decay_split_pass_rate
+                >= policy.min_predictability_decay_stress_split_pass_rate
+                if require_predictability_decay_stress
+                else True,
+            },
+            {
+                **_numeric_check(
+                    metric="predictability_decay_stress_best_split_share",
+                    observed=predictability_decay_best_split_share,
+                    operator="lte",
+                    threshold=policy.max_predictability_decay_stress_best_split_share,
+                ),
+                "source_marker": "tkan_lob_alpha_decay_arxiv_2601_02310_2026",
+                "passed": predictability_decay_best_split_share
+                <= policy.max_predictability_decay_stress_best_split_share
+                if require_predictability_decay_stress
+                else True,
+            },
+            {
+                **_numeric_check(
+                    metric="post_cost_net_pnl_after_predictability_decay_stress",
+                    observed=predictability_decay_stress_net_pnl,
+                    operator="gte",
+                    threshold=target_net_pnl_per_day,
+                ),
+                "source_marker": "tkan_lob_alpha_decay_arxiv_2601_02310_2026",
+                "passed": predictability_decay_stress_net_pnl >= target_net_pnl_per_day
+                if require_predictability_decay_stress
                 else True,
             },
         )

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -1939,6 +1939,14 @@ def _persist_epoch_ledgers(
             promotion_readiness = _mapping(summary.get("promotion_readiness"))
             if promotion_readiness:
                 portfolio_payload["promotion_readiness"] = dict(promotion_readiness)
+            paper_probation_candidate = _mapping(
+                _mapping(summary.get("candidate_board")).get(
+                    "paper_probation_candidate"
+                )
+            )
+            paper_probation_authorized = _boolish(
+                paper_probation_candidate.get("paper_probation_authorized")
+            )
             portfolio_status = "blocked"
             if bool(portfolio.objective_scorecard.get("oracle_passed")):
                 portfolio_status = (
@@ -1946,7 +1954,10 @@ def _persist_epoch_ledgers(
                     if _boolish(promotion_readiness.get("promotable"))
                     else "target_met"
                 )
-            elif _boolish(portfolio.objective_scorecard.get("target_met")):
+            elif (
+                _boolish(portfolio.objective_scorecard.get("target_met"))
+                and paper_probation_authorized
+            ):
                 portfolio_status = "paper_probation"
             session.add(
                 AutoresearchPortfolioCandidate(
@@ -7648,6 +7659,166 @@ def _candidate_spec_requires_order_type_execution_quality(spec: CandidateSpec) -
     )
 
 
+def _candidate_spec_requires_predictability_decay_stress(
+    spec: CandidateSpec,
+) -> bool:
+    overlay_ids = set(
+        _string_list_from_value(spec.parameter_space.get("mechanism_overlay_ids"))
+    )
+    return (
+        "alpha_decay_predictability_stress" in overlay_ids
+        or _boolish(spec.promotion_contract.get("requires_predictability_decay_stress"))
+        or _boolish(spec.promotion_contract.get("requires_horizon_decay_curve"))
+        or _boolish(
+            spec.promotion_contract.get("requires_spread_adjusted_label_replay")
+        )
+        or "required_predictability_decay_stress" in spec.hard_vetoes
+        or "required_horizon_decay_curve" in spec.hard_vetoes
+        or "required_spread_adjusted_label_replay" in spec.hard_vetoes
+    )
+
+
+def _candidate_board_predictability_decay_summary(
+    spec: CandidateSpec, scorecard: Mapping[str, Any], *, target: Decimal
+) -> dict[str, Any]:
+    required = _candidate_spec_requires_predictability_decay_stress(spec)
+    artifact_refs = _string_list_from_value(
+        scorecard.get("predictability_decay_stress_artifact_refs")
+        or scorecard.get("predictability_decay_stress_artifact_ref")
+        or scorecard.get("alpha_decay_stress_artifact_ref")
+    )
+    available_refs = set(
+        _string_list_from_value(scorecard.get("replay_artifact_refs"))
+        or _string_list_from_value(scorecard.get("artifact_refs"))
+    )
+    horizon_count = _candidate_board_first_int_field(
+        scorecard,
+        (
+            "predictability_decay_stress_horizon_count",
+            "horizon_decay_curve_horizon_count",
+        ),
+    )
+    tight_spread_count = _candidate_board_first_int_field(
+        scorecard,
+        ("tight_spread_regime_slice_count", "tight_spread_regime_count"),
+    )
+    split_pass_rate = _decimal(
+        scorecard.get("predictability_decay_stress_split_pass_rate")
+        or scorecard.get("decay_stress_split_pass_rate")
+    )
+    best_split_share = _decimal(
+        scorecard.get("predictability_decay_stress_best_split_share")
+        or scorecard.get("decay_stress_best_split_share"),
+        default="1",
+    )
+    stress_net_pnl_per_day = _decimal(
+        scorecard.get("post_cost_net_pnl_after_predictability_decay_stress")
+        or scorecard.get("predictability_decay_stress_net_pnl_per_day")
+    )
+    min_horizon_count = _candidate_board_int_field(
+        spec.hard_vetoes, "required_min_decay_stress_horizon_count"
+    )
+    if min_horizon_count <= 0:
+        min_horizon_count = 3
+    min_tight_spread_count = _candidate_board_int_field(
+        spec.hard_vetoes, "required_min_tight_spread_regime_count"
+    )
+    if min_tight_spread_count <= 0:
+        min_tight_spread_count = 20
+    min_split_pass_rate = _decimal(
+        spec.hard_vetoes.get("required_min_decay_stress_split_pass_rate"),
+        default="0.60",
+    )
+    max_best_split_share = _decimal(
+        spec.hard_vetoes.get("required_max_decay_stress_best_split_share"),
+        default="0.35",
+    )
+    blockers: list[str] = []
+    missing_artifact_refs: list[str] = []
+    if required:
+        if not _boolish(
+            scorecard.get("predictability_decay_stress_passed")
+            or scorecard.get("alpha_decay_stress_passed")
+        ):
+            blockers.append("predictability_decay_stress_passed_failed")
+        if not artifact_refs:
+            blockers.append("predictability_decay_stress_artifact_present_failed")
+        missing_artifact_refs = [
+            ref for ref in artifact_refs if available_refs and ref not in available_refs
+        ]
+        if missing_artifact_refs:
+            blockers.append(
+                "predictability_decay_stress_artifact_ref_missing_from_bundle"
+            )
+        if not _boolish(
+            scorecard.get("horizon_decay_curve_present")
+            or scorecard.get("predictability_horizon_decay_curve_present")
+        ):
+            blockers.append("horizon_decay_curve_present_failed")
+        if not _boolish(
+            scorecard.get("spread_adjusted_label_replay_present")
+            or scorecard.get("spread_adjusted_labels_present")
+        ):
+            blockers.append("spread_adjusted_label_replay_present_failed")
+        if horizon_count < min_horizon_count:
+            blockers.append("predictability_decay_stress_horizon_count_failed")
+        if tight_spread_count < min_tight_spread_count:
+            blockers.append("tight_spread_regime_slice_count_failed")
+        if split_pass_rate < min_split_pass_rate:
+            blockers.append("predictability_decay_stress_split_pass_rate_failed")
+        if best_split_share > max_best_split_share:
+            blockers.append("predictability_decay_stress_best_split_share_failed")
+        if stress_net_pnl_per_day < target:
+            blockers.append(
+                "post_cost_net_pnl_after_predictability_decay_stress_failed"
+            )
+    return {
+        "required": required,
+        "passed": not blockers,
+        "blockers": blockers,
+        "artifact_refs": artifact_refs,
+        "missing_replay_artifact_refs": missing_artifact_refs
+        if required and artifact_refs
+        else [],
+        "horizon_count": horizon_count,
+        "min_horizon_count": min_horizon_count,
+        "tight_spread_regime_slice_count": tight_spread_count,
+        "min_tight_spread_regime_slice_count": min_tight_spread_count,
+        "split_pass_rate": str(split_pass_rate),
+        "min_split_pass_rate": str(min_split_pass_rate),
+        "best_split_share": str(best_split_share),
+        "max_best_split_share": str(max_best_split_share),
+        "stress_net_pnl_per_day": str(stress_net_pnl_per_day),
+        "target_net_pnl_per_day": str(target),
+        "source_marker": "tkan_lob_alpha_decay_arxiv_2601_02310_2026",
+    }
+
+
+def _candidate_board_scorecard_with_predictability_decay_blockers(
+    spec: CandidateSpec, scorecard: Mapping[str, Any], *, target: Decimal
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    summary = _candidate_board_predictability_decay_summary(
+        spec, scorecard, target=target
+    )
+    updated_scorecard = dict(scorecard)
+    blockers = [
+        _string(blocker)
+        for blocker in cast(Sequence[Any], summary.get("blockers") or ())
+        if _string(blocker)
+    ]
+    if blockers:
+        updated_scorecard["oracle_passed"] = False
+        oracle_payload = dict(_mapping(updated_scorecard.get("profit_target_oracle")))
+        oracle_blockers = [
+            _string(blocker)
+            for blocker in cast(Sequence[Any], oracle_payload.get("blockers") or ())
+            if _string(blocker)
+        ]
+        oracle_payload["blockers"] = list(dict.fromkeys([*oracle_blockers, *blockers]))
+        updated_scorecard["profit_target_oracle"] = oracle_payload
+    return updated_scorecard, summary
+
+
 def _candidate_board_order_type_execution_quality_summary(
     spec: CandidateSpec, scorecard: Mapping[str, Any]
 ) -> dict[str, Any]:
@@ -8250,6 +8421,23 @@ def _candidate_board_closest_promotion_candidate(
     return replayed_rows[0]
 
 
+def _candidate_board_paper_probation_admission_blockers(
+    row: Mapping[str, Any],
+) -> list[str]:
+    blockers: list[str] = []
+    runtime_ledger_refs = _candidate_board_runtime_ledger_refs(row)
+    if not runtime_ledger_refs:
+        blockers.append("paper_probation_runtime_ledger_artifact_missing")
+    if _candidate_board_int_field(row, "runtime_ledger_artifact_row_count") <= 0:
+        blockers.append("paper_probation_runtime_ledger_row_count_missing")
+    if _candidate_board_int_field(row, "runtime_ledger_artifact_fill_count") <= 0:
+        blockers.append("paper_probation_runtime_ledger_fill_count_missing")
+    window_start, window_end = _candidate_board_runtime_window_bounds(row)
+    if not window_start or not window_end:
+        blockers.append("paper_probation_runtime_window_bounds_missing")
+    return blockers
+
+
 def _candidate_board_paper_probation_candidate(
     rows: Sequence[Mapping[str, Any]],
     *,
@@ -8267,6 +8455,14 @@ def _candidate_board_paper_probation_candidate(
         and _string(row.get("runtime_strategy_name"))
     ]
     if not candidates:
+        return None
+
+    admitted_candidates = [
+        candidate
+        for candidate in candidates
+        if not _candidate_board_paper_probation_admission_blockers(candidate)
+    ]
+    if not admitted_candidates:
         return None
 
     def rank(row: Mapping[str, Any]) -> tuple[Any, ...]:
@@ -8288,8 +8484,8 @@ def _candidate_board_paper_probation_candidate(
             _string(row.get("candidate_spec_id")),
         )
 
-    candidates.sort(key=rank, reverse=True)
-    candidate = dict(candidates[0])
+    admitted_candidates.sort(key=rank, reverse=True)
+    candidate = dict(admitted_candidates[0])
     lower_bound = _candidate_board_lower_bound_net_pnl(candidate)
     deployable_missing_count = deployable_lower_bound_missing_count(candidate)
     deployable_failed_gate_count = deployable_proof_failed_gate_count(candidate)
@@ -8793,6 +8989,15 @@ def _candidate_board_payload(
         raw_scorecard = (
             dict(evidence.objective_scorecard) if evidence is not None else {}
         )
+        mechanism_overlay_ids = _string_list_from_value(
+            spec.parameter_space.get("mechanism_overlay_ids")
+        )
+        if mechanism_overlay_ids:
+            raw_scorecard.setdefault("mechanism_overlay_ids", mechanism_overlay_ids)
+        if evidence is not None:
+            raw_scorecard.setdefault(
+                "replay_artifact_refs", list(evidence.replay_artifact_refs)
+            )
         scorecard = _candidate_board_scorecard_with_evidence_blockers(
             raw_scorecard, evidence
         )
@@ -8816,6 +9021,11 @@ def _candidate_board_payload(
                 replay_artifact_refs=evidence.replay_artifact_refs
                 if evidence is not None
                 else (),
+            )
+        )
+        scorecard, predictability_decay_summary = (
+            _candidate_board_scorecard_with_predictability_decay_blockers(
+                spec, scorecard, target=target
             )
         )
         selected_for_replay = bool(selection.get("selected_for_replay"))
@@ -8844,6 +9054,7 @@ def _candidate_board_payload(
                 "family_template_id": spec.family_template_id,
                 "runtime_family": spec.runtime_family,
                 "runtime_strategy_name": spec.runtime_strategy_name,
+                "mechanism_overlay_ids": mechanism_overlay_ids,
                 "pre_replay_rank": _rank_sort_value(pre_replay.get("rank")),
                 "pre_replay_proposal_score": str(
                     pre_replay.get("proposal_score") or ""
@@ -9047,6 +9258,7 @@ def _candidate_board_payload(
                 "regime_specialist_validation": regime_specialist_validation,
                 "rejected_signal_outcome_learning": rejected_signal_summary,
                 "order_type_execution_quality": order_type_summary,
+                "predictability_decay_stress": predictability_decay_summary,
                 "evidence_lineage": evidence_lineage,
                 "replay_window_coverage": replay_window_coverage,
                 "blockers": blockers,

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -3985,6 +3985,52 @@ def _candidate_artifact_refs(item: Mapping[str, Any]) -> list[str]:
     return list(dict.fromkeys(refs))
 
 
+def _candidate_runtime_ledger_artifact_refs(item: Mapping[str, Any]) -> list[str]:
+    refs: list[str] = []
+    scorecard = _mapping(item.get("objective_scorecard"))
+    for source in (item, scorecard):
+        for key in (
+            "exact_replay_ledger_artifact_ref",
+            "runtime_ledger_artifact_ref",
+        ):
+            ref = str(source.get(key) or "").strip()
+            if ref:
+                refs.append(ref)
+        for key in (
+            "exact_replay_ledger_artifact_refs",
+            "runtime_ledger_artifact_refs",
+        ):
+            raw_refs = source.get(key)
+            if isinstance(raw_refs, str):
+                ref = raw_refs.strip()
+                if ref:
+                    refs.append(ref)
+                continue
+            for raw_ref in cast(Sequence[Any], raw_refs or ()):
+                ref = str(raw_ref).strip()
+                if ref:
+                    refs.append(ref)
+    for raw_ref in cast(Sequence[Any], item.get("replay_artifact_refs") or ()):
+        ref = str(raw_ref).strip()
+        ref_lower = ref.lower()
+        if ref and (
+            "exact-replay-ledger" in ref_lower
+            or "exact_replay_ledger" in ref_lower
+            or "runtime-ledger" in ref_lower
+            or "runtime_ledger" in ref_lower
+        ):
+            refs.append(ref)
+    return list(dict.fromkeys(refs))
+
+
+def _candidate_runtime_ledger_count(item: Mapping[str, Any], *keys: str) -> int:
+    scorecard = _mapping(item.get("objective_scorecard"))
+    values: list[int] = []
+    for source in (item, scorecard):
+        values.extend(_nonnegative_int_metric(source.get(key)) for key in keys)
+    return max(values, default=0)
+
+
 def _paper_probation_required_actions(hard_vetoes: Sequence[str]) -> list[str]:
     reasons = {str(reason) for reason in hard_vetoes}
     actions = ["collect_runtime_ledger_paper_evidence"]
@@ -4080,10 +4126,24 @@ def _build_paper_probation_shortlist(
         hard_vetoes = [
             str(reason) for reason in cast(Sequence[Any], item.get("hard_vetoes") or ())
         ]
-        artifact_refs = _candidate_artifact_refs(item)
+        artifact_refs = _candidate_runtime_ledger_artifact_refs(item)
+        runtime_ledger_row_count = _candidate_runtime_ledger_count(
+            item,
+            "runtime_ledger_artifact_row_count",
+            "exact_replay_ledger_artifact_row_count",
+        )
+        runtime_ledger_fill_count = _candidate_runtime_ledger_count(
+            item,
+            "runtime_ledger_artifact_fill_count",
+            "exact_replay_ledger_artifact_fill_count",
+        )
         blockers: list[str] = []
         if not artifact_refs:
-            blockers.append("missing_runtime_or_replay_ledger_artifact")
+            blockers.append("missing_exact_or_runtime_ledger_artifact")
+        if runtime_ledger_row_count <= 0:
+            blockers.append("missing_runtime_ledger_row_count")
+        if runtime_ledger_fill_count <= 0:
+            blockers.append("missing_runtime_ledger_fill_count")
         paper_probation_allowed = not blockers
         shortlist.append(
             {
@@ -4103,6 +4163,9 @@ def _build_paper_probation_shortlist(
                     objective_veto_policy=objective_veto_policy,
                     hard_vetoes=hard_vetoes,
                 ),
+                "runtime_ledger_artifact_refs": artifact_refs,
+                "runtime_ledger_artifact_row_count": runtime_ledger_row_count,
+                "runtime_ledger_artifact_fill_count": runtime_ledger_fill_count,
                 "net_pnl_per_day": str(
                     _candidate_metric_value(
                         item,

--- a/services/torghut/tests/test_profit_target_oracle.py
+++ b/services/torghut/tests/test_profit_target_oracle.py
@@ -290,6 +290,77 @@ class TestProfitTargetOracle(TestCase):
 
         self.assertTrue(result["passed"])
 
+    def test_profit_target_oracle_rejects_alpha_decay_overlay_without_stress(
+        self,
+    ) -> None:
+        scorecard = {
+            **_passing_scorecard(),
+            "mechanism_overlay_ids": ["alpha_decay_predictability_stress"],
+            "predictability_decay_stress_passed": False,
+            "horizon_decay_curve_present": False,
+            "spread_adjusted_label_replay_present": False,
+            "predictability_decay_stress_horizon_count": 2,
+            "tight_spread_regime_slice_count": 19,
+            "predictability_decay_stress_split_pass_rate": "0.59",
+            "predictability_decay_stress_best_split_share": "0.36",
+            "post_cost_net_pnl_after_predictability_decay_stress": "499.99",
+        }
+
+        result = evaluate_profit_target_oracle(
+            scorecard,
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertFalse(result["passed"])
+        self.assertIn("predictability_decay_stress_passed_failed", result["blockers"])
+        self.assertIn(
+            "predictability_decay_stress_artifact_present_failed",
+            result["blockers"],
+        )
+        self.assertIn("horizon_decay_curve_present_failed", result["blockers"])
+        self.assertIn("spread_adjusted_label_replay_present_failed", result["blockers"])
+        self.assertIn(
+            "predictability_decay_stress_horizon_count_failed",
+            result["blockers"],
+        )
+        self.assertIn("tight_spread_regime_slice_count_failed", result["blockers"])
+        self.assertIn(
+            "predictability_decay_stress_split_pass_rate_failed",
+            result["blockers"],
+        )
+        self.assertIn(
+            "predictability_decay_stress_best_split_share_failed",
+            result["blockers"],
+        )
+        self.assertIn(
+            "post_cost_net_pnl_after_predictability_decay_stress_failed",
+            result["blockers"],
+        )
+
+    def test_profit_target_oracle_accepts_alpha_decay_stress_contract(
+        self,
+    ) -> None:
+        scorecard = {
+            **_passing_scorecard(),
+            "requires_predictability_decay_stress": True,
+            "predictability_decay_stress_passed": True,
+            "predictability_decay_stress_artifact_ref": "/tmp/alpha-decay.json",
+            "horizon_decay_curve_present": True,
+            "spread_adjusted_label_replay_present": True,
+            "predictability_decay_stress_horizon_count": 3,
+            "tight_spread_regime_slice_count": 20,
+            "predictability_decay_stress_split_pass_rate": "0.60",
+            "predictability_decay_stress_best_split_share": "0.35",
+            "post_cost_net_pnl_after_predictability_decay_stress": "505",
+        }
+
+        result = evaluate_profit_target_oracle(
+            scorecard,
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertTrue(result["passed"])
+
     def test_profit_target_oracle_rejects_market_limit_policy_without_order_type_tca_evidence(
         self,
     ) -> None:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -6228,7 +6228,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             dataset_snapshot_id="snapshot-hmicro-runtime-proof",
             feature_spec_hash="hash-hmicro-proof",
             code_commit="commit-test",
-            replay_artifact_refs=("paper-window.json",),
+            replay_artifact_refs=(
+                "paper-window.json",
+                "paper-window-exact-replay-ledger.json",
+            ),
             objective_scorecard={
                 "net_pnl_per_day": "82.50",
                 "target_met": False,
@@ -6238,6 +6241,17 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "orders_submitted_count": 7,
                 "trade_count": 7,
                 "executable_replay_submitted_order_count": 7,
+                "exact_replay_ledger_artifact_ref": "paper-window-exact-replay-ledger.json",
+                "runtime_ledger_artifact_row_count": 21,
+                "runtime_ledger_artifact_fill_count": 7,
+                "replay_lineage": {
+                    "windows": {
+                        "full_window": {
+                            "start_date": "2026-05-18",
+                            "end_date": "2026-05-20",
+                        }
+                    }
+                },
                 "profit_target_oracle": {
                     "blockers": [
                         "portfolio_post_cost_net_pnl_per_day_failed",
@@ -6317,6 +6331,82 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             board["double_oos_summary"]["blockers"],
         )
         self.assertRegex(board["status_digest"], r"^[0-9a-f]{64}$")
+
+    def test_candidate_board_rejects_alpha_decay_overlay_without_stress(
+        self,
+    ) -> None:
+        spec = replace(
+            self._candidate_spec("spec-alpha-decay-missing-stress"),
+            parameter_space={
+                "mechanism_overlay_ids": ["alpha_decay_predictability_stress"]
+            },
+            promotion_contract={
+                "requires_predictability_decay_stress": True,
+                "requires_horizon_decay_curve": True,
+                "requires_spread_adjusted_label_replay": True,
+            },
+        )
+        evidence = runner.CandidateEvidenceBundle(
+            schema_version="torghut.candidate-evidence-bundle.v1",
+            evidence_bundle_id="ev-alpha-decay-missing-stress",
+            candidate_id="cand-alpha-decay-missing-stress",
+            candidate_spec_id=spec.candidate_spec_id,
+            dataset_snapshot_id="snapshot-alpha-decay-missing-stress",
+            feature_spec_hash="hash-alpha-decay-missing-stress",
+            code_commit="commit-test",
+            replay_artifact_refs=("alpha-decay-replay.json",),
+            objective_scorecard={
+                "net_pnl_per_day": "725",
+                "target_met": True,
+                "oracle_passed": True,
+                "trade_decision_count": 14,
+                "orders_submitted_count": 14,
+                "trade_count": 14,
+                "profit_target_oracle": {"blockers": []},
+            },
+            fold_metrics=(),
+            stress_metrics=(),
+            cost_calibration={"status": "provisional", "source": "paper_runtime"},
+            null_comparator={},
+            promotion_readiness={},
+        )
+
+        board = runner._candidate_board_payload(
+            epoch_id="epoch-alpha-decay-missing-stress",
+            output_dir=Path("/tmp/epoch-alpha-decay-missing-stress"),
+            target=Decimal("500"),
+            candidate_specs=(spec,),
+            candidate_selection={
+                "rows": [
+                    {
+                        "candidate_spec_id": spec.candidate_spec_id,
+                        "selected_for_replay": True,
+                    }
+                ]
+            },
+            pre_replay_proposal_rows=(),
+            proposal_rows=(),
+            evidence_bundles=(evidence,),
+            portfolio=None,
+            promotion_readiness={"promotable": False},
+            runtime_closure={},
+        )
+
+        row = board["rows"][0]
+        self.assertFalse(row["oracle_passed"])
+        self.assertFalse(row["predictability_decay_stress"]["passed"])
+        self.assertIn(
+            "predictability_decay_stress_passed_failed",
+            row["predictability_decay_stress"]["blockers"],
+        )
+        self.assertIn(
+            "predictability_decay_stress_passed_failed",
+            row["blockers"],
+        )
+        self.assertEqual(
+            row["predictability_decay_stress"]["source_marker"],
+            "tkan_lob_alpha_decay_arxiv_2601_02310_2026",
+        )
 
     def test_candidate_board_surfaces_paper_probation_without_promotion(
         self,
@@ -6534,7 +6624,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             dataset_snapshot_id="snapshot-close-probation",
             feature_spec_hash="hash-close-probation",
             code_commit="commit-test",
-            replay_artifact_refs=("close-probation.json",),
+            replay_artifact_refs=(
+                "close-probation.json",
+                "close-probation-exact-replay-ledger.json",
+            ),
             objective_scorecard={
                 "net_pnl_per_day": "480",
                 "market_impact_stress_passed": True,
@@ -6571,6 +6664,17 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 "trade_decision_count": 8,
                 "orders_submitted_count": 8,
                 "trade_count": 8,
+                "exact_replay_ledger_artifact_ref": "close-probation-exact-replay-ledger.json",
+                "runtime_ledger_artifact_row_count": 24,
+                "runtime_ledger_artifact_fill_count": 8,
+                "replay_lineage": {
+                    "windows": {
+                        "full_window": {
+                            "start_date": "2026-05-18",
+                            "end_date": "2026-05-21",
+                        }
+                    }
+                },
                 "profit_target_oracle": {
                     "blockers": [
                         "min_daily_net_pnl_failed",
@@ -6675,6 +6779,42 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             0,
         )
         self.assertFalse(probation_candidate["final_promotion_allowed"])
+
+    def test_candidate_board_paper_probation_requires_runtime_ledger_admission(
+        self,
+    ) -> None:
+        generic_row = {
+            "candidate_spec_id": "spec-generic-paper",
+            "candidate_id": "cand-generic-paper",
+            "hypothesis_id": "hyp-generic-paper",
+            "runtime_family": "microbar_cross_sectional_pairs",
+            "runtime_strategy_name": "microbar_cross_sectional_pairs-runtime",
+            "replay_artifact_refs": ["generic-replay.json"],
+        }
+        ledger_row = {
+            **generic_row,
+            "candidate_spec_id": "spec-ledger-paper",
+            "candidate_id": "cand-ledger-paper",
+            "exact_replay_ledger_artifact_ref": "ledger-exact-replay-ledger.json",
+            "runtime_ledger_artifact_row_count": 18,
+            "runtime_ledger_artifact_fill_count": 6,
+            "runtime_window_start": "2026-05-18",
+            "runtime_window_end": "2026-05-20",
+        }
+
+        self.assertEqual(
+            runner._candidate_board_paper_probation_admission_blockers(generic_row),
+            [
+                "paper_probation_runtime_ledger_artifact_missing",
+                "paper_probation_runtime_ledger_row_count_missing",
+                "paper_probation_runtime_ledger_fill_count_missing",
+                "paper_probation_runtime_window_bounds_missing",
+            ],
+        )
+        self.assertEqual(
+            runner._candidate_board_paper_probation_admission_blockers(ledger_row),
+            [],
+        )
 
     def test_candidate_board_runtime_window_plan_dedupes_and_blocks_incomplete_targets(
         self,
@@ -7441,7 +7581,13 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                         "status": "blocked_pending_promotion_prerequisites",
                         "promotable": False,
                         "blockers": ["oracle_blocked"],
-                    }
+                    },
+                    "candidate_board": {
+                        "paper_probation_candidate": {
+                            "candidate_id": "candidate-test",
+                            "paper_probation_authorized": True,
+                        }
+                    },
                 },
                 runner_config={},
                 started_at=started_at,
@@ -7456,6 +7602,56 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             saved.payload_json["promotion_readiness"]["blockers"], ["oracle_blocked"]
         )
+
+    def test_epoch_ledgers_keep_target_met_oracle_failed_blocked_without_paper_probation_authority(
+        self,
+    ) -> None:
+        portfolio = runner.PortfolioCandidateSpec(
+            schema_version="torghut.portfolio-candidate-spec.v1",
+            portfolio_candidate_id="portfolio-paper-probation-blocked",
+            source_candidate_ids=("candidate-test",),
+            target_net_pnl_per_day=Decimal("500"),
+            sleeves=(),
+            capital_budget={},
+            correlation_budget={},
+            drawdown_budget={},
+            evidence_refs=(),
+            objective_scorecard={"oracle_passed": False, "target_met": True},
+            optimizer_report={},
+        )
+        started_at = datetime(2026, 5, 8, 17, 0, 0)
+        completed_at = datetime(2026, 5, 8, 17, 1, 0)
+
+        with patch(
+            "scripts.run_whitepaper_autoresearch_profit_target.SessionLocal",
+            side_effect=lambda: Session(self.engine),
+        ):
+            runner._persist_epoch_ledgers(
+                epoch_id="epoch-paper-probation-blocked",
+                status="ok",
+                target_net_pnl_per_day=Decimal("500"),
+                paper_run_ids=[],
+                sources=[],
+                candidate_specs=[],
+                proposal_rows=[],
+                portfolio=portfolio,
+                summary={
+                    "promotion_readiness": {
+                        "status": "blocked_pending_promotion_prerequisites",
+                        "promotable": False,
+                        "blockers": ["oracle_blocked"],
+                    }
+                },
+                runner_config={},
+                started_at=started_at,
+                completed_at=completed_at,
+            )
+
+        with Session(self.engine) as session:
+            saved = session.execute(select(AutoresearchPortfolioCandidate)).scalar_one()
+
+        self.assertEqual(saved.status, "blocked")
+        self.assertFalse(saved.payload_json["promotion_readiness"]["promotable"])
 
     def test_feedback_evidence_loader_reconstructs_paper_probation_candidates(
         self,

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -2097,8 +2097,10 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     "min_cash": "-161171.80",
                 },
                 "full_window": {"net_per_day": "406.58", "net_pnl": "813.16"},
-                "runtime_ledger_artifact_ref": "/tmp/microbar-ledger.json",
-                "replay_artifact_refs": ["/tmp/microbar-ledger.json"],
+                "runtime_ledger_artifact_ref": "/tmp/microbar-runtime-ledger.json",
+                "runtime_ledger_artifact_row_count": 12,
+                "runtime_ledger_artifact_fill_count": 4,
+                "replay_artifact_refs": ["/tmp/microbar-runtime-ledger.json"],
                 "hard_vetoes": [
                     "gross_exposure_pct_equity_above_max",
                     "min_cash_below_min",
@@ -2162,9 +2164,42 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertFalse(shortlist[0]["paper_probation_allowed"])
         self.assertEqual(
             shortlist[0]["probation_blockers"],
-            ["missing_runtime_or_replay_ledger_artifact"],
+            [
+                "missing_exact_or_runtime_ledger_artifact",
+                "missing_runtime_ledger_row_count",
+                "missing_runtime_ledger_fill_count",
+            ],
         )
         self.assertFalse(shortlist[0]["promotion_allowed"])
+
+    def test_paper_probation_shortlist_blocks_generic_replay_artifact(self) -> None:
+        shortlist = frontier._build_paper_probation_shortlist(
+            [
+                {
+                    "candidate_id": "positive-generic-replay-only",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "175",
+                        "net_pnl": "350",
+                        "max_gross_exposure_pct_equity": "0.5",
+                        "min_cash": "100",
+                    },
+                    "full_window": {"net_per_day": "175", "net_pnl": "350"},
+                    "replay_artifact_refs": ["/tmp/generic-replay.json"],
+                    "hard_vetoes": [],
+                }
+            ],
+            top_n=1,
+            objective_veto_policy=frontier.ObjectiveVetoPolicy(
+                required_max_gross_exposure_pct_equity=Decimal("1"),
+                required_min_cash=Decimal("0"),
+            ),
+        )
+
+        self.assertFalse(shortlist[0]["paper_probation_allowed"])
+        self.assertIn(
+            "missing_exact_or_runtime_ledger_artifact",
+            shortlist[0]["probation_blockers"],
+        )
 
     def test_generate_symbol_prune_children_removes_worst_symbols_from_universe(
         self,


### PR DESCRIPTION
## Summary

- Requires exact/runtime-ledger artifacts, row counts, fill counts, and window bounds before a near-miss Torghut candidate can be admitted to paper probation.
- Adds T-KAN/TLOB-style predictability-decay stress gates to the profit oracle and candidate board so alpha-decay overlays cannot pass without horizon, spread-label, split, artifact, and post-cost PnL evidence.
- Tightens frontier paper-probation shortlists to reject generic replay artifacts and persist target-met/oracle-failed portfolios as paper probation only when the candidate board explicitly authorizes evidence collection.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff format app/trading/discovery/profit_target_oracle.py scripts/run_whitepaper_autoresearch_profit_target.py scripts/search_consistent_profitability_frontier.py tests/test_profit_target_oracle.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_search_consistent_profitability_frontier.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/profit_target_oracle.py scripts/run_whitepaper_autoresearch_profit_target.py scripts/search_consistent_profitability_frontier.py tests/test_profit_target_oracle.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_search_consistent_profitability_frontier.py`
- `cd services/torghut && uv run --frozen pytest tests/test_profit_target_oracle.py tests/test_search_consistent_profitability_frontier.py tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
