### PR TITLE
chore(torghut): promote image 5562f77b

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -71,7 +71,7 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-771-gaaa18f989
+              value: v0.572.0
             - name: TORGHUT_OPTIONS_COMMIT
               value: 5562f77bf1a76256a9ccc39d45054b3a5789dd29
           ports:

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -71,7 +71,7 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.571.1-771-gaaa18f989
+              value: v0.572.0
             - name: TORGHUT_OPTIONS_COMMIT
               value: 5562f77bf1a76256a9ccc39d45054b3a5789dd29
           ports:

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-24T06:22:57Z"
+        client.knative.dev/updateTimestamp: "2026-05-24T06:29:33Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -499,7 +499,7 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-771-gaaa18f989
+              value: v0.572.0
             - name: TORGHUT_COMMIT
               value: 5562f77bf1a76256a9ccc39d45054b3a5789dd29
             - name: TORGHUT_IMAGE_DIGEST

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-24T06:22:57Z"
+        client.knative.dev/updateTimestamp: "2026-05-24T06:29:33Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -320,7 +320,7 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.571.1-771-gaaa18f989
+              value: v0.572.0
             - name: TORGHUT_COMMIT
               value: 5562f77bf1a76256a9ccc39d45054b3a5789dd29
             - name: TORGHUT_IMAGE_DIGEST


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `5562f77bf1a76256a9ccc39d45054b3a5789dd29`
- Image tag: `5562f77b`
- Image digest: `sha256:ca51c4fc15b4185982e9c674361d08d84d335791728435d5316a73378556555d`