### PR TITLE
fix(torghut): persist health report AgentRun artifacts

### DIFF
--- a/argocd/applications/torghut/agents-domain/kustomization.yaml
+++ b/argocd/applications/torghut/agents-domain/kustomization.yaml
@@ -12,6 +12,9 @@ resources:
   - codex-research-secretbinding.yaml
   - codex-research-agent.yaml
   - codex-research-agent-system-prompt-configmap.yaml
+  - torghut-health-agentprovider.yaml
+  - torghut-health-agent.yaml
+  - torghut-health-secretbinding.yaml
   - torghut-market-context-agentprovider.yaml
   - torghut-fundamentals-agent.yaml
   - torghut-news-agent.yaml

--- a/argocd/applications/torghut/agents-domain/torghut-agentruns.yaml
+++ b/argocd/applications/torghut/agents-domain/torghut-agentruns.yaml
@@ -18,6 +18,8 @@ spec:
     - Do not mutate cluster state.
     - Do not open PRs.
     - Assume kubectl is unavailable or unreliable.
+    - Persist the final report exactly at `/workspace/.agentrun/torghut-health/report.md`.
+    - Do not finish until that Markdown report file exists and contains the verdict.
 
     Inputs (from AgentRun parameters):
     - torghutNamespace
@@ -51,6 +53,7 @@ spec:
     Output:
     - Produce a concise Markdown report with sections: Summary, WS, Flink, Trading, Guardrails, Freshness.
     - Conclude with a single health verdict: healthy | degraded | down.
+    - Write the same Markdown report to `/workspace/.agentrun/torghut-health/report.md`; create the parent directory first if needed.
 ---
 apiVersion: agents.proompteng.ai/v1alpha1
 kind: ImplementationSpec

--- a/argocd/applications/torghut/agents-domain/torghut-health-agent.yaml
+++ b/argocd/applications/torghut/agents-domain/torghut-health-agent.yaml
@@ -1,0 +1,12 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: Agent
+metadata:
+  name: torghut-health-agent
+spec:
+  providerRef:
+    name: torghut-health-report
+  defaults:
+    systemPromptRef:
+      kind: ConfigMap
+      name: codex-agent-system-prompt
+      key: system-prompt.md

--- a/argocd/applications/torghut/agents-domain/torghut-health-agentprovider.yaml
+++ b/argocd/applications/torghut/agents-domain/torghut-health-agentprovider.yaml
@@ -1,0 +1,78 @@
+apiVersion: agents.proompteng.ai/v1alpha1
+kind: AgentProvider
+metadata:
+  name: torghut-health-report
+spec:
+  binary: /usr/local/bin/agent-runner
+  adapter:
+    type: codex-app-server
+    codex:
+      model: gpt-5.3-codex-spark
+      effort: xhigh
+      sandbox: danger-full-access
+      approval: never
+      cwd: /workspace/lab
+      threadConfig:
+        mcp_servers: {}
+        web_search: live
+      secretEnv:
+        - name: AGENTS_ARTIFACTS_ACCESS_KEY_ID
+          secretName: observability-minio-creds
+          key: accesskey
+        - name: AGENTS_ARTIFACTS_SECRET_ACCESS_KEY
+          secretName: observability-minio-creds
+          key: secretkey
+  argsTemplate: []
+  envTemplate:
+    CODEX_LOG_LEVEL: info
+    AGENT_RUN_NAME: "{{agentRun.name}}"
+    AGENT_RUN_NAMESPACE: "{{agentRun.namespace}}"
+    CODEX_MODEL: gpt-5.3-codex-spark
+    CODEX_MODEL_FALLBACKS: gpt-5.5,gpt-5.4,gpt-5.4-mini,gpt-5.2-codex,gpt-5-codex
+    CODEX_MAX_SESSION_ATTEMPTS: "5"
+    HF_BASE_URL: https://router.huggingface.co/v1
+    HF_MODEL: meta-llama/Llama-3.1-8B-Instruct:novita
+    AGENTS_ARTIFACTS_ENDPOINT: http://observability-minio.minio.svc.cluster.local:9000
+    AGENTS_ARTIFACTS_BUCKET: agents-artifacts
+    AGENTS_ARTIFACTS_SECURE: "false"
+  inputFiles:
+    - path: /root/.codex/config.toml
+      content: |-
+        model = "gpt-5.3-codex-spark"
+        model_reasoning_summary = "none"
+        model_reasoning_effort = "xhigh"
+        model_verbosity = "medium"
+        approval_policy = "never"
+        sandbox_mode = "danger-full-access"
+        web_search = "live"
+        suppress_unstable_features_warning = true
+
+        [features]
+        undo = true
+        enable_request_compression = true
+        apply_patch_freeform = true
+        unified_exec = true
+        shell_snapshot = true
+        steer = true
+        multi_agent = true
+        child_agents_md = true
+        collaboration_modes = true
+        responses_websockets = false
+        goals = true
+
+        [shell_environment_policy]
+        ignore_default_excludes = true
+
+        [projects."/workspace/lab"]
+        trust_level = "trusted"
+
+        [projects."/root"]
+        trust_level = "trusted"
+  outputArtifacts:
+    - name: torghut-health-report
+      path: /workspace/.agentrun/torghut-health/report.md
+      key: torghut/health/{{ agentRun.name }}/report.md
+    - name: runner-log
+      path: /workspace/.agent/runner.log
+    - name: runner-status
+      path: /workspace/.agent/status.json

