### PR TITLE
feat(torghut): rank exact replay ledgers

### DIFF
--- a/services/torghut/app/trading/discovery/replay_ledger_ranker.py
+++ b/services/torghut/app/trading/discovery/replay_ledger_ranker.py
@@ -1,0 +1,616 @@
+"""Rank exact replay ledger artifacts with runtime-ledger PnL semantics."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, cast
+
+from app.trading.discovery.profit_target_oracle import ProfitTargetOraclePolicy
+from app.trading.runtime_ledger import RuntimeLedgerBucket, build_runtime_ledger_buckets
+
+EXACT_REPLAY_LEDGER_RANKING_SCHEMA_VERSION = "torghut.exact-replay-ledger-ranking.v1"
+_LIVE_PROMOTION_AUTHORITIES = frozenset(
+    {
+        "live",
+        "live_runtime_ledger",
+        "runtime_live",
+        "runtime_execution_ledger",
+        "live_paper_runtime_ledger",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ReplayLedgerRankingPolicy:
+    target_net_pnl_per_day: Decimal
+    min_window_weekday_count: int
+    min_avg_filled_notional_per_day: Decimal
+    max_best_day_share: Decimal
+    max_gross_exposure_pct_equity: Decimal
+    start_equity: Decimal | None
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "target_net_pnl_per_day": str(self.target_net_pnl_per_day),
+            "min_window_weekday_count": self.min_window_weekday_count,
+            "min_avg_filled_notional_per_day": str(
+                self.min_avg_filled_notional_per_day
+            ),
+            "max_best_day_share": str(self.max_best_day_share),
+            "max_gross_exposure_pct_equity": str(self.max_gross_exposure_pct_equity),
+            "start_equity": str(self.start_equity)
+            if self.start_equity is not None
+            else None,
+        }
+
+
+@dataclass(frozen=True)
+class ReplayLedgerCandidateRanking:
+    artifact_ref: str
+    candidate_id: str
+    promotion_status: str
+    promotion_blockers: tuple[str, ...]
+    runtime_ledger_blockers: tuple[str, ...]
+    window_start: datetime
+    window_end: datetime
+    window_weekday_count: int
+    active_day_count: int
+    positive_day_count: int
+    negative_day_count: int
+    fill_count: int
+    decision_count: int
+    submitted_order_count: int
+    closed_trade_count: int
+    open_position_count: int
+    total_filled_notional: Decimal
+    avg_filled_notional_per_window_weekday: Decimal
+    avg_filled_notional_per_active_day: Decimal
+    total_net_pnl_after_costs: Decimal
+    window_net_pnl_per_day: Decimal
+    active_net_pnl_per_day: Decimal
+    gross_strategy_pnl: Decimal
+    cost_amount: Decimal
+    best_day_share: Decimal
+    worst_day_net_pnl: Decimal
+    max_drawdown: Decimal
+    profit_factor: Decimal | None
+    max_single_fill_notional: Decimal
+    max_single_fill_notional_pct_equity: Decimal | None
+    daily_net_pnl_after_costs: Mapping[str, Decimal]
+    symbols: tuple[str, ...]
+    stage: str
+    source: str
+    promotion_authority: str
+    cost_basis_counts: Mapping[str, int]
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "artifact_ref": self.artifact_ref,
+            "candidate_id": self.candidate_id,
+            "promotion_status": self.promotion_status,
+            "promotion_blockers": list(self.promotion_blockers),
+            "runtime_ledger_blockers": list(self.runtime_ledger_blockers),
+            "window_start": self.window_start.isoformat(),
+            "window_end": self.window_end.isoformat(),
+            "window_weekday_count": self.window_weekday_count,
+            "active_day_count": self.active_day_count,
+            "positive_day_count": self.positive_day_count,
+            "negative_day_count": self.negative_day_count,
+            "fill_count": self.fill_count,
+            "decision_count": self.decision_count,
+            "submitted_order_count": self.submitted_order_count,
+            "closed_trade_count": self.closed_trade_count,
+            "open_position_count": self.open_position_count,
+            "total_filled_notional": str(self.total_filled_notional),
+            "avg_filled_notional_per_window_weekday": str(
+                self.avg_filled_notional_per_window_weekday
+            ),
+            "avg_filled_notional_per_active_day": str(
+                self.avg_filled_notional_per_active_day
+            ),
+            "total_net_pnl_after_costs": str(self.total_net_pnl_after_costs),
+            "window_net_pnl_per_day": str(self.window_net_pnl_per_day),
+            "active_net_pnl_per_day": str(self.active_net_pnl_per_day),
+            "gross_strategy_pnl": str(self.gross_strategy_pnl),
+            "cost_amount": str(self.cost_amount),
+            "best_day_share": str(self.best_day_share),
+            "worst_day_net_pnl": str(self.worst_day_net_pnl),
+            "max_drawdown": str(self.max_drawdown),
+            "profit_factor": str(self.profit_factor)
+            if self.profit_factor is not None
+            else None,
+            "max_single_fill_notional": str(self.max_single_fill_notional),
+            "max_single_fill_notional_pct_equity": str(
+                self.max_single_fill_notional_pct_equity
+            )
+            if self.max_single_fill_notional_pct_equity is not None
+            else None,
+            "daily_net_pnl_after_costs": {
+                day: str(value)
+                for day, value in sorted(self.daily_net_pnl_after_costs.items())
+            },
+            "symbols": list(self.symbols),
+            "stage": self.stage,
+            "source": self.source,
+            "promotion_authority": self.promotion_authority,
+            "cost_basis_counts": dict(sorted(self.cost_basis_counts.items())),
+        }
+
+
+@dataclass(frozen=True)
+class ReplayLedgerRankingFailure:
+    artifact_ref: str
+    reason: str
+
+    def to_payload(self) -> dict[str, str]:
+        return {"artifact_ref": self.artifact_ref, "reason": self.reason}
+
+
+def default_replay_ledger_ranking_policy(
+    *,
+    target_net_pnl_per_day: Decimal = Decimal("500"),
+    start_equity: Decimal | None = None,
+) -> ReplayLedgerRankingPolicy:
+    oracle_policy = ProfitTargetOraclePolicy()
+    return ReplayLedgerRankingPolicy(
+        target_net_pnl_per_day=target_net_pnl_per_day,
+        min_window_weekday_count=oracle_policy.min_observed_trading_days,
+        min_avg_filled_notional_per_day=oracle_policy.min_avg_filled_notional_per_day,
+        max_best_day_share=oracle_policy.max_best_day_share,
+        max_gross_exposure_pct_equity=oracle_policy.max_gross_exposure_pct_equity,
+        start_equity=start_equity
+        if start_equity is not None
+        else oracle_policy.default_start_equity,
+    )
+
+
+def rank_replay_ledger_payload(
+    payload: Mapping[str, Any],
+    *,
+    artifact_ref: str,
+    policy: ReplayLedgerRankingPolicy,
+) -> ReplayLedgerCandidateRanking:
+    start, end = _ledger_window(payload)
+    raw_rows = payload.get("runtime_ledger_rows")
+    if not isinstance(raw_rows, Sequence) or isinstance(raw_rows, (str, bytes)):
+        raise ValueError("runtime_ledger_rows_missing")
+    rows = _runtime_rows_with_defaults(payload, cast(Sequence[object], raw_rows))
+    if not rows:
+        raise ValueError("runtime_ledger_rows_invalid")
+
+    full_bucket = _full_window_bucket(rows=rows, start=start, end=end)
+    daily_buckets = build_runtime_ledger_buckets(
+        rows,
+        bucket_ranges=_daily_bucket_ranges(start, end),
+        require_order_lifecycle=True,
+    )
+    weekday_buckets = [
+        bucket for bucket in daily_buckets if bucket.bucket_started_at.weekday() < 5
+    ]
+    if not weekday_buckets:
+        raise ValueError("window_weekdays_missing")
+
+    daily_net = {
+        bucket.bucket_started_at.date().isoformat(): bucket.net_strategy_pnl_after_costs
+        for bucket in weekday_buckets
+    }
+    total_net = full_bucket.net_strategy_pnl_after_costs
+    active_buckets = [
+        bucket
+        for bucket in weekday_buckets
+        if bucket.fill_count > 0 or bucket.net_strategy_pnl_after_costs != 0
+    ]
+    active_day_count = len(active_buckets)
+    positive_days = [value for value in daily_net.values() if value > 0]
+    negative_days = [value for value in daily_net.values() if value < 0]
+    window_weekday_count = len(weekday_buckets)
+    total_filled_notional = full_bucket.filled_notional
+    max_single_fill_notional = _max_single_fill_notional(rows)
+    max_single_fill_notional_pct_equity = (
+        max_single_fill_notional / policy.start_equity
+        if policy.start_equity is not None and policy.start_equity > 0
+        else None
+    )
+    blockers = _promotion_blockers(
+        payload=payload,
+        full_bucket=full_bucket,
+        total_net=total_net,
+        daily_net=daily_net,
+        window_weekday_count=window_weekday_count,
+        avg_filled_notional_per_window_weekday=_safe_divide(
+            total_filled_notional,
+            Decimal(window_weekday_count),
+        ),
+        max_single_fill_notional_pct_equity=max_single_fill_notional_pct_equity,
+        policy=policy,
+    )
+
+    return ReplayLedgerCandidateRanking(
+        artifact_ref=artifact_ref,
+        candidate_id=str(payload.get("candidate_id") or Path(artifact_ref).stem),
+        promotion_status="blocked_pending_runtime_promotion_proof"
+        if blockers
+        else "candidate_replay_evidence_only",
+        promotion_blockers=tuple(blockers),
+        runtime_ledger_blockers=tuple(full_bucket.blockers),
+        window_start=start,
+        window_end=end,
+        window_weekday_count=window_weekday_count,
+        active_day_count=active_day_count,
+        positive_day_count=len(positive_days),
+        negative_day_count=len(negative_days),
+        fill_count=full_bucket.fill_count,
+        decision_count=full_bucket.decision_count,
+        submitted_order_count=full_bucket.submitted_order_count,
+        closed_trade_count=full_bucket.closed_trade_count,
+        open_position_count=full_bucket.open_position_count,
+        total_filled_notional=total_filled_notional,
+        avg_filled_notional_per_window_weekday=_safe_divide(
+            total_filled_notional,
+            Decimal(window_weekday_count),
+        ),
+        avg_filled_notional_per_active_day=_safe_divide(
+            total_filled_notional,
+            Decimal(active_day_count),
+        ),
+        total_net_pnl_after_costs=total_net,
+        window_net_pnl_per_day=_safe_divide(
+            total_net,
+            Decimal(window_weekday_count),
+        ),
+        active_net_pnl_per_day=_safe_divide(
+            total_net,
+            Decimal(active_day_count),
+        ),
+        gross_strategy_pnl=full_bucket.gross_strategy_pnl,
+        cost_amount=full_bucket.cost_amount,
+        best_day_share=_best_day_share(daily_net, total_net),
+        worst_day_net_pnl=min(daily_net.values(), default=Decimal("0")),
+        max_drawdown=_max_drawdown(daily_net),
+        profit_factor=_profit_factor(daily_net),
+        max_single_fill_notional=max_single_fill_notional,
+        max_single_fill_notional_pct_equity=max_single_fill_notional_pct_equity,
+        daily_net_pnl_after_costs=daily_net,
+        symbols=_symbols(rows),
+        stage=str(payload.get("stage") or ""),
+        source=str(payload.get("source") or ""),
+        promotion_authority=str(payload.get("promotion_authority") or ""),
+        cost_basis_counts=full_bucket.cost_basis_counts,
+    )
+
+
+def rank_replay_ledger_files(
+    paths: Sequence[Path],
+    *,
+    policy: ReplayLedgerRankingPolicy,
+) -> tuple[list[ReplayLedgerCandidateRanking], list[ReplayLedgerRankingFailure]]:
+    rankings: list[ReplayLedgerCandidateRanking] = []
+    failures: list[ReplayLedgerRankingFailure] = []
+    seen: set[Path] = set()
+    for path in paths:
+        resolved = path.expanduser().resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        try:
+            payload = json.loads(resolved.read_text())
+            if not isinstance(payload, Mapping):
+                raise ValueError("ledger_payload_not_object")
+            rankings.append(
+                rank_replay_ledger_payload(
+                    cast(Mapping[str, Any], payload),
+                    artifact_ref=str(resolved),
+                    policy=policy,
+                )
+            )
+        except Exception as exc:
+            failures.append(
+                ReplayLedgerRankingFailure(
+                    artifact_ref=str(resolved),
+                    reason=str(exc) or exc.__class__.__name__,
+                )
+            )
+    rankings.sort(key=_ranking_sort_key)
+    return rankings, failures
+
+
+def build_replay_ledger_ranking_report(
+    paths: Sequence[Path],
+    *,
+    policy: ReplayLedgerRankingPolicy,
+    limit: int | None = None,
+) -> dict[str, object]:
+    rankings, failures = rank_replay_ledger_files(paths, policy=policy)
+    limited_rankings = (
+        rankings[:limit] if limit is not None and limit >= 0 else rankings
+    )
+    return {
+        "schema_version": EXACT_REPLAY_LEDGER_RANKING_SCHEMA_VERSION,
+        "policy": policy.to_payload(),
+        "candidate_count": len(rankings),
+        "failure_count": len(failures),
+        "candidates": [ranking.to_payload() for ranking in limited_rankings],
+        "failures": [failure.to_payload() for failure in failures],
+    }
+
+
+def _ledger_window(payload: Mapping[str, Any]) -> tuple[datetime, datetime]:
+    full_window = _mapping(payload.get("full_window"))
+    start = _parse_window_datetime(
+        payload.get("window_start")
+        or payload.get("bucket_started_at")
+        or payload.get("started_at")
+        or payload.get("start")
+        or full_window.get("start_date")
+    )
+    end = _parse_window_datetime(
+        payload.get("window_end")
+        or payload.get("bucket_ended_at")
+        or payload.get("ended_at")
+        or payload.get("end")
+        or full_window.get("end_date"),
+        date_end=True,
+    )
+    if start is None or end is None:
+        raise ValueError("window_bounds_missing")
+    if end <= start:
+        raise ValueError("window_end_before_start")
+    return start, end
+
+
+def _runtime_rows_with_defaults(
+    payload: Mapping[str, Any],
+    raw_rows: Sequence[object],
+) -> list[Mapping[str, object]]:
+    defaults = {
+        key: payload.get(key)
+        for key in (
+            "account_label",
+            "source",
+            "execution_policy_hash",
+            "cost_model_hash",
+            "lineage_hash",
+            "replay_data_hash",
+            "cost_basis",
+        )
+        if payload.get(key) not in (None, "")
+    }
+    rows: list[Mapping[str, object]] = []
+    for raw_row in raw_rows:
+        if not isinstance(raw_row, Mapping):
+            return []
+        row = dict(cast(Mapping[str, object], raw_row))
+        for key, value in defaults.items():
+            row.setdefault(key, value)
+        rows.append(row)
+    return rows
+
+
+def _full_window_bucket(
+    *,
+    rows: Sequence[Mapping[str, object]],
+    start: datetime,
+    end: datetime,
+) -> RuntimeLedgerBucket:
+    buckets = build_runtime_ledger_buckets(
+        rows,
+        bucket_ranges=[(start, end)],
+        require_order_lifecycle=True,
+    )
+    if len(buckets) != 1:
+        raise ValueError("runtime_ledger_bucket_missing")
+    return buckets[0]
+
+
+def _promotion_blockers(
+    *,
+    payload: Mapping[str, Any],
+    full_bucket: RuntimeLedgerBucket,
+    total_net: Decimal,
+    daily_net: Mapping[str, Decimal],
+    window_weekday_count: int,
+    avg_filled_notional_per_window_weekday: Decimal,
+    max_single_fill_notional_pct_equity: Decimal | None,
+    policy: ReplayLedgerRankingPolicy,
+) -> list[str]:
+    blockers = list(full_bucket.blockers)
+    stage = str(payload.get("stage") or "").lower()
+    promotion_authority = str(payload.get("promotion_authority") or "").lower()
+    if (
+        stage not in {"paper", "live"}
+        and promotion_authority not in _LIVE_PROMOTION_AUTHORITIES
+    ):
+        blockers.append("replay_artifact_only_not_live")
+    if window_weekday_count < policy.min_window_weekday_count:
+        blockers.append("window_weekday_count_below_min_observed_trading_days")
+    if (
+        _safe_divide(total_net, Decimal(window_weekday_count))
+        < policy.target_net_pnl_per_day
+    ):
+        blockers.append("window_net_pnl_per_day_below_target")
+    if avg_filled_notional_per_window_weekday < policy.min_avg_filled_notional_per_day:
+        blockers.append("avg_filled_notional_per_day_below_min")
+    if _best_day_share(daily_net, total_net) > policy.max_best_day_share:
+        blockers.append("best_day_share_above_max")
+    if max_single_fill_notional_pct_equity is None:
+        blockers.append("start_equity_missing_for_exposure_check")
+    elif max_single_fill_notional_pct_equity > policy.max_gross_exposure_pct_equity:
+        blockers.append("max_single_fill_notional_pct_equity_above_max")
+    return _dedupe(blockers)
+
+
+def _daily_bucket_ranges(
+    start: datetime,
+    end: datetime,
+) -> list[tuple[datetime, datetime]]:
+    ranges: list[tuple[datetime, datetime]] = []
+    current_date = start.date()
+    current = datetime.combine(current_date, time.min, tzinfo=timezone.utc)
+    if current < start:
+        current = start
+    while current < end:
+        next_day = datetime.combine(
+            current.date() + timedelta(days=1),
+            time.min,
+            tzinfo=timezone.utc,
+        )
+        bucket_end = min(next_day, end)
+        ranges.append((current, bucket_end))
+        current = bucket_end
+    return ranges
+
+
+def _parse_window_datetime(value: object, *, date_end: bool = False) -> datetime | None:
+    if isinstance(value, datetime):
+        return _utc(value)
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        if "T" not in text and len(text) == 10:
+            parsed_date = date.fromisoformat(text)
+            parsed = datetime.combine(parsed_date, time.min, tzinfo=timezone.utc)
+            return parsed + timedelta(days=1) if date_end else parsed
+        return _utc(datetime.fromisoformat(text.replace("Z", "+00:00")))
+    except ValueError:
+        return None
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _best_day_share(daily_net: Mapping[str, Decimal], total_net: Decimal) -> Decimal:
+    if total_net <= 0:
+        return Decimal("1")
+    best = max(
+        (value for value in daily_net.values() if value > 0), default=Decimal("0")
+    )
+    return best / total_net
+
+
+def _max_drawdown(daily_net: Mapping[str, Decimal]) -> Decimal:
+    cumulative = Decimal("0")
+    peak = Decimal("0")
+    max_drawdown = Decimal("0")
+    for day in sorted(daily_net):
+        cumulative += daily_net[day]
+        peak = max(peak, cumulative)
+        max_drawdown = max(max_drawdown, peak - cumulative)
+    return max_drawdown
+
+
+def _profit_factor(daily_net: Mapping[str, Decimal]) -> Decimal | None:
+    positive = sum((value for value in daily_net.values() if value > 0), Decimal("0"))
+    negative = sum((value for value in daily_net.values() if value < 0), Decimal("0"))
+    if negative == 0:
+        return None
+    return positive / abs(negative)
+
+
+def _max_single_fill_notional(rows: Sequence[Mapping[str, object]]) -> Decimal:
+    values = [
+        notional
+        for row in rows
+        if _event_type(row) == "fill"
+        if (notional := _fill_notional(row)) is not None
+    ]
+    return max(values, default=Decimal("0"))
+
+
+def _fill_notional(row: Mapping[str, object]) -> Decimal | None:
+    explicit = _positive_decimal(
+        row.get("filled_notional") or row.get("notional") or row.get("fill_notional")
+    )
+    if explicit is not None:
+        return explicit
+    qty = _positive_decimal(
+        row.get("filled_qty") or row.get("qty") or row.get("quantity")
+    )
+    price = _positive_decimal(
+        row.get("avg_fill_price") or row.get("filled_avg_price") or row.get("price")
+    )
+    if qty is None or price is None:
+        return None
+    return qty * price
+
+
+def _symbols(rows: Sequence[Mapping[str, object]]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                str(symbol)
+                for row in rows
+                if (symbol := row.get("symbol")) not in (None, "")
+            }
+        )
+    )
+
+
+def _event_type(row: Mapping[str, object]) -> str:
+    raw = str(
+        row.get("ledger_event_type")
+        or row.get("runtime_ledger_event_type")
+        or row.get("event_type")
+        or ""
+    ).strip()
+    if raw:
+        normalized = raw.lower().replace("-", "_").replace(" ", "_")
+        if normalized in {"filled", "partial_fill", "partially_filled"}:
+            return "fill"
+        if normalized in {"trade_decision", "signal_decision"}:
+            return "decision"
+        if normalized in {"submitted", "accepted", "new", "new_order"}:
+            return "order_submitted"
+        return normalized
+    if row.get("filled_qty") is not None or row.get("avg_fill_price") is not None:
+        return "fill"
+    return ""
+
+
+def _positive_decimal(value: object) -> Decimal | None:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    if parsed <= 0:
+        return None
+    return parsed
+
+
+def _safe_divide(numerator: Decimal, denominator: Decimal) -> Decimal:
+    if denominator <= 0:
+        return Decimal("0")
+    return numerator / denominator
+
+
+def _dedupe(values: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _ranking_sort_key(candidate: ReplayLedgerCandidateRanking) -> tuple[object, ...]:
+    return (
+        -candidate.window_net_pnl_per_day,
+        -candidate.total_net_pnl_after_costs,
+        candidate.best_day_share,
+        candidate.max_drawdown,
+        candidate.candidate_id,
+    )

--- a/services/torghut/scripts/rank_replay_ledgers.py
+++ b/services/torghut/scripts/rank_replay_ledgers.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Rank exact replay ledger artifacts without granting promotion authority."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+from decimal import Decimal
+from pathlib import Path
+
+from app.trading.discovery.replay_ledger_ranker import (
+    build_replay_ledger_ranking_report,
+    default_replay_ledger_ranking_policy,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Rank exact replay ledger artifacts using runtime-ledger PnL semantics. "
+            "This is evidence triage only and does not promote candidates."
+        ),
+    )
+    parser.add_argument("ledger_paths", nargs="*", type=Path)
+    parser.add_argument(
+        "--ledger-glob",
+        action="append",
+        default=[],
+        help="Glob for exact replay ledger JSON artifacts; can be repeated.",
+    )
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--target-net-pnl-per-day", default="500")
+    parser.add_argument("--start-equity", default="")
+    return parser.parse_args()
+
+
+def _paths(args: argparse.Namespace) -> list[Path]:
+    paths = list(args.ledger_paths)
+    for pattern in args.ledger_glob:
+        paths.extend(Path(item) for item in glob.glob(str(pattern), recursive=True))
+    return paths
+
+
+def main() -> int:
+    args = _parse_args()
+    paths = _paths(args)
+    if not paths:
+        raise SystemExit("provide at least one ledger path or --ledger-glob")
+    start_equity = (
+        Decimal(args.start_equity) if str(args.start_equity).strip() else None
+    )
+    policy = default_replay_ledger_ranking_policy(
+        target_net_pnl_per_day=Decimal(str(args.target_net_pnl_per_day)),
+        start_equity=start_equity,
+    )
+    report = build_replay_ledger_ranking_report(
+        paths,
+        policy=policy,
+        limit=args.limit,
+    )
+    payload = json.dumps(report, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + "\n")
+    else:
+        print(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/tests/test_replay_ledger_ranker.py
+++ b/services/torghut/tests/test_replay_ledger_ranker.py
@@ -1,0 +1,484 @@
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+import app.trading.discovery.replay_ledger_ranker as ranker
+import scripts.rank_replay_ledgers as rank_replay_ledgers_cli
+from app.trading.discovery.replay_ledger_ranker import (
+    ReplayLedgerRankingPolicy,
+    build_replay_ledger_ranking_report,
+    default_replay_ledger_ranking_policy,
+    rank_replay_ledger_files,
+    rank_replay_ledger_payload,
+)
+
+
+def _ts(day: int, minute: int = 0) -> str:
+    return datetime(2026, 5, day, 14, 30 + minute, tzinfo=timezone.utc).isoformat()
+
+
+def _round_trip(
+    *,
+    day: int,
+    symbol: str,
+    qty: str,
+    buy_price: str,
+    sell_price: str,
+    prefix: str,
+) -> list[dict[str, object]]:
+    return [
+        {
+            "event_type": "decision",
+            "executed_at": _ts(day, 0),
+            "decision_id": f"{prefix}-buy-decision",
+            "symbol": symbol,
+        },
+        {
+            "event_type": "order_submitted",
+            "executed_at": _ts(day, 1),
+            "decision_id": f"{prefix}-buy-decision",
+            "order_id": f"{prefix}-buy-order",
+            "symbol": symbol,
+        },
+        {
+            "event_type": "fill",
+            "executed_at": _ts(day, 2),
+            "decision_id": f"{prefix}-buy-decision",
+            "order_id": f"{prefix}-buy-order",
+            "symbol": symbol,
+            "side": "buy",
+            "filled_qty": qty,
+            "avg_fill_price": buy_price,
+            "cost_amount": "1",
+        },
+        {
+            "event_type": "decision",
+            "executed_at": _ts(day, 10),
+            "decision_id": f"{prefix}-sell-decision",
+            "symbol": symbol,
+        },
+        {
+            "event_type": "order_submitted",
+            "executed_at": _ts(day, 11),
+            "decision_id": f"{prefix}-sell-decision",
+            "order_id": f"{prefix}-sell-order",
+            "symbol": symbol,
+        },
+        {
+            "event_type": "fill",
+            "executed_at": _ts(day, 12),
+            "decision_id": f"{prefix}-sell-decision",
+            "order_id": f"{prefix}-sell-order",
+            "symbol": symbol,
+            "side": "sell",
+            "filled_qty": qty,
+            "avg_fill_price": sell_price,
+            "cost_amount": "1",
+        },
+    ]
+
+
+def _payload(
+    candidate_id: str,
+    rows: list[dict[str, object]],
+    *,
+    promotion_authority: str = "replay_artifact_only_not_live",
+) -> dict[str, object]:
+    return {
+        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+        "candidate_id": candidate_id,
+        "window_start": "2026-05-18",
+        "window_end": "2026-05-22",
+        "account_label": "TORGHUT_REPLAY",
+        "cost_basis": "local_replay_transaction_cost_model",
+        "execution_policy_hash": "policy-sha",
+        "cost_model_hash": "cost-sha",
+        "lineage_hash": "lineage-sha",
+        "promotion_authority": promotion_authority,
+        "stage": "replay",
+        "source": "local_intraday_tsmom_replay",
+        "runtime_ledger_rows": rows,
+    }
+
+
+def _policy() -> ReplayLedgerRankingPolicy:
+    return ReplayLedgerRankingPolicy(
+        target_net_pnl_per_day=Decimal("500"),
+        min_window_weekday_count=20,
+        min_avg_filled_notional_per_day=Decimal("300000"),
+        max_best_day_share=Decimal("0.25"),
+        max_gross_exposure_pct_equity=Decimal("1.0"),
+        start_equity=Decimal("1000"),
+    )
+
+
+def test_ranker_uses_runtime_ledger_net_pnl_and_window_day_ranking(
+    tmp_path: Path,
+) -> None:
+    concentrated = _payload(
+        "concentrated-active-day-winner",
+        _round_trip(
+            day=18,
+            symbol="NVDA",
+            qty="10",
+            buy_price="100",
+            sell_price="110.2",
+            prefix="concentrated",
+        ),
+    )
+    distributed = _payload(
+        "distributed-window-winner",
+        [
+            *_round_trip(
+                day=18,
+                symbol="NVDA",
+                qty="4",
+                buy_price="100",
+                sell_price="110.5",
+                prefix="dist-1",
+            ),
+            *_round_trip(
+                day=19,
+                symbol="AAPL",
+                qty="4",
+                buy_price="100",
+                sell_price="110.5",
+                prefix="dist-2",
+            ),
+            *_round_trip(
+                day=20,
+                symbol="AMD",
+                qty="4",
+                buy_price="100",
+                sell_price="110.5",
+                prefix="dist-3",
+            ),
+        ],
+    )
+    concentrated_path = tmp_path / "concentrated.json"
+    distributed_path = tmp_path / "distributed.json"
+    concentrated_path.write_text(json.dumps(concentrated))
+    distributed_path.write_text(json.dumps(distributed))
+
+    report = build_replay_ledger_ranking_report(
+        [concentrated_path, distributed_path],
+        policy=_policy(),
+    )
+    top = report["candidates"][0]
+
+    assert top["candidate_id"] == "distributed-window-winner"
+    assert top["total_net_pnl_after_costs"] == "120.0"
+    assert top["window_net_pnl_per_day"] == "24.0"
+    assert top["active_net_pnl_per_day"] == "40.0"
+
+
+def test_ranker_blocks_replay_only_and_over_equity_artifacts() -> None:
+    ranking = rank_replay_ledger_payload(
+        _payload(
+            "oversized-replay-only",
+            _round_trip(
+                day=18,
+                symbol="NVDA",
+                qty="20",
+                buy_price="100",
+                sell_price="101",
+                prefix="oversized",
+            ),
+        ),
+        artifact_ref="/tmp/oversized.json",
+        policy=_policy(),
+    )
+
+    assert ranking.max_single_fill_notional_pct_equity == Decimal("2.02")
+    assert "replay_artifact_only_not_live" in ranking.promotion_blockers
+    assert "max_single_fill_notional_pct_equity_above_max" in ranking.promotion_blockers
+    assert ranking.promotion_status == "blocked_pending_runtime_promotion_proof"
+
+
+def test_default_policy_tracks_oracle_promotion_gates() -> None:
+    policy = default_replay_ledger_ranking_policy(
+        target_net_pnl_per_day=Decimal("250"),
+        start_equity=Decimal("2000"),
+    )
+
+    assert policy.target_net_pnl_per_day == Decimal("250")
+    assert policy.min_window_weekday_count == 20
+    assert policy.min_avg_filled_notional_per_day == Decimal("300000")
+    assert policy.start_equity == Decimal("2000")
+
+
+def test_rank_files_reports_invalid_payloads_and_skips_duplicates(
+    tmp_path: Path,
+) -> None:
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("[]")
+    missing = tmp_path / "missing.json"
+
+    rankings, failures = rank_replay_ledger_files(
+        [invalid, invalid, missing],
+        policy=_policy(),
+    )
+
+    assert rankings == []
+    assert [failure.reason for failure in failures] == [
+        "ledger_payload_not_object",
+        f"[Errno 2] No such file or directory: '{missing}'",
+    ]
+    assert failures[0].to_payload() == {
+        "artifact_ref": str(invalid.resolve()),
+        "reason": "ledger_payload_not_object",
+    }
+
+
+def test_rank_payload_rejects_malformed_ledger_inputs() -> None:
+    valid_window = {
+        "window_start": "2026-05-18",
+        "window_end": "2026-05-22",
+    }
+    with pytest.raises(ValueError, match="runtime_ledger_rows_missing"):
+        rank_replay_ledger_payload(
+            valid_window, artifact_ref="/tmp/x.json", policy=_policy()
+        )
+
+    with pytest.raises(ValueError, match="runtime_ledger_rows_invalid"):
+        rank_replay_ledger_payload(
+            {**valid_window, "runtime_ledger_rows": ["not-a-row"]},
+            artifact_ref="/tmp/x.json",
+            policy=_policy(),
+        )
+
+    with pytest.raises(ValueError, match="window_bounds_missing"):
+        rank_replay_ledger_payload(
+            {
+                "runtime_ledger_rows": _round_trip(
+                    day=18,
+                    symbol="NVDA",
+                    qty="1",
+                    buy_price="1",
+                    sell_price="2",
+                    prefix="missing-window",
+                )
+            },
+            artifact_ref="/tmp/x.json",
+            policy=_policy(),
+        )
+
+    with pytest.raises(ValueError, match="window_end_before_start"):
+        rank_replay_ledger_payload(
+            {
+                "window_start": "2026-05-22",
+                "window_end": "2026-05-18",
+                "runtime_ledger_rows": _round_trip(
+                    day=18,
+                    symbol="NVDA",
+                    qty="1",
+                    buy_price="1",
+                    sell_price="2",
+                    prefix="reversed",
+                ),
+            },
+            artifact_ref="/tmp/x.json",
+            policy=_policy(),
+        )
+
+
+def test_rank_payload_rejects_windows_without_weekdays() -> None:
+    with pytest.raises(ValueError, match="window_weekdays_missing"):
+        rank_replay_ledger_payload(
+            _payload(
+                "weekend-only",
+                _round_trip(
+                    day=16,
+                    symbol="NVDA",
+                    qty="1",
+                    buy_price="100",
+                    sell_price="101",
+                    prefix="weekend",
+                ),
+            )
+            | {"window_start": "2026-05-16", "window_end": "2026-05-17"},
+            artifact_ref="/tmp/weekend.json",
+            policy=_policy(),
+        )
+
+
+def test_full_window_bucket_failure_is_reported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        ranker, "build_runtime_ledger_buckets", lambda *args, **kwargs: []
+    )
+
+    with pytest.raises(ValueError, match="runtime_ledger_bucket_missing"):
+        ranker.rank_replay_ledger_payload(
+            _payload(
+                "bucket-missing",
+                _round_trip(
+                    day=18,
+                    symbol="NVDA",
+                    qty="1",
+                    buy_price="100",
+                    sell_price="101",
+                    prefix="bucket-missing",
+                ),
+            ),
+            artifact_ref="/tmp/bucket.json",
+            policy=_policy(),
+        )
+
+
+def test_ranker_flags_missing_equity_and_supports_helper_edge_cases() -> None:
+    ranking = rank_replay_ledger_payload(
+        _payload(
+            "missing-equity",
+            _round_trip(
+                day=18,
+                symbol="NVDA",
+                qty="1",
+                buy_price="100",
+                sell_price="101",
+                prefix="missing-equity",
+            ),
+        ),
+        artifact_ref="/tmp/missing-equity.json",
+        policy=ReplayLedgerRankingPolicy(
+            target_net_pnl_per_day=Decimal("500"),
+            min_window_weekday_count=20,
+            min_avg_filled_notional_per_day=Decimal("300000"),
+            max_best_day_share=Decimal("0.25"),
+            max_gross_exposure_pct_equity=Decimal("1.0"),
+            start_equity=None,
+        ),
+    )
+
+    assert "start_equity_missing_for_exposure_check" in ranking.promotion_blockers
+    assert ranker._daily_bucket_ranges(
+        datetime(2026, 5, 18, 14, 30, tzinfo=timezone.utc),
+        datetime(2026, 5, 18, 15, 0, tzinfo=timezone.utc),
+    )[0][0] == datetime(2026, 5, 18, 14, 30, tzinfo=timezone.utc)
+    assert ranker._parse_window_datetime("") is None
+    assert ranker._parse_window_datetime("bad-date") is None
+    assert ranker._parse_window_datetime("2026-05-18T14:30:00Z") == datetime(
+        2026,
+        5,
+        18,
+        14,
+        30,
+        tzinfo=timezone.utc,
+    )
+    assert ranker._utc(datetime(2026, 5, 18, 14, 30)) == datetime(
+        2026,
+        5,
+        18,
+        14,
+        30,
+        tzinfo=timezone.utc,
+    )
+    assert ranker._best_day_share(
+        {"2026-05-18": Decimal("-1")}, Decimal("-1")
+    ) == Decimal("1")
+    assert ranker._profit_factor(
+        {"2026-05-18": Decimal("3"), "2026-05-19": Decimal("-2")}
+    ) == Decimal("1.5")
+    assert ranker._fill_notional({"filled_notional": "123.45"}) == Decimal("123.45")
+    assert ranker._fill_notional({"filled_qty": "0", "avg_fill_price": "100"}) is None
+    assert ranker._event_type({"event_type": "filled"}) == "fill"
+    assert ranker._event_type({"event_type": "trade_decision"}) == "decision"
+    assert ranker._event_type({"event_type": "submitted"}) == "order_submitted"
+    assert ranker._event_type({"filled_qty": "1"}) == "fill"
+    assert ranker._positive_decimal("0") is None
+    assert ranker._positive_decimal("not-decimal") is None
+    assert ranker._safe_divide(Decimal("1"), Decimal("0")) == Decimal("0")
+    assert ranker._dedupe(["a", "a", "b"]) == ["a", "b"]
+
+
+def test_rank_replay_ledgers_cli_writes_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ledger_path = tmp_path / "ledger.json"
+    output_path = tmp_path / "report.json"
+    ledger_path.write_text(
+        json.dumps(
+            _payload(
+                "cli-ledger",
+                _round_trip(
+                    day=18,
+                    symbol="NVDA",
+                    qty="1",
+                    buy_price="100",
+                    sell_price="101",
+                    prefix="cli",
+                ),
+            )
+        )
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "rank_replay_ledgers.py",
+            str(ledger_path),
+            "--output",
+            str(output_path),
+            "--limit",
+            "1",
+            "--target-net-pnl-per-day",
+            "25",
+            "--start-equity",
+            "1000",
+        ],
+    )
+
+    assert rank_replay_ledgers_cli.main() == 0
+    report = json.loads(output_path.read_text())
+    assert report["candidates"][0]["candidate_id"] == "cli-ledger"
+    assert report["policy"]["target_net_pnl_per_day"] == "25"
+    assert report["policy"]["start_equity"] == "1000"
+
+
+def test_rank_replay_ledgers_cli_supports_glob_and_stdout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    ledger_path = tmp_path / "ledger.json"
+    ledger_path.write_text(
+        json.dumps(
+            _payload(
+                "glob-ledger",
+                _round_trip(
+                    day=18,
+                    symbol="NVDA",
+                    qty="1",
+                    buy_price="100",
+                    sell_price="101",
+                    prefix="glob",
+                ),
+            )
+        )
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["rank_replay_ledgers.py", "--ledger-glob", str(tmp_path / "*.json")],
+    )
+
+    assert rank_replay_ledgers_cli.main() == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["candidates"][0]["candidate_id"] == "glob-ledger"
+
+
+def test_rank_replay_ledgers_cli_requires_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["rank_replay_ledgers.py"])
+
+    with pytest.raises(SystemExit, match="provide at least one ledger path"):
+        rank_replay_ledgers_cli.main()


### PR DESCRIPTION
## Summary

- Add a Torghut exact replay ledger ranker that reuses runtime-ledger buckets for post-cost PnL evidence.
- Add a CLI to rank local exact-replay-ledger artifacts without granting promotion authority.
- Add regression coverage for window-day ranking and replay/exposure blockers.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_replay_ledger_ranker.py`
- `uv run --frozen ruff format app/trading/discovery/replay_ledger_ranker.py scripts/rank_replay_ledgers.py tests/test_replay_ledger_ranker.py`
- `uv run --frozen ruff check app/trading/discovery/replay_ledger_ranker.py scripts/rank_replay_ledgers.py tests/test_replay_ledger_ranker.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/rank_replay_ledgers.py --ledger-glob '/tmp/frontier-artifacts/**/*exact-replay-ledger.json' --ledger-glob '/tmp/torghut-frontier/**/*exact-replay-ledger.json' --limit 10 --output /tmp/torghut-frontier/exact-ledger-ranking-20260523.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
