### PR TITLE
fix(torghut): capture rejected seed replay ledgers

### DIFF
--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -191,6 +191,7 @@ _CONSISTENCY_REPAIR_MAX_SIGNAL_THRESHOLD_RELAXATIONS = 2
 class _WorklistItem:
     params_candidate: dict[str, Any]
     strategy_overrides: dict[str, Any]
+    candidate_record_seed: bool = False
     symbol_prune_iteration: int = 0
     loss_repair_iteration: int = 0
     consistency_repair_iteration: int = 0
@@ -698,6 +699,15 @@ def _parse_args() -> argparse.Namespace:
             "This replays known candidate params exactly before exploring variants."
         ),
     )
+    parser.add_argument(
+        "--capture-rejected-seed-full-window-ledger",
+        action="store_true",
+        help=(
+            "For checked-in candidate-record seeds rejected by the train screen, "
+            "still run a full-window exact replay ledger capture as proof-only evidence. "
+            "The candidate remains train-screen rejected and non-promotable."
+        ),
+    )
     parser.add_argument("--json-output", type=Path)
     parser.add_argument(
         "--symbol-prune-iterations",
@@ -1133,6 +1143,7 @@ def _iter_initial_worklist_candidates(
         yield _WorklistItem(
             params_candidate=dict(params_candidate),
             strategy_overrides=dict(override_candidate),
+            candidate_record_seed=True,
         )
     for override_candidate in override_candidates:
         for params_candidate in _iter_parameter_candidates(parameter_grid):
@@ -1950,6 +1961,15 @@ def _exact_replay_ledger_artifact_update(
     candidate_index: int,
     candidate_id: str,
     full_window_payload: Mapping[str, Any],
+    dataset_snapshot_id: str = "",
+    replay_lineage: Mapping[str, Any] | None = None,
+    candidate_evaluation_key: Mapping[str, Any] | None = None,
+    replay_tape_validation: Mapping[str, Any] | None = None,
+    candidate_search_key: str = "",
+    candidate_symbols: Sequence[str] = (),
+    full_window_start: date | None = None,
+    full_window_end: date | None = None,
+    proof_only_reason: str = "",
 ) -> dict[str, Any]:
     ledger_payload = _mapping(full_window_payload.get("exact_replay_ledger"))
     raw_rows = ledger_payload.get("runtime_ledger_rows")
@@ -1966,6 +1986,60 @@ def _exact_replay_ledger_artifact_update(
         "artifact_kind": "exact_replay_ledger",
         "candidate_id": candidate_id,
     }
+    if dataset_snapshot_id:
+        artifact_payload["dataset_snapshot_id"] = dataset_snapshot_id
+    if replay_lineage:
+        artifact_payload["replay_lineage"] = dict(replay_lineage)
+        artifact_payload["replay_lineage_hash"] = str(
+            replay_lineage.get("lineage_hash") or ""
+        )
+    if candidate_evaluation_key:
+        artifact_payload["candidate_evaluation_key_payload"] = dict(
+            candidate_evaluation_key
+        )
+        artifact_payload["candidate_evaluation_key"] = str(
+            candidate_evaluation_key.get("candidate_evaluation_key") or ""
+        )
+    if replay_tape_validation:
+        artifact_payload["replay_tape"] = {
+            "status": str(replay_tape_validation.get("status") or ""),
+            "tape_path": str(replay_tape_validation.get("tape_path") or ""),
+            "manifest_path": str(replay_tape_validation.get("manifest_path") or ""),
+            "selected_row_count": int(
+                replay_tape_validation.get("selected_row_count") or 0
+            ),
+            "selected_symbols": list(
+                cast(
+                    Sequence[Any], replay_tape_validation.get("selected_symbols") or ()
+                )
+            ),
+            "source_query_digest": str(
+                replay_tape_validation.get("source_query_digest") or ""
+            ),
+            "source_table_versions": dict(
+                cast(
+                    Mapping[str, Any],
+                    replay_tape_validation.get("source_table_versions") or {},
+                )
+            ),
+            "artifact_refs": dict(
+                cast(
+                    Mapping[str, Any], replay_tape_validation.get("artifact_refs") or {}
+                )
+            ),
+        }
+    if candidate_search_key:
+        artifact_payload["candidate_search_key"] = candidate_search_key
+    if candidate_symbols:
+        artifact_payload["candidate_symbols"] = list(candidate_symbols)
+    if full_window_start is not None and full_window_end is not None:
+        artifact_payload["full_window"] = {
+            "start_date": full_window_start.isoformat(),
+            "end_date": full_window_end.isoformat(),
+        }
+    if proof_only_reason:
+        artifact_payload["proof_only"] = True
+        artifact_payload["proof_only_reason"] = proof_only_reason
     _write_json_output(artifact_path, artifact_payload)
     return {
         "exact_replay_ledger_artifact_ref": artifact_ref,
@@ -4751,6 +4825,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                 )
                 holdout_replay_skipped = bool(train_screen_failures)
                 full_window_replay_skipped = bool(train_screen_failures)
+                proof_only_full_window_replay_captured = False
                 if train_screen_failures:
                     train_screen_only_candidates += 1
                     second_oos_start = window.second_oos_start
@@ -4767,7 +4842,41 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                         if second_oos_start is not None and second_oos_end is not None
                         else None
                     )
-                    full_window_payload = train_payload
+                    if (
+                        bool(
+                            getattr(
+                                args,
+                                "capture_rejected_seed_full_window_ledger",
+                                False,
+                            )
+                        )
+                        and worklist_item.candidate_record_seed
+                    ):
+                        full_replay_candidates_started += 1
+                        proof_only_full_window_replay_captured = True
+                        full_window_replay_skipped = False
+                        full_window_payload = run_replay(
+                            _build_replay_config(
+                                strategy_configmap_path=candidate_configmap_path,
+                                clickhouse_http_url=str(args.clickhouse_http_url),
+                                clickhouse_username=(
+                                    str(args.clickhouse_username).strip() or None
+                                ),
+                                clickhouse_password=clickhouse_password,
+                                start_date=full_window_start,
+                                end_date=full_window_end,
+                                start_equity=Decimal(str(args.start_equity)),
+                                chunk_minutes=max(1, int(args.chunk_minutes)),
+                                symbols=candidate_symbols,
+                                progress_log_interval_seconds=max(
+                                    1, int(args.progress_log_seconds)
+                                ),
+                                capture_trace_funnel=collect_train_gate_diagnostics,
+                                capture_exact_replay_ledger=True,
+                            )
+                        )
+                    else:
+                        full_window_payload = train_payload
                 else:
                     full_replay_candidates_started += 1
                     holdout_payload = run_replay(
@@ -4871,33 +4980,12 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     - second_oos_penalty
                 )
                 candidate_payload = base_result.to_payload()
-                exact_replay_ledger_update = _exact_replay_ledger_artifact_update(
-                    args=args,
-                    root=root,
-                    candidate_index=candidate_index,
-                    candidate_id=str(candidate_payload["candidate_id"]),
-                    full_window_payload=full_window_payload,
-                )
-                if exact_replay_ledger_update:
-                    artifact_ref = str(
-                        exact_replay_ledger_update["exact_replay_ledger_artifact_ref"]
-                    )
-                    candidate_payload.update(exact_replay_ledger_update)
-                    candidate_payload["replay_artifact_refs"] = list(
-                        dict.fromkeys(
-                            [
-                                *cast(
-                                    Sequence[Any],
-                                    candidate_payload.get("replay_artifact_refs") or (),
-                                ),
-                                artifact_ref,
-                            ]
-                        )
-                    )
+                exact_replay_ledger_update: dict[str, Any] = {}
                 order_type_ablation_update: dict[str, Any] = {}
                 if (
                     order_type_ablation_policy.enabled
                     and not full_window_replay_skipped
+                    and not proof_only_full_window_replay_captured
                     and order_type_ablation_evaluated
                     < order_type_ablation_policy.max_candidates
                 ):
@@ -5025,6 +5113,42 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                 candidate_payload["candidate_evaluation_key_payload"] = (
                     candidate_evaluation_key
                 )
+                exact_replay_ledger_update = _exact_replay_ledger_artifact_update(
+                    args=args,
+                    root=root,
+                    candidate_index=candidate_index,
+                    candidate_id=str(candidate_payload["candidate_id"]),
+                    full_window_payload=full_window_payload,
+                    dataset_snapshot_id=dataset_snapshot_receipt.snapshot_id,
+                    replay_lineage=replay_lineage,
+                    candidate_evaluation_key=candidate_evaluation_key,
+                    replay_tape_validation=replay_tape_validation,
+                    candidate_search_key=candidate_key,
+                    candidate_symbols=candidate_symbols,
+                    full_window_start=full_window_start,
+                    full_window_end=full_window_end,
+                    proof_only_reason=(
+                        "train_screen_rejected_candidate_record_seed"
+                        if proof_only_full_window_replay_captured
+                        else ""
+                    ),
+                )
+                if exact_replay_ledger_update:
+                    artifact_ref = str(
+                        exact_replay_ledger_update["exact_replay_ledger_artifact_ref"]
+                    )
+                    candidate_payload.update(exact_replay_ledger_update)
+                    candidate_payload["replay_artifact_refs"] = list(
+                        dict.fromkeys(
+                            [
+                                *cast(
+                                    Sequence[Any],
+                                    candidate_payload.get("replay_artifact_refs") or (),
+                                ),
+                                artifact_ref,
+                            ]
+                        )
+                    )
                 candidate_payload["screening"] = {
                     "schema_version": "torghut.frontier-train-screen.v1",
                     "enabled": bool(getattr(args, "train_screening", True)),
@@ -5036,6 +5160,9 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     "max_train_worst_day_loss": str(max_train_screen_worst_day_loss),
                     "holdout_replay_skipped": holdout_replay_skipped,
                     "full_window_replay_skipped": full_window_replay_skipped,
+                    "proof_only_full_window_replay_captured": (
+                        proof_only_full_window_replay_captured
+                    ),
                     "second_oos_replay_skipped": bool(
                         train_screen_failures and window.second_oos_days
                     ),
@@ -5043,13 +5170,20 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                 candidate_payload["staged_search"] = {
                     "schema_version": "torghut.frontier-candidate-staged-search.v1",
                     "stage": (
-                        "train_screen_only" if holdout_replay_skipped else "full_replay"
+                        "train_screen_rejected_full_window_proof"
+                        if proof_only_full_window_replay_captured
+                        else (
+                            "train_screen_only"
+                            if holdout_replay_skipped
+                            else "full_replay"
+                        )
                     ),
                     "train_screen_multiplier": int(
                         staged_search["train_screen_multiplier"]
                     ),
                     "full_replay_candidate_budget": full_replay_candidate_budget,
                     "full_replay_candidates_started": full_replay_candidates_started,
+                    "candidate_record_seed": worklist_item.candidate_record_seed,
                 }
                 if worklist_item.pruned_symbol is not None:
                     candidate_payload["pruned_symbol"] = worklist_item.pruned_symbol

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -120,6 +120,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     "3",
                     "--candidate-record",
                     str(root / "candidate.json"),
+                    "--capture-rejected-seed-full-window-ledger",
                     "--no-train-screening",
                     "--min-train-screen-net-per-day",
                     "-50",
@@ -143,6 +144,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(args.max_candidates_to_evaluate, 12)
         self.assertEqual(args.staged_train_screen_multiplier, 3)
         self.assertEqual(args.candidate_record, [root / "candidate.json"])
+        self.assertTrue(args.capture_rejected_seed_full_window_ledger)
         self.assertFalse(args.train_screening)
         self.assertEqual(args.min_train_screen_net_per_day, "-50")
         self.assertEqual(args.min_train_screen_active_ratio, "0.25")
@@ -696,8 +698,10 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
 
         self.assertEqual(first.params_candidate, {"entry_start_minute_utc": "810"})
         self.assertEqual(first.strategy_overrides, {"max_notional_per_trade": "50000"})
+        self.assertTrue(first.candidate_record_seed)
         self.assertEqual(second.params_candidate, {"long_stop_loss_bps": "10"})
         self.assertEqual(second.strategy_overrides, {"max_notional_per_trade": "63180"})
+        self.assertFalse(second.candidate_record_seed)
 
     def test_candidate_symbols_prefers_cli_filter_then_universe_override(self) -> None:
         self.assertEqual(
@@ -1458,6 +1462,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             min_train_screen_net_per_day="0",
             min_train_screen_active_ratio="0.50",
             max_train_screen_worst_day_loss="",
+            capture_rejected_seed_full_window_ledger=False,
         )
 
     def test_resolve_frontier_replay_windows_keeps_second_oos_independent(
@@ -4197,6 +4202,197 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             self.assertTrue(top["screening"]["full_window_replay_skipped"])
             self.assertIn("train_no_decisions", top["hard_vetoes"])
             self.assertIn("train_net_per_day_below_screen", top["hard_vetoes"])
+
+    def test_rejected_candidate_record_can_capture_full_window_exact_ledger(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = self._write_strategy_configmap(root)
+            sweep_config = self._write_sweep_config(root)
+            candidate_record = root / "candidate.json"
+            candidate_record.write_text(
+                json.dumps(
+                    {
+                        "candidate_id": "H-TSMOM-LIQ-01",
+                        "candidate_strategy": {
+                            "strategy_name": "intraday-tsmom-profit-v3",
+                            "universe_symbols": ["NVDA"],
+                            "max_notional_per_trade": "50000",
+                            "params": {"long_stop_loss_bps": "12"},
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            json_output = root / "frontier.json"
+            args = self._make_args(
+                strategy_configmap=strategy_configmap,
+                sweep_config=sweep_config,
+                json_output=json_output,
+            )
+            args.candidate_record = [candidate_record]
+            args.capture_rejected_seed_full_window_ledger = True
+            args.max_candidates_to_evaluate = 1
+            args.min_train_screen_net_per_day = "1"
+            recent_days = tuple(
+                date(2026, 3, 18) + timedelta(days=index) for index in range(6)
+            )
+            snapshot_receipt = SimpleNamespace(
+                snapshot_id="snap-rejected-seed-proof",
+                is_fresh=True,
+                stale_override_used=False,
+                to_payload=lambda: {
+                    "snapshot_id": "snap-rejected-seed-proof",
+                    "source": "ta",
+                    "window_size": "PT1S",
+                    "start_day": "2026-03-18",
+                    "end_day": "2026-03-23",
+                    "expected_last_trading_day": "2026-03-23",
+                    "is_fresh": True,
+                    "missing_days": [],
+                    "row_count": 123,
+                    "stale_override_used": False,
+                    "witnesses": [],
+                },
+            )
+            replay_calls: list[tuple[str, str, bool]] = []
+
+            def fake_run_replay(config: object) -> dict[str, object]:
+                start_date = str(getattr(config, "start_date"))
+                end_date = str(getattr(config, "end_date"))
+                capture_ledger = bool(
+                    getattr(config, "capture_exact_replay_ledger", False)
+                )
+                replay_calls.append((start_date, end_date, capture_ledger))
+                if capture_ledger:
+                    payload = self._payload(
+                        start_date=start_date,
+                        end_date=end_date,
+                        daily_net={
+                            "2026-03-18": "25",
+                            "2026-03-19": "25",
+                            "2026-03-20": "25",
+                            "2026-03-21": "25",
+                            "2026-03-22": "25",
+                            "2026-03-23": "25",
+                        },
+                        decision_count=2,
+                        filled_count=2,
+                        wins=2,
+                        losses=0,
+                    )
+                    payload["exact_replay_ledger"] = {
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "account_label": "TORGHUT_REPLAY",
+                        "execution_policy_hash": "policy-sha",
+                        "cost_model_hash": "cost-sha",
+                        "lineage_hash": "ledger-lineage-sha",
+                        "fill_row_count": 2,
+                        "runtime_ledger_rows": [
+                            {
+                                "event_type": "decision",
+                                "executed_at": "2026-03-18T14:35:00+00:00",
+                                "decision_id": "decision-buy",
+                                "order_id": "order-buy",
+                            },
+                            {
+                                "event_type": "order_submitted",
+                                "executed_at": "2026-03-18T14:35:01+00:00",
+                                "decision_id": "decision-buy",
+                                "order_id": "order-buy",
+                            },
+                            {
+                                "event_type": "fill",
+                                "executed_at": "2026-03-18T14:35:02+00:00",
+                                "decision_id": "decision-buy",
+                                "order_id": "order-buy",
+                                "symbol": "NVDA",
+                                "side": "buy",
+                                "filled_qty": "1",
+                                "avg_fill_price": "100",
+                                "cost_amount": "0.10",
+                                "cost_basis": "local_replay_transaction_cost_model",
+                            },
+                        ],
+                    }
+                    return payload
+                return self._payload(
+                    start_date=start_date,
+                    end_date=end_date,
+                    daily_net={
+                        "2026-03-18": "0",
+                        "2026-03-19": "0",
+                        "2026-03-20": "0",
+                    },
+                    decision_count=0,
+                    filled_count=0,
+                    wins=0,
+                    losses=0,
+                )
+
+            with (
+                patch(
+                    "scripts.search_consistent_profitability_frontier._resolve_recent_trading_days",
+                    return_value=recent_days,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt",
+                    return_value=snapshot_receipt,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot"
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.run_replay",
+                    side_effect=fake_run_replay,
+                ),
+            ):
+                payload = frontier.run_consistent_profitability_frontier(args)
+
+            self.assertEqual(
+                replay_calls,
+                [
+                    ("2026-03-18", "2026-03-20", False),
+                    ("2026-03-18", "2026-03-23", True),
+                ],
+            )
+            top = payload["top"][0]
+            self.assertEqual(top["screening"]["status"], "rejected")
+            self.assertTrue(top["screening"]["holdout_replay_skipped"])
+            self.assertFalse(top["screening"]["full_window_replay_skipped"])
+            self.assertTrue(top["screening"]["proof_only_full_window_replay_captured"])
+            self.assertEqual(
+                top["staged_search"]["stage"],
+                "train_screen_rejected_full_window_proof",
+            )
+            self.assertTrue(top["staged_search"]["candidate_record_seed"])
+            self.assertIn("train_no_decisions", top["hard_vetoes"])
+            exact_ledger_ref = Path(
+                top["objective_scorecard"]["exact_replay_ledger_artifact_ref"]
+            )
+            self.assertTrue(exact_ledger_ref.exists())
+            artifact = json.loads(exact_ledger_ref.read_text(encoding="utf-8"))
+            self.assertTrue(artifact["proof_only"])
+            self.assertEqual(
+                artifact["proof_only_reason"],
+                "train_screen_rejected_candidate_record_seed",
+            )
+            self.assertEqual(
+                artifact["dataset_snapshot_id"], "snap-rejected-seed-proof"
+            )
+            self.assertEqual(
+                artifact["candidate_evaluation_key"], top["candidate_evaluation_key"]
+            )
+            self.assertEqual(
+                artifact["replay_lineage_hash"],
+                top["replay_lineage"]["lineage_hash"],
+            )
+            self.assertEqual(
+                artifact["full_window"],
+                {"start_date": "2026-03-18", "end_date": "2026-03-23"},
+            )
+            self.assertEqual(artifact["candidate_symbols"], ["NVDA"])
 
     def test_run_frontier_staged_train_screen_expands_cheap_stage(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Adds an opt-in frontier flag to capture full-window exact replay ledger artifacts for checked-in candidate-record seeds that fail train screening.
- Keeps those candidates explicitly rejected and non-promotable while preserving ledger refs, row/fill counts, replay lineage, candidate evaluation keys, dataset snapshot ids, and proof-only labels.
- Prevents proof-only rejected-seed capture from triggering extra order-type ablation work.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `cd services/torghut && uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'paper_probation or runtime_window_import_plan' -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
