### PR TITLE
fix(torghut): require runtime ledger authority in frontier proof

### DIFF
--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -14,7 +14,7 @@ import sys
 import tempfile
 from collections import Counter, deque
 from dataclasses import dataclass
-from datetime import date, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal, InvalidOperation, ROUND_CEILING, ROUND_DOWN
 from pathlib import Path
 from typing import Any, Callable, Iterable, Iterator, Mapping, Sequence, cast
@@ -55,6 +55,11 @@ from app.trading.discovery.replay_tape import (
     slice_tape_by_symbols,
     slice_tape_by_window,
     validate_tape_freshness,
+)
+from app.trading.runtime_ledger import (
+    POST_COST_PNL_BASIS,
+    RuntimeLedgerBucket,
+    build_runtime_ledger_buckets,
 )
 from app.trading.reporting import (
     ProfitabilityConstraintPolicy,
@@ -1954,6 +1959,132 @@ def _order_type_ablation_artifact_dir(
     return root / "frontier-artifacts"
 
 
+def _frontier_ledger_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _frontier_ledger_datetime(value: Any, *, date_end: bool = False) -> datetime | None:
+    text = _frontier_ledger_text(value)
+    if not text:
+        return None
+    try:
+        if "T" not in text and len(text) == 10:
+            parsed_date = date.fromisoformat(text)
+            parsed = datetime.combine(parsed_date, time.min, tzinfo=timezone.utc)
+            return parsed + timedelta(days=1) if date_end else parsed
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _frontier_exact_replay_bucket_range(
+    *,
+    ledger_payload: Mapping[str, Any],
+    full_window_start: date | None,
+    full_window_end: date | None,
+) -> tuple[datetime, datetime] | None:
+    full_window = _mapping(ledger_payload.get("full_window"))
+    start = _frontier_ledger_datetime(
+        ledger_payload.get("window_start")
+        or ledger_payload.get("bucket_started_at")
+        or ledger_payload.get("started_at")
+        or ledger_payload.get("start")
+        or full_window.get("start_date")
+        or (full_window_start.isoformat() if full_window_start is not None else "")
+    )
+    end = _frontier_ledger_datetime(
+        ledger_payload.get("window_end")
+        or ledger_payload.get("bucket_ended_at")
+        or ledger_payload.get("ended_at")
+        or ledger_payload.get("end")
+        or full_window.get("end_date")
+        or (full_window_end.isoformat() if full_window_end is not None else ""),
+        date_end=True,
+    )
+    if start is None or end is None or end <= start:
+        return None
+    return (start, end)
+
+
+def _frontier_exact_replay_rows(
+    ledger_payload: Mapping[str, Any],
+    raw_rows: Sequence[object],
+) -> list[Mapping[str, object]]:
+    defaults = {
+        key: ledger_payload.get(key)
+        for key in (
+            "account_label",
+            "source",
+            "execution_policy_hash",
+            "cost_model_hash",
+            "lineage_hash",
+            "replay_data_hash",
+            "cost_basis",
+        )
+        if ledger_payload.get(key) not in (None, "")
+    }
+    rows: list[Mapping[str, object]] = []
+    for raw_row in raw_rows:
+        if not isinstance(raw_row, Mapping):
+            return []
+        row = dict(cast(Mapping[str, object], raw_row))
+        for key, value in defaults.items():
+            row.setdefault(key, value)
+        rows.append(row)
+    return rows
+
+
+def _frontier_exact_replay_bucket_has_authority(bucket: RuntimeLedgerBucket) -> bool:
+    return (
+        not bucket.blockers
+        and bucket.fill_count > 0
+        and bucket.decision_count > 0
+        and bucket.submitted_order_count > 0
+        and bucket.closed_trade_count > 0
+        and bucket.open_position_count == 0
+        and bucket.filled_notional > 0
+        and bucket.post_cost_expectancy_bps is not None
+        and bool(bucket.cost_basis_counts)
+        and bool(bucket.execution_policy_hash_counts)
+        and bool(bucket.cost_model_hash_counts)
+        and bool(bucket.lineage_hash_counts)
+        and bucket.pnl_basis == POST_COST_PNL_BASIS
+    )
+
+
+def _frontier_exact_replay_bucket(
+    *,
+    ledger_payload: Mapping[str, Any],
+    raw_rows: Sequence[object],
+    full_window_start: date | None,
+    full_window_end: date | None,
+) -> RuntimeLedgerBucket | None:
+    bucket_range = _frontier_exact_replay_bucket_range(
+        ledger_payload=ledger_payload,
+        full_window_start=full_window_start,
+        full_window_end=full_window_end,
+    )
+    if bucket_range is None:
+        return None
+    runtime_rows = _frontier_exact_replay_rows(ledger_payload, raw_rows)
+    if not runtime_rows:
+        return None
+    buckets = build_runtime_ledger_buckets(
+        runtime_rows,
+        bucket_ranges=[bucket_range],
+        require_order_lifecycle=True,
+    )
+    if len(buckets) != 1:
+        return None
+    bucket = buckets[0]
+    if not _frontier_exact_replay_bucket_has_authority(bucket):
+        return None
+    return bucket
+
+
 def _exact_replay_ledger_artifact_update(
     *,
     args: argparse.Namespace,
@@ -1974,6 +2105,20 @@ def _exact_replay_ledger_artifact_update(
     ledger_payload = _mapping(full_window_payload.get("exact_replay_ledger"))
     raw_rows = ledger_payload.get("runtime_ledger_rows")
     if not isinstance(raw_rows, list) or not raw_rows:
+        return {}
+    runtime_bucket = _frontier_exact_replay_bucket(
+        ledger_payload=ledger_payload,
+        raw_rows=cast(Sequence[object], raw_rows),
+        full_window_start=full_window_start,
+        full_window_end=full_window_end,
+    )
+    if runtime_bucket is None:
+        return {}
+    try:
+        fill_row_count = int(ledger_payload.get("fill_row_count") or 0)
+    except (TypeError, ValueError):
+        return {}
+    if fill_row_count != runtime_bucket.fill_count:
         return {}
     artifact_dir = _order_type_ablation_artifact_dir(args=args, root=root)
     artifact_path = (
@@ -2044,10 +2189,21 @@ def _exact_replay_ledger_artifact_update(
     return {
         "exact_replay_ledger_artifact_ref": artifact_ref,
         "runtime_ledger_artifact_ref": artifact_ref,
+        "exact_replay_ledger_artifact_row_count": len(raw_rows),
+        "exact_replay_ledger_artifact_fill_count": fill_row_count,
         "runtime_ledger_artifact_row_count": len(raw_rows),
-        "runtime_ledger_artifact_fill_count": int(
-            ledger_payload.get("fill_row_count") or 0
+        "runtime_ledger_artifact_fill_count": fill_row_count,
+        "runtime_ledger_closed_trade_count": runtime_bucket.closed_trade_count,
+        "runtime_ledger_open_position_count": runtime_bucket.open_position_count,
+        "runtime_ledger_filled_notional": str(runtime_bucket.filled_notional),
+        "runtime_ledger_net_strategy_pnl_after_costs": str(
+            runtime_bucket.net_strategy_pnl_after_costs
         ),
+        "runtime_ledger_post_cost_expectancy_bps": str(
+            runtime_bucket.post_cost_expectancy_bps
+        ),
+        "runtime_ledger_pnl_basis": POST_COST_PNL_BASIS,
+        "runtime_ledger_pnl_source": "exact_replay_runtime_ledger",
     }
 
 

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -24,7 +24,284 @@ from app.trading.models import SignalEnvelope
 import scripts.search_consistent_profitability_frontier as frontier
 
 
+def _authoritative_exact_replay_rows() -> list[dict[str, object]]:
+    return [
+        {
+            "event_type": "decision",
+            "executed_at": "2026-03-18T14:35:00+00:00",
+            "decision_id": "decision-buy",
+            "order_id": "order-buy",
+            "symbol": "NVDA",
+            "side": "buy",
+        },
+        {
+            "event_type": "order_submitted",
+            "executed_at": "2026-03-18T14:35:01+00:00",
+            "decision_id": "decision-buy",
+            "order_id": "order-buy",
+            "symbol": "NVDA",
+            "side": "buy",
+        },
+        {
+            "event_type": "fill",
+            "executed_at": "2026-03-18T14:35:02+00:00",
+            "decision_id": "decision-buy",
+            "order_id": "order-buy",
+            "symbol": "NVDA",
+            "side": "buy",
+            "filled_qty": "1",
+            "avg_fill_price": "100",
+            "cost_amount": "0.10",
+            "cost_basis": "local_replay_transaction_cost_model",
+        },
+        {
+            "event_type": "decision",
+            "executed_at": "2026-03-18T14:40:00+00:00",
+            "decision_id": "decision-sell",
+            "order_id": "order-sell",
+            "symbol": "NVDA",
+            "side": "sell",
+        },
+        {
+            "event_type": "order_submitted",
+            "executed_at": "2026-03-18T14:40:01+00:00",
+            "decision_id": "decision-sell",
+            "order_id": "order-sell",
+            "symbol": "NVDA",
+            "side": "sell",
+        },
+        {
+            "event_type": "fill",
+            "executed_at": "2026-03-18T14:40:02+00:00",
+            "decision_id": "decision-sell",
+            "order_id": "order-sell",
+            "symbol": "NVDA",
+            "side": "sell",
+            "filled_qty": "1",
+            "avg_fill_price": "101",
+            "cost_amount": "0.10",
+            "cost_basis": "local_replay_transaction_cost_model",
+        },
+    ]
+
+
+def _authoritative_exact_replay_ledger_payload(
+    *,
+    rows: list[dict[str, object]] | None = None,
+    fill_row_count: int = 2,
+) -> dict[str, object]:
+    return {
+        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+        "account_label": "TORGHUT_REPLAY",
+        "execution_policy_hash": "policy-sha",
+        "cost_model_hash": "cost-sha",
+        "lineage_hash": "ledger-lineage-sha",
+        "fill_row_count": fill_row_count,
+        "runtime_ledger_rows": rows if rows is not None else _authoritative_exact_replay_rows(),
+    }
+
+
 class TestSearchConsistentProfitabilityFrontier(TestCase):
+    def test_exact_replay_ledger_artifact_update_stamps_authoritative_bucket(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            args = Namespace(json_output=root / "frontier.json")
+
+            update = frontier._exact_replay_ledger_artifact_update(
+                args=args,
+                root=root,
+                candidate_index=3,
+                candidate_id="candidate-ledger-authority",
+                full_window_payload={
+                    "exact_replay_ledger": _authoritative_exact_replay_ledger_payload()
+                },
+                dataset_snapshot_id="snapshot-ledger",
+                replay_lineage={"lineage_hash": "lineage-sha"},
+                candidate_evaluation_key={"candidate_evaluation_key": "eval-key"},
+                candidate_symbols=("NVDA",),
+                full_window_start=date(2026, 3, 18),
+                full_window_end=date(2026, 3, 23),
+            )
+
+            exact_ledger_ref = Path(update["exact_replay_ledger_artifact_ref"])
+
+            self.assertTrue(exact_ledger_ref.exists())
+            self.assertEqual(update["exact_replay_ledger_artifact_row_count"], 6)
+            self.assertEqual(update["exact_replay_ledger_artifact_fill_count"], 2)
+            self.assertEqual(update["runtime_ledger_artifact_row_count"], 6)
+            self.assertEqual(update["runtime_ledger_artifact_fill_count"], 2)
+            self.assertEqual(update["runtime_ledger_closed_trade_count"], 1)
+            self.assertEqual(update["runtime_ledger_open_position_count"], 0)
+            self.assertEqual(update["runtime_ledger_filled_notional"], "201")
+            self.assertEqual(
+                update["runtime_ledger_net_strategy_pnl_after_costs"], "0.80"
+            )
+            self.assertGreater(
+                Decimal(str(update["runtime_ledger_post_cost_expectancy_bps"])),
+                Decimal("0"),
+            )
+            self.assertEqual(
+                update["runtime_ledger_pnl_basis"],
+                "realized_strategy_pnl_after_explicit_costs",
+            )
+            self.assertEqual(
+                update["runtime_ledger_pnl_source"],
+                "exact_replay_runtime_ledger",
+            )
+
+    def test_exact_replay_ledger_artifact_update_rejects_weak_bucket(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            args = Namespace(json_output=root / "frontier.json")
+
+            update = frontier._exact_replay_ledger_artifact_update(
+                args=args,
+                root=root,
+                candidate_index=4,
+                candidate_id="candidate-placeholder-ledger",
+                full_window_payload={
+                    "exact_replay_ledger": _authoritative_exact_replay_ledger_payload(
+                        rows=[
+                            {
+                                "event_type": "fill",
+                                "executed_at": "2026-03-18T14:35:02+00:00",
+                                "decision_id": "decision-buy",
+                                "order_id": "order-buy",
+                                "symbol": "NVDA",
+                                "side": "buy",
+                                "filled_qty": "1",
+                                "avg_fill_price": "100",
+                                "cost_amount": "0.10",
+                                "cost_basis": "local_replay_transaction_cost_model",
+                            },
+                        ],
+                        fill_row_count=1,
+                    )
+                },
+                full_window_start=date(2026, 3, 18),
+                full_window_end=date(2026, 3, 23),
+            )
+
+        self.assertEqual(update, {})
+
+    def test_exact_replay_ledger_artifact_update_rejects_fill_count_mismatch(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            args = Namespace(json_output=root / "frontier.json")
+
+            update = frontier._exact_replay_ledger_artifact_update(
+                args=args,
+                root=root,
+                candidate_index=5,
+                candidate_id="candidate-mismatched-ledger",
+                full_window_payload={
+                    "exact_replay_ledger": _authoritative_exact_replay_ledger_payload(
+                        fill_row_count=1
+                    )
+                },
+                full_window_start=date(2026, 3, 18),
+                full_window_end=date(2026, 3, 23),
+            )
+
+        self.assertEqual(update, {})
+
+    def test_exact_replay_ledger_artifact_update_rejects_malformed_fill_count(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            args = Namespace(json_output=root / "frontier.json")
+            ledger_payload = _authoritative_exact_replay_ledger_payload()
+            ledger_payload["fill_row_count"] = "not-an-int"
+
+            update = frontier._exact_replay_ledger_artifact_update(
+                args=args,
+                root=root,
+                candidate_index=6,
+                candidate_id="candidate-malformed-ledger",
+                full_window_payload={"exact_replay_ledger": ledger_payload},
+                full_window_start=date(2026, 3, 18),
+                full_window_end=date(2026, 3, 23),
+            )
+
+        self.assertEqual(update, {})
+
+    def test_exact_replay_ledger_artifact_update_rejects_missing_bucket_range(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            args = Namespace(json_output=root / "frontier.json")
+
+            update = frontier._exact_replay_ledger_artifact_update(
+                args=args,
+                root=root,
+                candidate_index=7,
+                candidate_id="candidate-missing-window-ledger",
+                full_window_payload={
+                    "exact_replay_ledger": _authoritative_exact_replay_ledger_payload()
+                },
+            )
+
+        self.assertEqual(update, {})
+
+    def test_exact_replay_ledger_artifact_update_rejects_non_mapping_rows(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            args = Namespace(json_output=root / "frontier.json")
+
+            update = frontier._exact_replay_ledger_artifact_update(
+                args=args,
+                root=root,
+                candidate_index=8,
+                candidate_id="candidate-bad-row-ledger",
+                full_window_payload={
+                    "exact_replay_ledger": _authoritative_exact_replay_ledger_payload(
+                        rows=cast(list[dict[str, object]], ["bad-row"])
+                    )
+                },
+                full_window_start=date(2026, 3, 18),
+                full_window_end=date(2026, 3, 23),
+            )
+
+        self.assertEqual(update, {})
+
+    def test_frontier_ledger_datetime_handles_empty_invalid_and_timezone_forms(
+        self,
+    ) -> None:
+        self.assertIsNone(frontier._frontier_ledger_datetime(""))
+        self.assertIsNone(frontier._frontier_ledger_datetime("not-a-date"))
+        self.assertEqual(
+            frontier._frontier_ledger_datetime("2026-03-18T14:35:00"),
+            datetime(2026, 3, 18, 14, 35, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            frontier._frontier_ledger_datetime("2026-03-18T14:35:00Z"),
+            datetime(2026, 3, 18, 14, 35, tzinfo=timezone.utc),
+        )
+
+    def test_frontier_exact_replay_bucket_rejects_empty_bucket_build(self) -> None:
+        with patch(
+            "scripts.search_consistent_profitability_frontier.build_runtime_ledger_buckets",
+            return_value=[],
+        ):
+            bucket = frontier._frontier_exact_replay_bucket(
+                ledger_payload=_authoritative_exact_replay_ledger_payload(),
+                raw_rows=_authoritative_exact_replay_rows(),
+                full_window_start=date(2026, 3, 18),
+                full_window_end=date(2026, 3, 23),
+            )
+
+        self.assertIsNone(bucket)
+
     def test_candidate_replay_lineage_payload_hashes_window_coverage(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -1290,6 +1567,21 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 exact_ledger_artifact["artifact_kind"], "exact_replay_ledger"
             )
             self.assertEqual(scorecard["runtime_ledger_artifact_row_count"], 6)
+            self.assertEqual(scorecard["runtime_ledger_artifact_fill_count"], 2)
+            self.assertEqual(scorecard["runtime_ledger_closed_trade_count"], 1)
+            self.assertEqual(scorecard["runtime_ledger_open_position_count"], 0)
+            self.assertEqual(scorecard["runtime_ledger_filled_notional"], "201")
+            self.assertEqual(
+                scorecard["runtime_ledger_net_strategy_pnl_after_costs"], "0.80"
+            )
+            self.assertEqual(
+                scorecard["runtime_ledger_pnl_basis"],
+                "realized_strategy_pnl_after_explicit_costs",
+            )
+            self.assertEqual(
+                scorecard["runtime_ledger_pnl_source"],
+                "exact_replay_runtime_ledger",
+            )
             artifact = json.loads(artifact_ref.read_text(encoding="utf-8"))
             self.assertEqual(
                 artifact["schema_version"], "torghut.order-type-ablation.v1"
@@ -4289,32 +4581,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                         "cost_model_hash": "cost-sha",
                         "lineage_hash": "ledger-lineage-sha",
                         "fill_row_count": 2,
-                        "runtime_ledger_rows": [
-                            {
-                                "event_type": "decision",
-                                "executed_at": "2026-03-18T14:35:00+00:00",
-                                "decision_id": "decision-buy",
-                                "order_id": "order-buy",
-                            },
-                            {
-                                "event_type": "order_submitted",
-                                "executed_at": "2026-03-18T14:35:01+00:00",
-                                "decision_id": "decision-buy",
-                                "order_id": "order-buy",
-                            },
-                            {
-                                "event_type": "fill",
-                                "executed_at": "2026-03-18T14:35:02+00:00",
-                                "decision_id": "decision-buy",
-                                "order_id": "order-buy",
-                                "symbol": "NVDA",
-                                "side": "buy",
-                                "filled_qty": "1",
-                                "avg_fill_price": "100",
-                                "cost_amount": "0.10",
-                                "cost_basis": "local_replay_transaction_cost_model",
-                            },
-                        ],
+                        "runtime_ledger_rows": _authoritative_exact_replay_rows(),
                     }
                     return payload
                 return self._payload(


### PR DESCRIPTION
## Summary

- Require frontier exact-replay ledger artifacts to rebuild an authoritative runtime ledger bucket before stamping runtime ledger proof fields.
- Reject weak or malformed frontier ledger evidence, including missing bucket windows, non-mapping rows, incomplete order lifecycle, invalid fill counts, open positions, missing provenance hashes, and non-post-cost PnL basis.
- Record authoritative runtime ledger PnL basis, source, closed-trade count, open-position count, filled notional, and net post-cost PnL on accepted frontier candidate scorecards.
- Update frontier tests to use closed buy/sell lifecycle rows and cover the fail-closed branches.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `cd services/torghut && uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -q`
- `cd services/torghut && rm -f .coverage coverage.xml && uv run --frozen coverage run --branch --source=scripts -m pytest tests/test_search_consistent_profitability_frontier.py -q && uv run --frozen coverage xml -o coverage.xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main && rm -f .coverage coverage.xml`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check origin/main..HEAD`

## Screenshots (if applicable)

N/A - backend/search harness change.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
