### PR TITLE
fix(docker): scope bun rollout to enabled apps

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -18,6 +18,16 @@ on:
         required: false
         type: boolean
         default: true
+      build_app:
+        description: 'Build and publish apps/app image'
+        required: false
+        type: boolean
+        default: true
+      build_docs:
+        description: 'Build and publish apps/docs image'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   changes:
@@ -26,14 +36,8 @@ jobs:
       contents: read
     outputs:
       proompteng: ${{ github.event_name == 'workflow_dispatch' && steps.manual.outputs.proompteng || steps.filter.outputs.proompteng }}
-      app: ${{ steps.filter.outputs.app }}
-      cms: ${{ steps.filter.outputs.cms }}
-      docs: ${{ steps.filter.outputs.docs }}
-      kitty-krew: ${{ steps.filter.outputs.kitty-krew }}
-      reviseur: ${{ steps.filter.outputs.reviseur }}
-      alchimie: ${{ steps.filter.outputs.alchimie }}
-      bonjour: ${{ steps.filter.outputs.bonjour }}
-      khoshut: ${{ steps.filter.outputs.khoshut }}
+      app: ${{ github.event_name == 'workflow_dispatch' && steps.manual.outputs.app || steps.filter.outputs.app }}
+      docs: ${{ github.event_name == 'workflow_dispatch' && steps.manual.outputs.docs || steps.filter.outputs.docs }}
 
     steps:
       - name: Checkout
@@ -51,38 +55,26 @@ jobs:
             app:
               - 'apps/app/**'
               - 'packages/design/**'
-            cms:
-              - 'apps/cms/**'
             docs:
               - 'apps/docs/**'
               - 'packages/design/**'
-            kitty-krew:
-              - 'apps/kitty-krew/**'
-            reviseur:
-              - 'apps/reviseur/**'
-            alchimie:
-              - 'apps/alchimie/**'
-            bonjour:
-              - 'services/bonjour/**'
-            khoshut:
-              - 'services/khoshut/**'
 
       - name: Manual build selection
         id: manual
         if: github.event_name == 'workflow_dispatch'
         run: |
-          if [ "${{ github.event.inputs.build_proompteng }}" = "true" ]; then
-            echo "proompteng=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "proompteng=false" >> "$GITHUB_OUTPUT"
-          fi
+          {
+            echo "proompteng=${{ github.event.inputs.build_proompteng }}"
+            echo "app=${{ github.event.inputs.build_app }}"
+            echo "docs=${{ github.event.inputs.build_docs }}"
+          } >> "$GITHUB_OUTPUT"
 
   version:
     runs-on: arc-arm64
     permissions:
       contents: write
     needs: changes
-    if: ${{ needs.changes.outputs.proompteng == 'true' || needs.changes.outputs.app == 'true' || needs.changes.outputs.cms == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.kitty-krew == 'true' || needs.changes.outputs.reviseur == 'true' || needs.changes.outputs.alchimie == 'true' || needs.changes.outputs.bonjour == 'true' || needs.changes.outputs.khoshut == 'true' }}
+    if: ${{ needs.changes.outputs.proompteng == 'true' || needs.changes.outputs.app == 'true' || needs.changes.outputs.docs == 'true' }}
     outputs:
       new_tag: ${{ steps.tag_version.outputs.new_tag }}
       changelog: ${{ steps.tag_version.outputs.changelog }}
@@ -134,70 +126,6 @@ jobs:
       context: .
       new_tag: ${{ needs.version.outputs.new_tag }}
 
