### PR TITLE
fix(torghut): preserve replay proof handoff targets

### DIFF
--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -45,6 +45,15 @@ DEFAULT_AUTORESEARCH_RUNTIME_WINDOW_STATUSES = (
 RUNTIME_WINDOW_TARGET_METADATA_KEYS = (
     "candidate_spec_id",
     "candidate_selection",
+    "runtime_ledger_artifact_refs",
+    "runtime_ledger_artifact_ref",
+    "exact_replay_ledger_artifact_refs",
+    "exact_replay_ledger_artifact_ref",
+    "runtime_ledger_artifact_row_count",
+    "runtime_ledger_artifact_fill_count",
+    "runtime_ledger_target_metadata_blockers",
+    "window_start",
+    "window_end",
     "paper_probation_authorized",
     "paper_probation_authorization_scope",
     "evidence_collection_stage",
@@ -287,6 +296,8 @@ class RuntimeWindowImportTarget:
     source_manifest_ref: str
     source_kind: str
     delay_adjusted_depth_stress_report_ref: str
+    window_start: str = ""
+    window_end: str = ""
     artifact_refs: tuple[str, ...] = ()
     target_metadata: Mapping[str, Any] | None = None
 
@@ -432,6 +443,8 @@ def _registry_runtime_window_targets(
                 ).strip()
                 or "paper_runtime_observed",
                 delay_adjusted_depth_stress_report_ref="",
+                window_start="",
+                window_end="",
             )
         )
     return targets
@@ -515,6 +528,8 @@ def _runtime_window_targets_from_plan(
                     "delay_adjusted_depth_stress_report_ref",
                     "runtime_window_delay_adjusted_depth_stress_report_ref",
                 ),
+                window_start=str(payload.get("window_start") or "").strip(),
+                window_end=str(payload.get("window_end") or "").strip(),
                 artifact_refs=_runtime_window_target_artifact_refs(payload),
                 target_metadata=_runtime_window_target_metadata(payload),
             )
@@ -523,14 +538,23 @@ def _runtime_window_targets_from_plan(
 
 
 def _runtime_window_target_artifact_refs(payload: Mapping[str, Any]) -> tuple[str, ...]:
-    raw_refs = payload.get("artifact_refs")
-    if not isinstance(raw_refs, Sequence) or isinstance(
-        raw_refs, (str, bytes, bytearray)
-    ):
-        return ()
     refs: list[str] = []
-    for item in raw_refs:
-        ref = _as_text(item)
+    for key in (
+        "artifact_refs",
+        "runtime_ledger_artifact_refs",
+        "exact_replay_ledger_artifact_refs",
+    ):
+        raw_refs = payload.get(key)
+        if not isinstance(raw_refs, Sequence) or isinstance(
+            raw_refs, (str, bytes, bytearray)
+        ):
+            continue
+        for item in raw_refs:
+            ref = _as_text(item)
+            if ref is not None and ref not in refs:
+                refs.append(ref)
+    for key in ("runtime_ledger_artifact_ref", "exact_replay_ledger_artifact_ref"):
+        ref = _as_text(payload.get(key))
         if ref is not None and ref not in refs:
             refs.append(ref)
     return tuple(refs)
@@ -674,6 +698,8 @@ def _runtime_window_targets(
                     "delay_adjusted_depth_stress_report_ref",
                     "runtime_window_delay_adjusted_depth_stress_report_ref",
                 ),
+                window_start=value("window_start", "runtime_window_start"),
+                window_end=value("window_end", "runtime_window_end"),
             )
         )
     seen_hypothesis_ids = {target.hypothesis_id for target in targets}
