### PR TITLE
fix(agents): wire artifact bucket credentials

### DIFF
--- a/argocd/applications/agents/agents-artifacts-objectbucketclaim.yaml
+++ b/argocd/applications/agents/agents-artifacts-objectbucketclaim.yaml
@@ -1,0 +1,8 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: agents-artifacts
+  namespace: agents
+spec:
+  bucketName: agents-artifacts
+  storageClassName: rook-ceph-bucket

--- a/argocd/applications/agents/codex-secretbinding.yaml
+++ b/argocd/applications/agents/codex-secretbinding.yaml
@@ -16,6 +16,6 @@ spec:
     - github-token
     - codex-auth
     - graf-api
-    - observability-minio-creds
+    - agents-artifacts
     - hf-router-token
     - nats-agents-credentials

--- a/argocd/applications/agents/graf-codex-agent.yaml
+++ b/argocd/applications/agents/graf-codex-agent.yaml
@@ -15,5 +15,5 @@ spec:
       - codex-auth
       - github-token
       - graf-api
-      - observability-minio-creds
+      - agents-artifacts
       - nats-agents-credentials

--- a/argocd/applications/agents/graf-codex-agentprovider.yaml
+++ b/argocd/applications/agents/graf-codex-agentprovider.yaml
@@ -21,11 +21,11 @@ spec:
           key: bearer-tokens
           optional: true
         - name: AGENTS_ARTIFACTS_ACCESS_KEY_ID
-          secretName: observability-minio-creds
-          key: accesskey
+          secretName: agents-artifacts
+          key: AWS_ACCESS_KEY_ID
         - name: AGENTS_ARTIFACTS_SECRET_ACCESS_KEY
-          secretName: observability-minio-creds
-          key: secretkey
+          secretName: agents-artifacts
+          key: AWS_SECRET_ACCESS_KEY
         - name: GITHUB_TOKEN
           secretName: github-token
           key: token
@@ -34,7 +34,7 @@ spec:
   envTemplate:
     CODEX_LOG_LEVEL: info
     CODEX_GRAF_BASE_URL: http://graf.graf.svc.cluster.local
-    AGENTS_ARTIFACTS_ENDPOINT: http://observability-minio.minio.svc.cluster.local:9000
+    AGENTS_ARTIFACTS_ENDPOINT: http://rook-ceph-rgw-objectstore.rook-ceph.svc:80
     AGENTS_ARTIFACTS_BUCKET: agents-artifacts
     AGENTS_ARTIFACTS_SECURE: "false"
   inputFiles:

--- a/argocd/applications/agents/kustomization.yaml
+++ b/argocd/applications/agents/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
   - agents-primitives-approvalpolicy.yaml
   - agents-primitives-signal.yaml
   - agents-primitives-signal-delivery.yaml
+  - agents-artifacts-objectbucketclaim.yaml
   - agents-primitives-artifact.yaml
   - agents-primitives-budget.yaml
   - agents-primitives-workspace.yaml

--- a/argocd/applications/torghut/agents-domain/torghut-health-agentprovider.yaml
+++ b/argocd/applications/torghut/agents-domain/torghut-health-agentprovider.yaml
@@ -17,11 +17,11 @@ spec:
         web_search: live
       secretEnv:
         - name: AGENTS_ARTIFACTS_ACCESS_KEY_ID
-          secretName: observability-minio-creds
-          key: accesskey
+          secretName: agents-artifacts
+          key: AWS_ACCESS_KEY_ID
         - name: AGENTS_ARTIFACTS_SECRET_ACCESS_KEY
-          secretName: observability-minio-creds
-          key: secretkey
+          secretName: agents-artifacts
+          key: AWS_SECRET_ACCESS_KEY
   argsTemplate: []
   envTemplate:
     CODEX_LOG_LEVEL: info
@@ -32,7 +32,7 @@ spec:
     CODEX_MAX_SESSION_ATTEMPTS: "5"
     HF_BASE_URL: https://router.huggingface.co/v1
     HF_MODEL: meta-llama/Llama-3.1-8B-Instruct:novita
-    AGENTS_ARTIFACTS_ENDPOINT: http://observability-minio.minio.svc.cluster.local:9000
+    AGENTS_ARTIFACTS_ENDPOINT: http://rook-ceph-rgw-objectstore.rook-ceph.svc:80
     AGENTS_ARTIFACTS_BUCKET: agents-artifacts
     AGENTS_ARTIFACTS_SECURE: "false"
   inputFiles:

--- a/argocd/applications/torghut/agents-domain/torghut-health-secretbinding.yaml
+++ b/argocd/applications/torghut/agents-domain/torghut-health-secretbinding.yaml
@@ -8,4 +8,4 @@ spec:
       name: torghut-health-agent
   allowedSecrets:
     - codex-auth
-    - observability-minio-creds
+    - agents-artifacts

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -364,6 +364,54 @@ describe('scheduled AgentRun templates', () => {
     }
   })
 
