### PR TITLE
feat(torghut): keep screening after replay budget

### DIFF
--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -355,6 +355,8 @@ def _staged_search_budget_payload(
     candidate_budget: int,
     full_replay_candidates_started: int = 0,
     train_screen_only_candidates: int = 0,
+    full_replay_budget_discarded_candidates: int = 0,
+    proof_only_full_window_replay_captures: int = 0,
 ) -> dict[str, Any]:
     train_screening_enabled = bool(getattr(args, "train_screening", True))
     train_screen_multiplier = max(
@@ -380,6 +382,16 @@ def _staged_search_budget_payload(
         "full_replay_candidate_budget": full_replay_budget,
         "full_replay_candidates_started": max(0, int(full_replay_candidates_started)),
         "train_screen_only_candidates": max(0, int(train_screen_only_candidates)),
+        "full_replay_budget_discarded_candidates": max(
+            0, int(full_replay_budget_discarded_candidates)
+        ),
+        "positive_rejected_full_window_ledger_capture_budget": max(
+            0,
+            int(getattr(args, "capture_positive_rejected_full_window_ledgers", 0) or 0),
+        ),
+        "proof_only_full_window_replay_captures": max(
+            0, int(proof_only_full_window_replay_captures)
+        ),
     }
 
 
@@ -712,6 +724,25 @@ def _parse_args() -> argparse.Namespace:
             "still run a full-window exact replay ledger capture as proof-only evidence. "
             "The candidate remains train-screen rejected and non-promotable."
         ),
