### PR TITLE
chore(agents): promote images e7dd3817

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: 9cf8cd69
-  digest: sha256:c7fb413b47038d1ead9032d35056f4e056776637691bf262f5306711db7249e5
+  tag: e7dd3817
+  digest: sha256:b9038a2152ed0e0ed7de94b5386c1ea17a71279a1b6e35c652c5de675440f3cb
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,26 +11,26 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: 9cf8cd69
-    digest: sha256:141c9f8079eef3c47eb62b5e5e5a991ba3c9c6cd95c415bd7e718242d7d4fc4c
+    tag: e7dd3817
+    digest: sha256:4395b6e3fca1c0b5b21875337e74a7d8e01362e88c51757b456b2d6a167068f2
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: 9cf8cd6954d9498ae002755949ff8389fb3d6d51
-      AGENTS_GITOPS_REVISION: 9cf8cd6954d9498ae002755949ff8389fb3d6d51
-      AGENTS_SOURCE_CI_RUN_ID: "26246295502"
+      AGENTS_SOURCE_HEAD_SHA: e7dd38173e693196b0f76afbe53b20d5238fd11a
+      AGENTS_GITOPS_REVISION: e7dd38173e693196b0f76afbe53b20d5238fd11a
+      AGENTS_SOURCE_CI_RUN_ID: "26343731989"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:141c9f8079eef3c47eb62b5e5e5a991ba3c9c6cd95c415bd7e718242d7d4fc4c
-      AGENTS_SERVING_BUILD_COMMIT: 9cf8cd6954d9498ae002755949ff8389fb3d6d51
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:141c9f8079eef3c47eb62b5e5e5a991ba3c9c6cd95c415bd7e718242d7d4fc4c
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:4395b6e3fca1c0b5b21875337e74a7d8e01362e88c51757b456b2d6a167068f2
+      AGENTS_SERVING_BUILD_COMMIT: e7dd38173e693196b0f76afbe53b20d5238fd11a
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:4395b6e3fca1c0b5b21875337e74a7d8e01362e88c51757b456b2d6a167068f2
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: 9cf8cd69
-    digest: sha256:143819c7bbf89f2988c411be72148531c7716417671d00a8872d5e0a46eaa0cf
+    tag: e7dd3817
+    digest: sha256:9ca5303fc1f6d370110c7ddefef76c5446abae7b797e8b38a512019a9ed17ce7
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun
@@ -85,8 +85,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: 9cf8cd69
-    digest: sha256:c7fb413b47038d1ead9032d35056f4e056776637691bf262f5306711db7249e5
+    tag: e7dd3817
+    digest: sha256:b9038a2152ed0e0ed7de94b5386c1ea17a71279a1b6e35c652c5de675440f3cb
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `e7dd38173e693196b0f76afbe53b20d5238fd11a`
- Image tag: `e7dd3817`
- Agents build run: `26343731989`
- Promotion source: `workflow_run`