### PR TITLE
fix(torghut): require artifact ledger counts in portfolios

### DIFF
--- a/services/torghut/app/trading/discovery/portfolio_optimizer.py
+++ b/services/torghut/app/trading/discovery/portfolio_optimizer.py
@@ -404,8 +404,6 @@ def _exact_replay_ledger_row_count(bundle: CandidateEvidenceBundle) -> int:
             _decimal(
                 scorecard.get("exact_replay_ledger_artifact_row_count")
                 or scorecard.get("runtime_ledger_artifact_row_count")
-                or scorecard.get("exact_replay_ledger_row_count")
-                or scorecard.get("runtime_ledger_row_count")
             )
         ),
     )
@@ -419,8 +417,6 @@ def _exact_replay_ledger_fill_count(bundle: CandidateEvidenceBundle) -> int:
             _decimal(
                 scorecard.get("exact_replay_ledger_artifact_fill_count")
                 or scorecard.get("runtime_ledger_artifact_fill_count")
-                or scorecard.get("exact_replay_ledger_fill_count")
-                or scorecard.get("runtime_ledger_fill_count")
             )
         ),
     )

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -98,7 +98,7 @@ def _executable_scorecard_fields(index: int | str = 0) -> dict[str, object]:
 
 
 class TestPortfolioOptimizer(TestCase):
-    def test_exact_replay_ledger_helpers_accept_list_refs_and_runtime_alias_counts(
+    def test_exact_replay_ledger_helpers_accept_list_refs_and_runtime_artifact_counts(
         self,
     ) -> None:
         bundle = evidence_bundle_from_frontier_candidate(
@@ -134,6 +134,33 @@ class TestPortfolioOptimizer(TestCase):
         self.assertEqual(
             portfolio_optimizer_module._exact_replay_ledger_fill_count(bundle),
             6,
+        )
+
+    def test_exact_replay_ledger_helpers_reject_non_artifact_count_aliases(
+        self,
+    ) -> None:
+        bundle = evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-ledger-summary-alias",
+            candidate={
+                "candidate_id": "cand-ledger-summary-alias",
+                "objective_scorecard": {
+                    "exact_replay_ledger_row_count": "7",
+                    "runtime_ledger_row_count": "7",
+                    "exact_replay_ledger_fill_count": "6",
+                    "runtime_ledger_fill_count": "6",
+                },
+            },
+            dataset_snapshot_id="snapshot-ledger-summary-alias",
+            result_path="/tmp/cand-ledger-summary-alias.json",
+        )
+
+        self.assertEqual(
+            portfolio_optimizer_module._exact_replay_ledger_row_count(bundle),
+            0,
+        )
+        self.assertEqual(
+            portfolio_optimizer_module._exact_replay_ledger_fill_count(bundle),
+            0,
         )
 
     def test_oracle_blocker_count_treats_malformed_payloads_as_unblocked(


### PR DESCRIPTION
## Summary

- Require portfolio exact replay ledger row and fill counts to come from artifact-backed scorecard fields only.
- Stop upgrading copied summary aliases such as `runtime_ledger_row_count` into artifact proof counts.
- Add a regression test proving non-artifact ledger count aliases contribute zero proof authority.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_portfolio_optimizer.py -k "exact_replay_ledger_helpers"`
- `uv run --frozen ruff check app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen pytest tests/test_portfolio_optimizer.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check app/trading/discovery/portfolio_optimizer.py tests/test_portfolio_optimizer.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