+    )
+    parser.add_argument(
+        "--capture-positive-rejected-full-window-ledgers",
+        dest="capture_positive_rejected_full_window_ledgers",
+        type=int,
+        default=0,
+        help=(
+            "Capture up to N proof-only full-window exact replay ledgers for "
+            "positive train-screen rejects or candidates that pass the train "
+            "screen after the full-replay budget is exhausted. Candidates remain "
+            "blocked by their train/budget vetoes and non-promotable."
+        ),
+    )
+    parser.add_argument(
+        "--capture-top-rejected-full-window-ledgers",
+        dest="capture_positive_rejected_full_window_ledgers",
+        type=int,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
     )
     parser.add_argument("--json-output", type=Path)
     parser.add_argument(
@@ -3207,6 +3238,11 @@ def _train_screen_failures(
     return list(dict.fromkeys(failures))
 
 
+def _positive_train_screen_candidate(train_payload: Mapping[str, Any]) -> bool:
+    summary = summarize_replay_profitability(train_payload)
+    return summary.decision_count > 0 and summary.net_per_day > Decimal("0")
+
+
 def _symbol_contributions_from_replay_payload(
     payload: Mapping[str, Any],
 ) -> dict[str, dict[str, Any]]:
@@ -4874,6 +4910,8 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         )
         full_replay_candidates_started = 0
         train_screen_only_candidates = 0
+        full_replay_budget_discarded_candidates = 0
+        proof_only_full_window_replay_captures = 0
         initial_candidates = _iter_initial_worklist_candidates(
             parameter_grid=parameter_grid,
             override_candidates=override_candidates,
@@ -4909,12 +4947,6 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                 if (
                     train_screen_candidate_budget > 0
                     and len(scored) >= train_screen_candidate_budget
-                ):
-                    budget_exhausted = True
-                    break
-                if (
-                    full_replay_candidate_budget > 0
-                    and full_replay_candidates_started >= full_replay_candidate_budget
                 ):
                     budget_exhausted = True
                     break
@@ -4979,11 +5011,30 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     if bool(getattr(args, "train_screening", True))
                     else []
                 )
-                holdout_replay_skipped = bool(train_screen_failures)
-                full_window_replay_skipped = bool(train_screen_failures)
+                full_replay_budget_exhausted = (
+                    not train_screen_failures
+                    and full_replay_candidate_budget > 0
+                    and full_replay_candidates_started >= full_replay_candidate_budget
+                )
+                full_replay_skip_reasons = (
+                    ["full_replay_candidate_budget_exhausted"]
+                    if full_replay_budget_exhausted
+                    else []
+                )
+                holdout_replay_skipped = bool(
+                    train_screen_failures or full_replay_skip_reasons
+                )
+                full_window_replay_skipped = bool(
+                    train_screen_failures or full_replay_skip_reasons
+                )
                 proof_only_full_window_replay_captured = False
-                if train_screen_failures:
-                    train_screen_only_candidates += 1
+                proof_only_full_window_reason = ""
+                if holdout_replay_skipped:
+                    if train_screen_failures:
+                        train_screen_only_candidates += 1
+                    if full_replay_skip_reasons:
+                        full_replay_budget_discarded_candidates += 1
+                        budget_exhausted = True
                     second_oos_start = window.second_oos_start
                     second_oos_end = window.second_oos_end
                     holdout_payload = _empty_replay_payload(
@@ -4998,7 +5049,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                         if second_oos_start is not None and second_oos_end is not None
                         else None
                     )
-                    if (
+                    capture_rejected_seed_ledger = (
                         bool(
                             getattr(
                                 args,
@@ -5007,10 +5058,38 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                             )
                         )
                         and worklist_item.candidate_record_seed
-                    ):
+                        and bool(train_screen_failures)
+                    )
+                    top_rejected_capture_budget = max(
+                        0,
+                        int(
+                            getattr(
+                                args,
+                                "capture_positive_rejected_full_window_ledgers",
+                                0,
+                            )
+                            or 0
+                        ),
+                    )
+                    capture_ranked_rejected_ledger = (
+                        proof_only_full_window_replay_captures
+                        < top_rejected_capture_budget
+                        and _positive_train_screen_candidate(train_payload)
+                    )
+                    if capture_rejected_seed_ledger or capture_ranked_rejected_ledger:
                         full_replay_candidates_started += 1
+                        proof_only_full_window_replay_captures += 1
                         proof_only_full_window_replay_captured = True
                         full_window_replay_skipped = False
+                        proof_only_full_window_reason = (
+                            "train_screen_rejected_candidate_record_seed"
+                            if capture_rejected_seed_ledger
+                            else (
+                                "full_replay_budget_exhausted_positive_train_screen"
+                                if full_replay_skip_reasons
+                                else "positive_train_screen_reject"
+                            )
+                        )
                         full_window_payload = run_replay(
                             _build_replay_config(
                                 strategy_configmap_path=candidate_configmap_path,
@@ -5284,7 +5363,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     full_window_start=full_window_start,
                     full_window_end=full_window_end,
                     proof_only_reason=(
-                        "train_screen_rejected_candidate_record_seed"
+                        proof_only_full_window_reason
                         if proof_only_full_window_replay_captured
                         else ""
                     ),
@@ -5316,20 +5395,28 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     "max_train_worst_day_loss": str(max_train_screen_worst_day_loss),
                     "holdout_replay_skipped": holdout_replay_skipped,
                     "full_window_replay_skipped": full_window_replay_skipped,
+                    "full_replay_skip_reasons": full_replay_skip_reasons,
                     "proof_only_full_window_replay_captured": (
                         proof_only_full_window_replay_captured
                     ),
                     "second_oos_replay_skipped": bool(
-                        train_screen_failures and window.second_oos_days
+                        (train_screen_failures or full_replay_skip_reasons)
+                        and window.second_oos_days
                     ),
                 }
                 candidate_payload["staged_search"] = {
                     "schema_version": "torghut.frontier-candidate-staged-search.v1",
                     "stage": (
-                        "train_screen_rejected_full_window_proof"
+                        (
+                            "full_replay_budget_exhausted_full_window_proof"
+                            if full_replay_skip_reasons
+                            else "train_screen_rejected_full_window_proof"
+                        )
                         if proof_only_full_window_replay_captured
                         else (
-                            "train_screen_only"
+                            "train_screen_passed_full_replay_budget_exhausted"
+                            if full_replay_skip_reasons
+                            else "train_screen_only"
                             if holdout_replay_skipped
                             else "full_replay"
                         )
@@ -5339,6 +5426,12 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     ),
                     "full_replay_candidate_budget": full_replay_candidate_budget,
                     "full_replay_candidates_started": full_replay_candidates_started,
+                    "full_replay_budget_discarded_candidates": (
+                        full_replay_budget_discarded_candidates
+                    ),
+                    "proof_only_full_window_replay_captures": (
+                        proof_only_full_window_replay_captures
+                    ),
                     "candidate_record_seed": worklist_item.candidate_record_seed,
                 }
                 if worklist_item.pruned_symbol is not None:
@@ -5471,6 +5564,7 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                     )
                 )
                 hard_vetoes.extend(train_screen_failures)
