### PR TITLE
feat(torghut): rank whitepaper mechanism contracts

### DIFF
--- a/services/torghut/app/trading/discovery/mlx_training_data.py
+++ b/services/torghut/app/trading/discovery/mlx_training_data.py
@@ -17,7 +17,52 @@ from app.trading.discovery.objectives import (
     deployable_proof_failed_gate_count,
 )
 
-MLX_RANKER_SCHEMA_VERSION = "torghut.mlx-ranker.v2"
+MLX_RANKER_SCHEMA_VERSION = "torghut.mlx-ranker.v3"
+
+_MECHANISM_OVERLAY_IDS = (
+    "cluster_lob_event_clustering",
+    "mixed_market_limit_execution_policy",
+    "queue_position_survival_fill_curve",
+    "mpc_dynamic_execution_schedule",
+    "alpha_decay_predictability_stress",
+    "nonlinear_market_impact_tca",
+    "simulation_reality_gap_implementation_risk",
+    "implementation_risk_backtest_stability",
+    "replay_paper_live_semantic_parity",
+    "intraday_volume_periodicity_execution",
+    "macro_announcement_dvar_momentum",
+    "ofi_lob_continuation_response",
+    "order_flow_filtration_parent_trade_obi",
+    "rejected_signal_outcome_calibration",
+    "delay_adjusted_depth_stress",
+    "ohlcv_only_falsification",
+)
+_MECHANISM_OVERLAY_FEATURE_NAMES = tuple(
+    f"paper_overlay_{overlay_id}" for overlay_id in _MECHANISM_OVERLAY_IDS
+)
+_PAPER_CONTRACT_FEATURE_NAMES = (
+    "paper_source_claim_count",
+    "paper_signal_claim_count",
+    "paper_execution_claim_count",
+    "paper_validation_claim_count",
+    "paper_risk_claim_count",
+    "paper_avg_claim_confidence",
+    "paper_source_data_requirement_count",
+    "paper_validation_requirement_count",
+    "paper_validation_data_requirement_count",
+    "paper_mechanism_overlay_count",
+    "paper_mechanism_required_evidence_count",
+    "paper_requires_route_tca",
+    "paper_requires_live_paper_parity",
+    "paper_requires_lob_event_stream",
+    "paper_requires_fill_outcomes",
+    "paper_requires_execution_shortfall",
+    "paper_requires_implementation_uncertainty",
+    "paper_requires_rejected_signal_labels",
+    "paper_requires_executable_quote",
+    "paper_promotion_requires_count",
+    "paper_promotion_rejects_count",
+)
 
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:
@@ -159,6 +204,16 @@ def _mapping(value: Any) -> Mapping[str, Any]:
     return {}
 
 
