### PR TITLE
revert(torghut): rollback failed promotion df08de420d644bd3d4e9c39f8493f87f8612d2bd

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-720-gf7274e806
+              value: v0.571.1-718-gfa3159731
             - name: TORGHUT_OPTIONS_COMMIT
-              value: f7274e806599fa8130aa74cf33611febbc758dd9
+              value: fa3159731a118acb31e07e272faa496444d64373
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-720-gf7274e806
+              value: v0.571.1-718-gfa3159731
             - name: TORGHUT_OPTIONS_COMMIT
-              value: f7274e806599fa8130aa74cf33611febbc758dd9
+              value: fa3159731a118acb31e07e272faa496444d64373
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -75,7 +75,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+                  value: sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-23T18:34:54Z"
+        client.knative.dev/updateTimestamp: "2026-05-23T18:02:56Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
           ports:
             - name: http1
               containerPort: 8181
@@ -499,11 +499,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-720-gf7274e806
+              value: v0.571.1-718-gfa3159731
             - name: TORGHUT_COMMIT
-              value: f7274e806599fa8130aa74cf33611febbc758dd9
+              value: fa3159731a118acb31e07e272faa496444d64373
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+              value: sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-23T18:34:54Z"
+        client.knative.dev/updateTimestamp: "2026-05-23T18:02:56Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
           ports:
             - name: http1
               containerPort: 8181
@@ -320,11 +320,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-720-gf7274e806
+              value: v0.571.1-718-gfa3159731
             - name: TORGHUT_COMMIT
-              value: f7274e806599fa8130aa74cf33611febbc758dd9
+              value: fa3159731a118acb31e07e272faa496444d64373
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+              value: sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -132,7 +132,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f8013aa274005eccec5e28bd31716529f354e1a0072b86dbac717d7a3ae60998
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:196c5bf661dac46d7c8e39c83e8bd8e78e04e614708c26c1035635c86c977470
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `df08de420d644bd3d4e9c39f8493f87f8612d2bd`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/26340499307`
- Rollback source: `HEAD^` manifests from the failed run checkout