### PR TITLE
fix(torghut): require exact ledger rows for runtime closure

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -6985,6 +6985,15 @@ def _runtime_report_int(value: Any, *, default: int = 0) -> int:
         return default
 
 
+_EXACT_REPLAY_LEDGER_ARTIFACT_KIND = "exact_replay_ledger"
+_EXACT_REPLAY_LEDGER_SCHEMA_VERSIONS = frozenset(
+    {
+        "torghut.exact_replay_ledger.rows.v1",
+        "torghut.exact_replay_ledger.v1",
+    }
+)
+
+
 def _runtime_report_source_markers(report: Mapping[str, Any]) -> list[str]:
     return sorted(set(_string_list_from_value(report.get("source_markers"))))
 
@@ -7029,19 +7038,25 @@ def _runtime_closure_exact_replay_ledger_update(
     if not artifact_ref:
         return {}
     ledger = _load_json_mapping_artifact(artifact_ref)
-    raw_rows = ledger.get("runtime_ledger_rows")
-    row_count = _runtime_report_int(
-        ledger.get("runtime_ledger_artifact_row_count")
-        or ledger.get("exact_replay_ledger_artifact_row_count")
-        or ledger.get("row_count")
-        or (len(raw_rows) if isinstance(raw_rows, list) else 0)
+    if _string(ledger.get("artifact_kind")) != _EXACT_REPLAY_LEDGER_ARTIFACT_KIND:
+        return {}
+    schema_version = _string(
+        ledger.get("schema_version")
+        or ledger.get("ledger_schema_version")
+        or ledger.get("runtime_ledger_schema_version")
     )
+    if schema_version not in _EXACT_REPLAY_LEDGER_SCHEMA_VERSIONS:
+        return {}
+    raw_rows = ledger.get("runtime_ledger_rows")
+    if not isinstance(raw_rows, list) or not raw_rows:
+        return {}
+    if not all(isinstance(row, Mapping) for row in raw_rows):
+        return {}
+    row_count = len(raw_rows)
     fill_count = _runtime_report_int(
         ledger.get("runtime_ledger_artifact_fill_count")
         or ledger.get("exact_replay_ledger_artifact_fill_count")
         or ledger.get("fill_row_count")
-        or ledger.get("filled_count")
-        or _mapping(ledger.get("summary")).get("filled_count")
     )
     return {
         "exact_replay_ledger_artifact_ref": artifact_ref,

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4804,6 +4804,116 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertTrue(runtime_program.runtime_closure_policy.execute_parity_replay)
         self.assertTrue(runtime_program.runtime_closure_policy.execute_approval_replay)
 
+    def test_runtime_closure_exact_replay_ledger_rejects_summary_counts_without_rows(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            artifact_path = Path(tmpdir) / "ledger.json"
+            artifact_path.write_text(
+                json.dumps(
+                    {
+                        "artifact_kind": "runtime_summary",
+                        "row_count": 99,
+                        "filled_count": 99,
+                        "summary": {"filled_count": 99},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                runner._runtime_closure_exact_replay_ledger_update(
+                    {"exact_replay_ledger_artifact_path": str(artifact_path)}
+                ),
+                {},
+            )
+
+            artifact_path.write_text(
+                json.dumps(
+                    {
+                        "artifact_kind": "exact_replay_ledger",
+                        "schema_version": "torghut.runtime_summary.v1",
+                        "runtime_ledger_rows": [{"id": 1}],
+                        "fill_row_count": 1,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                runner._runtime_closure_exact_replay_ledger_update(
+                    {"exact_replay_ledger_artifact_path": str(artifact_path)}
+                ),
+                {},
+            )
+
+            artifact_path.write_text(
+                json.dumps(
+                    {
+                        "artifact_kind": "exact_replay_ledger",
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "row_count": 99,
+                        "filled_count": 99,
+                        "summary": {"filled_count": 99},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                runner._runtime_closure_exact_replay_ledger_update(
+                    {"exact_replay_ledger_artifact_path": str(artifact_path)}
+                ),
+                {},
+            )
+
+            artifact_path.write_text(
+                json.dumps(
+                    {
+                        "artifact_kind": "exact_replay_ledger",
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "runtime_ledger_rows": ["not-a-row"],
+                        "fill_row_count": 1,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                runner._runtime_closure_exact_replay_ledger_update(
+                    {"exact_replay_ledger_artifact_path": str(artifact_path)}
+                ),
+                {},
+            )
+
+            artifact_path.write_text(
+                json.dumps(
+                    {
+                        "artifact_kind": "exact_replay_ledger",
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "runtime_ledger_rows": [{"id": 1}],
+                        "row_count": 99,
+                        "filled_count": 99,
+                        "summary": {"filled_count": 99},
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            update = runner._runtime_closure_exact_replay_ledger_update(
+                {"exact_replay_ledger_artifact_path": str(artifact_path)}
+            )
+
+        self.assertEqual(update["exact_replay_ledger_artifact_row_count"], 1)
+        self.assertEqual(update["runtime_ledger_artifact_row_count"], 1)
+        self.assertEqual(update["exact_replay_ledger_artifact_fill_count"], 0)
+        self.assertEqual(update["runtime_ledger_artifact_fill_count"], 0)
+
     def test_runtime_closure_proof_updates_portfolio_oracle_from_real_artifacts(
         self,
     ) -> None:
@@ -4875,6 +4985,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 json.dumps(
                     {
                         "artifact_kind": "exact_replay_ledger",
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
                         "runtime_ledger_rows": [{"id": 1}, {"id": 2}],
                         "fill_row_count": 2,
                     }


### PR DESCRIPTION
## Summary

- Require runtime-closure exact replay ledger artifacts to declare `artifact_kind=exact_replay_ledger` and an accepted exact replay ledger schema.
- Require actual non-empty `runtime_ledger_rows` before runtime closure can update oracle ledger proof fields.
- Stop deriving runtime-closure ledger row/fill proof from loose `row_count`, `filled_count`, or `summary.filled_count` fields.
- Add regression coverage for generic summary artifacts and rowless exact-ledger artifacts.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k "runtime_closure_exact_replay_ledger_rejects_summary_counts_without_rows or runtime_closure_proof_updates_portfolio_oracle_from_real_artifacts" -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
