### PR TITLE
chore(symphony): promote image 5562f77b

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-21T07:24:37Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-24T06:13:00Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c1b2639f"
-    digest: sha256:b65364a44c565924d3d8d3fb12672da8226c3f67dcf408eaa6b287c247ee5e65
+    newTag: "5562f77b"
+    digest: sha256:a742058a50896af4ec59684a497eec97c5354d6309c659eb838a4775a4772646

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-21T07:24:37Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-24T06:13:00Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c1b2639f"
-    digest: sha256:b65364a44c565924d3d8d3fb12672da8226c3f67dcf408eaa6b287c247ee5e65
+    newTag: "5562f77b"
+    digest: sha256:a742058a50896af4ec59684a497eec97c5354d6309c659eb838a4775a4772646

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-21T07:24:37Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-24T06:13:00Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c1b2639f"
-    digest: sha256:b65364a44c565924d3d8d3fb12672da8226c3f67dcf408eaa6b287c247ee5e65
+    newTag: "5562f77b"
+    digest: sha256:a742058a50896af4ec59684a497eec97c5354d6309c659eb838a4775a4772646


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `5562f77bf1a76256a9ccc39d45054b3a5789dd29`
- Image tag: `5562f77b`
- Image digest: `sha256:a742058a50896af4ec59684a497eec97c5354d6309c659eb838a4775a4772646`