### PR TITLE
feat(torghut): explain exact ledger blockers

### DIFF
--- a/services/torghut/app/trading/discovery/replay_ledger_remediation.py
+++ b/services/torghut/app/trading/discovery/replay_ledger_remediation.py
@@ -1,0 +1,345 @@
+"""Turn exact replay ledger blockers into the next honest search actions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from decimal import Decimal, InvalidOperation
+from typing import Any, cast
+
+EXACT_REPLAY_LEDGER_REMEDIATION_SCHEMA_VERSION = (
+    "torghut.exact-replay-ledger-remediation.v1"
+)
+
+_RUNTIME_PROMOTION_EVIDENCE = (
+    "runtime_closure_bundle_with_scheduler_v3_parity",
+    "live_or_live_paper_runtime_ledger_rows_with_order_lifecycle",
+    "post_cost_net_pnl_after_costs_over_policy_window",
+    "promotion_readiness_json_with_no_blockers",
+)
+
+
+def build_replay_ledger_remediation_report(
+    ranking_report: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build a deterministic next-step report from a replay ledger ranking report."""
+
+    policy = _mapping(ranking_report.get("policy"))
+    candidates = _candidate_mappings(ranking_report.get("candidates"))
+    best_candidate = candidates[0] if candidates else None
+    if best_candidate is None:
+        return {
+            "schema_version": EXACT_REPLAY_LEDGER_REMEDIATION_SCHEMA_VERSION,
+            "status": "blocked_no_exact_replay_ledger_candidates",
+            "promotion_allowed": False,
+            "ranking_schema_version": _string(ranking_report.get("schema_version")),
+            "candidate_id": None,
+            "artifact_ref": None,
+            "promotion_status": None,
+            "promotion_blockers": ["exact_replay_ledger_candidate_missing"],
+            "runtime_ledger_blockers": [],
+            "required_evidence": list(_RUNTIME_PROMOTION_EVIDENCE),
+            "metric_snapshot": _metric_snapshot({}, policy),
+            "recommended_objective_adjustments": {
+                "ranking_basis": "full_window_post_cost_net_pnl_per_day",
+                "evidence_basis": "exact_replay_ledger_rows",
+            },
+            "recommended_search_actions": [
+                {
+                    "action": "produce_exact_replay_ledger_artifacts",
+                    "reason": "no_rankable_runtime_ledger_rows_found",
+                    "parameter_hints": [
+                        "enable_exact_replay_ledger_output",
+                        "inspect_experiment_result_refs",
+                    ],
+                }
+            ],
+            "blocker_remediations": [],
+        }
+
+    promotion_blockers = _string_list(best_candidate.get("promotion_blockers"))
+    runtime_blockers = _string_list(best_candidate.get("runtime_ledger_blockers"))
+    blockers = _dedupe([*promotion_blockers, *runtime_blockers])
+    blocker_remediations = [
+        _blocker_remediation(blocker, best_candidate=best_candidate, policy=policy)
+        for blocker in blockers
+    ]
+    status = (
+        "blocked_pending_runtime_promotion_proof"
+        if not _has_search_blockers(promotion_blockers, runtime_blockers)
+        else "blocked_pending_search_remediation"
+    )
+
+    return {
+        "schema_version": EXACT_REPLAY_LEDGER_REMEDIATION_SCHEMA_VERSION,
+        "status": status,
+        "promotion_allowed": False,
+        "ranking_schema_version": _string(ranking_report.get("schema_version")),
+        "candidate_id": _string(best_candidate.get("candidate_id")),
+        "artifact_ref": _string(best_candidate.get("artifact_ref")),
+        "promotion_status": _string(best_candidate.get("promotion_status")),
+        "promotion_blockers": promotion_blockers,
+        "runtime_ledger_blockers": runtime_blockers,
+        "required_evidence": list(_RUNTIME_PROMOTION_EVIDENCE),
+        "metric_snapshot": _metric_snapshot(best_candidate, policy),
+        "recommended_objective_adjustments": _recommended_objective_adjustments(
+            blockers=promotion_blockers,
+            policy=policy,
+        ),
+        "recommended_search_actions": _recommended_search_actions(
+            blockers=blockers,
+            best_candidate=best_candidate,
+            policy=policy,
+        ),
+        "blocker_remediations": blocker_remediations,
+    }
+
+
+def _has_search_blockers(
+    promotion_blockers: Sequence[str],
+    runtime_blockers: Sequence[str],
+) -> bool:
+    non_search_blockers = {"replay_artifact_only_not_live"}
+    return any(
+        blocker not in non_search_blockers for blocker in promotion_blockers
+    ) or bool(runtime_blockers)
+
+
+def _recommended_objective_adjustments(
+    *,
+    blockers: Sequence[str],
+    policy: Mapping[str, Any],
+) -> dict[str, str]:
+    adjustments: dict[str, str] = {
+        "ranking_basis": "full_window_post_cost_net_pnl_per_day",
+        "evidence_basis": "exact_replay_ledger_rows",
+    }
+    if "window_net_pnl_per_day_below_target" in blockers:
+        adjustments["target_net_pnl_per_day"] = _string(
+            policy.get("target_net_pnl_per_day")
+        )
+    if "avg_filled_notional_per_day_below_min" in blockers:
+        adjustments["min_avg_filled_notional_per_day"] = _string(
+            policy.get("min_avg_filled_notional_per_day")
+        )
+    if "best_day_share_above_max" in blockers:
+        adjustments["max_best_day_share"] = _string(policy.get("max_best_day_share"))
+    if "max_single_fill_notional_pct_equity_above_max" in blockers:
+        adjustments["max_gross_exposure_pct_equity"] = _string(
+            policy.get("max_gross_exposure_pct_equity")
+        )
+    if "window_weekday_count_below_min_observed_trading_days" in blockers:
+        adjustments["min_window_weekday_count"] = _string(
+            policy.get("min_window_weekday_count")
+        )
+    return {key: value for key, value in adjustments.items() if value != ""}
+
+
+def _recommended_search_actions(
+    *,
+    blockers: Sequence[str],
+    best_candidate: Mapping[str, Any],
+    policy: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    if not blockers:
+        return [
+            {
+                "action": "start_runtime_paper_validation",
+                "reason": "exact_replay_policy_checks_passed_but_runtime_proof_missing",
+                "parameter_hints": ["scheduler_v3_parity", "live_paper_runtime_ledger"],
+            }
+        ]
+    return [
+        _blocker_remediation(blocker, best_candidate=best_candidate, policy=policy)
+        for blocker in blockers
+    ]
+
+
+def _blocker_remediation(
+    blocker: str,
+    *,
+    best_candidate: Mapping[str, Any],
+    policy: Mapping[str, Any],
+) -> dict[str, Any]:
+    if blocker == "replay_artifact_only_not_live":
+        return {
+            "blocker": blocker,
+            "action": "run_runtime_closure_then_live_paper_ledger_validation",
+            "reason": "replay_ledgers_are_research_evidence_not_promotion_authority",
+            "parameter_hints": [
+                "runtime_closure",
+                "scheduler_v3_parity",
+                "live_paper_runtime_ledger",
+            ],
+        }
+    if blocker == "window_weekday_count_below_min_observed_trading_days":
+        return {
+            "blocker": blocker,
+            "action": "extend_full_window_or_supply_longer_manifest_verified_tape",
+            "reason": "ranked_candidate_window_is_too_short_for_policy",
+            "observed": _string(best_candidate.get("window_weekday_count")),
+            "threshold": _string(policy.get("min_window_weekday_count")),
+            "parameter_hints": [
+                "increase_full_window_days",
+                "set_full_window_start_date_and_end_date",
+                "materialize_replay_tape",
+            ],
+        }
+    if blocker == "window_net_pnl_per_day_below_target":
+        return {
+            "blocker": blocker,
+            "action": "bias_search_to_full_window_net_pnl_per_day_not_active_day_only",
+            "reason": "candidate_does_not_reach_policy_daily_profit_after_costs",
+            "observed": _string(best_candidate.get("window_net_pnl_per_day")),
+            "threshold": _string(policy.get("target_net_pnl_per_day")),
+            "required_multiplier": _required_multiplier(
+                observed=best_candidate.get("window_net_pnl_per_day"),
+                threshold=policy.get("target_net_pnl_per_day"),
+            ),
+            "parameter_hints": [
+                "increase_candidate_breadth",
+                "rank_by_window_net_pnl_per_day",
+                "keep_post_cost_objective",
+            ],
+        }
+    if blocker == "avg_filled_notional_per_day_below_min":
+        return {
+            "blocker": blocker,
+            "action": "increase_tradeable_breadth_without_raising_single_fill_exposure",
+            "reason": "candidate_does_not_generate_enough_daily_filled_notional",
+            "observed": _string(
+                best_candidate.get("avg_filled_notional_per_window_weekday")
+            ),
+            "threshold": _string(policy.get("min_avg_filled_notional_per_day")),
+            "required_multiplier": _required_multiplier(
+                observed=best_candidate.get("avg_filled_notional_per_window_weekday"),
+                threshold=policy.get("min_avg_filled_notional_per_day"),
+            ),
+            "parameter_hints": [
+                "expand_symbol_universe",
+                "increase_top_n_candidates",
+                "increase_proposal_batch_size",
+                "keep_exposure_cap_active",
+            ],
+        }
+    if blocker == "best_day_share_above_max":
+        return {
+            "blocker": blocker,
+            "action": "penalize_single_day_pnl_concentration",
+            "reason": "too_much_profit_comes_from_one_day",
+            "observed": _string(best_candidate.get("best_day_share")),
+            "threshold": _string(policy.get("max_best_day_share")),
+            "parameter_hints": [
+                "lower_best_day_share_weight",
+                "increase_regime_diversity",
+                "prefer_portfolio_sleeves",
+            ],
+        }
+    if blocker == "max_single_fill_notional_pct_equity_above_max":
+        return {
+            "blocker": blocker,
+            "action": "cap_per_fill_notional_before_scaling_notional",
+            "reason": "single_fill_exposure_is_above_policy_limit",
+            "observed": _string(
+                best_candidate.get("max_single_fill_notional_pct_equity")
+            ),
+            "threshold": _string(policy.get("max_gross_exposure_pct_equity")),
+            "parameter_hints": [
+                "reduce_max_position_notional_pct_equity",
+                "slice_orders",
+                "do_not_scale_candidate_until_exposure_passes",
+            ],
+        }
+    if blocker == "start_equity_missing_for_exposure_check":
+        return {
+            "blocker": blocker,
+            "action": "rerun_ranking_with_start_equity",
+            "reason": "exposure_gate_cannot_be_evaluated_without_equity",
+            "parameter_hints": ["set_start_equity"],
+        }
+    return {
+        "blocker": blocker,
+        "action": "fix_runtime_ledger_or_policy_blocker_before_research_continues",
+        "reason": "unmapped_replay_ledger_blocker",
+        "parameter_hints": ["inspect_exact_replay_ledger_rows", "inspect_policy"],
+    }
+
+
+def _metric_snapshot(
+    best_candidate: Mapping[str, Any],
+    policy: Mapping[str, Any],
+) -> dict[str, str]:
+    keys = {
+        "target_net_pnl_per_day": policy.get("target_net_pnl_per_day"),
+        "window_net_pnl_per_day": best_candidate.get("window_net_pnl_per_day"),
+        "active_net_pnl_per_day": best_candidate.get("active_net_pnl_per_day"),
+        "total_net_pnl_after_costs": best_candidate.get("total_net_pnl_after_costs"),
+        "min_window_weekday_count": policy.get("min_window_weekday_count"),
+        "window_weekday_count": best_candidate.get("window_weekday_count"),
+        "min_avg_filled_notional_per_day": policy.get(
+            "min_avg_filled_notional_per_day"
+        ),
+        "avg_filled_notional_per_window_weekday": best_candidate.get(
+            "avg_filled_notional_per_window_weekday"
+        ),
+        "max_best_day_share": policy.get("max_best_day_share"),
+        "best_day_share": best_candidate.get("best_day_share"),
+        "max_gross_exposure_pct_equity": policy.get("max_gross_exposure_pct_equity"),
+        "max_single_fill_notional_pct_equity": best_candidate.get(
+            "max_single_fill_notional_pct_equity"
+        ),
+    }
+    return {key: _string(value) for key, value in keys.items() if _string(value)}
+
+
+def _required_multiplier(*, observed: object, threshold: object) -> str | None:
+    observed_decimal = _decimal(observed)
+    threshold_decimal = _decimal(threshold)
+    if observed_decimal is None or threshold_decimal is None or observed_decimal <= 0:
+        return None
+    return str(threshold_decimal / observed_decimal)
+
+
+def _candidate_mappings(value: object) -> tuple[Mapping[str, Any], ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return ()
+    sequence = cast(Sequence[object], value)
+    return tuple(
+        cast(Mapping[str, Any], item) for item in sequence if isinstance(item, Mapping)
+    )
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value)
+    return {}
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    sequence = cast(Sequence[object], value)
+    return [parsed for item in sequence if (parsed := _string(item))]
+
+
+def _dedupe(values: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _string(value: object) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _decimal(value: object) -> Decimal | None:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -68,6 +68,9 @@ from app.trading.discovery.replay_ledger_ranker import (
     build_replay_ledger_ranking_report,
     default_replay_ledger_ranking_policy,
 )
+from app.trading.discovery.replay_ledger_remediation import (
+    build_replay_ledger_remediation_report,
+)
 from app.trading.discovery.replay_tape import (
     ReplayTapeManifest,
     build_source_query_digest,
@@ -1640,6 +1643,7 @@ def _live_progress_payload(
     descriptors: list[MlxCandidateDescriptor],
     proposal_scores: list[ProposalScore],
     best_exact_replay_ledger_candidate: Mapping[str, Any] | None = None,
+    exact_replay_ledger_remediation: Mapping[str, Any] | None = None,
     selected_for_replay: ProposalSelectionEntry | None = None,
     selected_descriptor: MlxCandidateDescriptor | None = None,
 ) -> dict[str, Any]:
@@ -1656,6 +1660,11 @@ def _live_progress_payload(
         "best_exact_replay_ledger_candidate": (
             dict(best_exact_replay_ledger_candidate)
             if best_exact_replay_ledger_candidate is not None
+            else None
+        ),
+        "exact_replay_ledger_remediation": (
+            dict(exact_replay_ledger_remediation)
+            if exact_replay_ledger_remediation is not None
             else None
         ),
     }
@@ -1768,6 +1777,20 @@ def _write_exact_replay_ledger_ranking(
     }
 
 
+def _write_exact_replay_ledger_remediation(
+    *,
+    run_root: Path,
+    ranking_report: Mapping[str, Any],
+) -> dict[str, Any]:
+    path = run_root / "exact-replay-ledger-remediation.json"
+    report = build_replay_ledger_remediation_report(ranking_report)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    return {
+        "path": str(path),
+        "report": report,
+    }
+
+
 def _persist_run_outputs(
     *,
     run_root: Path,
@@ -1818,6 +1841,10 @@ def _persist_run_outputs(
         run_root=run_root,
         program=program,
     )
+    exact_replay_ledger_remediation = _write_exact_replay_ledger_remediation(
+        run_root=run_root,
+        ranking_report=cast(Mapping[str, Any], exact_replay_ledger_ranking["report"]),
+    )
     summary: dict[str, Any] = {
         "status": status,
         "runner_run_id": runner_run_id,
@@ -1833,6 +1860,8 @@ def _persist_run_outputs(
         "snapshot_manifest_path": str(snapshot_manifest_path),
         "exact_replay_ledger_ranking_path": exact_replay_ledger_ranking["path"],
         "exact_replay_ledger_ranking": exact_replay_ledger_ranking["report"],
+        "exact_replay_ledger_remediation_path": exact_replay_ledger_remediation["path"],
+        "exact_replay_ledger_remediation": exact_replay_ledger_remediation["report"],
         "best_exact_replay_ledger_candidate": exact_replay_ledger_ranking[
             "best_candidate"
         ],
@@ -1849,6 +1878,10 @@ def _persist_run_outputs(
             best_exact_replay_ledger_candidate=cast(
                 Mapping[str, Any] | None,
                 exact_replay_ledger_ranking["best_candidate"],
+            ),
+            exact_replay_ledger_remediation=cast(
+                Mapping[str, Any] | None,
+                exact_replay_ledger_remediation["report"],
             ),
             selected_for_replay=selected_for_replay,
             selected_descriptor=selected_descriptor,

--- a/services/torghut/tests/test_replay_ledger_remediation.py
+++ b/services/torghut/tests/test_replay_ledger_remediation.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from unittest import TestCase
+
+from app.trading.discovery.replay_ledger_remediation import (
+    build_replay_ledger_remediation_report,
+)
+
+
+class TestReplayLedgerRemediation(TestCase):
+    def test_report_maps_replay_blockers_to_next_search_actions(self) -> None:
+        report = build_replay_ledger_remediation_report(
+            {
+                "schema_version": "torghut.exact-replay-ledger-ranking.v1",
+                "policy": {
+                    "target_net_pnl_per_day": "500",
+                    "min_window_weekday_count": 20,
+                    "min_avg_filled_notional_per_day": "300000",
+                    "max_best_day_share": "0.25",
+                    "max_gross_exposure_pct_equity": "0.05",
+                },
+                "candidates": [
+                    {
+                        "candidate_id": "candidate-1",
+                        "artifact_ref": "/tmp/candidate-1-exact-replay-ledger.json",
+                        "promotion_status": "blocked_pending_runtime_promotion_proof",
+                        "promotion_blockers": [
+                            "replay_artifact_only_not_live",
+                            "window_net_pnl_per_day_below_target",
+                            "avg_filled_notional_per_day_below_min",
+                            "best_day_share_above_max",
+                            "max_single_fill_notional_pct_equity_above_max",
+                        ],
+                        "runtime_ledger_blockers": [],
+                        "window_net_pnl_per_day": "125",
+                        "active_net_pnl_per_day": "625",
+                        "total_net_pnl_after_costs": "1000",
+                        "window_weekday_count": 8,
+                        "avg_filled_notional_per_window_weekday": "150000",
+                        "best_day_share": "0.50",
+                        "max_single_fill_notional_pct_equity": "0.12",
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(report["status"], "blocked_pending_search_remediation")
+        self.assertFalse(report["promotion_allowed"])
+        self.assertEqual(report["candidate_id"], "candidate-1")
+        self.assertEqual(
+            report["recommended_objective_adjustments"]["target_net_pnl_per_day"],
+            "500",
+        )
+        self.assertEqual(
+            report["recommended_objective_adjustments"][
+                "min_avg_filled_notional_per_day"
+            ],
+            "300000",
+        )
+        actions = {item["action"] for item in report["recommended_search_actions"]}
+        self.assertIn(
+            "run_runtime_closure_then_live_paper_ledger_validation",
+            actions,
+        )
+        self.assertIn(
+            "bias_search_to_full_window_net_pnl_per_day_not_active_day_only",
+            actions,
+        )
+        self.assertIn(
+            "increase_tradeable_breadth_without_raising_single_fill_exposure",
+            actions,
+        )
+        self.assertIn("penalize_single_day_pnl_concentration", actions)
+        self.assertIn("cap_per_fill_notional_before_scaling_notional", actions)
+
+    def test_report_blocks_when_no_ranked_ledgers_exist(self) -> None:
+        report = build_replay_ledger_remediation_report(
+            {
+                "schema_version": "torghut.exact-replay-ledger-ranking.v1",
+                "policy": {"target_net_pnl_per_day": "500"},
+                "candidates": [],
+            }
+        )
+
+        self.assertEqual(
+            report["status"],
+            "blocked_no_exact_replay_ledger_candidates",
+        )
+        self.assertFalse(report["promotion_allowed"])
+        self.assertEqual(
+            report["promotion_blockers"],
+            ["exact_replay_ledger_candidate_missing"],
+        )
+        self.assertEqual(
+            report["recommended_search_actions"][0]["action"],
+            "produce_exact_replay_ledger_artifacts",
+        )
+
+    def test_report_requires_runtime_proof_when_replay_checks_pass(self) -> None:
+        report = build_replay_ledger_remediation_report(
+            {
+                "schema_version": "torghut.exact-replay-ledger-ranking.v1",
+                "policy": {"target_net_pnl_per_day": "500"},
+                "candidates": [
+                    {
+                        "candidate_id": "candidate-runtime-ready",
+                        "promotion_status": "candidate_replay_evidence_only",
+                        "promotion_blockers": [],
+                        "runtime_ledger_blockers": [],
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(
+            report["status"],
+            "blocked_pending_runtime_promotion_proof",
+        )
+        self.assertFalse(report["promotion_allowed"])
+        self.assertEqual(
+            report["recommended_search_actions"][0]["action"],
+            "start_runtime_paper_validation",
+        )
+
+    def test_report_handles_malformed_shapes_without_promotion(self) -> None:
+        report = build_replay_ledger_remediation_report(
+            {
+                "schema_version": "torghut.exact-replay-ledger-ranking.v1",
+                "policy": "not-a-policy",
+                "candidates": "not-a-candidate-list",
+            }
+        )
+
+        self.assertEqual(
+            report["status"],
+            "blocked_no_exact_replay_ledger_candidates",
+        )
+        self.assertEqual(report["metric_snapshot"], {})
+
+    def test_report_keeps_unknown_and_start_equity_blockers_actionable(self) -> None:
+        report = build_replay_ledger_remediation_report(
+            {
+                "schema_version": "torghut.exact-replay-ledger-ranking.v1",
+                "policy": {
+                    "target_net_pnl_per_day": "500",
+                    "min_window_weekday_count": 20,
+                },
+                "candidates": [
+                    {
+                        "candidate_id": "candidate-blocked",
+                        "promotion_status": "blocked_pending_runtime_promotion_proof",
+                        "promotion_blockers": [
+                            "window_net_pnl_per_day_below_target",
+                            "start_equity_missing_for_exposure_check",
+                            "unknown_runtime_gate",
+                            "unknown_runtime_gate",
+                        ],
+                        "runtime_ledger_blockers": "not-a-list",
+                        "window_net_pnl_per_day": "not-a-number",
+                    }
+                ],
+            }
+        )
+
+        actions = {
+            item["action"]: item for item in report["recommended_search_actions"]
+        }
+        self.assertIsNone(
+            actions["bias_search_to_full_window_net_pnl_per_day_not_active_day_only"][
+                "required_multiplier"
+            ]
+        )
+        self.assertEqual(
+            actions["rerun_ranking_with_start_equity"]["parameter_hints"],
+            ["set_start_equity"],
+        )
+        self.assertEqual(
+            actions["fix_runtime_ledger_or_policy_blocker_before_research_continues"][
+                "blocker"
+            ],
+            "unknown_runtime_gate",
+        )

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -542,10 +542,27 @@ class TestStrategyAutoresearch(TestCase):
                 )
 
             ranking_path = Path(summary["exact_replay_ledger_ranking_path"])
+            remediation_path = Path(summary["exact_replay_ledger_remediation_path"])
             ranking = json.loads(ranking_path.read_text(encoding="utf-8"))
+            remediation = json.loads(remediation_path.read_text(encoding="utf-8"))
 
             self.assertEqual(ranking["candidate_count"], 1)
             self.assertEqual(ranking["failure_count"], 0)
+            self.assertEqual(
+                remediation["candidate_id"],
+                "ledger-ranked-1",
+            )
+            self.assertFalse(remediation["promotion_allowed"])
+            self.assertEqual(
+                summary["exact_replay_ledger_remediation"]["candidate_id"],
+                "ledger-ranked-1",
+            )
+            self.assertEqual(
+                summary["live_progress"]["exact_replay_ledger_remediation"][
+                    "candidate_id"
+                ],
+                "ledger-ranked-1",
+            )
             self.assertEqual(
                 summary["best_exact_replay_ledger_candidate"]["candidate_id"],
                 "ledger-ranked-1",


### PR DESCRIPTION
## Summary

- Adds an exact replay ledger remediation report that turns ranking blockers into next-run evidence requirements and search actions without granting promotion authority.
- Persists `exact-replay-ledger-remediation.json` from autoresearch runs and exposes it in `summary.json` plus `live_progress`.
- Adds focused coverage for blocker remediation mapping and autoresearch output persistence.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_replay_ledger_remediation.py tests/test_strategy_autoresearch.py -k 'replay_ledger_remediation or exact_replay_ledger_ranking'`
- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/replay_ledger_remediation.py scripts/run_strategy_autoresearch_loop.py tests/test_replay_ledger_remediation.py tests/test_strategy_autoresearch.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen python scripts/rank_replay_ledgers.py --ledger-glob '/private/tmp/torghut-current-replay/**/*exact-replay-ledger.json' --ledger-glob '/private/tmp/torghut-frontier-proof-20260522/**/*exact-replay-ledger.json' --limit 10 --output /tmp/torghut-exact-ledger-ranking-20260523.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
