### PR TITLE
fix(torghut): prioritize live gate renewal targets

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -35,6 +35,7 @@ spec:
                     --strategy-spec-ref intraday_tsmom_v2@research \
                     --runtime-window-import \
                     --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/status \
+                    --runtime-window-target-plan-exclusive \
                     --runtime-window-targets-from-latest-autoresearch \
                     --runtime-window-targets-from-registry \
                     --runtime-window-hypothesis-id H-TSMOM-01 \

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -156,6 +156,14 @@ def _parse_args() -> argparse.Namespace:
         default=5.0,
     )
     parser.add_argument(
+        "--runtime-window-target-plan-exclusive",
+        action="store_true",
+        help=(
+            "When a runtime-window target plan ref/url yields at least one target, "
+            "skip latest-autoresearch and registry fallback targets for this run."
+        ),
+    )
+    parser.add_argument(
         "--runtime-window-targets-from-latest-autoresearch",
         action="store_true",
         help=(
@@ -747,8 +755,14 @@ def _runtime_window_targets(
 ) -> list[RuntimeWindowImportTarget]:
     specs = [str(item) for item in getattr(args, "runtime_window_target", []) or []]
     plan_targets = _runtime_window_plan_targets(args)
-    autoresearch_targets = _latest_autoresearch_runtime_window_targets(args)
-    registry_targets = _registry_runtime_window_targets(args)
+    plan_exclusive = bool(getattr(args, "runtime_window_target_plan_exclusive", False))
+    fallback_enabled = not (plan_exclusive and plan_targets)
+    autoresearch_targets = (
+        _latest_autoresearch_runtime_window_targets(args) if fallback_enabled else []
+    )
+    registry_targets = (
+        _registry_runtime_window_targets(args) if fallback_enabled else []
+    )
     if (
         not specs
         and not plan_targets

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -817,6 +817,7 @@ class TestLiveConfigManifestContract(TestCase):
             "http://torghut.torghut.svc.cluster.local/trading/status",
             args,
         )
+        self.assertIn("--runtime-window-target-plan-exclusive", args)
         self.assertIn("--runtime-window-targets-from-latest-autoresearch", args)
         self.assertIn("--runtime-window-targets-from-registry", args)
         self.assertIn("--runtime-window-hypothesis-id H-TSMOM-01", args)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -522,6 +522,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             runtime_window_target_plan_ref=[],
             runtime_window_target_plan_url=[status_path.as_uri()],
             runtime_window_target_plan_url_timeout_seconds=2.0,
+            runtime_window_target_plan_exclusive=False,
             runtime_window_targets_from_latest_autoresearch=False,
             runtime_window_targets_from_registry=False,
             runtime_window_hypothesis_id="",
@@ -557,6 +558,120 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual(targets[0].target_metadata["max_notional"], "0")
         self.assertEqual(targets[0].target_metadata["promotion_allowed"], False)
         self.assertEqual(targets[0].target_metadata["final_promotion_allowed"], False)
+
+    def test_runtime_window_target_plan_exclusive_skips_fallback_targets(
+        self,
+    ) -> None:
+        plan_path = Path(self.tmp_dir) / "candidate-board.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "runtime_window_import_plan": {
+                        "targets": [
+                            {
+                                "candidate_id": "cand-plan",
+                                "hypothesis_id": "H-PAIRS-01",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                            }
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        args = SimpleNamespace(
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_target_plan_url=[],
+            runtime_window_target_plan_url_timeout_seconds=2.0,
+            runtime_window_target_plan_exclusive=True,
+            runtime_window_targets_from_latest_autoresearch=True,
+            runtime_window_targets_from_registry=True,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with (
+            patch.object(
+                renewal,
+                "_latest_autoresearch_runtime_window_targets",
+                side_effect=AssertionError("autoresearch fallback should be skipped"),
+            ),
+            patch.object(
+                renewal,
+                "_registry_runtime_window_targets",
+                side_effect=AssertionError("registry fallback should be skipped"),
+            ),
+        ):
+            targets = renewal._runtime_window_targets(args)
+
+        self.assertEqual([target.hypothesis_id for target in targets], ["H-PAIRS-01"])
+        self.assertEqual(targets[0].candidate_id, "cand-plan")
+
+    def test_runtime_window_target_plan_exclusive_allows_fallback_when_plan_empty(
+        self,
+    ) -> None:
+        plan_path = Path(self.tmp_dir) / "candidate-board.json"
+        plan_path.write_text(
+            json.dumps({"runtime_window_import_plan": {"targets": []}}),
+            encoding="utf-8",
+        )
+        fallback_target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-FALLBACK-01",
+            candidate_id="cand-fallback",
+            observed_stage="paper",
+            strategy_family="fallback_family",
+            source_dsn_env="SIM_DB_DSN",
+            strategy_name="fallback-strategy-v1",
+            account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="",
+            source_manifest_ref="",
+            source_kind="paper_runtime_observed",
+            delay_adjusted_depth_stress_report_ref="",
+            window_start="",
+            window_end="",
+        )
+        args = SimpleNamespace(
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_target_plan_url=[],
+            runtime_window_target_plan_url_timeout_seconds=2.0,
+            runtime_window_target_plan_exclusive=True,
+            runtime_window_targets_from_latest_autoresearch=True,
+            runtime_window_targets_from_registry=False,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with patch.object(
+            renewal,
+            "_latest_autoresearch_runtime_window_targets",
+            return_value=[fallback_target],
+        ):
+            targets = renewal._runtime_window_targets(args)
+
+        self.assertEqual(
+            [target.hypothesis_id for target in targets],
+            ["H-FALLBACK-01"],
+        )
 
     def test_runtime_window_target_plan_payload_accepts_top_level_gate_plan_and_fallback(
         self,


### PR DESCRIPTION
## Summary

- Add `--runtime-window-target-plan-exclusive` to the empirical promotion renewal script so a non-empty live target plan suppresses autoresearch and registry fallbacks for that run.
- Wire the Torghut empirical renewal CronJob to use plan-exclusive mode, keeping the next renewal focused on live gate H-PAIRS import-plan targets when present.
- Cover the exclusive and empty-plan fallback behaviors in renewal tests and assert the GitOps manifest keeps the new flag.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k 'target_plan_exclusive or live_gate_plan_url' -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k empirical_promotion_renewal -q`
- `uv run --frozen ruff format scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py -q`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
