### PR TITLE
fix(torghut): require authoritative exact replay ledger rows

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -11,7 +11,7 @@ import signal
 import socket
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, replace
-from datetime import UTC, date, datetime, time
+from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
@@ -75,7 +75,11 @@ from app.trading.discovery.profit_target_oracle import (
     ProfitTargetOraclePolicy,
     evaluate_profit_target_oracle,
 )
-from app.trading.runtime_ledger import POST_COST_PNL_BASIS
+from app.trading.runtime_ledger import (
+    POST_COST_PNL_BASIS,
+    RuntimeLedgerBucket,
+    build_runtime_ledger_buckets,
+)
 from app.trading.discovery.replay_tape import (
     build_source_query_digest,
     materialize_signal_tape,
@@ -6996,6 +7000,82 @@ _EXACT_REPLAY_LEDGER_SCHEMA_VERSIONS = frozenset(
 _EXACT_REPLAY_RUNTIME_LEDGER_PNL_SOURCE = "exact_replay_runtime_ledger"
 
 
+def _runtime_closure_ledger_datetime(value: Any, *, date_end: bool = False) -> datetime | None:
+    text = _string(value)
+    if not text:
+        return None
+    try:
+        if "T" not in text and len(text) == 10:
+            parsed_date = date.fromisoformat(text)
+            parsed = datetime.combine(parsed_date, time.min, tzinfo=UTC)
+            return parsed + timedelta(days=1) if date_end else parsed
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _runtime_closure_exact_replay_bucket_range(
+    ledger: Mapping[str, Any],
+) -> tuple[datetime, datetime] | None:
+    start = _runtime_closure_ledger_datetime(
+        ledger.get("window_start")
+        or ledger.get("bucket_started_at")
+        or ledger.get("started_at")
+        or ledger.get("start"),
+    )
+    end = _runtime_closure_ledger_datetime(
+        ledger.get("window_end")
+        or ledger.get("bucket_ended_at")
+        or ledger.get("ended_at")
+        or ledger.get("end"),
+        date_end=True,
+    )
+    if start is None or end is None or end <= start:
+        return None
+    return (start, end)
+
+
+def _runtime_closure_replay_bucket_has_authority(bucket: RuntimeLedgerBucket) -> bool:
+    return (
+        not bucket.blockers
+        and bucket.fill_count > 0
+        and bucket.decision_count > 0
+        and bucket.submitted_order_count > 0
+        and bucket.closed_trade_count > 0
+        and bucket.open_position_count == 0
+        and bucket.filled_notional > 0
+        and bool(bucket.cost_basis_counts)
+        and bool(bucket.execution_policy_hash_counts)
+        and bool(bucket.cost_model_hash_counts)
+        and bool(bucket.lineage_hash_counts)
+        and bucket.pnl_basis == POST_COST_PNL_BASIS
+    )
+
+
+def _runtime_closure_exact_replay_bucket(
+    *,
+    ledger: Mapping[str, Any],
+    rows: Sequence[Mapping[str, object]],
+) -> RuntimeLedgerBucket | None:
+    bucket_range = _runtime_closure_exact_replay_bucket_range(ledger)
+    if bucket_range is None:
+        return None
+    buckets = build_runtime_ledger_buckets(
+        rows,
+        bucket_ranges=[bucket_range],
+        require_order_lifecycle=True,
+    )
+    if len(buckets) != 1:
+        return None
+    bucket = buckets[0]
+    if not _runtime_closure_replay_bucket_has_authority(bucket):
+        return None
+    return bucket
+
+
 def _runtime_report_source_markers(report: Mapping[str, Any]) -> list[str]:
     return sorted(set(_string_list_from_value(report.get("source_markers"))))
 
@@ -7054,12 +7134,25 @@ def _runtime_closure_exact_replay_ledger_update(
         return {}
     if not all(isinstance(row, Mapping) for row in raw_rows):
         return {}
+    runtime_rows = [
+        cast(Mapping[str, object], row)
+        for row in cast(Sequence[object], raw_rows)
+        if isinstance(row, Mapping)
+    ]
+    runtime_bucket = _runtime_closure_exact_replay_bucket(
+        ledger=ledger,
+        rows=runtime_rows,
+    )
+    if runtime_bucket is None:
+        return {}
     row_count = len(raw_rows)
     fill_count = _runtime_report_int(
         ledger.get("runtime_ledger_artifact_fill_count")
         or ledger.get("exact_replay_ledger_artifact_fill_count")
         or ledger.get("fill_row_count")
     )
+    if fill_count != runtime_bucket.fill_count:
+        return {}
     return {
         "exact_replay_ledger_artifact_ref": artifact_ref,
         "runtime_ledger_artifact_ref": artifact_ref,
@@ -7067,6 +7160,17 @@ def _runtime_closure_exact_replay_ledger_update(
         "runtime_ledger_artifact_row_count": row_count,
         "exact_replay_ledger_artifact_fill_count": fill_count,
         "runtime_ledger_artifact_fill_count": fill_count,
+        "runtime_ledger_closed_trade_count": runtime_bucket.closed_trade_count,
+        "runtime_ledger_open_position_count": runtime_bucket.open_position_count,
+        "runtime_ledger_filled_notional": str(runtime_bucket.filled_notional),
+        "runtime_ledger_net_strategy_pnl_after_costs": str(
+            runtime_bucket.net_strategy_pnl_after_costs
+        ),
+        "runtime_ledger_post_cost_expectancy_bps": str(
+            runtime_bucket.post_cost_expectancy_bps
+        )
+        if runtime_bucket.post_cost_expectancy_bps is not None
+        else None,
         "portfolio_post_cost_net_pnl_basis": POST_COST_PNL_BASIS,
         "portfolio_post_cost_net_pnl_source": _EXACT_REPLAY_RUNTIME_LEDGER_PNL_SOURCE,
         "runtime_ledger_pnl_basis": POST_COST_PNL_BASIS,

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -43,6 +43,79 @@ from app.trading.models import SignalEnvelope
 _CHIP_UNIVERSE = list(runner.LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE)
 
 
+def _authoritative_exact_replay_ledger_rows() -> list[dict[str, object]]:
+    base_row: dict[str, object] = {
+        "account_label": "paper",
+        "strategy_id": "intraday-tsmom-profit-v3",
+        "symbol": "AAPL",
+        "source": "exact_replay",
+        "execution_policy_hash": "execution-policy-hash",
+        "cost_model_hash": "cost-model-hash",
+        "lineage_hash": "lineage-hash",
+        "replay_data_hash": "replay-data-hash",
+    }
+    return [
+        {
+            **base_row,
+            "event_type": "decision",
+            "executed_at": "2026-05-20T14:00:00Z",
+            "side": "buy",
+            "decision_id": "decision-1",
+            "order_id": "order-1",
+        },
+        {
+            **base_row,
+            "event_type": "order_submitted",
+            "executed_at": "2026-05-20T14:00:01Z",
+            "side": "buy",
+            "decision_id": "decision-1",
+            "order_id": "order-1",
+        },
+        {
+            **base_row,
+            "event_type": "fill",
+            "executed_at": "2026-05-20T14:00:02Z",
+            "side": "buy",
+            "decision_id": "decision-1",
+            "order_id": "order-1",
+            "filled_qty": "1",
+            "avg_fill_price": "100",
+            "filled_notional": "100",
+            "cost_amount": "0.10",
+            "cost_basis": "explicit_replay_fee_model",
+        },
+        {
+            **base_row,
+            "event_type": "decision",
+            "executed_at": "2026-05-20T14:10:00Z",
+            "side": "sell",
+            "decision_id": "decision-2",
+            "order_id": "order-2",
+        },
+        {
+            **base_row,
+            "event_type": "order_submitted",
+            "executed_at": "2026-05-20T14:10:01Z",
+            "side": "sell",
+            "decision_id": "decision-2",
+            "order_id": "order-2",
+        },
+        {
+            **base_row,
+            "event_type": "fill",
+            "executed_at": "2026-05-20T14:10:02Z",
+            "side": "sell",
+            "decision_id": "decision-2",
+            "order_id": "order-2",
+            "filled_qty": "1",
+            "avg_fill_price": "101",
+            "filled_notional": "101",
+            "cost_amount": "0.10",
+            "cost_basis": "explicit_replay_fee_model",
+        },
+    ]
+
+
 def _source_jsonl_payload() -> dict[str, object]:
     return {
         "run_id": "paper-jsonl-2026",
@@ -4807,6 +4880,32 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
     def test_runtime_closure_exact_replay_ledger_rejects_summary_counts_without_rows(
         self,
     ) -> None:
+        self.assertIsNone(runner._runtime_closure_ledger_datetime(None))
+        self.assertIsNone(runner._runtime_closure_ledger_datetime("not-a-date"))
+        self.assertEqual(
+            runner._runtime_closure_ledger_datetime("2026-05-20T14:00:00"),
+            datetime(2026, 5, 20, 14, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            runner._runtime_closure_ledger_datetime("2026-05-20T14:00:00-04:00"),
+            datetime(2026, 5, 20, 18, tzinfo=timezone.utc),
+        )
+        self.assertIsNone(
+            runner._runtime_closure_exact_replay_bucket(
+                ledger={"window_start": "2026-05-20", "window_end": "2026-05-19"},
+                rows=_authoritative_exact_replay_ledger_rows(),
+            )
+        )
+        with patch.object(runner, "build_runtime_ledger_buckets", return_value=[]):
+            self.assertIsNone(
+                runner._runtime_closure_exact_replay_bucket(
+                    ledger={
+                        "window_start": "2026-05-20",
+                        "window_end": "2026-05-20",
+                    },
+                    rows=_authoritative_exact_replay_ledger_rows(),
+                )
+            )
         with TemporaryDirectory() as tmpdir:
             artifact_path = Path(tmpdir) / "ledger.json"
             artifact_path.write_text(
@@ -4896,9 +4995,54 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                         "artifact_kind": "exact_replay_ledger",
                         "schema_version": "torghut.exact_replay_ledger.rows.v1",
                         "runtime_ledger_rows": [{"id": 1}],
+                        "window_start": "2026-05-20",
+                        "window_end": "2026-05-20",
                         "row_count": 99,
-                        "filled_count": 99,
-                        "summary": {"filled_count": 99},
+                        "fill_row_count": 1,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                runner._runtime_closure_exact_replay_ledger_update(
+                    {"exact_replay_ledger_artifact_path": str(artifact_path)}
+                ),
+                {},
+            )
+
+            artifact_path.write_text(
+                json.dumps(
+                    {
+                        "artifact_kind": "exact_replay_ledger",
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "window_start": "2026-05-20",
+                        "window_end": "2026-05-20",
+                        "fill_row_count": 1,
+                        "runtime_ledger_rows": _authoritative_exact_replay_ledger_rows(),
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                runner._runtime_closure_exact_replay_ledger_update(
+                    {"exact_replay_ledger_artifact_path": str(artifact_path)}
+                ),
+                {},
+            )
+
+            artifact_path.write_text(
+                json.dumps(
+                    {
+                        "artifact_kind": "exact_replay_ledger",
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "window_start": "2026-05-20",
+                        "window_end": "2026-05-20",
+                        "fill_row_count": 2,
+                        "runtime_ledger_rows": _authoritative_exact_replay_ledger_rows(),
                     }
                 )
                 + "\n",
@@ -4909,10 +5053,16 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 {"exact_replay_ledger_artifact_path": str(artifact_path)}
             )
 
-        self.assertEqual(update["exact_replay_ledger_artifact_row_count"], 1)
-        self.assertEqual(update["runtime_ledger_artifact_row_count"], 1)
-        self.assertEqual(update["exact_replay_ledger_artifact_fill_count"], 0)
-        self.assertEqual(update["runtime_ledger_artifact_fill_count"], 0)
+        self.assertEqual(update["exact_replay_ledger_artifact_row_count"], 6)
+        self.assertEqual(update["runtime_ledger_artifact_row_count"], 6)
+        self.assertEqual(update["exact_replay_ledger_artifact_fill_count"], 2)
+        self.assertEqual(update["runtime_ledger_artifact_fill_count"], 2)
+        self.assertEqual(update["runtime_ledger_closed_trade_count"], 1)
+        self.assertEqual(update["runtime_ledger_open_position_count"], 0)
+        self.assertEqual(update["runtime_ledger_filled_notional"], "201")
+        self.assertEqual(
+            update["runtime_ledger_net_strategy_pnl_after_costs"], "0.80"
+        )
         self.assertEqual(
             update["portfolio_post_cost_net_pnl_basis"],
             "realized_strategy_pnl_after_explicit_costs",
@@ -4994,7 +5144,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                     {
                         "artifact_kind": "exact_replay_ledger",
                         "schema_version": "torghut.exact_replay_ledger.rows.v1",
-                        "runtime_ledger_rows": [{"id": 1}, {"id": 2}],
+                        "window_start": "2026-05-20",
+                        "window_end": "2026-05-20",
+                        "runtime_ledger_rows": _authoritative_exact_replay_ledger_rows(),
                         "fill_row_count": 2,
                     }
                 )
@@ -5161,7 +5313,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertEqual(
             updated.objective_scorecard["exact_replay_ledger_artifact_row_count"],
-            2,
+            6,
         )
         self.assertEqual(
             updated.objective_scorecard["exact_replay_ledger_artifact_fill_count"],


### PR DESCRIPTION
## Summary

- Requires exact replay ledger artifacts to rebuild an authoritative runtime ledger bucket before they can stamp portfolio/runtime post-cost PnL authority.
- Rejects placeholder ledger rows, missing/invalid replay windows, incomplete order lifecycle evidence, open positions, missing cost/hash lineage, and mismatched fill counts.
- Adds regression coverage for both direct exact-ledger updates and portfolio runtime-closure oracle updates.

## Related Issues

None

## Testing

- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_runtime_closure_exact_replay_ledger_rejects_summary_counts_without_rows tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_runtime_closure_proof_updates_portfolio_oracle_from_real_artifacts -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `rm -f .coverage coverage.xml && uv run --frozen coverage run --branch --source=scripts -m pytest tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_runtime_closure_exact_replay_ledger_rejects_summary_counts_without_rows tests/test_run_whitepaper_autoresearch_profit_target.py::TestRunWhitepaperAutoresearchProfitTarget::test_runtime_closure_proof_updates_portfolio_oracle_from_real_artifacts -q && uv run --frozen coverage xml -o coverage.xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main && rm -f .coverage coverage.xml`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
