### PR TITLE
fix(torghut): allow paper probes from route repair book

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -562,6 +562,38 @@ class SimpleTradingPipeline(TradingPipeline):
         return repair_symbols
 
     @staticmethod
+    def _proof_floor_symbol_route_probe_reasons(
+        proof_floor: Mapping[str, object],
+        symbol: str,
+    ) -> set[str]:
+        route_book = proof_floor.get("route_reacquisition_book")
+        if not isinstance(route_book, Mapping):
+            return set()
+        summary = cast(Mapping[str, Any], route_book).get("summary")
+        if not isinstance(summary, Mapping):
+            return set()
+        repair_candidates = cast(Mapping[str, Any], summary).get("repair_candidates")
+        if not isinstance(repair_candidates, list):
+            return set()
+
+        normalized_symbol = symbol.strip().upper()
+        reasons: set[str] = set()
+        for raw_candidate in cast(list[object], repair_candidates):
+            if not isinstance(raw_candidate, Mapping):
+                continue
+            candidate = cast(Mapping[str, Any], raw_candidate)
+            candidate_symbol = str(candidate.get("symbol") or "").strip().upper()
+            if not candidate_symbol or candidate_symbol != normalized_symbol:
+                continue
+            state = str(candidate.get("state") or "").strip()
+            if state not in {"missing", "probing"}:
+                continue
+            reason = str(candidate.get("reason") or "").strip()
+            if reason in _PAPER_ROUTE_PROBE_REASONS:
+                reasons.add(reason)
+        return reasons
+
+    @staticmethod
     def _paper_route_probe_reference_price(
         decision: StrategyDecision,
     ) -> Decimal | None:
@@ -645,11 +677,18 @@ class SimpleTradingPipeline(TradingPipeline):
             for item in cast(list[object], proof_floor.get("blocking_reasons") or [])
             if str(item).strip()
         }
-        if not (blocking_reasons & _PAPER_ROUTE_PROBE_REASONS):
+        symbol = decision.symbol.strip().upper()
+        symbol_route_probe_reasons = self._proof_floor_symbol_route_probe_reasons(
+            proof_floor,
+            symbol,
+        )
+        if not (
+            (blocking_reasons & _PAPER_ROUTE_PROBE_REASONS)
+            or symbol_route_probe_reasons
+        ):
             return None
 
         repair_symbols = self._proof_floor_route_repair_symbols(proof_floor)
-        symbol = decision.symbol.strip().upper()
         if repair_symbols and symbol not in repair_symbols:
             return None
 
@@ -659,7 +698,7 @@ class SimpleTradingPipeline(TradingPipeline):
             "max_notional": str(cap),
             "symbol": symbol,
             "side": decision.action,
-            "blocking_reasons": sorted(blocking_reasons),
+            "blocking_reasons": sorted(blocking_reasons | symbol_route_probe_reasons),
             "route_repair_symbols": sorted(repair_symbols),
         }
 

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -2907,8 +2907,19 @@ class TestTradingPipeline(TestCase):
             SimpleTradingPipeline._proof_floor_route_repair_symbols({}), set()
         )
         self.assertEqual(
+            SimpleTradingPipeline._proof_floor_symbol_route_probe_reasons({}, "NVDA"),
+            set(),
+        )
+        self.assertEqual(
             SimpleTradingPipeline._proof_floor_route_repair_symbols(
                 {"route_reacquisition_book": {}}
+            ),
+            set(),
+        )
+        self.assertEqual(
+            SimpleTradingPipeline._proof_floor_symbol_route_probe_reasons(
+                {"route_reacquisition_book": {}},
+                "NVDA",
             ),
             set(),
         )
@@ -2924,6 +2935,31 @@ class TestTradingPipeline(TestCase):
                 }
             ),
             {"NVDA", "MU"},
+        )
+        self.assertEqual(
+            SimpleTradingPipeline._proof_floor_symbol_route_probe_reasons(
+                {
+                    "route_reacquisition_book": {
+                        "summary": {
+                            "repair_candidates": [
+                                object(),
+                                {
+                                    "symbol": "MU",
+                                    "state": "missing",
+                                    "reason": "execution_tca_symbol_missing",
+                                },
+                                {
+                                    "symbol": "NVDA",
+                                    "state": "blocked",
+                                    "reason": "execution_tca_symbol_missing",
+                                },
+                            ]
+                        }
+                    }
+                },
+                "NVDA",
+            ),
+            set(),
         )
 
         decision = StrategyDecision(
@@ -3066,6 +3102,36 @@ class TestTradingPipeline(TestCase):
                 proof_floor=no_route_reason_floor,
                 decision=decision,
             )
+        )
+
+        symbol_level_route_repair_floor = {
+            **proof_floor,
+            "blocking_reasons": ["alpha_readiness_not_promotion_eligible"],
+            "route_reacquisition_book": {
+                "summary": {
+                    "repair_candidate_symbols": ["NVDA"],
+                    "repair_candidates": [
+                        {
+                            "symbol": "NVDA",
+                            "state": "missing",
+                            "reason": "execution_tca_symbol_missing",
+                        }
+                    ],
+                }
+            },
+        }
+        symbol_level_probe_context = pipeline._paper_route_probe_context(
+            proof_floor=symbol_level_route_repair_floor,
+            decision=decision,
+        )
+        self.assertIsNotNone(symbol_level_probe_context)
+        assert symbol_level_probe_context is not None
+        self.assertEqual(
+            symbol_level_probe_context.get("mode"), "paper_route_acquisition"
+        )
+        self.assertIn(
+            "execution_tca_symbol_missing",
+            cast(list[str], symbol_level_probe_context.get("blocking_reasons")),
         )
 
         wrong_symbol_floor = {


### PR DESCRIPTION
## Summary

- Allows the simple paper lane to use symbol-level route repair candidates from the proof-floor route reacquisition book when deciding whether a bounded paper route probe is allowed.
- Keeps live mode, simple-submit disablement, proof-floor zero-notional gates, and final promotion gates unchanged.
- Adds regression coverage for the current failure mode where top-level proof-floor blockers are alpha-readiness related but the route book identifies a missing-TCA paper probe candidate.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_route_probe' -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `uv run --frozen ruff format app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py --check`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
