### PR TITLE
fix(torghut): cap parallel replay frontier budget

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -119,6 +119,7 @@ _CANDIDATE_BOARD_RUNTIME_SESSION_TZ = ZoneInfo("America/New_York")
 _CANDIDATE_BOARD_RUNTIME_SESSION_OPEN = time(hour=9, minute=30)
 _CANDIDATE_BOARD_RUNTIME_SESSION_CLOSE = time(hour=16, minute=0)
 _DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC = 8
+_DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES = 16
 _DEFAULT_CLICKHOUSE_HTTP_URL = (
     "http://torghut-clickhouse.torghut.svc.cluster.local:8123"
 )
@@ -365,6 +366,16 @@ def _parse_args() -> argparse.Namespace:
         help=(
             "Maximum number of bounded real-replay shards to run concurrently. "
             "Defaults to 1 for the legacy sequential behavior."
+        ),
+    )
+    parser.add_argument(
+        "--real-replay-max-parallel-frontier-candidates",
+        type=int,
+        default=_DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
+        help=(
+            "Safety cap on concurrent exact-frontier candidate budget across "
+            "real-replay shards. Requested workers are reduced when their "
+            "combined shard budgets would exceed this value."
         ),
     )
     parser.add_argument(
@@ -6693,6 +6704,44 @@ def _retry_real_replay_failed_shard_specs(
     return deduped_retry_evidence, tuple(replay_results), remaining_failures, summary
 
 
+def _replay_shard_frontier_candidate_budget(plan: _ReplayShardPlan) -> int:
+    return max(1, int(getattr(plan.args, "max_total_frontier_candidates", 1) or 1))
+
+
+def _bounded_real_replay_shard_workers(
+    *,
+    args: argparse.Namespace,
+    plans: Sequence[_ReplayShardPlan],
+) -> int:
+    requested_workers = max(
+        1,
+        min(
+            len(plans) or 1,
+            int(getattr(args, "real_replay_shard_workers", 1) or 1),
+        ),
+    )
+    max_parallel_frontier_candidates = max(
+        0,
+        int(
+            getattr(
+                args,
+                "real_replay_max_parallel_frontier_candidates",
+                _DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
+            )
+            or 0
+        ),
+    )
+    if not plans or max_parallel_frontier_candidates <= 0:
+        return requested_workers
+    largest_shard_budget = max(
+        _replay_shard_frontier_candidate_budget(plan) for plan in plans
+    )
+    budget_capped_workers = max(
+        1, max_parallel_frontier_candidates // largest_shard_budget
+    )
+    return max(1, min(requested_workers, budget_capped_workers))
+
+
 def _run_real_replay_shards(
     *,
     args: argparse.Namespace,
@@ -6712,12 +6761,9 @@ def _run_real_replay_shards(
         shard_timeout_seconds=shard_timeout_seconds,
     )
     bounded_shard_size = max(1, int(shard_size))
-    shard_workers = max(
-        1,
-        min(
-            len(plans) or 1,
-            int(getattr(args, "real_replay_shard_workers", 1) or 1),
-        ),
+    shard_workers = _bounded_real_replay_shard_workers(
+        args=args,
+        plans=plans,
     )
     if shard_workers <= 1:
         outcomes = [_execute_real_replay_shard(plan) for plan in plans]
@@ -7000,7 +7046,9 @@ _EXACT_REPLAY_LEDGER_SCHEMA_VERSIONS = frozenset(
 _EXACT_REPLAY_RUNTIME_LEDGER_PNL_SOURCE = "exact_replay_runtime_ledger"
 
 
-def _runtime_closure_ledger_datetime(value: Any, *, date_end: bool = False) -> datetime | None:
+def _runtime_closure_ledger_datetime(
+    value: Any, *, date_end: bool = False
+) -> datetime | None:
     text = _string(value)
     if not text:
         return None
@@ -10574,6 +10622,14 @@ def run_whitepaper_autoresearch_profit_target(
             ),
             "real_replay_shard_workers": int(
                 getattr(args, "real_replay_shard_workers", 1) or 1
+            ),
+            "real_replay_max_parallel_frontier_candidates": int(
+                getattr(
+                    args,
+                    "real_replay_max_parallel_frontier_candidates",
+                    _DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
+                )
+                or _DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES
             ),
             "real_replay_failed_spec_retries": int(
                 getattr(args, "real_replay_failed_spec_retries", 1) or 0

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -241,6 +241,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             real_replay_shard_size=0,
             real_replay_shard_timeout_seconds=0,
             real_replay_shard_workers=1,
+            real_replay_max_parallel_frontier_candidates=runner._DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
             real_replay_failed_spec_retries=1,
             real_replay_retry_timeout_seconds=0,
             real_replay_retry_max_frontier_candidates_per_spec=1,
@@ -5060,9 +5061,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(update["runtime_ledger_closed_trade_count"], 1)
         self.assertEqual(update["runtime_ledger_open_position_count"], 0)
         self.assertEqual(update["runtime_ledger_filled_notional"], "201")
-        self.assertEqual(
-            update["runtime_ledger_net_strategy_pnl_after_costs"], "0.80"
-        )
+        self.assertEqual(update["runtime_ledger_net_strategy_pnl_after_costs"], "0.80")
         self.assertEqual(
             update["portfolio_post_cost_net_pnl_basis"],
             "realized_strategy_pnl_after_explicit_costs",
@@ -9195,6 +9194,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(parsed.real_replay_shard_size, 0)
         self.assertEqual(parsed.real_replay_shard_timeout_seconds, 0)
         self.assertEqual(parsed.real_replay_shard_workers, 1)
+        self.assertEqual(
+            parsed.real_replay_max_parallel_frontier_candidates,
+            runner._DEFAULT_REAL_REPLAY_MAX_PARALLEL_FRONTIER_CANDIDATES,
+        )
         self.assertEqual(parsed.replay_tape_path, Path(tmpdir) / "tape.jsonl")
         self.assertEqual(
             parsed.replay_tape_manifest, Path(tmpdir) / "tape.manifest.json"
@@ -10161,6 +10164,43 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             [item["shard_index"] for item in result.replay_results],
             [1, 2, 3],
+        )
+
+    def test_real_replay_shards_caps_workers_by_parallel_frontier_budget(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "epoch"
+            cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
+                [runner.RECENT_WHITEPAPER_SEEDS[0]]
+            )
+            compilation = runner.compile_whitepaper_candidate_specs(
+                hypothesis_cards=cards,
+                family_template_dir=Path("config/trading/families"),
+                seed_sweep_dir=Path("config/trading"),
+            )
+            specs = compilation.executable_specs[:6]
+            args = self._args(output_dir)
+            args.max_frontier_candidates_per_spec = 4
+            args.max_total_frontier_candidates = 24
+            args.real_replay_shard_workers = 8
+            args.real_replay_max_parallel_frontier_candidates = 10
+
+            plans = runner._build_real_replay_shards(
+                args=args,
+                output_dir=output_dir,
+                specs=specs,
+                shard_size=2,
+                shard_timeout_seconds=7,
+            )
+
+        self.assertEqual(
+            [runner._replay_shard_frontier_candidate_budget(plan) for plan in plans],
+            [8, 8, 8],
+        )
+        self.assertEqual(
+            runner._bounded_real_replay_shard_workers(args=args, plans=plans),
+            1,
         )
 
     def test_incomplete_sharded_replay_cannot_report_oracle_candidate_found(


### PR DESCRIPTION
## Summary

- Adds `--real-replay-max-parallel-frontier-candidates` as a safety cap for sharded exact real-replay runs.
- Caps effective shard workers by the largest per-shard frontier budget so high requested worker counts cannot multiply replay spend beyond the configured cap.
- Persists the cap in epoch runner config and adds regression coverage for worker throttling.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'parse_args or real_replay_shards' -q`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
