### PR TITLE
fix(torghut): block non-authoritative promotion evidence

### DIFF
--- a/services/torghut/app/trading/autonomy/lane.py
+++ b/services/torghut/app/trading/autonomy/lane.py
@@ -6116,15 +6116,12 @@ def _resolve_hypothesis_window_evidence(
     runtime_observation_has_runtime_ledger_profit_proof = (
         _runtime_observation_has_ledger_profit_proof(runtime_observation_payload)
     )
-    simulation_observation_without_runtime_ledger_profit_proof = (
-        runtime_observation_source_kind.startswith('simulation_')
-        and not runtime_observation_has_runtime_ledger_profit_proof
-    )
+    simulation_observation = runtime_observation_source_kind.startswith('simulation_')
     qualified_runtime_observation = (
         runtime_observation_authoritative
         and runtime_observation_stage == observed_stage
         and runtime_observation_provenance == expected_provenance
-        and not simulation_observation_without_runtime_ledger_profit_proof
+        and not simulation_observation
     )
     if qualified_runtime_observation:
         evidence_provenance = expected_provenance
@@ -6151,8 +6148,8 @@ def _resolve_hypothesis_window_evidence(
         )
         capital_stage = 'shadow'
         qualification_reason = (
-            'simulation_runtime_without_runtime_ledger_profit_proof'
-            if simulation_observation_without_runtime_ledger_profit_proof
+            'simulation_source_replay_only'
+            if simulation_observation
             else 'runtime_observation_contract_missing_or_ineligible'
         )
     return (

--- a/services/torghut/app/trading/discovery/profit_target_oracle.py
+++ b/services/torghut/app/trading/discovery/profit_target_oracle.py
@@ -26,8 +26,6 @@ _ACCEPTED_MARKET_IMPACT_STRESS_MODELS = frozenset(
     {
         "almgren_chriss",
         "almgren-chriss",
-        "almgren_chriss_proxy",
-        "almgren-chriss-proxy",
         "square_root",
         "square-root",
         "power_law",
@@ -125,6 +123,9 @@ class ProfitTargetOraclePolicy:
     min_order_type_ablation_sample_count: int = 60
     max_order_type_opportunity_cost_bps: Decimal = Decimal("8")
     max_market_order_spread_bps: Decimal = Decimal("8")
+    require_mpc_dynamic_execution_schedule: bool = False
+    min_mpc_schedule_trace_sample_count: int = 60
+    max_mpc_schedule_shortfall_bps: Decimal = Decimal("8")
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -238,6 +239,9 @@ class ProfitTargetOraclePolicy:
                 self.max_order_type_opportunity_cost_bps
             ),
             "max_market_order_spread_bps": str(self.max_market_order_spread_bps),
+            "require_mpc_dynamic_execution_schedule": self.require_mpc_dynamic_execution_schedule,
+            "min_mpc_schedule_trace_sample_count": self.min_mpc_schedule_trace_sample_count,
+            "max_mpc_schedule_shortfall_bps": str(self.max_mpc_schedule_shortfall_bps),
         }
 
 
@@ -377,6 +381,27 @@ def _requires_order_type_execution_quality(
         )
     )
     return "mixed_market_limit_execution_policy" in overlay_ids
+
+
+def _requires_mpc_dynamic_execution_schedule(
+    scorecard: Mapping[str, Any], policy: ProfitTargetOraclePolicy
+) -> bool:
+    if policy.require_mpc_dynamic_execution_schedule:
+        return True
+    if _boolish(
+        scorecard.get("requires_mpc_dynamic_execution_schedule")
+        or scorecard.get("required_mpc_dynamic_execution_schedule")
+        or scorecard.get("requires_dynamic_execution_schedule")
+    ):
+        return True
+    overlay_ids = set(
+        _string_sequence(
+            scorecard.get("mechanism_overlay_ids")
+            or scorecard.get("mechanism_overlays")
+            or scorecard.get("overlay_ids")
+        )
+    )
+    return "mpc_dynamic_execution_schedule" in overlay_ids
 
 
 def _requires_implementation_uncertainty_stability(
@@ -939,8 +964,7 @@ def evaluate_profit_target_oracle(
                 "threshold": sorted(_ACCEPTED_LEDGER_PNL_BASES),
                 "source_marker": "exact_replay_runtime_ledger_authority",
                 "passed": (
-                    portfolio_post_cost_net_pnl_basis
-                    in _ACCEPTED_LEDGER_PNL_BASES
+                    portfolio_post_cost_net_pnl_basis in _ACCEPTED_LEDGER_PNL_BASES
                 )
                 if policy.require_exact_replay_ledger
                 else True,
@@ -952,8 +976,7 @@ def evaluate_profit_target_oracle(
                 "threshold": sorted(_ACCEPTED_LEDGER_PNL_SOURCES),
                 "source_marker": "exact_replay_runtime_ledger_authority",
                 "passed": (
-                    portfolio_post_cost_net_pnl_source
-                    in _ACCEPTED_LEDGER_PNL_SOURCES
+                    portfolio_post_cost_net_pnl_source in _ACCEPTED_LEDGER_PNL_SOURCES
                 )
                 if policy.require_exact_replay_ledger
                 else True,
@@ -1823,6 +1846,176 @@ def evaluate_profit_target_oracle(
                 if require_order_type_execution_quality
                 else Decimal("999999"),
             ),
+        )
+    )
+    require_mpc_dynamic_execution_schedule = _requires_mpc_dynamic_execution_schedule(
+        scorecard, policy
+    )
+    execution_schedule_trace_artifact_refs = _artifact_refs(
+        scorecard,
+        "execution_schedule_trace_artifact_ref",
+        "execution_schedule_trace_artifact_refs",
+        "mpc_schedule_trace_artifact_ref",
+    )
+    liquidity_forecast_artifact_refs = _artifact_refs(
+        scorecard,
+        "liquidity_forecast_artifact_ref",
+        "liquidity_forecast_artifact_refs",
+        "mpc_liquidity_forecast_artifact_ref",
+    )
+    inventory_path_artifact_refs = _artifact_refs(
+        scorecard,
+        "inventory_path_artifact_ref",
+        "inventory_path_artifact_refs",
+        "inventory_path_trace_artifact_ref",
+        "mpc_inventory_path_artifact_ref",
+    )
+    execution_shortfall_artifact_refs = _artifact_refs(
+        scorecard,
+        "execution_shortfall_artifact_ref",
+        "execution_shortfall_artifact_refs",
+        "mpc_execution_shortfall_artifact_ref",
+    )
+    mpc_ablation_artifact_refs = _artifact_refs(
+        scorecard,
+        "mpc_schedule_shortfall_ablation_artifact_ref",
+        "mpc_schedule_shortfall_ablation_artifact_refs",
+        "dynamic_execution_schedule_ablation_artifact_ref",
+    )
+    execution_schedule_trace_present = bool(
+        execution_schedule_trace_artifact_refs
+    ) or _boolish(
+        scorecard.get("execution_schedule_trace_present")
+        or scorecard.get("mpc_schedule_trace_present")
+    )
+    liquidity_forecast_present = bool(liquidity_forecast_artifact_refs) or _boolish(
+        scorecard.get("liquidity_forecast_present")
+        or scorecard.get("mpc_liquidity_forecast_present")
+    )
+    inventory_path_present = bool(inventory_path_artifact_refs) or _boolish(
+        scorecard.get("inventory_path_trace_present")
+        or scorecard.get("inventory_path_present")
+        or scorecard.get("mpc_inventory_path_present")
+    )
+    mpc_execution_shortfall_evidence_present = (
+        bool(execution_shortfall_artifact_refs) or execution_shortfall_evidence_present
+    )
+    mpc_schedule_shortfall_ablation_passed = _boolish(
+        scorecard.get("mpc_schedule_shortfall_ablation_passed")
+        or scorecard.get("dynamic_execution_schedule_ablation_passed")
+    )
+    mpc_schedule_trace_sample_count = _nonnegative_int(
+        scorecard.get("mpc_schedule_trace_sample_count")
+        or scorecard.get("execution_schedule_trace_sample_count")
+    )
+    checks.extend(
+        (
+            {
+                "metric": "execution_schedule_trace_present",
+                "observed": str(execution_schedule_trace_present).lower(),
+                "operator": "eq",
+                "threshold": "true",
+                "source_marker": "mpc_trade_execution_arxiv_2603_28898_2026",
+                "passed": execution_schedule_trace_present
+                if require_mpc_dynamic_execution_schedule
+                else True,
+            },
+            {
+                "metric": "liquidity_forecast_present",
+                "observed": str(liquidity_forecast_present).lower(),
+                "operator": "eq",
+                "threshold": "true",
+                "source_marker": "mpc_trade_execution_arxiv_2603_28898_2026",
+                "passed": liquidity_forecast_present
+                if require_mpc_dynamic_execution_schedule
+                else True,
+            },
+            {
+                "metric": "inventory_path_trace_present",
+                "observed": str(inventory_path_present).lower(),
+                "operator": "eq",
+                "threshold": "true",
+                "source_marker": "mpc_trade_execution_arxiv_2603_28898_2026",
+                "passed": inventory_path_present
+                if require_mpc_dynamic_execution_schedule
+                else True,
+            },
+            {
+                "metric": "mpc_execution_shortfall_evidence_present",
+                "observed": str(mpc_execution_shortfall_evidence_present).lower(),
+                "operator": "eq",
+                "threshold": "true",
+                "source_marker": "mpc_trade_execution_arxiv_2603_28898_2026",
+                "passed": mpc_execution_shortfall_evidence_present
+                if require_mpc_dynamic_execution_schedule
+                else True,
+            },
+            {
+                "metric": "mpc_route_tca_evidence_present",
+                "observed": str(route_tca_evidence_present).lower(),
+                "operator": "eq",
+                "threshold": "true",
+                "source_marker": "mpc_trade_execution_arxiv_2603_28898_2026",
+                "passed": route_tca_evidence_present
+                if require_mpc_dynamic_execution_schedule
+                else True,
+            },
+            {
+                "metric": "mpc_schedule_shortfall_ablation_passed",
+                "observed": str(mpc_schedule_shortfall_ablation_passed).lower(),
+                "operator": "eq",
+                "threshold": "true",
+                "source_marker": "mpc_trade_execution_arxiv_2603_28898_2026",
+                "passed": (
+                    mpc_schedule_shortfall_ablation_passed
+                    and bool(mpc_ablation_artifact_refs)
+                )
+                if require_mpc_dynamic_execution_schedule
+                else True,
+            },
+            _numeric_check(
+                metric="mpc_schedule_trace_sample_count",
+                observed=Decimal(mpc_schedule_trace_sample_count),
+                operator="gte",
+                threshold=Decimal(policy.min_mpc_schedule_trace_sample_count)
+                if require_mpc_dynamic_execution_schedule
+                else Decimal("0"),
+            ),
+            _numeric_check(
+                metric="mpc_schedule_shortfall_bps",
+                observed=_decimal(
+                    scorecard.get("mpc_schedule_shortfall_bps")
+                    or scorecard.get("dynamic_execution_schedule_shortfall_bps"),
+                    default="999999",
+                ),
+                operator="lte",
+                threshold=policy.max_mpc_schedule_shortfall_bps
+                if require_mpc_dynamic_execution_schedule
+                else Decimal("999999"),
+            ),
+            {
+                **_numeric_check(
+                    metric="mpc_schedule_shortfall_net_pnl_per_day",
+                    observed=_decimal(
+                        scorecard.get("mpc_schedule_shortfall_net_pnl_per_day")
+                        or scorecard.get(
+                            "post_cost_net_pnl_after_mpc_schedule_shortfall_stress"
+                        )
+                    ),
+                    operator="gte",
+                    threshold=target_net_pnl_per_day,
+                ),
+                "source_marker": "mpc_trade_execution_arxiv_2603_28898_2026",
+                "passed": _decimal(
+                    scorecard.get("mpc_schedule_shortfall_net_pnl_per_day")
+                    or scorecard.get(
+                        "post_cost_net_pnl_after_mpc_schedule_shortfall_stress"
+                    )
+                )
+                >= target_net_pnl_per_day
+                if require_mpc_dynamic_execution_schedule
+                else True,
+            },
         )
     )
     double_oos_artifact_refs = _artifact_refs(

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -596,6 +596,8 @@ def _runtime_promotion_blocking_reasons(
     budget: Decimal,
 ) -> list[str]:
     reasons: list[str] = []
+    if observed_stage == "paper":
+        reasons.append("paper_stage_evidence_collection_only")
     if inserted <= 0:
         reasons.append("runtime_window_evidence_missing")
     if total_session_samples < manifest.min_sample_count_for_live_canary:

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -411,19 +411,19 @@ def _runtime_observation_authority_payload(
     tca_rows: list[dict[str, object]],
 ) -> dict[str, object]:
     has_runtime_ledger_profit_proof = _runtime_ledger_profit_proof_present(tca_rows)
+    if source_kind.startswith("simulation_"):
+        return {
+            "authoritative": False,
+            "authority_reason": "simulation_source_replay_only",
+            "promotion_authority": "blocked",
+            "runtime_ledger_profit_proof_present": has_runtime_ledger_profit_proof,
+        }
     if has_runtime_ledger_profit_proof:
         return {
             "authoritative": True,
             "authority_reason": "runtime_ledger_profit_proof",
             "promotion_authority": "runtime_ledger",
             "runtime_ledger_profit_proof_present": True,
-        }
-    if source_kind.startswith("simulation_"):
-        return {
-            "authoritative": False,
-            "authority_reason": "simulation_runtime_without_runtime_ledger_profit_proof",
-            "promotion_authority": "blocked",
-            "runtime_ledger_profit_proof_present": False,
         }
     return {
         "authoritative": False,

--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -2224,7 +2224,7 @@ def _exact_replay_ledger_artifact_update(
         artifact_payload["proof_only"] = True
         artifact_payload["proof_only_reason"] = proof_only_reason
     _write_json_output(artifact_path, artifact_payload)
-    return {
+    update: dict[str, Any] = {
         "exact_replay_ledger_artifact_ref": artifact_ref,
         "runtime_ledger_artifact_ref": artifact_ref,
         "exact_replay_ledger_artifact_row_count": len(raw_rows),
@@ -2243,6 +2243,12 @@ def _exact_replay_ledger_artifact_update(
         "runtime_ledger_pnl_basis": POST_COST_PNL_BASIS,
         "runtime_ledger_pnl_source": "exact_replay_runtime_ledger",
     }
+    if proof_only_reason:
+        update["exact_replay_ledger_artifact_proof_only"] = True
+        update["exact_replay_ledger_artifact_proof_only_reason"] = proof_only_reason
+        update["runtime_ledger_artifact_proof_only"] = True
+        update["runtime_ledger_artifact_proof_only_reason"] = proof_only_reason
+    return update
 
 
 def _order_type_replay_arm_summary(
@@ -4485,6 +4491,15 @@ def _build_paper_probation_shortlist(
             blockers.append("missing_runtime_ledger_row_count")
         if runtime_ledger_fill_count <= 0:
             blockers.append("missing_runtime_ledger_fill_count")
+        screening = _mapping(item.get("screening"))
+        staged_search = _mapping(item.get("staged_search"))
+        if (
+            bool(item.get("exact_replay_ledger_artifact_proof_only"))
+            or bool(item.get("runtime_ledger_artifact_proof_only"))
+            or bool(screening.get("proof_only_full_window_replay_captured"))
+            or str(staged_search.get("stage") or "").endswith("_full_window_proof")
+        ):
+            blockers.append("proof_only_full_window_replay_not_probation_authority")
         paper_probation_allowed = not blockers
         shortlist.append(
             {

--- a/services/torghut/tests/test_autonomous_lane.py
+++ b/services/torghut/tests/test_autonomous_lane.py
@@ -135,7 +135,7 @@ class TestAutonomousLane(TestCase):
         self.assertEqual(capital_stage, "shadow")
         self.assertEqual(
             qualification["qualification_reason"],
-            "simulation_runtime_without_runtime_ledger_profit_proof",
+            "simulation_source_replay_only",
         )
         self.assertEqual(
             qualification["runtime_observation_has_runtime_ledger_profit_proof"],
@@ -143,7 +143,7 @@ class TestAutonomousLane(TestCase):
         )
         self.assertFalse(qualification["qualified_runtime_observation"])
 
-    def test_runtime_observation_evidence_accepts_simulation_with_ledger_profit_proof(
+    def test_runtime_observation_evidence_keeps_simulation_replay_only_with_ledger_profit_proof(
         self,
     ) -> None:
         provenance, maturity, capital_stage, qualification = (
@@ -163,16 +163,20 @@ class TestAutonomousLane(TestCase):
             )
         )
 
-        self.assertEqual(provenance, "paper_runtime_observed")
-        self.assertEqual(maturity, "empirically_validated")
+        self.assertEqual(provenance, "historical_market_replay")
+        self.assertEqual(maturity, "calibrated")
         self.assertEqual(capital_stage, "shadow")
         self.assertEqual(
             qualification["runtime_observation_has_runtime_ledger_profit_proof"],
             True,
         )
-        self.assertTrue(qualification["qualified_runtime_observation"])
+        self.assertFalse(qualification["qualified_runtime_observation"])
+        self.assertEqual(
+            qualification["qualification_reason"],
+            "simulation_source_replay_only",
+        )
 
-    def test_runtime_observation_evidence_accepts_explicit_ledger_profit_proof_flag(
+    def test_runtime_observation_evidence_keeps_simulation_replay_only_with_explicit_ledger_profit_proof_flag(
         self,
     ) -> None:
         provenance, _, _, qualification = _resolve_hypothesis_window_evidence(
@@ -189,12 +193,16 @@ class TestAutonomousLane(TestCase):
             min_sample_count_for_scale_up=20,
         )
 
-        self.assertEqual(provenance, "paper_runtime_observed")
+        self.assertEqual(provenance, "historical_market_replay")
         self.assertEqual(
             qualification["runtime_observation_has_runtime_ledger_profit_proof"],
             True,
         )
-        self.assertTrue(qualification["qualified_runtime_observation"])
+        self.assertFalse(qualification["qualified_runtime_observation"])
+        self.assertEqual(
+            qualification["qualification_reason"],
+            "simulation_source_replay_only",
+        )
 
     def test_gate_forecast_metrics_fail_closed_for_non_authoritative_router_outputs(self) -> None:
         signals = [

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -185,6 +185,27 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(payload["promotion_authority"], "runtime_ledger")
         self.assertEqual(payload["runtime_ledger_profit_proof_present"], True)
 
+    def test_runtime_observation_authority_keeps_simulation_replay_only(
+        self,
+    ) -> None:
+        payload = _runtime_observation_authority_payload(
+            source_kind="simulation_paper_runtime",
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "post_cost_expectancy_bps": Decimal("40"),
+                    "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+                    "post_cost_promotion_eligible": True,
+                    "runtime_ledger_bucket": _complete_runtime_ledger_bucket(),
+                }
+            ],
+        )
+
+        self.assertEqual(payload["authoritative"], False)
+        self.assertEqual(payload["authority_reason"], "simulation_source_replay_only")
+        self.assertEqual(payload["promotion_authority"], "blocked")
+        self.assertEqual(payload["runtime_ledger_profit_proof_present"], True)
+
     def test_parse_args_accepts_dataset_snapshot_ref(self) -> None:
         with patch(
             "sys.argv",
@@ -1687,7 +1708,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(runtime_payload["authoritative"], False)
         self.assertEqual(
             runtime_payload["authority_reason"],
-            "simulation_runtime_without_runtime_ledger_profit_proof",
+            "simulation_source_replay_only",
         )
         self.assertEqual(runtime_payload["promotion_authority"], "blocked")
         self.assertEqual(runtime_payload["runtime_ledger_profit_proof_present"], False)
@@ -1796,7 +1817,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(runtime_payload["authoritative"], False)
         self.assertEqual(
             runtime_payload["authority_reason"],
-            "simulation_runtime_without_runtime_ledger_profit_proof",
+            "simulation_source_replay_only",
         )
         self.assertEqual(runtime_payload["promotion_authority"], "blocked")
         self.assertEqual(runtime_payload["runtime_ledger_profit_proof_present"], False)

--- a/services/torghut/tests/test_profit_target_oracle.py
+++ b/services/torghut/tests/test_profit_target_oracle.py
@@ -170,7 +170,7 @@ class TestProfitTargetOracle(TestCase):
         self.assertFalse(result["passed"])
         self.assertIn("fill_survival_rate_failed", result["blockers"])
 
-    def test_profit_target_oracle_accepts_almgren_chriss_proxy_impact(
+    def test_profit_target_oracle_rejects_almgren_chriss_proxy_impact(
         self,
     ) -> None:
         scorecard = {
@@ -185,8 +185,64 @@ class TestProfitTargetOracle(TestCase):
             target_net_pnl_per_day=Decimal("500"),
         )
 
+        self.assertFalse(result["passed"])
+        self.assertIn("market_impact_stress_model_failed", result["blockers"])
+
+    def test_profit_target_oracle_enforces_mpc_dynamic_schedule_overlay(
+        self,
+    ) -> None:
+        scorecard = {
+            **_passing_scorecard(),
+            "mechanism_overlay_ids": ["mpc_dynamic_execution_schedule"],
+        }
+
+        result = evaluate_profit_target_oracle(
+            scorecard,
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
+        self.assertFalse(result["passed"])
+        self.assertIn("execution_schedule_trace_present_failed", result["blockers"])
+        self.assertIn("liquidity_forecast_present_failed", result["blockers"])
+        self.assertIn("inventory_path_trace_present_failed", result["blockers"])
+        self.assertIn(
+            "mpc_execution_shortfall_evidence_present_failed", result["blockers"]
+        )
+        self.assertIn("mpc_route_tca_evidence_present_failed", result["blockers"])
+        self.assertIn(
+            "mpc_schedule_shortfall_ablation_passed_failed", result["blockers"]
+        )
+        self.assertIn("mpc_schedule_trace_sample_count_failed", result["blockers"])
+        self.assertIn("mpc_schedule_shortfall_bps_failed", result["blockers"])
+        self.assertIn(
+            "mpc_schedule_shortfall_net_pnl_per_day_failed", result["blockers"]
+        )
+
+    def test_profit_target_oracle_accepts_mpc_dynamic_schedule_overlay_with_real_evidence(
+        self,
+    ) -> None:
+        scorecard = {
+            **_passing_scorecard(),
+            "mechanism_overlay_ids": ["mpc_dynamic_execution_schedule"],
+            "execution_schedule_trace_artifact_ref": "/tmp/mpc-schedule-trace.json",
+            "execution_schedule_trace_sample_count": 80,
+            "liquidity_forecast_artifact_ref": "/tmp/mpc-liquidity-forecast.json",
+            "inventory_path_trace_artifact_ref": "/tmp/mpc-inventory-path.json",
+            "execution_shortfall_artifact_ref": "/tmp/mpc-shortfall.json",
+            "route_tca_artifact_ref": "/tmp/mpc-route-tca.json",
+            "mpc_schedule_shortfall_ablation_passed": True,
+            "mpc_schedule_shortfall_ablation_artifact_ref": "/tmp/mpc-ablation.json",
+            "mpc_schedule_shortfall_bps": "6",
+            "mpc_schedule_shortfall_net_pnl_per_day": "520",
+        }
+
+        result = evaluate_profit_target_oracle(
+            scorecard,
+            target_net_pnl_per_day=Decimal("500"),
+        )
+
         self.assertTrue(result["passed"])
-        self.assertNotIn("market_impact_stress_model_failed", result["blockers"])
+        self.assertNotIn("execution_schedule_trace_present_failed", result["blockers"])
 
     def test_profit_target_oracle_rejects_implementation_uncertainty_below_target(
         self,

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -1098,7 +1098,7 @@ class TestRuntimeWindowImport(TestCase):
         )
         self.assertEqual(decision.allowed, False)
 
-    def test_persist_observed_runtime_windows_allows_h_micro_with_fresh_delay_depth_stress(
+    def test_persist_observed_runtime_windows_keeps_paper_depth_evidence_only(
         self,
     ) -> None:
         buckets = build_observed_runtime_buckets(
@@ -1193,8 +1193,11 @@ class TestRuntimeWindowImport(TestCase):
             session.commit()
             decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
 
-        self.assertEqual(summary["promotion_allowed"], True)
-        self.assertEqual(summary["promotion_blocking_reasons"], [])
+        self.assertEqual(summary["promotion_allowed"], False)
+        self.assertEqual(
+            summary["promotion_blocking_reasons"],
+            ["paper_stage_evidence_collection_only"],
+        )
         self.assertEqual(
             summary["delay_adjusted_depth_stress"],
             {
@@ -1220,7 +1223,7 @@ class TestRuntimeWindowImport(TestCase):
                 "queue_ahead_depletion_sample_count": 44,
             },
         )
-        self.assertEqual(decision.allowed, True)
+        self.assertEqual(decision.allowed, False)
         self.assertEqual(
             decision.payload_json["delay_adjusted_depth_stress"],
             summary["delay_adjusted_depth_stress"],

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -2540,6 +2540,44 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
             shortlist[0]["probation_blockers"],
         )
 
+    def test_paper_probation_shortlist_blocks_proof_only_exact_replay_ledger(
+        self,
+    ) -> None:
+        shortlist = frontier._build_paper_probation_shortlist(
+            [
+                {
+                    "candidate_id": "positive-proof-only",
+                    "objective_scorecard": {
+                        "net_pnl_per_day": "225",
+                        "net_pnl": "450",
+                        "max_gross_exposure_pct_equity": "0.5",
+                        "min_cash": "100",
+                    },
+                    "full_window": {"net_per_day": "225", "net_pnl": "450"},
+                    "runtime_ledger_artifact_ref": "/tmp/proof-only-ledger.json",
+                    "runtime_ledger_artifact_row_count": 12,
+                    "runtime_ledger_artifact_fill_count": 4,
+                    "exact_replay_ledger_artifact_proof_only": True,
+                    "screening": {"proof_only_full_window_replay_captured": True},
+                    "staged_search": {
+                        "stage": "full_replay_budget_exhausted_full_window_proof"
+                    },
+                    "hard_vetoes": [],
+                }
+            ],
+            top_n=1,
+            objective_veto_policy=frontier.ObjectiveVetoPolicy(
+                required_max_gross_exposure_pct_equity=Decimal("1"),
+                required_min_cash=Decimal("0"),
+            ),
+        )
+
+        self.assertFalse(shortlist[0]["paper_probation_allowed"])
+        self.assertIn(
+            "proof_only_full_window_replay_not_probation_authority",
+            shortlist[0]["probation_blockers"],
+        )
+
     def test_generate_symbol_prune_children_removes_worst_symbols_from_universe(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Blocks paper-stage runtime imports from persisting promotion-allowed decisions; paper remains evidence collection only.
- Keeps simulation-sourced runtime observations replay-only even when exact replay ledger proof is present.
- Prevents proof-only full-window replay ledgers from authorizing paper probation.
- Tightens promotion oracle evidence by rejecting proxy-only market-impact models and enforcing MPC dynamic-schedule artifacts, sample counts, shortfall ablation, route TCA, and net-PnL-after-shortfall proof.

## Related Issues

None

## Testing

- `uv run pytest tests/test_profit_target_oracle.py tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_persist_observed_runtime_windows_keeps_paper_depth_evidence_only tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_persist_observed_runtime_windows_keeps_paper_probation_evidence_only tests/test_import_hypothesis_runtime_windows.py::TestImportHypothesisRuntimeWindows::test_runtime_observation_authority_keeps_simulation_replay_only tests/test_import_hypothesis_runtime_windows.py::TestImportHypothesisRuntimeWindows::test_main_attaches_delay_adjusted_depth_report_to_runtime_payload tests/test_import_hypothesis_runtime_windows.py::TestImportHypothesisRuntimeWindows::test_main_quarantines_report_runtime_pnl_when_tca_rows_are_empty tests/test_search_consistent_profitability_frontier.py::TestSearchConsistentProfitabilityFrontier::test_paper_probation_shortlist_blocks_proof_only_exact_replay_ledger tests/test_search_consistent_profitability_frontier.py::TestSearchConsistentProfitabilityFrontier::test_paper_probation_shortlist_labels_vetoed_candidate_as_paper_only tests/test_autonomous_lane.py::TestAutonomousLane::test_runtime_observation_evidence_keeps_simulation_replay_only_with_ledger_profit_proof tests/test_autonomous_lane.py::TestAutonomousLane::test_runtime_observation_evidence_keeps_simulation_replay_only_with_explicit_ledger_profit_proof_flag`
- `uv run ruff check app/trading/discovery/profit_target_oracle.py app/trading/runtime_window_import.py app/trading/autonomy/lane.py scripts/import_hypothesis_runtime_windows.py scripts/search_consistent_profitability_frontier.py tests/test_profit_target_oracle.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_search_consistent_profitability_frontier.py tests/test_autonomous_lane.py`
- `uv run ruff format --check app/trading/discovery/profit_target_oracle.py app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py scripts/search_consistent_profitability_frontier.py tests/test_profit_target_oracle.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_search_consistent_profitability_frontier.py`
- `uv run pytest tests/test_profit_target_oracle.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_search_consistent_profitability_frontier.py tests/test_autonomous_lane.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