+                hard_vetoes.extend(full_replay_skip_reasons)
                 if second_oos_summary is not None:
                     hard_vetoes.extend(
                         str(reason)
@@ -6052,6 +6146,8 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                             candidate_budget=candidate_budget,
                             full_replay_candidates_started=full_replay_candidates_started,
                             train_screen_only_candidates=train_screen_only_candidates,
+                            full_replay_budget_discarded_candidates=full_replay_budget_discarded_candidates,
+                            proof_only_full_window_replay_captures=proof_only_full_window_replay_captures,
                         ),
                     )
                     _write_json_output(args.json_output, partial_payload)
@@ -6070,7 +6166,12 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
         objective_veto_policy=objective_veto_policy,
         top_n=max(1, int(args.top_n)),
         status="candidate_budget_exhausted"
-        if budget_exhausted and (worklist or not initial_candidates_exhausted)
+        if budget_exhausted
+        and (
+            worklist
+            or not initial_candidates_exhausted
+            or full_replay_budget_discarded_candidates > 0
+        )
         else "completed",
         pending_candidates=len(worklist) + (0 if initial_candidates_exhausted else 1),
         replay_tape_validation=replay_tape_validation,
@@ -6079,6 +6180,8 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
             candidate_budget=candidate_budget,
             full_replay_candidates_started=full_replay_candidates_started,
             train_screen_only_candidates=train_screen_only_candidates,
+            full_replay_budget_discarded_candidates=full_replay_budget_discarded_candidates,
+            proof_only_full_window_replay_captures=proof_only_full_window_replay_captures,
         ),
     )
     if args.json_output is not None:

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -97,7 +97,9 @@ def _authoritative_exact_replay_ledger_payload(
         "cost_model_hash": "cost-sha",
         "lineage_hash": "ledger-lineage-sha",
         "fill_row_count": fill_row_count,
-        "runtime_ledger_rows": rows if rows is not None else _authoritative_exact_replay_rows(),
+        "runtime_ledger_rows": rows
+        if rows is not None
+        else _authoritative_exact_replay_rows(),
     }
 
 
@@ -398,6 +400,8 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                     "--candidate-record",
                     str(root / "candidate.json"),
                     "--capture-rejected-seed-full-window-ledger",
+                    "--capture-positive-rejected-full-window-ledgers",
+                    "2",
                     "--no-train-screening",
                     "--min-train-screen-net-per-day",
                     "-50",
@@ -422,6 +426,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual(args.staged_train_screen_multiplier, 3)
         self.assertEqual(args.candidate_record, [root / "candidate.json"])
         self.assertTrue(args.capture_rejected_seed_full_window_ledger)
+        self.assertEqual(args.capture_positive_rejected_full_window_ledgers, 2)
         self.assertFalse(args.train_screening)
         self.assertEqual(args.min_train_screen_net_per_day, "-50")
         self.assertEqual(args.min_train_screen_active_ratio, "0.25")
@@ -1755,6 +1760,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             min_train_screen_active_ratio="0.50",
             max_train_screen_worst_day_loss="",
             capture_rejected_seed_full_window_ledger=False,
+            capture_positive_rejected_full_window_ledgers=0,
         )
 
     def test_resolve_frontier_replay_windows_keeps_second_oos_independent(
@@ -4660,6 +4666,351 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
                 {"start_date": "2026-03-18", "end_date": "2026-03-23"},
             )
             self.assertEqual(artifact["candidate_symbols"], ["NVDA"])
