### PR TITLE
fix(torghut): stamp replay evidence lineage

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -9,6 +9,7 @@ import json
 import os
 import signal
 import socket
+import subprocess
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, replace
 from datetime import UTC, date, datetime, time, timedelta
@@ -131,6 +132,14 @@ _REJECTED_SIGNAL_OUTCOME_REQUIRED_FIELDS = (
     "route_tca",
     "post_cost_net_pnl",
     "executable_quote",
+)
+_CODE_COMMIT_ENV_VARS = (
+    "TORGHUT_CODE_COMMIT",
+    "GITHUB_SHA",
+    "BUILDKITE_COMMIT",
+    "SOURCE_COMMIT",
+    "GIT_COMMIT",
+    "REVISION",
 )
 _PROGRAM_SOURCE_DEFAULT_CONFIDENCE = "0.70"
 _SECOND_OOS_WINDOW_ID = "second_oos"
@@ -1528,6 +1537,49 @@ def _mapping(value: Any) -> dict[str, Any]:
 
 def _string(value: Any) -> str:
     return str(value if value is not None else "").strip()
+
+
+def _current_code_commit() -> str:
+    for name in _CODE_COMMIT_ENV_VARS:
+        value = _string(os.getenv(name))
+        if value:
+            return value
+
+    repo_root = Path(__file__).resolve().parents[3]
+    try:
+        rev = subprocess.run(
+            ("git", "-C", str(repo_root), "rev-parse", "HEAD"),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "unknown"
+    commit = _string(rev.stdout)
+    if rev.returncode != 0 or not commit:
+        return "unknown"
+
+    dirty = False
+    for args in (
+        ("git", "-C", str(repo_root), "diff", "--quiet"),
+        ("git", "-C", str(repo_root), "diff", "--cached", "--quiet"),
+    ):
+        try:
+            result = subprocess.run(
+                args,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=3,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            dirty = True
+            break
+        if result.returncode != 0:
+            dirty = True
+            break
+    return f"{commit}-dirty" if dirty else commit
 
 
 def _list_of_mappings(value: Any) -> list[Mapping[str, Any]]:
@@ -6125,6 +6177,7 @@ def _run_synthetic_replay(
 ) -> EpochReplayResult:
     evidence_bundles: list[CandidateEvidenceBundle] = []
     replay_results: list[Mapping[str, Any]] = []
+    code_commit = _current_code_commit()
     for rank, spec in enumerate(specs[: max(1, max_candidates)], start=1):
         candidate = _synthetic_candidate_payload(spec, rank=rank)
         result_path = (
@@ -6144,6 +6197,7 @@ def _run_synthetic_replay(
                 candidate=candidate,
                 dataset_snapshot_id="synthetic-recent-whitepaper-2025-2026",
                 result_path=str(result_path),
+                code_commit=code_commit,
             )
         )
         replay_results.append(result_payload)
@@ -6246,6 +6300,8 @@ def _real_replay_result_from_factory_payload(
 ) -> EpochReplayResult:
     specs_by_id = specs_by_id or {}
     evidence_bundles: list[CandidateEvidenceBundle] = []
+    build = _mapping(factory_payload.get("build"))
+    code_commit = _string(build.get("commit")) or _current_code_commit()
     for item in _list_of_mappings(factory_payload.get("experiments")):
         result_path = str(item.get("result_path") or "")
         if not result_path:
@@ -6287,6 +6343,7 @@ def _real_replay_result_from_factory_payload(
                     candidate=candidate,
                     dataset_snapshot_id=dataset_snapshot_id,
                     result_path=result_path,
+                    code_commit=code_commit,
                 )
             )
     return EpochReplayResult(
@@ -8218,6 +8275,8 @@ def _candidate_board_evidence_lineage_summary(
         blockers.append("feature_spec_hash_missing")
     if not code_commit or code_commit.lower() == "unknown":
         blockers.append("code_commit_missing_or_unknown")
+    elif code_commit.endswith("-dirty"):
+        blockers.append("code_commit_dirty")
     if not replay_artifact_refs:
         blockers.append("replay_artifact_missing")
 

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -3279,20 +3279,22 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 encoding="utf-8",
             )
 
-            replay = runner._real_replay_result_from_factory_payload(
-                {
-                    "experiments": [
-                        {
-                            "candidate_spec_id": spec.candidate_spec_id,
-                            "result_path": str(result_path),
-                            "dataset_snapshot_id": "snap-real-replay-shape",
-                        }
-                    ]
-                },
-                specs_by_id={spec.candidate_spec_id: spec},
-            )
+            with patch.object(runner, "_current_code_commit", return_value="abc123"):
+                replay = runner._real_replay_result_from_factory_payload(
+                    {
+                        "experiments": [
+                            {
+                                "candidate_spec_id": spec.candidate_spec_id,
+                                "result_path": str(result_path),
+                                "dataset_snapshot_id": "snap-real-replay-shape",
+                            }
+                        ]
+                    },
+                    specs_by_id={spec.candidate_spec_id: spec},
+                )
 
         self.assertEqual(len(replay.evidence_bundles), 1)
+        self.assertEqual(replay.evidence_bundles[0].code_commit, "abc123")
         scorecard = replay.evidence_bundles[0].objective_scorecard
         self.assertEqual(
             scorecard["feedback_shape_key"],
@@ -3306,6 +3308,104 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             scorecard["execution_signature"],
             runner._candidate_spec_execution_signature(spec),
         )
+
+    def test_current_code_commit_uses_git_when_env_commit_is_missing(self) -> None:
+        rev_parse = runner.subprocess.CompletedProcess(
+            args=("git", "rev-parse", "HEAD"),
+            returncode=0,
+            stdout="abc123\n",
+        )
+        clean_diff = runner.subprocess.CompletedProcess(
+            args=("git", "diff", "--quiet"),
+            returncode=0,
+            stdout="",
+        )
+        with (
+            patch.object(runner.os, "getenv", return_value=""),
+            patch.object(
+                runner.subprocess,
+                "run",
+                side_effect=[rev_parse, clean_diff, clean_diff],
+            ) as run,
+        ):
+            self.assertEqual(runner._current_code_commit(), "abc123")
+
+        self.assertEqual(run.call_count, 3)
+
+    def test_current_code_commit_prefers_env_commit(self) -> None:
+        with (
+            patch.object(
+                runner.os,
+                "getenv",
+                side_effect=lambda name: (
+                    "env123" if name == "TORGHUT_CODE_COMMIT" else ""
+                ),
+            ),
+            patch.object(runner.subprocess, "run") as run,
+        ):
+            self.assertEqual(runner._current_code_commit(), "env123")
+
+        run.assert_not_called()
+
+    def test_current_code_commit_marks_dirty_or_unknown_git_state(self) -> None:
+        rev_parse = runner.subprocess.CompletedProcess(
+            args=("git", "rev-parse", "HEAD"),
+            returncode=0,
+            stdout="abc123\n",
+        )
+        dirty_diff = runner.subprocess.CompletedProcess(
+            args=("git", "diff", "--quiet"),
+            returncode=1,
+            stdout="",
+        )
+        bad_rev_parse = runner.subprocess.CompletedProcess(
+            args=("git", "rev-parse", "HEAD"),
+            returncode=128,
+            stdout="",
+        )
+        with (
+            patch.object(runner.os, "getenv", return_value=""),
+            patch.object(
+                runner.subprocess,
+                "run",
+                side_effect=[rev_parse, dirty_diff],
+            ),
+        ):
+            self.assertEqual(runner._current_code_commit(), "abc123-dirty")
+        with (
+            patch.object(runner.os, "getenv", return_value=""),
+            patch.object(runner.subprocess, "run", side_effect=OSError("git missing")),
+        ):
+            self.assertEqual(runner._current_code_commit(), "unknown")
+        with (
+            patch.object(runner.os, "getenv", return_value=""),
+            patch.object(runner.subprocess, "run", return_value=bad_rev_parse),
+        ):
+            self.assertEqual(runner._current_code_commit(), "unknown")
+        with (
+            patch.object(runner.os, "getenv", return_value=""),
+            patch.object(
+                runner.subprocess,
+                "run",
+                side_effect=[rev_parse, OSError("diff missing")],
+            ),
+        ):
+            self.assertEqual(runner._current_code_commit(), "abc123-dirty")
+
+    def test_synthetic_replay_evidence_carries_code_commit(self) -> None:
+        spec = self._candidate_spec("spec-synthetic-replay-code-commit")
+        with TemporaryDirectory() as tmpdir:
+            with patch.object(
+                runner, "_current_code_commit", return_value="synthetic123"
+            ):
+                replay = runner._run_synthetic_replay(
+                    specs=(spec,),
+                    output_dir=Path(tmpdir),
+                    max_candidates=1,
+                )
+
+        self.assertEqual(len(replay.evidence_bundles), 1)
+        self.assertEqual(replay.evidence_bundles[0].code_commit, "synthetic123")
 
     def test_candidate_selection_blocks_synthetic_nonpositive_expected_value(
         self,
@@ -5593,6 +5693,10 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             ),
             ["profit_target_oracle_failed"],
         )
+        dirty_lineage = runner._candidate_board_evidence_lineage_summary(
+            replace(evidence, code_commit="commit-test-dirty")
+        )
+        self.assertEqual(dirty_lineage["blockers"], ["code_commit_dirty"])
         self.assertEqual(
             runner._candidate_board_status(
                 selected_for_replay=True,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -8,7 +8,7 @@ import tempfile
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import Mock, patch
-from typing import Any, Callable, cast
+from typing import Any, Callable, Mapping, cast
 
 from sqlalchemy import create_engine, select
 from sqlalchemy.exc import SQLAlchemyError
@@ -60,6 +60,7 @@ from app.trading.scheduler.pipeline_helpers import (
     _project_open_orders_onto_positions,
 )
 from app.trading.scheduler.state import TradingState
+from app.trading.submission_council import build_hypothesis_runtime_summary
 from app.trading.tca import AdaptiveExecutionPolicyDecision
 from app.trading.universe import UniverseResolver
 
@@ -1480,6 +1481,82 @@ class TestTradingPipeline(TestCase):
                 )
             )
             session.commit()
+
+    def test_hypothesis_runtime_summary_counts_valid_live_runtime_window_certificate(
+        self,
+    ) -> None:
+        self._seed_promotion_certificate_evidence(
+            strategy_family="intraday_continuation",
+        )
+
+        with self.session_local() as session:
+            summary = build_hypothesis_runtime_summary(
+                session,
+                state=TradingState(),
+                market_context_status={},
+                tca_summary={"ready": True},
+            )
+
+        self.assertEqual(summary.get("promotion_eligible_total"), 1)
+        self.assertEqual(
+            summary.get("capital_stage_totals"), {"0.10x canary": 1, "shadow": 5}
+        )
+        items = [
+            cast(Mapping[str, object], item)
+            for item in cast(list[object], summary.get("items") or [])
+            if isinstance(item, Mapping)
+        ]
+        continuation = next(
+            item for item in items if item.get("hypothesis_id") == "H-CONT-01"
+        )
+        self.assertEqual(continuation.get("state"), "canary_live")
+        self.assertEqual(continuation.get("capital_stage"), "0.10x canary")
+        self.assertEqual(continuation.get("capital_multiplier"), "0.10")
+        self.assertTrue(continuation.get("promotion_eligible"))
+        self.assertEqual(continuation.get("reasons"), [])
+        observed = continuation.get("observed")
+        self.assertIsInstance(observed, Mapping)
+        self.assertTrue(
+            cast(Mapping[str, object], observed).get(
+                "runtime_window_certificate_applied"
+            )
+        )
+
+    def test_hypothesis_runtime_summary_rejects_mismatched_runtime_ledger_family(
+        self,
+    ) -> None:
+        self._seed_promotion_certificate_evidence(strategy_family="unregistered_demo")
+
+        with self.session_local() as session:
+            summary = build_hypothesis_runtime_summary(
+                session,
+                state=TradingState(),
+                market_context_status={},
+                tca_summary={"ready": True},
+            )
+
+        self.assertEqual(summary.get("promotion_eligible_total"), 0)
+        items = [
+            cast(Mapping[str, object], item)
+            for item in cast(list[object], summary.get("items") or [])
+            if isinstance(item, Mapping)
+        ]
+        continuation = next(
+            item for item in items if item.get("hypothesis_id") == "H-CONT-01"
+        )
+        self.assertFalse(continuation.get("promotion_eligible"))
+        self.assertIn(
+            "runtime_ledger_strategy_family_mismatch",
+            continuation.get("reasons") or [],
+        )
+        observed = continuation.get("observed")
+        self.assertIsInstance(observed, Mapping)
+        observed_map = cast(Mapping[str, object], observed)
+        self.assertTrue(observed_map.get("runtime_window_certificate_rejected"))
+        self.assertEqual(
+            observed_map.get("runtime_window_rejection_reasons"),
+            ["runtime_ledger_strategy_family_mismatch"],
+        )
 
     def _build_warmup_pipeline(
         self,


### PR DESCRIPTION
## Summary

- Stamp autoresearch replay evidence bundles with the current build/git commit so candidate-board lineage is auditable instead of `unknown`.
- Mark dirty local worktree evidence as explicitly blocked with `code_commit_dirty`, preserving fail-closed promotion behavior.
- Add regressions for runtime-window summary promotion counts and lineage blockers so valid ledger-backed certificates count while mismatched runtime evidence stays blocked.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_trading_pipeline.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
