### PR TITLE
chore(torghut): promote image 8f39b5f2

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-693-g5dcc15183
+              value: v0.571.1-696-g8f39b5f27
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 5dcc15183a1f6479c48a361a7727e16529415371
+              value: 8f39b5f27d51ec483edd5634ffb61afcd626ccb5
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-693-g5dcc15183
+              value: v0.571.1-696-g8f39b5f27
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 5dcc15183a1f6479c48a361a7727e16529415371
+              value: 8f39b5f27d51ec483edd5634ffb61afcd626ccb5
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -75,7 +75,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+                  value: sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-23T13:16:13Z"
+        client.knative.dev/updateTimestamp: "2026-05-23T13:49:11Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
           ports:
             - name: http1
               containerPort: 8181
@@ -499,11 +499,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-693-g5dcc15183
+              value: v0.571.1-696-g8f39b5f27
             - name: TORGHUT_COMMIT
-              value: 5dcc15183a1f6479c48a361a7727e16529415371
+              value: 8f39b5f27d51ec483edd5634ffb61afcd626ccb5
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+              value: sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-23T13:16:13Z"
+        client.knative.dev/updateTimestamp: "2026-05-23T13:49:11Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
           ports:
             - name: http1
               containerPort: 8181
@@ -320,11 +320,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-693-g5dcc15183
+              value: v0.571.1-696-g8f39b5f27
             - name: TORGHUT_COMMIT
-              value: 5dcc15183a1f6479c48a361a7727e16529415371
+              value: 8f39b5f27d51ec483edd5634ffb61afcd626ccb5
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+              value: sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -132,7 +132,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:572cb1860584f945f1e256496c608a5c43f90c6d4ddcbcec344c4654b5a932ad
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `8f39b5f27d51ec483edd5634ffb61afcd626ccb5`
- Image tag: `8f39b5f2`
- Image digest: `sha256:099dd3ef6489e87a2d86fff24e498ba8e3935e9b068fa72a38837c4bce5180fa`