### PR TITLE
fix(torghut): surface runtime-ledger paper probation gate

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -1316,6 +1316,26 @@ def _runtime_ledger_paper_probation_import_plan(
     }
 
 
+def _paper_probation_eligible_total_with_runtime_ledger(
+    *,
+    legacy_total: int,
+    runtime_items: Sequence[Mapping[str, Any]],
+    runtime_ledger_candidates: Sequence[Mapping[str, object]],
+) -> int:
+    keys: set[tuple[str, str]] = set()
+    for item in runtime_items:
+        if not bool(item.get("paper_probation_eligible")):
+            continue
+        hypothesis_id = _safe_text(item.get("hypothesis_id")) or ""
+        candidate_id = _safe_text(item.get("candidate_id")) or ""
+        keys.add((hypothesis_id, candidate_id))
+    for candidate in runtime_ledger_candidates:
+        hypothesis_id = _safe_text(candidate.get("hypothesis_id")) or ""
+        candidate_id = _safe_text(candidate.get("candidate_id")) or ""
+        keys.add((hypothesis_id, candidate_id))
+    return max(legacy_total, len(keys))
+
+
 def _load_runtime_ledger_repair_candidates(
     session: Session,
     *,
@@ -2861,6 +2881,13 @@ def build_live_submission_gate_payload(
     paper_probation_eligible_total = _safe_int(
         summary.get("paper_probation_eligible_total")
     )
+    paper_probation_eligible_total = (
+        _paper_probation_eligible_total_with_runtime_ledger(
+            legacy_total=paper_probation_eligible_total,
+            runtime_items=runtime_items,
+            runtime_ledger_candidates=runtime_ledger_paper_probation_candidates,
+        )
+    )
     active_capital_stage = resolve_active_capital_stage(summary)
     segment_summary = _segment_summary(
         state=state,
@@ -2972,6 +2999,8 @@ def build_live_submission_gate_payload(
         blocked_reasons.append("critical_toggle_parity_diverged")
     if promotion_eligible_total <= 0:
         blocked_reasons.append("alpha_readiness_not_promotion_eligible")
+        if runtime_ledger_paper_probation_candidates:
+            blocked_reasons.append("paper_probation_evidence_collection_only")
     if empirical_ready is False:
         blocked_reasons.append("empirical_jobs_not_ready")
     if dspy_live_ready is False:

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -665,7 +665,11 @@ class TestSubmissionCouncil(TestCase):
             "runtime_ledger_candidate_mismatch", candidates[0]["reason_codes"]
         )
         paper_candidates = gate["runtime_ledger_paper_probation_candidates"]
+        self.assertEqual(gate["paper_probation_eligible_total"], 1)
         self.assertEqual(gate["runtime_ledger_paper_probation_eligible_total"], 1)
+        self.assertIn(
+            "paper_probation_evidence_collection_only", gate["blocked_reasons"]
+        )
         self.assertEqual(len(paper_candidates), 1)
         self.assertEqual(paper_candidates[0]["hypothesis_id"], "H-PAIRS-01")
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Count durable runtime-ledger paper-probation candidates in the live gate's top-level paper-probation total.
- Add an explicit `paper_probation_evidence_collection_only` blocker when runtime-ledger probation evidence exists but live promotion remains blocked.
- Extend submission-council coverage for the runtime-ledger paper-probation gate surface.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_submission_council.py -k 'runtime_ledger_paper_probation or surfaces_runtime_ledger_repair_candidates' -q`
- `uv run --frozen ruff format app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen pytest tests/test_submission_council.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_build_revenue_repair_digest.py tests/test_profitability_proof_floor.py -q`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
