### PR TITLE
fix(torghut): require ledger pnl for runtime import promotion

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -36,9 +36,6 @@ PROMOTION_GRADE_POST_COST_BASES = frozenset(
         "realized_strategy_pnl_after_explicit_costs",
     }
 )
-LIVE_PROMOTION_GRADE_POST_COST_BASES = frozenset(
-    {"realized_strategy_pnl_after_explicit_costs"}
-)
 RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
     {
         EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
@@ -259,6 +256,16 @@ def _runtime_ledger_bucket_payload(value: Any) -> dict[str, Any]:
     return {**bucket, "blockers": _runtime_ledger_bucket_blockers(bucket)}
 
 
+def _runtime_ledger_row_is_promotion_grade(row: _NormalizedTcaRow) -> bool:
+    return (
+        row.post_cost_expectancy_bps is not None
+        and row.post_cost_promotion_eligible
+        and row.post_cost_expectancy_basis == POST_COST_PNL_BASIS
+        and bool(row.runtime_ledger_bucket)
+        and not _runtime_ledger_bucket_blockers(row.runtime_ledger_bucket)
+    )
+
+
 def _runtime_ledger_post_cost_from_rows(
     rows: Sequence[_NormalizedTcaRow],
 ) -> tuple[Decimal | None, Decimal, Decimal, int]:
@@ -266,13 +273,7 @@ def _runtime_ledger_post_cost_from_rows(
     total_notional = Decimal("0")
     sample_count = 0
     for row in rows:
-        if (
-            not row.post_cost_promotion_eligible
-            or row.post_cost_expectancy_basis
-            != "realized_strategy_pnl_after_explicit_costs"
-            or not row.runtime_ledger_bucket
-            or _runtime_ledger_bucket_blockers(row.runtime_ledger_bucket)
-        ):
+        if not _runtime_ledger_row_is_promotion_grade(row):
             continue
         net_pnl = _optional_decimal(
             row.runtime_ledger_bucket.get("net_strategy_pnl_after_costs")
@@ -611,12 +612,8 @@ def _runtime_promotion_blocking_reasons(
         reasons.append("recent_slippage_budget_exceeded")
     if total_post_cost_promotion_sample_count <= 0:
         reasons.append("post_cost_pnl_basis_missing")
-    if observed_stage == "live" and (
-        sum(
-            total_post_cost_basis_counts.get(basis, 0)
-            for basis in LIVE_PROMOTION_GRADE_POST_COST_BASES
-        )
-        <= 0
+    if (
+        runtime_ledger_notional_weighted_sample_count <= 0
         or runtime_ledger_notional_weighted_sample_count
         < total_post_cost_promotion_sample_count
     ):
@@ -775,10 +772,7 @@ def build_observed_runtime_buckets(
             if row.abs_slippage_bps is not None
         ]
         promotion_post_cost_rows = [
-            row
-            for row in bucket_tca
-            if row.post_cost_expectancy_bps is not None
-            and row.post_cost_promotion_eligible
+            row for row in bucket_tca if _runtime_ledger_row_is_promotion_grade(row)
         ]
         runtime_ledger_post_cost_bps: Decimal | None
         runtime_ledger_net: Decimal
@@ -805,19 +799,9 @@ def build_observed_runtime_buckets(
         if runtime_ledger_post_cost_bps is not None:
             post_cost_expectancy_bps = runtime_ledger_post_cost_bps
             post_cost_expectancy_aggregation = "runtime_ledger_notional_weighted"
-        elif promotion_post_cost_rows:
-            post_cost_expectancy_bps = sum(
-                (
-                    row.post_cost_expectancy_bps
-                    for row in promotion_post_cost_rows
-                    if row.post_cost_expectancy_bps is not None
-                ),
-                Decimal("0"),
-            ) / Decimal(len(promotion_post_cost_rows))
-            post_cost_expectancy_aggregation = "promotion_bps_average"
         else:
             post_cost_expectancy_bps = Decimal("0")
-            post_cost_expectancy_aggregation = "no_promotion_grade_post_cost_rows"
+            post_cost_expectancy_aggregation = "no_runtime_ledger_post_cost_rows"
         buckets.append(
             ObservedRuntimeBucket(
                 window_started_at=bucket_start,
@@ -1060,20 +1044,10 @@ def persist_observed_runtime_windows(
     for bucket in sorted_buckets:
         total_post_cost_basis_counter.update(bucket.post_cost_basis_counts)
     total_post_cost_basis_counts = dict(sorted(total_post_cost_basis_counter.items()))
-    total_post_cost = sum(
-        (
-            bucket.post_cost_expectancy_bps * Decimal(bucket.market_session_count)
-            for bucket in sorted_buckets
-        ),
-        Decimal("0"),
-    )
     latest_three_budget_ok = (
         all(bucket.avg_abs_slippage_bps <= budget for bucket in sorted_buckets[-3:])
         if sorted_buckets
         else False
-    )
-    average_post_cost = (
-        (total_post_cost / total_weight) if total_weight > 0 else Decimal("0")
     )
     (
         runtime_ledger_average_post_cost,
@@ -1085,7 +1059,8 @@ def persist_observed_runtime_windows(
         average_post_cost = runtime_ledger_average_post_cost
         post_cost_expectancy_aggregation = "runtime_ledger_notional_weighted"
     else:
-        post_cost_expectancy_aggregation = "promotion_bps_session_weighted_average"
+        average_post_cost = Decimal("0")
+        post_cost_expectancy_aggregation = "no_runtime_ledger_post_cost_rows"
     average_slippage = (
         sum(
             (

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -183,6 +183,43 @@ class TestRuntimeWindowImport(TestCase):
             {"realized_strategy_pnl": 1},
         )
 
+    def test_build_observed_runtime_buckets_requires_runtime_ledger_bucket_for_pnl_basis(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    6,
+                )
+            ],
+            decision_times=[datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+            execution_times=[datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("4"),
+                    "post_cost_expectancy_bps": Decimal("50"),
+                    **_runtime_pnl_basis(),
+                }
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        self.assertEqual(buckets[0].post_cost_expectancy_bps, Decimal("0"))
+        self.assertEqual(buckets[0].post_cost_promotion_sample_count, 0)
+        self.assertEqual(
+            buckets[0].payload_json["post_cost_expectancy_aggregation"],
+            "no_runtime_ledger_post_cost_rows",
+        )
+        self.assertEqual(
+            buckets[0].post_cost_basis_counts,
+            {"realized_strategy_pnl_after_explicit_costs": 1},
+        )
+
     def test_build_observed_runtime_buckets_weights_runtime_ledger_by_notional(
         self,
     ) -> None:
@@ -827,6 +864,76 @@ class TestRuntimeWindowImport(TestCase):
         )
         self.assertEqual(decision.allowed, False)
 
+    def test_persist_observed_runtime_windows_blocks_paper_without_runtime_ledger_pnl(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    40,
+                ),
+                (
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 30, tzinfo=timezone.utc),
+                    40,
+                ),
+            ],
+            decision_times=[
+                datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 15, 5, tzinfo=timezone.utc),
+            ],
+            execution_times=[
+                datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
+            ],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("1"),
+                    "post_cost_expectancy_bps": Decimal("80"),
+                    **_runtime_pnl_basis(),
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("1"),
+                    "post_cost_expectancy_bps": Decimal("80"),
+                    **_runtime_pnl_basis(),
+                },
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        with self.session_local() as session:
+            summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-paper-no-runtime-ledger-pnl",
+                candidate_id="cand-paper-no-runtime-ledger",
+                hypothesis_id="H-CONT-01",
+                observed_stage="paper",
+                strategy_family="intraday_continuation",
+                source_manifest_ref="config/trading/hypotheses/h-cont-01.json",
+                buckets=buckets,
+            )
+            session.commit()
+            decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
+
+        self.assertEqual(summary["promotion_allowed"], False)
+        self.assertEqual(summary["post_cost_promotion_sample_count"], 0)
+        self.assertEqual(summary["avg_post_cost_expectancy_bps"], "0")
+        self.assertEqual(
+            summary["post_cost_expectancy_aggregation"],
+            "no_runtime_ledger_post_cost_rows",
+        )
+        self.assertIn(
+            "runtime_ledger_pnl_basis_missing",
+            summary["promotion_blocking_reasons"],
+        )
+        self.assertEqual(decision.allowed, False)
+
     def test_build_observed_runtime_buckets_cannot_upgrade_tca_basis_to_promotion_grade(
         self,
     ) -> None:
@@ -942,12 +1049,26 @@ class TestRuntimeWindowImport(TestCase):
                     "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("4"),
                     "post_cost_expectancy_bps": Decimal("12"),
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        filled_notional="1000",
+                        gross_strategy_pnl="1.4",
+                        cost_amount="0.2",
+                        net_strategy_pnl_after_costs="1.2",
+                        post_cost_expectancy_bps="12",
+                    ),
                     **_runtime_pnl_basis(),
                 },
                 {
                     "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("5"),
                     "post_cost_expectancy_bps": Decimal("12"),
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        filled_notional="1000",
+                        gross_strategy_pnl="1.4",
+                        cost_amount="0.2",
+                        net_strategy_pnl_after_costs="1.2",
+                        post_cost_expectancy_bps="12",
+                    ),
                     **_runtime_pnl_basis(),
                 },
             ],
@@ -1006,12 +1127,26 @@ class TestRuntimeWindowImport(TestCase):
                     "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("4"),
                     "post_cost_expectancy_bps": Decimal("12"),
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        filled_notional="1000",
+                        gross_strategy_pnl="1.4",
+                        cost_amount="0.2",
+                        net_strategy_pnl_after_costs="1.2",
+                        post_cost_expectancy_bps="12",
+                    ),
                     **_runtime_pnl_basis(),
                 },
                 {
                     "computed_at": datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
                     "abs_slippage_bps": Decimal("5"),
                     "post_cost_expectancy_bps": Decimal("12"),
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        filled_notional="1000",
+                        gross_strategy_pnl="1.4",
+                        cost_amount="0.2",
+                        net_strategy_pnl_after_costs="1.2",
+                        post_cost_expectancy_bps="12",
+                    ),
                     **_runtime_pnl_basis(),
                 },
             ],
