### PR TITLE
fix(torghut): require runtime ledger proof for live scale

### DIFF
--- a/services/torghut/app/trading/completion.py
+++ b/services/torghut/app/trading/completion.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
@@ -15,11 +16,13 @@ from sqlalchemy.orm import Session
 from ..models import (
     StrategyHypothesisMetricWindow,
     StrategyPromotionDecision,
+    StrategyRuntimeLedgerBucket,
     VNextCompletionGateResult,
     VNextEmpiricalJobRun,
 )
 from .empirical_jobs import EMPIRICAL_JOB_TYPES, build_empirical_jobs_status
 from .hypotheses import HypothesisManifest, load_hypothesis_registry
+from .runtime_ledger import EXACT_REPLAY_LEDGER_SCHEMA_VERSION, POST_COST_PNL_BASIS
 
 
 def _runtime_matrix_path() -> Path:
@@ -101,7 +104,7 @@ def _safe_int(value: Any, *, default: int = 0) -> int:
 def _safe_float(value: Any, *, default: float = 0.0) -> float:
     if isinstance(value, bool):
         return float(int(value))
-    if isinstance(value, (int, float)):
+    if isinstance(value, (Decimal, int, float)):
         return float(value)
     if isinstance(value, str):
         stripped = value.strip()
@@ -564,6 +567,142 @@ def _windows_with_allowed_promotion_decisions(
     return [row for row in rows if (key := _promotion_decision_key_for_window(row)) is not None and key in allowed_keys]
 
 
+_RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
+    {
+        EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
+        'torghut.runtime-ledger-bucket.v1',
+    }
+)
+
+
+def _utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _positive_hash_count(value: Any) -> bool:
+    mapping = _as_dict(value)
+    return bool(mapping) and any(_safe_int(count) > 0 for count in mapping.values())
+
+
+def _runtime_ledger_bucket_matches_window(
+    bucket: StrategyRuntimeLedgerBucket,
+    window: StrategyHypothesisMetricWindow,
+) -> bool:
+    identity_matches = (
+        _as_text(bucket.run_id) == _as_text(window.run_id)
+        and _as_text(bucket.hypothesis_id) == _as_text(window.hypothesis_id)
+        and _as_text(bucket.candidate_id) == _as_text(window.candidate_id)
+        and _as_text(bucket.observed_stage) == _as_text(window.observed_stage)
+    )
+    if not identity_matches:
+        return False
+    window_started = _utc(window.window_started_at)
+    window_ended = _utc(window.window_ended_at)
+    bucket_started = _utc(bucket.bucket_started_at)
+    bucket_ended = _utc(bucket.bucket_ended_at)
+    if window_started is None or window_ended is None or bucket_started is None or bucket_ended is None:
+        return True
+    return bucket_started <= window_ended and bucket_ended >= window_started
+
+
+def _runtime_ledger_bucket_is_promotion_grade(bucket: StrategyRuntimeLedgerBucket) -> bool:
+    blockers = [item for item in _as_list(bucket.blockers_json) if str(item).strip()]
+    return (
+        _as_text(bucket.ledger_schema_version) in _RUNTIME_LEDGER_BUCKET_SCHEMAS
+        and _as_text(bucket.pnl_basis) == POST_COST_PNL_BASIS
+        and not blockers
+        and _safe_int(bucket.fill_count) > 0
+        and _safe_int(bucket.decision_count) > 0
+        and _safe_int(bucket.submitted_order_count) > 0
+        and _safe_int(bucket.closed_trade_count) > 0
+        and _safe_int(bucket.open_position_count) == 0
+        and bucket.filled_notional > 0
+        and _positive_hash_count(bucket.execution_policy_hash_counts)
+        and _positive_hash_count(bucket.cost_model_hash_counts)
+        and _positive_hash_count(bucket.lineage_hash_counts)
+    )
+
+
+def _runtime_ledger_bucket_summary(
+    rows: Sequence[StrategyRuntimeLedgerBucket],
+) -> dict[str, Any]:
+    total_filled_notional = sum(
+        (row.filled_notional for row in rows),
+        Decimal('0'),
+    )
+    total_net_pnl = sum(
+        (row.net_strategy_pnl_after_costs for row in rows),
+        Decimal('0'),
+    )
+    expectancy_bps = (
+        float((total_net_pnl / total_filled_notional) * Decimal('10000'))
+        if total_filled_notional > 0
+        else 0.0
+    )
+    return {
+        'runtime_ledger_bucket_count': len(rows),
+        'runtime_ledger_fill_count': sum(max(0, _safe_int(row.fill_count)) for row in rows),
+        'runtime_ledger_submitted_order_count': sum(
+            max(0, _safe_int(row.submitted_order_count)) for row in rows
+        ),
+        'runtime_ledger_closed_trade_count': sum(max(0, _safe_int(row.closed_trade_count)) for row in rows),
+        'runtime_ledger_filled_notional': float(total_filled_notional),
+        'runtime_ledger_net_strategy_pnl_after_costs': float(total_net_pnl),
+        'runtime_ledger_post_cost_expectancy_bps': expectancy_bps,
+        'db_row_refs': [str(row.id) for row in rows],
+    }
+
+
+def _runtime_ledger_bucket_refs_for_windows(
+    session: Session,
+    rows: Sequence[StrategyHypothesisMetricWindow],
+) -> tuple[list[StrategyHypothesisMetricWindow], list[StrategyRuntimeLedgerBucket], list[str]]:
+    hypothesis_ids = sorted(
+        {hypothesis_id for row in rows if (hypothesis_id := _as_text(row.hypothesis_id)) is not None}
+    )
+    run_ids = sorted({run_id for row in rows if (run_id := _as_text(row.run_id)) is not None})
+    if not hypothesis_ids or not run_ids:
+        return [], [], [str(row.id) for row in rows]
+    buckets = list(
+        session.execute(
+            select(StrategyRuntimeLedgerBucket)
+            .where(StrategyRuntimeLedgerBucket.hypothesis_id.in_(hypothesis_ids))
+            .where(StrategyRuntimeLedgerBucket.run_id.in_(run_ids))
+            .order_by(
+                StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
+                StrategyRuntimeLedgerBucket.created_at.desc(),
+            )
+        ).scalars()
+    )
+    backed_windows: list[StrategyHypothesisMetricWindow] = []
+    matched_buckets: list[StrategyRuntimeLedgerBucket] = []
+    unbacked_window_refs: list[str] = []
+    used_bucket_ids: set[str] = set()
+    for window in rows:
+        matched_bucket: StrategyRuntimeLedgerBucket | None = None
+        for bucket in buckets:
+            bucket_id = str(bucket.id)
+            if bucket_id in used_bucket_ids:
+                continue
+            if not _runtime_ledger_bucket_matches_window(bucket, window):
+                continue
+            if not _runtime_ledger_bucket_is_promotion_grade(bucket):
+                continue
+            matched_bucket = bucket
+            used_bucket_ids.add(bucket_id)
+            break
+        if matched_bucket is None:
+            unbacked_window_refs.append(str(window.id))
+            continue
+        backed_windows.append(window)
+        matched_buckets.append(matched_bucket)
+    return backed_windows, matched_buckets, unbacked_window_refs
+
+
 def _window_gate_summary(
     rows: Sequence[StrategyHypothesisMetricWindow],
 ) -> dict[str, Any]:
