### PR TITLE
fix(torghut): forward frontier repair controls

### DIFF
--- a/services/torghut/scripts/run_strategy_factory_v2.py
+++ b/services/torghut/scripts/run_strategy_factory_v2.py
@@ -138,6 +138,62 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--staged-train-screen-multiplier",
+        type=int,
+        default=1,
+        help=(
+            "When train screening is enabled, evaluate this multiple of the "
+            "full-replay budget through the cheaper train screen."
+        ),
+    )
+    parser.add_argument(
+        "--capture-rejected-seed-full-window-ledger",
+        action="store_true",
+        help=(
+            "Capture proof-only exact full-window ledgers for checked-in "
+            "candidate-record seeds rejected by train screening."
+        ),
+    )
+    parser.add_argument(
+        "--capture-positive-rejected-full-window-ledgers",
+        dest="capture_positive_rejected_full_window_ledgers",
+        type=int,
+        default=0,
+        help=(
+            "Capture up to N proof-only exact full-window ledgers for positive "
+            "train-screen rejects or candidates over the full-replay budget."
+        ),
+    )
+    parser.add_argument(
+        "--capture-top-rejected-full-window-ledgers",
+        dest="capture_positive_rejected_full_window_ledgers",
+        type=int,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--symbol-prune-iterations",
+        type=int,
+        default=0,
+        help="Generate bounded child candidates by pruning downside symbols.",
+    )
+    parser.add_argument("--symbol-prune-candidates", type=int, default=1)
+    parser.add_argument("--symbol-prune-min-universe-size", type=int, default=2)
+    parser.add_argument(
+        "--loss-repair-iterations",
+        type=int,
+        default=0,
+        help="Generate bounded child candidates that tighten loss controls.",
+    )
+    parser.add_argument("--loss-repair-candidates", type=int, default=1)
+    parser.add_argument(
+        "--consistency-repair-iterations",
+        type=int,
+        default=0,
+        help="Generate bounded child candidates that repair positive near-misses.",
+    )
+    parser.add_argument("--consistency-repair-candidates", type=int, default=2)
+    parser.add_argument(
         "--persist-results",
         dest="persist_results",
         action="store_true",
@@ -479,10 +535,38 @@ def _frontier_args(
             if max_candidates_to_evaluate is not None
             else int(getattr(args, "max_candidates_to_evaluate", 0))
         ),
+        staged_train_screen_multiplier=max(
+            1, int(getattr(args, "staged_train_screen_multiplier", 1) or 1)
+        ),
         json_output=json_output,
-        symbol_prune_iterations=0,
-        symbol_prune_candidates=1,
-        symbol_prune_min_universe_size=2,
+        capture_rejected_seed_full_window_ledger=bool(
+            getattr(args, "capture_rejected_seed_full_window_ledger", False)
+        ),
+        capture_positive_rejected_full_window_ledgers=max(
+            0,
+            int(getattr(args, "capture_positive_rejected_full_window_ledgers", 0) or 0),
+        ),
+        symbol_prune_iterations=max(
+            0, int(getattr(args, "symbol_prune_iterations", 0) or 0)
+        ),
+        symbol_prune_candidates=max(
+            1, int(getattr(args, "symbol_prune_candidates", 1) or 1)
+        ),
+        symbol_prune_min_universe_size=max(
+            1, int(getattr(args, "symbol_prune_min_universe_size", 2) or 2)
+        ),
+        loss_repair_iterations=max(
+            0, int(getattr(args, "loss_repair_iterations", 0) or 0)
+        ),
+        loss_repair_candidates=max(
+            1, int(getattr(args, "loss_repair_candidates", 1) or 1)
+        ),
+        consistency_repair_iterations=max(
+            0, int(getattr(args, "consistency_repair_iterations", 0) or 0)
+        ),
+        consistency_repair_candidates=max(
+            1, int(getattr(args, "consistency_repair_candidates", 2) or 2)
+        ),
     )
 
 

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -358,6 +358,53 @@ def _parse_args() -> argparse.Namespace:
             "frontier run. 0 uses the research program replay budget."
         ),
     )