-  build-cms:
-    needs: [changes, version]
-    if: ${{ needs.changes.outputs.cms == 'true' }}
-    uses: ./.github/workflows/docker-build-common.yaml
-    with:
-      image_name: cms
-      dockerfile: ./apps/cms/Dockerfile
-      context: .
-      new_tag: ${{ needs.version.outputs.new_tag }}
-
-  build-kitty-krew:
-    needs: [changes, version]
-    if: ${{ needs.changes.outputs.kitty-krew == 'true' }}
-    uses: ./.github/workflows/docker-build-common.yaml
-    with:
-      image_name: kitty-krew
-      dockerfile: ./apps/kitty-krew/Dockerfile
-      context: .
-      new_tag: ${{ needs.version.outputs.new_tag }}
-
-  build-reviseur:
-    needs: [changes, version]
-    if: ${{ needs.changes.outputs.reviseur == 'true' }}
-    uses: ./.github/workflows/docker-build-common.yaml
-    with:
-      image_name: reviseur
-      dockerfile: ./apps/reviseur/Dockerfile
-      context: .
-      new_tag: ${{ needs.version.outputs.new_tag }}
-
-  build-alchimie:
-    needs: [changes, version]
-    if: ${{ needs.changes.outputs.alchimie == 'true' }}
-    uses: ./.github/workflows/docker-build-common.yaml
-    with:
-      image_name: alchimie
-      dockerfile: ./apps/alchimie/Dockerfile
-      context: ./apps/alchimie
-      new_tag: ${{ needs.version.outputs.new_tag }}
-      platforms: linux/arm64
-
-  build-bonjour:
-    needs: [changes, version]
-    if: ${{ needs.changes.outputs.bonjour == 'true' }}
-    uses: ./.github/workflows/docker-build-common.yaml
-    with:
-      image_name: bonjour
-      dockerfile: ./services/bonjour/Dockerfile
-      context: .
-      new_tag: ${{ needs.version.outputs.new_tag }}
-
-  build-khoshut:
-    needs: [changes, version]
-    if: ${{ needs.changes.outputs.khoshut == 'true' }}
-    uses: ./.github/workflows/docker-build-common.yaml
-    with:
-      image_name: khoshut
-      dockerfile: ./services/khoshut/Dockerfile
-      context: .
-      new_tag: ${{ needs.version.outputs.new_tag }}
-      turbo_scope: '@proompteng/khoshut'
-      turbo_copy: 'tsconfig.base.json'
-      bun_version: 1.3.14
-
   cleanup-release:
     runs-on: arc-arm64
     permissions:
@@ -207,13 +135,7 @@ jobs:
         version,
         build-proompteng,
         build-app,
-        build-cms,
         build-docs,
-        build-kitty-krew,
-        build-reviseur,
-        build-alchimie,
-        build-bonjour,
-        build-khoshut,
       ]
     if: failure()
     steps:

--- a/apps/cms/Dockerfile
+++ b/apps/cms/Dockerfile
@@ -14,8 +14,7 @@ COPY scripts/run-husky-install.mjs ./scripts/run-husky-install.mjs
 COPY --parents apps/*/package.json ./
 COPY --parents packages/*/package.json ./
 COPY --parents services/*/package.json ./
-# Root workspaces include nested service package manifests, so keep the reduced install graph complete.
-COPY --parents services/agents/*/package.json ./
+# Root workspaces include `services/jangar/*`, so include nested workspace manifests too.
 COPY --parents services/jangar/*/package.json ./
 RUN bun install --frozen-lockfile --ignore-scripts
 

--- a/apps/kitty-krew/Dockerfile
+++ b/apps/kitty-krew/Dockerfile
@@ -13,8 +13,7 @@ COPY scripts/run-husky-install.mjs ./scripts/run-husky-install.mjs
 COPY --parents apps/*/package.json ./
 COPY --parents packages/*/package.json ./
 COPY --parents services/*/package.json ./
-# Root workspaces include nested service package manifests, so keep the reduced install graph complete.
-COPY --parents services/agents/*/package.json ./
+# Root workspaces include `services/jangar/*`, so include nested workspace manifests too.
 COPY --parents services/jangar/*/package.json ./
 
 # Copy the kitty-krew workspace source

