### PR TITLE
fix(torghut): import live paper probation targets

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -34,6 +34,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref intraday_tsmom_v2@research \
                     --runtime-window-import \
+                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/status \
                     --runtime-window-targets-from-latest-autoresearch \
                     --runtime-window-targets-from-registry \
                     --runtime-window-hypothesis-id H-TSMOM-01 \

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -8,6 +8,8 @@ import json
 import os
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta, timezone
 from pathlib import Path
@@ -52,8 +54,10 @@ RUNTIME_WINDOW_TARGET_METADATA_KEYS = (
     "runtime_ledger_artifact_row_count",
     "runtime_ledger_artifact_fill_count",
     "runtime_ledger_target_metadata_blockers",
+    "runtime_ledger_bucket_ref",
     "window_start",
     "window_end",
+    "max_notional",
     "replay_selection_reason",
     "paper_contract_candidate",
     "paper_contract_selected_for_replay",
@@ -135,6 +139,21 @@ def _parse_args() -> argparse.Namespace:
             "artifact. Explicit --runtime-window-target entries take precedence "
             "over duplicate hypothesis_id values."
         ),
+    )
+    parser.add_argument(
+        "--runtime-window-target-plan-url",
+        action="append",
+        default=[],
+        help=(
+            "Repeatable URL returning either a runtime-window import plan or a "
+            "/trading/status payload with live_submission_gate."
+            "runtime_ledger_paper_probation_import_plan."
+        ),
+    )
+    parser.add_argument(
+        "--runtime-window-target-plan-url-timeout-seconds",
+        type=float,
+        default=5.0,
     )
     parser.add_argument(
         "--runtime-window-targets-from-latest-autoresearch",
@@ -357,8 +376,56 @@ def _read_runtime_window_target_plan(ref: str) -> dict[str, Any]:
     data = _as_dict(payload)
     if not data:
         raise RuntimeError(f"runtime_window_target_plan_ref_invalid:{path}")
-    plan = _as_dict(data.get("runtime_window_import_plan")) or data
+    plan = _runtime_window_target_plan_from_payload(data)
     return plan
+
+
+def _runtime_window_target_plan_from_payload(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    direct_plan = _as_dict(payload.get("runtime_window_import_plan"))
+    if direct_plan:
+        return direct_plan
+    gate = _as_dict(payload.get("live_submission_gate"))
+    gate_plan = _as_dict(gate.get("runtime_ledger_paper_probation_import_plan"))
+    if gate_plan:
+        return gate_plan
+    top_level_gate_plan = _as_dict(
+        payload.get("runtime_ledger_paper_probation_import_plan")
+    )
+    if top_level_gate_plan:
+        return top_level_gate_plan
+    return _as_dict(payload)
+
+
+def _read_runtime_window_target_plan_url(
+    ref: str,
+    *,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    url = ref.strip()
+    if not url:
+        raise RuntimeError("runtime_window_target_plan_url_empty")
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(
+            request, timeout=max(timeout_seconds, 0.1)
+        ) as response:
+            raw = response.read(5_000_001)
+    except (OSError, TimeoutError, urllib.error.URLError) as exc:
+        raise RuntimeError(
+            f"runtime_window_target_plan_url_fetch_failed:{url}"
+        ) from exc
+    if len(raw) > 5_000_000:
+        raise RuntimeError(f"runtime_window_target_plan_url_too_large:{url}")
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except Exception as exc:
+        raise RuntimeError(f"runtime_window_target_plan_url_invalid:{url}") from exc
+    data = _as_dict(payload)
+    if not data:
+        raise RuntimeError(f"runtime_window_target_plan_url_invalid:{url}")
+    return _runtime_window_target_plan_from_payload(data)
 
 
 def _runtime_family_harnesses(family_dir: str) -> dict[str, dict[str, str]]:
@@ -460,14 +527,28 @@ def _registry_runtime_window_targets(
 def _runtime_window_plan_targets(
     args: argparse.Namespace,
 ) -> list[RuntimeWindowImportTarget]:
-    refs = [
+    file_refs = [
         str(item).strip()
         for item in getattr(args, "runtime_window_target_plan_ref", []) or []
         if str(item).strip()
     ]
+    url_refs = [
+        str(item).strip()
+        for item in getattr(args, "runtime_window_target_plan_url", []) or []
+        if str(item).strip()
+    ]
     targets: list[RuntimeWindowImportTarget] = []
-    for ref in refs:
+    for ref in file_refs:
         plan = _read_runtime_window_target_plan(ref)
+        targets.extend(_runtime_window_targets_from_plan(plan=plan, ref=ref, args=args))
+    timeout_seconds = float(
+        getattr(args, "runtime_window_target_plan_url_timeout_seconds", 5.0) or 5.0
+    )
+    for ref in url_refs:
+        plan = _read_runtime_window_target_plan_url(
+            ref,
+            timeout_seconds=timeout_seconds,
+        )
         targets.extend(_runtime_window_targets_from_plan(plan=plan, ref=ref, args=args))
     return targets
 
@@ -589,8 +670,14 @@ def _runtime_window_target_metadata(payload: Mapping[str, Any]) -> dict[str, Any
 
 def _runtime_window_target_identity(
     target: RuntimeWindowImportTarget,
-) -> tuple[str, str, str]:
-    return (target.hypothesis_id, target.candidate_id, target.strategy_name)
+) -> tuple[str, str, str, str, str]:
+    return (
+        target.hypothesis_id,
+        target.candidate_id,
+        target.strategy_name,
+        target.window_start,
+        target.window_end,
+    )
 
 
 def _runtime_window_autoresearch_statuses(args: argparse.Namespace) -> set[str]:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -812,6 +812,11 @@ class TestLiveConfigManifestContract(TestCase):
 
         args = "\n".join(str(item) for item in container.get("args", []))
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
+        self.assertIn(
+            "--runtime-window-target-plan-url "
+            "http://torghut.torghut.svc.cluster.local/trading/status",
+            args,
+        )
         self.assertIn("--runtime-window-targets-from-latest-autoresearch", args)
         self.assertIn("--runtime-window-targets-from-registry", args)
         self.assertIn("--runtime-window-hypothesis-id H-TSMOM-01", args)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -459,6 +459,186 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         )
         self.assertEqual(targets[0].dataset_snapshot_ref, "snapshot-paper-probation")
 
+    def test_runtime_window_targets_from_live_gate_plan_url_preserve_window_targets(
+        self,
+    ) -> None:
+        status_path = Path(self.tmp_dir) / "trading-status.json"
+        status_path.write_text(
+            json.dumps(
+                {
+                    "live_submission_gate": {
+                        "runtime_ledger_paper_probation_import_plan": {
+                            "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                            "targets": [
+                                {
+                                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                                    "hypothesis_id": "H-PAIRS-01",
+                                    "observed_stage": "paper",
+                                    "strategy_family": "microbar_cross_sectional_pairs",
+                                    "strategy_name": "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                                    "account_label": "TORGHUT_REPLAY",
+                                    "source_dsn_env": "TORGHUT_DURABLE_RUNTIME_LEDGER_SOURCE_DSN",
+                                    "source_kind": "durable_runtime_ledger_bucket",
+                                    "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                                    "window_start": "2026-05-13T17:00:00+00:00",
+                                    "window_end": "2026-05-13T17:30:00+00:00",
+                                    "paper_probation_authorized": True,
+                                    "promotion_allowed": False,
+                                    "final_promotion_authorized": False,
+                                    "final_promotion_allowed": False,
+                                    "max_notional": "0",
+                                    "runtime_ledger_bucket_ref": "bucket:first",
+                                },
+                                {
+                                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                                    "hypothesis_id": "H-PAIRS-01",
+                                    "observed_stage": "paper",
+                                    "strategy_family": "microbar_cross_sectional_pairs",
+                                    "strategy_name": "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                                    "account_label": "TORGHUT_REPLAY",
+                                    "source_dsn_env": "TORGHUT_DURABLE_RUNTIME_LEDGER_SOURCE_DSN",
+                                    "source_kind": "durable_runtime_ledger_bucket",
+                                    "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                                    "window_start": "2026-05-21T17:00:00+00:00",
+                                    "window_end": "2026-05-21T17:30:00+00:00",
+                                    "paper_probation_authorized": True,
+                                    "promotion_allowed": False,
+                                    "final_promotion_authorized": False,
+                                    "final_promotion_allowed": False,
+                                    "max_notional": "0",
+                                    "runtime_ledger_bucket_ref": "bucket:second",
+                                },
+                            ],
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        args = SimpleNamespace(
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[],
+            runtime_window_target_plan_url=[status_path.as_uri()],
+            runtime_window_target_plan_url_timeout_seconds=2.0,
+            runtime_window_targets_from_latest_autoresearch=False,
+            runtime_window_targets_from_registry=False,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        targets = renewal._runtime_window_targets(args)
+
+        self.assertEqual(len(targets), 2)
+        self.assertEqual(
+            [target.window_start for target in targets],
+            [
+                "2026-05-13T17:00:00+00:00",
+                "2026-05-21T17:00:00+00:00",
+            ],
+        )
+        self.assertEqual(
+            targets[0].source_dsn_env,
+            "TORGHUT_DURABLE_RUNTIME_LEDGER_SOURCE_DSN",
+        )
+        assert targets[0].target_metadata is not None
+        self.assertEqual(
+            targets[0].target_metadata["runtime_ledger_bucket_ref"], "bucket:first"
+        )
+        self.assertEqual(targets[0].target_metadata["max_notional"], "0")
+        self.assertEqual(targets[0].target_metadata["promotion_allowed"], False)
+        self.assertEqual(targets[0].target_metadata["final_promotion_allowed"], False)
+
+    def test_runtime_window_target_plan_payload_accepts_top_level_gate_plan_and_fallback(
+        self,
+    ) -> None:
+        top_level_plan = renewal._runtime_window_target_plan_from_payload(
+            {
+                "runtime_ledger_paper_probation_import_plan": {
+                    "targets": [{"hypothesis_id": "H-PAIRS-01"}]
+                }
+            }
+        )
+        fallback_plan = renewal._runtime_window_target_plan_from_payload(
+            {"targets": [{"hypothesis_id": "H-FALLBACK-01"}]}
+        )
+
+        self.assertEqual(top_level_plan["targets"][0]["hypothesis_id"], "H-PAIRS-01")
+        self.assertEqual(fallback_plan["targets"][0]["hypothesis_id"], "H-FALLBACK-01")
+
+    def test_runtime_window_target_plan_url_failures_are_fail_closed(self) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError, "runtime_window_target_plan_url_empty"
+        ):
+            renewal._read_runtime_window_target_plan_url("", timeout_seconds=1.0)
+
+        with (
+            patch.object(
+                renewal.urllib.request,
+                "urlopen",
+                side_effect=renewal.urllib.error.URLError("connection refused"),
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "runtime_window_target_plan_url_fetch_failed",
+            ),
+        ):
+            renewal._read_runtime_window_target_plan_url(
+                "http://torghut.invalid/status",
+                timeout_seconds=1.0,
+            )
+
+        response = MagicMock()
+        response.__enter__.return_value.read.return_value = b"x" * 5_000_001
+        with (
+            patch.object(renewal.urllib.request, "urlopen", return_value=response),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "runtime_window_target_plan_url_too_large",
+            ),
+        ):
+            renewal._read_runtime_window_target_plan_url(
+                "http://torghut.invalid/status",
+                timeout_seconds=1.0,
+            )
+
+        response = MagicMock()
+        response.__enter__.return_value.read.return_value = b"{"
+        with (
+            patch.object(renewal.urllib.request, "urlopen", return_value=response),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "runtime_window_target_plan_url_invalid",
+            ),
+        ):
+            renewal._read_runtime_window_target_plan_url(
+                "http://torghut.invalid/status",
+                timeout_seconds=1.0,
+            )
+
+        response = MagicMock()
+        response.__enter__.return_value.read.return_value = b"[]"
+        with (
+            patch.object(renewal.urllib.request, "urlopen", return_value=response),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "runtime_window_target_plan_url_invalid",
+            ),
+        ):
+            renewal._read_runtime_window_target_plan_url(
+                "http://torghut.invalid/status",
+                timeout_seconds=1.0,
+            )
+
     def test_runtime_window_targets_from_candidate_board_plan_preserve_probation_handoff(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds a runtime-window target plan URL source to `renew_latest_empirical_promotion_jobs.py`.
- Allows the renewal job to extract `runtime_ledger_paper_probation_import_plan` from live `/trading/status` payloads.
- Preserves same candidate/strategy targets across distinct bounded runtime-ledger windows.
- Wires the existing Torghut empirical promotion renewal CronJob to consume the live Torghut status endpoint through GitOps.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py::TestRunEmpiricalPromotionJobs::test_runtime_window_targets_from_live_gate_plan_url_preserve_window_targets -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py::TestRunEmpiricalPromotionJobs::test_runtime_window_targets_from_live_gate_plan_url_preserve_window_targets tests/test_run_empirical_promotion_jobs.py::TestRunEmpiricalPromotionJobs::test_runtime_window_target_plan_payload_accepts_top_level_gate_plan_and_fallback tests/test_run_empirical_promotion_jobs.py::TestRunEmpiricalPromotionJobs::test_runtime_window_target_plan_url_failures_are_fail_closed -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_empirical_promotion_renewal_imports_paper_windows_from_sim_db -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
