### PR TITLE
fix(torghut): surface runtime ledger repair candidates

### DIFF
--- a/services/torghut/app/trading/executable_alpha_receipts.py
+++ b/services/torghut/app/trading/executable_alpha_receipts.py
@@ -153,6 +153,7 @@ _CLOSED_SESSION_REPAIR_REASONS = {
     "closed_session_tca_evidence_hold",
 }
 _ALPHA_RUNTIME_REPLAY_CLASS = "alpha_runtime_window_refresh"
+_RUNTIME_LEDGER_ECONOMIC_REPAIR_CLASS = "runtime_ledger_economic_repair"
 _ZERO_RUNTIME_EVIDENCE_REASONS = {
     "hypothesis_window_decisions_missing",
     "hypothesis_window_orders_missing",
@@ -1337,6 +1338,45 @@ def _top_alpha_runtime_replay_target(
     return sorted(candidates, key=_alpha_runtime_replay_key)[0]
 
 
+def _runtime_ledger_repair_candidates(
+    live_submission_gate: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    return [
+        _mapping(item)
+        for item in _sequence(
+            live_submission_gate.get("runtime_ledger_repair_candidates")
+        )
+        if _text(_mapping(item).get("hypothesis_id"))
+    ]
+
+
+def _runtime_ledger_repair_key(
+    item: Mapping[str, Any],
+) -> tuple[int, int, int, int, float, float, float, str]:
+    filled_notional = _float(item.get("filled_notional")) or 0.0
+    net_pnl = _float(item.get("net_strategy_pnl_after_costs")) or 0.0
+    expectancy_bps = _float(item.get("post_cost_expectancy_bps")) or 0.0
+    return (
+        int(filled_notional > 0),
+        int(_int(item.get("fill_count")) > 0),
+        int(_int(item.get("closed_trade_count")) > 0),
+        int(net_pnl > 0 and expectancy_bps > 0),
+        net_pnl,
+        expectancy_bps,
+        filled_notional,
+        _text(item.get("hypothesis_id")),
+    )
+
+
+def _top_runtime_ledger_economic_repair_candidate(
+    live_submission_gate: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    candidates = _runtime_ledger_repair_candidates(live_submission_gate)
+    if not candidates:
+        return {}
+    return sorted(candidates, key=_runtime_ledger_repair_key, reverse=True)[0]
+
+
 def _alpha_runtime_confidence(item: Mapping[str, Any]) -> str:
     reasons = set(_alpha_runtime_repair_reason_codes(item))
     if reasons.intersection(_ZERO_RUNTIME_EVIDENCE_REASONS):
@@ -1344,6 +1384,180 @@ def _alpha_runtime_confidence(item: Mapping[str, Any]) -> str:
     if reasons.intersection(_HARD_ALPHA_ECONOMIC_REASONS):
         return "low"
     return "medium"
+
+
+def _runtime_ledger_economic_repair_item(
+    *,
+    item: Mapping[str, Any],
+    account_label: str | None,
+    trading_mode: str,
+    proof_floor_receipt: Mapping[str, Any],
+    live_submission_gate: Mapping[str, Any],
+    empirical_jobs_status: Mapping[str, Any],
+    quant_evidence: Mapping[str, Any],
+    market_context_status: Mapping[str, Any],
+    jangar_contract_graduation_ref: Mapping[str, Any],
+) -> dict[str, object]:
+    hypothesis_id = _text(item.get("hypothesis_id"), "unknown")
+    candidate_id = _text(item.get("candidate_id"))
+    strategy_id = _text(item.get("strategy_id")) or _text(
+        item.get("runtime_strategy_name")
+    )
+    reasons = _string_list(item.get("reason_codes"))
+    blockers = set(_string_list(proof_floor_receipt.get("blocking_reasons")))
+    blockers.update(_string_list(live_submission_gate.get("blocked_reasons")))
+    blockers.update(reasons)
+    blockers.update(_empirical_blockers(empirical_jobs_status))
+    blockers.update(_quant_blockers(quant_evidence))
+    blockers.update(_market_context_blockers(market_context_status))
+    graduation_state, graduation_reasons = _graduation_state(
+        jangar_contract_graduation_ref
+    )
+    if graduation_state != "current":
+        blockers.update(graduation_reasons)
+
+    runtime_bucket = _mapping(item.get("runtime_ledger_bucket"))
+    replay_id = "replay:" + _stable_hash(
+        "runtime-ledger-economic-repair",
+        {
+            "hypothesis_id": hypothesis_id,
+            "candidate_id": candidate_id,
+            "strategy_id": strategy_id,
+            "run_id": item.get("run_id"),
+            "bucket_started_at": item.get("bucket_started_at"),
+            "bucket_ended_at": item.get("bucket_ended_at"),
+            "account_label": account_label,
+            "trading_mode": trading_mode,
+            "proof_floor_generated_at": proof_floor_receipt.get("generated_at"),
+        },
+    )
+    after_cost_edge_bps = _float(item.get("post_cost_expectancy_bps"))
+    return {
+        "replay_id": replay_id,
+        "hypothesis_id": hypothesis_id,
+        "candidate_id": candidate_id or None,
+        "strategy_id": strategy_id or None,
+        "target_symbols": _string_list(item.get("target_symbols")),
+        "replay_class": _RUNTIME_LEDGER_ECONOMIC_REPAIR_CLASS,
+        "before_refs": {
+            "runtime_ledger_candidate": {
+                "source": item.get("source"),
+                "promotion_authority": item.get("promotion_authority"),
+                "run_id": item.get("run_id"),
+                "candidate_id": candidate_id or None,
+                "strategy_id": strategy_id or None,
+                "strategy_family": item.get("strategy_family"),
+                "runtime_strategy_name": item.get("runtime_strategy_name"),
+                "observed_stage": item.get("observed_stage"),
+                "account": item.get("account"),
+                "bucket_started_at": item.get("bucket_started_at"),
+                "bucket_ended_at": item.get("bucket_ended_at"),
+                "fill_count": item.get("fill_count"),
+                "submitted_order_count": item.get("submitted_order_count"),
+                "closed_trade_count": item.get("closed_trade_count"),
+                "open_position_count": item.get("open_position_count"),
+                "filled_notional": item.get("filled_notional"),
+                "net_strategy_pnl_after_costs": item.get(
+                    "net_strategy_pnl_after_costs"
+                ),
+                "post_cost_expectancy_bps": item.get("post_cost_expectancy_bps"),
+                "reason_codes": reasons,
+                "ledger_schema_version": item.get("ledger_schema_version"),
+                "pnl_basis": item.get("pnl_basis"),
+                "runtime_ledger_bucket": dict(runtime_bucket),
+            },
+            "proof_floor": {
+                "schema_version": proof_floor_receipt.get("schema_version"),
+                "generated_at": proof_floor_receipt.get("generated_at"),
+                "route_state": proof_floor_receipt.get("route_state"),
+                "capital_state": proof_floor_receipt.get("capital_state"),
+                "blocking_reasons": _string_list(
+                    proof_floor_receipt.get("blocking_reasons")
+                ),
+            },
+            "empirical_jobs": {
+                "ready": bool(empirical_jobs_status.get("ready")),
+                "status": empirical_jobs_status.get("status"),
+                "authority": empirical_jobs_status.get("authority"),
+            },
+            "quant_evidence": {
+                "status": quant_evidence.get("status"),
+                "source_url": quant_evidence.get("source_url"),
+                "latest_metrics_count": quant_evidence.get("latest_metrics_count"),
+            },
+            "market_context": {
+                "status": market_context_status.get("status"),
+                "state": market_context_status.get("state")
+                or market_context_status.get("overallState")
+                or market_context_status.get("overall_state"),
+                "alert_active": bool(market_context_status.get("alert_active")),
+                "alert_reason": market_context_status.get("alert_reason"),
+            },
+            "jangar_contract_graduation": dict(jangar_contract_graduation_ref),
+        },
+        "required_after_refs": [
+            "live_runtime_ledger_receipt",
+            "runtime_window_ledger_receipt",
+            "promotion_grade_post_cost_pnl_receipt",
+            "promotion_decision_receipt",
+            "alpha_readiness_receipt",
+            "empirical_job_receipt",
+            "jangar_contract_graduation_receipt",
+        ],
+        "expected_profit_unlock": {
+            "expected_blocker_delta": max(1, len(set(reasons))),
+            "expected_profit_effect": "convert_runtime_ledger_economic_bucket_into_promotion_certificate",
+            "after_cost_edge_bps": after_cost_edge_bps,
+            "observed_net_pnl_after_costs": item.get("net_strategy_pnl_after_costs"),
+        },
+        "expected_cost": {
+            "class": "runtime_ledger_economic_repair",
+            "max_runtime_seconds": 900,
+        },
+        "confidence": "medium"
+        if after_cost_edge_bps is not None and after_cost_edge_bps > 0
+        else "low",
+        "max_runtime_seconds": 900,
+        "max_notional": "0",
+        "guardrails": [
+            {
+                "code": "zero_notional_required",
+                "status": "pass",
+                "limit": "0",
+            },
+            {
+                "code": "runtime_ledger_authority_required",
+                "status": "blocked",
+                "required_stage": "live",
+                "observed_stage": item.get("observed_stage"),
+                "required_basis": "realized_strategy_pnl_after_explicit_costs",
+            },
+            {
+                "code": "promotion_certificate_required",
+                "status": "blocked",
+                "blocking_reason_codes": sorted(set(blockers)),
+            },
+        ],
+        "falsification_rules": [
+            "runtime_ledger_bucket_not_reproducible",
+            "live_runtime_ledger_missing",
+            "post_cost_pnl_non_positive_after_refresh",
+            "promotion_decision_still_not_allowed",
+        ],
+        "owner": "torghut",
+        "remaining_blockers": sorted(blocker for blocker in blockers if blocker),
+        "capital_effect": {
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "paper_canary": "held",
+            "live_micro_canary": "blocked",
+        },
+        "rollback_target": {
+            "capital_state": "zero_notional",
+            "live_submit_enabled": False,
+            "replay_class": _RUNTIME_LEDGER_ECONOMIC_REPAIR_CLASS,
+        },
+    }
 
 
 def _alpha_runtime_blockers(
@@ -1637,6 +1851,24 @@ def _candidate_replays(
     route_records = _route_records(proof_floor_receipt)
     replays: list[dict[str, object]] = []
 
+    runtime_ledger_target = _top_runtime_ledger_economic_repair_candidate(
+        live_submission_gate
+    )
+    if runtime_ledger_target:
+        replays.append(
+            _runtime_ledger_economic_repair_item(
+                item=runtime_ledger_target,
+                account_label=account_label,
+                trading_mode=trading_mode,
+                proof_floor_receipt=proof_floor_receipt,
+                live_submission_gate=live_submission_gate,
+                empirical_jobs_status=empirical_jobs_status,
+                quant_evidence=quant_evidence,
+                market_context_status=market_context_status,
+                jangar_contract_graduation_ref=jangar_contract_graduation_ref,
+            )
+        )
+
     alpha_target = _top_alpha_runtime_replay_target(live_submission_gate)
     if alpha_target:
         replays.append(
@@ -1753,7 +1985,14 @@ def _receipt_for_replay(
     graduation_state: GraduationState = (
         "candidate"
         if target_symbols
-        or (replay_class == _ALPHA_RUNTIME_REPLAY_CLASS and replay.get("hypothesis_id"))
+        or (
+            replay_class
+            in {
+                _ALPHA_RUNTIME_REPLAY_CLASS,
+                _RUNTIME_LEDGER_ECONOMIC_REPAIR_CLASS,
+            }
+            and replay.get("hypothesis_id")
+        )
         else "failed"
     )
     receipt_id = "receipt:" + _stable_hash(

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -77,6 +77,9 @@ _AUTORESEARCH_PORTFOLIO_READY_STATUSES = (
     "accepted",
     "promoted",
 )
+_PROMOTION_GRADE_RUNTIME_LEDGER_PNL_BASIS = "realized_strategy_pnl_after_explicit_costs"
+_RUNTIME_LEDGER_REPAIR_SCAN_LIMIT = 256
+_RUNTIME_LEDGER_REPAIR_CANDIDATE_LIMIT = 8
 
 
 def _autoresearch_portfolio_current_oracle_passed(
@@ -976,6 +979,233 @@ def _runtime_ledger_selection_score(payload: Mapping[str, object] | None) -> int
     ):
         score += 1
     return score
+
+
+def _runtime_ledger_target_reason_codes(
+    payload: Mapping[str, object],
+    *,
+    manifest: Mapping[str, object],
+) -> list[str]:
+    reasons: list[str] = []
+    expected_candidate = _safe_text(manifest.get("candidate_id"))
+    actual_candidate = _safe_text(payload.get("candidate_id"))
+    if expected_candidate is not None:
+        if actual_candidate is None:
+            reasons.append("runtime_ledger_candidate_missing")
+        elif actual_candidate != expected_candidate:
+            reasons.append("runtime_ledger_candidate_mismatch")
+
+    expected_family = _normalized_strategy_family(manifest.get("strategy_family"))
+    actual_family = _normalized_strategy_family(payload.get("strategy_family"))
+    if (
+        expected_family is not None
+        and actual_family is not None
+        and actual_family != expected_family
+    ):
+        reasons.append("runtime_ledger_strategy_family_mismatch")
+    return reasons
+
+
+def _runtime_ledger_repair_reason_codes(
+    payload: Mapping[str, object],
+    *,
+    manifest: Mapping[str, object],
+) -> list[str]:
+    reasons = [
+        str(reason).strip()
+        for reason in cast(Sequence[object], payload.get("blockers") or [])
+        if str(reason).strip()
+    ]
+    reasons.extend(_runtime_ledger_target_reason_codes(payload, manifest=manifest))
+    if _safe_text(payload.get("observed_stage")) != "live":
+        reasons.append("runtime_ledger_stage_not_live")
+    if (
+        _safe_text(payload.get("pnl_basis"))
+        != _PROMOTION_GRADE_RUNTIME_LEDGER_PNL_BASIS
+    ):
+        reasons.append("runtime_ledger_pnl_basis_missing")
+    if (_safe_decimal(payload.get("filled_notional")) or Decimal("0")) <= 0:
+        reasons.append("runtime_ledger_filled_notional_missing")
+    if _safe_int(payload.get("fill_count")) <= 0:
+        reasons.append("runtime_ledger_fills_missing")
+    if _safe_int(payload.get("closed_trade_count")) <= 0:
+        reasons.append("runtime_ledger_closed_trades_missing")
+    if _safe_int(payload.get("open_position_count")) > 0:
+        reasons.append("unclosed_position")
+    if (
+        _safe_decimal(payload.get("net_strategy_pnl_after_costs")) or Decimal("0")
+    ) <= 0:
+        reasons.append("post_cost_pnl_non_positive")
+    expectancy_bps = _safe_decimal(payload.get("post_cost_expectancy_bps"))
+    if expectancy_bps is None:
+        reasons.append("runtime_ledger_expectancy_missing")
+    elif expectancy_bps <= 0:
+        reasons.append("post_cost_expectancy_non_positive")
+    if (
+        _runtime_ledger_hash_count(
+            payload,
+            payload_key="execution_policy_hash_counts",
+            observed={},
+            observed_key="runtime_ledger_execution_policy_hash_count",
+        )
+        <= 0
+    ):
+        reasons.append("runtime_ledger_execution_policy_hash_missing")
+    if (
+        _runtime_ledger_hash_count(
+            payload,
+            payload_key="cost_model_hash_counts",
+            observed={},
+            observed_key="runtime_ledger_cost_model_hash_count",
+        )
+        <= 0
+    ):
+        reasons.append("runtime_ledger_cost_model_hash_missing")
+    if (
+        _runtime_ledger_hash_count(
+            payload,
+            payload_key="lineage_hash_counts",
+            observed={},
+            observed_key="runtime_ledger_lineage_hash_count",
+        )
+        <= 0
+    ):
+        reasons.append("runtime_ledger_lineage_hash_missing")
+    return _normalize_reason_codes(reasons)
+
+
+def _runtime_ledger_repair_score(
+    candidate: Mapping[str, object],
+) -> tuple[int, int, int, int, int, Decimal, Decimal, Decimal, float]:
+    reason_codes = set(
+        str(reason).strip()
+        for reason in cast(Sequence[object], candidate.get("reason_codes") or [])
+        if str(reason).strip()
+    )
+    filled_notional = _safe_decimal(candidate.get("filled_notional")) or Decimal("0")
+    net_pnl = _safe_decimal(candidate.get("net_strategy_pnl_after_costs")) or Decimal(
+        "0"
+    )
+    expectancy_bps = _safe_decimal(
+        candidate.get("post_cost_expectancy_bps")
+    ) or Decimal("0")
+    ended_at = _coerce_aware_datetime(candidate.get("bucket_ended_at"))
+    observed_stage = _safe_text(candidate.get("observed_stage"))
+    return (
+        (
+            int(filled_notional > 0),
+            int(_safe_int(candidate.get("fill_count")) > 0),
+            int(_safe_int(candidate.get("closed_trade_count")) > 0),
+            int(net_pnl > 0),
+            int(expectancy_bps > 0),
+            net_pnl,
+            expectancy_bps,
+            filled_notional,
+            ended_at.timestamp() if ended_at is not None else 0.0,
+        )
+        if observed_stage != "live" or reason_codes
+        else (
+            2,
+            2,
+            2,
+            2,
+            2,
+            net_pnl,
+            expectancy_bps,
+            filled_notional,
+            ended_at.timestamp() if ended_at is not None else 0.0,
+        )
+    )
+
+
+def _load_runtime_ledger_repair_candidates(
+    session: Session,
+    *,
+    registry_items: Sequence[Mapping[str, object]],
+    limit: int = _RUNTIME_LEDGER_REPAIR_CANDIDATE_LIMIT,
+) -> list[dict[str, object]]:
+    manifests = {
+        str(item.get("hypothesis_id") or "").strip(): item
+        for item in registry_items
+        if str(item.get("hypothesis_id") or "").strip()
+    }
+    hypothesis_ids = sorted(manifests)
+    if not hypothesis_ids or limit <= 0:
+        return []
+
+    rows = (
+        session.execute(
+            select(StrategyRuntimeLedgerBucket)
+            .where(StrategyRuntimeLedgerBucket.hypothesis_id.in_(hypothesis_ids))
+            .order_by(
+                StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
+                StrategyRuntimeLedgerBucket.created_at.desc(),
+            )
+            .limit(_RUNTIME_LEDGER_REPAIR_SCAN_LIMIT)
+        )
+        .scalars()
+        .all()
+    )
+
+    candidates: list[dict[str, object]] = []
+    seen: set[tuple[str, str, str, str, str]] = set()
+    for row in rows:
+        payload = _runtime_ledger_bucket_payload(row)
+        if (
+            _safe_int(payload.get("submitted_order_count")) <= 0
+            and _safe_int(payload.get("fill_count")) <= 0
+            and _safe_int(payload.get("closed_trade_count")) <= 0
+        ):
+            continue
+        manifest = manifests.get(row.hypothesis_id) or {}
+        candidate_key = (
+            str(payload.get("hypothesis_id") or ""),
+            str(payload.get("candidate_id") or ""),
+            str(payload.get("run_id") or ""),
+            str(payload.get("bucket_started_at") or ""),
+            str(payload.get("bucket_ended_at") or ""),
+        )
+        if candidate_key in seen:
+            continue
+        seen.add(candidate_key)
+        reason_codes = _runtime_ledger_repair_reason_codes(
+            payload,
+            manifest=manifest,
+        )
+        candidates.append(
+            {
+                "source": "strategy_runtime_ledger_buckets",
+                "promotion_authority": "runtime_ledger_candidate_only",
+                "hypothesis_id": payload.get("hypothesis_id"),
+                "candidate_id": payload.get("candidate_id"),
+                "strategy_id": manifest.get("strategy_id")
+                or payload.get("runtime_strategy_name"),
+                "strategy_family": payload.get("strategy_family")
+                or manifest.get("strategy_family"),
+                "runtime_strategy_name": payload.get("runtime_strategy_name"),
+                "observed_stage": payload.get("observed_stage"),
+                "run_id": payload.get("run_id"),
+                "bucket_started_at": payload.get("bucket_started_at"),
+                "bucket_ended_at": payload.get("bucket_ended_at"),
+                "account": payload.get("account_label"),
+                "fill_count": payload.get("fill_count"),
+                "decision_count": payload.get("decision_count"),
+                "submitted_order_count": payload.get("submitted_order_count"),
+                "closed_trade_count": payload.get("closed_trade_count"),
+                "open_position_count": payload.get("open_position_count"),
+                "filled_notional": payload.get("filled_notional"),
+                "net_strategy_pnl_after_costs": payload.get(
+                    "net_strategy_pnl_after_costs"
+                ),
+                "post_cost_expectancy_bps": payload.get("post_cost_expectancy_bps"),
+                "ledger_schema_version": payload.get("ledger_schema_version"),
+                "pnl_basis": payload.get("pnl_basis"),
+                "reason_codes": reason_codes,
+                "runtime_ledger_bucket": payload,
+            }
+        )
+
+    return sorted(candidates, key=_runtime_ledger_repair_score, reverse=True)[:limit]
 
 
 def _certificate_evidence_selection_key(
@@ -2370,6 +2600,15 @@ def build_live_submission_gate_payload(
     )
     now = datetime.now(timezone.utc)
     registry = load_hypothesis_registry()
+    registry_item_payloads = [item.model_dump(mode="json") for item in registry.items]
+    runtime_ledger_repair_candidates = (
+        _load_runtime_ledger_repair_candidates(
+            session,
+            registry_items=registry_item_payloads,
+        )
+        if session is not None
+        else []
+    )
     evidence_rows = (
         [dict(item) for item in promotion_certificate_evidence]
         if promotion_certificate_evidence is not None
@@ -2505,6 +2744,7 @@ def build_live_submission_gate_payload(
             },
             "lineage_ref": _default_lineage_ref(),
             "evaluated_tuples": [],
+            "runtime_ledger_repair_candidates": runtime_ledger_repair_candidates,
             "profit_window_contract": profit_window_contract,
             "profit_lease_projection": profit_lease_projection,
         }
@@ -2527,7 +2767,7 @@ def build_live_submission_gate_payload(
         evidence=evidence_rows,
         segment_summary=segment_summary,
         runtime_items=runtime_items,
-        registry_items=[item.model_dump(mode="json") for item in registry.items],
+        registry_items=registry_item_payloads,
         max_age_seconds=max_age_seconds,
         now=now,
         window=_safe_text(quant_evidence.get("window")),
@@ -2685,6 +2925,7 @@ def build_live_submission_gate_payload(
         "evidence_tuple": evidence_tuple,
         "lineage_ref": lineage_ref,
         "evaluated_tuples": evaluated_tuples,
+        "runtime_ledger_repair_candidates": runtime_ledger_repair_candidates,
         "profit_window_contract": profit_window_contract,
         "profit_lease_projection": profit_lease_projection,
     }

--- a/services/torghut/tests/test_executable_alpha_receipts.py
+++ b/services/torghut/tests/test_executable_alpha_receipts.py
@@ -259,6 +259,114 @@ def test_capital_replay_board_prioritizes_live_alpha_runtime_tuple() -> None:
     assert receipts[0]["guardrail_result"]["passed"] is False
 
 
+def test_capital_replay_board_prioritizes_runtime_ledger_economic_repair_candidate() -> (
+    None
+):
+    projection = _projection(
+        live_submission_gate={
+            "allowed": False,
+            "blocked_reasons": [
+                "alpha_readiness_not_promotion_eligible",
+                "simple_submit_disabled",
+            ],
+            "runtime_ledger_repair_candidates": [
+                {
+                    "source": "strategy_runtime_ledger_buckets",
+                    "promotion_authority": "runtime_ledger_candidate_only",
+                    "hypothesis_id": "H-CONT-01",
+                    "candidate_id": "chip-paper-microbar-composite@execution-proof",
+                    "strategy_id": "microbar_volume_continuation_long_top2_chip_v1@paper",
+                    "strategy_family": "intraday_continuation",
+                    "runtime_strategy_name": "microbar-volume-continuation-long-top2-chip-v1",
+                    "observed_stage": "paper",
+                    "run_id": "cont-zero-fill",
+                    "account": "TORGHUT_SIM",
+                    "fill_count": 0,
+                    "submitted_order_count": 9,
+                    "closed_trade_count": 0,
+                    "open_position_count": 0,
+                    "filled_notional": "0",
+                    "net_strategy_pnl_after_costs": "0",
+                    "post_cost_expectancy_bps": None,
+                    "reason_codes": [
+                        "runtime_ledger_stage_not_live",
+                        "zero_fill_runtime_ledger",
+                    ],
+                    "runtime_ledger_bucket": {"run_id": "cont-zero-fill"},
+                },
+                {
+                    "source": "strategy_runtime_ledger_buckets",
+                    "promotion_authority": "runtime_ledger_candidate_only",
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                    "strategy_family": "microbar_cross_sectional_pairs",
+                    "runtime_strategy_name": "microbar-pairs-vwap-cap-safe",
+                    "observed_stage": "paper",
+                    "run_id": "pairs-realized-runtime",
+                    "bucket_started_at": "2026-05-13T17:00:00+00:00",
+                    "bucket_ended_at": "2026-05-13T17:30:00+00:00",
+                    "account": "TORGHUT_SIM",
+                    "fill_count": 2,
+                    "submitted_order_count": 2,
+                    "closed_trade_count": 2,
+                    "open_position_count": 0,
+                    "filled_notional": "127090.02495200",
+                    "net_strategy_pnl_after_costs": "567.44720578",
+                    "post_cost_expectancy_bps": "44.64923238",
+                    "ledger_schema_version": "torghut.runtime-ledger-bucket.v1",
+                    "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
+                    "reason_codes": [
+                        "runtime_ledger_stage_not_live",
+                        "runtime_ledger_candidate_mismatch",
+                    ],
+                    "runtime_ledger_bucket": {
+                        "run_id": "pairs-realized-runtime",
+                        "filled_notional": "127090.02495200",
+                    },
+                },
+            ],
+            "evaluated_tuples": [
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "candidate_id": "chip-paper-microbar-composite@execution-proof",
+                    "strategy_id": "microbar_volume_continuation_long_top2_chip_v1@paper",
+                    "capital_state": "shadow",
+                    "capital_stage": "shadow",
+                    "window": "15m",
+                    "reason_codes": ["hypothesis_window_evidence_stale"],
+                }
+            ],
+        }
+    )
+    board = cast(Mapping[str, Any], projection["capital_replay_board"])
+    replay_items = cast(list[Mapping[str, Any]], board["replay_items"])
+    ledger_replay = replay_items[0]
+
+    assert ledger_replay["hypothesis_id"] == "H-PAIRS-01"
+    assert ledger_replay["candidate_id"] == "c88421d619759b2cfaa6f4d0"
+    assert ledger_replay["replay_class"] == "runtime_ledger_economic_repair"
+    assert ledger_replay["max_notional"] == "0"
+    assert ledger_replay["expected_profit_unlock"]["after_cost_edge_bps"] == 44.64923238
+    assert "runtime_ledger_stage_not_live" in ledger_replay["remaining_blockers"]
+    runtime_ref = cast(Mapping[str, Any], ledger_replay["before_refs"])[
+        "runtime_ledger_candidate"
+    ]
+    assert runtime_ref["net_strategy_pnl_after_costs"] == "567.44720578"
+    assert any(
+        guardrail["code"] == "promotion_certificate_required"
+        for guardrail in cast(list[Mapping[str, Any]], ledger_replay["guardrails"])
+    )
+
+    receipts = cast(
+        list[Mapping[str, Any]],
+        cast(Mapping[str, Any], projection["executable_alpha_receipts"])["receipts"],
+    )
+    assert receipts[0]["hypothesis_id"] == "H-PAIRS-01"
+    assert receipts[0]["graduation_state"] == "candidate"
+    assert receipts[0]["capital_effect"]["max_notional"] == "0"
+
+
 def test_receipts_keep_superficially_good_route_out_of_paper_candidate() -> None:
     proof_floor = _proof_floor(blocking_reasons=[])
     projection = _projection(

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -490,6 +490,181 @@ class TestSubmissionCouncil(TestCase):
         self.assertIsNone(rev["post_cost_expectancy_bps"])
         self.assertGreaterEqual(len(summary["runtime_ledger_buckets"]), 4)
 
+    def test_build_live_submission_gate_payload_surfaces_runtime_ledger_repair_candidates(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        now = datetime.now(timezone.utc)
+
+        class _RegistryItem:
+            def __init__(
+                self,
+                *,
+                hypothesis_id: str,
+                candidate_id: str,
+                strategy_id: str,
+                strategy_family: str,
+            ) -> None:
+                self.hypothesis_id = hypothesis_id
+                self._payload = {
+                    "hypothesis_id": hypothesis_id,
+                    "candidate_id": candidate_id,
+                    "strategy_id": strategy_id,
+                    "strategy_family": strategy_family,
+                    "lane_id": strategy_family,
+                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                    "segment_dependencies": [],
+                }
+
+            def model_dump(self, *, mode: str = "json") -> dict[str, object]:
+                return dict(self._payload)
+
+        registry = SimpleNamespace(
+            loaded=True,
+            path="test-registry",
+            errors=[],
+            items=[
+                _RegistryItem(
+                    hypothesis_id="H-CONT-01",
+                    candidate_id="chip-paper-microbar-composite@execution-proof",
+                    strategy_id="microbar_volume_continuation_long_top2_chip_v1@paper",
+                    strategy_family="intraday_continuation",
+                ),
+                _RegistryItem(
+                    hypothesis_id="H-PAIRS-01",
+                    candidate_id="spec-d74b07b2aaab8d0cfa8a4c38",
+                    strategy_id="microbar_cross_sectional_pairs_v1@research",
+                    strategy_family="microbar_cross_sectional_pairs",
+                ),
+            ],
+        )
+
+        with session_local() as session:
+            session.add_all(
+                [
+                    StrategyRuntimeLedgerBucket(
+                        run_id="cont-zero-fill",
+                        candidate_id="chip-paper-microbar-composite@execution-proof",
+                        hypothesis_id="H-CONT-01",
+                        observed_stage="paper",
+                        bucket_started_at=now - timedelta(minutes=30),
+                        bucket_ended_at=now - timedelta(minutes=15),
+                        account_label="TORGHUT_SIM",
+                        runtime_strategy_name="microbar-volume-continuation-long-top2-chip-v1",
+                        strategy_family="intraday_continuation",
+                        fill_count=0,
+                        decision_count=9,
+                        submitted_order_count=9,
+                        cancelled_order_count=0,
+                        rejected_order_count=0,
+                        unfilled_order_count=9,
+                        closed_trade_count=0,
+                        open_position_count=0,
+                        filled_notional=Decimal("0"),
+                        gross_strategy_pnl=Decimal("0"),
+                        cost_amount=Decimal("0"),
+                        net_strategy_pnl_after_costs=Decimal("0"),
+                        post_cost_expectancy_bps=None,
+                        ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={},
+                        cost_model_hash_counts={},
+                        lineage_hash_counts={},
+                        blockers_json=["zero_fill_runtime_ledger"],
+                    ),
+                    StrategyRuntimeLedgerBucket(
+                        run_id="pairs-realized-runtime",
+                        candidate_id="c88421d619759b2cfaa6f4d0",
+                        hypothesis_id="H-PAIRS-01",
+                        observed_stage="paper",
+                        bucket_started_at=now - timedelta(minutes=45),
+                        bucket_ended_at=now - timedelta(minutes=30),
+                        account_label="TORGHUT_SIM",
+                        runtime_strategy_name="microbar-pairs-vwap-cap-safe",
+                        strategy_family="microbar_cross_sectional_pairs",
+                        fill_count=2,
+                        decision_count=2,
+                        submitted_order_count=2,
+                        cancelled_order_count=0,
+                        rejected_order_count=0,
+                        unfilled_order_count=0,
+                        closed_trade_count=2,
+                        open_position_count=0,
+                        filled_notional=Decimal("127090.02495200"),
+                        gross_strategy_pnl=Decimal("581.44720578"),
+                        cost_amount=Decimal("14"),
+                        net_strategy_pnl_after_costs=Decimal("567.44720578"),
+                        post_cost_expectancy_bps=Decimal("44.64923238"),
+                        ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={"policy": 2},
+                        cost_model_hash_counts={"cost": 2},
+                        lineage_hash_counts={"lineage": 2},
+                        blockers_json=[],
+                    ),
+                ]
+            )
+            session.commit()
+
+            with patch(
+                "app.trading.submission_council.load_hypothesis_registry",
+                return_value=registry,
+            ):
+                gate = build_live_submission_gate_payload(
+                    SimpleNamespace(
+                        market_session_open=True,
+                        last_autonomy_promotion_eligible=False,
+                        last_autonomy_promotion_action=None,
+                        drift_live_promotion_eligible=False,
+                        last_market_context_freshness_seconds=45,
+                        metrics=SimpleNamespace(
+                            feature_batch_rows_total=9,
+                            feature_null_rate={"price": 0.0},
+                            feature_staleness_ms_p95=250,
+                            feature_duplicate_ratio=0.0,
+                            decision_state_total={},
+                        ),
+                    ),
+                    hypothesis_summary={
+                        "summary": {
+                            "promotion_eligible_total": 0,
+                            "capital_stage_totals": {"shadow": 2},
+                            "dependency_quorum": {
+                                "decision": "allow",
+                                "reasons": [],
+                                "message": "ready",
+                            },
+                        },
+                        "items": [],
+                    },
+                    empirical_jobs_status={"ready": True, "status": "healthy"},
+                    dspy_runtime_status={"mode": "inactive"},
+                    quant_health_status=self._healthy_quant_status(),
+                    promotion_certificate_evidence=[],
+                    session=session,
+                )
+
+        candidates = gate["runtime_ledger_repair_candidates"]
+        self.assertIsInstance(candidates, list)
+        self.assertEqual(candidates[0]["hypothesis_id"], "H-PAIRS-01")
+        self.assertEqual(candidates[0]["candidate_id"], "c88421d619759b2cfaa6f4d0")
+        self.assertEqual(candidates[0]["net_strategy_pnl_after_costs"], "567.44720578")
+        self.assertEqual(
+            candidates[0]["promotion_authority"], "runtime_ledger_candidate_only"
+        )
+        self.assertIn("runtime_ledger_stage_not_live", candidates[0]["reason_codes"])
+        self.assertIn(
+            "runtime_ledger_candidate_mismatch", candidates[0]["reason_codes"]
+        )
+        self.assertEqual(candidates[1]["hypothesis_id"], "H-CONT-01")
+
     def test_metric_window_activity_rejects_tca_proxy_expectancy(self) -> None:
         metric_window = SimpleNamespace(
             market_session_count=3,


### PR DESCRIPTION
## Summary

- Adds live-gate `runtime_ledger_repair_candidates` sourced from durable `strategy_runtime_ledger_buckets`.
- Ranks repair candidates by real filled notional, closed trades, post-cost net PnL, and expectancy while preserving blockers such as paper stage and manifest candidate mismatch.
- Adds a zero-notional `runtime_ledger_economic_repair` replay-board item so positive runtime ledger buckets can be converted into promotion evidence without authorizing capital.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/submission_council.py app/trading/executable_alpha_receipts.py tests/test_submission_council.py tests/test_executable_alpha_receipts.py`
- `uv run --frozen pytest tests/test_submission_council.py -k 'runtime_ledger_repair_candidates or latest_runtime_ledger_summary or stale_summary_with_session_live_runtime_evidence' -q`
- `uv run --frozen pytest tests/test_executable_alpha_receipts.py -k 'runtime_ledger_economic_repair or live_alpha_runtime_tuple' -q`
- `uv run --frozen ruff check app/trading/submission_council.py app/trading/executable_alpha_receipts.py tests/test_submission_council.py tests/test_executable_alpha_receipts.py`
- `uv run --frozen pytest tests/test_submission_council.py tests/test_executable_alpha_receipts.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
