### PR TITLE
feat(torghut): forward staged replay screening

### DIFF
--- a/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
@@ -162,6 +162,35 @@ research_sources:
         asset_scope: limit_order_book_intraday
         horizon_scope: short_horizon_returns
         expected_direction: neutral
+  - source_id: optimal_signal_extraction_order_flow_2026
+    title: 'Optimal Signal Extraction from Order Flow'
+    url: https://arxiv.org/abs/2512.18648
+    published_at: '2026-02-20'
+    claims:
+      - claim_id: matched_filter_normalization
+        claim_type: feature_recipe
+        summary: Order-flow normalization should match the scaling behavior of the signal-generating process.
+        implication: Prefer bounded mutation neighborhoods that explicitly compare market-cap, volume, and notional scaling.
+        data_requirements:
+          - order_flow_intensity
+          - market_cap
+          - turnover
+          - short_horizon_returns
+        asset_scope: us_equities_intraday
+        horizon_scope: intraday_microstructure
+        expected_direction: positive
+      - claim_id: informed_executor_scaling
+        claim_type: signal_mechanism
+        summary: Different participant types can encode information through different order-flow scaling conventions.
+        implication: Keep normalization choice visible in candidate evidence and replay survivors instead of pooling all flow transforms.
+        data_requirements:
+          - participant_flow_proxy
+          - order_flow_intensity
+          - volume_profile
+          - market_cap
+        asset_scope: us_equities_intraday
+        horizon_scope: intraday_microstructure
+        expected_direction: positive
   - source_id: volume_imbalance_secret_2026
     title: 'Understanding the worst-kept secret of high-frequency trading'
     url: https://link.springer.com/article/10.1007/s00780-026-00585-9

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -349,6 +349,15 @@ def _parse_args() -> argparse.Namespace:
             "candidate specs. Defaults to --max-candidates when omitted."
         ),
     )
+    parser.add_argument(
+        "--staged-train-screen-multiplier",
+        type=int,
+        default=0,
+        help=(
+            "Optional override for cheap train-screen candidate breadth per "
+            "frontier run. 0 uses the research program replay budget."
+        ),
+    )
     parser.add_argument("--real-replay-timeout-seconds", type=int, default=0)
     parser.add_argument(
         "--real-replay-shard-size",
@@ -6277,6 +6286,9 @@ def _run_real_replay(
         top_n=args.top_k,
         max_candidates_to_evaluate=max_candidates_to_evaluate,
         max_total_candidates_to_evaluate=max_total_candidates_to_evaluate,
+        staged_train_screen_multiplier=max(
+            1, int(getattr(args, "staged_train_screen_multiplier", 1) or 1)
+        ),
         persist_results=args.persist_results,
     )
     factory_payload = (
@@ -6902,6 +6914,15 @@ def _load_epoch_program(args: argparse.Namespace) -> StrategyAutoresearchProgram
             ),
         )
     return program
+
+
+def _resolved_staged_train_screen_multiplier(
+    args: argparse.Namespace, program: StrategyAutoresearchProgram
+) -> int:
+    override = int(getattr(args, "staged_train_screen_multiplier", 0) or 0)
+    if override > 0:
+        return max(1, override)
+    return max(1, int(program.replay_budget.staged_train_screen_multiplier))
 
 
 def _epoch_mlx_snapshot_manifest(
@@ -9906,6 +9927,9 @@ def run_whitepaper_autoresearch_profit_target(
                         default="1.00",
                     ),
                 )
+            ),
+            "staged_train_screen_multiplier": _resolved_staged_train_screen_multiplier(
+                args, program
             ),
         }
     )

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -237,6 +237,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             progress_log_seconds=30,
             max_frontier_candidates_per_spec=runner._DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC,
             max_total_frontier_candidates=0,
+            staged_train_screen_multiplier=0,
             real_replay_timeout_seconds=0,
             real_replay_shard_size=0,
             real_replay_shard_timeout_seconds=0,
@@ -9443,6 +9444,8 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                     "TORGHUT_CLICKHOUSE_PASSWORD",
                     "--max-total-frontier-candidates",
                     "7",