+def _mapping_sequence(value: Any) -> tuple[Mapping[str, Any], ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return ()
+    return tuple(
+        cast(Mapping[str, Any], item)
+        for item in cast(Sequence[Any], value)
+        if isinstance(item, Mapping)
+    )
+
+
 def _positive_or_default(value: float, default: float) -> float:
     return value if value > 0.0 else default
 
@@ -226,6 +281,171 @@ def _sequence_strings(value: Any) -> tuple[str, ...]:
     return tuple(
         str(item).strip() for item in cast(Sequence[Any], value) if str(item).strip()
     )
+
+
+def _strings(value: Any) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes, bytearray)):
+        normalized = str(value).strip()
+        return (normalized,) if normalized else ()
+    if isinstance(value, Sequence):
+        return tuple(
+            str(item).strip()
+            for item in cast(Sequence[Any], value)
+            if str(item).strip()
+        )
+    return ()
+
+
+def _unique_string_count(items: Sequence[Mapping[str, Any]], key: str) -> float:
+    values: set[str] = set()
+    for item in items:
+        values.update(_strings(item.get(key)))
+    return float(len(values))
+
+
+def _unique_strings(items: Sequence[Mapping[str, Any]], key: str) -> set[str]:
+    values: set[str] = set()
+    for mapping_item in items:
+        values.update(value.lower() for value in _strings(mapping_item.get(key)))
+    return values
+
+
+def _claim_type_count(
+    claims: Sequence[Mapping[str, Any]], claim_types: set[str]
+) -> float:
+    return float(
+        sum(
+            1
+            for item in claims
+            if str(item.get("claim_type") or "").strip().lower() in claim_types
+        )
+    )
+
+
+def _average_claim_confidence(claims: Sequence[Mapping[str, Any]]) -> float:
+    values = [
+        _float(item.get("confidence"))
+        for item in claims
+        if _float(item.get("confidence")) > 0.0
+    ]
+    return _mean(values)
+
+
+def _truthy_contract_key_count(contract: Mapping[str, Any], prefix: str) -> float:
+    return float(
+        sum(
+            1
+            for key, value in contract.items()
+            if str(key).startswith(prefix) and _truthy_feature(value) > 0.0
+        )
+    )
+
+
+def _requirement_present(requirements: set[str], tokens: Sequence[str]) -> float:
+    return 1.0 if any(token in requirements for token in tokens) else 0.0
+
+
+def _mechanism_overlay_ids(spec: CandidateSpec) -> set[str]:
+    overlay_ids = set(_strings(spec.parameter_space.get("mechanism_overlay_ids")))
+    for contract in _mapping_sequence(spec.feature_contract.get("mechanism_overlays")):
+        overlay_ids.update(_strings(contract.get("overlay_id")))
+    return overlay_ids
+
+
+def _paper_contract_feature_values(spec: CandidateSpec) -> Mapping[str, float]:
+    source_claims = _mapping_sequence(spec.feature_contract.get("source_claims"))
+    validation_requirements = _mapping_sequence(
+        spec.feature_contract.get("validation_requirements")
+    )
+    mechanism_overlays = _mapping_sequence(
+        spec.feature_contract.get("mechanism_overlays")
+    )
+    overlay_ids = _mechanism_overlay_ids(spec)
+    contract_requirements = (
+        _unique_strings(source_claims, "data_requirements")
+        | _unique_strings(validation_requirements, "data_requirements")
+        | _unique_strings(mechanism_overlays, "required_evidence")
+    )
+    mechanism_required_evidence_count = _unique_string_count(
+        mechanism_overlays, "required_evidence"
+    )
+    feature_values = {
+        "paper_source_claim_count": float(len(source_claims)),
+        "paper_signal_claim_count": _claim_type_count(
+            source_claims,
+            {
+                "feature_recipe",
+                "signal_mechanism",
+                "strategy_mechanism",
+                "portfolio_construction",
+            },
+        ),
+        "paper_execution_claim_count": _claim_type_count(
+            source_claims, {"execution_assumption"}
+        ),
+        "paper_validation_claim_count": _claim_type_count(
+            source_claims, {"validation_requirement"}
+        ),
+        "paper_risk_claim_count": _claim_type_count(
+            source_claims, {"risk_constraint", "market_regime"}
+        ),
+        "paper_avg_claim_confidence": _average_claim_confidence(source_claims),
+        "paper_source_data_requirement_count": _unique_string_count(
+            source_claims, "data_requirements"
+        ),
+        "paper_validation_requirement_count": float(len(validation_requirements)),
+        "paper_validation_data_requirement_count": _unique_string_count(
+            validation_requirements, "data_requirements"
+        ),
+        "paper_mechanism_overlay_count": float(len(overlay_ids)),
+        "paper_mechanism_required_evidence_count": mechanism_required_evidence_count,
+        "paper_requires_route_tca": _requirement_present(
+            contract_requirements, ("route_tca",)
+        ),
+        "paper_requires_live_paper_parity": _requirement_present(
+            contract_requirements, ("live_paper_parity",)
+        ),
+        "paper_requires_lob_event_stream": _requirement_present(
+            contract_requirements,
+            ("lob_event_stream", "lob_events", "clustered_order_events"),
+        ),
+        "paper_requires_fill_outcomes": _requirement_present(
+            contract_requirements,
+            ("fill_outcomes", "order_lifecycle_fill_evidence"),
+        ),
+        "paper_requires_execution_shortfall": _requirement_present(
+            contract_requirements, ("execution_shortfall",)
+        ),
+        "paper_requires_implementation_uncertainty": _requirement_present(
+            contract_requirements,
+            (
+                "implementation_uncertainty_interval",
+                "implementation_uncertainty_stability",
+                "multi_engine_replay",
+            ),
+        ),
+        "paper_requires_rejected_signal_labels": _requirement_present(
+            contract_requirements,
+            ("rejected_signal_log", "outcome_labels", "counterfactual_return"),
+        ),
+        "paper_requires_executable_quote": _requirement_present(
+            contract_requirements,
+            ("executable_quote", "executable_quote_evidence"),
+        ),
+        "paper_promotion_requires_count": _truthy_contract_key_count(
+            spec.promotion_contract, "requires_"
+        ),
+        "paper_promotion_rejects_count": _truthy_contract_key_count(
+            spec.promotion_contract, "rejects_"
+        ),
+    }
+    for overlay_id, feature_name in zip(
+        _MECHANISM_OVERLAY_IDS,
+        _MECHANISM_OVERLAY_FEATURE_NAMES,
+        strict=True,
+    ):
+        feature_values[feature_name] = 1.0 if overlay_id in overlay_ids else 0.0
+    return feature_values
 
 
 def _capital_rank_count_floor(
@@ -618,7 +838,10 @@ def build_mlx_training_rows(
             "history_deployable_lower_bound_target_shortfall",
             "history_deployable_lower_bound_missing_count",
             "history_deployable_lower_bound_failed_gate_count",
+            *_PAPER_CONTRACT_FEATURE_NAMES,
+            *_MECHANISM_OVERLAY_FEATURE_NAMES,
         )
+        paper_contract_features = _paper_contract_feature_values(spec)
         capital_features = candidate_spec_capital_features(spec)
         params = _params(spec)
         target_net_pnl_per_day = _float(spec.objective.get("target_net_pnl_per_day"))
@@ -797,6 +1020,14 @@ def build_mlx_training_rows(
             deployable_lower_bound_target_shortfall,
             deployable_lower_bound_missing_count,
             deployable_lower_bound_failed_gate_count,
+            *(
+                _float(paper_contract_features.get(feature_name))
+                for feature_name in _PAPER_CONTRACT_FEATURE_NAMES
+            ),
+            *(
+                _float(paper_contract_features.get(feature_name))
+                for feature_name in _MECHANISM_OVERLAY_FEATURE_NAMES
+            ),
         )
         target = (
             deployable_lower_bound_net_pnl_per_day

--- a/services/torghut/tests/test_mlx_training_data.py
+++ b/services/torghut/tests/test_mlx_training_data.py
@@ -320,6 +320,132 @@ class TestMlxTrainingData(TestCase):
         self.assertEqual(first_row["entry_order_type_prefer_limit"], 1.0)
         self.assertEqual(first_row["market_order_spread_bps_max"], 6.0)
 
+    def test_training_rows_encode_whitepaper_mechanism_contract_features(
+        self,
+    ) -> None:
+        spec = CandidateSpec(
+            schema_version="torghut.candidate-spec.v1",
+            candidate_spec_id="spec-paper-contract",
+            hypothesis_id="H-PAPER-CONTRACT",
+            family_template_id="microbar_cross_sectional_pairs_v1",
+            candidate_kind="configuration",
+            runtime_family="microbar_cross_sectional_pairs",
+            runtime_strategy_name="microbar-cross-sectional-pairs-v1",
+            feature_contract={
+                "source_claims": [
+                    {
+                        "claim_id": "claim-fill-survival",
+                        "claim_type": "execution_assumption",
+                        "confidence": "0.70",
+                        "data_requirements": [
+                            "queue_position",
+                            "time_to_fill_quantiles",
+                        ],
+                    },
+                    {
+                        "claim_id": "claim-sim-reality-gap",
+                        "claim_type": "validation_requirement",
+                        "confidence": "0.80",
+                        "data_requirements": [
+                            "simulation_live_parity_metrics",
+                            "fill_outcomes",
+                        ],
+                    },
+                    {
+                        "claim_id": "claim-ofi-response",
+                        "claim_type": "signal_mechanism",
+                        "confidence": "0.90",
+                        "data_requirements": [
+                            "order_flow_imbalance",
+                            "microprice_bias",
+                        ],
+                    },
+                ],
+                "validation_requirements": [
+                    {
+                        "claim_id": "claim-sim-reality-gap",
+                        "data_requirements": [
+                            "live_paper_parity",
+                            "route_tca",
+                        ],
+                    }
+                ],
+                "mechanism_overlays": [
+                    {
+                        "overlay_id": "simulation_reality_gap_implementation_risk",
+                        "required_evidence": [
+                            "simulation_live_parity_metrics",
+                            "fill_outcomes",
+                            "route_tca",
+                        ],
+                    },
+                    {
+                        "overlay_id": "queue_position_survival_fill_curve",
+                        "required_evidence": [
+                            "queue_position",
+                            "survival_fill_curve",
+                        ],
+                    },
+                ],
+            },
+            parameter_space={
+                "mechanism_overlay_ids": [
+                    "simulation_reality_gap_implementation_risk",
+                    "queue_position_survival_fill_curve",
+                    "ofi_lob_continuation_response",
+                ]
+            },
+            strategy_overrides={
+                "max_notional_per_trade": "25000",
+                "max_position_pct_equity": "0.25",
+                "params": {
+                    "capital_profile": "initial_equity_cash_constrained_1x",
+                    "max_entries_per_session": "2",
+                    "max_gross_exposure_pct_equity": "1.0",
+                },
+            },
+            objective={"target_net_pnl_per_day": "500"},
+            hard_vetoes={"required_min_daily_notional": "250000"},
+            expected_failure_modes=(),
+            promotion_contract={
+                "requires_simulation_live_parity_metrics": True,
+                "requires_fill_outcomes": True,
+                "rejects_synthetic_lob_fillability_as_capital_gate": True,
+            },
+        )
+
+        rows = build_mlx_training_rows(candidate_specs=[spec], evidence_bundles=[])
+        features = rows[0].to_payload()["features"]
+
+        self.assertEqual(features["paper_source_claim_count"], 3.0)
+        self.assertEqual(features["paper_signal_claim_count"], 1.0)
+        self.assertEqual(features["paper_execution_claim_count"], 1.0)
+        self.assertEqual(features["paper_validation_claim_count"], 1.0)
+        self.assertAlmostEqual(features["paper_avg_claim_confidence"], 0.8)
+        self.assertEqual(features["paper_source_data_requirement_count"], 6.0)
+        self.assertEqual(features["paper_validation_requirement_count"], 1.0)
+        self.assertEqual(features["paper_validation_data_requirement_count"], 2.0)
+        self.assertEqual(features["paper_mechanism_overlay_count"], 3.0)
+        self.assertEqual(features["paper_mechanism_required_evidence_count"], 5.0)
+        self.assertEqual(features["paper_requires_route_tca"], 1.0)
+        self.assertEqual(features["paper_requires_live_paper_parity"], 1.0)
+        self.assertEqual(features["paper_requires_fill_outcomes"], 1.0)
+        self.assertEqual(features["paper_requires_executable_quote"], 0.0)
+        self.assertEqual(features["paper_promotion_requires_count"], 2.0)
+        self.assertEqual(features["paper_promotion_rejects_count"], 1.0)
+        self.assertEqual(
+            features["paper_overlay_simulation_reality_gap_implementation_risk"],
+            1.0,
+        )
+        self.assertEqual(
+            features["paper_overlay_queue_position_survival_fill_curve"],
+            1.0,
+        )
+        self.assertEqual(features["paper_overlay_ofi_lob_continuation_response"], 1.0)
+        self.assertEqual(
+            features["paper_overlay_mixed_market_limit_execution_policy"], 0.0
+        )
+
     def test_negative_rank_bucket_lift_demotes_to_heuristic_order(self) -> None:
         rows = [
             MlxTrainingRow(

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -3906,7 +3906,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             self.assertEqual(
                 pre_replay_model_payload["row_count"], payload["candidate_spec_count"]
             )
-            self.assertEqual(model_payload["schema_version"], "torghut.mlx-ranker.v2")
+            self.assertEqual(model_payload["schema_version"], "torghut.mlx-ranker.v3")
             self.assertEqual(
                 model_payload["row_count"], payload["candidate_spec_count"]
             )
@@ -8444,7 +8444,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 backend_preference="numpy-fallback",
             )
 
-        self.assertEqual(model_payload["schema_version"], "torghut.mlx-ranker.v2")
+        self.assertEqual(model_payload["schema_version"], "torghut.mlx-ranker.v3")
         self.assertEqual(model_payload["backend"], "numpy-fallback")
         self.assertIn("rank_bucket_lift", model_payload)
         self.assertIn(model_payload["model_status"], {"active", "demoted_to_heuristic"})

--- a/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
+++ b/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
@@ -230,7 +230,7 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
         model = train_mlx_ranker(rows, backend_preference="numpy-fallback", steps=128)
         ranked = rank_training_rows(model=model, rows=rows)
 
-        self.assertEqual(model.schema_version, "torghut.mlx-ranker.v2")
+        self.assertEqual(model.schema_version, "torghut.mlx-ranker.v3")
         self.assertEqual(model.backend, "numpy-fallback")
         self.assertEqual(model.row_count, 2)
         self.assertEqual(ranked[0].candidate_spec_id, high_spec.candidate_spec_id)


### PR DESCRIPTION
## Summary

- Bump the MLX autoresearch ranker schema to `torghut.mlx-ranker.v3`.
- Add whitepaper source-claim, validation-contract, evidence-requirement, promotion-contract, and mechanism-overlay features to MLX training rows.
- Keep the change limited to pre-replay ranking inputs; promotion gates and runtime-ledger authority remain unchanged.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/discovery/mlx_training_data.py tests/test_mlx_training_data.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_whitepaper_autoresearch_artifacts.py`
- `uv run --frozen ruff check app/trading/discovery/mlx_training_data.py tests/test_mlx_training_data.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_whitepaper_autoresearch_artifacts.py`
- `uv run --frozen pytest tests/test_mlx_training_data.py -q`
- `uv run --frozen pytest tests/test_candidate_specs.py -k 'structured_source_claims or simulation_reality_gap or alpha_decay or rejected_signal' -q`
- `uv run --frozen pytest tests/test_whitepaper_candidate_compiler.py -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'seed_recent_whitepapers_runs_end_to_end_and_writes_artifacts or train_ranker_script_helper_reads_runner_artifacts or train_ranker_script_main_writes_model_and_scores' -q`
- `uv run --frozen pytest tests/test_whitepaper_autoresearch_artifacts.py -k 'mlx_ranker' -q`
- `uv run --frozen pytest tests/test_whitepaper_autoresearch_artifacts.py -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

MLX ranker payload schema changes from `torghut.mlx-ranker.v2` to `torghut.mlx-ranker.v3` because the feature vector changed. Existing v2 ranker artifacts should be regenerated before reuse.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