--- a/argocd/applications/torghut/agents-domain/torghut-health-secretbinding.yaml
+++ b/argocd/applications/torghut/agents-domain/torghut-health-secretbinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: security.proompteng.ai/v1alpha1
+kind: SecretBinding
+metadata:
+  name: torghut-health-agent-secrets
+spec:
+  subjects:
+    - kind: Agent
+      name: torghut-health-agent
+  allowedSecrets:
+    - codex-auth
+    - observability-minio-creds

--- a/packages/scripts/src/torghut/__tests__/agents-domain-smoke.test.ts
+++ b/packages/scripts/src/torghut/__tests__/agents-domain-smoke.test.ts
@@ -104,6 +104,64 @@ describe('Agents domain scheduled AgentRun templates', () => {
     expect(objectAt(health, 'capacityFailurePolicy')).toBe('block')
   })
 
+  it('wires Torghut health reports to durable AgentRun artifacts', () => {
+    const kustomization = readYamlObjects('argocd/applications/torghut/agents-domain/kustomization.yaml')[0]
+    const resources = objectAt(kustomization, 'resources') as string[] | undefined
+    expect(resources).toContain('torghut-health-agentprovider.yaml')
+    expect(resources).toContain('torghut-health-agent.yaml')
+    expect(resources).toContain('torghut-health-secretbinding.yaml')
+
+    const provider = readYamlObjects(
+      'argocd/applications/torghut/agents-domain/torghut-health-agentprovider.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'AgentProvider')
+    const providerSpec = objectAt(provider, 'spec')
+    const adapter = objectAt(providerSpec, 'adapter')
+    const codex = objectAt(adapter, 'codex')
+    const secretEnv = objectAt(codex, 'secretEnv') as Record<string, unknown>[] | undefined
+    const outputArtifacts = objectAt(providerSpec, 'outputArtifacts') as Record<string, unknown>[] | undefined
+    const healthArtifact = outputArtifacts?.find((artifact) => objectAt(artifact, 'name') === 'torghut-health-report')
+
+    expect(objectAt(objectAt(provider, 'metadata'), 'name')).toBe('torghut-health-report')
+    expect(secretEnv).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'AGENTS_ARTIFACTS_ACCESS_KEY_ID',
+          secretName: 'observability-minio-creds',
+          key: 'accesskey',
+        }),
+        expect.objectContaining({
+          name: 'AGENTS_ARTIFACTS_SECRET_ACCESS_KEY',
+          secretName: 'observability-minio-creds',
+          key: 'secretkey',
+        }),
+      ]),
+    )
+    expect(healthArtifact).toEqual({
+      name: 'torghut-health-report',
+      path: '/workspace/.agentrun/torghut-health/report.md',
+      key: 'torghut/health/{{ agentRun.name }}/report.md',
+    })
+
+    const agent = readYamlObjects('argocd/applications/torghut/agents-domain/torghut-health-agent.yaml').find(
+      (manifest) => objectAt(manifest, 'kind') === 'Agent',
+    )
+    expect(objectAt(objectAt(objectAt(agent, 'spec'), 'providerRef'), 'name')).toBe('torghut-health-report')
+
+    const secretBinding = readYamlObjects(
+      'argocd/applications/torghut/agents-domain/torghut-health-secretbinding.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'SecretBinding')
+    const allowedSecrets = objectAt(objectAt(secretBinding, 'spec'), 'allowedSecrets') as string[] | undefined
+    expect(allowedSecrets).toEqual(expect.arrayContaining(['codex-auth', 'observability-minio-creds']))
+
+    const healthSpec = readYamlObjects('argocd/applications/torghut/agents-domain/torghut-agentruns.yaml').find(
+      (manifest) =>
+        objectAt(manifest, 'kind') === 'ImplementationSpec' && nameOf(manifest) === 'torghut-health-report-v1',
+    )
+    const healthText = stringAt(objectAt(healthSpec, 'spec'), 'text')
+    expect(healthText).toContain('/workspace/.agentrun/torghut-health/report.md')
+    expect(healthText).toContain('Do not finish until that Markdown report file exists')
+  })
+
   it('keeps scheduled template retention aligned with the swarm brownout window', () => {
     const manifestPaths = [
       ...swarmAgentRunTemplatePaths,

--- a/services/agents/src/runner/codex-app-server.test.ts
+++ b/services/agents/src/runner/codex-app-server.test.ts
@@ -69,6 +69,7 @@ describe('codex app-server runner adapter', () => {
       runPath,
       `${JSON.stringify({
         implementation: { text: 'implement the feature' },
+        agentRun: { name: 'run-1' },
         systemPrompt: 'system instructions',
         parameters: { artifactName: 'research-result' },
         goal: { objective: 'ship the feature', tokenBudget: 1234 },
@@ -110,7 +111,7 @@ describe('codex app-server runner adapter', () => {
             {
               name: 'codex-artifact',
               path: '/workspace/{{ inputs.stage }}/{{ run.parameters.artifactName }}.json',
-              key: 'codex-research/{{ run.parameters.artifactName }}.json',
+              key: 'codex-research/{{ agentRun.name }}/{{ run.parameters.artifactName }}.json',
             },
           ],
         },
@@ -173,8 +174,8 @@ describe('codex app-server runner adapter', () => {
         {
           name: 'codex-artifact',
           path: '/workspace/research/research-result.json',
-          key: 'codex-research/research-result.json',
-          url: 's3://argo-workflows/codex-research/research-result.json',
+          key: 'codex-research/run-1/research-result.json',
+          url: 's3://argo-workflows/codex-research/run-1/research-result.json',
         },
       ],
     })

--- a/services/agents/src/runner/codex-app-server.ts
+++ b/services/agents/src/runner/codex-app-server.ts
@@ -986,6 +986,7 @@ export const runCodexAppServerAdapterEffect = ({
     yield* validateCodexAdapterEffect(adapter)
     const runPayload = yield* loadRunPayloadEffect(spec)
     state.outputArtifacts = renderOutputArtifacts(spec.providerSpec?.outputArtifacts, {
+      ...runPayload,
       ...buildTemplateContext(spec),
       run: runPayload,
     })


### PR DESCRIPTION
## Summary

- Adds a Torghut-specific health AgentProvider, Agent, and SecretBinding wired to `observability-minio-creds` for artifact uploads.
- Declares a keyed `torghut-health-report` output artifact at `/workspace/.agentrun/torghut-health/report.md` so health runs fail closed when no report is written.
- Extends the Codex app-server runner artifact template context so upload keys can render top-level run payload fields such as `agentRun.name`.
- Adds smoke and runner coverage for the durable health report artifact path.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/agents-domain-smoke.test.ts`
- `bunx vitest run --config vitest.config.ts src/runner/codex-app-server.test.ts src/runner/artifact-upload.test.ts src/server/agents-controller/job-runtime.test.ts` from `services/agents`
- `bun run --filter @proompteng/agents tsc`
- `bunx oxfmt --check argocd/applications/torghut/agents-domain/kustomization.yaml argocd/applications/torghut/agents-domain/torghut-agentruns.yaml argocd/applications/torghut/agents-domain/torghut-health-agent.yaml argocd/applications/torghut/agents-domain/torghut-health-agentprovider.yaml argocd/applications/torghut/agents-domain/torghut-health-secretbinding.yaml packages/scripts/src/torghut/__tests__/agents-domain-smoke.test.ts services/agents/src/runner/codex-app-server.ts services/agents/src/runner/codex-app-server.test.ts`
- `bun run --filter @proompteng/agents lint`
- `bun run --filter @proompteng/agents lint:oxlint` (passed with existing warnings only)
- `kubectl kustomize argocd/applications/torghut/agents-domain >/tmp/torghut-agents-domain-render.yaml && rg -n "name: torghut-health-agent|name: torghut-health-report|torghut/health/\\{\\{ agentRun.name \\}\\}/report.md|observability-minio-creds|Do not finish until" /tmp/torghut-agents-domain-render.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