@@ -736,6 +762,28 @@ def _runtime_window_bounds(
             raise RuntimeError("runtime_window_end_must_be_after_start")
         return start, end
     return _latest_completed_regular_session(now)
+
+
+def _runtime_window_target_plan_bounds(
+    target: RuntimeWindowImportTarget,
+) -> tuple[datetime, datetime] | None:
+    start_arg = str(target.window_start or "").strip()
+    end_arg = str(target.window_end or "").strip()
+    if bool(start_arg) != bool(end_arg):
+        raise RuntimeError(
+            "runtime_window_target_plan_bounds_require_start_and_end:"
+            f"{target.hypothesis_id}:{target.candidate_id}"
+        )
+    if not start_arg or not end_arg:
+        return None
+    start = _parse_dt(start_arg)
+    end = _parse_dt(end_arg)
+    if end <= start:
+        raise RuntimeError(
+            "runtime_window_target_plan_end_must_be_after_start:"
+            f"{target.hypothesis_id}:{target.candidate_id}"
+        )
+    return start, end
 
 
 def _explicit_runtime_window_bounds(
@@ -998,7 +1046,11 @@ def _run_runtime_window_import_target(
 ) -> dict[str, Any]:
     runtime_manifest = _read_runtime_window_manifest(target.source_manifest_ref)
     window_selection = "explicit_or_default"
-    if allow_source_activity_window:
+    target_plan_window = _runtime_window_target_plan_bounds(target)
+    if target_plan_window is not None:
+        window_start, window_end = target_plan_window
+        window_selection = "target_plan_window"
+    elif allow_source_activity_window:
         source_activity_window = _latest_source_activity_window(
             target=target,
             runtime_manifest=runtime_manifest,

--- a/services/torghut/scripts/run_strategy_autoresearch_loop.py
+++ b/services/torghut/scripts/run_strategy_autoresearch_loop.py
@@ -1166,6 +1166,38 @@ def _history_record(
             or full_window.get("max_gross_exposure_pct_equity")
         ),
         "min_cash": _string(scorecard.get("min_cash") or full_window.get("min_cash")),
+        "exact_replay_ledger_artifact_ref": _string(
+            scorecard.get("exact_replay_ledger_artifact_ref")
+            or candidate_payload.get("exact_replay_ledger_artifact_ref")
+        ),
+        "runtime_ledger_artifact_ref": _string(
+            scorecard.get("runtime_ledger_artifact_ref")
+            or candidate_payload.get("runtime_ledger_artifact_ref")
+        ),
+        "exact_replay_ledger_artifact_row_count": _string(
+            scorecard.get("exact_replay_ledger_artifact_row_count")
+            or candidate_payload.get("exact_replay_ledger_artifact_row_count")
+        ),
+        "exact_replay_ledger_artifact_fill_count": _string(
+            scorecard.get("exact_replay_ledger_artifact_fill_count")
+            or candidate_payload.get("exact_replay_ledger_artifact_fill_count")
+        ),
+        "runtime_ledger_artifact_row_count": _string(
+            scorecard.get("runtime_ledger_artifact_row_count")
+            or candidate_payload.get("runtime_ledger_artifact_row_count")
+        ),
+        "runtime_ledger_artifact_fill_count": _string(
+            scorecard.get("runtime_ledger_artifact_fill_count")
+            or candidate_payload.get("runtime_ledger_artifact_fill_count")
+        ),
+        "runtime_ledger_pnl_basis": _string(
+            scorecard.get("runtime_ledger_pnl_basis")
+            or candidate_payload.get("runtime_ledger_pnl_basis")
+        ),
+        "runtime_ledger_pnl_source": _string(
+            scorecard.get("runtime_ledger_pnl_source")
+            or candidate_payload.get("runtime_ledger_pnl_source")
+        ),
         "negative_cash_observation_count": int(
             scorecard.get("negative_cash_observation_count")
             or full_window.get("negative_cash_observation_count")
@@ -1252,6 +1284,310 @@ def _best_history_record(history: list[dict[str, Any]]) -> dict[str, Any] | None
         ),
     )
     return sorted_history[0]
+
+
+def _strategy_name_from_strategy_id(strategy_id: str) -> str:
+    base = strategy_id.split("@", 1)[0].strip()
+    return base.replace("_", "-") if base else ""
+
+
+def _hypothesis_manifest_rows() -> list[dict[str, str]]:
+    hypothesis_dir = _REPO_ROOT / "services/torghut/config/trading/hypotheses"
+    rows: list[dict[str, str]] = []
+    if not hypothesis_dir.exists():
+        return rows
+    for path in sorted(hypothesis_dir.glob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        data = _mapping(payload)
+        hypothesis_id = _string(data.get("hypothesis_id"))
+        if not hypothesis_id:
+            continue
+        strategy_id = _string(data.get("strategy_id"))
+        rows.append(
+            {
+                "hypothesis_id": hypothesis_id,
+                "strategy_id": strategy_id,
+                "strategy_id_base": strategy_id.split("@", 1)[0].strip(),
+                "strategy_name": _string(data.get("strategy_name"))
+                or _strategy_name_from_strategy_id(strategy_id),
+                "strategy_family": _string(data.get("strategy_family")),
+                "candidate_id": _string(data.get("candidate_id")),
+                "dataset_snapshot_ref": _string(data.get("dataset_snapshot_ref")),
+                "source_manifest_ref": str(path),
+            }
+        )
+    return rows
+
+
+def _hypothesis_manifest_for_history_row(
+    row: Mapping[str, Any],
+) -> dict[str, str]:
+    family_template_id = _string(row.get("family_template_id"))
+    runtime_family = _string(row.get("runtime_family"))
+    runtime_strategy_name = _string(row.get("runtime_strategy_name"))
+    for manifest in _hypothesis_manifest_rows():
+        if family_template_id and manifest["strategy_id_base"] == family_template_id:
+            return manifest
+    for manifest in _hypothesis_manifest_rows():
+        if runtime_family and manifest["strategy_family"] == runtime_family:
+            return manifest
+    for manifest in _hypothesis_manifest_rows():
+        if runtime_strategy_name and manifest["strategy_name"] == runtime_strategy_name:
+            return manifest
+    return {}
+
+
+def _dedupe_nonempty_strings(values: list[Any]) -> list[str]:
+    items: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = _string(value)
+        if not text:
+            continue
+        key = (
+            str(Path(text).expanduser().resolve(strict=False))
+            if text.startswith("/")
+            else text
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        items.append(text)
+    return items
+
+
+def _exact_replay_history_row(
+    *,
+    history: list[dict[str, Any]],
+    candidate_id: str,
+) -> dict[str, Any] | None:
+    for row in history:
+        if _string(row.get("candidate_id")) == candidate_id:
+            return row
+    return None
+
+
+def _exact_replay_runtime_window_blockers(
+    *,
+    best_exact_replay_ledger_candidate: Mapping[str, Any] | None,
+    history_row: Mapping[str, Any] | None,
+    hypothesis_manifest: Mapping[str, str],
+    artifact_refs: list[str],
+    promotion_blockers: list[str],
+    runtime_ledger_blockers: list[str],
+) -> list[dict[str, Any]]:
+    blockers: list[dict[str, Any]] = []
+    if best_exact_replay_ledger_candidate is None:
+        blockers.append(
+            {
+                "blocker": "exact_replay_ledger_candidate_missing",
+                "remediation": "produce_exact_replay_ledger_artifacts",
+            }
+        )
+        return blockers
+    candidate_id = _string(best_exact_replay_ledger_candidate.get("candidate_id"))
+    if history_row is None:
+        blockers.append(
+            {
+                "blocker": "candidate_history_row_missing",
+                "candidate_id": candidate_id,
+                "remediation": "rerun_strategy_autoresearch_with_history_persistence",
+            }
+        )
+    if not hypothesis_manifest:
+        blockers.append(
+            {
+                "blocker": "hypothesis_manifest_missing",
+                "candidate_id": candidate_id,
+                "remediation": (
+                    "add or select a checked-in hypothesis manifest before runtime "
+                    "paper evidence can be imported"
+                ),
+            }
+        )
+    if history_row is not None:
+        missing_fields = [
+            field
+            for field in ("runtime_family", "runtime_strategy_name")
+            if not _string(history_row.get(field))
+        ]
+        if missing_fields:
+            blockers.append(
+                {
+                    "blocker": "runtime_harness_metadata_missing",
+                    "candidate_id": candidate_id,
+                    "missing_fields": missing_fields,
+                }
+            )
+    if not artifact_refs:
+        blockers.append(
+            {
+                "blocker": "runtime_ledger_artifact_ref_missing",
+                "candidate_id": candidate_id,
+                "remediation": "enable exact replay ledger artifact output",
+            }
+        )
+    blocker_names = _dedupe_nonempty_strings(
+        [*promotion_blockers, *runtime_ledger_blockers]
+    )
+    search_blockers = [
+        blocker
+        for blocker in blocker_names
+        if blocker != "replay_artifact_only_not_live"
+    ]
+    if search_blockers:
+        blockers.append(
+            {
+                "blocker": "exact_replay_search_blockers_remaining",
+                "candidate_id": candidate_id,
+                "blocking_reasons": search_blockers,
+                "remediation": (
+                    "keep search remediation active; any runtime-window target is "
+                    "evidence collection only and cannot authorize promotion"
+                ),
+            }
+        )
+    return blockers
+
+
+def _strategy_autoresearch_runtime_window_import_plan(
+    *,
+    history: list[dict[str, Any]],
+    best_exact_replay_ledger_candidate: Mapping[str, Any] | None,
+    exact_replay_ledger_remediation: Mapping[str, Any],
+) -> dict[str, Any]:
+    candidate_id = (
+        _string(best_exact_replay_ledger_candidate.get("candidate_id"))
+        if best_exact_replay_ledger_candidate is not None
+        else ""
+    )
+    history_row = (
+        _exact_replay_history_row(history=history, candidate_id=candidate_id)
+        if candidate_id
+        else None
+    )
+    hypothesis_manifest = (
+        _hypothesis_manifest_for_history_row(history_row)
+        if history_row is not None
+        else {}
+    )
+    promotion_blockers = [
+        _string(item)
+        for item in cast(
+            list[Any],
+            exact_replay_ledger_remediation.get("promotion_blockers") or [],
+        )
+        if _string(item)
+    ]
+    runtime_ledger_blockers = [
+        _string(item)
+        for item in cast(
+            list[Any],
+            exact_replay_ledger_remediation.get("runtime_ledger_blockers") or [],
+        )
+        if _string(item)
+    ]
+    artifact_refs = _dedupe_nonempty_strings(
+        [
+            best_exact_replay_ledger_candidate.get("artifact_ref")
+            if best_exact_replay_ledger_candidate is not None
+            else "",
+            history_row.get("runtime_ledger_artifact_ref") if history_row else "",
+            history_row.get("exact_replay_ledger_artifact_ref") if history_row else "",
+        ]
+    )
+    blockers = _exact_replay_runtime_window_blockers(
+        best_exact_replay_ledger_candidate=best_exact_replay_ledger_candidate,
+        history_row=history_row,
+        hypothesis_manifest=hypothesis_manifest,
+        artifact_refs=artifact_refs,
+        promotion_blockers=promotion_blockers,
+        runtime_ledger_blockers=runtime_ledger_blockers,
+    )
+    targets: list[dict[str, Any]] = []
+    if (
+        best_exact_replay_ledger_candidate is not None
+        and history_row is not None
+        and hypothesis_manifest
+        and artifact_refs
+    ):
+        target_metadata_blockers = _dedupe_nonempty_strings(
+            [
+                *promotion_blockers,
+                *runtime_ledger_blockers,
+                "paper_probation_evidence_collection_only",
+            ]
+        )
+        row_count = _string(history_row.get("runtime_ledger_artifact_row_count"))
+        fill_count = _string(history_row.get("runtime_ledger_artifact_fill_count"))
+        search_blockers = [
+            blocker
+            for blocker in _dedupe_nonempty_strings(
+                [*promotion_blockers, *runtime_ledger_blockers]
+            )
+            if blocker != "replay_artifact_only_not_live"
+        ]
+        probation_allowed = not search_blockers
+        window_start = _string(best_exact_replay_ledger_candidate.get("window_start"))
+        window_end = _string(best_exact_replay_ledger_candidate.get("window_end"))
+        target = {
+            "run_id": _string(history_row.get("runner_run_id"))
+            or "strategy-autoresearch-runtime-window-import",
+            "candidate_id": candidate_id,
+            "hypothesis_id": hypothesis_manifest["hypothesis_id"],
+            "observed_stage": "paper",
+            "strategy_family": _string(history_row.get("runtime_family")),
+            "strategy_name": _string(history_row.get("runtime_strategy_name")),
+            "account_label": "TORGHUT_REPLAY",
+            "source_kind": "simulation_exact_replay_runtime_ledger",
+            "source_manifest_ref": hypothesis_manifest["source_manifest_ref"],
+            "dataset_snapshot_ref": _string(history_row.get("dataset_snapshot_id"))
+            or hypothesis_manifest["dataset_snapshot_ref"],
+            "artifact_refs": artifact_refs,
+            "runtime_ledger_artifact_refs": artifact_refs,
+            "runtime_ledger_artifact_ref": artifact_refs[0],
+            "exact_replay_ledger_artifact_ref": artifact_refs[0],
+            "window_start": window_start,
+            "window_end": window_end,
+            "candidate_selection": "exact_replay_ledger_best_candidate",
+            "selected_by": "strategy_autoresearch_exact_replay_ledger_ranking",
+            "selection_reason": _string(
+                exact_replay_ledger_remediation.get("status")
+            ),
+            "paper_probation_authorized": probation_allowed,
+            "paper_probation_authorization_scope": "evidence_collection_only",
+            "evidence_collection_stage": "paper",
+            "probation_allowed": probation_allowed,
+            "probation_reason": "exact_replay_policy_checks_passed"
+            if probation_allowed
+            else "exact_replay_search_blockers_remaining",
+            "promotion_allowed": False,
+            "final_promotion_authorized": False,
+            "final_promotion_allowed": False,
+            "final_promotion_blockers": target_metadata_blockers,
+            "runtime_ledger_target_metadata_blockers": target_metadata_blockers,
+            "handoff": "runtime_window_import_from_exact_replay_ledger",
+            "promotion_gate": "runtime_ledger_live_or_live_paper_required",
+        }
+        if row_count:
+            target["runtime_ledger_artifact_row_count"] = row_count
+        if fill_count:
+            target["runtime_ledger_artifact_fill_count"] = fill_count
+        targets.append(target)
+    return {
+        "schema_version": "torghut.runtime-window-import-plan.v1",
+        "source": "strategy_autoresearch_exact_replay_ledger",
+        "purpose": (
+            "handoff exact replay-ledger winners into bounded paper/runtime-window "
+            "evidence collection without authorizing final promotion"
+        ),
+        "promotion_allowed": False,
+        "targets": targets,
+        "blockers": blockers,
+    }
 
 
 def _runtime_closure_candidate(
@@ -1934,6 +2270,33 @@ def _persist_run_outputs(
         portfolio=portfolio,
         runtime_closure=summary["runtime_closure"],
     )
+    runtime_window_import_plan = _strategy_autoresearch_runtime_window_import_plan(
+        history=history,
+        best_exact_replay_ledger_candidate=cast(
+            Mapping[str, Any] | None,
+            exact_replay_ledger_ranking["best_candidate"],
+        ),
+        exact_replay_ledger_remediation=cast(
+            Mapping[str, Any],
+            exact_replay_ledger_remediation["report"],
+        ),
+    )
+    summary["runtime_window_import_plan"] = runtime_window_import_plan
+    summary["candidate_board"] = {
+        "schema_version": "torghut.strategy-autoresearch-candidate-board.v1",
+        "current_answer": "promotion_candidate_found"
+        if bool(_mapping(summary["promotion_readiness"]).get("promotable"))
+        else "no_promotion_ready_candidate",
+        "promotion_allowed": False,
+        "best_research_candidate": best_candidate,
+        "best_exact_replay_ledger_candidate": summary[
+            "best_exact_replay_ledger_candidate"
+        ],
+        "exact_replay_ledger_remediation": summary[
+            "exact_replay_ledger_remediation"
+        ],
+        "runtime_window_import_plan": runtime_window_import_plan,
+    }
     if error is not None:
         summary["error"] = dict(error)
     promotion_readiness_path.write_text(

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -540,6 +540,84 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             },
         )
 
+    def test_runtime_window_targets_from_plan_preserve_exact_replay_artifact_handoff(
+        self,
+    ) -> None:
+        plan_path = Path(self.tmp_dir) / "candidate-board.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "runtime_window_import_plan": {
+                        "schema_version": "torghut.runtime-window-import-plan.v1",
+                        "targets": [
+                            {
+                                "candidate_id": "cand-exact-replay",
+                                "hypothesis_id": "H-PAIRS-01",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                                "source_kind": "simulation_exact_replay_runtime_ledger",
+                                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                                "dataset_snapshot_ref": "snapshot-exact",
+                                "artifact_refs": ["proof/replay-summary.json"],
+                                "runtime_ledger_artifact_ref": "proof/exact-replay-ledger.json",
+                                "runtime_ledger_artifact_row_count": 12,
+                                "runtime_ledger_artifact_fill_count": 4,
+                                "window_start": "2026-05-18T13:30:00Z",
+                                "window_end": "2026-05-18T20:00:00Z",
+                                "runtime_ledger_target_metadata_blockers": [
+                                    "replay_artifact_only_not_live"
+                                ],
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "final_promotion_allowed": False,
+                            }
+                        ],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        args = SimpleNamespace(
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_targets_from_registry=False,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        targets = renewal._runtime_window_targets(args)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(
+            targets[0].artifact_refs,
+            ("proof/replay-summary.json", "proof/exact-replay-ledger.json"),
+        )
+        self.assertEqual(targets[0].window_start, "2026-05-18T13:30:00Z")
+        self.assertEqual(targets[0].window_end, "2026-05-18T20:00:00Z")
+        assert targets[0].target_metadata is not None
+        self.assertEqual(
+            targets[0].target_metadata["runtime_ledger_artifact_ref"],
+            "proof/exact-replay-ledger.json",
+        )
+        self.assertEqual(
+            targets[0].target_metadata["runtime_ledger_artifact_row_count"],
+            12,
+        )
+        self.assertEqual(
+            targets[0].target_metadata["window_start"],
+            "2026-05-18T13:30:00Z",
+        )
+
     def test_runtime_window_targets_from_latest_autoresearch_epoch(self) -> None:
         args = SimpleNamespace(
             runtime_window_autoresearch_status=[],
@@ -1325,6 +1403,135 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         assert payload is not None
         self.assertEqual(payload["window_start"], "2026-05-18T13:30:00Z")
         self.assertEqual(payload["window_end"], "2026-05-18T20:00:00Z")
+
+    def test_runtime_window_import_uses_target_plan_window_and_artifacts(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-pairs-01.json"
+        hypothesis_path.write_text(
+            json.dumps({"candidate_id": "cand-exact-replay"}),
+            encoding="utf-8",
+        )
+        plan_path = self.tmp_dir / "candidate-board.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "runtime_window_import_plan": {
+                        "targets": [
+                            {
+                                "candidate_id": "cand-exact-replay",
+                                "hypothesis_id": "H-PAIRS-01",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                                "source_manifest_ref": str(hypothesis_path),
+                                "source_kind": "simulation_exact_replay_runtime_ledger",
+                                "runtime_ledger_artifact_ref": "proof/exact-replay-ledger.json",
+                                "window_start": "2026-05-18T13:30:00Z",
+                                "window_end": "2026-05-18T20:00:00Z",
+                            }
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        completed = SimpleNamespace(
+            stdout=json.dumps({"inserted_windows": 1, "promotion_decision": "blocked"})
+        )
+        args = SimpleNamespace(
+            runtime_window_import=True,
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_targets_from_latest_autoresearch=False,
+            runtime_window_targets_from_registry=False,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_start="",
+            runtime_window_end="",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with (
+            patch.object(renewal.subprocess, "run", return_value=completed) as run_mock,
+            patch.object(
+                renewal,
+                "_latest_source_activity_window",
+                return_value=(
+                    datetime(2026, 5, 15, 13, 30, tzinfo=timezone.utc),
+                    datetime(2026, 5, 15, 20, 0, tzinfo=timezone.utc),
+                ),
+            ) as source_window_mock,
+        ):
+            payload = renewal._run_runtime_window_import(
+                args=args,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                now=datetime(2026, 5, 19, 21, 23, tzinfo=timezone.utc),
+            )
+
+        source_window_mock.assert_not_called()
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertEqual(payload["window_selection"], "target_plan_window")
+        command = run_mock.call_args.args[0]
+        self.assertEqual(
+            command[command.index("--window-start") + 1],
+            "2026-05-18T13:30:00Z",
+        )
+        self.assertEqual(
+            command[command.index("--window-end") + 1],
+            "2026-05-18T20:00:00Z",
+        )
+        self.assertIn("proof/exact-replay-ledger.json", command)
+
+    def test_runtime_window_target_plan_bounds_fail_closed(self) -> None:
+        base = {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "candidate-1",
+            "observed_stage": "paper",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "source_dsn_env": "SIM_DB_DSN",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "account_label": "TORGHUT_REPLAY",
+            "dataset_snapshot_ref": "snapshot-1",
+            "source_manifest_ref": "h-pairs-01.json",
+            "source_kind": "simulation_exact_replay_runtime_ledger",
+            "delay_adjusted_depth_stress_report_ref": "",
+        }
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "runtime_window_target_plan_bounds_require_start_and_end",
+        ):
+            renewal._runtime_window_target_plan_bounds(
+                renewal.RuntimeWindowImportTarget(
+                    **base,
+                    window_start="2026-05-18T13:30:00Z",
+                )
+            )
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "runtime_window_target_plan_end_must_be_after_start",
+        ):
+            renewal._runtime_window_target_plan_bounds(
+                renewal.RuntimeWindowImportTarget(
+                    **base,
+                    window_start="2026-05-18T20:00:00Z",
+                    window_end="2026-05-18T13:30:00Z",
+                )
+            )
 
     def test_latest_source_activity_window_uses_execution_eligible_decisions(
         self,

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -177,6 +177,107 @@ class TestStrategyAutoresearch(TestCase):
             "parent=candidate-1; mutate=max_entries_per_session",
         )
 
+    def test_runtime_window_plan_helpers_surface_missing_handoffs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            with patch.object(runner, "_REPO_ROOT", root):
+                self.assertEqual(runner._hypothesis_manifest_rows(), [])
+
+            hypothesis_dir = root / "services/torghut/config/trading/hypotheses"
+            hypothesis_dir.mkdir(parents=True)
+            (hypothesis_dir / "bad.json").write_text("{", encoding="utf-8")
+            (hypothesis_dir / "missing-id.json").write_text(
+                json.dumps({"strategy_id": "ignored_v1@research"}),
+                encoding="utf-8",
+            )
+            (hypothesis_dir / "by-family.json").write_text(
+                json.dumps(
+                    {
+                        "hypothesis_id": "H-BY-FAMILY",
+                        "strategy_id": "other_v1@research",
+                        "strategy_family": "runtime_family_match",
+                        "dataset_snapshot_ref": "snapshot-family",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (hypothesis_dir / "by-name.json").write_text(
+                json.dumps(
+                    {
+                        "hypothesis_id": "H-BY-NAME",
+                        "strategy_id": "name_match_v1@research",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.object(runner, "_REPO_ROOT", root):
+                rows = runner._hypothesis_manifest_rows()
+                self.assertEqual(
+                    [row["hypothesis_id"] for row in rows],
+                    ["H-BY-FAMILY", "H-BY-NAME"],
+                )
+                self.assertEqual(
+                    runner._hypothesis_manifest_for_history_row(
+                        {
+                            "family_template_id": "",
+                            "runtime_family": "runtime_family_match",
+                            "runtime_strategy_name": "",
+                        }
+                    )["hypothesis_id"],
+                    "H-BY-FAMILY",
+                )
+                self.assertEqual(
+                    runner._hypothesis_manifest_for_history_row(
+                        {
+                            "family_template_id": "",
+                            "runtime_family": "",
+                            "runtime_strategy_name": "name-match-v1",
+                        }
+                    )["hypothesis_id"],
+                    "H-BY-NAME",
+                )
+
+        self.assertIsNone(
+            runner._exact_replay_history_row(history=[], candidate_id="missing")
+        )
+        no_candidate_blockers = runner._exact_replay_runtime_window_blockers(
+            best_exact_replay_ledger_candidate=None,
+            history_row=None,
+            hypothesis_manifest={},
+            artifact_refs=[],
+            promotion_blockers=[],
+            runtime_ledger_blockers=[],
+        )
+        self.assertEqual(
+            no_candidate_blockers[0]["blocker"],
+            "exact_replay_ledger_candidate_missing",
+        )
+        missing_handoff_blockers = runner._exact_replay_runtime_window_blockers(
+            best_exact_replay_ledger_candidate={"candidate_id": "candidate-1"},
+            history_row={},
+            hypothesis_manifest={},
+            artifact_refs=[],
+            promotion_blockers=[],
+            runtime_ledger_blockers=[],
+        )
+        blocker_names = {item["blocker"] for item in missing_handoff_blockers}
+        self.assertIn("hypothesis_manifest_missing", blocker_names)
+        self.assertIn("runtime_harness_metadata_missing", blocker_names)
+        self.assertIn("runtime_ledger_artifact_ref_missing", blocker_names)
+        missing_history_blockers = runner._exact_replay_runtime_window_blockers(
+            best_exact_replay_ledger_candidate={"candidate_id": "candidate-1"},
+            history_row=None,
+            hypothesis_manifest={},
+            artifact_refs=[],
+            promotion_blockers=[],
+            runtime_ledger_blockers=[],
+        )
+        self.assertIn(
+            "candidate_history_row_missing",
+            {item["blocker"] for item in missing_history_blockers},
+        )
+
     def test_runtime_closure_candidate_rejects_failed_or_vetoed_candidates(
         self,
     ) -> None:
@@ -572,7 +673,49 @@ class TestStrategyAutoresearch(TestCase):
                     program_id=program.program_id,
                     frontier_runs=1,
                     objective_met=False,
-                    history=[],
+                    history=[
+                        {
+                            "runner_run_id": "strategy-autoresearch-test",
+                            "experiment_index": 1,
+                            "iteration": 1,
+                            "family_template_id": "microbar_cross_sectional_pairs_v1",
+                            "candidate_id": "ledger-ranked-1",
+                            "parent_candidate_id": None,
+                            "status": "keep",
+                            "objective_met": False,
+                            "mutation_label": "seed",
+                            "dataset_snapshot_id": "snapshot-exact",
+                            "sweep_config_path": "sweep.yaml",
+                            "result_path": "result.json",
+                            "candidate_params": {},
+                            "candidate_strategy_overrides": {},
+                            "disable_other_strategies": True,
+                            "train_start_date": "",
+                            "train_end_date": "",
+                            "holdout_start_date": "",
+                            "holdout_end_date": "",
+                            "full_window_start_date": "2026-05-18",
+                            "full_window_end_date": "2026-05-22",
+                            "normalization_regime": "",
+                            "net_pnl_per_day": "59.6",
+                            "deployable_lower_bound_net_pnl_per_day": "59.6",
+                            "deployable_lower_bound_missing_count": 0,
+                            "deployable_lower_bound_failed_gate_count": 0,
+                            "active_day_ratio": "0.2",
+                            "best_day_share": "1",
+                            "max_drawdown": "0",
+                            "hard_vetoes": [],
+                            "pareto_tier": 1,
+                            "runtime_family": "microbar_cross_sectional_pairs",
+                            "runtime_strategy_name": "microbar-cross-sectional-pairs-v1",
+                            "exact_replay_ledger_artifact_ref": str(artifact_path),
+                            "runtime_ledger_artifact_ref": str(artifact_path),
+                            "exact_replay_ledger_artifact_row_count": "6",
+                            "exact_replay_ledger_artifact_fill_count": "2",
+                            "runtime_ledger_artifact_row_count": "6",
+                            "runtime_ledger_artifact_fill_count": "2",
+                        }
+                    ],
                     manifest=manifest,
                     descriptors=[],
                     proposal_scores=[],
@@ -615,6 +758,29 @@ class TestStrategyAutoresearch(TestCase):
             self.assertIn(
                 "replay_artifact_only_not_live",
                 summary["best_exact_replay_ledger_candidate"]["promotion_blockers"],
+            )
+            plan = summary["runtime_window_import_plan"]
+            self.assertFalse(plan["promotion_allowed"])
+            self.assertEqual(len(plan["targets"]), 1)
+            target = plan["targets"][0]
+            self.assertEqual(target["candidate_id"], "ledger-ranked-1")
+            self.assertEqual(target["hypothesis_id"], "H-PAIRS-01")
+            self.assertEqual(len(target["artifact_refs"]), 1)
+            self.assertEqual(
+                Path(target["artifact_refs"][0]).resolve(strict=False),
+                artifact_path.resolve(strict=False),
+            )
+            self.assertEqual(
+                target["runtime_ledger_artifact_row_count"],
+                "6",
+            )
+            self.assertFalse(target["promotion_allowed"])
+            self.assertFalse(target["final_promotion_authorized"])
+            self.assertEqual(
+                summary["candidate_board"]["runtime_window_import_plan"]["targets"][
+                    0
+                ]["candidate_id"],
+                "ledger-ranked-1",
             )
 
     def test_exact_replay_ledger_paths_collects_refs_and_skips_bad_results(


### PR DESCRIPTION
## Summary

- Preserves exact replay/runtime ledger artifact refs, row/fill counts, and plan window bounds through runtime-window target parsing.
- Makes runtime-window imports honor target-plan windows before source-activity fallback, so replay artifacts are checked against their actual evidence window.
- Emits a strategy-autoresearch candidate-board runtime-window import plan from exact replay-ledger ranking/remediation without authorizing promotion.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py tests/test_strategy_autoresearch.py tests/test_replay_ledger_remediation.py tests/test_replay_ledger_guided_search.py -q`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py scripts/run_strategy_autoresearch_loop.py tests/test_run_empirical_promotion_jobs.py tests/test_strategy_autoresearch.py`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py tests/test_strategy_autoresearch.py tests/test_replay_ledger_remediation.py tests/test_replay_ledger_guided_search.py --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
