### PR TITLE
fix(torghut): carry runtime ledger import metadata

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -297,10 +297,16 @@ def _runtime_ledger_post_cost_from_rows(
 
 def _paper_probation_blocking_reasons(runtime_payload: Mapping[str, Any]) -> list[str]:
     target_metadata = _mapping(runtime_payload.get("target_metadata"))
-    if not target_metadata:
-        return []
-
     reasons: list[str] = []
+    reasons.extend(
+        _string_list(runtime_payload.get("runtime_ledger_target_metadata_blockers"))
+    )
+    reasons.extend(
+        _string_list(target_metadata.get("runtime_ledger_target_metadata_blockers"))
+    )
+    if not target_metadata:
+        return list(dict.fromkeys(reasons))
+
     paper_probation_authorized = _observation_bool(
         target_metadata.get("paper_probation_authorized")
     )
@@ -313,7 +319,7 @@ def _paper_probation_blocking_reasons(runtime_payload: Mapping[str, Any]) -> lis
         reasons.append("final_promotion_not_authorized")
     if _observation_bool(target_metadata.get("final_promotion_allowed")) is False:
         reasons.append("final_promotion_not_allowed")
-    return reasons
+    return list(dict.fromkeys(reasons))
 
 
 def _delay_adjusted_depth_stress_blocking_reasons(

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -9,7 +9,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence, cast
 
 import psycopg
 from sqlalchemy import select
@@ -303,6 +303,92 @@ def _nonnegative_int(value: Any) -> int:
         return max(0, int(Decimal(str(value))))
     except Exception:
         return 0
+
+
+def _metadata_text_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray)):
+        return []
+    return [
+        text for item in cast(Sequence[Any], value) if (text := str(item or "").strip())
+    ]
+
+
+def _runtime_ledger_target_metadata_artifact_refs(
+    target_metadata: Mapping[str, Any],
+) -> list[str]:
+    refs: list[str] = []
+    for key in (
+        "runtime_ledger_artifact_refs",
+        "exact_replay_ledger_artifact_refs",
+    ):
+        refs.extend(_metadata_text_list(target_metadata.get(key)))
+    for key in (
+        "runtime_ledger_artifact_ref",
+        "exact_replay_ledger_artifact_ref",
+    ):
+        refs.extend(_metadata_text_list(target_metadata.get(key)))
+    return list(dict.fromkeys(refs))
+
+
+def _metadata_nonnegative_int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return _nonnegative_int(value)
+
+
+def _runtime_ledger_target_metadata_blockers(
+    *,
+    target_metadata: Mapping[str, Any],
+    runtime_ledger_artifact_metadata: Mapping[str, Any],
+    window_start: datetime,
+    window_end: datetime,
+) -> list[str]:
+    metadata = _as_mapping(target_metadata)
+    if not metadata:
+        return []
+
+    blockers: list[str] = []
+    planned_refs = _runtime_ledger_target_metadata_artifact_refs(metadata)
+    if planned_refs:
+        loaded_refs = _metadata_text_list(
+            runtime_ledger_artifact_metadata.get("runtime_ledger_artifact_refs")
+        )
+        if set(planned_refs) != set(loaded_refs):
+            blockers.append("runtime_ledger_artifact_refs_mismatch")
+
+    for key, blocker in (
+        (
+            "runtime_ledger_artifact_row_count",
+            "runtime_ledger_artifact_row_count_mismatch",
+        ),
+        (
+            "runtime_ledger_artifact_fill_count",
+            "runtime_ledger_artifact_fill_count_mismatch",
+        ),
+    ):
+        planned_count = _metadata_nonnegative_int_or_none(metadata.get(key))
+        if planned_count is None:
+            continue
+        loaded_count = _nonnegative_int(runtime_ledger_artifact_metadata.get(key))
+        if planned_count != loaded_count:
+            blockers.append(blocker)
+
+    for key, actual_bound in (
+        ("window_start", window_start),
+        ("window_end", window_end),
+    ):
+        expected_bound = _parse_dt_or_none(metadata.get(key))
+        if metadata.get(key) is not None and expected_bound != actual_bound:
+            blockers.append("runtime_ledger_window_bounds_mismatch")
+            break
+
+    return list(dict.fromkeys(blockers))
 
 
 def _runtime_ledger_profit_proof_present(
@@ -1132,6 +1218,12 @@ def main() -> int:
     target_metadata = _parse_target_metadata(
         str(getattr(args, "target_metadata_json", "") or "")
     )
+    runtime_ledger_target_metadata_blockers = _runtime_ledger_target_metadata_blockers(
+        target_metadata=target_metadata,
+        runtime_ledger_artifact_metadata=runtime_ledger_artifact_metadata,
+        window_start=window_start,
+        window_end=window_end,
+    )
     if not decisions and not executions and not tca_rows:
         summary = _source_activity_missing_summary(
             run_id=args.run_id,
@@ -1216,6 +1308,7 @@ def main() -> int:
         "artifact_refs": artifact_refs,
         "dataset_snapshot_ref": dataset_snapshot_ref,
         "target_metadata": target_metadata,
+        "runtime_ledger_target_metadata_blockers": runtime_ledger_target_metadata_blockers,
         **runtime_ledger_artifact_metadata,
         **runtime_ledger_durable_metadata,
         "report_post_cost_expectancy_bps": (

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -11,11 +11,12 @@ import signal
 import socket
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, replace
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, time
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
 from urllib.parse import urlparse
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import select
 
@@ -109,6 +110,9 @@ _DEFAULT_DAILY_PROFIT_TARGET = "500"
 _DEFAULT_PORTFOLIO_PROFIT_PROGRAM = Path(
     "config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml"
 )
+_CANDIDATE_BOARD_RUNTIME_SESSION_TZ = ZoneInfo("America/New_York")
+_CANDIDATE_BOARD_RUNTIME_SESSION_OPEN = time(hour=9, minute=30)
+_CANDIDATE_BOARD_RUNTIME_SESSION_CLOSE = time(hour=16, minute=0)
 _DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC = 8
 _DEFAULT_CLICKHOUSE_HTTP_URL = (
     "http://torghut-clickhouse.torghut.svc.cluster.local:8123"
@@ -8700,6 +8704,50 @@ def _candidate_board_runtime_window_bounds(
     return "", ""
 
 
+def _candidate_board_date_only(value: str) -> date | None:
+    text = _string(value)
+    if not text or "T" in text or " " in text:
+        return None
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _candidate_board_regular_session_bound(value: str, *, end: bool) -> str:
+    text = _string(value)
+    trading_day = _candidate_board_date_only(text)
+    if trading_day is None:
+        return text
+    session_time = (
+        _CANDIDATE_BOARD_RUNTIME_SESSION_CLOSE
+        if end
+        else _CANDIDATE_BOARD_RUNTIME_SESSION_OPEN
+    )
+    return (
+        datetime.combine(
+            trading_day,
+            session_time,
+            tzinfo=_CANDIDATE_BOARD_RUNTIME_SESSION_TZ,
+        )
+        .astimezone(UTC)
+        .isoformat()
+    )
+
+
+def _candidate_board_runtime_window_import_bounds(
+    row: Mapping[str, Any],
+) -> tuple[str, str]:
+    window_start = _string(row.get("runtime_window_start") or row.get("window_start"))
+    window_end = _string(row.get("runtime_window_end") or row.get("window_end"))
+    if not window_start or not window_end:
+        window_start, window_end = _candidate_board_runtime_window_bounds(row)
+    return (
+        _candidate_board_regular_session_bound(window_start, end=False),
+        _candidate_board_regular_session_bound(window_end, end=True),
+    )
+
+
 def _candidate_board_runtime_ledger_refs(row: Mapping[str, Any]) -> tuple[str, ...]:
     refs: list[str] = []
     for key in (
@@ -8774,6 +8822,19 @@ def _candidate_board_runtime_import_args(target: Mapping[str, Any]) -> list[str]
         ref = _string(artifact_ref)
         if ref:
             args.extend(["--artifact-ref", ref])
+    target_metadata = _mapping(target.get("target_metadata"))
+    if target_metadata:
+        args.extend(
+            [
+                "--target-metadata-json",
+                json.dumps(
+                    target_metadata,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    default=str,
+                ),
+            ]
+        )
     args.append("--json")
     return args
 
@@ -8822,10 +8883,7 @@ def _candidate_board_runtime_window_import_plan(
         runtime_ledger_artifact_ref = _string(row.get("runtime_ledger_artifact_ref"))
         if not runtime_ledger_artifact_ref and runtime_ledger_artifact_refs:
             runtime_ledger_artifact_ref = runtime_ledger_artifact_refs[0]
-        window_start = _string(
-            row.get("runtime_window_start") or row.get("window_start")
-        )
-        window_end = _string(row.get("runtime_window_end") or row.get("window_end"))
+        window_start, window_end = _candidate_board_runtime_window_import_bounds(row)
         account_label = _string(row.get("account_label"))
         if not account_label and runtime_ledger_artifact_refs:
             account_label = "TORGHUT_REPLAY"
@@ -8930,7 +8988,6 @@ def _candidate_board_runtime_window_import_plan(
                     ],
                 }
             )
-        target["import_command_args"] = _candidate_board_runtime_import_args(target)
         target["target_metadata"] = {
             key: value
             for key, value in target.items()
@@ -8940,6 +8997,7 @@ def _candidate_board_runtime_window_import_plan(
                 "target_metadata",
             }
         }
+        target["import_command_args"] = _candidate_board_runtime_import_args(target)
         targets.append(target)
 
     return {

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -30,6 +30,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _runtime_ledger_bucket_profit_proof_present,
     _runtime_ledger_event_type,
     _runtime_ledger_profit_proof_present,
+    _runtime_ledger_target_metadata_blockers,
     _runtime_ledger_tca_rows_from_durable_buckets,
     _runtime_ledger_tca_rows_from_artifacts,
     _strategy_name_candidates,
@@ -384,6 +385,53 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             _parse_target_metadata("{")
         with self.assertRaisesRegex(RuntimeError, "target_metadata_json_not_mapping"):
             _parse_target_metadata("[]")
+
+    def test_runtime_ledger_target_metadata_blockers_fail_closed_on_mismatch(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+        artifact_metadata = {
+            "runtime_ledger_artifact_refs": ["exact-ledger.json"],
+            "runtime_ledger_artifact_row_count": 6,
+            "runtime_ledger_artifact_fill_count": 2,
+        }
+
+        self.assertEqual(
+            _runtime_ledger_target_metadata_blockers(
+                target_metadata={
+                    "runtime_ledger_artifact_refs": ["exact-ledger.json"],
+                    "runtime_ledger_artifact_row_count": 6,
+                    "runtime_ledger_artifact_fill_count": 2,
+                    "window_start": "2026-03-06T14:30:00+00:00",
+                    "window_end": "2026-03-06T15:00:00+00:00",
+                },
+                runtime_ledger_artifact_metadata=artifact_metadata,
+                window_start=window_start,
+                window_end=window_end,
+            ),
+            [],
+        )
+        self.assertEqual(
+            _runtime_ledger_target_metadata_blockers(
+                target_metadata={
+                    "runtime_ledger_artifact_refs": ["different-ledger.json"],
+                    "runtime_ledger_artifact_row_count": 7,
+                    "runtime_ledger_artifact_fill_count": 3,
+                    "window_start": "2026-03-06T14:35:00+00:00",
+                    "window_end": "2026-03-06T15:00:00+00:00",
+                },
+                runtime_ledger_artifact_metadata=artifact_metadata,
+                window_start=window_start,
+                window_end=window_end,
+            ),
+            [
+                "runtime_ledger_artifact_refs_mismatch",
+                "runtime_ledger_artifact_row_count_mismatch",
+                "runtime_ledger_artifact_fill_count_mismatch",
+                "runtime_ledger_window_bounds_mismatch",
+            ],
+        )
 
     def test_main_requires_source_dsn_or_durable_runtime_ledger_bucket(self) -> None:
         args = SimpleNamespace(
@@ -1289,7 +1337,15 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 artifact_ref=[str(artifact_path)],
                 delay_adjusted_depth_stress_report_ref="",
                 dataset_snapshot_ref="runtime-ledger-artifact-snapshot",
-                target_metadata_json="",
+                target_metadata_json=json.dumps(
+                    {
+                        "runtime_ledger_artifact_refs": [str(artifact_path)],
+                        "runtime_ledger_artifact_row_count": 6,
+                        "runtime_ledger_artifact_fill_count": 2,
+                        "window_start": "2026-03-06T14:30:00+00:00",
+                        "window_end": "2026-03-06T15:00:00+00:00",
+                    }
+                ),
                 dependency_quorum_decision="allow",
                 continuity_ok="true",
                 drift_ok="true",
@@ -1355,6 +1411,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertEqual(runtime_payload["runtime_ledger_artifact_row_count"], 6)
         self.assertEqual(runtime_payload["runtime_ledger_artifact_fill_count"], 2)
+        self.assertEqual(runtime_payload["runtime_ledger_target_metadata_blockers"], [])
         self.assertEqual(
             runtime_payload["authority_reason"], "runtime_ledger_profit_proof"
         )

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -6523,8 +6523,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             target["source_kind"], "simulation_exact_replay_runtime_ledger"
         )
         self.assertEqual(target["account_label"], "TORGHUT_REPLAY")
-        self.assertEqual(target["window_start"], "2026-05-18")
-        self.assertEqual(target["window_end"], "2026-05-20")
+        self.assertEqual(target["window_start"], "2026-05-18T13:30:00+00:00")
+        self.assertEqual(target["window_end"], "2026-05-20T20:00:00+00:00")
         self.assertEqual(target["dataset_snapshot_ref"], "snapshot-paper-probation")
         self.assertEqual(
             target["artifact_refs"],
@@ -6544,6 +6544,26 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn(
             "paper-probation-exact-ledger.json", target["import_command_args"]
         )
+        self.assertIn("--target-metadata-json", target["import_command_args"])
+        metadata_arg_index = (
+            target["import_command_args"].index("--target-metadata-json") + 1
+        )
+        import_metadata = json.loads(target["import_command_args"][metadata_arg_index])
+        self.assertEqual(
+            import_metadata["runtime_ledger_artifact_refs"],
+            ["paper-probation-exact-ledger.json"],
+        )
+        self.assertEqual(import_metadata["runtime_ledger_artifact_row_count"], 27)
+        self.assertEqual(import_metadata["runtime_ledger_artifact_fill_count"], 9)
+        self.assertEqual(
+            import_metadata["exact_replay_ledger_artifact_ref"],
+            "paper-probation-exact-ledger.json",
+        )
+        self.assertEqual(import_metadata["window_start"], target["window_start"])
+        self.assertEqual(import_metadata["window_end"], target["window_end"])
+        self.assertTrue(import_metadata["paper_probation_authorized"])
+        self.assertFalse(import_metadata["promotion_allowed"])
+        self.assertFalse(import_metadata["final_promotion_authorized"])
         self.assertEqual(target["handoff"], "runtime_window_import_only")
         self.assertEqual(
             target["promotion_gate"], "existing_runtime_governance_fail_closed"
@@ -6911,6 +6931,25 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "paper-runtime-plan-exact-replay-ledger.json",
             plan["targets"][0]["import_command_args"],
         )
+        self.assertIn(
+            "--target-metadata-json",
+            plan["targets"][0]["import_command_args"],
+        )
+        metadata_arg_index = (
+            plan["targets"][0]["import_command_args"].index("--target-metadata-json")
+            + 1
+        )
+        import_metadata = json.loads(
+            plan["targets"][0]["import_command_args"][metadata_arg_index]
+        )
+        self.assertEqual(
+            import_metadata["runtime_ledger_artifact_refs"],
+            ["paper-runtime-plan-exact-replay-ledger.json"],
+        )
+        self.assertEqual(import_metadata["runtime_ledger_artifact_row_count"], 36)
+        self.assertEqual(import_metadata["runtime_ledger_artifact_fill_count"], 12)
+        self.assertEqual(import_metadata["window_start"], "2026-05-18T13:30:00+00:00")
+        self.assertEqual(import_metadata["window_end"], "2026-05-20T20:00:00+00:00")
         self.assertEqual(fallback_plan["status"], "ready")
         self.assertEqual(fallback_plan["target_count"], 1)
         self.assertEqual(

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -1145,6 +1145,9 @@ class TestRuntimeWindowImport(TestCase):
                 source_manifest_ref="config/trading/hypotheses/h-micro-01.json",
                 buckets=buckets,
                 runtime_observation_payload={
+                    "runtime_ledger_target_metadata_blockers": [
+                        "runtime_ledger_artifact_refs_mismatch"
+                    ],
                     "target_metadata": {
                         "paper_probation_authorized": True,
                         "evidence_collection_stage": "paper",
@@ -1173,6 +1176,10 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(summary["promotion_allowed"], False)
         self.assertIn(
             "paper_probation_evidence_collection_only",
+            summary["promotion_blocking_reasons"],
+        )
+        self.assertIn(
+            "runtime_ledger_artifact_refs_mismatch",
             summary["promotion_blocking_reasons"],
         )
         self.assertIn(


### PR DESCRIPTION
## Summary

- Normalize candidate-board date-only runtime windows to regular-session UTC bounds before building import targets.
- Pass candidate-board runtime-window target metadata into `import_hypothesis_runtime_windows.py`, including exact/runtime ledger refs, row/fill counts, window bounds, and paper-probation fail-closed fields.
- Add importer reconciliation blockers for mismatched planned ledger refs, row counts, fill counts, or window bounds, and preserve those blockers in runtime promotion decisions.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/run_whitepaper_autoresearch_profit_target.py scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k "target_metadata or runtime_ledger_artifact" -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k "paper_probation or runtime_window_plan" -q`
- `uv run --frozen pytest tests/test_runtime_window_import.py -k "paper_probation or target_metadata" -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Post-rebase: `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- Post-rebase: `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k "target_metadata or runtime_ledger_artifact" -q`
- Post-rebase: `uv run --frozen pyright --project pyrightconfig.json`
- Post-rebase: `uv run --frozen pyright --project pyrightconfig.alpha.json`
- Post-rebase: `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
