### PR TITLE
fix(torghut): surface runtime ledger paper probation

### DIFF
--- a/services/torghut/app/trading/executable_alpha_receipts.py
+++ b/services/torghut/app/trading/executable_alpha_receipts.py
@@ -154,6 +154,11 @@ _CLOSED_SESSION_REPAIR_REASONS = {
 }
 _ALPHA_RUNTIME_REPLAY_CLASS = "alpha_runtime_window_refresh"
 _RUNTIME_LEDGER_ECONOMIC_REPAIR_CLASS = "runtime_ledger_economic_repair"
+_RUNTIME_LEDGER_PAPER_PROBATION_REASON = "runtime_ledger_stage_not_live"
+_RUNTIME_LEDGER_PAPER_PROBATION_ALLOWED_REASONS = {
+    _RUNTIME_LEDGER_PAPER_PROBATION_REASON
+}
+_RUNTIME_LEDGER_PROMOTION_PNL_BASIS = "realized_strategy_pnl_after_explicit_costs"
 _ZERO_RUNTIME_EVIDENCE_REASONS = {
     "hypothesis_window_decisions_missing",
     "hypothesis_window_orders_missing",
@@ -1386,6 +1391,25 @@ def _alpha_runtime_confidence(item: Mapping[str, Any]) -> str:
     return "medium"
 
 
+def _runtime_ledger_paper_probation_eligible(
+    item: Mapping[str, Any],
+    *,
+    reason_codes: Sequence[str],
+) -> bool:
+    reasons = {reason for reason in reason_codes if reason}
+    return (
+        _text(item.get("observed_stage")) == "paper"
+        and reasons == _RUNTIME_LEDGER_PAPER_PROBATION_ALLOWED_REASONS
+        and _text(item.get("pnl_basis")) == _RUNTIME_LEDGER_PROMOTION_PNL_BASIS
+        and (_float(item.get("filled_notional")) or 0.0) > 0.0
+        and _int(item.get("fill_count")) > 0
+        and _int(item.get("closed_trade_count")) > 0
+        and _int(item.get("open_position_count")) == 0
+        and (_float(item.get("net_strategy_pnl_after_costs")) or 0.0) > 0.0
+        and (_float(item.get("post_cost_expectancy_bps")) or 0.0) > 0.0
+    )
+
+
 def _runtime_ledger_economic_repair_item(
     *,
     item: Mapping[str, Any],
@@ -1432,6 +1456,10 @@ def _runtime_ledger_economic_repair_item(
         },
     )
     after_cost_edge_bps = _float(item.get("post_cost_expectancy_bps"))
+    paper_probation_eligible = _runtime_ledger_paper_probation_eligible(
+        item,
+        reason_codes=reasons,
+    )
     return {
         "replay_id": replay_id,
         "hypothesis_id": hypothesis_id,
@@ -1517,6 +1545,16 @@ def _runtime_ledger_economic_repair_item(
         "confidence": "medium"
         if after_cost_edge_bps is not None and after_cost_edge_bps > 0
         else "low",
+        "paper_probation_eligible": paper_probation_eligible,
+        "paper_probation_scope": "evidence_collection_only"
+        if paper_probation_eligible
+        else None,
+        "paper_probation_reason_codes": sorted(reasons)
+        if paper_probation_eligible
+        else [],
+        "paper_probation_target_capital_stage": "shadow"
+        if paper_probation_eligible
+        else None,
         "max_runtime_seconds": 900,
         "max_notional": "0",
         "guardrails": [
@@ -1982,19 +2020,20 @@ def _receipt_for_replay(
     blockers = _string_list(replay.get("remaining_blockers"))
     replay_id = _text(replay.get("replay_id"))
     replay_class = _text(replay.get("replay_class"))
-    graduation_state: GraduationState = (
-        "candidate"
-        if target_symbols
-        or (
-            replay_class
-            in {
-                _ALPHA_RUNTIME_REPLAY_CLASS,
-                _RUNTIME_LEDGER_ECONOMIC_REPAIR_CLASS,
-            }
-            and replay.get("hypothesis_id")
-        )
-        else "failed"
-    )
+    graduation_state: GraduationState
+    if bool(replay.get("paper_probation_eligible")):
+        graduation_state = "paper_replay_candidate"
+    elif target_symbols or (
+        replay_class
+        in {
+            _ALPHA_RUNTIME_REPLAY_CLASS,
+            _RUNTIME_LEDGER_ECONOMIC_REPAIR_CLASS,
+        }
+        and replay.get("hypothesis_id")
+    ):
+        graduation_state = "candidate"
+    else:
+        graduation_state = "failed"
     receipt_id = "receipt:" + _stable_hash(
         "executable-alpha",
         {
@@ -2027,6 +2066,13 @@ def _receipt_for_replay(
             "reason_codes": blockers or ["awaiting_zero_notional_replay"],
         },
         "graduation_state": graduation_state,
+        "paper_probation_eligible": bool(replay.get("paper_probation_eligible")),
+        "paper_probation_scope": replay.get("paper_probation_scope"),
+        "paper_probation_reason_codes": replay.get("paper_probation_reason_codes")
+        or [],
+        "paper_probation_target_capital_stage": replay.get(
+            "paper_probation_target_capital_stage"
+        ),
         "jangar_contract_graduation_ref": dict(jangar_contract_graduation_ref),
         "remaining_blockers": blockers,
         "capital_effect": replay.get("capital_effect"),
@@ -2101,6 +2147,9 @@ def build_capital_replay_projection(
     receipt_state_totals = Counter(
         _text(receipt.get("graduation_state"), "unknown") for receipt in receipts
     )
+    paper_replay_candidate_count = sum(
+        1 for replay in replays if bool(replay.get("paper_probation_eligible"))
+    )
     board = {
         "schema_version": CAPITAL_REPLAY_BOARD_SCHEMA_VERSION,
         "board_id": board_id,
@@ -2120,7 +2169,7 @@ def build_capital_replay_projection(
             "zero_notional_replay_count": sum(
                 1 for replay in replays if _text(replay.get("max_notional")) == "0"
             ),
-            "paper_replay_candidate_count": 0,
+            "paper_replay_candidate_count": paper_replay_candidate_count,
             "capital_ready": False,
         },
         "rollback_target": {
@@ -2137,7 +2186,7 @@ def build_capital_replay_projection(
             "summary": {
                 "receipts_total": len(receipts),
                 "graduation_state_totals": dict(sorted(receipt_state_totals.items())),
-                "paper_replay_candidate_count": 0,
+                "paper_replay_candidate_count": paper_replay_candidate_count,
                 "zero_notional_receipt_count": len(receipts),
                 "capital_ready": False,
             },

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -1118,6 +1118,55 @@ def _runtime_ledger_repair_score(
     )
 
 
+_RUNTIME_LEDGER_PAPER_PROBATION_REASON = "runtime_ledger_stage_not_live"
+_RUNTIME_LEDGER_PAPER_PROBATION_ALLOWED_REASONS = {
+    _RUNTIME_LEDGER_PAPER_PROBATION_REASON
+}
+
+
+def _runtime_ledger_paper_probation_eligible(
+    candidate: Mapping[str, object],
+) -> bool:
+    reasons = {
+        str(reason).strip()
+        for reason in cast(Sequence[object], candidate.get("reason_codes") or [])
+        if str(reason).strip()
+    }
+    return (
+        _safe_text(candidate.get("observed_stage")) == "paper"
+        and reasons == _RUNTIME_LEDGER_PAPER_PROBATION_ALLOWED_REASONS
+        and _safe_text(candidate.get("pnl_basis"))
+        == _PROMOTION_GRADE_RUNTIME_LEDGER_PNL_BASIS
+        and (_safe_decimal(candidate.get("filled_notional")) or Decimal("0")) > 0
+        and _safe_int(candidate.get("fill_count")) > 0
+        and _safe_int(candidate.get("closed_trade_count")) > 0
+        and _safe_int(candidate.get("open_position_count")) == 0
+        and (
+            _safe_decimal(candidate.get("net_strategy_pnl_after_costs")) or Decimal("0")
+        )
+        > 0
+        and (_safe_decimal(candidate.get("post_cost_expectancy_bps")) or Decimal("0"))
+        > 0
+    )
+
+
+def _runtime_ledger_paper_probation_candidates(
+    candidates: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    return [
+        {
+            **dict(candidate),
+            "paper_probation_eligible": True,
+            "paper_probation_scope": "evidence_collection_only",
+            "paper_probation_reason_codes": [_RUNTIME_LEDGER_PAPER_PROBATION_REASON],
+            "paper_probation_target_capital_stage": "shadow",
+            "max_notional": "0",
+        }
+        for candidate in candidates
+        if _runtime_ledger_paper_probation_eligible(candidate)
+    ]
+
+
 def _load_runtime_ledger_repair_candidates(
     session: Session,
     *,
@@ -2609,6 +2658,9 @@ def build_live_submission_gate_payload(
         if session is not None
         else []
     )
+    runtime_ledger_paper_probation_candidates = (
+        _runtime_ledger_paper_probation_candidates(runtime_ledger_repair_candidates)
+    )
     evidence_rows = (
         [dict(item) for item in promotion_certificate_evidence]
         if promotion_certificate_evidence is not None
@@ -2745,6 +2797,12 @@ def build_live_submission_gate_payload(
             "lineage_ref": _default_lineage_ref(),
             "evaluated_tuples": [],
             "runtime_ledger_repair_candidates": runtime_ledger_repair_candidates,
+            "runtime_ledger_paper_probation_candidates": (
+                runtime_ledger_paper_probation_candidates
+            ),
+            "runtime_ledger_paper_probation_eligible_total": len(
+                runtime_ledger_paper_probation_candidates
+            ),
             "profit_window_contract": profit_window_contract,
             "profit_lease_projection": profit_lease_projection,
         }
@@ -2926,6 +2984,12 @@ def build_live_submission_gate_payload(
         "lineage_ref": lineage_ref,
         "evaluated_tuples": evaluated_tuples,
         "runtime_ledger_repair_candidates": runtime_ledger_repair_candidates,
+        "runtime_ledger_paper_probation_candidates": (
+            runtime_ledger_paper_probation_candidates
+        ),
+        "runtime_ledger_paper_probation_eligible_total": len(
+            runtime_ledger_paper_probation_candidates
+        ),
         "profit_window_contract": profit_window_contract,
         "profit_lease_projection": profit_lease_projection,
     }

--- a/services/torghut/tests/test_executable_alpha_receipts.py
+++ b/services/torghut/tests/test_executable_alpha_receipts.py
@@ -318,7 +318,6 @@ def test_capital_replay_board_prioritizes_runtime_ledger_economic_repair_candida
                     "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
                     "reason_codes": [
                         "runtime_ledger_stage_not_live",
-                        "runtime_ledger_candidate_mismatch",
                     ],
                     "runtime_ledger_bucket": {
                         "run_id": "pairs-realized-runtime",
@@ -348,6 +347,11 @@ def test_capital_replay_board_prioritizes_runtime_ledger_economic_repair_candida
     assert ledger_replay["replay_class"] == "runtime_ledger_economic_repair"
     assert ledger_replay["max_notional"] == "0"
     assert ledger_replay["expected_profit_unlock"]["after_cost_edge_bps"] == 44.64923238
+    assert ledger_replay["paper_probation_eligible"] is True
+    assert ledger_replay["paper_probation_scope"] == "evidence_collection_only"
+    assert ledger_replay["paper_probation_reason_codes"] == [
+        "runtime_ledger_stage_not_live"
+    ]
     assert "runtime_ledger_stage_not_live" in ledger_replay["remaining_blockers"]
     runtime_ref = cast(Mapping[str, Any], ledger_replay["before_refs"])[
         "runtime_ledger_candidate"
@@ -357,13 +361,17 @@ def test_capital_replay_board_prioritizes_runtime_ledger_economic_repair_candida
         guardrail["code"] == "promotion_certificate_required"
         for guardrail in cast(list[Mapping[str, Any]], ledger_replay["guardrails"])
     )
+    assert (
+        cast(Mapping[str, Any], board["summary"])["paper_replay_candidate_count"] == 1
+    )
 
     receipts = cast(
         list[Mapping[str, Any]],
         cast(Mapping[str, Any], projection["executable_alpha_receipts"])["receipts"],
     )
     assert receipts[0]["hypothesis_id"] == "H-PAIRS-01"
-    assert receipts[0]["graduation_state"] == "candidate"
+    assert receipts[0]["graduation_state"] == "paper_replay_candidate"
+    assert receipts[0]["paper_probation_eligible"] is True
     assert receipts[0]["capital_effect"]["max_notional"] == "0"
 
 

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -663,6 +663,14 @@ class TestSubmissionCouncil(TestCase):
         self.assertNotIn(
             "runtime_ledger_candidate_mismatch", candidates[0]["reason_codes"]
         )
+        paper_candidates = gate["runtime_ledger_paper_probation_candidates"]
+        self.assertEqual(gate["runtime_ledger_paper_probation_eligible_total"], 1)
+        self.assertEqual(len(paper_candidates), 1)
+        self.assertEqual(paper_candidates[0]["hypothesis_id"], "H-PAIRS-01")
+        self.assertEqual(
+            paper_candidates[0]["paper_probation_scope"], "evidence_collection_only"
+        )
+        self.assertEqual(paper_candidates[0]["max_notional"], "0")
         self.assertEqual(candidates[1]["hypothesis_id"], "H-CONT-01")
 
     def test_metric_window_activity_rejects_tca_proxy_expectancy(self) -> None:


### PR DESCRIPTION
## Summary

- Exposes positive paper-stage runtime ledger repair candidates as explicit paper-probation/evidence-collection candidates in the live submission gate.
- Marks matching runtime-ledger economic repair replay items and executable-alpha receipts as `paper_replay_candidate` while preserving `max_notional=0`.
- Keeps final promotion fail-closed: live runtime ledger proof and promotion certificates are still required before capital.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/submission_council.py app/trading/executable_alpha_receipts.py tests/test_submission_council.py tests/test_executable_alpha_receipts.py`
- `uv run --frozen ruff check app/trading/submission_council.py app/trading/executable_alpha_receipts.py tests/test_submission_council.py tests/test_executable_alpha_receipts.py`
- `uv run --frozen pytest tests/test_executable_alpha_receipts.py tests/test_submission_council.py -q`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
