### PR TITLE
fix(torghut): reuse supplied replay tapes for mlx bundles

### DIFF
--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -696,6 +696,18 @@ def _full_window_signal_config(
         flatten_eod=True,
         start_equity=Decimal(str(args.start_equity)),
         symbols=snapshot_symbols,
+        replay_tape_path=(
+            Path(replay_tape_path).resolve()
+            if (replay_tape_path := getattr(args, "replay_tape_path", None)) is not None
+            else None
+        ),
+        replay_tape_manifest_path=(
+            Path(replay_tape_manifest).resolve()
+            if (replay_tape_manifest := getattr(args, "replay_tape_manifest", None))
+            is not None
+            else None
+        ),
+        allow_stale_tape=bool(getattr(args, "allow_stale_tape", False)),
         progress_log_interval_seconds=max(1, int(args.progress_log_seconds)),
     )
 

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -700,6 +700,62 @@ class TestStrategyAutoresearch(TestCase):
         self.assertTrue(tape_exists)
         self.assertTrue(manifest_exists)
 
+    def test_write_signal_bundle_uses_supplied_replay_tape_without_clickhouse(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            configmap_path = root / "strategy-configmap.yaml"
+            configmap_path.write_text("apiVersion: v1\nkind: ConfigMap\n")
+            bundle_paths = runner._mlx_bundle_paths(root)
+            tape_path = root / "provided-tape.jsonl"
+            signal_row = SignalEnvelope(
+                event_ts=datetime(2026, 3, 20, 13, 30, tzinfo=UTC),
+                symbol="AMAT",
+                seq=1,
+                source="ta",
+                timeframe="1Sec",
+                payload={"price": "180.10"},
+            )
+            manifest = runner.materialize_signal_tape(
+                rows=[signal_row],
+                tape_path=tape_path,
+                dataset_snapshot_ref="provided-snapshot",
+                symbols=("AMAT",),
+                start_date=date(2026, 3, 20),
+                end_date=date(2026, 3, 20),
+                source_query_digest="digest",
+            )
+            args = Namespace(
+                strategy_configmap=configmap_path,
+                clickhouse_http_url="http://example.invalid:8123",
+                clickhouse_username="torghut",
+                clickhouse_password="secret",
+                start_equity="31590.02",
+                chunk_minutes=10,
+                progress_log_seconds=30,
+                replay_tape_path=tape_path,
+                replay_tape_manifest=runner.default_manifest_path(tape_path),
+                allow_stale_tape=False,
+            )
+
+            with patch(
+                "scripts.run_strategy_autoresearch_loop.replay_mod._http_query",
+                side_effect=AssertionError("clickhouse should not be queried"),
+            ):
+                stats = runner._maybe_write_signal_bundle(
+                    args=args,
+                    snapshot_symbols=("AMAT",),
+                    bundle_paths=bundle_paths,
+                    full_window_start_date="2026-03-20",
+                    full_window_end_date="2026-03-20",
+                    existing=None,
+                )
+
+        assert stats is not None
+        self.assertEqual(stats.row_count, manifest.row_count)
+        self.assertEqual(stats.symbol_count, 1)
+
     def test_materialize_run_replay_tape_selects_latest_complete_window(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Thread supplied replay tape paths into the full-window MLX signal bundle config used by strategy autoresearch.
- Preserve the supplied replay tape manifest and stale-tape policy so bundle generation can reuse an already-materialized, validated tape.
- Add a regression test that fails if supplied-tape bundle generation reaches back into ClickHouse.

## Related Issues

None

## Testing

- `uv run pytest tests/test_strategy_autoresearch.py::TestStrategyAutoresearch::test_write_signal_bundle_uses_supplied_replay_tape_without_clickhouse`
- `uv run pytest tests/test_strategy_autoresearch.py::TestStrategyAutoresearch::test_materialize_run_replay_tape_writes_bundle_and_receipt tests/test_strategy_autoresearch.py::TestStrategyAutoresearch::test_write_signal_bundle_uses_supplied_replay_tape_without_clickhouse tests/test_strategy_autoresearch.py::TestStrategyAutoresearch::test_provided_replay_tape_receipt_reads_manifest_and_handles_missing`
- `uv run ruff check scripts/run_strategy_autoresearch_loop.py tests/test_strategy_autoresearch.py`
- `uv run ruff format --check scripts/run_strategy_autoresearch_loop.py tests/test_strategy_autoresearch.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Bounded local smoke with `--clickhouse-http-url http://example.invalid:8123`, supplied replay tape `/tmp/torghut-frontier/short-real-20260523T103106Z/strategy-autoresearch-20260523T103108Z/replay-tape.jsonl`, and output `/tmp/torghut-frontier/supplied-tape-smoke-20260523T104115Z/latest-summary.json`. Result: `status=ok`, `objective_met=false`, MLX manifest `signal_row_count=10692`, `signal_symbol_count=4`, and provided tape freshness receipt persisted.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
