### PR TITLE
feat(torghut): surface autoresearch ledger rankings

### DIFF
--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -64,6 +64,10 @@ from app.trading.discovery.promotion_contract import (
 from app.trading.discovery.portfolio_candidates import PortfolioCandidateSpec
 from app.trading.discovery.portfolio_optimizer import optimize_portfolio_candidate
 from app.trading.discovery.profit_target_oracle import ProfitTargetOraclePolicy
+from app.trading.discovery.replay_ledger_ranker import (
+    build_replay_ledger_ranking_report,
+    default_replay_ledger_ranking_policy,
+)
 from app.trading.discovery.replay_tape import (
     ReplayTapeManifest,
     build_source_query_digest,
@@ -1635,6 +1639,7 @@ def _live_progress_payload(
     history: list[dict[str, Any]],
     descriptors: list[MlxCandidateDescriptor],
     proposal_scores: list[ProposalScore],
+    best_exact_replay_ledger_candidate: Mapping[str, Any] | None = None,
     selected_for_replay: ProposalSelectionEntry | None = None,
     selected_descriptor: MlxCandidateDescriptor | None = None,
 ) -> dict[str, Any]:
@@ -1648,6 +1653,11 @@ def _live_progress_payload(
         "experiment_result_count": len(snapshots),
         "latest_experiment": snapshots[-1] if snapshots else None,
         "best_experiment_candidate": _best_experiment_snapshot(snapshots),
+        "best_exact_replay_ledger_candidate": (
+            dict(best_exact_replay_ledger_candidate)
+            if best_exact_replay_ledger_candidate is not None
+            else None
+        ),
     }
     if selected_for_replay is not None:
         payload["selected_for_replay"] = {
@@ -1670,6 +1680,92 @@ def _live_progress_payload(
             ),
         }
     return payload
+
+
+def _exact_replay_ledger_refs(value: Any) -> list[str]:
+    refs: list[str] = []
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if key in {
+                "exact_replay_ledger_artifact_ref",
+                "runtime_ledger_artifact_ref",
+            }:
+                ref = _string(item)
+                if ref:
+                    refs.append(ref)
+                continue
+            if key in {
+                "exact_replay_ledger_artifact_refs",
+                "runtime_ledger_artifact_refs",
+            }:
+                if isinstance(item, (list, tuple)):
+                    refs.extend(ref for raw in item if (ref := _string(raw)))
+                else:
+                    ref = _string(item)
+                    if ref:
+                        refs.append(ref)
+                continue
+            refs.extend(_exact_replay_ledger_refs(item))
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            refs.extend(_exact_replay_ledger_refs(item))
+    return refs
+
+
+def _resolve_run_artifact_ref(ref: str, *, base_dir: Path) -> Path:
+    path = Path(ref).expanduser()
+    if path.is_absolute():
+        return path
+    return base_dir / path
+
+
+def _exact_replay_ledger_paths(run_root: Path) -> tuple[Path, ...]:
+    paths: list[Path] = []
+    seen: set[str] = set()
+
+    def add(path: Path) -> None:
+        key = str(path.expanduser().resolve(strict=False))
+        if key in seen:
+            return
+        seen.add(key)
+        paths.append(path)
+
+    for path in sorted(run_root.glob("**/*exact-replay-ledger.json")):
+        if path.is_file():
+            add(path)
+
+    for result_path in sorted((run_root / "experiments").glob("*/result.json")):
+        try:
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError):
+            continue
+        for ref in _exact_replay_ledger_refs(payload):
+            add(_resolve_run_artifact_ref(ref, base_dir=result_path.parent))
+    return tuple(paths)
+
+
+def _write_exact_replay_ledger_ranking(
+    *,
+    run_root: Path,
+    program: StrategyAutoresearchProgram,
+) -> dict[str, Any]:
+    path = run_root / "exact-replay-ledger-ranking.json"
+    policy = default_replay_ledger_ranking_policy(
+        target_net_pnl_per_day=program.objective.target_net_pnl_per_day,
+        start_equity=program.objective.default_start_equity,
+    )
+    report = build_replay_ledger_ranking_report(
+        _exact_replay_ledger_paths(run_root),
+        policy=policy,
+        limit=20,
+    )
+    path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    candidates = cast(list[dict[str, Any]], report.get("candidates") or [])
+    return {
+        "path": str(path),
+        "report": report,
+        "best_candidate": candidates[0] if candidates else None,
+    }
 
 
 def _persist_run_outputs(
@@ -1718,6 +1814,10 @@ def _persist_run_outputs(
         proposal_diagnostics=proposal_diagnostics,
     )
     notebook_paths = write_autoresearch_notebooks(run_root)
+    exact_replay_ledger_ranking = _write_exact_replay_ledger_ranking(
+        run_root=run_root,
+        program=program,
+    )
     summary: dict[str, Any] = {
         "status": status,
         "runner_run_id": runner_run_id,
@@ -1731,6 +1831,11 @@ def _persist_run_outputs(
         "research_dossier_path": str(research_dossier_path),
         "promotion_readiness_path": str(promotion_readiness_path),
         "snapshot_manifest_path": str(snapshot_manifest_path),
+        "exact_replay_ledger_ranking_path": exact_replay_ledger_ranking["path"],
+        "exact_replay_ledger_ranking": exact_replay_ledger_ranking["report"],
+        "best_exact_replay_ledger_candidate": exact_replay_ledger_ranking[
+            "best_candidate"
+        ],
         "mlx_exports": dict(mlx_exports),
         "notebooks": [str(path) for path in notebook_paths],
         "best_candidate": _best_history_record(history),
@@ -1741,6 +1846,10 @@ def _persist_run_outputs(
             history=history,
             descriptors=descriptors,
             proposal_scores=proposal_scores,
+            best_exact_replay_ledger_candidate=cast(
+                Mapping[str, Any] | None,
+                exact_replay_ledger_ranking["best_candidate"],
+            ),
             selected_for_replay=selected_for_replay,
             selected_descriptor=selected_descriptor,
         ),

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -387,6 +387,235 @@ class TestStrategyAutoresearch(TestCase):
             self.assertTrue(summary["promotion_readiness"]["promotable"])
             self.assertEqual(promotion_readiness_file["candidate_id"], "port-1")
 
+    def test_persist_run_outputs_surfaces_exact_replay_ledger_ranking(self) -> None:
+        class RuntimeSummary:
+            def to_payload(self) -> dict[str, object]:
+                return {
+                    "status": "pending_runtime_parity",
+                    "next_required_steps": ["scheduler_v3_parity_replay"],
+                    "promotion_prerequisites": {
+                        "allowed": False,
+                        "reasons": ["gate_report_missing"],
+                    },
+                    "rollback_readiness": {"ready": False},
+                }
+
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            program_path, family_dir = self._write_program_fixture(root)
+            program_payload = yaml.safe_load(program_path.read_text(encoding="utf-8"))
+            program = load_strategy_autoresearch_program(
+                program_path, family_dir=family_dir
+            )
+            run_root = root / "run"
+            artifact_path = (
+                run_root
+                / "experiments"
+                / "001-breakout-iter-1"
+                / "frontier-artifacts"
+                / "result"
+                / "candidate-0001-exact-replay-ledger.json"
+            )
+            artifact_path.parent.mkdir(parents=True)
+            artifact_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "candidate_id": "ledger-ranked-1",
+                        "window_start": "2026-05-18",
+                        "window_end": "2026-05-22",
+                        "account_label": "TORGHUT_REPLAY",
+                        "cost_basis": "local_replay_transaction_cost_model",
+                        "execution_policy_hash": "policy-sha",
+                        "cost_model_hash": "cost-sha",
+                        "lineage_hash": "lineage-sha",
+                        "promotion_authority": "replay_artifact_only_not_live",
+                        "stage": "replay",
+                        "source": "local_intraday_tsmom_replay",
+                        "runtime_ledger_rows": [
+                            {
+                                "event_type": "decision",
+                                "executed_at": "2026-05-18T14:30:00+00:00",
+                                "decision_id": "buy-decision",
+                                "symbol": "NVDA",
+                            },
+                            {
+                                "event_type": "order_submitted",
+                                "executed_at": "2026-05-18T14:31:00+00:00",
+                                "decision_id": "buy-decision",
+                                "order_id": "buy-order",
+                                "symbol": "NVDA",
+                            },
+                            {
+                                "event_type": "fill",
+                                "executed_at": "2026-05-18T14:32:00+00:00",
+                                "decision_id": "buy-decision",
+                                "order_id": "buy-order",
+                                "symbol": "NVDA",
+                                "side": "buy",
+                                "filled_qty": "10",
+                                "avg_fill_price": "100",
+                                "cost_amount": "1",
+                            },
+                            {
+                                "event_type": "decision",
+                                "executed_at": "2026-05-18T14:40:00+00:00",
+                                "decision_id": "sell-decision",
+                                "symbol": "NVDA",
+                            },
+                            {
+                                "event_type": "order_submitted",
+                                "executed_at": "2026-05-18T14:41:00+00:00",
+                                "decision_id": "sell-decision",
+                                "order_id": "sell-order",
+                                "symbol": "NVDA",
+                            },
+                            {
+                                "event_type": "fill",
+                                "executed_at": "2026-05-18T14:42:00+00:00",
+                                "decision_id": "sell-decision",
+                                "order_id": "sell-order",
+                                "symbol": "NVDA",
+                                "side": "sell",
+                                "filled_qty": "10",
+                                "avg_fill_price": "130",
+                                "cost_amount": "1",
+                            },
+                        ],
+                    },
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+            manifest = runner.MlxSnapshotManifest(
+                snapshot_id="snap-1",
+                created_at="2026-05-20T00:00:00+00:00",
+                source_window_start="2026-05-01",
+                source_window_end="2026-05-15",
+                train_days=6,
+                holdout_days=3,
+                full_window_days=9,
+                symbols=("NVDA",),
+                bar_interval="1Sec",
+                quote_quality_policy_id="quote-quality-v1",
+                feature_set_id="torghut.mlx-autoresearch.v1",
+                cross_sectional_feature_flags={},
+                prior_day_feature_flags={},
+                tape_freshness_receipts=(),
+                row_counts={},
+                tensor_bundle_paths={},
+                manifest_hash="hash-1",
+            )
+
+            with (
+                patch(
+                    "scripts.run_strategy_autoresearch_loop._write_portfolio_outputs",
+                    return_value=(None, {}),
+                ),
+                patch(
+                    "scripts.run_strategy_autoresearch_loop.write_runtime_closure_bundle",
+                    return_value=RuntimeSummary(),
+                ),
+                patch(
+                    "scripts.run_strategy_autoresearch_loop.write_mlx_notebook_exports",
+                    return_value={},
+                ),
+                patch(
+                    "scripts.run_strategy_autoresearch_loop.write_autoresearch_notebooks",
+                    return_value=[],
+                ),
+            ):
+                summary = runner._persist_run_outputs(
+                    run_root=run_root,
+                    program=program,
+                    program_payload=program_payload,
+                    runner_run_id="strategy-autoresearch-test",
+                    program_id=program.program_id,
+                    frontier_runs=1,
+                    objective_met=False,
+                    history=[],
+                    manifest=manifest,
+                    descriptors=[],
+                    proposal_scores=[],
+                    worklist=[],
+                    status="ok",
+                )
+
+            ranking_path = Path(summary["exact_replay_ledger_ranking_path"])
+            ranking = json.loads(ranking_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(ranking["candidate_count"], 1)
+            self.assertEqual(ranking["failure_count"], 0)
+            self.assertEqual(
+                summary["best_exact_replay_ledger_candidate"]["candidate_id"],
+                "ledger-ranked-1",
+            )
+            self.assertEqual(
+                summary["live_progress"]["best_exact_replay_ledger_candidate"][
+                    "candidate_id"
+                ],
+                "ledger-ranked-1",
+            )
+            self.assertIn(
+                "replay_artifact_only_not_live",
+                summary["best_exact_replay_ledger_candidate"]["promotion_blockers"],
+            )
+
+    def test_exact_replay_ledger_paths_collects_refs_and_skips_bad_results(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            run_root = root / "run"
+            experiment_root = run_root / "experiments" / "001-breakout"
+            artifact_path = (
+                experiment_root
+                / "frontier-artifacts"
+                / "result"
+                / "candidate-0001-exact-replay-ledger.json"
+            )
+            artifact_path.parent.mkdir(parents=True)
+            artifact_path.write_text("{}", encoding="utf-8")
+            absolute_path = root / "absolute-exact-replay-ledger.json"
+            relative_runtime_ref = "runtime-ledger.json"
+            result_path = experiment_root / "result.json"
+            result_path.write_text(
+                json.dumps(
+                    {
+                        "top": [
+                            {
+                                "exact_replay_ledger_artifact_ref": str(artifact_path),
+                                "exact_replay_ledger_artifact_refs": [
+                                    str(absolute_path),
+                                    "",
+                                ],
+                                "nested": {
+                                    "runtime_ledger_artifact_ref": relative_runtime_ref,
+                                    "runtime_ledger_artifact_refs": "scalar-runtime-ledger.json",
+                                },
+                            }
+                        ],
+                    },
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+            bad_result_path = run_root / "experiments" / "bad" / "result.json"
+            bad_result_path.parent.mkdir(parents=True)
+            bad_result_path.write_text("{", encoding="utf-8")
+
+            paths = runner._exact_replay_ledger_paths(run_root)
+
+            self.assertEqual(
+                paths,
+                (
+                    artifact_path,
+                    absolute_path,
+                    experiment_root / relative_runtime_ref,
+                    experiment_root / "scalar-runtime-ledger.json",
+                ),
+            )
+
     def test_load_mutation_space_rejects_invalid_mode(self) -> None:
         with self.assertRaisesRegex(ValueError, "autoresearch_mutation_mode_invalid"):
             autoresearch._load_mutation_space({"mode": "bad-mode"})


### PR DESCRIPTION
## Summary

- Writes `exact-replay-ledger-ranking.json` for every strategy autoresearch run using the runtime-ledger exact replay ranker.
- Surfaces the best exact replay ledger candidate and blockers in `summary.json` and `live_progress`.
- Adds regression coverage proving autoresearch summaries expose ranked ledger evidence without granting promotion.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format scripts/run_strategy_autoresearch_loop.py tests/test_strategy_autoresearch.py`
- `uv run --frozen ruff check scripts/run_strategy_autoresearch_loop.py tests/test_strategy_autoresearch.py`
- `uv run --frozen pytest tests/test_strategy_autoresearch.py -k 'persist_run_outputs_surfaces_exact_replay_ledger_ranking or persist_run_outputs_uses_oracle_passed_portfolio_for_runtime_closure'`
- `uv run --frozen pytest tests/test_strategy_autoresearch.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
