### PR TITLE
feat(torghut): write paper probation handoff

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -9704,6 +9704,37 @@ def _candidate_board_payload(
     }
 
 
+def _paper_probation_handoff_payload(
+    candidate_board: Mapping[str, Any],
+) -> dict[str, Any]:
+    candidates = _list_of_mappings(candidate_board.get("paper_probation_candidates"))
+    import_plan = _mapping(candidate_board.get("runtime_window_import_plan"))
+    import_plan_ready = _string(import_plan.get("status")) == "ready"
+    blockers: list[str] = []
+    if not candidates:
+        blockers.append("paper_probation_candidate_missing")
+    if not import_plan_ready:
+        blockers.append("runtime_window_import_plan_not_ready")
+    status = "ready" if candidates and import_plan_ready else "not_ready"
+    return {
+        "schema_version": "torghut.paper-probation-handoff.v1",
+        "status": status,
+        "current_answer": _string(candidate_board.get("current_answer")),
+        "evidence_collection_stage": "paper",
+        "authorization_scope": "evidence_collection_only",
+        "paper_probation_authorized": status == "ready",
+        "probation_allowed": status == "ready",
+        "promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "final_promotion_allowed": False,
+        "promotion_gate": "existing_runtime_governance_fail_closed",
+        "blockers": blockers,
+        "candidate_count": len(candidates),
+        "candidates": candidates,
+        "runtime_window_import_plan": import_plan,
+    }
+
+
 def _portfolio_with_runtime_closure_proof(
     *,
     portfolio: PortfolioCandidateSpec,
@@ -10594,6 +10625,9 @@ def run_whitepaper_autoresearch_profit_target(
     )
     candidate_board_path = output_dir / "candidate-board.json"
     _write_json(candidate_board_path, candidate_board)
+    paper_probation_handoff = _paper_probation_handoff_payload(candidate_board)
+    paper_probation_handoff_path = output_dir / "paper-probation-handoff.json"
+    _write_json(paper_probation_handoff_path, paper_probation_handoff)
     profitability_goal = _profitability_search_goal(
         args=args,
         output_dir=output_dir,
@@ -10654,6 +10688,7 @@ def run_whitepaper_autoresearch_profit_target(
         "false_positive_table": false_positive_table,
         "best_false_negative_table": best_false_negative_table,
         "candidate_board": candidate_board,
+        "paper_probation_handoff": paper_probation_handoff,
         "candidate_search_remediation": candidate_search_remediation,
         "profitability_search_goal": profitability_goal,
         "best_portfolio_candidate": portfolio.to_payload()
@@ -10697,6 +10732,7 @@ def run_whitepaper_autoresearch_profit_target(
                 output_dir / "portfolio-optimizer-report.json"
             ),
             "candidate_board": str(candidate_board_path),
+            "paper_probation_handoff": str(paper_probation_handoff_path),
             "candidate_search_remediation": str(remediation_path)
             if candidate_search_remediation is not None
             else None,

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -3743,6 +3743,29 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 summary["artifacts"]["candidate_board"],
                 str((output_dir / "candidate-board.json").resolve()),
             )
+            paper_probation_handoff = json.loads(
+                (output_dir / "paper-probation-handoff.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(
+                paper_probation_handoff["schema_version"],
+                "torghut.paper-probation-handoff.v1",
+            )
+            self.assertFalse(paper_probation_handoff["promotion_allowed"])
+            self.assertFalse(paper_probation_handoff["final_promotion_allowed"])
+            self.assertEqual(
+                paper_probation_handoff["runtime_window_import_plan"],
+                candidate_board["runtime_window_import_plan"],
+            )
+            self.assertEqual(
+                summary["paper_probation_handoff"],
+                paper_probation_handoff,
+            )
+            self.assertEqual(
+                summary["artifacts"]["paper_probation_handoff"],
+                str((output_dir / "paper-probation-handoff.json").resolve()),
+            )
             self.assertEqual(
                 summary["false_positive_table"], payload["false_positive_table"]
             )
@@ -6998,6 +7021,22 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertFalse(target["final_promotion_authorized"])
         self.assertFalse(target["final_promotion_allowed"])
         self.assertEqual(target["selection_reason"], "target_met_but_oracle_blocked")
+        handoff = runner._paper_probation_handoff_payload(board)
+        self.assertEqual(
+            handoff["schema_version"], "torghut.paper-probation-handoff.v1"
+        )
+        self.assertEqual(handoff["status"], "ready")
+        self.assertTrue(handoff["paper_probation_authorized"])
+        self.assertFalse(handoff["promotion_allowed"])
+        self.assertFalse(handoff["final_promotion_allowed"])
+        self.assertEqual(handoff["candidate_count"], 1)
+        self.assertEqual(
+            handoff["candidates"][0]["candidate_id"], "cand-paper-probation"
+        )
+        self.assertEqual(
+            handoff["runtime_window_import_plan"]["target_count"],
+            1,
+        )
 
     def test_candidate_board_paper_probation_prefers_lower_bound_economics(
         self,


### PR DESCRIPTION
## Summary

- Add a first-class `paper-probation-handoff.json` artifact for close Torghut candidates that are eligible only for paper evidence collection.
- Mirror the handoff into `summary.json` with explicit `promotion_allowed: false` and `final_promotion_allowed: false` fail-closed flags.
- Preserve the existing runtime-window import plan inside the handoff so paper/probation collection is auditable from the replay/runtime ledger refs.
- Cover the ready handoff path and end-to-end artifact write in the whitepaper profit-target runner tests.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k "paper_probation or seed_recent_whitepapers_runs_end_to_end" -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