+
+    def test_positive_rejected_candidates_can_capture_capped_full_window_ledgers(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = self._write_strategy_configmap(root)
+            sweep_config = root / "sweep.yaml"
+            sweep_config.write_text(
+                yaml.safe_dump(
+                    {
+                        "schema_version": "torghut.replay-frontier-sweep.v1",
+                        "family": "intraday_tsmom_consistent",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "disable_other_strategies": True,
+                        "constraints": {
+                            "holdout_target_net_per_day": "200",
+                            "min_active_holdout_days": 2,
+                            "max_worst_holdout_day_loss": "200",
+                            "min_profit_factor": "1.0",
+                        },
+                        "consistency_constraints": {
+                            "target_net_per_day": "200",
+                            "min_active_days": 2,
+                            "max_worst_day_loss": "300",
+                            "max_negative_days": 1,
+                            "max_drawdown": "400",
+                            "require_every_day_active": True,
+                        },
+                        "strategy_overrides": {
+                            "universe_symbols": [["NVDA"]],
+                        },
+                        "parameters": {
+                            "long_stop_loss_bps": ["12", "14"],
+                        },
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+            args = self._make_args(
+                strategy_configmap=strategy_configmap,
+                sweep_config=sweep_config,
+                json_output=root / "frontier.json",
+            )
+            args.max_candidates_to_evaluate = 2
+            args.min_train_screen_net_per_day = "50"
+            args.capture_positive_rejected_full_window_ledgers = 1
+            recent_days = tuple(
+                date(2026, 3, 18) + timedelta(days=index) for index in range(6)
+            )
+            snapshot_receipt = SimpleNamespace(
+                snapshot_id="snap-positive-reject-proof",
+                is_fresh=True,
+                stale_override_used=False,
+                to_payload=lambda: {
+                    "snapshot_id": "snap-positive-reject-proof",
+                    "source": "ta",
+                    "window_size": "PT1S",
+                    "start_day": "2026-03-18",
+                    "end_day": "2026-03-23",
+                    "expected_last_trading_day": "2026-03-23",
+                    "is_fresh": True,
+                    "missing_days": [],
+                    "row_count": 123,
+                    "stale_override_used": False,
+                    "witnesses": [],
+                },
+            )
+            replay_calls: list[tuple[str, str, bool]] = []
+
+            def fake_run_replay(config: object) -> dict[str, object]:
+                start_date = str(getattr(config, "start_date"))
+                end_date = str(getattr(config, "end_date"))
+                capture_ledger = bool(
+                    getattr(config, "capture_exact_replay_ledger", False)
+                )
+                replay_calls.append((start_date, end_date, capture_ledger))
+                if capture_ledger:
+                    payload = self._payload(
+                        start_date=start_date,
+                        end_date=end_date,
+                        daily_net={
+                            "2026-03-18": "30",
+                            "2026-03-19": "30",
+                            "2026-03-20": "30",
+                            "2026-03-21": "30",
+                            "2026-03-22": "30",
+                            "2026-03-23": "30",
+                        },
+                        decision_count=2,
+                        filled_count=2,
+                        wins=2,
+                        losses=0,
+                    )
+                    payload["exact_replay_ledger"] = {
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "account_label": "TORGHUT_REPLAY",
+                        "execution_policy_hash": "policy-sha",
+                        "cost_model_hash": "cost-sha",
+                        "lineage_hash": "ledger-lineage-sha",
+                        "fill_row_count": 2,
+                        "runtime_ledger_rows": _authoritative_exact_replay_rows(),
+                    }
+                    return payload
+                return self._payload(
+                    start_date=start_date,
+                    end_date=end_date,
+                    daily_net={
+                        "2026-03-18": "10",
+                        "2026-03-19": "10",
+                        "2026-03-20": "10",
+                    },
+                    decision_count=3,
+                    filled_count=3,
+                    wins=3,
+                    losses=0,
+                )
+
+            with (
+                patch(
+                    "scripts.search_consistent_profitability_frontier._resolve_recent_trading_days",
+                    return_value=recent_days,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt",
+                    return_value=snapshot_receipt,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot"
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.run_replay",
+                    side_effect=fake_run_replay,
+                ),
+            ):
+                payload = frontier.run_consistent_profitability_frontier(args)
+
+            self.assertEqual(
+                replay_calls,
+                [
+                    ("2026-03-18", "2026-03-20", False),
+                    ("2026-03-18", "2026-03-23", True),
+                    ("2026-03-18", "2026-03-20", False),
+                ],
+            )
+            staged = payload["progress"]["staged_search"]
+            self.assertEqual(
+                staged["positive_rejected_full_window_ledger_capture_budget"], 1
+            )
+            self.assertEqual(staged["proof_only_full_window_replay_captures"], 1)
+            captured = [
+                item
+                for item in payload["top"]
+                if item["screening"]["proof_only_full_window_replay_captured"]
+            ]
+            self.assertEqual(len(captured), 1)
+            top = captured[0]
+            self.assertEqual(
+                top["staged_search"]["stage"],
+                "train_screen_rejected_full_window_proof",
+            )
+            self.assertIn("train_net_per_day_below_screen", top["hard_vetoes"])
+            exact_ledger_ref = Path(
+                top["objective_scorecard"]["exact_replay_ledger_artifact_ref"]
+            )
+            artifact = json.loads(exact_ledger_ref.read_text(encoding="utf-8"))
+            self.assertTrue(artifact["proof_only"])
+            self.assertEqual(
+                artifact["proof_only_reason"], "positive_train_screen_reject"
+            )
+
+    def test_staged_search_continues_screening_after_full_replay_budget(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = self._write_strategy_configmap(root)
+            sweep_config = root / "sweep.yaml"
+            sweep_config.write_text(
+                yaml.safe_dump(
+                    {
+                        "schema_version": "torghut.replay-frontier-sweep.v1",
+                        "family": "intraday_tsmom_consistent",
+                        "strategy_name": "intraday-tsmom-profit-v3",
+                        "disable_other_strategies": True,
+                        "constraints": {
+                            "holdout_target_net_per_day": "1",
+                            "min_active_holdout_days": 1,
+                            "max_worst_holdout_day_loss": "200",
+                            "min_profit_factor": "1.0",
+                        },
+                        "consistency_constraints": {
+                            "target_net_per_day": "1",
+                            "min_active_days": 1,
+                            "max_worst_day_loss": "300",
+                            "max_negative_days": 1,
+                            "max_drawdown": "400",
+                            "require_every_day_active": False,
+                        },
+                        "strategy_overrides": {
+                            "universe_symbols": [["NVDA"]],
+                        },
+                        "parameters": {
+                            "long_stop_loss_bps": ["12", "14", "16"],
+                        },
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+            args = self._make_args(
+                strategy_configmap=strategy_configmap,
+                sweep_config=sweep_config,
+                json_output=root / "frontier.json",
+            )
+            args.max_candidates_to_evaluate = 1
+            args.staged_train_screen_multiplier = 3
+            args.capture_positive_rejected_full_window_ledgers = 1
+            args.min_train_screen_net_per_day = "1"
+            recent_days = tuple(
+                date(2026, 3, 18) + timedelta(days=index) for index in range(6)
+            )
+            snapshot_receipt = SimpleNamespace(
+                snapshot_id="snap-budget-discard-proof",
+                is_fresh=True,
+                stale_override_used=False,
+                to_payload=lambda: {
+                    "snapshot_id": "snap-budget-discard-proof",
+                    "source": "ta",
+                    "window_size": "PT1S",
+                    "start_day": "2026-03-18",
+                    "end_day": "2026-03-23",
+                    "expected_last_trading_day": "2026-03-23",
+                    "is_fresh": True,
+                    "missing_days": [],
+                    "row_count": 123,
+                    "stale_override_used": False,
+                    "witnesses": [],
+                },
+            )
+            replay_calls: list[tuple[str, str, bool]] = []
+
+            def fake_run_replay(config: object) -> dict[str, object]:
+                start_date = str(getattr(config, "start_date"))
+                end_date = str(getattr(config, "end_date"))
+                capture_ledger = bool(
+                    getattr(config, "capture_exact_replay_ledger", False)
+                )
+                replay_calls.append((start_date, end_date, capture_ledger))
+                daily_net = {
+                    day.isoformat(): "10"
+                    for day in (
+                        date.fromisoformat(start_date) + timedelta(days=index)
+                        for index in range(
+                            (
+                                date.fromisoformat(end_date)
+                                - date.fromisoformat(start_date)
+                            ).days
+                            + 1
+                        )
+                    )
+                }
+                payload = self._payload(
+                    start_date=start_date,
+                    end_date=end_date,
+                    daily_net=daily_net,
+                    decision_count=len(daily_net),
+                    filled_count=len(daily_net),
+                    wins=len(daily_net),
+                    losses=0,
+                )
+                if capture_ledger:
+                    payload["exact_replay_ledger"] = {
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "account_label": "TORGHUT_REPLAY",
+                        "execution_policy_hash": "policy-sha",
+                        "cost_model_hash": "cost-sha",
+                        "lineage_hash": "ledger-lineage-sha",
+                        "fill_row_count": 2,
+                        "runtime_ledger_rows": _authoritative_exact_replay_rows(),
+                    }
+                return payload
+
+            with (
+                patch(
+                    "scripts.search_consistent_profitability_frontier._resolve_recent_trading_days",
+                    return_value=recent_days,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.build_dataset_snapshot_receipt",
+                    return_value=snapshot_receipt,
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.ensure_fresh_snapshot"
+                ),
+                patch(
+                    "scripts.search_consistent_profitability_frontier.run_replay",
+                    side_effect=fake_run_replay,
+                ),
+            ):
+                payload = frontier.run_consistent_profitability_frontier(args)
+
+            self.assertEqual(payload["status"], "candidate_budget_exhausted")
+            self.assertEqual(payload["candidate_count"], 3)
+            self.assertEqual(
+                replay_calls,
+                [
+                    ("2026-03-18", "2026-03-20", False),
+                    ("2026-03-21", "2026-03-23", False),
+                    ("2026-03-18", "2026-03-23", True),
+                    ("2026-03-18", "2026-03-20", False),
+                    ("2026-03-18", "2026-03-23", True),
+                    ("2026-03-18", "2026-03-20", False),
+                ],
+            )
+            staged = payload["progress"]["staged_search"]
+            self.assertEqual(staged["full_replay_budget_discarded_candidates"], 2)
+            self.assertEqual(staged["proof_only_full_window_replay_captures"], 1)
+            budget_items = [
+                item
+                for item in payload["top"]
+                if "full_replay_candidate_budget_exhausted" in item["hard_vetoes"]
+            ]
+            self.assertEqual(len(budget_items), 2)
+            self.assertEqual(
+                [item["staged_search"]["stage"] for item in budget_items],
+                [
+                    "full_replay_budget_exhausted_full_window_proof",
+                    "train_screen_passed_full_replay_budget_exhausted",
+                ],
+            )
+            self.assertTrue(
+                budget_items[0]["screening"]["proof_only_full_window_replay_captured"]
+            )
+            exact_ledger_ref = Path(
+                budget_items[0]["objective_scorecard"][
+                    "exact_replay_ledger_artifact_ref"
+                ]
+            )
+            artifact = json.loads(exact_ledger_ref.read_text(encoding="utf-8"))
+            self.assertEqual(
+                artifact["proof_only_reason"],
+                "full_replay_budget_exhausted_positive_train_screen",
+            )
 
     def test_run_frontier_staged_train_screen_expands_cheap_stage(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Lets staged frontier search keep running cheap train-screen evaluations up to the train-screen budget after the expensive full-replay budget is exhausted.
- Adds an explicit capped `--capture-positive-rejected-full-window-ledgers` proof-only path for positive train-screen rejects and full-replay-budget-discarded candidates.
- Stamps budget-discard/proof-only counters, skip reasons, and vetoes so these candidates remain non-promotable while still surfacing useful exact-ledger evidence.

## Related Issues

None

## Testing

- `uv run --frozen ruff format --check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen ruff check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -q`
- `rm -f .coverage coverage.xml && uv run --frozen coverage run --branch --source=scripts -m pytest tests/test_search_consistent_profitability_frontier.py -q && uv run --frozen coverage xml -o coverage.xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