+    parser.add_argument(
+        "--capture-rejected-seed-full-window-ledger",
+        action="store_true",
+        help=(
+            "Forward proof-only rejected seed ledger capture to strategy factory. "
+            "Captured candidates remain non-promotable."
+        ),
+    )
+    parser.add_argument(
+        "--capture-positive-rejected-full-window-ledgers",
+        dest="capture_positive_rejected_full_window_ledgers",
+        type=int,
+        default=0,
+        help=(
+            "Forward proof-only full-window ledger capture for positive train-screen "
+            "rejects or over-budget positives. Captured candidates remain blocked."
+        ),
+    )
+    parser.add_argument(
+        "--capture-top-rejected-full-window-ledgers",
+        dest="capture_positive_rejected_full_window_ledgers",
+        type=int,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--symbol-prune-iterations",
+        type=int,
+        default=0,
+        help="Override program symbol-prune repair iterations for real replay.",
+    )
+    parser.add_argument("--symbol-prune-candidates", type=int, default=0)
+    parser.add_argument("--symbol-prune-min-universe-size", type=int, default=0)
+    parser.add_argument(
+        "--loss-repair-iterations",
+        type=int,
+        default=0,
+        help="Override program loss-repair iterations for real replay.",
+    )
+    parser.add_argument("--loss-repair-candidates", type=int, default=0)
+    parser.add_argument(
+        "--consistency-repair-iterations",
+        type=int,
+        default=0,
+        help="Override program consistency-repair iterations for real replay.",
+    )
+    parser.add_argument("--consistency-repair-candidates", type=int, default=0)
     parser.add_argument("--real-replay-timeout-seconds", type=int, default=0)
     parser.add_argument(
         "--real-replay-shard-size",
@@ -6289,6 +6336,34 @@ def _run_real_replay(
         staged_train_screen_multiplier=max(
             1, int(getattr(args, "staged_train_screen_multiplier", 1) or 1)
         ),
+        capture_rejected_seed_full_window_ledger=bool(
+            getattr(args, "capture_rejected_seed_full_window_ledger", False)
+        ),
+        capture_positive_rejected_full_window_ledgers=max(
+            0,
+            int(getattr(args, "capture_positive_rejected_full_window_ledgers", 0) or 0),
+        ),
+        symbol_prune_iterations=max(
+            0, int(getattr(args, "symbol_prune_iterations", 0) or 0)
+        ),
+        symbol_prune_candidates=max(
+            1, int(getattr(args, "symbol_prune_candidates", 1) or 1)
+        ),
+        symbol_prune_min_universe_size=max(
+            1, int(getattr(args, "symbol_prune_min_universe_size", 2) or 2)
+        ),
+        loss_repair_iterations=max(
+            0, int(getattr(args, "loss_repair_iterations", 0) or 0)
+        ),
+        loss_repair_candidates=max(
+            1, int(getattr(args, "loss_repair_candidates", 1) or 1)
+        ),
+        consistency_repair_iterations=max(
+            0, int(getattr(args, "consistency_repair_iterations", 0) or 0)
+        ),
+        consistency_repair_candidates=max(
+            1, int(getattr(args, "consistency_repair_candidates", 2) or 2)
+        ),
         persist_results=args.persist_results,
     )
     factory_payload = (
@@ -6923,6 +6998,59 @@ def _resolved_staged_train_screen_multiplier(
     if override > 0:
         return max(1, override)
     return max(1, int(program.replay_budget.staged_train_screen_multiplier))
+
+
+def _resolved_program_family_int_arg(
+    args: argparse.Namespace,
+    program: StrategyAutoresearchProgram,
+    name: str,
+    *,
+    default: int,
+    minimum: int,
+) -> int:
+    override = int(getattr(args, name, 0) or 0)
+    if override > 0:
+        return max(minimum, override)
+    program_value = max(
+        (int(getattr(family, name, default)) for family in program.families),
+        default=default,
+    )
+    return max(minimum, program_value)
+
+
+def _resolved_real_replay_frontier_controls(
+    args: argparse.Namespace, program: StrategyAutoresearchProgram
+) -> dict[str, Any]:
+    return {
+        "symbol_prune_iterations": _resolved_program_family_int_arg(
+            args, program, "symbol_prune_iterations", default=0, minimum=0
+        ),
+        "symbol_prune_candidates": _resolved_program_family_int_arg(
+            args, program, "symbol_prune_candidates", default=1, minimum=1
+        ),
+        "symbol_prune_min_universe_size": _resolved_program_family_int_arg(
+            args, program, "symbol_prune_min_universe_size", default=2, minimum=1
+        ),
+        "loss_repair_iterations": _resolved_program_family_int_arg(
+            args, program, "loss_repair_iterations", default=0, minimum=0
+        ),
+        "loss_repair_candidates": _resolved_program_family_int_arg(
+            args, program, "loss_repair_candidates", default=1, minimum=1
+        ),
+        "consistency_repair_iterations": _resolved_program_family_int_arg(
+            args, program, "consistency_repair_iterations", default=0, minimum=0
+        ),
+        "consistency_repair_candidates": _resolved_program_family_int_arg(
+            args, program, "consistency_repair_candidates", default=2, minimum=1
+        ),
+        "capture_rejected_seed_full_window_ledger": bool(
+            getattr(args, "capture_rejected_seed_full_window_ledger", False)
+        ),
+        "capture_positive_rejected_full_window_ledgers": max(
+            0,
+            int(getattr(args, "capture_positive_rejected_full_window_ledgers", 0) or 0),
+        ),
+    }
 
 
 def _epoch_mlx_snapshot_manifest(
@@ -9962,6 +10090,7 @@ def run_whitepaper_autoresearch_profit_target(
             "staged_train_screen_multiplier": _resolved_staged_train_screen_multiplier(
                 args, program
             ),
+            **_resolved_real_replay_frontier_controls(args, program),
         }
     )
     target = _decimal(args.target_net_pnl_per_day, default=_DEFAULT_DAILY_PROFIT_TARGET)

--- a/services/torghut/tests/test_run_strategy_factory_v2.py
+++ b/services/torghut/tests/test_run_strategy_factory_v2.py
@@ -227,6 +227,24 @@ class TestRunStrategyFactoryV2(TestCase):
                     str(seed_dir / "tape.jsonl"),
                     "--replay-tape-manifest",
                     str(seed_dir / "tape.manifest.json"),
+                    "--staged-train-screen-multiplier",
+                    "4",
+                    "--capture-positive-rejected-full-window-ledgers",
+                    "2",
+                    "--symbol-prune-iterations",
+                    "1",
+                    "--symbol-prune-candidates",
+                    "3",
+                    "--symbol-prune-min-universe-size",
+                    "5",
+                    "--loss-repair-iterations",
+                    "1",
+                    "--loss-repair-candidates",
+                    "2",
+                    "--consistency-repair-iterations",
+                    "1",
+                    "--consistency-repair-candidates",
+                    "4",
                     "--no-persist-results",
                 ],
             ):
@@ -247,6 +265,15 @@ class TestRunStrategyFactoryV2(TestCase):
         self.assertTrue(parsed.prefetch_full_window_rows)
         self.assertEqual(parsed.replay_tape_path, seed_dir / "tape.jsonl")
         self.assertEqual(parsed.replay_tape_manifest, seed_dir / "tape.manifest.json")
+        self.assertEqual(parsed.staged_train_screen_multiplier, 4)
+        self.assertEqual(parsed.capture_positive_rejected_full_window_ledgers, 2)
+        self.assertEqual(parsed.symbol_prune_iterations, 1)
+        self.assertEqual(parsed.symbol_prune_candidates, 3)
+        self.assertEqual(parsed.symbol_prune_min_universe_size, 5)
+        self.assertEqual(parsed.loss_repair_iterations, 1)
+        self.assertEqual(parsed.loss_repair_candidates, 2)
+        self.assertEqual(parsed.consistency_repair_iterations, 1)
+        self.assertEqual(parsed.consistency_repair_candidates, 4)
         self.assertFalse(parsed.persist_results)
         self.assertEqual(runner._list_of_strings("not-a-list"), [])
         self.assertEqual(
@@ -293,6 +320,44 @@ class TestRunStrategyFactoryV2(TestCase):
 
         self.assertEqual(parsed.clickhouse_http_url, "http://127.0.0.1:8123")
         self.assertEqual(parsed.clickhouse_username, "reader")
+
+    def test_frontier_args_forwards_repair_and_proof_capture_controls(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            args = self._args(
+                output_dir=root / "out",
+                strategy_configmap=root / "strategy-configmap.yaml",
+                family_template_dir=root / "families",
+                seed_sweep_dir=root / "seed",
+            )
+            args.staged_train_screen_multiplier = 5
+            args.capture_rejected_seed_full_window_ledger = True
+            args.capture_positive_rejected_full_window_ledgers = 3
+            args.symbol_prune_iterations = 1
+            args.symbol_prune_candidates = 2
+            args.symbol_prune_min_universe_size = 4
+            args.loss_repair_iterations = 1
+            args.loss_repair_candidates = 2
+            args.consistency_repair_iterations = 1
+            args.consistency_repair_candidates = 3
+
+            frontier_args = runner._frontier_args(
+                args=args,
+                strategy_configmap=args.strategy_configmap,
+                sweep_config=root / "compiled-sweep.yaml",
+                json_output=root / "result.json",
+            )
+
+        self.assertEqual(frontier_args.staged_train_screen_multiplier, 5)
+        self.assertTrue(frontier_args.capture_rejected_seed_full_window_ledger)
+        self.assertEqual(frontier_args.capture_positive_rejected_full_window_ledgers, 3)
+        self.assertEqual(frontier_args.symbol_prune_iterations, 1)
+        self.assertEqual(frontier_args.symbol_prune_candidates, 2)
+        self.assertEqual(frontier_args.symbol_prune_min_universe_size, 4)
+        self.assertEqual(frontier_args.loss_repair_iterations, 1)
+        self.assertEqual(frontier_args.loss_repair_candidates, 2)
+        self.assertEqual(frontier_args.consistency_repair_iterations, 1)
+        self.assertEqual(frontier_args.consistency_repair_candidates, 3)
 
     def test_frontier_args_forwards_replay_tape_paths(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -238,6 +238,15 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             max_frontier_candidates_per_spec=runner._DEFAULT_MAX_FRONTIER_CANDIDATES_PER_SPEC,
             max_total_frontier_candidates=0,
             staged_train_screen_multiplier=0,
+            capture_rejected_seed_full_window_ledger=False,
+            capture_positive_rejected_full_window_ledgers=0,
+            symbol_prune_iterations=0,
+            symbol_prune_candidates=0,
+            symbol_prune_min_universe_size=0,
+            loss_repair_iterations=0,
+            loss_repair_candidates=0,
+            consistency_repair_iterations=0,
+            consistency_repair_candidates=0,
             real_replay_timeout_seconds=0,
             real_replay_shard_size=0,
             real_replay_shard_timeout_seconds=0,
@@ -9485,6 +9494,23 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                     "7",
                     "--staged-train-screen-multiplier",
                     "4",
+                    "--capture-rejected-seed-full-window-ledger",
+                    "--capture-positive-rejected-full-window-ledgers",
+                    "3",
+                    "--symbol-prune-iterations",
+                    "1",
+                    "--symbol-prune-candidates",
+                    "2",
+                    "--symbol-prune-min-universe-size",
+                    "4",
+                    "--loss-repair-iterations",
+                    "1",
+                    "--loss-repair-candidates",
+                    "2",
+                    "--consistency-repair-iterations",
+                    "1",
+                    "--consistency-repair-candidates",
+                    "5",
                     "--replay-tape-path",
                     str(Path(tmpdir) / "tape.jsonl"),
                     "--replay-tape-manifest",
@@ -9512,6 +9538,15 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertEqual(parsed.max_total_frontier_candidates, 7)
         self.assertEqual(parsed.staged_train_screen_multiplier, 4)
+        self.assertTrue(parsed.capture_rejected_seed_full_window_ledger)
+        self.assertEqual(parsed.capture_positive_rejected_full_window_ledgers, 3)
+        self.assertEqual(parsed.symbol_prune_iterations, 1)
+        self.assertEqual(parsed.symbol_prune_candidates, 2)
+        self.assertEqual(parsed.symbol_prune_min_universe_size, 4)
+        self.assertEqual(parsed.loss_repair_iterations, 1)
+        self.assertEqual(parsed.loss_repair_candidates, 2)
+        self.assertEqual(parsed.consistency_repair_iterations, 1)
+        self.assertEqual(parsed.consistency_repair_candidates, 5)
         self.assertEqual(parsed.real_replay_shard_size, 0)
         self.assertEqual(parsed.real_replay_shard_timeout_seconds, 0)
         self.assertEqual(parsed.real_replay_shard_workers, 1)
@@ -10020,7 +10055,9 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertEqual(captured_budget, [24])
         self.assertEqual(len(result.evidence_bundles), 0)
 
-    def test_real_replay_forwards_staged_train_screen_multiplier(self) -> None:
+    def test_real_replay_forwards_frontier_repair_and_proof_capture_controls(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             output_dir = Path(tmpdir) / "epoch"
             result_path = output_dir / "result.json"
@@ -10039,12 +10076,44 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 ]
             }
             captured_multiplier: list[int] = []
+            captured_controls: list[dict[str, object]] = []
 
             def fake_run(
                 factory_args: Namespace, *, source_specs: object
             ) -> dict[str, object]:
                 captured_multiplier.append(
                     int(factory_args.staged_train_screen_multiplier)
+                )
+                captured_controls.append(
+                    {
+                        "capture_rejected_seed_full_window_ledger": bool(
+                            factory_args.capture_rejected_seed_full_window_ledger
+                        ),
+                        "capture_positive_rejected_full_window_ledgers": int(
+                            factory_args.capture_positive_rejected_full_window_ledgers
+                        ),
+                        "symbol_prune_iterations": int(
+                            factory_args.symbol_prune_iterations
+                        ),
+                        "symbol_prune_candidates": int(
+                            factory_args.symbol_prune_candidates
+                        ),
+                        "symbol_prune_min_universe_size": int(
+                            factory_args.symbol_prune_min_universe_size
+                        ),
+                        "loss_repair_iterations": int(
+                            factory_args.loss_repair_iterations
+                        ),
+                        "loss_repair_candidates": int(
+                            factory_args.loss_repair_candidates
+                        ),
+                        "consistency_repair_iterations": int(
+                            factory_args.consistency_repair_iterations
+                        ),
+                        "consistency_repair_candidates": int(
+                            factory_args.consistency_repair_candidates
+                        ),
+                    }
                 )
                 return factory_payload
 
@@ -10063,6 +10132,15 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 )
                 args = self._args(output_dir)
                 args.staged_train_screen_multiplier = 3
+                args.capture_rejected_seed_full_window_ledger = True
+                args.capture_positive_rejected_full_window_ledgers = 2
+                args.symbol_prune_iterations = 1
+                args.symbol_prune_candidates = 2
+                args.symbol_prune_min_universe_size = 4
+                args.loss_repair_iterations = 1
+                args.loss_repair_candidates = 1
+                args.consistency_repair_iterations = 1
+                args.consistency_repair_candidates = 2
                 result = runner._run_real_replay(
                     args,
                     output_dir=output_dir,
@@ -10070,6 +10148,22 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 )
 
         self.assertEqual(captured_multiplier, [3])
+        self.assertEqual(
+            captured_controls,
+            [
+                {
+                    "capture_rejected_seed_full_window_ledger": True,
+                    "capture_positive_rejected_full_window_ledgers": 2,
+                    "symbol_prune_iterations": 1,
+                    "symbol_prune_candidates": 2,
+                    "symbol_prune_min_universe_size": 4,
+                    "loss_repair_iterations": 1,
+                    "loss_repair_candidates": 1,
+                    "consistency_repair_iterations": 1,
+                    "consistency_repair_candidates": 2,
+                }
+            ],
+        )
         self.assertEqual(len(result.evidence_bundles), 0)
 
     def test_program_replay_budget_supplies_staged_train_screen_multiplier(
@@ -10077,15 +10171,34 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
     ) -> None:
         args = self._args(Path("/tmp/epoch"))
         program = runner._load_epoch_program(args)
+        controls = runner._resolved_real_replay_frontier_controls(args, program)
 
         self.assertEqual(
             runner._resolved_staged_train_screen_multiplier(args, program),
             3,
         )
+        self.assertEqual(controls["symbol_prune_iterations"], 1)
+        self.assertEqual(controls["symbol_prune_candidates"], 2)
+        self.assertEqual(controls["symbol_prune_min_universe_size"], 5)
+        self.assertEqual(controls["loss_repair_iterations"], 1)
+        self.assertEqual(controls["loss_repair_candidates"], 1)
+        self.assertEqual(controls["consistency_repair_iterations"], 1)
+        self.assertEqual(controls["consistency_repair_candidates"], 2)
+        self.assertFalse(controls["capture_rejected_seed_full_window_ledger"])
+        self.assertEqual(controls["capture_positive_rejected_full_window_ledgers"], 0)
         args.staged_train_screen_multiplier = 4
+        args.symbol_prune_candidates = 5
+        args.capture_positive_rejected_full_window_ledgers = 6
+        override_controls = runner._resolved_real_replay_frontier_controls(
+            args, program
+        )
         self.assertEqual(
             runner._resolved_staged_train_screen_multiplier(args, program),
             4,
+        )
+        self.assertEqual(override_controls["symbol_prune_candidates"], 5)
+        self.assertEqual(
+            override_controls["capture_positive_rejected_full_window_ledgers"], 6
         )
 
     def test_sharded_real_replay_continues_after_candidate_timeout(self) -> None:


### PR DESCRIPTION
## Summary

- Forward strategy-factory v2 staged train-screen breadth, symbol-prune repair, loss-repair, consistency-repair, and proof-only rejected-positive ledger capture controls into frontier runs.
- Resolve portfolio whitepaper real-replay repair controls from the research program by default while preserving CLI overrides for bounded replay batches.
- Add regression coverage for CLI parsing and the whitepaper-to-factory-to-frontier control contract.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/run_strategy_factory_v2.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_strategy_factory_v2.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_strategy_factory_v2.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_strategy_factory_v2.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pytest tests/test_run_strategy_factory_v2.py -k 'frontier_args or global_candidate_budget' -q`
- `uv run --frozen pytest tests/test_run_strategy_factory_v2.py -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'parse_args_covers_cli_defaults_and_flags or real_replay_forwards_frontier_repair_and_proof_capture_controls or program_replay_budget_supplies_staged_train_screen_multiplier' -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
