### PR TITLE
chore(torghut): promote image f69d756f

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-689-g6d22b6a3a
+              value: v0.571.1-692-gf69d756f1
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 6d22b6a3ac91089796402c5694f7720d6a6f5f0b
+              value: f69d756f1aa987d1c023e5613f89e4f9867e9bd2
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-689-g6d22b6a3a
+              value: v0.571.1-692-gf69d756f1
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 6d22b6a3ac91089796402c5694f7720d6a6f5f0b
+              value: f69d756f1aa987d1c023e5613f89e4f9867e9bd2
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -75,7 +75,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+                  value: sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-23T12:16:31Z"
+        client.knative.dev/updateTimestamp: "2026-05-23T12:48:58Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
           ports:
             - name: http1
               containerPort: 8181
@@ -499,11 +499,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-689-g6d22b6a3a
+              value: v0.571.1-692-gf69d756f1
             - name: TORGHUT_COMMIT
-              value: 6d22b6a3ac91089796402c5694f7720d6a6f5f0b
+              value: f69d756f1aa987d1c023e5613f89e4f9867e9bd2
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+              value: sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-23T12:16:31Z"
+        client.knative.dev/updateTimestamp: "2026-05-23T12:48:58Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
           ports:
             - name: http1
               containerPort: 8181
@@ -320,11 +320,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-689-g6d22b6a3a
+              value: v0.571.1-692-gf69d756f1
             - name: TORGHUT_COMMIT
-              value: 6d22b6a3ac91089796402c5694f7720d6a6f5f0b
+              value: f69d756f1aa987d1c023e5613f89e4f9867e9bd2
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+              value: sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -132,7 +132,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:b01ece284c93f9bd9c11594389d5f68f71e887120f16a3f845d0b774540160cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `f69d756f1aa987d1c023e5613f89e4f9867e9bd2`
- Image tag: `f69d756f`
- Image digest: `sha256:049bca6f525127525629dd8032aa358f310afb4c3131a8712ed6374f103c0ad6`