+  it('wires Codex artifact uploads to the Agents-owned Rook bucket claim', () => {
+    const kustomization = readYamlObjects('argocd/applications/agents/kustomization.yaml')[0]
+    const resources = objectAt(kustomization, 'resources') as string[] | undefined
+    expect(resources).toContain('agents-artifacts-objectbucketclaim.yaml')
+
+    const bucketClaim = readYamlObjects('argocd/applications/agents/agents-artifacts-objectbucketclaim.yaml').find(
+      (manifest) => objectAt(manifest, 'kind') === 'ObjectBucketClaim',
+    )
+    expect(objectAt(objectAt(bucketClaim, 'metadata'), 'name')).toBe('agents-artifacts')
+    expect(objectAt(objectAt(bucketClaim, 'spec'), 'bucketName')).toBe('agents-artifacts')
+    expect(objectAt(objectAt(bucketClaim, 'spec'), 'storageClassName')).toBe('rook-ceph-bucket')
+
+    const provider = readYamlObjects('argocd/applications/agents/graf-codex-agentprovider.yaml').find(
+      (manifest) => objectAt(manifest, 'kind') === 'AgentProvider',
+    )
+    const providerSpec = objectAt(provider, 'spec')
+    const adapter = objectAt(providerSpec, 'adapter')
+    const codex = objectAt(adapter, 'codex')
+    const secretEnv = objectAt(codex, 'secretEnv') as Record<string, unknown>[] | undefined
+
+    expect(secretEnv).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'AGENTS_ARTIFACTS_ACCESS_KEY_ID',
+          secretName: 'agents-artifacts',
+          key: 'AWS_ACCESS_KEY_ID',
+        }),
+        expect.objectContaining({
+          name: 'AGENTS_ARTIFACTS_SECRET_ACCESS_KEY',
+          secretName: 'agents-artifacts',
+          key: 'AWS_SECRET_ACCESS_KEY',
+        }),
+      ]),
+    )
+    expect(objectAt(objectAt(providerSpec, 'envTemplate'), 'AGENTS_ARTIFACTS_ENDPOINT')).toBe(
+      'http://rook-ceph-rgw-objectstore.rook-ceph.svc:80',
+    )
+
+    const agent = readYamlObjects('argocd/applications/agents/graf-codex-agent.yaml').find(
+      (manifest) => objectAt(manifest, 'kind') === 'Agent',
+    )
+    const allowedSecrets = objectAt(objectAt(objectAt(agent, 'spec'), 'security'), 'allowedSecrets') as
+      | string[]
+      | undefined
+    expect(allowedSecrets).toEqual(expect.arrayContaining(['codex-auth', 'agents-artifacts']))
+    expect(allowedSecrets).not.toContain('observability-minio-creds')
+  })
+
   it('keeps the chart workflow smoke provider on the fake app-server', () => {
     const provider = readYamlObjects('charts/agents/examples/agentprovider-smoke.yaml').find(
       (manifest) => objectAt(manifest, 'kind') === 'AgentProvider',

--- a/packages/scripts/src/torghut/__tests__/agents-domain-smoke.test.ts
+++ b/packages/scripts/src/torghut/__tests__/agents-domain-smoke.test.ts
@@ -126,15 +126,18 @@ describe('Agents domain scheduled AgentRun templates', () => {
       expect.arrayContaining([
         expect.objectContaining({
           name: 'AGENTS_ARTIFACTS_ACCESS_KEY_ID',
-          secretName: 'observability-minio-creds',
-          key: 'accesskey',
+          secretName: 'agents-artifacts',
+          key: 'AWS_ACCESS_KEY_ID',
         }),
         expect.objectContaining({
           name: 'AGENTS_ARTIFACTS_SECRET_ACCESS_KEY',
-          secretName: 'observability-minio-creds',
-          key: 'secretkey',
+          secretName: 'agents-artifacts',
+          key: 'AWS_SECRET_ACCESS_KEY',
         }),
       ]),
+    )
+    expect(objectAt(objectAt(providerSpec, 'envTemplate'), 'AGENTS_ARTIFACTS_ENDPOINT')).toBe(
+      'http://rook-ceph-rgw-objectstore.rook-ceph.svc:80',
     )
     expect(healthArtifact).toEqual({
       name: 'torghut-health-report',
@@ -151,7 +154,7 @@ describe('Agents domain scheduled AgentRun templates', () => {
       'argocd/applications/torghut/agents-domain/torghut-health-secretbinding.yaml',
     ).find((manifest) => objectAt(manifest, 'kind') === 'SecretBinding')
     const allowedSecrets = objectAt(objectAt(secretBinding, 'spec'), 'allowedSecrets') as string[] | undefined
-    expect(allowedSecrets).toEqual(expect.arrayContaining(['codex-auth', 'observability-minio-creds']))
+    expect(allowedSecrets).toEqual(expect.arrayContaining(['codex-auth', 'agents-artifacts']))
 
     const healthSpec = readYamlObjects('argocd/applications/torghut/agents-domain/torghut-agentruns.yaml').find(
       (manifest) =>


### PR DESCRIPTION
## Summary

- Adds an `agents-artifacts` `ObjectBucketClaim` in the `agents` GitOps app so Rook/Ceph creates the live bucket credentials in the namespace where AgentRun pods start.
- Rewires Graf/Torghut Codex artifact providers from the absent `observability-minio-creds` secret to the live `agents-artifacts` secret and Rook RGW endpoint.
- Updates Torghut health SecretBinding and smoke tests so durable health-report AgentRun artifacts use the same storage path that exists in this cluster.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts packages/scripts/src/torghut/__tests__/agents-domain-smoke.test.ts`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts packages/scripts/src/torghut/__tests__/agents-domain-smoke.test.ts`
- `kubectl kustomize argocd/applications/torghut/agents-domain >/tmp/torghut-agents-domain-secret-render.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/agents >/tmp/agents-app-secret-render.yaml`
- `rg -n "observability-minio-creds|kind: ObjectBucketClaim|name: agents-artifacts|rook-ceph-rgw-objectstore|AWS_ACCESS_KEY_ID" /tmp/agents-app-secret-render.yaml /tmp/torghut-agents-domain-secret-render.yaml`
- `git diff --check`
- `bun run --filter @proompteng/scripts lint`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