--- a/apps/reviseur/Dockerfile
+++ b/apps/reviseur/Dockerfile
@@ -15,8 +15,7 @@ COPY scripts/run-husky-install.mjs ./scripts/run-husky-install.mjs
 COPY --parents apps/*/package.json ./
 COPY --parents packages/*/package.json ./
 COPY --parents services/*/package.json ./
-# Root workspaces include nested service package manifests, so keep the reduced install graph complete.
-COPY --parents services/agents/*/package.json ./
+# Root workspaces include `services/jangar/*`, so include nested workspace manifests too.
 COPY --parents services/jangar/*/package.json ./
 ENV HUSKY=0
 RUN bun install --frozen-lockfile --ignore-scripts

--- a/docs/superpowers/plans/2026-05-23-bun-1.3.14-upgrade.md
+++ b/docs/superpowers/plans/2026-05-23-bun-1.3.14-upgrade.md
@@ -4,7 +4,7 @@
 
 **Goal:** Upgrade the repository from Bun 1.3.13 to the latest stable Bun release, 1.3.14, and roll it out through CI/CD.
 
-**Architecture:** Treat Bun as a repo-wide runtime contract. Update source-of-truth package metadata, CI setup actions, Docker image tags and ARGs, bootstrap scripts, deployment manifests, and user-facing tooling docs together so local, CI, image-build, and GitOps paths converge on the same version.
+**Architecture:** Treat Bun as a repo-wide runtime contract. Update source-of-truth package metadata, CI setup actions, Docker image tags and ARGs, bootstrap scripts, deployment manifests, and user-facing tooling docs together so local, CI, image-build, and GitOps paths converge on the same version. Limit image publish rollout to applications that are enabled by Argo CD ApplicationSet selectors; disabled entries must not drive image publish jobs.
 
 **Tech Stack:** Bun 1.3.14, Node 24.11.1, GitHub Actions, Docker/oven-bun images, Argo CD manifests, Terraform/Coder bootstrap, Oxfmt/Oxlint, Bun tests.
 
@@ -13,6 +13,7 @@
 ### Task 1: Confirm Upstream Version And Baseline
 
 **Files:**
+
 - Modify: none
 
 - [x] **Step 1: Confirm latest stable release**
@@ -36,6 +37,7 @@ Expected: clean worktree on a branch created from current `origin/main`.
 ### Task 2: Update Runtime Pins
 
 **Files:**
+
 - Modify: `.github/workflows/*.yml`
 - Modify: `.github/workflows/*.yaml`
 - Modify: `package.json`
@@ -60,6 +62,7 @@ Expected: if frozen lock rejects the package metadata changes, rerun `bun instal
 ### Task 3: Validate Upgrade
 
 **Files:**
+
 - Modify: none unless validation exposes a required fix
 
 - [x] **Step 1: Check remaining stale pins**
@@ -89,6 +92,7 @@ Expected: all changed workflows parse.
 ### Task 4: Rollout Through CI
 
 **Files:**
+
 - Modify: `.github/PULL_REQUEST_TEMPLATE.md` only if the template changed upstream; otherwise use it as input
 
 - [ ] **Step 1: Commit**
@@ -110,3 +114,14 @@ Expected: required checks pass.
 Run: `gh pr merge <pr> --squash -R proompteng/lab`
 
 Expected: PR merged to `main`; downstream build/deploy workflows pick up Bun 1.3.14 pins.
+
+- [x] **Step 5: Correct rollout scope from Argo CD ApplicationSets**
+
+Source of truth:
+
+- `argocd/applicationsets/product.yaml` enables `proompteng`, `app`, and `docs`.
+- `argocd/applicationsets/product.yaml` disables `cms`, `kitty-krew`, `reviseur`, and `khoshut`.
+- `argocd/applicationsets/cdk8s.yaml` disables `bonjour`.
+- `alchimie` is not a standalone enabled Argo CD application in the ApplicationSets.
+
+Expected: `.github/workflows/docker-build-push.yaml` publishes only enabled ApplicationSet image targets covered by that workflow: `proompteng`, `app`, and `docs`. Manual dispatch can also regenerate only those three enabled targets after the scope fix merges.


### PR DESCRIPTION
## Summary

- Limits the generic Docker image publish workflow to Bun-backed applications that are enabled by Argo CD ApplicationSets: `proompteng`, `app`, and `docs`.
- Removes disabled/non-enabled rollout targets from the workflow: `cms`, `kitty-krew`, `reviseur`, `alchimie`, `bonjour`, and `khoshut`.
- Adds manual dispatch inputs for the enabled targets so the cancelled Bun rollout can be regenerated without publishing disabled application images.
- Reverts the unnecessary disabled app Dockerfile manifest-copy changes and records the ApplicationSet-derived scope in the Bun rollout plan.

## Related Issues

None

## Testing

- `ruby -ryaml -e 'Dir["argocd/applicationsets/*.yaml"].sort.each do |file| data=YAML.load_file(file); next unless data["kind"]=="ApplicationSet"; elements=[]; (data.dig("spec","generators")||[]).each do |gen| lists=gen.dig("matrix","generators")||[]; lists.each { |g| elements.concat(g.dig("list","elements")||[]) } end; selected=elements.select { |e| e.is_a?(Hash) && !["false","False","0"].include?(e["enabled"].to_s) && e["name"] }; puts "#{file}: #{selected.map { |e| e["name"] }.join(", ")}" unless selected.empty?; end'`
- `rg -n "build_(cms|kitty|reviseur|alchimie|bonjour|khoshut)|outputs\\.(cms|kitty-krew|reviseur|alchimie|bonjour|khoshut)|image_name: (cms|kitty-krew|reviseur|alchimie|bonjour|khoshut)" .github/workflows/docker-build-push.yaml || true`
- `actionlint -ignore 'label "arc-arm64" is unknown' .github/workflows/docker-build-push.yaml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-build-push.yaml"); puts "workflow yaml ok"'`
- `git diff --check HEAD~1..HEAD`
- `bunx oxfmt --check docs/superpowers/plans/2026-05-23-bun-1.3.14-upgrade.md`
- `docker build --progress=plain --target deps -f apps/landing/Dockerfile .`
- `docker build --progress=plain --target deps -f apps/app/Dockerfile .`
- `docker build --progress=plain --target deps -f apps/docs/Dockerfile .`
- `gh release view v0.572.1 -R proompteng/lab --json tagName,url --jq . || true`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Disabled/non-enabled applications no longer publish images from the generic Docker Build and Push workflow.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
