### PR TITLE
fix(torghut): align pairs manifest with runtime ledger candidate

### DIFF
--- a/services/torghut/config/trading/hypotheses/h-pairs-01.json
+++ b/services/torghut/config/trading/hypotheses/h-pairs-01.json
@@ -3,7 +3,7 @@
   "hypothesis_id": "H-PAIRS-01",
   "lane_id": "microbar-cross-sectional-pairs",
   "strategy_family": "microbar_cross_sectional_pairs",
-  "candidate_id": "spec-d74b07b2aaab8d0cfa8a4c38",
+  "candidate_id": "c88421d619759b2cfaa6f4d0",
   "strategy_id": "microbar_cross_sectional_pairs_v1@research",
   "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
   "initial_state": "blocked",

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -33,7 +33,7 @@ from app.trading.runtime_ledger import (
 _MANIFEST_CANDIDATE_IDS = {
     "H-CONT-01": "chip-paper-microbar-composite@execution-proof",
     "H-MICRO-01": "chip-paper-microbar-composite@execution-proof",
-    "H-PAIRS-01": "spec-d74b07b2aaab8d0cfa8a4c38",
+    "H-PAIRS-01": "c88421d619759b2cfaa6f4d0",
     "H-REV-01": "chip-paper-microbar-composite@execution-proof",
     "H-TSMOM-01": "spec-83161ae16d17828eabcc58cc",
     "H-TSMOM-LIQ-01": "H-TSMOM-LIQ-01",

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -373,7 +373,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                 json.dumps(
                     {
                         "hypothesis-id": "H-PAIRS-01",
-                        "candidate_id": "spec-d74b07b2aaab8d0cfa8a4c38",
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
                         "strategy_family": "microbar_cross_sectional_pairs",
                         "strategy_name": "microbar-cross-sectional-pairs-v1",
                         "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -539,7 +539,7 @@ class TestSubmissionCouncil(TestCase):
                 ),
                 _RegistryItem(
                     hypothesis_id="H-PAIRS-01",
-                    candidate_id="spec-d74b07b2aaab8d0cfa8a4c38",
+                    candidate_id="c88421d619759b2cfaa6f4d0",
                     strategy_id="microbar_cross_sectional_pairs_v1@research",
                     strategy_family="microbar_cross_sectional_pairs",
                 ),
@@ -660,7 +660,7 @@ class TestSubmissionCouncil(TestCase):
             candidates[0]["promotion_authority"], "runtime_ledger_candidate_only"
         )
         self.assertIn("runtime_ledger_stage_not_live", candidates[0]["reason_codes"])
-        self.assertIn(
+        self.assertNotIn(
             "runtime_ledger_candidate_mismatch", candidates[0]["reason_codes"]
         )
         self.assertEqual(candidates[1]["hypothesis_id"], "H-CONT-01")


### PR DESCRIPTION
## Summary

- Aligns the `H-PAIRS-01` hypothesis manifest with the runtime-ledger-backed candidate `c88421d619759b2cfaa6f4d0`.
- Updates readiness and runtime-window tests so the ledger repair path no longer reports a candidate mismatch when the manifest and durable ledger agree.
- Keeps capital authorization blocked: the remaining live gate still requires live-stage runtime ledger proof, promotion-grade post-cost PnL receipts, and alpha readiness.

## Related Issues

None

## Testing

- `uv run --frozen ruff format tests/test_hypotheses.py tests/test_submission_council.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen pytest tests/test_submission_council.py -k 'runtime_ledger_repair_candidates or latest_runtime_ledger_summary or stale_summary_with_session_live_runtime_evidence' -q`
- `uv run --frozen pytest tests/test_hypotheses.py -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k 'runtime_window_target_accepts_json_payload' -q`
- `uv run --frozen ruff check tests/test_hypotheses.py tests/test_submission_council.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen pytest tests/test_submission_council.py tests/test_hypotheses.py tests/test_run_empirical_promotion_jobs.py -q`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