@@ -1362,8 +1497,17 @@ class TestRuntimeWindowImport(TestCase):
             summary["promotion_blocking_reasons"],
         )
         self.assertIn(
-            "post_cost_expectancy_below_manifest_threshold",
+            "runtime_ledger_pnl_basis_missing",
             summary["promotion_blocking_reasons"],
+        )
+        self.assertIn(
+            "post_cost_expectancy_non_positive",
+            summary["promotion_blocking_reasons"],
+        )
+        self.assertEqual(summary["avg_post_cost_expectancy_bps"], "0")
+        self.assertEqual(
+            summary["post_cost_expectancy_aggregation"],
+            "no_runtime_ledger_post_cost_rows",
         )
         self.assertEqual(decision.allowed, False)
         self.assertEqual(decision.state, "shadow")


### PR DESCRIPTION
## Summary

- Require runtime-window imports to have a valid runtime-ledger bucket before explicit-cost PnL counts as promotion-grade.
- Remove promotion-bps average fallbacks from persisted runtime-window promotion decisions when no runtime ledger is present.
- Add regressions for bucket construction, paper-stage imports without ledger PnL, and weak paper receipts under the stricter ledger authority model.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/runtime_window_import.py tests/test_runtime_window_import.py`
- `uv run --frozen ruff check app/trading/runtime_window_import.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen pytest tests/test_runtime_window_import.py -k "requires_runtime_ledger_bucket_for_pnl_basis or blocks_paper_without_runtime_ledger_pnl or allows_h_micro_with_fresh_delay_depth_stress or blocks_h_micro_without_delay_depth_stress" -q`
- `uv run --frozen pytest tests/test_runtime_window_import.py -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k "runtime_ledger or simulation_report or promotion" -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
