### PR TITLE
chore(torghut): promote image e268c6fc

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-752-g7bff4df98
+              value: v0.571.1-755-ge268c6fce
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 7bff4df98943fe86bb75d7671c2a6f9ce5869073
+              value: e268c6fced3671398155b2dd0e617cb69b86b6d5
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-752-g7bff4df98
+              value: v0.571.1-755-ge268c6fce
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 7bff4df98943fe86bb75d7671c2a6f9ce5869073
+              value: e268c6fced3671398155b2dd0e617cb69b86b6d5
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -75,7 +75,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+                  value: sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-24T00:08:56Z"
+        client.knative.dev/updateTimestamp: "2026-05-24T00:50:38Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
           ports:
             - name: http1
               containerPort: 8181
@@ -499,11 +499,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-752-g7bff4df98
+              value: v0.571.1-755-ge268c6fce
             - name: TORGHUT_COMMIT
-              value: 7bff4df98943fe86bb75d7671c2a6f9ce5869073
+              value: e268c6fced3671398155b2dd0e617cb69b86b6d5
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+              value: sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-24T00:08:56Z"
+        client.knative.dev/updateTimestamp: "2026-05-24T00:50:38Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
           ports:
             - name: http1
               containerPort: 8181
@@ -320,11 +320,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-752-g7bff4df98
+              value: v0.571.1-755-ge268c6fce
             - name: TORGHUT_COMMIT
-              value: 7bff4df98943fe86bb75d7671c2a6f9ce5869073
+              value: e268c6fced3671398155b2dd0e617cb69b86b6d5
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+              value: sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -132,7 +132,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec7aa3cced0ee47eb078ada2b6264fd07ce2d38e89e9b58734a17619b4f8794f
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `e268c6fced3671398155b2dd0e617cb69b86b6d5`
- Image tag: `e268c6fc`
- Image digest: `sha256:ec13f286602b27dfeb6bb77aff2bb50713843b04867bc669f58670750324677c`