### PR TITLE
chore(torghut): promote image 5562f77b

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-763-gcbc3e8380
+              value: v0.571.1-771-gaaa18f989
             - name: TORGHUT_OPTIONS_COMMIT
-              value: cbc3e8380420bfa6815a311b185896591a897fd6
+              value: 5562f77bf1a76256a9ccc39d45054b3a5789dd29
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-763-gcbc3e8380
+              value: v0.571.1-771-gaaa18f989
             - name: TORGHUT_OPTIONS_COMMIT
-              value: cbc3e8380420bfa6815a311b185896591a897fd6
+              value: 5562f77bf1a76256a9ccc39d45054b3a5789dd29
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash
@@ -77,7 +77,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+                  value: sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-24T02:28:58Z"
+        client.knative.dev/updateTimestamp: "2026-05-24T06:22:57Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
           ports:
             - name: http1
               containerPort: 8181
@@ -499,11 +499,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-763-gcbc3e8380
+              value: v0.571.1-771-gaaa18f989
             - name: TORGHUT_COMMIT
-              value: cbc3e8380420bfa6815a311b185896591a897fd6
+              value: 5562f77bf1a76256a9ccc39d45054b3a5789dd29
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+              value: sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-24T02:28:58Z"
+        client.knative.dev/updateTimestamp: "2026-05-24T06:22:57Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
           ports:
             - name: http1
               containerPort: 8181
@@ -320,11 +320,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-763-gcbc3e8380
+              value: v0.571.1-771-gaaa18f989
             - name: TORGHUT_COMMIT
-              value: cbc3e8380420bfa6815a311b185896591a897fd6
+              value: 5562f77bf1a76256a9ccc39d45054b3a5789dd29
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+              value: sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -132,7 +132,7 @@ spec:
           - name: allowStaleTape
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:0c826152b0cc76a0ff99681e96b906809c114cb15c44030549d1c81f0b138425
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

- Promote Torghut image `5562f77b` from the successful `torghut-build-push` release contract.
- Update Torghut, Torghut sim, workflow templates, CronJobs, analysis templates, and Torghut options deployments to digest `sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d`.
- Carry source commit `5562f77bf1a76256a9ccc39d45054b3a5789dd29`, which contains PR #7709's paper route-probe repair path.

## Related Issues

None

## Testing

- `git diff --check`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
