### PR TITLE
fix(torghut): require ledger proof for runtime authority

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -411,7 +411,14 @@ def _runtime_observation_authority_payload(
     tca_rows: list[dict[str, object]],
 ) -> dict[str, object]:
     has_runtime_ledger_profit_proof = _runtime_ledger_profit_proof_present(tca_rows)
-    if source_kind.startswith("simulation_") and not has_runtime_ledger_profit_proof:
+    if has_runtime_ledger_profit_proof:
+        return {
+            "authoritative": True,
+            "authority_reason": "runtime_ledger_profit_proof",
+            "promotion_authority": "runtime_ledger",
+            "runtime_ledger_profit_proof_present": True,
+        }
+    if source_kind.startswith("simulation_"):
         return {
             "authoritative": False,
             "authority_reason": "simulation_runtime_without_runtime_ledger_profit_proof",
@@ -419,18 +426,10 @@ def _runtime_observation_authority_payload(
             "runtime_ledger_profit_proof_present": False,
         }
     return {
-        "authoritative": True,
-        "authority_reason": (
-            "runtime_ledger_profit_proof"
-            if has_runtime_ledger_profit_proof
-            else "observed_runtime_activity"
-        ),
-        "promotion_authority": (
-            "runtime_ledger"
-            if has_runtime_ledger_profit_proof
-            else "observed_runtime_activity"
-        ),
-        "runtime_ledger_profit_proof_present": has_runtime_ledger_profit_proof,
+        "authoritative": False,
+        "authority_reason": "runtime_without_runtime_ledger_profit_proof",
+        "promotion_authority": "blocked",
+        "runtime_ledger_profit_proof_present": False,
     }
 
 

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -30,6 +30,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _runtime_ledger_bucket_profit_proof_present,
     _runtime_ledger_event_type,
     _runtime_ledger_profit_proof_present,
+    _runtime_observation_authority_payload,
     _runtime_ledger_target_metadata_blockers,
     _runtime_ledger_tca_rows_from_durable_buckets,
     _runtime_ledger_tca_rows_from_artifacts,
@@ -139,6 +140,51 @@ def _complete_runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
 
 
 class TestImportHypothesisRuntimeWindows(TestCase):
+    def test_runtime_observation_authority_requires_runtime_ledger_profit_proof(
+        self,
+    ) -> None:
+        payload = _runtime_observation_authority_payload(
+            source_kind="live_runtime_observed",
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("4"),
+                    "post_cost_expectancy_bps": Decimal("12"),
+                    "post_cost_expectancy_basis": POST_COST_BASIS_TCA_PROXY,
+                    "post_cost_promotion_eligible": False,
+                }
+            ],
+        )
+
+        self.assertEqual(payload["authoritative"], False)
+        self.assertEqual(
+            payload["authority_reason"],
+            "runtime_without_runtime_ledger_profit_proof",
+        )
+        self.assertEqual(payload["promotion_authority"], "blocked")
+        self.assertEqual(payload["runtime_ledger_profit_proof_present"], False)
+
+    def test_runtime_observation_authority_accepts_runtime_ledger_profit_proof(
+        self,
+    ) -> None:
+        payload = _runtime_observation_authority_payload(
+            source_kind="live_runtime_observed",
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "post_cost_expectancy_bps": Decimal("40"),
+                    "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+                    "post_cost_promotion_eligible": True,
+                    "runtime_ledger_bucket": _complete_runtime_ledger_bucket(),
+                }
+            ],
+        )
+
+        self.assertEqual(payload["authoritative"], True)
+        self.assertEqual(payload["authority_reason"], "runtime_ledger_profit_proof")
+        self.assertEqual(payload["promotion_authority"], "runtime_ledger")
+        self.assertEqual(payload["runtime_ledger_profit_proof_present"], True)
+
     def test_parse_args_accepts_dataset_snapshot_ref(self) -> None:
         with patch(
             "sys.argv",


### PR DESCRIPTION
## Summary

- Require runtime-window imports to mark observed paper/live runtime activity as non-authoritative unless promotion-grade runtime-ledger profit proof is present.
- Keep exact/durable runtime ledger buckets as the only runtime observation path that can set `promotion_authority=runtime_ledger`.
- Add regression coverage for non-ledger observed runtime activity and valid runtime-ledger proof.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && rm -f .coverage coverage.xml && uv run --frozen coverage run --branch --source=scripts -m pytest tests/test_import_hypothesis_runtime_windows.py -q && uv run --frozen coverage xml -o coverage.xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A - runtime import semantics only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
