### PR TITLE
fix(torghut): validate replay window handoff metadata

### DIFF
--- a/services/torghut/app/trading/discovery/replay_runtime_window_plan.py
+++ b/services/torghut/app/trading/discovery/replay_runtime_window_plan.py
@@ -58,6 +58,7 @@ def build_replay_runtime_window_handoff(
     runtime_plan = _build_runtime_window_import_plan(
         best_candidate=best_candidate,
         remediation_report=remediation_report,
+        ranking_policy=policy.to_payload(),
         hypothesis_id=_text(hypothesis_id) or "",
         source_manifest_ref=_text(source_manifest_ref) or "",
         run_id=_text(run_id) or "",
@@ -100,6 +101,7 @@ def _build_runtime_window_import_plan(
     *,
     best_candidate: Mapping[str, Any] | None,
     remediation_report: Mapping[str, Any],
+    ranking_policy: Mapping[str, Any],
     hypothesis_id: str,
     source_manifest_ref: str,
     run_id: str,
@@ -145,6 +147,10 @@ def _build_runtime_window_import_plan(
         )
         probation_allowed = not search_blockers
         artifact_counts = _runtime_ledger_artifact_counts(artifact_ref)
+        replay_window_metadata = _target_replay_window_metadata(
+            best_candidate=best_candidate,
+            ranking_policy=ranking_policy,
+        )
         window_start = _text(best_candidate.get("window_start"))
         window_end = _text(best_candidate.get("window_end"))
         target: dict[str, Any] = {
@@ -164,6 +170,7 @@ def _build_runtime_window_import_plan(
             "exact_replay_ledger_artifact_ref": artifact_ref,
             "window_start": window_start,
             "window_end": window_end,
+            **replay_window_metadata,
             "candidate_selection": "exact_replay_ledger_best_candidate",
             "selected_by": "replay_runtime_window_handoff_ranking",
             "selection_reason": _text(remediation_report.get("status")),
@@ -279,6 +286,44 @@ def _target_metadata_blockers(
             "paper_probation_evidence_collection_only",
         ]
     )
+
+
+def _target_replay_window_metadata(
+    *,
+    best_candidate: Mapping[str, Any],
+    ranking_policy: Mapping[str, Any],
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    for source_key, target_key in (
+        ("window_weekday_count", "replay_window_weekday_count"),
+        ("active_day_count", "replay_active_day_count"),
+        ("positive_day_count", "replay_positive_day_count"),
+        ("negative_day_count", "replay_negative_day_count"),
+        ("window_net_pnl_per_day", "replay_window_net_pnl_per_day"),
+        ("active_net_pnl_per_day", "replay_active_net_pnl_per_day"),
+        ("total_net_pnl_after_costs", "replay_total_net_pnl_after_costs"),
+        (
+            "avg_filled_notional_per_window_weekday",
+            "replay_avg_filled_notional_per_window_weekday",
+        ),
+        ("best_day_share", "replay_best_day_share"),
+    ):
+        if (value := best_candidate.get(source_key)) is not None:
+            metadata[target_key] = value
+    for source_key, target_key in (
+        ("min_window_weekday_count", "replay_min_window_weekday_count"),
+        ("target_net_pnl_per_day", "replay_target_net_pnl_per_day"),
+        (
+            "min_avg_filled_notional_per_day",
+            "replay_min_avg_filled_notional_per_day",
+        ),
+        ("max_best_day_share", "replay_max_best_day_share"),
+        ("max_gross_exposure_pct_equity", "replay_max_gross_exposure_pct_equity"),
+        ("start_equity", "replay_start_equity"),
+    ):
+        if (value := ranking_policy.get(source_key)) is not None:
+            metadata[target_key] = value
+    return metadata
 
 
 def _search_blockers(

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
@@ -388,6 +388,40 @@ def _runtime_ledger_target_metadata_blockers(
             blockers.append("runtime_ledger_window_bounds_mismatch")
             break
 
+    expected_candidate_id = _text_or_none(metadata.get("candidate_id"))
+    loaded_candidate_id = _text_or_none(
+        runtime_ledger_artifact_metadata.get("runtime_ledger_artifact_candidate_id")
+    )
+    if (
+        expected_candidate_id is not None
+        and loaded_candidate_id is not None
+        and expected_candidate_id != loaded_candidate_id
+    ):
+        blockers.append("runtime_ledger_artifact_candidate_id_mismatch")
+
+    planned_window_weekdays = _metadata_nonnegative_int_or_none(
+        metadata.get("replay_window_weekday_count")
+    )
+    loaded_window_weekdays = _metadata_nonnegative_int_or_none(
+        runtime_ledger_artifact_metadata.get(
+            "runtime_ledger_artifact_window_weekday_count"
+        )
+    )
+    if planned_window_weekdays is not None:
+        if loaded_window_weekdays is None:
+            blockers.append("runtime_ledger_artifact_window_weekday_count_missing")
+        elif planned_window_weekdays != loaded_window_weekdays:
+            blockers.append("runtime_ledger_artifact_window_weekday_count_mismatch")
+
+    min_window_weekdays = _metadata_nonnegative_int_or_none(
+        metadata.get("replay_min_window_weekday_count")
+    )
+    if min_window_weekdays is not None:
+        if loaded_window_weekdays is None:
+            blockers.append("runtime_ledger_artifact_window_weekday_count_missing")
+        elif loaded_window_weekdays < min_window_weekdays:
+            blockers.append("runtime_ledger_artifact_window_weekday_count_below_min")
+
     return list(dict.fromkeys(blockers))
 
 
@@ -728,6 +762,83 @@ def _runtime_ledger_activity_times(
     return decision_times, execution_times
 
 
+def _parse_artifact_window_datetime(
+    value: Any,
+    *,
+    date_end: bool = False,
+) -> datetime | None:
+    if isinstance(value, datetime):
+        return (
+            value.astimezone(timezone.utc)
+            if value.tzinfo
+            else value.replace(tzinfo=timezone.utc)
+        )
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        if "T" not in text and len(text) == 10:
+            parsed_date = date.fromisoformat(text)
+            parsed = datetime.combine(parsed_date, time.min, tzinfo=timezone.utc)
+            return parsed + timedelta(days=1) if date_end else parsed
+        return _parse_dt(text)
+    except Exception:
+        return None
+
+
+def _runtime_ledger_artifact_window_metadata(
+    *,
+    payload: Mapping[str, Any],
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    full_window = _as_mapping(payload.get("full_window"))
+    start = _parse_artifact_window_datetime(
+        payload.get("window_start")
+        or payload.get("bucket_started_at")
+        or payload.get("started_at")
+        or payload.get("start")
+        or full_window.get("start_date")
+    )
+    end = _parse_artifact_window_datetime(
+        payload.get("window_end")
+        or payload.get("bucket_ended_at")
+        or payload.get("ended_at")
+        or payload.get("end")
+        or full_window.get("end_date"),
+        date_end=True,
+    )
+    if start is None or end is None:
+        row_times = [
+            row_time
+            for row in rows
+            if (row_time := _runtime_ledger_row_time(row)) is not None
+        ]
+        if row_times:
+            start = min(row_times) if start is None else start
+            end = max(row_times) + timedelta(microseconds=1) if end is None else end
+    if start is None or end is None or end <= start:
+        return {}
+    return {
+        "runtime_ledger_artifact_window_start": start.isoformat(),
+        "runtime_ledger_artifact_window_end": end.isoformat(),
+        "runtime_ledger_artifact_window_weekday_count": _window_weekday_count(
+            start=start,
+            end=end,
+        ),
+    }
+
+
+def _window_weekday_count(*, start: datetime, end: datetime) -> int:
+    count = 0
+    current = datetime.combine(start.date(), time.min, tzinfo=timezone.utc)
+    while current < end:
+        next_day = current + timedelta(days=1)
+        if current.weekday() < 5 and next_day > start:
+            count += 1
+        current = next_day
+    return count
+
+
 def _runtime_ledger_tca_rows_from_artifacts(
     *,
     artifact_refs: list[str],
@@ -737,6 +848,8 @@ def _runtime_ledger_tca_rows_from_artifacts(
     tca_rows: list[dict[str, object]] = []
     loaded_refs: list[str] = []
     ignored_refs: list[str] = []
+    artifact_candidates: list[str] = []
+    artifact_window_metadata: list[dict[str, Any]] = []
     for ref in artifact_refs:
         payload = _load_json_artifact(ref)
         if not payload:
@@ -748,6 +861,13 @@ def _runtime_ledger_tca_rows_from_artifacts(
             continue
         loaded_refs.append(ref)
         ledger_rows.extend(rows)
+        if candidate_id := _text_or_none(payload.get("candidate_id")):
+            artifact_candidates.append(candidate_id)
+        if metadata := _runtime_ledger_artifact_window_metadata(
+            payload=payload,
+            rows=rows,
+        ):
+            artifact_window_metadata.append(metadata)
     decision_times, execution_times = _runtime_ledger_activity_times(ledger_rows)
     runtime_bucket_ranges = [(start, end) for start, end, _ in bucket_ranges]
     if ledger_rows and runtime_bucket_ranges:
@@ -777,6 +897,10 @@ def _runtime_ledger_tca_rows_from_artifacts(
         ),
         "runtime_ledger_artifact_tca_row_count": len(tca_rows),
     }
+    if len(set(artifact_candidates)) == 1:
+        metadata["runtime_ledger_artifact_candidate_id"] = artifact_candidates[0]
+    if len(artifact_window_metadata) == 1:
+        metadata.update(artifact_window_metadata[0])
     return decision_times, execution_times, tca_rows, metadata
 
 

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -460,16 +460,21 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
         artifact_metadata = {
             "runtime_ledger_artifact_refs": ["exact-ledger.json"],
+            "runtime_ledger_artifact_candidate_id": "cand-one",
             "runtime_ledger_artifact_row_count": 6,
             "runtime_ledger_artifact_fill_count": 2,
+            "runtime_ledger_artifact_window_weekday_count": 5,
         }
 
         self.assertEqual(
             _runtime_ledger_target_metadata_blockers(
                 target_metadata={
                     "runtime_ledger_artifact_refs": ["exact-ledger.json"],
+                    "candidate_id": "cand-one",
                     "runtime_ledger_artifact_row_count": 6,
                     "runtime_ledger_artifact_fill_count": 2,
+                    "replay_window_weekday_count": 5,
+                    "replay_min_window_weekday_count": 5,
                     "window_start": "2026-03-06T14:30:00+00:00",
                     "window_end": "2026-03-06T15:00:00+00:00",
                 },
@@ -483,8 +488,11 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             _runtime_ledger_target_metadata_blockers(
                 target_metadata={
                     "runtime_ledger_artifact_refs": ["different-ledger.json"],
+                    "candidate_id": "different-cand",
                     "runtime_ledger_artifact_row_count": 7,
                     "runtime_ledger_artifact_fill_count": 3,
+                    "replay_window_weekday_count": 4,
+                    "replay_min_window_weekday_count": 20,
                     "window_start": "2026-03-06T14:35:00+00:00",
                     "window_end": "2026-03-06T15:00:00+00:00",
                 },
@@ -497,6 +505,9 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "runtime_ledger_artifact_row_count_mismatch",
                 "runtime_ledger_artifact_fill_count_mismatch",
                 "runtime_ledger_window_bounds_mismatch",
+                "runtime_ledger_artifact_candidate_id_mismatch",
+                "runtime_ledger_artifact_window_weekday_count_mismatch",
+                "runtime_ledger_artifact_window_weekday_count_below_min",
             ],
         )
 
@@ -803,6 +814,9 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 json.dumps(
                     {
                         "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "candidate_id": "artifact-candidate-1",
+                        "window_start": "2026-03-06",
+                        "window_end": "2026-03-06",
                         "account_label": "TORGHUT_SIM",
                         "strategy_id": "intraday-tsmom-profit-v3",
                         "execution_policy_hash": "policy-sha",
@@ -902,6 +916,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(ledger_bucket["blockers"], [])
         self.assertEqual(metadata["runtime_ledger_artifact_row_count"], 6)
         self.assertEqual(metadata["runtime_ledger_artifact_tca_row_count"], 1)
+        self.assertEqual(
+            metadata["runtime_ledger_artifact_candidate_id"], "artifact-candidate-1"
+        )
+        self.assertEqual(metadata["runtime_ledger_artifact_window_weekday_count"], 1)
 
     def test_runtime_ledger_artifact_helpers_fail_closed_on_loose_rows(self) -> None:
         aware_time = datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)

--- a/services/torghut/tests/test_replay_runtime_window_plan.py
+++ b/services/torghut/tests/test_replay_runtime_window_plan.py
@@ -151,9 +151,16 @@ def test_handoff_builds_non_promotional_runtime_window_target(
     assert target["runtime_ledger_artifact_refs"] == [str(artifact_path.resolve())]
     assert target["runtime_ledger_artifact_row_count"] == 6
     assert target["runtime_ledger_artifact_fill_count"] == 2
+    assert target["replay_window_weekday_count"] == 5
+    assert target["replay_min_window_weekday_count"] == 20
+    assert target["replay_target_net_pnl_per_day"] == "500"
     assert target["paper_probation_authorized"] is False
     assert target["promotion_allowed"] is False
     assert target["final_promotion_authorized"] is False
+    assert (
+        "window_weekday_count_below_min_observed_trading_days"
+        in target["runtime_ledger_target_metadata_blockers"]
+    )
     assert (
         "paper_probation_evidence_collection_only" in target["final_promotion_blockers"]
     )


### PR DESCRIPTION
## Summary

- Adds replay-window metric and policy metadata to exact replay runtime-window handoff targets.
- Derives candidate id and replay artifact window weekday coverage while importing exact replay ledger artifacts.
- Fails target metadata validation when artifact candidate/window proof does not match the planned handoff or falls below the replay policy floor.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_replay_runtime_window_plan.py tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen ruff format --check app/trading/discovery/replay_runtime_window_plan.py scripts/import_hypothesis_runtime_windows.py tests/test_replay_runtime_window_plan.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff check app/trading/discovery/replay_runtime_window_plan.py scripts/import_hypothesis_runtime_windows.py tests/test_replay_runtime_window_plan.py tests/test_import_hypothesis_runtime_windows.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
