### PR TITLE
fix(torghut): block stale runtime ledger proof

### DIFF
--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -1038,6 +1038,18 @@ def _runtime_ledger_provenance_blockers(
     return tuple(blockers)
 
 
+def _runtime_ledger_window_bound_blockers(
+    *,
+    bucket_started_at: datetime | None,
+    bucket_ended_at: datetime | None,
+) -> tuple[str, ...]:
+    if bucket_started_at is None or bucket_ended_at is None:
+        return ("runtime_ledger_window_bounds_missing",)
+    if bucket_ended_at < bucket_started_at:
+        return ("runtime_ledger_window_bounds_mismatch",)
+    return ()
+
+
 def _runtime_ledger_blockers(row: Mapping[str, Any]) -> tuple[str, ...]:
     raw: object = (
         row.get("blockers")
@@ -1102,6 +1114,8 @@ def _resolve_runtime_ledger_readiness_inputs(
     lineage_hash_count = _hash_count(row.get("lineage_hash_counts"))
     ledger_schema_version = _runtime_text(row.get("ledger_schema_version"))
     pnl_basis = _runtime_text(row.get("pnl_basis"))
+    bucket_started_at = _parse_iso8601(row.get("bucket_started_at"))
+    bucket_ended_at = _parse_iso8601(row.get("bucket_ended_at"))
     blockers = _dedupe_runtime_ledger_blockers(
         (
             *_runtime_ledger_blockers(row),
@@ -1116,6 +1130,10 @@ def _resolve_runtime_ledger_readiness_inputs(
                 execution_policy_hash_count=execution_policy_hash_count,
                 cost_model_hash_count=cost_model_hash_count,
                 lineage_hash_count=lineage_hash_count,
+            ),
+            *_runtime_ledger_window_bound_blockers(
+                bucket_started_at=bucket_started_at,
+                bucket_ended_at=bucket_ended_at,
             ),
         )
     )
@@ -1137,8 +1155,8 @@ def _resolve_runtime_ledger_readiness_inputs(
             row.get("net_strategy_pnl_after_costs")
         ),
         post_cost_expectancy_bps=_optional_decimal(row.get("post_cost_expectancy_bps")),
-        bucket_started_at=_parse_iso8601(row.get("bucket_started_at")),
-        bucket_ended_at=_parse_iso8601(row.get("bucket_ended_at")),
+        bucket_started_at=bucket_started_at,
+        bucket_ended_at=bucket_ended_at,
         blockers=blockers,
         execution_policy_hash_count=execution_policy_hash_count,
         cost_model_hash_count=cost_model_hash_count,
@@ -1567,6 +1585,12 @@ def compile_hypothesis_runtime_statuses(
             runtime_ledger_summary,
             manifest=manifest,
         )
+        runtime_ledger_age_minutes: int | None = None
+        if runtime_ledger_inputs.bucket_ended_at is not None:
+            runtime_ledger_age_minutes = max(
+                0,
+                int((now - runtime_ledger_inputs.bucket_ended_at).total_seconds() / 60),
+            )
         tca_age_minutes: int | None = None
         if tca_inputs.last_computed_at is not None:
             tca_age_minutes = max(
@@ -1616,6 +1640,18 @@ def compile_hypothesis_runtime_statuses(
                 and evidence_age_minutes > requirements.max_evidence_age_minutes
             ):
                 reasons.append("evidence_continuity_stale")
+        if (
+            runtime_ledger_inputs.proof_present
+            and requirements.max_evidence_age_minutes is not None
+            and runtime_ledger_age_minutes is not None
+            and runtime_ledger_age_minutes > requirements.max_evidence_age_minutes
+        ):
+            if market_session_open is False:
+                informational_reasons.append(
+                    "closed_session_runtime_ledger_evidence_hold"
+                )
+            else:
+                reasons.append("runtime_ledger_evidence_stale")
         if requirements.require_delay_adjusted_depth_stress:
             if (
                 delay_depth_stress.check_count
@@ -1863,6 +1899,7 @@ def compile_hypothesis_runtime_statuses(
                 if runtime_ledger_inputs.bucket_ended_at is not None
                 else None
             ),
+            "runtime_ledger_age_minutes": runtime_ledger_age_minutes,
             "runtime_ledger_blockers": list(runtime_ledger_inputs.blockers),
             "runtime_ledger_execution_policy_hash_count": (
                 runtime_ledger_inputs.execution_policy_hash_count

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -446,6 +446,106 @@ class TestHypothesisReadiness(TestCase):
         self.assertEqual(cont["observed"]["runtime_ledger_observed_stage"], "paper")
         self.assertNotIn("post_cost_expectancy_non_positive", cont["reasons"])
 
+    def test_compile_hypothesis_runtime_statuses_blocks_stale_runtime_ledger_profit_authority(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        state = _state(
+            feature_rows=5,
+            drift_checks=3,
+            evidence_checks=2,
+            signal_lag_seconds=15,
+            evidence_report={
+                "ok": True,
+                "checked_at": "2026-03-06T16:35:00+00:00",
+            },
+        )
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=state,
+            tca_summary={
+                "order_count": 45,
+                "avg_abs_slippage_bps": 4,
+                "avg_realized_shortfall_bps": -8,
+                "last_computed_at": "2026-03-06T16:35:00+00:00",
+            },
+            runtime_ledger_summary=_runtime_ledger_summary(
+                "H-CONT-01",
+                submitted_order_count=45,
+                post_cost_expectancy_bps="8",
+            ),
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 3, 6, 16, 40, tzinfo=timezone.utc),
+        )
+
+        cont = next(item for item in statuses if item["hypothesis_id"] == "H-CONT-01")
+        self.assertFalse(cont["promotion_eligible"])
+        self.assertEqual(cont["state"], "shadow")
+        self.assertIn("runtime_ledger_evidence_stale", cont["reasons"])
+        self.assertEqual(cont["observed"]["runtime_ledger_age_minutes"], 45)
+
+    def test_compile_hypothesis_runtime_statuses_blocks_runtime_ledger_missing_window_bounds(
+        self,
+    ) -> None:
+        registry = load_hypothesis_registry()
+        state = _state(
+            feature_rows=5,
+            drift_checks=3,
+            evidence_checks=2,
+            signal_lag_seconds=15,
+            evidence_report={
+                "ok": True,
+                "checked_at": "2026-03-06T15:45:00+00:00",
+            },
+        )
+        statuses = compile_hypothesis_runtime_statuses(
+            registry=registry,
+            state=state,
+            tca_summary={
+                "order_count": 45,
+                "avg_abs_slippage_bps": 4,
+                "avg_realized_shortfall_bps": -8,
+                "last_computed_at": "2026-03-06T15:50:00+00:00",
+            },
+            runtime_ledger_summary={
+                "by_hypothesis": {
+                    "H-CONT-01": {
+                        "hypothesis_id": "H-CONT-01",
+                        "candidate_id": _MANIFEST_CANDIDATE_IDS["H-CONT-01"],
+                        "observed_stage": "live",
+                        "strategy_family": _MANIFEST_STRATEGY_FAMILIES["H-CONT-01"],
+                        "submitted_order_count": 45,
+                        "closed_trade_count": 8,
+                        "filled_notional": "100000",
+                        "post_cost_expectancy_bps": "8",
+                        "ledger_schema_version": EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+                        "pnl_basis": POST_COST_PNL_BASIS,
+                        "execution_policy_hash_counts": {"policy-sha": 1},
+                        "cost_model_hash_counts": {"cost-sha": 1},
+                        "lineage_hash_counts": {"lineage-sha": 1},
+                    }
+                }
+            },
+            market_context_status={"last_freshness_seconds": 60},
+            jangar_dependency_quorum=JangarDependencyQuorumStatus(
+                decision="allow",
+                reasons=[],
+                message="ok",
+            ),
+            now=datetime(2026, 3, 6, 16, 0, tzinfo=timezone.utc),
+        )
+
+        cont = next(item for item in statuses if item["hypothesis_id"] == "H-CONT-01")
+        self.assertFalse(cont["promotion_eligible"])
+        self.assertIn("runtime_ledger_window_bounds_missing", cont["reasons"])
+        self.assertIsNone(cont["observed"]["runtime_ledger_bucket_started_at"])
+        self.assertIsNone(cont["observed"]["runtime_ledger_bucket_ended_at"])
+
     def test_htsmom_liq_manifest_keeps_candidate_identity_but_blocks_paper_ledger(
         self,
     ) -> None:
@@ -528,6 +628,7 @@ class TestHypothesisReadiness(TestCase):
                         "candidate_id": candidate_id,
                         "observed_stage": "paper",
                         "strategy_family": strategy_family,
+                        "bucket_started_at": "2026-03-06T15:45:00+00:00",
                         "bucket_ended_at": "2026-03-06T15:55:00+00:00",
                         "submitted_order_count": 45,
                         "post_cost_expectancy_bps": "8",
@@ -544,6 +645,7 @@ class TestHypothesisReadiness(TestCase):
                         "candidate_id": candidate_id,
                         "observed_stage": "live",
                         "strategy_family": strategy_family,
+                        "bucket_started_at": "2026-03-06T15:15:00+00:00",
                         "bucket_ended_at": "2026-03-06T15:30:00+00:00",
                         "submitted_order_count": 45,
                         "closed_trade_count": 8,
@@ -647,6 +749,7 @@ class TestHypothesisReadiness(TestCase):
                         "candidate_id": _MANIFEST_CANDIDATE_IDS["H-CONT-01"],
                         "observed_stage": "live",
                         "strategy_family": _MANIFEST_STRATEGY_FAMILIES["H-CONT-01"],
+                        "bucket_started_at": "2026-03-06T15:45:00+00:00",
                         "bucket_ended_at": "2026-03-06T15:55:00+00:00",
                         "submitted_order_count": 45,
                         "post_cost_expectancy_bps": "8",
@@ -715,6 +818,7 @@ class TestHypothesisReadiness(TestCase):
                         "candidate_id": _MANIFEST_CANDIDATE_IDS["H-CONT-01"],
                         "observed_stage": "live",
                         "strategy_family": _MANIFEST_STRATEGY_FAMILIES["H-CONT-01"],
+                        "bucket_started_at": "2026-03-06T15:45:00+00:00",
                         "bucket_ended_at": "2026-03-06T15:55:00+00:00",
                         "submitted_order_count": 45,
                         "closed_trade_count": 5,
@@ -1295,6 +1399,10 @@ class TestHypothesisReadiness(TestCase):
         self.assertIn("slippage_budget_exceeded", cont["reasons"])
         self.assertIn("closed_session_signal_hold", cont["informational_reasons"])
         self.assertIn("closed_session_tca_evidence_hold", cont["informational_reasons"])
+        self.assertIn(
+            "closed_session_runtime_ledger_evidence_hold",
+            cont["informational_reasons"],
+        )
         self.assertNotIn("market_context_stale", rev["reasons"])
         self.assertIn(
             "closed_session_market_context_hold", rev["informational_reasons"]


### PR DESCRIPTION
## Summary

- Add runtime-ledger bucket bound validation to hypothesis readiness so live proof without bucket start/end timestamps blocks promotion.
- Block stale runtime-ledger profitability proof using the manifest evidence-age window, while preserving the existing closed-session freshness hold behavior.
- Add regressions for stale runtime-ledger proof, missing runtime-ledger window bounds, and closed-session runtime-ledger evidence holds.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/hypotheses.py tests/test_hypotheses.py`
- `uv run --frozen ruff check app/trading/hypotheses.py tests/test_hypotheses.py`
- `uv run --frozen pytest tests/test_hypotheses.py -k "runtime_ledger_profit_authority or runtime_ledger_missing_window_bounds or stale_runtime_ledger_profit_authority or prefers_live_runtime_ledger_row" -q`
- `uv run --frozen pytest tests/test_hypotheses.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
