### PR TITLE
feat(torghut): guide search from replay ledger blockers

### DIFF
--- a/services/torghut/app/trading/discovery/replay_ledger_guided_search.py
+++ b/services/torghut/app/trading/discovery/replay_ledger_guided_search.py
@@ -1,0 +1,398 @@
+"""Apply exact replay-ledger remediation to follow-up search sweeps."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation, ROUND_CEILING, ROUND_DOWN
+from typing import Any, cast
+
+REPLAY_LEDGER_GUIDED_SEARCH_SCHEMA_VERSION = "torghut.replay-ledger-guided-search.v1"
+
+_BREADTH_BLOCKERS = frozenset(
+    {
+        "avg_filled_notional_per_day_below_min",
+        "window_net_pnl_per_day_below_target",
+    }
+)
+_CONCENTRATION_BLOCKER = "best_day_share_above_max"
+_EXPOSURE_BLOCKER = "max_single_fill_notional_pct_equity_above_max"
+_WINDOW_BLOCKER = "window_weekday_count_below_min_observed_trading_days"
+_BREADTH_PARAMETER_KEYS = (
+    "top_n",
+    "rank_count",
+    "max_pair_legs",
+    "max_entries_per_session",
+    "max_concurrent_positions",
+)
+_MAX_BREADTH_FACTOR = Decimal("4")
+_MAX_TOP_N = 12
+_MAX_ENTRY_COUNT = 12
+
+
+@dataclass(frozen=True)
+class ReplayLedgerGuidedSweep:
+    sweep_config: dict[str, Any]
+    applied_actions: tuple[str, ...]
+
+    @property
+    def applied(self) -> bool:
+        return bool(self.applied_actions)
+
+    @property
+    def mutation_label_suffix(self) -> str:
+        return "+".join(self.applied_actions)
+
+
+def apply_replay_ledger_remediation_guidance(
+    *,
+    sweep_config: Mapping[str, Any],
+    remediation_report: Mapping[str, Any] | None,
+) -> ReplayLedgerGuidedSweep:
+    """Convert exact replay-ledger blockers into bounded next-sweep adjustments."""
+
+    payload = _json_clone(sweep_config)
+    if remediation_report is None:
+        return ReplayLedgerGuidedSweep(sweep_config=payload, applied_actions=())
+
+    blockers = _search_blockers(remediation_report)
+    if not blockers:
+        return ReplayLedgerGuidedSweep(sweep_config=payload, applied_actions=())
+
+    policy = _policy_from_report(remediation_report)
+    actions: list[str] = []
+    parameter_changes: list[dict[str, str]] = []
+
+    if blockers & _BREADTH_BLOCKERS:
+        if _expand_breadth_parameters(
+            payload=payload,
+            multiplier=_search_breadth_multiplier(remediation_report),
+            parameter_changes=parameter_changes,
+        ):
+            actions.append("breadth")
+
+    if _CONCENTRATION_BLOCKER in blockers:
+        if _tighten_best_day_share(
+            payload=payload,
+            policy=policy,
+            parameter_changes=parameter_changes,
+        ):
+            actions.append("concentration")
+
+    if _EXPOSURE_BLOCKER in blockers:
+        if _tighten_exposure_caps(
+            payload=payload,
+            policy=policy,
+            parameter_changes=parameter_changes,
+        ):
+            actions.append("exposure")
+
+    if _WINDOW_BLOCKER in blockers:
+        actions.append("window")
+
+    if actions:
+        metadata = _mapping(payload.get("metadata"))
+        metadata["replay_ledger_guided_search"] = {
+            "schema_version": REPLAY_LEDGER_GUIDED_SEARCH_SCHEMA_VERSION,
+            "source_candidate_id": _string(remediation_report.get("candidate_id")),
+            "status": _string(remediation_report.get("status")),
+            "blockers": sorted(blockers),
+            "applied_actions": list(actions),
+            "parameter_changes": parameter_changes,
+            "metric_snapshot": dict(
+                _mapping(remediation_report.get("metric_snapshot"))
+            ),
+        }
+        payload["metadata"] = metadata
+
+    return ReplayLedgerGuidedSweep(
+        sweep_config=payload,
+        applied_actions=tuple(actions),
+    )
+
+
+def _json_clone(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(json.dumps(payload, default=str)))
+
+
+def _mapping(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    mapping = cast(Mapping[object, Any], value)
+    return {str(key): item for key, item in mapping.items()}
+
+
+def _string(value: object) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _string_list(value: object) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return ()
+    sequence = cast(Sequence[object], value)
+    return tuple(parsed for item in sequence if (parsed := _string(item)))
+
+
+def _decimal(value: object) -> Decimal | None:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+
+def _format_decimal(value: Decimal) -> str:
+    if value == 0:
+        return "0"
+    formatted = format(value.normalize(), "f")
+    if "." in formatted:
+        return formatted.rstrip("0").rstrip(".") or "0"
+    return formatted
+
+
+def _as_values(value: object) -> list[object]:
+    if isinstance(value, list):
+        return list(cast(list[object], value))
+    if value is None:
+        return []
+    return [value]
+
+
+def _positive_decimal_grid_values(value: object) -> tuple[Decimal, ...]:
+    decimals: list[Decimal] = []
+    for item in _as_values(value):
+        parsed = _decimal(item)
+        if parsed is not None and parsed > 0:
+            decimals.append(parsed)
+    return tuple(decimals)
+
+
+def _search_blockers(remediation_report: Mapping[str, Any]) -> set[str]:
+    blockers = {
+        *_string_list(remediation_report.get("promotion_blockers")),
+        *_string_list(remediation_report.get("runtime_ledger_blockers")),
+    }
+    blockers.discard("replay_artifact_only_not_live")
+    blockers.discard("exact_replay_ledger_candidate_missing")
+    return blockers
+
+
+def _policy_from_report(remediation_report: Mapping[str, Any]) -> dict[str, str]:
+    policy: dict[str, str] = {}
+    adjustments = _mapping(remediation_report.get("recommended_objective_adjustments"))
+    metric_snapshot = _mapping(remediation_report.get("metric_snapshot"))
+    for key in (
+        "max_best_day_share",
+        "max_gross_exposure_pct_equity",
+        "target_net_pnl_per_day",
+        "min_avg_filled_notional_per_day",
+        "start_equity",
+    ):
+        value = _string(adjustments.get(key)) or _string(metric_snapshot.get(key))
+        if value:
+            policy[key] = value
+    return policy
+
+
+def _search_breadth_multiplier(remediation_report: Mapping[str, Any]) -> Decimal:
+    multiplier = Decimal("2")
+    for action in _mapping_sequence(
+        remediation_report.get("recommended_search_actions")
+    ):
+        required = _decimal(action.get("required_multiplier"))
+        if required is not None and required > multiplier:
+            multiplier = required
+    return min(_MAX_BREADTH_FACTOR, multiplier)
+
+
+def _mapping_sequence(value: object) -> tuple[Mapping[str, Any], ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return ()
+    sequence = cast(Sequence[object], value)
+    return tuple(
+        cast(Mapping[str, Any], item) for item in sequence if isinstance(item, Mapping)
+    )
+
+
+def _ceil_to_int(value: Decimal) -> int:
+    return int(value.to_integral_value(rounding=ROUND_CEILING))
+
+
+def _expand_breadth_parameters(
+    *,
+    payload: dict[str, Any],
+    multiplier: Decimal,
+    parameter_changes: list[dict[str, str]],
+) -> bool:
+    parameters = _mapping(payload.get("parameters"))
+    changed = False
+    factor = max(2, _ceil_to_int(multiplier))
+    for key in _BREADTH_PARAMETER_KEYS:
+        if key not in parameters:
+            continue
+        maximum = _MAX_TOP_N if key in {"top_n", "rank_count"} else _MAX_ENTRY_COUNT
+        values = _expanded_positive_int_grid(
+            parameters.get(key),
+            factor=factor,
+            maximum=maximum,
+        )
+        if not values:
+            continue
+        before = _normalized_grid(parameters.get(key))
+        if values == before:
+            continue
+        parameters[key] = values
+        changed = True
+        parameter_changes.append(
+            {
+                "key": f"parameters.{key}",
+                "before": ",".join(before),
+                "after": ",".join(values),
+            }
+        )
+    if changed:
+        payload["parameters"] = parameters
+    return changed
+
+
+def _expanded_positive_int_grid(
+    value: object,
+    *,
+    factor: int,
+    maximum: int,
+) -> list[str]:
+    expanded: set[int] = set()
+    for item in _positive_decimal_grid_values(value):
+        current = max(1, _ceil_to_int(item))
+        expanded.add(min(maximum, current))
+        expanded.add(min(maximum, current * factor))
+    return [str(item) for item in sorted(expanded)]
+
+
+def _normalized_grid(value: object) -> list[str]:
+    return [_string(item) for item in _as_values(value) if _string(item)]
+
+
+def _tighten_best_day_share(
+    *,
+    payload: dict[str, Any],
+    policy: Mapping[str, str],
+    parameter_changes: list[dict[str, str]],
+) -> bool:
+    threshold = _decimal(policy.get("max_best_day_share"))
+    if threshold is None or threshold <= 0:
+        return False
+    consistency = _mapping(payload.get("consistency_constraints"))
+    before = _string(consistency.get("max_best_day_share_of_total_pnl"))
+    before_decimal = _decimal(before)
+    if before_decimal is not None and before_decimal <= threshold:
+        return False
+    after = _format_decimal(threshold)
+    consistency["max_best_day_share_of_total_pnl"] = after
+    payload["consistency_constraints"] = consistency
+    parameter_changes.append(
+        {
+            "key": "consistency_constraints.max_best_day_share_of_total_pnl",
+            "before": before,
+            "after": after,
+        }
+    )
+    return True
+
+
+def _tighten_exposure_caps(
+    *,
+    payload: dict[str, Any],
+    policy: Mapping[str, str],
+    parameter_changes: list[dict[str, str]],
+) -> bool:
+    max_gross = _decimal(policy.get("max_gross_exposure_pct_equity"))
+    if max_gross is None or max_gross <= 0:
+        return False
+    parameters = _mapping(payload.get("parameters"))
+    strategy_overrides = _mapping(payload.get("strategy_overrides"))
+    changed = False
+
+    changed |= _cap_grid(
+        container=parameters,
+        key="max_gross_exposure_pct_equity",
+        maximum=max_gross,
+        fallback=max_gross,
+        label="parameters.max_gross_exposure_pct_equity",
+        parameter_changes=parameter_changes,
+    )
+
+    max_entries = _max_entry_count(parameters)
+    per_entry_pct = (max_gross / Decimal(max_entries)).quantize(
+        Decimal("0.000001"),
+        rounding=ROUND_DOWN,
+    )
+    changed |= _cap_grid(
+        container=strategy_overrides,
+        key="max_position_pct_equity",
+        maximum=per_entry_pct,
+        fallback=per_entry_pct,
+        label="strategy_overrides.max_position_pct_equity",
+        parameter_changes=parameter_changes,
+    )
+
+    start_equity = _decimal(policy.get("start_equity"))
+    if start_equity is not None and start_equity > 0:
+        per_trade_notional = (start_equity * per_entry_pct).quantize(
+            Decimal("0.01"),
+            rounding=ROUND_DOWN,
+        )
+        changed |= _cap_grid(
+            container=strategy_overrides,
+            key="max_notional_per_trade",
+            maximum=per_trade_notional,
+            fallback=per_trade_notional,
+            label="strategy_overrides.max_notional_per_trade",
+            parameter_changes=parameter_changes,
+        )
+
+    if changed:
+        payload["parameters"] = parameters
+        payload["strategy_overrides"] = strategy_overrides
+    return changed
+
+
+def _cap_grid(
+    *,
+    container: dict[str, Any],
+    key: str,
+    maximum: Decimal,
+    fallback: Decimal,
+    label: str,
+    parameter_changes: list[dict[str, str]],
+) -> bool:
+    before = _normalized_grid(container.get(key))
+    kept = [
+        value
+        for value in _positive_decimal_grid_values(container.get(key))
+        if value <= maximum
+    ]
+    if not kept:
+        kept = [fallback]
+    after = [_format_decimal(value) for value in kept]
+    if after == before:
+        return False
+    container[key] = after
+    parameter_changes.append(
+        {
+            "key": label,
+            "before": ",".join(before),
+            "after": ",".join(after),
+        }
+    )
+    return True
+
+
+def _max_entry_count(parameters: Mapping[str, Any]) -> int:
+    for key in ("max_concurrent_positions", "max_pair_legs", "top_n", "rank_count"):
+        values = _positive_decimal_grid_values(parameters.get(key))
+        if values:
+            return max(1, min(_MAX_ENTRY_COUNT, _ceil_to_int(max(values))))
+    return 1

--- a/services/torghut/app/trading/discovery/replay_ledger_remediation.py
+++ b/services/torghut/app/trading/discovery/replay_ledger_remediation.py
@@ -287,6 +287,7 @@ def _metric_snapshot(
         "max_single_fill_notional_pct_equity": best_candidate.get(
             "max_single_fill_notional_pct_equity"
         ),
+        "start_equity": policy.get("start_equity"),
     }
     return {key: _string(value) for key, value in keys.items() if _string(value)}
 

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -68,6 +68,9 @@ from app.trading.discovery.replay_ledger_ranker import (
     build_replay_ledger_ranking_report,
     default_replay_ledger_ranking_policy,
 )
+from app.trading.discovery.replay_ledger_guided_search import (
+    apply_replay_ledger_remediation_guidance,
+)
 from app.trading.discovery.replay_ledger_remediation import (
     build_replay_ledger_remediation_report,
 )
@@ -419,6 +422,24 @@ def _apply_objective_capital_limits(
     payload["parameters"] = parameters
     payload["strategy_overrides"] = strategy_overrides
     return payload
+
+
+def _apply_exact_replay_guidance_to_next_sweep(
+    *,
+    sweep_config: Mapping[str, Any],
+    mutation_label: str,
+    remediation_report: Mapping[str, Any],
+) -> tuple[dict[str, Any], str]:
+    guided_sweep = apply_replay_ledger_remediation_guidance(
+        sweep_config=sweep_config,
+        remediation_report=remediation_report,
+    )
+    if not guided_sweep.applied:
+        return guided_sweep.sweep_config, mutation_label
+    return (
+        guided_sweep.sweep_config,
+        f"{mutation_label}; replay-guidance={guided_sweep.mutation_label_suffix}",
+    )
 
 
 def _slug(value: str) -> str:
@@ -2033,7 +2054,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
     manifest = _refresh_manifest()
     frontier_runs = 0
     objective_met = False
-    _persist_run_outputs(
+    summary = _persist_run_outputs(
         run_root=run_root,
         program=program,
         program_payload=program.to_payload(),
@@ -2048,6 +2069,9 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         worklist=worklist,
         status="running",
         closure_execution_context=closure_execution_context,
+    )
+    latest_exact_replay_ledger_remediation = _mapping(
+        summary.get("exact_replay_ledger_remediation")
     )
     signal_bundle_stats, materialized_replay_tape_receipt = (
         _maybe_materialize_run_replay_tape(
@@ -2101,7 +2125,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         }
     )
     manifest = _refresh_manifest()
-    _persist_run_outputs(
+    summary = _persist_run_outputs(
         run_root=run_root,
         program=program,
         program_payload=program.to_payload(),
@@ -2116,6 +2140,9 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
         worklist=worklist,
         status="running",
         closure_execution_context=closure_execution_context,
+    )
+    latest_exact_replay_ledger_remediation = _mapping(
+        summary.get("exact_replay_ledger_remediation")
     )
     try:
         while worklist:
@@ -2186,7 +2213,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                 if selected_score is not None
                 else None
             )
-            _persist_run_outputs(
+            summary = _persist_run_outputs(
                 run_root=run_root,
                 program=program,
                 program_payload=program.to_payload(),
@@ -2203,6 +2230,9 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                 selected_for_replay=selected_for_replay,
                 selected_descriptor=current_descriptor,
                 closure_execution_context=closure_execution_context,
+            )
+            latest_exact_replay_ledger_remediation = _mapping(
+                summary.get("exact_replay_ledger_remediation")
             )
             try:
                 frontier_payload = run_consistent_profitability_frontier(
@@ -2257,7 +2287,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                     json.dumps(frontier_payload, indent=2, sort_keys=True),
                     encoding="utf-8",
                 )
-                _persist_run_outputs(
+                summary = _persist_run_outputs(
                     run_root=run_root,
                     program=program,
                     program_payload=program.to_payload(),
@@ -2273,10 +2303,26 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                     status="running",
                     closure_execution_context=closure_execution_context,
                 )
+                latest_exact_replay_ledger_remediation = _mapping(
+                    summary.get("exact_replay_ledger_remediation")
+                )
                 continue
             result_path.write_text(
                 json.dumps(frontier_payload, indent=2, sort_keys=True),
                 encoding="utf-8",
+            )
+            exact_replay_ledger_ranking = _write_exact_replay_ledger_ranking(
+                run_root=run_root,
+                program=program,
+            )
+            exact_replay_ledger_remediation = _write_exact_replay_ledger_remediation(
+                run_root=run_root,
+                ranking_report=cast(
+                    Mapping[str, Any], exact_replay_ledger_ranking["report"]
+                ),
+            )
+            latest_exact_replay_ledger_remediation = _mapping(
+                exact_replay_ledger_remediation["report"]
             )
             dataset_snapshot_id = _string(
                 _mapping(frontier_payload.get("dataset_snapshot_receipt")).get(
@@ -2436,6 +2482,14 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                     holdout_day_count=max(1, int(args.holdout_days)),
                     full_window_day_count=_default_full_window_day_count(args),
                 )
+                (
+                    next_sweep_config,
+                    mutation_label,
+                ) = _apply_exact_replay_guidance_to_next_sweep(
+                    sweep_config=next_sweep_config,
+                    mutation_label=mutation_label,
+                    remediation_report=latest_exact_replay_ledger_remediation,
+                )
                 next_sweep_config = _apply_objective_capital_limits(
                     sweep_config=next_sweep_config,
                     max_gross_exposure_pct_equity=program.objective.max_gross_exposure_pct_equity,
@@ -2450,7 +2504,7 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                         parent_candidate_id=candidate_id,
                     )
                 )
-            _persist_run_outputs(
+            summary = _persist_run_outputs(
                 run_root=run_root,
                 program=program,
                 program_payload=program.to_payload(),
@@ -2465,6 +2519,9 @@ def run_strategy_autoresearch_loop(args: argparse.Namespace) -> dict[str, Any]:
                 worklist=worklist,
                 status="running",
                 closure_execution_context=closure_execution_context,
+            )
+            latest_exact_replay_ledger_remediation = _mapping(
+                summary.get("exact_replay_ledger_remediation")
             )
             if objective_met and program.objective.stop_when_objective_met:
                 break

--- a/services/torghut/tests/test_replay_ledger_guided_search.py
+++ b/services/torghut/tests/test_replay_ledger_guided_search.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from unittest import TestCase
+
+from app.trading.discovery.replay_ledger_guided_search import (
+    apply_replay_ledger_remediation_guidance,
+)
+
+
+class TestReplayLedgerGuidedSearch(TestCase):
+    def test_search_blockers_expand_breadth_and_tighten_risk(self) -> None:
+        result = apply_replay_ledger_remediation_guidance(
+            sweep_config={
+                "schema_version": "torghut.replay-frontier-sweep.v1",
+                "consistency_constraints": {
+                    "max_best_day_share_of_total_pnl": "0.55",
+                },
+                "parameters": {
+                    "top_n": ["1", "2"],
+                    "max_pair_legs": ["2"],
+                    "max_entries_per_session": ["1"],
+                    "max_gross_exposure_pct_equity": ["6.0", "8.0"],
+                },
+                "strategy_overrides": {
+                    "max_position_pct_equity": ["6.0", "8.0"],
+                    "max_notional_per_trade": ["157950.10"],
+                },
+            },
+            remediation_report={
+                "status": "blocked_pending_search_remediation",
+                "candidate_id": "candidate-1",
+                "promotion_blockers": [
+                    "replay_artifact_only_not_live",
+                    "avg_filled_notional_per_day_below_min",
+                    "best_day_share_above_max",
+                    "max_single_fill_notional_pct_equity_above_max",
+                ],
+                "runtime_ledger_blockers": [],
+                "recommended_objective_adjustments": {
+                    "max_best_day_share": "0.25",
+                    "max_gross_exposure_pct_equity": "1.0",
+                    "start_equity": "31590.02",
+                },
+                "recommended_search_actions": [
+                    {
+                        "action": "increase_tradeable_breadth_without_raising_single_fill_exposure",
+                        "required_multiplier": "1.9",
+                    }
+                ],
+                "metric_snapshot": {
+                    "avg_filled_notional_per_window_weekday": "159425.58",
+                    "best_day_share": "1",
+                    "max_single_fill_notional_pct_equity": "5.08",
+                },
+            },
+        )
+
+        self.assertTrue(result.applied)
+        self.assertEqual(
+            result.applied_actions,
+            ("breadth", "concentration", "exposure"),
+        )
+        self.assertEqual(result.sweep_config["parameters"]["top_n"], ["1", "2", "4"])
+        self.assertEqual(result.sweep_config["parameters"]["max_pair_legs"], ["2", "4"])
+        self.assertEqual(
+            result.sweep_config["parameters"]["max_entries_per_session"],
+            ["1", "2"],
+        )
+        self.assertEqual(
+            result.sweep_config["consistency_constraints"][
+                "max_best_day_share_of_total_pnl"
+            ],
+            "0.25",
+        )
+        self.assertEqual(
+            result.sweep_config["parameters"]["max_gross_exposure_pct_equity"],
+            ["1"],
+        )
+        self.assertEqual(
+            result.sweep_config["strategy_overrides"]["max_position_pct_equity"],
+            ["0.25"],
+        )
+        self.assertEqual(
+            result.sweep_config["strategy_overrides"]["max_notional_per_trade"],
+            ["7897.5"],
+        )
+        self.assertEqual(
+            result.sweep_config["metadata"]["replay_ledger_guided_search"][
+                "source_candidate_id"
+            ],
+            "candidate-1",
+        )
+
+    def test_runtime_only_blocker_does_not_mutate_search(self) -> None:
+        result = apply_replay_ledger_remediation_guidance(
+            sweep_config={"parameters": {"top_n": ["2"]}},
+            remediation_report={
+                "status": "blocked_pending_runtime_promotion_proof",
+                "promotion_blockers": ["replay_artifact_only_not_live"],
+                "runtime_ledger_blockers": [],
+            },
+        )
+
+        self.assertFalse(result.applied)
+        self.assertEqual(result.sweep_config, {"parameters": {"top_n": ["2"]}})
+
+    def test_window_blocker_is_recorded_without_guessing_dates(self) -> None:
+        result = apply_replay_ledger_remediation_guidance(
+            sweep_config={"parameters": {"entry_cooldown_seconds": ["600"]}},
+            remediation_report={
+                "status": "blocked_pending_search_remediation",
+                "candidate_id": "candidate-short-window",
+                "promotion_blockers": [
+                    "window_weekday_count_below_min_observed_trading_days"
+                ],
+                "runtime_ledger_blockers": [],
+                "metric_snapshot": {"window_weekday_count": "2"},
+            },
+        )
+
+        self.assertTrue(result.applied)
+        self.assertEqual(result.applied_actions, ("window",))
+        self.assertEqual(
+            result.sweep_config["metadata"]["replay_ledger_guided_search"]["blockers"],
+            ["window_weekday_count_below_min_observed_trading_days"],
+        )

--- a/services/torghut/tests/test_replay_ledger_remediation.py
+++ b/services/torghut/tests/test_replay_ledger_remediation.py
@@ -18,6 +18,7 @@ class TestReplayLedgerRemediation(TestCase):
                     "min_avg_filled_notional_per_day": "300000",
                     "max_best_day_share": "0.25",
                     "max_gross_exposure_pct_equity": "0.05",
+                    "start_equity": "31590.02",
                 },
                 "candidates": [
                     {
@@ -57,6 +58,7 @@ class TestReplayLedgerRemediation(TestCase):
             ],
             "300000",
         )
+        self.assertEqual(report["metric_snapshot"]["start_equity"], "31590.02")
         actions = {item["action"] for item in report["recommended_search_actions"]}
         self.assertIn(
             "run_runtime_closure_then_live_paper_ledger_validation",

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -138,6 +138,45 @@ class TestStrategyAutoresearch(TestCase):
         )
         self.assertEqual(limited["parameters"]["max_entries_per_session"], ["12"])
 
+    def test_exact_replay_guidance_updates_next_sweep_label(self) -> None:
+        sweep, label = runner._apply_exact_replay_guidance_to_next_sweep(
+            sweep_config={
+                "parameters": {
+                    "max_entries_per_session": ["1"],
+                },
+            },
+            mutation_label="parent=candidate-1; mutate=max_entries_per_session",
+            remediation_report={
+                "status": "blocked_pending_search_remediation",
+                "candidate_id": "candidate-1",
+                "promotion_blockers": ["avg_filled_notional_per_day_below_min"],
+                "runtime_ledger_blockers": [],
+                "recommended_search_actions": [{"required_multiplier": "2.0"}],
+            },
+        )
+
+        self.assertEqual(sweep["parameters"]["max_entries_per_session"], ["1", "2"])
+        self.assertEqual(
+            label,
+            "parent=candidate-1; mutate=max_entries_per_session; replay-guidance=breadth",
+        )
+
+    def test_exact_replay_guidance_keeps_label_when_no_search_blocker(self) -> None:
+        sweep, label = runner._apply_exact_replay_guidance_to_next_sweep(
+            sweep_config={"parameters": {"max_entries_per_session": ["1"]}},
+            mutation_label="parent=candidate-1; mutate=max_entries_per_session",
+            remediation_report={
+                "promotion_blockers": ["replay_artifact_only_not_live"],
+                "runtime_ledger_blockers": [],
+            },
+        )
+
+        self.assertEqual(sweep["parameters"]["max_entries_per_session"], ["1"])
+        self.assertEqual(
+            label,
+            "parent=candidate-1; mutate=max_entries_per_session",
+        )
+
     def test_runtime_closure_candidate_rejects_failed_or_vetoed_candidates(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds replay-ledger guided search adjustments that convert exact replay blockers into bounded next-sweep breadth, concentration, exposure, and window metadata actions.
- Refreshes exact replay-ledger remediation immediately after each frontier result so child mutations use current blockers instead of waiting another generation.
- Includes `start_equity` in remediation metric snapshots so guided exposure caps can compute per-trade notional limits from the evidence report.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_replay_ledger_guided_search.py tests/test_replay_ledger_remediation.py tests/test_strategy_autoresearch.py -q`
- `uv run --frozen pytest tests/test_replay_ledger_guided_search.py tests/test_replay_ledger_remediation.py tests/test_strategy_autoresearch.py --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen ruff check app/trading/discovery/replay_ledger_guided_search.py app/trading/discovery/replay_ledger_remediation.py tests/test_replay_ledger_guided_search.py tests/test_replay_ledger_remediation.py tests/test_strategy_autoresearch.py scripts/run_strategy_autoresearch_loop.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