+                    "--staged-train-screen-multiplier",
+                    "4",
                     "--replay-tape-path",
                     str(Path(tmpdir) / "tape.jsonl"),
                     "--replay-tape-manifest",
@@ -9469,6 +9472,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             runner._DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC,
         )
         self.assertEqual(parsed.max_total_frontier_candidates, 7)
+        self.assertEqual(parsed.staged_train_screen_multiplier, 4)
         self.assertEqual(parsed.real_replay_shard_size, 0)
         self.assertEqual(parsed.real_replay_shard_timeout_seconds, 0)
         self.assertEqual(parsed.real_replay_shard_workers, 1)
@@ -9976,6 +9980,74 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
 
         self.assertEqual(captured_budget, [24])
         self.assertEqual(len(result.evidence_bundles), 0)
+
+    def test_real_replay_forwards_staged_train_screen_multiplier(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "epoch"
+            result_path = output_dir / "result.json"
+            result_path.parent.mkdir(parents=True)
+            result_path.write_text(
+                json.dumps({"top": []}),
+                encoding="utf-8",
+            )
+            factory_payload = {
+                "experiments": [
+                    {
+                        "experiment_id": "spec-real-exp",
+                        "dataset_snapshot_id": "snap-real",
+                        "result_path": str(result_path),
+                    }
+                ]
+            }
+            captured_multiplier: list[int] = []
+
+            def fake_run(
+                factory_args: Namespace, *, source_specs: object
+            ) -> dict[str, object]:
+                captured_multiplier.append(
+                    int(factory_args.staged_train_screen_multiplier)
+                )
+                return factory_payload
+
+            with patch.object(
+                runner.strategy_factory_runner,
+                "run_strategy_factory_v2_from_specs",
+                side_effect=fake_run,
+            ):
+                cards = claim_compiler_script.compile_sources_to_hypothesis_cards(
+                    [runner.RECENT_WHITEPAPER_SEEDS[0]]
+                )
+                compilation = runner.compile_whitepaper_candidate_specs(
+                    hypothesis_cards=cards,
+                    family_template_dir=Path("config/trading/families"),
+                    seed_sweep_dir=Path("config/trading"),
+                )
+                args = self._args(output_dir)
+                args.staged_train_screen_multiplier = 3
+                result = runner._run_real_replay(
+                    args,
+                    output_dir=output_dir,
+                    specs=compilation.executable_specs[:1],
+                )
+
+        self.assertEqual(captured_multiplier, [3])
+        self.assertEqual(len(result.evidence_bundles), 0)
+
+    def test_program_replay_budget_supplies_staged_train_screen_multiplier(
+        self,
+    ) -> None:
+        args = self._args(Path("/tmp/epoch"))
+        program = runner._load_epoch_program(args)
+
+        self.assertEqual(
+            runner._resolved_staged_train_screen_multiplier(args, program),
+            3,
+        )
+        args.staged_train_screen_multiplier = 4
+        self.assertEqual(
+            runner._resolved_staged_train_screen_multiplier(args, program),
+            4,
+        )
 
     def test_sharded_real_replay_continues_after_candidate_timeout(self) -> None:
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Forward the active research program's `staged_train_screen_multiplier` into the real replay frontier factory.
- Add a CLI override for staged train-screen breadth while preserving the program replay-budget default.
- Add the 2026 order-flow signal extraction source to the active `$500/day` portfolio autoresearch corpus.
- Cover the new forwarding/default behavior in the whitepaper profit-target runner tests.

## Related Issues

None

## Testing

- `uv run --frozen ruff format --check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py --cov=scripts.run_whitepaper_autoresearch_profit_target --cov-report=term-missing --cov-report=xml -q`
- `uv run --frozen python scripts/check_changed_line_coverage.py --coverage-file coverage.xml --diff-base origin/main --min-changed-line-coverage 100`
- `uv run --frozen python scripts/run_whitepaper_autoresearch_profit_target.py --program config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml --output-dir /tmp/torghut-staged-smoke-20260523 --epoch-id staged-smoke-20260523 --selection-only --max-candidates 1 --top-k 1 --exploration-slots 0 --no-persist-results`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
