### PR TITLE
fix(docker): include nested agents workspace manifests

### DIFF
--- a/apps/app/Dockerfile
+++ b/apps/app/Dockerfile
@@ -14,7 +14,8 @@ COPY scripts/run-husky-install.mjs ./scripts/run-husky-install.mjs
 COPY --parents apps/*/package.json ./
 COPY --parents packages/*/package.json ./
 COPY --parents services/*/package.json ./
-# Root workspaces include `services/jangar/*`, so include nested workspace manifests too.
+# Root workspaces include nested service package manifests, so keep the reduced install graph complete.
+COPY --parents services/agents/*/package.json ./
 COPY --parents services/jangar/*/package.json ./
 RUN bun install --frozen-lockfile --ignore-scripts
 

--- a/apps/cms/Dockerfile
+++ b/apps/cms/Dockerfile
@@ -14,7 +14,8 @@ COPY scripts/run-husky-install.mjs ./scripts/run-husky-install.mjs
 COPY --parents apps/*/package.json ./
 COPY --parents packages/*/package.json ./
 COPY --parents services/*/package.json ./
-# Root workspaces include `services/jangar/*`, so include nested workspace manifests too.
+# Root workspaces include nested service package manifests, so keep the reduced install graph complete.
+COPY --parents services/agents/*/package.json ./
 COPY --parents services/jangar/*/package.json ./
 RUN bun install --frozen-lockfile --ignore-scripts
 

--- a/apps/kitty-krew/Dockerfile
+++ b/apps/kitty-krew/Dockerfile
@@ -13,7 +13,8 @@ COPY scripts/run-husky-install.mjs ./scripts/run-husky-install.mjs
 COPY --parents apps/*/package.json ./
 COPY --parents packages/*/package.json ./
 COPY --parents services/*/package.json ./
-# Root workspaces include `services/jangar/*`, so include nested workspace manifests too.
+# Root workspaces include nested service package manifests, so keep the reduced install graph complete.
+COPY --parents services/agents/*/package.json ./
 COPY --parents services/jangar/*/package.json ./
 
 # Copy the kitty-krew workspace source

--- a/apps/landing/Dockerfile
+++ b/apps/landing/Dockerfile
@@ -14,7 +14,8 @@ COPY scripts/run-husky-install.mjs ./scripts/run-husky-install.mjs
 COPY --parents apps/*/package.json ./
 COPY --parents packages/*/package.json ./
 COPY --parents services/*/package.json ./
-# Root workspaces include `services/jangar/*`, so include nested workspace manifests too.
+# Root workspaces include nested service package manifests, so keep the reduced install graph complete.
+COPY --parents services/agents/*/package.json ./
 COPY --parents services/jangar/*/package.json ./
 RUN bun install --frozen-lockfile --ignore-scripts
 

--- a/apps/reviseur/Dockerfile
+++ b/apps/reviseur/Dockerfile
@@ -15,7 +15,8 @@ COPY scripts/run-husky-install.mjs ./scripts/run-husky-install.mjs
 COPY --parents apps/*/package.json ./
 COPY --parents packages/*/package.json ./
 COPY --parents services/*/package.json ./
-# Root workspaces include `services/jangar/*`, so include nested workspace manifests too.
+# Root workspaces include nested service package manifests, so keep the reduced install graph complete.
+COPY --parents services/agents/*/package.json ./
 COPY --parents services/jangar/*/package.json ./
 ENV HUSKY=0
 RUN bun install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
## Summary

- Includes `services/agents/*/package.json` in reduced Docker build contexts that run root `bun install --frozen-lockfile`.
- Keeps app, cms, landing, reviseur, and kitty-krew Docker installs aligned with the root workspace graph after the Bun 1.3.14 upgrade.
- Fixes the main-branch Docker rollout failures where Bun reported lockfile drift inside pruned image contexts.

## Related Issues

None

## Testing

- `bun install --frozen-lockfile`
- `git diff --check`
- `docker build --progress=plain --target deps -f apps/app/Dockerfile .`
- `docker build --progress=plain --target deps -f apps/cms/Dockerfile .`
- `docker build --progress=plain --target deps -f apps/landing/Dockerfile .`
- `docker build --progress=plain --target deps -f apps/reviseur/Dockerfile .`
- `docker build --progress=plain --target builder -f apps/kitty-krew/Dockerfile .`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
