### PR TITLE
feat(torghut): collect multiple probation candidates

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -8617,11 +8617,58 @@ def _candidate_board_paper_probation_admission_blockers(
     return blockers
 
 
-def _candidate_board_paper_probation_candidate(
+def _paper_probation_candidate_payload(
+    *,
+    candidate: Mapping[str, Any],
+    target: Decimal,
+    rank: int,
+) -> dict[str, Any]:
+    payload = dict(candidate)
+    lower_bound = _candidate_board_lower_bound_net_pnl(payload)
+    deployable_missing_count = deployable_lower_bound_missing_count(payload)
+    deployable_failed_gate_count = deployable_proof_failed_gate_count(payload)
+    final_promotion_blockers = [
+        _string(blocker)
+        for blocker in cast(Sequence[Any], payload.get("blockers") or ())
+        if _string(blocker)
+    ]
+    if not final_promotion_blockers:
+        final_promotion_blockers.append("final_promotion_requires_runtime_governance")
+    payload.update(
+        {
+            "candidate_selection": "oracle_recommended_paper_probation",
+            "paper_probation_tier": "paper_probation",
+            "paper_probation_rank": rank,
+            "paper_probation_authorized": True,
+            "probation_allowed": True,
+            "paper_probation_authorization_scope": "evidence_collection_only",
+            "evidence_collection_stage": "paper",
+            "probation_reason": "runtime_evidence_collection_only",
+            "selection_reason": "target_met_but_oracle_blocked"
+            if bool(payload.get("target_met"))
+            else "closest_lower_bound_economics_below_target",
+            "selected_by": "candidate_board_paper_probation_candidate",
+            "probation_lower_bound_net_pnl_per_day": str(lower_bound),
+            "probation_target_shortfall": str(max(target - lower_bound, Decimal("0"))),
+            "deployable_lower_bound_missing_count": deployable_missing_count,
+            "deployable_lower_bound_failed_gate_count": deployable_failed_gate_count,
+            "promotion_allowed": False,
+            "promotion_gate": "existing_runtime_governance_fail_closed",
+            "final_promotion_authorized": False,
+            "final_promotion_allowed": False,
+            "promotion_blockers": list(dict.fromkeys(final_promotion_blockers)),
+            "final_promotion_blockers": list(dict.fromkeys(final_promotion_blockers)),
+        }
+    )
+    return payload
+
+
+def _candidate_board_paper_probation_candidates(
     rows: Sequence[Mapping[str, Any]],
     *,
     target: Decimal,
-) -> dict[str, Any] | None:
+    limit: int = 1,
+) -> tuple[dict[str, Any], ...]:
     candidates = [
         dict(row)
         for row in rows
@@ -8634,15 +8681,16 @@ def _candidate_board_paper_probation_candidate(
         and _string(row.get("runtime_strategy_name"))
     ]
     if not candidates:
-        return None
+        return ()
 
     admitted_candidates = [
         candidate
         for candidate in candidates
         if not _candidate_board_paper_probation_admission_blockers(candidate)
+        and _candidate_board_lower_bound_net_pnl(candidate) > 0
     ]
     if not admitted_candidates:
-        return None
+        return ()
 
     def rank(row: Mapping[str, Any]) -> tuple[Any, ...]:
         lower_bound = _candidate_board_lower_bound_net_pnl(row)
@@ -8664,43 +8712,28 @@ def _candidate_board_paper_probation_candidate(
         )
 
     admitted_candidates.sort(key=rank, reverse=True)
-    candidate = dict(admitted_candidates[0])
-    lower_bound = _candidate_board_lower_bound_net_pnl(candidate)
-    deployable_missing_count = deployable_lower_bound_missing_count(candidate)
-    deployable_failed_gate_count = deployable_proof_failed_gate_count(candidate)
-    final_promotion_blockers = [
-        _string(blocker)
-        for blocker in cast(Sequence[Any], candidate.get("blockers") or ())
-        if _string(blocker)
-    ]
-    if not final_promotion_blockers:
-        final_promotion_blockers.append("final_promotion_requires_runtime_governance")
-    candidate.update(
-        {
-            "candidate_selection": "oracle_recommended_paper_probation",
-            "paper_probation_tier": "paper_probation",
-            "paper_probation_authorized": True,
-            "probation_allowed": True,
-            "paper_probation_authorization_scope": "evidence_collection_only",
-            "evidence_collection_stage": "paper",
-            "probation_reason": "runtime_evidence_collection_only",
-            "selection_reason": "target_met_but_oracle_blocked"
-            if bool(candidate.get("target_met"))
-            else "closest_lower_bound_economics_below_target",
-            "selected_by": "candidate_board_paper_probation_candidate",
-            "probation_lower_bound_net_pnl_per_day": str(lower_bound),
-            "probation_target_shortfall": str(max(target - lower_bound, Decimal("0"))),
-            "deployable_lower_bound_missing_count": deployable_missing_count,
-            "deployable_lower_bound_failed_gate_count": deployable_failed_gate_count,
-            "promotion_allowed": False,
-            "promotion_gate": "existing_runtime_governance_fail_closed",
-            "final_promotion_authorized": False,
-            "final_promotion_allowed": False,
-            "promotion_blockers": list(dict.fromkeys(final_promotion_blockers)),
-            "final_promotion_blockers": list(dict.fromkeys(final_promotion_blockers)),
-        }
+    selected = admitted_candidates[: max(1, int(limit))]
+    return tuple(
+        _paper_probation_candidate_payload(
+            candidate=candidate,
+            target=target,
+            rank=index,
+        )
+        for index, candidate in enumerate(selected, start=1)
     )
-    return candidate
+
+
+def _candidate_board_paper_probation_candidate(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    target: Decimal,
+) -> dict[str, Any] | None:
+    candidates = _candidate_board_paper_probation_candidates(
+        rows,
+        target=target,
+        limit=1,
+    )
+    return candidates[0] if candidates else None
 
 
 def _candidate_board_status_digest(rows: Sequence[Mapping[str, Any]]) -> str:
@@ -9018,11 +9051,13 @@ def _candidate_board_runtime_window_import_plan(
     *,
     rows: Sequence[Mapping[str, Any]],
     paper_probation_candidate: Mapping[str, Any] | None,
-    promotion_subject: Mapping[str, Any] | None,
+    paper_probation_candidates: Sequence[Mapping[str, Any]] = (),
+    promotion_subject: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     source_rows: list[Mapping[str, Any]] = []
     if paper_probation_candidate is not None:
         source_rows.append(paper_probation_candidate)
+    source_rows.extend(paper_probation_candidates)
 
     if promotion_subject is not None and _boolish(promotion_subject.get("target_met")):
         portfolio_spec_ids = {
@@ -9198,6 +9233,7 @@ def _candidate_board_payload(
     portfolio: PortfolioCandidateSpec | None,
     promotion_readiness: Mapping[str, Any],
     runtime_closure: Mapping[str, Any],
+    paper_probation_target_limit: int = 1,
 ) -> dict[str, Any]:
     pre_replay_by_spec = _candidate_board_score_rows(pre_replay_proposal_rows)
     proposal_by_spec = _candidate_board_score_rows(proposal_rows)
@@ -9530,9 +9566,13 @@ def _candidate_board_payload(
     best_research_candidate = rows[0] if rows else None
     best_executed_candidate = _candidate_board_best_executed_candidate(rows)
     closest_promotion_candidate = _candidate_board_closest_promotion_candidate(rows)
-    paper_probation_candidate = _candidate_board_paper_probation_candidate(
+    paper_probation_candidates = _candidate_board_paper_probation_candidates(
         rows,
         target=target,
+        limit=paper_probation_target_limit,
+    )
+    paper_probation_candidate = (
+        paper_probation_candidates[0] if paper_probation_candidates else None
     )
     promotion_ready = _boolish(promotion_readiness.get("promotable"))
     promotion_subject = _candidate_board_portfolio_promotion_subject(
@@ -9564,10 +9604,13 @@ def _candidate_board_payload(
         "best_executed_candidate": best_executed_candidate,
         "closest_promotion_candidate": closest_promotion_candidate,
         "paper_probation_candidate": paper_probation_candidate,
+        "paper_probation_candidates": list(paper_probation_candidates),
+        "paper_probation_target_limit": max(1, int(paper_probation_target_limit)),
         "promotion_subject": promotion_subject,
         "runtime_window_import_plan": _candidate_board_runtime_window_import_plan(
             rows=rows,
-            paper_probation_candidate=paper_probation_candidate,
+            paper_probation_candidate=None,
+            paper_probation_candidates=paper_probation_candidates,
             promotion_subject=promotion_subject,
         ),
         "double_oos_summary": _candidate_board_double_oos_summary(rows),
@@ -10464,6 +10507,7 @@ def run_whitepaper_autoresearch_profit_target(
         portfolio=portfolio,
         promotion_readiness=promotion_readiness,
         runtime_closure=runtime_closure,
+        paper_probation_target_limit=program.replay_budget.exploration_slots,
     )
     candidate_board_path = output_dir / "candidate-board.json"
     _write_json(candidate_board_path, candidate_board)

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -6504,6 +6504,31 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             ),
             objective_scorecard={
                 "net_pnl_per_day": "82.50",
+                "market_impact_stress_passed": True,
+                "market_impact_stress_net_pnl_per_day": "82.50",
+                "delay_adjusted_depth_stress_passed": True,
+                "delay_adjusted_depth_stress_net_pnl_per_day": "82.50",
+                "post_cost_net_pnl_after_queue_position_survival_fill_stress": "82.50",
+                "double_oos_passed": True,
+                "double_oos_net_pnl_per_day": "82.50",
+                "double_oos_cost_shock_net_pnl_per_day": "82.50",
+                "implementation_uncertainty_stability_passed": True,
+                "implementation_uncertainty_lower_net_pnl_per_day": "82.50",
+                "conformal_tail_risk_passed": True,
+                "conformal_tail_risk_adjusted_net_pnl_per_day": "82.50",
+                "delay_adjusted_depth_fill_survival_evidence_present": True,
+                "delay_adjusted_depth_fill_survival_sample_count": 7,
+                "delay_adjusted_depth_fill_survival_rate": "0.85",
+                "queue_position_survival_fill_curve_evidence_present": True,
+                "queue_position_survival_sample_count": 7,
+                "queue_position_survival_fill_rate": "0.85",
+                "queue_position_survival_queue_ratio_p95": "0.25",
+                "queue_position_survival_queue_ahead_depletion_evidence_present": True,
+                "queue_position_survival_queue_ahead_depletion_sample_count": 7,
+                "delay_adjusted_depth_queue_ahead_depletion_evidence_present": True,
+                "delay_adjusted_depth_queue_ahead_depletion_sample_count": 7,
+                "queue_ahead_depletion_evidence_present": True,
+                "queue_ahead_depletion_sample_count": 7,
                 "target_met": False,
                 "oracle_passed": False,
                 "trading_day_count": 3,
@@ -6696,6 +6721,30 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             ),
             objective_scorecard={
                 "net_pnl_per_day": "525",
+                "market_impact_stress_passed": True,
+                "market_impact_stress_net_pnl_per_day": "525",
+                "delay_adjusted_depth_stress_passed": True,
+                "delay_adjusted_depth_stress_net_pnl_per_day": "525",
+                "post_cost_net_pnl_after_queue_position_survival_fill_stress": "525",
+                "double_oos_passed": True,
+                "double_oos_cost_shock_net_pnl_per_day": "525",
+                "implementation_uncertainty_stability_passed": True,
+                "implementation_uncertainty_lower_net_pnl_per_day": "525",
+                "conformal_tail_risk_passed": True,
+                "conformal_tail_risk_adjusted_net_pnl_per_day": "525",
+                "delay_adjusted_depth_fill_survival_evidence_present": True,
+                "delay_adjusted_depth_fill_survival_sample_count": 9,
+                "delay_adjusted_depth_fill_survival_rate": "0.85",
+                "queue_position_survival_fill_curve_evidence_present": True,
+                "queue_position_survival_sample_count": 9,
+                "queue_position_survival_fill_rate": "0.85",
+                "queue_position_survival_queue_ratio_p95": "0.25",
+                "queue_position_survival_queue_ahead_depletion_evidence_present": True,
+                "queue_position_survival_queue_ahead_depletion_sample_count": 9,
+                "delay_adjusted_depth_queue_ahead_depletion_evidence_present": True,
+                "delay_adjusted_depth_queue_ahead_depletion_sample_count": 9,
+                "queue_ahead_depletion_evidence_present": True,
+                "queue_ahead_depletion_sample_count": 9,
                 "target_met": True,
                 "oracle_passed": False,
                 "trade_decision_count": 9,
@@ -6850,6 +6899,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
     ) -> None:
         weak_spec = self._candidate_spec("spec-weak-probation")
         close_spec = self._candidate_spec("spec-close-probation")
+        bridge_spec = self._candidate_spec("spec-bridge-probation")
         raw_only_spec = self._candidate_spec("spec-raw-only-probation")
         weak_evidence = runner.CandidateEvidenceBundle(
             schema_version="torghut.candidate-evidence-bundle.v1",
@@ -7008,12 +7058,39 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             null_comparator={},
             promotion_readiness={},
         )
+        bridge_scorecard = {
+            **close_evidence.objective_scorecard,
+            "net_pnl_per_day": "315",
+            "market_impact_stress_net_pnl_per_day": "290",
+            "delay_adjusted_depth_stress_net_pnl_per_day": "280",
+            "post_cost_net_pnl_after_queue_position_survival_fill_stress": "260",
+            "double_oos_net_pnl_per_day": "270",
+            "double_oos_cost_shock_net_pnl_per_day": "270",
+            "implementation_uncertainty_lower_net_pnl_per_day": "260",
+            "conformal_tail_risk_adjusted_net_pnl_per_day": "260",
+            "exact_replay_ledger_artifact_ref": "bridge-probation-exact-replay-ledger.json",
+            "runtime_ledger_artifact_row_count": 18,
+            "runtime_ledger_artifact_fill_count": 6,
+        }
+        bridge_evidence = replace(
+            close_evidence,
+            evidence_bundle_id="ev-bridge-probation",
+            candidate_id="cand-bridge-probation",
+            candidate_spec_id=bridge_spec.candidate_spec_id,
+            dataset_snapshot_id="snapshot-bridge-probation",
+            feature_spec_hash="hash-bridge-probation",
+            replay_artifact_refs=(
+                "bridge-probation.json",
+                "bridge-probation-exact-replay-ledger.json",
+            ),
+            objective_scorecard=bridge_scorecard,
+        )
 
         board = runner._candidate_board_payload(
             epoch_id="epoch-paper-probation-economics",
             output_dir=Path("/tmp/epoch-paper-probation-economics"),
             target=Decimal("500"),
-            candidate_specs=(weak_spec, close_spec, raw_only_spec),
+            candidate_specs=(weak_spec, close_spec, bridge_spec, raw_only_spec),
             candidate_selection={
                 "rows": [
                     {
@@ -7022,6 +7099,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                     },
                     {
                         "candidate_spec_id": close_spec.candidate_spec_id,
+                        "selected_for_replay": True,
+                    },
+                    {
+                        "candidate_spec_id": bridge_spec.candidate_spec_id,
                         "selected_for_replay": True,
                     },
                     {
@@ -7046,16 +7127,35 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                     "rank": 3,
                     "proposal_score": "7.0",
                 },
+                {
+                    "candidate_spec_id": bridge_spec.candidate_spec_id,
+                    "rank": 4,
+                    "proposal_score": "6.0",
+                },
             ),
             proposal_rows=(),
-            evidence_bundles=(weak_evidence, close_evidence, raw_only_evidence),
+            evidence_bundles=(
+                weak_evidence,
+                close_evidence,
+                bridge_evidence,
+                raw_only_evidence,
+            ),
             portfolio=None,
             promotion_readiness={"promotable": False},
             runtime_closure={},
+            paper_probation_target_limit=2,
         )
 
         probation_candidate = board["paper_probation_candidate"]
         self.assertEqual(probation_candidate["candidate_id"], "cand-close-probation")
+        self.assertEqual(board["paper_probation_target_limit"], 2)
+        self.assertEqual(
+            [
+                candidate["candidate_id"]
+                for candidate in board["paper_probation_candidates"]
+            ],
+            ["cand-close-probation", "cand-bridge-probation"],
+        )
         self.assertEqual(
             probation_candidate["selection_reason"],
             "closest_lower_bound_economics_below_target",
@@ -7069,6 +7169,14 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             0,
         )
         self.assertFalse(probation_candidate["final_promotion_allowed"])
+        self.assertEqual(board["runtime_window_import_plan"]["target_count"], 2)
+        self.assertEqual(
+            [
+                target["candidate_id"]
+                for target in board["runtime_window_import_plan"]["targets"]
+            ],
+            ["cand-close-probation", "cand-bridge-probation"],
+        )
 
     def test_candidate_board_paper_probation_requires_runtime_ledger_admission(
         self,
@@ -7104,6 +7212,72 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(
             runner._candidate_board_paper_probation_admission_blockers(ledger_row),
             [],
+        )
+
+    def test_candidate_board_single_paper_probation_fallback_blocker(self) -> None:
+        row = {
+            "candidate_spec_id": "spec-single-probation",
+            "candidate_id": "cand-single-probation",
+            "hypothesis_id": "H-MICRO-01",
+            "runtime_family": "microstructure_breakout",
+            "runtime_strategy_name": "microbar-volume-continuation-long-top2-chip-v1",
+            "has_replay_evidence": True,
+            "oracle_passed": False,
+            "target_met": False,
+            "decision_count": 4,
+            "submitted_order_count": 4,
+            "filled_order_count": 4,
+            "exact_replay_ledger_artifact_ref": "single-exact-replay-ledger.json",
+            "runtime_ledger_artifact_row_count": 12,
+            "runtime_ledger_artifact_fill_count": 4,
+            "runtime_window_start": "2026-05-18",
+            "runtime_window_end": "2026-05-20",
+            "net_pnl_per_day": "215",
+            "market_impact_stress_passed": True,
+            "market_impact_stress_net_pnl_per_day": "190",
+            "delay_adjusted_depth_stress_passed": True,
+            "delay_adjusted_depth_stress_net_pnl_per_day": "180",
+            "post_cost_net_pnl_after_queue_position_survival_fill_stress": "170",
+            "double_oos_passed": True,
+            "double_oos_cost_shock_net_pnl_per_day": "175",
+            "implementation_uncertainty_stability_passed": True,
+            "implementation_uncertainty_lower_net_pnl_per_day": "165",
+            "conformal_tail_risk_passed": True,
+            "conformal_tail_risk_adjusted_net_pnl_per_day": "160",
+            "delay_adjusted_depth_fill_survival_evidence_present": True,
+            "delay_adjusted_depth_fill_survival_sample_count": 4,
+            "delay_adjusted_depth_fill_survival_rate": "0.85",
+            "queue_position_survival_fill_curve_evidence_present": True,
+            "queue_position_survival_sample_count": 4,
+            "queue_position_survival_fill_rate": "0.85",
+            "queue_position_survival_queue_ratio_p95": "0.25",
+            "queue_position_survival_queue_ahead_depletion_evidence_present": True,
+            "queue_position_survival_queue_ahead_depletion_sample_count": 4,
+            "delay_adjusted_depth_queue_ahead_depletion_evidence_present": True,
+            "delay_adjusted_depth_queue_ahead_depletion_sample_count": 4,
+            "queue_ahead_depletion_evidence_present": True,
+            "queue_ahead_depletion_sample_count": 4,
+            "blockers": [],
+        }
+
+        candidate = runner._candidate_board_paper_probation_candidate(
+            [row],
+            target=Decimal("500"),
+        )
+
+        self.assertIsNotNone(candidate)
+        assert candidate is not None
+        self.assertEqual(candidate["candidate_id"], "cand-single-probation")
+        self.assertEqual(
+            candidate["final_promotion_blockers"],
+            ["final_promotion_requires_runtime_governance"],
+        )
+        self.assertFalse(candidate["final_promotion_allowed"])
+        self.assertIsNone(
+            runner._candidate_board_paper_probation_candidate(
+                [],
+                target=Decimal("500"),
+            )
         )
 
     def test_candidate_board_runtime_window_plan_dedupes_and_blocks_incomplete_targets(


### PR DESCRIPTION
## Summary

- Emits a bounded `paper_probation_candidates` shortlist instead of only one near-miss candidate.
- Uses the existing replay-budget exploration slot count to control paper-runtime evidence collection fanout.
- Keeps every probation target promotion-blocked and requires positive deployable lower-bound economics before handoff.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'paper_probation or runtime_window_plan or separates_research_rank' -q`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k 'candidate_board_plan or runtime_window_targets_from_candidate_board_plan' -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
