### PR TITLE
fix(torghut): fail closed on partial replay proof

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -3198,6 +3198,33 @@ def _requires_synthetic_validation_only_policy(card: HypothesisCard) -> bool:
     )
 
 
+def _is_validation_or_execution_constraint_only(card: HypothesisCard) -> bool:
+    source_claims = _list_of_mappings(
+        card.implementation_constraints.get("source_claims")
+    )
+    claim_types = {
+        str(item.get("claim_type") or "").strip().lower()
+        for item in source_claims
+        if str(item.get("claim_type") or "").strip()
+    }
+    if not claim_types:
+        return False
+    signal_claim_types = {
+        "feature_recipe",
+        "signal_mechanism",
+        "strategy_mechanism",
+        "portfolio_construction",
+    }
+    if claim_types & signal_claim_types:
+        return False
+    return claim_types <= {
+        "execution_assumption",
+        "market_regime",
+        "risk_constraint",
+        "validation_requirement",
+    }
+
+
 def _paper_mechanism_haystack(card: HypothesisCard) -> str:
     validation_requirements = _list_of_mappings(
         card.implementation_constraints.get("validation_requirements")
@@ -4632,7 +4659,7 @@ def _families_for_hypothesis(
 ) -> tuple[tuple[str, int, tuple[str, ...]], ...]:
     scored = _family_scores_for_hypothesis(card)
     rejected_signal_rescue = _has_rejected_signal_outcome_calibration(card)
-    if rejected_signal_rescue:
+    if rejected_signal_rescue or _is_validation_or_execution_constraint_only(card):
         family_limit = _MAX_FAMILIES_PER_HYPOTHESIS
     else:
         family_limit = (

--- a/services/torghut/app/trading/discovery/evidence_bundles.py
+++ b/services/torghut/app/trading/discovery/evidence_bundles.py
@@ -498,6 +498,56 @@ def _is_synthetic_dataset_snapshot(dataset_snapshot_id: str) -> bool:
     )
 
 
+def _freshness_status_from_validation_status(status: str) -> str:
+    normalized = status.strip().lower()
+    if normalized == "valid":
+        return "fresh"
+    if normalized in {"stale_override", "stale", "expired", "not_fresh"}:
+        return "stale"
+    return normalized
+
+
+def _scorecard_with_freshness_lineage(
+    *,
+    scorecard: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+) -> dict[str, Any]:
+    enriched = dict(scorecard)
+    replay_tape = _mapping(candidate.get("replay_tape"))
+    if replay_tape and "replay_tape" not in enriched:
+        enriched["replay_tape"] = replay_tape
+
+    replay_status = _string(
+        replay_tape.get("status") or replay_tape.get("validation_status")
+    )
+    if replay_status and "tape_freshness_status" not in enriched:
+        enriched["tape_freshness_status"] = _freshness_status_from_validation_status(
+            replay_status
+        )
+    if _bool(replay_tape.get("stale_override_used")) or replay_status.lower() in {
+        "stale_override",
+        "stale",
+    }:
+        enriched["stale_override_used"] = True
+
+    dataset_receipt = _mapping(
+        candidate.get("dataset_snapshot_receipt")
+        or candidate.get("dataset_snapshot")
+        or candidate.get("dataset_receipt")
+    )
+    if dataset_receipt and "dataset_snapshot_receipt" not in enriched:
+        enriched["dataset_snapshot_receipt"] = dataset_receipt
+    if dataset_receipt:
+        if _bool(dataset_receipt.get("stale_override_used")):
+            enriched["stale_override_used"] = True
+        is_fresh = dataset_receipt.get("is_fresh")
+        if is_fresh is not None and "dataset_freshness_status" not in enriched:
+            enriched["dataset_freshness_status"] = (
+                "fresh" if _bool(is_fresh) else "stale"
+            )
+    return enriched
+
+
 def _decomposition_symbol_contribution_shares(
     candidate: Mapping[str, Any],
 ) -> dict[str, str]:
@@ -976,6 +1026,10 @@ def evidence_bundle_from_frontier_candidate(
         full_window=full_window,
         result_path=result_path,
     )
+    scorecard = _scorecard_with_freshness_lineage(
+        scorecard=scorecard,
+        candidate=candidate,
+    )
     stress_metrics = tuple(
         cast(Sequence[Mapping[str, Any]], candidate.get("stress_metrics") or ())
     )
@@ -1266,6 +1320,21 @@ def evidence_bundle_blockers(bundle: CandidateEvidenceBundle) -> tuple[str, ...]
         or scorecard.get("freshness_status")
     ).lower()
     if freshness in {"stale", "expired", "not_fresh"}:
+        blockers.append("stale_tape")
+    replay_tape = _mapping(scorecard.get("replay_tape"))
+    replay_status = _string(
+        replay_tape.get("status") or replay_tape.get("validation_status")
+    ).lower()
+    if _bool(replay_tape.get("stale_override_used")) or replay_status in {
+        "stale_override",
+        "stale",
+    }:
+        blockers.append("stale_tape")
+    dataset_receipt = _mapping(scorecard.get("dataset_snapshot_receipt"))
+    if _bool(dataset_receipt.get("stale_override_used")):
+        blockers.append("stale_tape")
+    receipt_is_fresh = dataset_receipt.get("is_fresh")
+    if receipt_is_fresh is not None and not _bool(receipt_is_fresh):
         blockers.append("stale_tape")
     validation_contract = _mapping(
         scorecard.get("validation_contract")

--- a/services/torghut/app/trading/discovery/replay_tape.py
+++ b/services/torghut/app/trading/discovery/replay_tape.py
@@ -328,8 +328,9 @@ def validate_tape_freshness(
         )
 
     requested_symbols = set(_normalize_symbols(symbols))
-    if requested_symbols and manifest.symbols:
-        missing = sorted(requested_symbols - set(manifest.symbols))
+    coverage_symbols = set(manifest.symbols or manifest.row_symbols)
+    if requested_symbols:
+        missing = sorted(requested_symbols - coverage_symbols)
         if missing:
             reasons.append(f"symbols_not_covered:{','.join(missing)}")
 
@@ -342,7 +343,19 @@ def validate_tape_freshness(
             + ",".join(day.isoformat() for day in missing_trading_days)
         )
 
-    missing_symbol_trading_days = tuple(
+    requested_trading_days = _business_days(start_date, end_date)
+    observed_day_set = {
+        day for day in manifest.observed_trading_days if start_date <= day <= end_date
+    }
+    for raw_day, raw_count in manifest.row_count_by_trading_day.items():
+        try:
+            day = date.fromisoformat(str(raw_day))
+        except ValueError:
+            continue
+        if start_date <= day <= end_date and int(raw_count or 0) > 0:
+            observed_day_set.add(day)
+    observed_trading_days = tuple(sorted(observed_day_set))
+    missing_symbol_entries = set(
         entry
         for entry in manifest.missing_symbol_trading_days
         if _symbol_day_entry_in_window(
@@ -352,6 +365,15 @@ def validate_tape_freshness(
             requested_symbols=requested_symbols,
         )
     )
+    missing_symbol_entries.update(
+        _missing_symbol_trading_days(
+            row_count_by_symbol_trading_day=manifest.row_count_by_symbol_trading_day,
+            requested_symbols=tuple(sorted(requested_symbols)),
+            requested_trading_days=requested_trading_days,
+            observed_trading_days=observed_trading_days,
+        )
+    )
+    missing_symbol_trading_days = tuple(sorted(missing_symbol_entries))
     if missing_symbol_trading_days:
         reasons.append(
             "symbol_trading_days_missing:" + ",".join(missing_symbol_trading_days)
@@ -368,24 +390,23 @@ def validate_tape_freshness(
         "dataset_snapshot_ref": manifest.dataset_snapshot_ref,
         "row_count": manifest.row_count,
         "trading_day_count": manifest.trading_day_count,
+        "requested_symbols": sorted(requested_symbols),
         "requested_trading_days": [
             item.isoformat() for item in manifest.requested_trading_days
         ],
         "observed_trading_days": [
             item.isoformat() for item in manifest.observed_trading_days
         ],
-        "missing_trading_days": [
-            item.isoformat() for item in manifest.missing_trading_days
-        ],
+        "missing_trading_days": [item.isoformat() for item in missing_trading_days],
         "row_count_by_trading_day": dict(manifest.row_count_by_trading_day),
-        "missing_symbol_trading_days": list(manifest.missing_symbol_trading_days),
+        "missing_symbol_trading_days": list(missing_symbol_trading_days),
         "row_count_by_symbol_trading_day": {
             symbol: dict(days)
             for symbol, days in manifest.row_count_by_symbol_trading_day.items()
         },
         "coverage_status": _coverage_status(
-            missing_trading_days=manifest.missing_trading_days,
-            missing_symbol_trading_days=manifest.missing_symbol_trading_days,
+            missing_trading_days=missing_trading_days,
+            missing_symbol_trading_days=missing_symbol_trading_days,
         ),
     }
 

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -5316,6 +5316,11 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                 candidate_payload["dataset_snapshot_id"] = (
                     dataset_snapshot_receipt.snapshot_id
                 )
+                candidate_payload["dataset_snapshot_receipt"] = (
+                    dataset_snapshot_receipt.to_payload()
+                )
+                if replay_tape_validation is not None:
+                    candidate_payload["replay_tape"] = dict(replay_tape_validation)
                 replay_lineage = _candidate_replay_lineage_payload(
                     candidate_configmap_path=candidate_configmap_path,
                     candidate_search_key=candidate_key,
@@ -5593,8 +5598,24 @@ def run_consistent_profitability_frontier(args: argparse.Namespace) -> dict[str,
                 candidate_payload["decomposition"] = decomposition.to_payload()
                 candidate_payload["normalization_regime"] = normalization_regime
                 objective_scorecard_payload = objective_scorecard.to_payload()
+                replay_tape_validation_status = str(
+                    (replay_tape_validation or {}).get("status") or ""
+                ).lower()
+                tape_freshness_status = replay_tape_validation_status
+                if replay_tape_validation_status in {"stale_override", "stale"}:
+                    tape_freshness_status = "stale"
+                elif replay_tape_validation_status == "valid":
+                    tape_freshness_status = "fresh"
                 objective_scorecard_payload.update(
                     {
+                        "dataset_freshness_status": (
+                            "fresh" if dataset_snapshot_receipt.is_fresh else "stale"
+                        ),
+                        "stale_override_used": bool(
+                            dataset_snapshot_receipt.stale_override_used
+                        ),
+                        "replay_tape_validation_status": replay_tape_validation_status,
+                        "tape_freshness_status": tape_freshness_status,
                         "market_impact_liquidity_evidence_present": bool(
                             full_window_summary.get(
                                 "market_impact_liquidity_evidence_present"

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -693,6 +693,55 @@ class TestCandidateSpecs(TestCase):
             specs[0].promotion_contract["rejects_classification_accuracy_without_costs"]
         )
 
+    def test_validation_only_lob_stress_does_not_portfolio_fanout(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-tlob-validation-only",
+            claims=[
+                {
+                    "claim_id": "tlob-alpha-decay-validation",
+                    "claim_type": "validation_requirement",
+                    "claim_text": (
+                        "TLOB dual attention limit order book forecasting shows "
+                        "predictability decay under tight spreads and high-volume "
+                        "algorithmic activity."
+                    ),
+                    "data_requirements": [
+                        "horizon_decay_curve",
+                        "spread_adjusted_labels",
+                        "tight_spread_regime_slices",
+                        "high_volume_regime_slices",
+                        "route_tca",
+                    ],
+                    "confidence": "0.78",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+        family_ids = {spec.family_template_id for spec in specs}
+        family_reasons = {
+            reason
+            for spec in specs
+            for reason in spec.feature_contract["family_selection"]["reasons"]
+        }
+
+        self.assertIn("intraday_tsmom_v2", family_ids)
+        self.assertIn("microbar_cross_sectional_pairs_v1", family_ids)
+        self.assertLessEqual(
+            len(family_ids),
+            candidate_specs_module._MAX_FAMILIES_PER_HYPOTHESIS,
+        )
+        self.assertNotIn("portfolio_sleeve_diversification", family_reasons)
+        self.assertTrue(
+            all(
+                "alpha_decay_predictability_stress"
+                in spec.parameter_space["mechanism_overlay_ids"]
+                for spec in specs
+            )
+        )
+
     def test_ohlcv_only_claim_adds_falsification_contract(self) -> None:
         cards = build_hypothesis_cards(
             source_run_id="paper-ohlcv-falsification",

--- a/services/torghut/tests/test_portfolio_optimizer.py
+++ b/services/torghut/tests/test_portfolio_optimizer.py
@@ -163,6 +163,47 @@ class TestPortfolioOptimizer(TestCase):
             0,
         )
 
+    def test_evidence_bundle_blockers_reject_nested_stale_replay_metadata(
+        self,
+    ) -> None:
+        bundle = evidence_bundle_from_frontier_candidate(
+            candidate_spec_id="spec-nested-stale",
+            candidate={
+                "candidate_id": "cand-nested-stale",
+                "replay_tape": {
+                    "status": "stale_override",
+                    "stale_override_used": True,
+                },
+                "dataset_snapshot_receipt": {
+                    "snapshot_id": "snapshot-stale",
+                    "is_fresh": False,
+                    "stale_override_used": True,
+                },
+                "objective_scorecard": {
+                    "net_pnl_per_day": "600",
+                    "active_day_ratio": "1.0",
+                    "positive_day_ratio": "1.0",
+                    "worst_day_loss": "0",
+                    "max_drawdown": "0",
+                    "best_day_share": "0.1",
+                    **_executable_scorecard_fields("nested-stale"),
+                },
+            },
+            dataset_snapshot_id="snapshot-nested-stale",
+            result_path="/tmp/cand-nested-stale.json",
+        )
+
+        self.assertIn("stale_tape", evidence_bundle_blockers(bundle))
+        self.assertTrue(bundle.objective_scorecard["stale_override_used"])
+        self.assertEqual(
+            bundle.objective_scorecard["tape_freshness_status"],
+            "stale",
+        )
+        self.assertEqual(
+            bundle.objective_scorecard["dataset_freshness_status"],
+            "stale",
+        )
+
     def test_oracle_blocker_count_treats_malformed_payloads_as_unblocked(
         self,
     ) -> None:

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -402,6 +402,46 @@ class TestReplayTape(TestCase):
             ["AAPL:2026-03-27"],
         )
 
+    def test_validate_tape_freshness_rejects_requested_symbol_absent_from_unscoped_manifest(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            manifest = materialize_signal_tape(
+                rows=[
+                    self._signal(day=26, seq=1, symbol="META"),
+                    self._signal(day=27, seq=2, symbol="META"),
+                ],
+                tape_path=Path(tmpdir) / "tape.jsonl",
+                dataset_snapshot_ref="snapshot-a",
+                symbols=(),
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 27),
+                source_query_digest=build_source_query_digest({"window": "a"}),
+            )
+
+        with self.assertRaisesRegex(ValueError, "symbols_not_covered:AAPL"):
+            validate_tape_freshness(
+                manifest,
+                start_date=date(2026, 3, 26),
+                end_date=date(2026, 3, 27),
+                symbols=("AAPL",),
+            )
+
+        receipt = validate_tape_freshness(
+            manifest,
+            start_date=date(2026, 3, 26),
+            end_date=date(2026, 3, 27),
+            symbols=("AAPL",),
+            allow_stale_tape=True,
+        )
+        self.assertEqual(receipt["status"], "stale_override")
+        self.assertEqual(receipt["requested_symbols"], ["AAPL"])
+        self.assertIn("symbols_not_covered:AAPL", receipt["reasons"])
+        self.assertEqual(
+            receipt["missing_symbol_trading_days"],
+            ["AAPL:2026-03-26", "AAPL:2026-03-27"],
+        )
+
     def test_materialize_tape_requires_symbol_day_coverage_when_strict(
         self,
     ) -> None:

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -554,6 +554,7 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
 
         self.assertEqual([row.symbol for row in rows], ["NVDA"])
         self.assertEqual(validation["status"], "valid")
+        self.assertEqual(validation["requested_symbols"], ["NVDA"])
         self.assertEqual(validation["selected_row_count"], 1)
         self.assertEqual(validation["selected_symbols"], ["NVDA"])
         self.assertEqual(
@@ -561,6 +562,41 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             build_source_query_digest({"query": "frontier"}),
         )
         self.assertEqual(validation["manifest_path"], "")
+
+    def test_load_replay_tape_rows_rejects_absent_requested_symbol_from_unscoped_manifest(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            tape_path = root / "frontier-tape.jsonl"
+            materialize_signal_tape(
+                rows=[
+                    SignalEnvelope(
+                        event_ts=datetime(2026, 3, 18, 17, 30, tzinfo=timezone.utc),
+                        symbol="META",
+                        timeframe="1Sec",
+                        seq=1,
+                        source="ta",
+                        payload={"price": Decimal("500.00")},
+                    ),
+                ],
+                tape_path=tape_path,
+                dataset_snapshot_ref="snapshot-frontier",
+                symbols=(),
+                start_date=date(2026, 3, 18),
+                end_date=date(2026, 3, 18),
+                source_query_digest=build_source_query_digest({"query": "frontier"}),
+            )
+
+            with self.assertRaisesRegex(ValueError, "symbols_not_covered:NVDA"):
+                frontier._load_replay_tape_rows(
+                    tape_path=tape_path,
+                    manifest_path=None,
+                    start_date=date(2026, 3, 18),
+                    end_date=date(2026, 3, 18),
+                    symbols=("NVDA",),
+                    allow_stale_tape=False,
+                )
 
     def test_clickhouse_password_env_resolution_keeps_secret_out_of_argv(self) -> None:
         with patch.dict("os.environ", {"TORGHUT_CLICKHOUSE_PASSWORD": "from-env"}):


### PR DESCRIPTION
## Summary

- Fail closed when replay tape validation requests symbols that are absent from an unscoped manifest, and recompute requested symbol-day coverage from manifest row counts.
- Carry dataset and replay-tape freshness metadata into each frontier candidate and evidence bundle so stale tape stays a promotion blocker after export.
- Keep validation/execution-only LOB stress papers limited to top scored candidate families at the $500/day target instead of portfolio-wide fanout.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_replay_tape.py tests/test_search_consistent_profitability_frontier.py tests/test_portfolio_optimizer.py tests/test_candidate_specs.py -k 'requested_symbol or replay_tape_rows or nested_stale or validation_only_lob_stress or portfolio_profit_target_adds_diversified_sleeve_families or exact_replay_ledger_helpers'`
- `uv run --frozen ruff check app/trading/discovery/evidence_bundles.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py scripts/search_consistent_profitability_frontier.py tests/test_portfolio_optimizer.py tests/test_replay_tape.py tests/test_search_consistent_profitability_frontier.py tests/test_candidate_specs.py`
- `uv run --frozen ruff format --check app/trading/discovery/evidence_bundles.py app/trading/discovery/replay_tape.py app/trading/discovery/candidate_specs.py scripts/search_consistent_profitability_frontier.py tests/test_portfolio_optimizer.py tests/test_replay_tape.py tests/test_search_consistent_profitability_frontier.py tests/test_candidate_specs.py`
- `uv run --frozen pytest tests/test_replay_tape.py tests/test_search_consistent_profitability_frontier.py tests/test_portfolio_optimizer.py tests/test_candidate_specs.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
