### PR TITLE
fix(agents): propagate workflow output artifacts

### DIFF
--- a/services/agents/src/server/agents-controller/index.integration.test.ts
+++ b/services/agents/src/server/agents-controller/index.integration.test.ts
@@ -2842,6 +2842,125 @@ describe('agents controller reconcileAgentRun', () => {
     expect(thirdSteps[1]?.phase).toBe('Succeeded')
   })
 
+  it('propagates workflow step output artifacts from runner pods', async () => {
+    const runnerMessage = JSON.stringify({
+      status: 'succeeded',
+      adapter: 'codex-app-server',
+      provider: 'torghut-health-report',
+      exitCode: 0,
+      artifacts: {
+        outputArtifacts: [
+          {
+            name: 'torghut-health-report',
+            path: '/workspace/.agentrun/torghut-health/report.md',
+            key: 'torghut/health/run-1/report.md',
+            url: 's3://agents-artifacts/torghut/health/run-1/report.md',
+          },
+        ],
+      },
+    })
+    const jobStatuses = new Map<string, Record<string, unknown>>()
+    const apply = vi.fn(async (resource: Record<string, unknown>) => {
+      const metadata = (resource.metadata ?? {}) as Record<string, unknown>
+      const uid = metadata.uid ?? `uid-${String(resource.kind ?? 'resource').toLowerCase()}`
+      const applied = { ...resource, metadata: { ...metadata, uid } }
+      if (resource.kind === 'Job') {
+        const name = (resource.metadata as Record<string, unknown> | undefined)?.name as string | undefined
+        if (name) {
+          jobStatuses.set(name, applied)
+        }
+      }
+      return applied
+    })
+    const kube = buildKube({
+      apply,
+      get: vi.fn(async (resource: string, name: string) => {
+        if (resource === RESOURCE_MAP.Agent) {
+          return {
+            metadata: { name: 'agent-1' },
+            spec: { providerRef: { name: 'provider-1' }, defaults: { systemPrompt: 'default-agent-prompt' } },
+          }
+        }
+        if (resource === RESOURCE_MAP.AgentProvider) {
+          return {
+            metadata: { name: 'provider-1' },
+            spec: { binary: '/usr/local/bin/agent-runner' },
+          }
+        }
+        if (resource === RESOURCE_MAP.ImplementationSpec) {
+          return { metadata: { name: 'impl-1' }, spec: { text: 'demo' } }
+        }
+        if (resource === 'job') {
+          return jobStatuses.get(name) ?? null
+        }
+        return null
+      }),
+      list: vi.fn(async (resource: string, _namespace: string, labelSelector?: string) => {
+        if (resource === 'pods' && labelSelector?.startsWith('job-name=')) {
+          return {
+            items: [
+              {
+                metadata: { name: 'workflow-step-pod' },
+                status: {
+                  startTime: '2026-05-23T21:39:00Z',
+                  containerStatuses: [{ name: 'agent-runner', state: { terminated: { message: runnerMessage } } }],
+                },
+              },
+            ],
+          }
+        }
+        return { items: [] }
+      }),
+    })
+
+    const agentRun = buildAgentRun({
+      spec: {
+        agentRef: { name: 'agent-1' },
+        implementationSpecRef: { name: 'impl-1' },
+        runtime: { type: 'workflow', config: {} },
+        workload: { image: defaultRunnerImage },
+        workflow: {
+          steps: [{ name: 'health-report' }],
+        },
+      },
+    })
+
+    await __test.reconcileAgentRun(kube as never, agentRun, 'agents', [], [], defaultConcurrency, buildInFlight(), 0)
+
+    const runningStatus = getLastStatus(kube)
+    const workflow = (runningStatus.workflow as Record<string, unknown>) ?? {}
+    const steps = (workflow.steps as Record<string, unknown>[]) ?? []
+    const jobName = (steps[0]?.jobRef as Record<string, unknown> | undefined)?.name as string | undefined
+    expect(jobName).toBeTruthy()
+
+    jobStatuses.set(jobName ?? '', {
+      ...jobStatuses.get(jobName ?? ''),
+      status: { succeeded: 1, startTime: '2026-05-23T21:39:00Z', completionTime: '2026-05-23T21:40:00Z' },
+    })
+
+    await __test.reconcileAgentRun(
+      kube as never,
+      { ...agentRun, status: runningStatus },
+      'agents',
+      [],
+      [],
+      defaultConcurrency,
+      buildInFlight(),
+      0,
+    )
+
+    const status = getLastStatus(kube)
+    expect(status.phase).toBe('Succeeded')
+    expect(status.artifacts).toEqual([
+      {
+        name: 'torghut-health-report',
+        path: '/workspace/.agentrun/torghut-health/report.md',
+        key: 'torghut/health/run-1/report.md',
+        url: 's3://agents-artifacts/torghut/health/run-1/report.md',
+      },
+    ])
+  })
+
   it('continues and stops loop workflow steps with CEL expressions', async () => {
     const previousLoopsEnabled = process.env.AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED
     process.env.AGENTS_CONTROLLER_WORKFLOW_LOOPS_ENABLED = 'true'

--- a/services/agents/src/server/agents-controller/workflow-reconciler.ts
+++ b/services/agents/src/server/agents-controller/workflow-reconciler.ts
@@ -14,6 +14,7 @@ import { resolveImplementation, resolveParameters } from './run-utils'
 import { buildRuntimeRef, parseRuntimeRef, type RuntimeRef } from './runtime-resources'
 import { resolveSystemPrompt } from './system-prompt'
 import { collectBlockedSecrets, resolveAuthSecretConfig, resolveVcsContext } from './vcs-context'
+import { extractRunnerStatusFromJobPods, mergeAgentRunArtifacts, runnerStatusOutputArtifacts } from './runner-status'
 import {
   normalizeWorkflowStatus,
   parseWorkflowSteps,
@@ -1134,6 +1135,25 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
       }
     }
 
+    let completedJobOutputArtifacts: Record<string, unknown>[] = []
+    for (const entry of completedJobs) {
+      const jobName = asString(readNested(entry.job, ['metadata', 'name']))
+      if (!jobName) continue
+      const runnerStatus = await extractRunnerStatusFromJobPods(kube, entry.namespace, jobName, [
+        'succeeded',
+        'failed',
+        'cancelled',
+      ])
+      const runnerArtifacts = runnerStatus ? runnerStatusOutputArtifacts(runnerStatus) : []
+      if (runnerArtifacts.length > 0) {
+        completedJobOutputArtifacts = mergeAgentRunArtifacts(completedJobOutputArtifacts, runnerArtifacts)
+      }
+    }
+    const artifactStatusUpdate =
+      completedJobOutputArtifacts.length > 0
+        ? { artifacts: mergeAgentRunArtifacts(status.artifacts, completedJobOutputArtifacts) }
+        : {}
+
     if (workflowFailure) {
       setWorkflowPhase(workflowStatus, 'Failed')
       const failureType =
@@ -1165,6 +1185,7 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
         conditions: updated,
         vcs: vcsStatus ?? undefined,
         contract: workflowContractStatus,
+        ...artifactStatusUpdate,
         ...(systemPromptHashUpdate ? { systemPromptHash: systemPromptHashUpdate } : {}),
       })
       for (const entry of completedJobs) {
@@ -1199,6 +1220,7 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
         workflow: workflowStatus,
         conditions: updated,
         vcs: vcsStatus ?? undefined,
+        ...artifactStatusUpdate,
         ...(systemPromptHashUpdate ? { systemPromptHash: systemPromptHashUpdate } : {}),
       })
       for (const entry of completedJobs) {
@@ -1232,6 +1254,7 @@ export const createWorkflowReconciler = (deps: WorkflowReconcilerDependencies) =
         conditions: updated,
         vcs: vcsStatus ?? undefined,
         contract: workflowContractStatus,
+        ...artifactStatusUpdate,
         ...(options.initialSubmit ? { specHash: hashAgentRunImmutableSpec(agentRun) } : {}),
         ...(systemPromptHashUpdate ? { systemPromptHash: systemPromptHashUpdate } : {}),
       })


### PR DESCRIPTION
## Summary

- Propagates runner `outputArtifacts` from completed workflow step pods into `AgentRun.status.artifacts`.
- Reuses the existing direct-job artifact extraction and de-duplication helpers for workflow terminal and running status updates.
- Adds an integration regression covering a workflow step that uploads the Torghut health report artifact pointer.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/agents test -- src/server/agents-controller/index.integration.test.ts src/server/agents-controller/runner-status.test.ts`
- `bun run --filter @proompteng/agents test`
- `bun run --filter @proompteng/agents tsc`
- `bun run --filter @proompteng/agents lint`
- `bun run --filter @proompteng/agents lint:oxlint`
- `bunx oxfmt --check services/agents/src/server/agents-controller/workflow-reconciler.ts services/agents/src/server/agents-controller/index.integration.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
