### PR TITLE
fix(torghut): surface paper route probe readiness

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -5373,6 +5373,12 @@ def _build_simple_lane_status_payload() -> dict[str, object]:
         "order_feed_telemetry_enabled": (
             settings.trading_simple_order_feed_telemetry_enabled
         ),
+        "paper_route_probe_enabled": (
+            settings.trading_simple_paper_route_probe_enabled
+        ),
+        "paper_route_probe_max_notional": (
+            settings.trading_simple_paper_route_probe_max_notional
+        ),
         "route_symbol_filter_enabled": settings.trading_pipeline_mode == "simple",
         "max_notional_per_order": settings.trading_simple_max_notional_per_order,
         "max_notional_per_symbol": settings.trading_simple_max_notional_per_symbol,

--- a/services/torghut/app/trading/proof_floor.py
+++ b/services/torghut/app/trading/proof_floor.py
@@ -824,11 +824,24 @@ def build_profitability_proof_floor_receipt(
             "live_submit_enabled": False,
         },
     }
-    receipt["route_reacquisition_book"] = build_route_reacquisition_book(
+    paper_route_probe_enabled = False
+    paper_route_probe_max_notional: object | None = None
+    if isinstance(simple_lane_status, Mapping):
+        paper_route_probe_enabled = _truthy(
+            simple_lane_status.get("paper_route_probe_enabled")
+        )
+        paper_route_probe_max_notional = simple_lane_status.get(
+            "paper_route_probe_max_notional"
+        )
+    route_reacquisition_book = build_route_reacquisition_book(
         proof_floor_receipt=receipt,
         trading_mode=trading_mode,
         market_session_open=market_session_open,
+        paper_route_probe_enabled=paper_route_probe_enabled,
+        paper_route_probe_max_notional=paper_route_probe_max_notional,
     )
+    receipt["route_reacquisition_book"] = route_reacquisition_book
+    receipt["paper_route_probe"] = route_reacquisition_book.get("paper_route_probe")
     return receipt
 
 

--- a/services/torghut/app/trading/route_reacquisition.py
+++ b/services/torghut/app/trading/route_reacquisition.py
@@ -7,6 +7,12 @@ from typing import Any, cast
 
 
 SCHEMA_VERSION = "torghut.route-reacquisition-book.v1"
+_PAPER_ROUTE_PROBE_REASONS = {
+    "execution_tca_route_universe_empty",
+    "execution_tca_symbol_missing",
+    "tca_evidence_stale",
+}
+_PAPER_ROUTE_PROBE_STATES = {"missing", "probing"}
 
 
 def _text(value: object, default: str = "") -> str:
@@ -42,6 +48,14 @@ def _float(value: object) -> float | None:
         except ValueError:
             return None
     return None
+
+
+def _positive_amount_text(value: object) -> str | None:
+    amount = _float(value)
+    if amount is None or amount <= 0:
+        return None
+    rendered = _text(value)
+    return rendered if rendered else str(amount)
 
 
 def _mapping(value: object) -> Mapping[str, Any]:
@@ -195,7 +209,7 @@ def _repair_candidate_rank(record: Mapping[str, object]) -> tuple[int, float, in
 
 
 def _repair_candidate(record: Mapping[str, object], *, rank: int) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "rank": rank,
         "symbol": _text(record.get("symbol")),
         "state": _text(record.get("state")),
@@ -206,6 +220,43 @@ def _repair_candidate(record: Mapping[str, object], *, rank: int) -> dict[str, o
         "paper_probe_notional_limit": "0",
         "next_repair_action": _text(record.get("next_repair_action")),
     }
+    paper_route_probe = _mapping(record.get("paper_route_probe"))
+    if paper_route_probe and bool(paper_route_probe.get("eligible")):
+        payload["paper_route_probe"] = dict(paper_route_probe)
+    return payload
+
+
+def _paper_route_probe_eligible(record: Mapping[str, object]) -> bool:
+    return (
+        _text(record.get("state")) in _PAPER_ROUTE_PROBE_STATES
+        and _text(record.get("reason")) in _PAPER_ROUTE_PROBE_REASONS
+    )
+
+
+def _paper_route_probe_blockers(
+    *,
+    trading_mode: str,
+    market_session_open: bool | None,
+    enabled: bool,
+    configured_limit: str | None,
+    eligible_symbol_count: int,
+) -> list[str]:
+    blockers: list[str] = []
+    if trading_mode != "paper":
+        blockers.append("not_paper_mode")
+    if not enabled:
+        blockers.append("paper_route_probe_disabled")
+    if configured_limit is None:
+        blockers.append("paper_route_probe_max_notional_invalid")
+    if market_session_open is not True:
+        blockers.append(
+            "market_session_closed"
+            if market_session_open is False
+            else "market_session_unknown"
+        )
+    if eligible_symbol_count <= 0:
+        blockers.append("paper_route_probe_candidate_missing")
+    return blockers
 
 
 def build_route_reacquisition_book(
@@ -213,6 +264,8 @@ def build_route_reacquisition_book(
     proof_floor_receipt: Mapping[str, Any],
     trading_mode: str,
     market_session_open: bool | None,
+    paper_route_probe_enabled: bool = False,
+    paper_route_probe_max_notional: object | None = None,
 ) -> dict[str, object]:
     """Build a symbol-level route repair book from proof-floor source refs.
 
@@ -295,6 +348,42 @@ def build_route_reacquisition_book(
             )
         )
 
+    configured_probe_limit = _positive_amount_text(paper_route_probe_max_notional)
+    eligible_probe_symbols = [
+        _text(item.get("symbol"))
+        for item in records
+        if _paper_route_probe_eligible(item)
+    ]
+    probe_blockers = _paper_route_probe_blockers(
+        trading_mode=trading_mode,
+        market_session_open=market_session_open,
+        enabled=paper_route_probe_enabled,
+        configured_limit=configured_probe_limit,
+        eligible_symbol_count=len(eligible_probe_symbols),
+    )
+    probe_active = not probe_blockers
+    effective_probe_limit = configured_probe_limit if probe_active else "0"
+    next_session_probe_limit = (
+        configured_probe_limit
+        if paper_route_probe_enabled
+        and trading_mode == "paper"
+        and configured_probe_limit is not None
+        else "0"
+    )
+    active_probe_symbols = eligible_probe_symbols if probe_active else []
+    for record in records:
+        eligible = _paper_route_probe_eligible(record)
+        record["paper_route_probe"] = {
+            "eligible": eligible,
+            "active": probe_active and eligible,
+            "notional_limit": effective_probe_limit if eligible else "0",
+            "next_session_notional_limit": next_session_probe_limit
+            if eligible
+            else "0",
+            "blocking_reasons": probe_blockers if eligible else [],
+            "capital_authority": "none",
+        }
+
     counts = {
         "routeable": sum(1 for item in records if item["state"] == "routeable"),
         "probing": sum(1 for item in records if item["state"] == "probing"),
@@ -353,7 +442,21 @@ def build_route_reacquisition_book(
                 _text(item.get("symbol")) for item in repair_candidates
             ],
             "repair_candidates": repair_candidates,
+            "paper_route_probe_eligible_symbols": eligible_probe_symbols,
+            "paper_route_probe_active_symbols": active_probe_symbols,
             "expected_unblock_value": expected_unblock_value,
+        },
+        "paper_route_probe": {
+            "configured_enabled": paper_route_probe_enabled,
+            "configured_max_notional": configured_probe_limit or "0",
+            "active": probe_active,
+            "effective_max_notional": effective_probe_limit,
+            "next_session_max_notional": next_session_probe_limit,
+            "eligible_symbol_count": len(eligible_probe_symbols),
+            "eligible_symbols": eligible_probe_symbols,
+            "active_symbols": active_probe_symbols,
+            "blocking_reasons": probe_blockers,
+            "capital_authority": "none",
         },
         "source_refs": {
             "proof_floor_generated_at": generated_at,

--- a/services/torghut/tests/test_profitability_proof_floor.py
+++ b/services/torghut/tests/test_profitability_proof_floor.py
@@ -947,6 +947,82 @@ def test_sim_routeable_symbol_becomes_repair_probe_without_capital_unlock() -> N
     assert nvda["paper_probe_notional_limit"] == "0"
 
 
+def test_paper_route_probe_config_flows_into_proof_floor_route_book() -> None:
+    receipt = build_profitability_proof_floor_receipt(
+        account_label="TORGHUT_SIM",
+        torghut_revision="torghut-sim-00670",
+        trading_mode="paper",
+        market_session_open=False,
+        live_submission_gate={
+            "allowed": True,
+            "reason": "non_live_mode",
+            "blocked_reasons": [],
+            "capital_stage": "paper",
+        },
+        hypothesis_payload={
+            "summary": {
+                "hypotheses_total": 1,
+                "promotion_eligible_total": 0,
+                "rollback_required_total": 0,
+                "state_totals": {"blocked": 1},
+            },
+            "items": [
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "reasons": ["runtime_ledger_proof_missing"],
+                    "promotion_eligible": False,
+                    "promotion_contract": {"max_avg_abs_slippage_bps": "20"},
+                }
+            ],
+        },
+        empirical_jobs_status=_healthy_empirical_jobs(),
+        quant_evidence=_healthy_quant_evidence(),
+        market_context_status=_healthy_market_context(),
+        tca_summary={
+            **_fresh_tca_summary(avg_abs_slippage_bps="5"),
+            "scope_symbols": ["AAPL", "AMZN"],
+            "scope_symbol_count": 2,
+            "symbol_breakdown": [
+                {
+                    "symbol": "AAPL",
+                    "order_count": 0,
+                    "avg_abs_slippage_bps": None,
+                    "max_abs_slippage_bps": None,
+                    "last_computed_at": None,
+                },
+                {
+                    "symbol": "AMZN",
+                    "order_count": 1,
+                    "avg_abs_slippage_bps": "3.07908692",
+                    "max_abs_slippage_bps": "3.07908692",
+                    "last_computed_at": NOW.isoformat(),
+                },
+            ],
+        },
+        simple_lane_status={
+            **_simple_lane_status(),
+            "paper_route_probe_enabled": True,
+            "paper_route_probe_max_notional": "25",
+        },
+        now=NOW,
+    )
+
+    probe = cast(Mapping[str, Any], receipt["paper_route_probe"])
+    route_book = cast(Mapping[str, Any], receipt["route_reacquisition_book"])
+    route_probe = cast(Mapping[str, Any], route_book["paper_route_probe"])
+    summary = cast(Mapping[str, Any], route_book["summary"])
+
+    assert receipt["route_state"] == "repair_only"
+    assert receipt["capital_state"] == "zero_notional"
+    assert probe == route_probe
+    assert probe["configured_enabled"] is True
+    assert probe["active"] is False
+    assert probe["next_session_max_notional"] == "25"
+    assert probe["eligible_symbols"] == ["AAPL"]
+    assert probe["capital_authority"] == "none"
+    assert summary["paper_route_probe_eligible_symbols"] == ["AAPL"]
+
+
 def test_settled_old_tca_exposes_execution_quality_instead_of_staleness() -> None:
     settled_at = NOW - timedelta(days=34)
     latest_execution_at = settled_at - timedelta(seconds=1)

--- a/services/torghut/tests/test_route_reacquisition.py
+++ b/services/torghut/tests/test_route_reacquisition.py
@@ -289,6 +289,128 @@ def test_route_book_ranks_zero_notional_repair_candidates_from_live_shape() -> N
     )
 
 
+def test_route_book_surfaces_paper_route_probe_readiness_without_capital_authority() -> (
+    None
+):
+    book = build_route_reacquisition_book(
+        proof_floor_receipt={
+            "generated_at": "2026-05-24T06:42:27.532861+00:00",
+            "account_label": "TORGHUT_SIM",
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "proof_dimensions": [
+                {
+                    "dimension": "execution_tca",
+                    "state": "pass",
+                    "reason": "execution_tca_route_universe_exclusions_applied",
+                    "source_ref": {
+                        "slippage_guardrail_bps": "6",
+                        "unsettled_execution_count": 0,
+                        "symbol_routes": {
+                            "scope_symbols": ["AAPL", "AMZN", "INTC", "NVDA"],
+                            "scope_symbol_count": 4,
+                            "routeable_symbols": [
+                                {
+                                    "symbol": "AMZN",
+                                    "order_count": 1,
+                                    "avg_abs_slippage_bps": "3.07908692",
+                                }
+                            ],
+                            "blocked_symbols": [
+                                {
+                                    "symbol": "NVDA",
+                                    "order_count": 6,
+                                    "avg_abs_slippage_bps": "92.210049075",
+                                }
+                            ],
+                            "missing_symbols": ["AAPL", "INTC"],
+                        },
+                    },
+                },
+                {"dimension": "market_context", "state": "pass"},
+                {"dimension": "quant_ingestion", "state": "pass"},
+                {"dimension": "alpha_readiness", "state": "fail"},
+            ],
+        },
+        trading_mode="paper",
+        market_session_open=False,
+        paper_route_probe_enabled=True,
+        paper_route_probe_max_notional=25.0,
+    )
+
+    probe = cast(Mapping[str, Any], book["paper_route_probe"])
+    assert probe["configured_enabled"] is True
+    assert probe["configured_max_notional"] == "25.0"
+    assert probe["active"] is False
+    assert probe["effective_max_notional"] == "0"
+    assert probe["next_session_max_notional"] == "25.0"
+    assert probe["eligible_symbols"] == ["AAPL", "INTC"]
+    assert probe["active_symbols"] == []
+    assert probe["blocking_reasons"] == ["market_session_closed"]
+    assert probe["capital_authority"] == "none"
+
+    summary = cast(Mapping[str, Any], book["summary"])
+    assert summary["paper_route_probe_eligible_symbols"] == ["AAPL", "INTC"]
+    assert summary["paper_route_probe_active_symbols"] == []
+    assert summary["repair_candidate_symbols"] == ["NVDA", "AAPL", "INTC"]
+
+    records = cast(list[Mapping[str, Any]], book["records"])
+    aapl = next(item for item in records if item["symbol"] == "AAPL")
+    aapl_probe = cast(Mapping[str, Any], aapl["paper_route_probe"])
+    assert aapl["paper_probe_notional_limit"] == "0"
+    assert aapl_probe["eligible"] is True
+    assert aapl_probe["active"] is False
+    assert aapl_probe["notional_limit"] == "0"
+    assert aapl_probe["next_session_notional_limit"] == "25.0"
+    assert aapl_probe["capital_authority"] == "none"
+
+    candidates = cast(list[Mapping[str, Any]], summary["repair_candidates"])
+    candidate = next(item for item in candidates if item["symbol"] == "AAPL")
+    candidate_probe = cast(Mapping[str, Any], candidate["paper_route_probe"])
+    assert candidate["paper_probe_notional_limit"] == "0"
+    assert candidate_probe["next_session_notional_limit"] == "25.0"
+
+
+def test_route_book_marks_paper_route_probe_active_only_when_market_open() -> None:
+    book = build_route_reacquisition_book(
+        proof_floor_receipt={
+            "generated_at": "2026-05-24T06:42:27.532861+00:00",
+            "account_label": "TORGHUT_SIM",
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "proof_dimensions": [
+                {
+                    "dimension": "execution_tca",
+                    "state": "pass",
+                    "reason": "execution_tca_route_universe_exclusions_applied",
+                    "source_ref": {
+                        "symbol_routes": {
+                            "scope_symbols": ["AAPL"],
+                            "scope_symbol_count": 1,
+                            "routeable_symbols": [],
+                            "blocked_symbols": [],
+                            "missing_symbols": ["AAPL"],
+                        }
+                    },
+                },
+                {"dimension": "market_context", "state": "pass"},
+                {"dimension": "quant_ingestion", "state": "pass"},
+                {"dimension": "alpha_readiness", "state": "fail"},
+            ],
+        },
+        trading_mode="paper",
+        market_session_open=True,
+        paper_route_probe_enabled=True,
+        paper_route_probe_max_notional="25",
+    )
+
+    probe = cast(Mapping[str, Any], book["paper_route_probe"])
+    assert probe["active"] is True
+    assert probe["effective_max_notional"] == "25"
+    assert probe["active_symbols"] == ["AAPL"]
+    assert probe["blocking_reasons"] == []
+
+
 def test_route_reacquisition_board_keeps_live_repair_zero_notional() -> None:
     proof_floor = {
         "generated_at": "2026-05-07T22:11:12.125118+00:00",


### PR DESCRIPTION
## Summary

- Adds paper route-probe readiness telemetry to the Torghut route reacquisition book without changing proof-floor capital authority.
- Surfaces configured probe enablement, configured/effective/next-session notional limits, eligible/active symbols, and blocking reasons.
- Wires simple-lane paper probe config into the profitability proof-floor route book and keeps legacy `paper_probe_notional_limit` at `0` while repair-only.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/route_reacquisition.py app/trading/proof_floor.py app/main.py tests/test_route_reacquisition.py tests/test_profitability_proof_floor.py`
- `uv run --frozen pytest tests/test_route_reacquisition.py tests/test_profitability_proof_floor.py -q`
- `uv run --frozen ruff check app/trading/route_reacquisition.py app/trading/proof_floor.py app/main.py tests/test_route_reacquisition.py tests/test_profitability_proof_floor.py`
- `git diff --check`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_trading_api.py::TestTradingApi::test_trading_status_surfaces_simple_lane_fields -q`
- After rebasing on current `origin/main`: `uv run --frozen pytest tests/test_route_reacquisition.py tests/test_profitability_proof_floor.py tests/test_trading_api.py::TestTradingApi::test_trading_status_surfaces_simple_lane_fields -q`
- After rebasing on current `origin/main`: `uv run --frozen ruff check app/trading/route_reacquisition.py app/trading/proof_floor.py app/main.py tests/test_route_reacquisition.py tests/test_profitability_proof_floor.py`
- After rebasing on current `origin/main`: `git diff --check`
- After rebasing on current `origin/main`: `uv run --frozen pyright --project pyrightconfig.json`
- After rebasing on current `origin/main`: `uv run --frozen pyright --project pyrightconfig.alpha.json`
- After rebasing on current `origin/main`: `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
