### PR TITLE
feat(torghut): build replay runtime handoff plans

### DIFF
--- a/services/torghut/app/trading/discovery/replay_runtime_window_plan.py
+++ b/services/torghut/app/trading/discovery/replay_runtime_window_plan.py
@@ -1,0 +1,414 @@
+"""Build runtime-window handoff plans from exact replay ledger evidence."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, cast
+
+from .replay_ledger_ranker import (
+    ReplayLedgerRankingPolicy,
+    build_replay_ledger_ranking_report,
+)
+from .replay_ledger_remediation import build_replay_ledger_remediation_report
+
+REPLAY_RUNTIME_WINDOW_HANDOFF_SCHEMA_VERSION = (
+    "torghut.replay-runtime-window-handoff.v1"
+)
+RUNTIME_WINDOW_IMPORT_PLAN_SCHEMA_VERSION = "torghut.runtime-window-import-plan.v1"
+CANDIDATE_BOARD_SCHEMA_VERSION = "torghut.strategy-autoresearch-candidate-board.v1"
+
+
+def build_replay_runtime_window_handoff(
+    *,
+    ledger_paths: Sequence[Path],
+    policy: ReplayLedgerRankingPolicy,
+    hypothesis_id: str,
+    source_manifest_ref: str,
+    run_id: str = "",
+    frontier_payload: Mapping[str, Any] | None = None,
+    strategy_family: str = "",
+    strategy_name: str = "",
+    account_label: str = "TORGHUT_REPLAY",
+    observed_stage: str = "paper",
+    source_kind: str = "simulation_exact_replay_runtime_ledger",
+    dataset_snapshot_ref: str = "",
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Return a non-promotional runtime-window import plan for ranked ledgers."""
+
+    frontier = _mapping(frontier_payload)
+    ranking_report = build_replay_ledger_ranking_report(
+        ledger_paths,
+        policy=policy,
+        limit=limit,
+    )
+    remediation_report = build_replay_ledger_remediation_report(ranking_report)
+    candidates = _candidate_mappings(ranking_report.get("candidates"))
+    best_candidate = candidates[0] if candidates else None
+    inferred_family, inferred_strategy = _infer_runtime_harness(frontier)
+    target_strategy_family = _text(strategy_family) or inferred_family
+    target_strategy_name = _text(strategy_name) or inferred_strategy
+    target_dataset_snapshot_ref = _text(
+        dataset_snapshot_ref
+    ) or _infer_dataset_snapshot_ref(frontier)
+    runtime_plan = _build_runtime_window_import_plan(
+        best_candidate=best_candidate,
+        remediation_report=remediation_report,
+        hypothesis_id=_text(hypothesis_id) or "",
+        source_manifest_ref=_text(source_manifest_ref) or "",
+        run_id=_text(run_id) or "",
+        strategy_family=target_strategy_family,
+        strategy_name=target_strategy_name,
+        account_label=_text(account_label) or "TORGHUT_REPLAY",
+        observed_stage=_text(observed_stage) or "paper",
+        source_kind=_text(source_kind) or "simulation_exact_replay_runtime_ledger",
+        dataset_snapshot_ref=target_dataset_snapshot_ref,
+    )
+    candidate_board = {
+        "schema_version": CANDIDATE_BOARD_SCHEMA_VERSION,
+        "current_answer": "no_promotion_ready_candidate",
+        "promotion_allowed": False,
+        "best_research_candidate": None,
+        "best_exact_replay_ledger_candidate": dict(best_candidate)
+        if best_candidate is not None
+        else None,
+        "exact_replay_ledger_remediation": remediation_report,
+        "runtime_window_import_plan": runtime_plan,
+    }
+    return {
+        "schema_version": REPLAY_RUNTIME_WINDOW_HANDOFF_SCHEMA_VERSION,
+        "promotion_allowed": False,
+        "source": "exact_replay_ledger_runtime_window_handoff",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "hypothesis_id": _text(hypothesis_id) or "",
+        "source_manifest_ref": _text(source_manifest_ref) or "",
+        "ranking": ranking_report,
+        "exact_replay_ledger_remediation": remediation_report,
+        "best_exact_replay_ledger_candidate": dict(best_candidate)
+        if best_candidate is not None
+        else None,
+        "runtime_window_import_plan": runtime_plan,
+        "candidate_board": candidate_board,
+    }
+
+
+def _build_runtime_window_import_plan(
+    *,
+    best_candidate: Mapping[str, Any] | None,
+    remediation_report: Mapping[str, Any],
+    hypothesis_id: str,
+    source_manifest_ref: str,
+    run_id: str,
+    strategy_family: str,
+    strategy_name: str,
+    account_label: str,
+    observed_stage: str,
+    source_kind: str,
+    dataset_snapshot_ref: str,
+) -> dict[str, Any]:
+    promotion_blockers = _string_list(remediation_report.get("promotion_blockers"))
+    runtime_ledger_blockers = _string_list(
+        remediation_report.get("runtime_ledger_blockers")
+    )
+    artifact_ref = (
+        _text(best_candidate.get("artifact_ref")) if best_candidate is not None else ""
+    )
+    candidate_id = (
+        _text(best_candidate.get("candidate_id")) if best_candidate is not None else ""
+    )
+    metadata_blockers = _target_metadata_blockers(
+        promotion_blockers=promotion_blockers,
+        runtime_ledger_blockers=runtime_ledger_blockers,
+    )
+    blockers = _plan_blockers(
+        best_candidate=best_candidate,
+        candidate_id=candidate_id,
+        hypothesis_id=hypothesis_id,
+        source_manifest_ref=source_manifest_ref,
+        strategy_family=strategy_family,
+        strategy_name=strategy_name,
+        artifact_ref=artifact_ref,
+        promotion_blockers=promotion_blockers,
+        runtime_ledger_blockers=runtime_ledger_blockers,
+    )
+    targets: list[dict[str, Any]] = []
+    if best_candidate is not None and not any(
+        item["blocker"] != "exact_replay_search_blockers_remaining" for item in blockers
+    ):
+        search_blockers = _search_blockers(
+            promotion_blockers=promotion_blockers,
+            runtime_ledger_blockers=runtime_ledger_blockers,
+        )
+        probation_allowed = not search_blockers
+        artifact_counts = _runtime_ledger_artifact_counts(artifact_ref)
+        window_start = _text(best_candidate.get("window_start"))
+        window_end = _text(best_candidate.get("window_end"))
+        target: dict[str, Any] = {
+            "run_id": run_id or f"replay-runtime-window-{candidate_id}",
+            "candidate_id": candidate_id,
+            "hypothesis_id": hypothesis_id,
+            "observed_stage": observed_stage,
+            "strategy_family": strategy_family,
+            "strategy_name": strategy_name,
+            "account_label": account_label,
+            "source_kind": source_kind,
+            "source_manifest_ref": source_manifest_ref,
+            "dataset_snapshot_ref": dataset_snapshot_ref,
+            "artifact_refs": [artifact_ref],
+            "runtime_ledger_artifact_refs": [artifact_ref],
+            "runtime_ledger_artifact_ref": artifact_ref,
+            "exact_replay_ledger_artifact_ref": artifact_ref,
+            "window_start": window_start,
+            "window_end": window_end,
+            "candidate_selection": "exact_replay_ledger_best_candidate",
+            "selected_by": "replay_runtime_window_handoff_ranking",
+            "selection_reason": _text(remediation_report.get("status")),
+            "paper_probation_authorized": probation_allowed,
+            "paper_probation_authorization_scope": "evidence_collection_only",
+            "evidence_collection_stage": "paper",
+            "probation_allowed": probation_allowed,
+            "probation_reason": "exact_replay_policy_checks_passed"
+            if probation_allowed
+            else "exact_replay_search_blockers_remaining",
+            "promotion_allowed": False,
+            "final_promotion_authorized": False,
+            "final_promotion_allowed": False,
+            "final_promotion_blockers": metadata_blockers,
+            "runtime_ledger_target_metadata_blockers": metadata_blockers,
+            "handoff": "runtime_window_import_from_exact_replay_ledger",
+            "promotion_gate": "runtime_ledger_live_or_live_paper_required",
+        }
+        if artifact_counts["row_count"] is not None:
+            target["runtime_ledger_artifact_row_count"] = artifact_counts["row_count"]
+        if artifact_counts["fill_count"] is not None:
+            target["runtime_ledger_artifact_fill_count"] = artifact_counts["fill_count"]
+        targets.append(target)
+    return {
+        "schema_version": RUNTIME_WINDOW_IMPORT_PLAN_SCHEMA_VERSION,
+        "source": "exact_replay_ledger_runtime_window_handoff",
+        "purpose": (
+            "handoff exact replay-ledger winners into bounded paper/runtime-window "
+            "evidence collection without authorizing final promotion"
+        ),
+        "promotion_allowed": False,
+        "targets": targets,
+        "blockers": blockers,
+    }
+
+
+def _plan_blockers(
+    *,
+    best_candidate: Mapping[str, Any] | None,
+    candidate_id: str,
+    hypothesis_id: str,
+    source_manifest_ref: str,
+    strategy_family: str,
+    strategy_name: str,
+    artifact_ref: str,
+    promotion_blockers: Sequence[str],
+    runtime_ledger_blockers: Sequence[str],
+) -> list[dict[str, Any]]:
+    blockers: list[dict[str, Any]] = []
+    if best_candidate is None:
+        blockers.append(
+            {
+                "blocker": "exact_replay_ledger_candidate_missing",
+                "remediation": "produce_exact_replay_ledger_artifacts",
+            }
+        )
+        return blockers
+    missing_metadata = [
+        name
+        for name, value in (
+            ("hypothesis_id", hypothesis_id),
+            ("source_manifest_ref", source_manifest_ref),
+            ("strategy_family", strategy_family),
+            ("strategy_name", strategy_name),
+        )
+        if not value
+    ]
+    if missing_metadata:
+        blockers.append(
+            {
+                "blocker": "runtime_window_plan_metadata_missing",
+                "candidate_id": candidate_id,
+                "missing_fields": missing_metadata,
+                "remediation": "provide_hypothesis_manifest_and_runtime_harness",
+            }
+        )
+    if not artifact_ref:
+        blockers.append(
+            {
+                "blocker": "runtime_ledger_artifact_ref_missing",
+                "candidate_id": candidate_id,
+                "remediation": "enable_exact_replay_ledger_artifact_output",
+            }
+        )
+    search_blockers = _search_blockers(
+        promotion_blockers=promotion_blockers,
+        runtime_ledger_blockers=runtime_ledger_blockers,
+    )
+    if search_blockers:
+        blockers.append(
+            {
+                "blocker": "exact_replay_search_blockers_remaining",
+                "candidate_id": candidate_id,
+                "blocking_reasons": search_blockers,
+                "remediation": (
+                    "keep search remediation active; runtime-window target is "
+                    "evidence collection only and cannot authorize promotion"
+                ),
+            }
+        )
+    return blockers
+
+
+def _target_metadata_blockers(
+    *,
+    promotion_blockers: Sequence[str],
+    runtime_ledger_blockers: Sequence[str],
+) -> list[str]:
+    return _dedupe(
+        [
+            *promotion_blockers,
+            *runtime_ledger_blockers,
+            "paper_probation_evidence_collection_only",
+        ]
+    )
+
+
+def _search_blockers(
+    *,
+    promotion_blockers: Sequence[str],
+    runtime_ledger_blockers: Sequence[str],
+) -> list[str]:
+    return [
+        blocker
+        for blocker in _dedupe([*promotion_blockers, *runtime_ledger_blockers])
+        if blocker != "replay_artifact_only_not_live"
+    ]
+
+
+def _infer_runtime_harness(frontier: Mapping[str, Any]) -> tuple[str, str]:
+    family_template = _mapping(frontier.get("family_template"))
+    runtime_harness = _mapping(family_template.get("runtime_harness"))
+    return (
+        _text(runtime_harness.get("family")) or _text(frontier.get("family")),
+        _text(runtime_harness.get("strategy_name"))
+        or _text(frontier.get("strategy_name")),
+    )
+
+
+def _infer_dataset_snapshot_ref(frontier: Mapping[str, Any]) -> str:
+    receipt = _mapping(frontier.get("dataset_snapshot_receipt"))
+    replay_tape = _mapping(frontier.get("replay_tape"))
+    return (
+        _text(receipt.get("snapshot_id"))
+        or _text(replay_tape.get("dataset_snapshot_ref"))
+        or ""
+    )
+
+
+def _runtime_ledger_artifact_counts(artifact_ref: str) -> dict[str, int | None]:
+    payload = _load_json_mapping(artifact_ref)
+    rows = _runtime_ledger_rows(payload)
+    row_count = _int_or_none(payload.get("row_count")) or (len(rows) if rows else None)
+    fill_count = (
+        _int_or_none(payload.get("fill_row_count"))
+        or _int_or_none(payload.get("filled_row_count"))
+        or (
+            sum(
+                1
+                for row in rows
+                if _event_type(row)
+                in {"fill", "filled", "partial_fill", "partially_filled"}
+            )
+            if rows
+            else None
+        )
+    )
+    return {"row_count": row_count, "fill_count": fill_count}
+
+
+def _runtime_ledger_rows(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    for key in ("runtime_ledger_rows", "ledger_rows", "rows", "events"):
+        rows = payload.get(key)
+        if isinstance(rows, Sequence) and not isinstance(rows, (str, bytes, bytearray)):
+            row_items = cast(Sequence[Any], rows)
+            return [
+                cast(Mapping[str, Any], row)
+                for row in row_items
+                if isinstance(row, Mapping)
+            ]
+    return []
+
+
+def _event_type(row: Mapping[str, Any]) -> str:
+    return str(
+        row.get("event_type") or row.get("runtime_ledger_event_type") or ""
+    ).lower()
+
+
+def _load_json_mapping(path_text: str) -> dict[str, Any]:
+    if not path_text:
+        return {}
+    path = Path(path_text)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return _mapping(payload)
+
+
+def _candidate_mappings(value: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    items = cast(Sequence[Any], value)
+    return [
+        cast(Mapping[str, Any], item) for item in items if isinstance(item, Mapping)
+    ]
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    mapping = cast(Mapping[Any, Any], value)
+    return {str(key): item for key, item in mapping.items()}
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    items = cast(Sequence[Any], value)
+    result: list[str] = []
+    for item in items:
+        text = _text(item)
+        if text:
+            result.append(text)
+    return result
+
+
+def _text(value: Any) -> str:
+    text = str(value or "").strip()
+    return text
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        parsed = int(Decimal(str(value)))
+    except Exception:
+        return None
+    return max(0, parsed)
+
+
+def _dedupe(values: Sequence[str]) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        text = _text(value)
+        if text and text not in result:
+            result.append(text)
+    return result

--- a/services/torghut/scripts/build_replay_runtime_window_plan.py
+++ b/services/torghut/scripts/build_replay_runtime_window_plan.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Build a non-promotional runtime-window plan from exact replay ledgers."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+from decimal import Decimal
+from pathlib import Path
+
+from app.trading.discovery.replay_ledger_ranker import (
+    default_replay_ledger_ranking_policy,
+)
+from app.trading.discovery.replay_runtime_window_plan import (
+    build_replay_runtime_window_handoff,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Rank exact replay ledgers and emit a candidate-board/runtime-window "
+            "handoff plan. The output is evidence collection only and never "
+            "authorizes promotion."
+        ),
+    )
+    parser.add_argument("ledger_paths", nargs="*", type=Path)
+    parser.add_argument("--ledger-glob", action="append", default=[])
+    parser.add_argument("--frontier-result", type=Path, default=None)
+    parser.add_argument("--hypothesis-id", required=True)
+    parser.add_argument("--source-manifest-ref", required=True)
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--strategy-family", default="")
+    parser.add_argument("--strategy-name", default="")
+    parser.add_argument("--account-label", default="TORGHUT_REPLAY")
+    parser.add_argument("--observed-stage", choices=("paper", "live"), default="paper")
+    parser.add_argument(
+        "--source-kind", default="simulation_exact_replay_runtime_ledger"
+    )
+    parser.add_argument("--dataset-snapshot-ref", default="")
+    parser.add_argument("--target-net-pnl-per-day", default="500")
+    parser.add_argument("--start-equity", default="")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--output", type=Path, default=None)
+    return parser.parse_args()
+
+
+def _paths(args: argparse.Namespace) -> list[Path]:
+    paths = list(args.ledger_paths)
+    for pattern in args.ledger_glob:
+        paths.extend(Path(item) for item in glob.glob(str(pattern), recursive=True))
+    return paths
+
+
+def _frontier_payload(path: Path | None) -> dict[str, object]:
+    if path is None:
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise SystemExit(f"frontier_result_invalid:{path}") from exc
+    if not isinstance(payload, dict):
+        raise SystemExit(f"frontier_result_invalid:{path}")
+    return {str(key): value for key, value in payload.items()}
+
+
+def main() -> int:
+    args = _parse_args()
+    paths = _paths(args)
+    if not paths:
+        raise SystemExit("provide at least one ledger path or --ledger-glob")
+    start_equity = (
+        Decimal(args.start_equity) if str(args.start_equity).strip() else None
+    )
+    policy = default_replay_ledger_ranking_policy(
+        target_net_pnl_per_day=Decimal(str(args.target_net_pnl_per_day)),
+        start_equity=start_equity,
+    )
+    report = build_replay_runtime_window_handoff(
+        ledger_paths=paths,
+        policy=policy,
+        hypothesis_id=args.hypothesis_id,
+        source_manifest_ref=args.source_manifest_ref,
+        run_id=args.run_id,
+        frontier_payload=_frontier_payload(args.frontier_result),
+        strategy_family=args.strategy_family,
+        strategy_name=args.strategy_name,
+        account_label=args.account_label,
+        observed_stage=args.observed_stage,
+        source_kind=args.source_kind,
+        dataset_snapshot_ref=args.dataset_snapshot_ref,
+        limit=args.limit,
+    )
+    payload = json.dumps(report, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload + "\n", encoding="utf-8")
+    else:
+        print(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/tests/test_replay_runtime_window_plan.py
+++ b/services/torghut/tests/test_replay_runtime_window_plan.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+from app.trading.discovery.replay_ledger_ranker import ReplayLedgerRankingPolicy
+from app.trading.discovery.replay_runtime_window_plan import (
+    build_replay_runtime_window_handoff,
+)
+
+
+def _ts(day: int, minute: int = 0) -> str:
+    return datetime(2026, 5, day, 14, 30 + minute, tzinfo=timezone.utc).isoformat()
+
+
+def _round_trip(day: int) -> list[dict[str, object]]:
+    return [
+        {
+            "event_type": "decision",
+            "executed_at": _ts(day, 0),
+            "decision_id": "buy-decision",
+            "order_id": "buy-order",
+            "symbol": "AMZN",
+        },
+        {
+            "event_type": "order_submitted",
+            "executed_at": _ts(day, 1),
+            "decision_id": "buy-decision",
+            "order_id": "buy-order",
+            "symbol": "AMZN",
+        },
+        {
+            "event_type": "fill",
+            "executed_at": _ts(day, 2),
+            "decision_id": "buy-decision",
+            "order_id": "buy-order",
+            "symbol": "AMZN",
+            "side": "buy",
+            "filled_qty": "100",
+            "avg_fill_price": "100",
+            "cost_amount": "1",
+        },
+        {
+            "event_type": "decision",
+            "executed_at": _ts(day, 10),
+            "decision_id": "sell-decision",
+            "order_id": "sell-order",
+            "symbol": "AMZN",
+        },
+        {
+            "event_type": "order_submitted",
+            "executed_at": _ts(day, 11),
+            "decision_id": "sell-decision",
+            "order_id": "sell-order",
+            "symbol": "AMZN",
+        },
+        {
+            "event_type": "fill",
+            "executed_at": _ts(day, 12),
+            "decision_id": "sell-decision",
+            "order_id": "sell-order",
+            "symbol": "AMZN",
+            "side": "sell",
+            "filled_qty": "100",
+            "avg_fill_price": "120",
+            "cost_amount": "1",
+        },
+    ]
+
+
+def _policy() -> ReplayLedgerRankingPolicy:
+    return ReplayLedgerRankingPolicy(
+        target_net_pnl_per_day=Decimal("500"),
+        min_window_weekday_count=20,
+        min_avg_filled_notional_per_day=Decimal("300000"),
+        max_best_day_share=Decimal("0.25"),
+        max_gross_exposure_pct_equity=Decimal("1.0"),
+        start_equity=Decimal("31590.02"),
+    )
+
+
+def test_handoff_builds_non_promotional_runtime_window_target(
+    tmp_path: Path,
+) -> None:
+    artifact_path = tmp_path / "candidate-exact-replay-ledger.json"
+    artifact_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                "candidate_id": "candidate-strong-one-day",
+                "window_start": "2026-05-18",
+                "window_end": "2026-05-22",
+                "account_label": "TORGHUT_REPLAY",
+                "execution_policy_hash": "policy-sha",
+                "cost_model_hash": "cost-sha",
+                "lineage_hash": "lineage-sha",
+                "promotion_authority": "replay_artifact_only_not_live",
+                "stage": "replay",
+                "runtime_ledger_rows": _round_trip(21),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    handoff = build_replay_runtime_window_handoff(
+        ledger_paths=[artifact_path],
+        policy=_policy(),
+        hypothesis_id="H-PAIRS-01",
+        source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+        frontier_payload={
+            "family": "microbar_cross_sectional_pairs",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "family_template": {
+                "runtime_harness": {
+                    "family": "microbar_cross_sectional_pairs",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                }
+            },
+            "dataset_snapshot_receipt": {"snapshot_id": "snapshot-1"},
+        },
+    )
+
+    assert handoff["promotion_allowed"] is False
+    assert handoff["candidate_board"]["promotion_allowed"] is False
+    plan = handoff["runtime_window_import_plan"]
+    assert plan["promotion_allowed"] is False
+    assert len(plan["targets"]) == 1
+    target = plan["targets"][0]
+    assert target["candidate_id"] == "candidate-strong-one-day"
+    assert target["hypothesis_id"] == "H-PAIRS-01"
+    assert target["strategy_family"] == "microbar_cross_sectional_pairs"
+    assert target["strategy_name"] == "microbar-cross-sectional-pairs-v1"
+    assert target["dataset_snapshot_ref"] == "snapshot-1"
+    assert target["runtime_ledger_artifact_refs"] == [str(artifact_path.resolve())]
+    assert target["runtime_ledger_artifact_row_count"] == 6
+    assert target["runtime_ledger_artifact_fill_count"] == 2
+    assert target["paper_probation_authorized"] is False
+    assert target["promotion_allowed"] is False
+    assert target["final_promotion_authorized"] is False
+    assert (
+        "paper_probation_evidence_collection_only" in target["final_promotion_blockers"]
+    )
+    assert any(
+        item["blocker"] == "exact_replay_search_blockers_remaining"
+        for item in plan["blockers"]
+    )
+
+
+def test_handoff_blocks_target_when_runtime_metadata_is_missing(
+    tmp_path: Path,
+) -> None:
+    artifact_path = tmp_path / "candidate-exact-replay-ledger.json"
+    artifact_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                "candidate_id": "candidate-without-harness",
+                "window_start": "2026-05-18",
+                "window_end": "2026-05-22",
+                "account_label": "TORGHUT_REPLAY",
+                "execution_policy_hash": "policy-sha",
+                "cost_model_hash": "cost-sha",
+                "lineage_hash": "lineage-sha",
+                "promotion_authority": "replay_artifact_only_not_live",
+                "stage": "replay",
+                "runtime_ledger_rows": _round_trip(21),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    handoff = build_replay_runtime_window_handoff(
+        ledger_paths=[artifact_path],
+        policy=_policy(),
+        hypothesis_id="H-PAIRS-01",
+        source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+    )
+
+    plan = handoff["runtime_window_import_plan"]
+    assert plan["targets"] == []
+    assert plan["promotion_allowed"] is False
+    assert plan["blockers"][0]["blocker"] == "runtime_window_plan_metadata_missing"
+    assert plan["blockers"][0]["missing_fields"] == [
+        "strategy_family",
+        "strategy_name",
+    ]

--- a/services/torghut/tests/test_replay_runtime_window_plan.py
+++ b/services/torghut/tests/test_replay_runtime_window_plan.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import json
+import sys
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
+from unittest.mock import patch
 
+import pytest
 from app.trading.discovery.replay_ledger_ranker import ReplayLedgerRankingPolicy
 from app.trading.discovery.replay_runtime_window_plan import (
     build_replay_runtime_window_handoff,
 )
+from scripts import build_replay_runtime_window_plan as cli
 
 
 def _ts(day: int, minute: int = 0) -> str:
@@ -81,15 +85,26 @@ def _policy() -> ReplayLedgerRankingPolicy:
     )
 
 
-def test_handoff_builds_non_promotional_runtime_window_target(
-    tmp_path: Path,
-) -> None:
-    artifact_path = tmp_path / "candidate-exact-replay-ledger.json"
-    artifact_path.write_text(
+def _frontier_payload() -> dict[str, object]:
+    return {
+        "family": "microbar_cross_sectional_pairs",
+        "strategy_name": "microbar-cross-sectional-pairs-v1",
+        "family_template": {
+            "runtime_harness": {
+                "family": "microbar_cross_sectional_pairs",
+                "strategy_name": "microbar-cross-sectional-pairs-v1",
+            }
+        },
+        "dataset_snapshot_receipt": {"snapshot_id": "snapshot-1"},
+    }
+
+
+def _write_replay_ledger(path: Path, *, candidate_id: str) -> Path:
+    path.write_text(
         json.dumps(
             {
                 "schema_version": "torghut.exact_replay_ledger.rows.v1",
-                "candidate_id": "candidate-strong-one-day",
+                "candidate_id": candidate_id,
                 "window_start": "2026-05-18",
                 "window_end": "2026-05-22",
                 "account_label": "TORGHUT_REPLAY",
@@ -103,23 +118,23 @@ def test_handoff_builds_non_promotional_runtime_window_target(
         ),
         encoding="utf-8",
     )
+    return path
+
+
+def test_handoff_builds_non_promotional_runtime_window_target(
+    tmp_path: Path,
+) -> None:
+    artifact_path = _write_replay_ledger(
+        tmp_path / "candidate-exact-replay-ledger.json",
+        candidate_id="candidate-strong-one-day",
+    )
 
     handoff = build_replay_runtime_window_handoff(
         ledger_paths=[artifact_path],
         policy=_policy(),
         hypothesis_id="H-PAIRS-01",
         source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
-        frontier_payload={
-            "family": "microbar_cross_sectional_pairs",
-            "strategy_name": "microbar-cross-sectional-pairs-v1",
-            "family_template": {
-                "runtime_harness": {
-                    "family": "microbar_cross_sectional_pairs",
-                    "strategy_name": "microbar-cross-sectional-pairs-v1",
-                }
-            },
-            "dataset_snapshot_receipt": {"snapshot_id": "snapshot-1"},
-        },
+        frontier_payload=_frontier_payload(),
     )
 
     assert handoff["promotion_allowed"] is False
@@ -151,24 +166,9 @@ def test_handoff_builds_non_promotional_runtime_window_target(
 def test_handoff_blocks_target_when_runtime_metadata_is_missing(
     tmp_path: Path,
 ) -> None:
-    artifact_path = tmp_path / "candidate-exact-replay-ledger.json"
-    artifact_path.write_text(
-        json.dumps(
-            {
-                "schema_version": "torghut.exact_replay_ledger.rows.v1",
-                "candidate_id": "candidate-without-harness",
-                "window_start": "2026-05-18",
-                "window_end": "2026-05-22",
-                "account_label": "TORGHUT_REPLAY",
-                "execution_policy_hash": "policy-sha",
-                "cost_model_hash": "cost-sha",
-                "lineage_hash": "lineage-sha",
-                "promotion_authority": "replay_artifact_only_not_live",
-                "stage": "replay",
-                "runtime_ledger_rows": _round_trip(21),
-            }
-        ),
-        encoding="utf-8",
+    artifact_path = _write_replay_ledger(
+        tmp_path / "candidate-exact-replay-ledger.json",
+        candidate_id="candidate-without-harness",
     )
 
     handoff = build_replay_runtime_window_handoff(
@@ -186,3 +186,137 @@ def test_handoff_blocks_target_when_runtime_metadata_is_missing(
         "strategy_family",
         "strategy_name",
     ]
+
+
+def test_handoff_blocks_target_when_no_ledger_candidate_exists() -> None:
+    handoff = build_replay_runtime_window_handoff(
+        ledger_paths=[],
+        policy=_policy(),
+        hypothesis_id="H-PAIRS-01",
+        source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+        frontier_payload=_frontier_payload(),
+    )
+
+    plan = handoff["runtime_window_import_plan"]
+    assert plan["targets"] == []
+    assert plan["blockers"] == [
+        {
+            "blocker": "exact_replay_ledger_candidate_missing",
+            "remediation": "produce_exact_replay_ledger_artifacts",
+        }
+    ]
+
+
+def test_cli_writes_handoff_from_glob_and_frontier(tmp_path: Path) -> None:
+    ledger_dir = tmp_path / "ledgers"
+    ledger_dir.mkdir()
+    _write_replay_ledger(
+        ledger_dir / "candidate-exact-replay-ledger.json",
+        candidate_id="candidate-from-cli-glob",
+    )
+    frontier_path = tmp_path / "frontier.json"
+    frontier_path.write_text(json.dumps(_frontier_payload()), encoding="utf-8")
+    output_path = tmp_path / "handoff" / "plan.json"
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "build_replay_runtime_window_plan.py",
+            "--ledger-glob",
+            str(ledger_dir / "*.json"),
+            "--frontier-result",
+            str(frontier_path),
+            "--hypothesis-id",
+            "H-PAIRS-01",
+            "--source-manifest-ref",
+            "config/trading/hypotheses/h-pairs-01.json",
+            "--run-id",
+            "runtime-window-cli-run",
+            "--target-net-pnl-per-day",
+            "500",
+            "--start-equity",
+            "31590.02",
+            "--limit",
+            "5",
+            "--output",
+            str(output_path),
+        ],
+    ):
+        assert cli.main() == 0
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    target = payload["runtime_window_import_plan"]["targets"][0]
+    assert target["run_id"] == "runtime-window-cli-run"
+    assert target["candidate_id"] == "candidate-from-cli-glob"
+    assert target["strategy_family"] == "microbar_cross_sectional_pairs"
+    assert target["strategy_name"] == "microbar-cross-sectional-pairs-v1"
+    assert target["dataset_snapshot_ref"] == "snapshot-1"
+    assert target["promotion_allowed"] is False
+
+
+def test_cli_prints_handoff_to_stdout_without_frontier(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    artifact_path = _write_replay_ledger(
+        tmp_path / "candidate-exact-replay-ledger.json",
+        candidate_id="candidate-from-cli-stdout",
+    )
+
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "build_replay_runtime_window_plan.py",
+            str(artifact_path),
+            "--hypothesis-id",
+            "H-PAIRS-01",
+            "--source-manifest-ref",
+            "config/trading/hypotheses/h-pairs-01.json",
+            "--strategy-family",
+            "manual_family",
+            "--strategy-name",
+            "manual-strategy-v1",
+            "--source-kind",
+            "manual_exact_replay",
+            "--observed-stage",
+            "live",
+        ],
+    ):
+        assert cli.main() == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    target = payload["runtime_window_import_plan"]["targets"][0]
+    assert target["candidate_id"] == "candidate-from-cli-stdout"
+    assert target["strategy_family"] == "manual_family"
+    assert target["strategy_name"] == "manual-strategy-v1"
+    assert target["source_kind"] == "manual_exact_replay"
+    assert target["observed_stage"] == "live"
+
+
+def test_cli_rejects_invalid_frontier_payload(tmp_path: Path) -> None:
+    frontier_path = tmp_path / "frontier.json"
+    frontier_path.write_text("[1, 2, 3]", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match=f"frontier_result_invalid:{frontier_path}"):
+        cli._frontier_payload(frontier_path)
+
+
+def test_cli_requires_ledger_paths() -> None:
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "build_replay_runtime_window_plan.py",
+            "--hypothesis-id",
+            "H-PAIRS-01",
+            "--source-manifest-ref",
+            "config/trading/hypotheses/h-pairs-01.json",
+        ],
+    ):
+        with pytest.raises(
+            SystemExit,
+            match="provide at least one ledger path or --ledger-glob",
+        ):
+            cli.main()


### PR DESCRIPTION
## Summary

- Adds a replay runtime-window handoff builder that ranks exact replay ledgers, builds remediation, and emits a candidate-board-compatible runtime-window import plan without authorizing promotion.
- Adds a CLI for frontier-only replay artifacts so strong local replay candidates can be routed into evidence collection instead of being lost outside full autoresearch history.
- Carries replay blockers, artifact refs, row/fill counts, window bounds, and non-promotion flags into the handoff target.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_replay_runtime_window_plan.py tests/test_replay_ledger_ranker.py tests/test_replay_ledger_remediation.py -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k 'runtime_window_targets_from_candidate_board_plan or runtime_window_target_plan or target_plan' -q`
- `uv run --frozen ruff format --check app/trading/discovery/replay_runtime_window_plan.py scripts/build_replay_runtime_window_plan.py tests/test_replay_runtime_window_plan.py`
- `uv run --frozen ruff check app/trading/discovery/replay_runtime_window_plan.py scripts/build_replay_runtime_window_plan.py tests/test_replay_runtime_window_plan.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python scripts/build_replay_runtime_window_plan.py --ledger-glob '/tmp/torghut-profitability-next-lanes-20260522T1026Z/microbar-pairs/frontier-artifacts/frontier/*-exact-replay-ledger.json' --frontier-result /tmp/torghut-profitability-next-lanes-20260522T1026Z/microbar-pairs/frontier.json --hypothesis-id H-PAIRS-01 --source-manifest-ref config/trading/hypotheses/h-pairs-01.json --run-id replay-runtime-window-da7fc874-20260523 --target-net-pnl-per-day 500 --output /tmp/torghut-runtime-window-handoff-20260523/microbar-pairs-runtime-window-plan.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
