### PR TITLE
fix(torghut): reject ambiguous ledger candidate proof

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -298,6 +298,25 @@ def _runtime_ledger_tca_row_from_bucket(
     }
 
 
+def _append_runtime_ledger_tca_row_blocker(
+    *,
+    tca_rows: list[dict[str, object]],
+    blocker: str,
+) -> None:
+    for row in tca_rows:
+        bucket = row.get("runtime_ledger_bucket")
+        if not isinstance(bucket, Mapping):
+            continue
+        bucket_payload = {str(key): item for key, item in bucket.items()}
+        blockers = _metadata_text_list(bucket_payload.get("blockers"))
+        if blocker not in blockers:
+            blockers.append(blocker)
+        bucket_payload["blockers"] = blockers
+        row["runtime_ledger_bucket"] = bucket_payload
+        row["runtime_ledger_blockers"] = blockers
+        row["post_cost_promotion_eligible"] = False
+
+
 def _nonnegative_int(value: Any) -> int:
     try:
         return max(0, int(Decimal(str(value))))
@@ -389,15 +408,22 @@ def _runtime_ledger_target_metadata_blockers(
             break
 
     expected_candidate_id = _text_or_none(metadata.get("candidate_id"))
+    loaded_candidate_ids = _metadata_text_list(
+        runtime_ledger_artifact_metadata.get("runtime_ledger_artifact_candidate_ids")
+    )
     loaded_candidate_id = _text_or_none(
         runtime_ledger_artifact_metadata.get("runtime_ledger_artifact_candidate_id")
     )
-    if (
-        expected_candidate_id is not None
-        and loaded_candidate_id is not None
-        and expected_candidate_id != loaded_candidate_id
-    ):
-        blockers.append("runtime_ledger_artifact_candidate_id_mismatch")
+    if expected_candidate_id is not None:
+        if loaded_candidate_ids:
+            if expected_candidate_id not in loaded_candidate_ids:
+                blockers.append("runtime_ledger_artifact_candidate_id_mismatch")
+            elif len(loaded_candidate_ids) > 1:
+                blockers.append("runtime_ledger_artifact_candidate_id_ambiguous")
+        elif loaded_candidate_id is None:
+            blockers.append("runtime_ledger_artifact_candidate_id_missing")
+        elif expected_candidate_id != loaded_candidate_id:
+            blockers.append("runtime_ledger_artifact_candidate_id_mismatch")
 
     planned_window_weekdays = _metadata_nonnegative_int_or_none(
         metadata.get("replay_window_weekday_count")
@@ -839,6 +865,32 @@ def _window_weekday_count(*, start: datetime, end: datetime) -> int:
     return count
 
 
+def _runtime_ledger_artifact_candidate_ids(
+    *,
+    payload: Mapping[str, Any],
+    rows: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    candidates: list[str] = []
+    for key in (
+        "candidate_id",
+        "candidateId",
+        "strategy_candidate_id",
+        "strategyCandidateId",
+    ):
+        if candidate_id := _text_or_none(payload.get(key)):
+            candidates.append(candidate_id)
+    for row in rows:
+        for key in (
+            "candidate_id",
+            "candidateId",
+            "strategy_candidate_id",
+            "strategyCandidateId",
+        ):
+            if candidate_id := _text_or_none(row.get(key)):
+                candidates.append(candidate_id)
+    return sorted(dict.fromkeys(candidates))
+
+
 def _runtime_ledger_tca_rows_from_artifacts(
     *,
     artifact_refs: list[str],
@@ -861,8 +913,9 @@ def _runtime_ledger_tca_rows_from_artifacts(
             continue
         loaded_refs.append(ref)
         ledger_rows.extend(rows)
-        if candidate_id := _text_or_none(payload.get("candidate_id")):
-            artifact_candidates.append(candidate_id)
+        artifact_candidates.extend(
+            _runtime_ledger_artifact_candidate_ids(payload=payload, rows=rows)
+        )
         if metadata := _runtime_ledger_artifact_window_metadata(
             payload=payload,
             rows=rows,
@@ -897,8 +950,20 @@ def _runtime_ledger_tca_rows_from_artifacts(
         ),
         "runtime_ledger_artifact_tca_row_count": len(tca_rows),
     }
-    if len(set(artifact_candidates)) == 1:
-        metadata["runtime_ledger_artifact_candidate_id"] = artifact_candidates[0]
+    unique_artifact_candidates = sorted(dict.fromkeys(artifact_candidates))
+    if unique_artifact_candidates:
+        metadata["runtime_ledger_artifact_candidate_ids"] = unique_artifact_candidates
+    if len(unique_artifact_candidates) == 1:
+        metadata["runtime_ledger_artifact_candidate_id"] = unique_artifact_candidates[0]
+    elif loaded_refs:
+        _append_runtime_ledger_tca_row_blocker(
+            tca_rows=tca_rows,
+            blocker=(
+                "runtime_ledger_artifact_candidate_id_missing"
+                if not unique_artifact_candidates
+                else "runtime_ledger_artifact_candidate_id_ambiguous"
+            ),
+        )
     if len(artifact_window_metadata) == 1:
         metadata.update(artifact_window_metadata[0])
     return decision_times, execution_times, tca_rows, metadata

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -511,6 +511,58 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ],
         )
 
+    def test_runtime_ledger_target_metadata_blocks_missing_or_mixed_candidate_ids(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+        target_metadata = {
+            "runtime_ledger_artifact_refs": ["exact-ledger.json"],
+            "candidate_id": "cand-one",
+        }
+
+        self.assertEqual(
+            _runtime_ledger_target_metadata_blockers(
+                target_metadata=target_metadata,
+                runtime_ledger_artifact_metadata={
+                    "runtime_ledger_artifact_refs": ["exact-ledger.json"],
+                    "runtime_ledger_artifact_row_count": 6,
+                },
+                window_start=window_start,
+                window_end=window_end,
+            ),
+            ["runtime_ledger_artifact_candidate_id_missing"],
+        )
+        self.assertEqual(
+            _runtime_ledger_target_metadata_blockers(
+                target_metadata=target_metadata,
+                runtime_ledger_artifact_metadata={
+                    "runtime_ledger_artifact_refs": ["exact-ledger.json"],
+                    "runtime_ledger_artifact_candidate_ids": [
+                        "cand-one",
+                        "cand-two",
+                    ],
+                    "runtime_ledger_artifact_row_count": 6,
+                },
+                window_start=window_start,
+                window_end=window_end,
+            ),
+            ["runtime_ledger_artifact_candidate_id_ambiguous"],
+        )
+        self.assertEqual(
+            _runtime_ledger_target_metadata_blockers(
+                target_metadata=target_metadata,
+                runtime_ledger_artifact_metadata={
+                    "runtime_ledger_artifact_refs": ["exact-ledger.json"],
+                    "runtime_ledger_artifact_candidate_ids": ["different-cand"],
+                    "runtime_ledger_artifact_row_count": 6,
+                },
+                window_start=window_start,
+                window_end=window_end,
+            ),
+            ["runtime_ledger_artifact_candidate_id_mismatch"],
+        )
+
     def test_main_requires_source_dsn_or_durable_runtime_ledger_bucket(self) -> None:
         args = SimpleNamespace(
             run_id="run-missing-source",
@@ -919,7 +971,104 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(
             metadata["runtime_ledger_artifact_candidate_id"], "artifact-candidate-1"
         )
+        self.assertEqual(
+            metadata["runtime_ledger_artifact_candidate_ids"],
+            ["artifact-candidate-1"],
+        )
         self.assertEqual(metadata["runtime_ledger_artifact_window_weekday_count"], 1)
+
+    def test_runtime_ledger_artifacts_derive_candidate_ids_from_rows(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            artifact_path = Path(temp_dir) / "exact-ledger-row-candidates.json"
+            artifact_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "account_label": "TORGHUT_SIM",
+                        "strategy_id": "intraday-tsmom-profit-v3",
+                        "execution_policy_hash": "policy-sha",
+                        "cost_model_hash": "cost-sha",
+                        "lineage_hash": "lineage-sha",
+                        "runtime_ledger_rows": [
+                            {
+                                "candidate_id": "row-candidate-1",
+                                "event_type": "decision",
+                                "executed_at": "2026-03-06T14:35:00Z",
+                                "decision_id": "decision-buy",
+                            },
+                            {
+                                "candidate_id": "row-candidate-1",
+                                "event_type": "order_submitted",
+                                "executed_at": "2026-03-06T14:35:01Z",
+                                "decision_id": "decision-buy",
+                                "order_id": "order-buy",
+                            },
+                            {
+                                "candidate_id": "row-candidate-1",
+                                "event_type": "fill",
+                                "executed_at": "2026-03-06T14:35:02Z",
+                                "decision_id": "decision-buy",
+                                "order_id": "order-buy",
+                                "symbol": "AAPL",
+                                "side": "buy",
+                                "filled_qty": "1",
+                                "avg_fill_price": "100",
+                                "cost_amount": "0.10",
+                                "cost_basis": "broker_reported_commission_and_fees",
+                            },
+                            {
+                                "candidate_id": "row-candidate-2",
+                                "event_type": "decision",
+                                "executed_at": "2026-03-06T14:40:00Z",
+                                "decision_id": "decision-sell",
+                            },
+                            {
+                                "candidate_id": "row-candidate-2",
+                                "event_type": "order_submitted",
+                                "executed_at": "2026-03-06T14:40:01Z",
+                                "decision_id": "decision-sell",
+                                "order_id": "order-sell",
+                            },
+                            {
+                                "candidate_id": "row-candidate-2",
+                                "event_type": "fill",
+                                "executed_at": "2026-03-06T14:40:02Z",
+                                "decision_id": "decision-sell",
+                                "order_id": "order-sell",
+                                "symbol": "AAPL",
+                                "side": "sell",
+                                "filled_qty": "1",
+                                "avg_fill_price": "101",
+                                "cost_amount": "0.10",
+                                "cost_basis": "broker_reported_commission_and_fees",
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            _, _, tca_rows, metadata = _runtime_ledger_tca_rows_from_artifacts(
+                artifact_refs=[str(artifact_path)],
+                bucket_ranges=[
+                    (
+                        datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                        datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                        6,
+                    )
+                ],
+            )
+
+        self.assertEqual(
+            metadata["runtime_ledger_artifact_candidate_ids"],
+            ["row-candidate-1", "row-candidate-2"],
+        )
+        self.assertNotIn("runtime_ledger_artifact_candidate_id", metadata)
+        self.assertEqual(tca_rows[0]["post_cost_promotion_eligible"], False)
+        self.assertIn(
+            "runtime_ledger_artifact_candidate_id_ambiguous",
+            tca_rows[0]["runtime_ledger_blockers"],
+        )
 
     def test_runtime_ledger_artifact_helpers_fail_closed_on_loose_rows(self) -> None:
         aware_time = datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)
@@ -1344,6 +1493,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 json.dumps(
                     {
                         "schema_version": "torghut.exact_replay_ledger.rows.v1",
+                        "candidate_id": "H-TSMOM-LIQ-01",
                         "account_label": "TORGHUT_SIM",
                         "strategy_id": "intraday-tsmom-profit-v3",
                         "execution_policy_hash": "policy-sha",
@@ -1425,6 +1575,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 target_metadata_json=json.dumps(
                     {
                         "runtime_ledger_artifact_refs": [str(artifact_path)],
+                        "candidate_id": "H-TSMOM-LIQ-01",
                         "runtime_ledger_artifact_row_count": 6,
                         "runtime_ledger_artifact_fill_count": 2,
                         "window_start": "2026-03-06T14:30:00+00:00",
@@ -1496,6 +1647,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertEqual(runtime_payload["runtime_ledger_artifact_row_count"], 6)
         self.assertEqual(runtime_payload["runtime_ledger_artifact_fill_count"], 2)
+        self.assertEqual(
+            runtime_payload["runtime_ledger_artifact_candidate_id"],
+            "H-TSMOM-LIQ-01",
+        )
         self.assertEqual(runtime_payload["runtime_ledger_target_metadata_blockers"], [])
         self.assertEqual(
             runtime_payload["authority_reason"], "runtime_ledger_profit_proof"


### PR DESCRIPTION
## Summary

- Derive exact replay/runtime ledger artifact candidate identity from both payload-level and row-level candidate fields.
- Fail closed when target runtime-window metadata expects a candidate but loaded ledger artifact identity is missing, mismatched, or ambiguous.
- Demote ledger-derived TCA rows with missing or mixed artifact candidate identity so they cannot become promotion-grade proof.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