@@ -873,6 +1012,7 @@ def _evaluate_live_canary_gate(
 
 def _evaluate_live_scale_gate(
     *,
+    session: Session,
     canary_gate: Mapping[str, Any],
     live_rows: Sequence[StrategyHypothesisMetricWindow],
     allowed_promotion_decision_keys: set[_PromotionDecisionKey],
@@ -914,16 +1054,24 @@ def _evaluate_live_scale_gate(
         candidate_rows,
         allowed_keys=allowed_promotion_decision_keys,
     )
-    summary = _window_gate_summary(qualifying)
+    ledger_qualifying, runtime_ledger_buckets, unbacked_window_refs = _runtime_ledger_bucket_refs_for_windows(
+        session,
+        qualifying,
+    )
+    summary = _window_gate_summary(ledger_qualifying)
+    ledger_summary = _runtime_ledger_bucket_summary(runtime_ledger_buckets)
+    summary['avg_post_cost_expectancy_bps'] = ledger_summary['runtime_ledger_post_cost_expectancy_bps']
     min_market_session_samples = _manifest_runtime_session_threshold(
         candidate_id=candidate_id,
-        rows=qualifying,
+        rows=ledger_qualifying,
         policy_parameters=_gate_policy_parameters(gate_definition),
         fallback_key='fallback_min_market_session_samples',
         default=120,
         manifest_attr='min_sample_count_for_scale_up',
     )
-    if summary['market_session_count'] < min_market_session_samples:
+    if not ledger_qualifying:
+        blocked_reason = 'runtime_ledger_profit_proof_missing'
+    elif summary['market_session_count'] < min_market_session_samples:
         blocked_reason = 'insufficient_live_runtime_sessions'
     elif summary['window_count'] < 10:
         blocked_reason = 'insufficient_live_runtime_windows'
@@ -943,7 +1091,12 @@ def _evaluate_live_scale_gate(
         'status': TRACE_STATUS_SATISFIED if blocked_reason is None else TRACE_STATUS_BLOCKED,
         'blocked_reason': blocked_reason,
         'artifact_refs': cast(list[str], canary_gate.get('artifact_refs') or []),
-        'db_row_refs': {'hypothesis_metric_windows': summary['db_row_refs']},
+        'db_row_refs': {
+            'hypothesis_metric_windows': summary['db_row_refs'],
+            'strategy_runtime_ledger_buckets': ledger_summary['db_row_refs'],
+            'runtime_ledger_unbacked_hypothesis_metric_windows': unbacked_window_refs,
+        },
+        'runtime_ledger_summary': ledger_summary,
         'dataset_snapshot_ref': canary_gate.get('dataset_snapshot_ref'),
         'candidate_id': canary_gate.get('candidate_id'),
     }
@@ -1132,6 +1285,7 @@ def build_doc29_completion_status(
                 gate_definition=gate_definition_by_id.get(DOC29_LIVE_CANARY_GATE),
             )
             scale = _evaluate_live_scale_gate(
+                session=session,
                 canary_gate=derived_canary,
                 live_rows=live_windows,
                 allowed_promotion_decision_keys=live_allowed_promotion_decisions,
@@ -1147,6 +1301,7 @@ def build_doc29_completion_status(
                 'candidate_id': scale.get('candidate_id'),
                 'artifact_refs': cast(list[str], scale.get('artifact_refs') or []),
                 'db_row_refs': cast(dict[str, Any], scale.get('db_row_refs') or {}),
+                'runtime_ledger_summary': cast(dict[str, Any], scale.get('runtime_ledger_summary') or {}),
                 'persisted_result_id': None,
                 'measured_at': None,
                 'freshness_state': 'fresh' if scale['status'] == TRACE_STATUS_SATISFIED else 'blocked',

--- a/services/torghut/tests/test_completion_trace.py
+++ b/services/torghut/tests/test_completion_trace.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from typing import Any
 from unittest import TestCase
 
@@ -12,6 +13,7 @@ from app.models import (
     Base,
     StrategyHypothesisMetricWindow,
     StrategyPromotionDecision,
+    StrategyRuntimeLedgerBucket,
     VNextEmpiricalJobRun,
 )
 from app.trading.completion import (
@@ -67,6 +69,48 @@ def _promotion_decision(
         state=state,
         allowed=allowed,
         reason_summary='runtime_evidence_thresholds_satisfied' if allowed else 'runtime_evidence_denied',
+    )
+
+
+def _runtime_ledger_bucket(
+    *,
+    run_id: str,
+    candidate_id: str = 'cand-1',
+    hypothesis_id: str = 'legacy_macd_rsi',
+    observed_stage: str = 'live',
+    bucket_started_at: datetime,
+    bucket_ended_at: datetime,
+    ledger_schema_version: str = 'torghut.runtime-ledger-bucket.v1',
+) -> StrategyRuntimeLedgerBucket:
+    return StrategyRuntimeLedgerBucket(
+        run_id=run_id,
+        candidate_id=candidate_id,
+        hypothesis_id=hypothesis_id,
+        observed_stage=observed_stage,
+        bucket_started_at=bucket_started_at,
+        bucket_ended_at=bucket_ended_at,
+        runtime_strategy_name='legacy-macd-rsi',
+        strategy_family='breakout_continuation_consistent',
+        fill_count=12,
+        decision_count=24,
+        submitted_order_count=12,
+        cancelled_order_count=0,
+        rejected_order_count=0,
+        unfilled_order_count=0,
+        closed_trade_count=6,
+        open_position_count=0,
+        filled_notional=Decimal('120000'),
+        gross_strategy_pnl=Decimal('20'),
+        cost_amount=Decimal('3.2'),
+        net_strategy_pnl_after_costs=Decimal('16.8'),
+        post_cost_expectancy_bps=Decimal('1.4'),
+        ledger_schema_version=ledger_schema_version,
+        pnl_basis='realized_strategy_pnl_after_explicit_costs',
+        execution_policy_hash_counts={'policy-hash': 12},
+        cost_model_hash_counts={'cost-hash': 12},
+        lineage_hash_counts={'lineage-hash': 12},
+        blockers_json=[],
+        payload_json={'source': 'test-runtime-ledger'},
     )
 
 
@@ -468,6 +512,7 @@ class TestCompletionTrace(TestCase):
             live_window_start = now - timedelta(days=1)
             for index in range(10):
                 run_id = f'live-run-{index}'
+                live_window_end = live_window_start + timedelta(minutes=index + 1)
                 session.add(
                     StrategyHypothesisMetricWindow(
                         run_id=run_id,
@@ -475,7 +520,7 @@ class TestCompletionTrace(TestCase):
                         hypothesis_id='legacy_macd_rsi',
                         observed_stage='live',
                         window_started_at=live_window_start,
-                        window_ended_at=live_window_start,
+                        window_ended_at=live_window_end,
                         market_session_count=12,
                         decision_count=220,
                         trade_count=215,
@@ -502,6 +547,13 @@ class TestCompletionTrace(TestCase):
                         state='0.50x live',
                     )
                 )
+                session.add(
+                    _runtime_ledger_bucket(
+                        run_id=run_id,
+                        bucket_started_at=live_window_start,
+                        bucket_ended_at=live_window_end,
+                    )
+                )
             session.commit()
 
             status = build_doc29_completion_status(
@@ -515,6 +567,162 @@ class TestCompletionTrace(TestCase):
         scale_gate = next(item for item in status['gates'] if item['gate_id'] == DOC29_LIVE_SCALE_GATE)
         self.assertEqual(canary_gate['status'], 'satisfied')
         self.assertEqual(scale_gate['status'], 'satisfied')
+        self.assertEqual(
+            len(scale_gate['db_row_refs']['strategy_runtime_ledger_buckets']),
+            10,
+        )
+        self.assertEqual(
+            scale_gate['runtime_ledger_summary']['runtime_ledger_post_cost_expectancy_bps'],
+            1.4,
+        )
+
+    def test_doc29_live_scale_blocks_non_runtime_ledger_window_pnl(self) -> None:
+        trace = build_completion_trace(
+            doc_id='doc29',
+            gate_ids_attempted=[DOC29_SIMULATION_FULL_DAY_GATE],
+            run_id='sim-2026-03-06-full-day',
+            dataset_snapshot_ref='snapshot-1',
+            candidate_id='cand-1',
+            workflow_name='torghut-historical-simulation',
+            analysis_run_names=[],
+            artifact_refs=['s3://artifacts/run-full-lifecycle-manifest.json'],
+            db_row_refs={},
+            status_snapshot={},
+            result_by_gate={
+                DOC29_SIMULATION_FULL_DAY_GATE: {
+                    'status': TRACE_STATUS_SATISFIED,
+                    'artifact_ref': 's3://artifacts/run-full-lifecycle-manifest.json',
+                    'acceptance_snapshot': {
+                        'trade_decisions': 640,
+                        'executions': 320,
+                        'execution_tca_metrics': 320,
+                        'execution_order_events': 320,
+                        'coverage_ratio': 0.99,
+                        'fill_price_error_budget_status': 'within_budget',
+                    },
+                }
+            },
+            blocked_reasons={},
+            git_revision='abc123',
+            image_digest='sha256:test',
+        )
+        with self.session_local() as session:
+            persist_completion_trace(session=session, trace_payload=trace)
+            _add_truthful_empirical_jobs(session)
+
+            now = datetime.now(timezone.utc)
+            paper_window_start = now - timedelta(days=2)
+            for index in range(4):
+                run_id = f'paper-ledger-missing-{index}'
+                session.add(
+                    StrategyHypothesisMetricWindow(
+                        run_id=run_id,
+                        candidate_id='cand-1',
+                        hypothesis_id='legacy_macd_rsi',
+                        observed_stage='paper',
+                        window_started_at=paper_window_start,
+                        window_ended_at=paper_window_start,
+                        market_session_count=10,
+                        decision_count=200,
+                        trade_count=194,
+                        order_count=194,
+                        evidence_provenance='paper_runtime_observed',
+                        evidence_maturity='empirically_validated',
+                        decision_alignment_ratio='0.97',
+                        avg_abs_slippage_bps='4.2',
+                        slippage_budget_bps='8.0',
+                        post_cost_expectancy_bps='1.1',
+                        continuity_ok=True,
+                        drift_ok=True,
+                        dependency_quorum_decision='allow',
+                        capital_stage='shadow',
+                        payload_json={},
+                    )
+                )
+                session.add(
+                    _promotion_decision(
+                        run_id=run_id,
+                        candidate_id='cand-1',
+                        hypothesis_id='legacy_macd_rsi',
+                        promotion_target='paper',
+                        state='0.10x canary',
+                    )
+                )
+
+            live_window_start = now - timedelta(days=1)
+            for index in range(10):
+                run_id = f'live-ledger-missing-{index}'
+                session.add(
+                    StrategyHypothesisMetricWindow(
+                        run_id=run_id,
+                        candidate_id='cand-1',
+                        hypothesis_id='legacy_macd_rsi',
+                        observed_stage='live',
+                        window_started_at=live_window_start,
+                        window_ended_at=live_window_start + timedelta(minutes=index + 1),
+                        market_session_count=12,
+                        decision_count=220,
+                        trade_count=215,
+                        order_count=215,
+                        evidence_provenance='live_runtime_observed',
+                        evidence_maturity='empirically_validated',
+                        decision_alignment_ratio='0.98',
+                        avg_abs_slippage_bps='4.5',
+                        slippage_budget_bps='8.0',
+                        post_cost_expectancy_bps='1.4',
+                        continuity_ok=True,
+                        drift_ok=True,
+                        dependency_quorum_decision='allow',
+                        capital_stage='0.50x live',
+                        payload_json={},
+                    )
+                )
+                session.add(
+                    _promotion_decision(
+                        run_id=run_id,
+                        candidate_id='cand-1',
+                        hypothesis_id='legacy_macd_rsi',
+                        promotion_target='live',
+                        state='0.50x live',
+                    )
+                )
+                if index == 0:
+                    session.add(
+                        _runtime_ledger_bucket(
+                            run_id=run_id,
+                            candidate_id='other-candidate',
+                            bucket_started_at=live_window_start,
+                            bucket_ended_at=live_window_start + timedelta(minutes=index + 1),
+                        )
+                    )
+                if index == 1:
+                    session.add(
+                        _runtime_ledger_bucket(
+                            run_id=run_id,
+                            bucket_started_at=live_window_start,
+                            bucket_ended_at=live_window_start + timedelta(minutes=index + 1),
+                            ledger_schema_version='torghut.loose_runtime_ledger.v0',
+                        )
+                    )
+            session.commit()
+
+            status = build_doc29_completion_status(
+                session=session,
+                stale_after_seconds=86400,
+                current_git_revision='abc123',
+                current_image_digest='sha256:test',
+            )
+
+        canary_gate = next(item for item in status['gates'] if item['gate_id'] == DOC29_LIVE_CANARY_GATE)
+        scale_gate = next(item for item in status['gates'] if item['gate_id'] == DOC29_LIVE_SCALE_GATE)
+        self.assertEqual(canary_gate['status'], 'satisfied')
+        self.assertEqual(scale_gate['status'], 'blocked')
+        self.assertEqual(scale_gate['blocked_reason'], 'runtime_ledger_profit_proof_missing')
+        self.assertEqual(scale_gate['db_row_refs']['strategy_runtime_ledger_buckets'], [])
+        self.assertEqual(
+            len(scale_gate['db_row_refs']['runtime_ledger_unbacked_hypothesis_metric_windows']),
+            10,
+        )
 
     def test_doc29_live_canary_requires_allowed_promotion_decision(self) -> None:
         trace = build_completion_trace(


### PR DESCRIPTION
## Summary

- Requires doc29 live-scale completion to count only live metric windows backed one-to-one by promotion-grade `StrategyRuntimeLedgerBucket` rows.
- Computes live-scale post-cost expectancy from runtime ledger net PnL over filled notional instead of trusting window averaged bps.
- Adds regression coverage proving proxy live-window PnL remains blocked when runtime ledger proof is missing or invalid.

## Related Issues

None

## Testing

- `uv run --frozen ruff check app/trading/completion.py tests/test_completion_trace.py`
- `uv run --frozen pytest tests/test_completion_trace.py -k live_scale -q`
- `uv run --frozen pytest tests/test_completion_trace.py -q`
- `uv run --frozen pytest tests/test_completion_trace.py --cov --cov-branch --cov-fail-under=0 --cov-report=xml:coverage.xml -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
