### PR TITLE
fix(torghut): audit paper route probe readiness

### DIFF
--- a/services/torghut/app/trading/revenue_repair.py
+++ b/services/torghut/app/trading/revenue_repair.py
@@ -711,6 +711,7 @@ def _summarize_route_reacquisition(
         proof_floor.get("route_reacquisition_book"),
     )
     summary = _mapping(route_book.get("summary"))
+    paper_route_probe = _mapping(route_book.get("paper_route_probe"))
     return {
         "schema_version": _text(route_book.get("schema_version"), "missing"),
         "state": _text(route_book.get("state"), "unknown"),
@@ -727,6 +728,38 @@ def _summarize_route_reacquisition(
         "repair_candidates": [
             _mapping(item) for item in _sequence(summary.get("repair_candidates"))
         ],
+        "paper_route_probe": {
+            "configured_enabled": _bool(paper_route_probe.get("configured_enabled")),
+            "configured_max_notional": _text(
+                paper_route_probe.get("configured_max_notional"), "0"
+            ),
+            "active": _bool(paper_route_probe.get("active")),
+            "effective_max_notional": _text(
+                paper_route_probe.get("effective_max_notional"), "0"
+            ),
+            "next_session_max_notional": _text(
+                paper_route_probe.get("next_session_max_notional"), "0"
+            ),
+            "eligible_symbol_count": _int(
+                paper_route_probe.get("eligible_symbol_count")
+            ),
+            "eligible_symbols": _string_items(
+                paper_route_probe.get("eligible_symbols")
+            ),
+            "active_symbols": _string_items(paper_route_probe.get("active_symbols")),
+            "blocking_reasons": _string_items(
+                paper_route_probe.get("blocking_reasons")
+            ),
+            "capital_authority": _text(
+                paper_route_probe.get("capital_authority"), "none"
+            ),
+        },
+        "paper_route_probe_eligible_symbols": _string_items(
+            summary.get("paper_route_probe_eligible_symbols")
+        ),
+        "paper_route_probe_active_symbols": _string_items(
+            summary.get("paper_route_probe_active_symbols")
+        ),
         "expected_unblock_value": _int(summary.get("expected_unblock_value")),
     }
 

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -15,6 +15,7 @@ from urllib.request import urlopen
 
 SCHEMA_VERSION = 'torghut.trading-readiness-verification.v1'
 ROUTE_REACQUISITION_BOARD_SCHEMA_VERSION = 'torghut.route-reacquisition-board.v1'
+ROUTE_REACQUISITION_BOOK_SCHEMA_VERSION = 'torghut.route-reacquisition-book.v1'
 _MISSING_QUANT_REASONS = {
     'quant_health_fetch_failed',
     'quant_health_missing',
@@ -65,6 +66,11 @@ def _decimal(value: object) -> Decimal | None:
         return None
 
 
+def _decimal_positive(value: object) -> bool:
+    parsed = _decimal(value)
+    return parsed is not None and parsed > 0
+
+
 def _mapping(value: object) -> Mapping[str, Any]:
     if isinstance(value, Mapping):
         return cast(Mapping[str, Any], value)
@@ -111,7 +117,9 @@ def _dimension_is_required(dimension: Mapping[str, Any]) -> bool:
     return True
 
 
-def _market_session_open(status: Mapping[str, Any], proof_floor: Mapping[str, Any]) -> bool:
+def _market_session_open(
+    status: Mapping[str, Any], proof_floor: Mapping[str, Any]
+) -> bool:
     metrics = _mapping(status.get('metrics'))
     if 'market_session_open' in metrics:
         return _bool(metrics.get('market_session_open'))
@@ -154,6 +162,45 @@ def _expected_floor_states(profile: str) -> tuple[set[str], set[str], set[str]]:
     )
 
 
+def _paper_route_probe_summary(
+    status: Mapping[str, Any],
+    proof_floor: Mapping[str, Any],
+) -> dict[str, Any]:
+    route_book = _mapping(status.get('route_reacquisition_book')) or _mapping(
+        proof_floor.get('route_reacquisition_book')
+    )
+    route_summary = _mapping(route_book.get('summary'))
+    probe = _mapping(route_book.get('paper_route_probe'))
+    eligible_symbols = _sequence(probe.get('eligible_symbols')) or _sequence(
+        route_summary.get('paper_route_probe_eligible_symbols')
+    )
+    active_symbols = _sequence(probe.get('active_symbols')) or _sequence(
+        route_summary.get('paper_route_probe_active_symbols')
+    )
+    return {
+        'route_book_present': bool(route_book),
+        'route_book_schema_version': _text(route_book.get('schema_version')),
+        'configured_enabled': _bool(probe.get('configured_enabled')),
+        'configured_max_notional': _text(probe.get('configured_max_notional'), '0'),
+        'active': _bool(probe.get('active')),
+        'effective_max_notional': _text(probe.get('effective_max_notional'), '0'),
+        'next_session_max_notional': _text(probe.get('next_session_max_notional'), '0'),
+        'eligible_symbol_count': _int(
+            probe.get('eligible_symbol_count'), default=len(eligible_symbols)
+        ),
+        'eligible_symbols': [
+            _text(symbol) for symbol in eligible_symbols if _text(symbol)
+        ],
+        'active_symbols': [_text(symbol) for symbol in active_symbols if _text(symbol)],
+        'blocking_reasons': [
+            _text(reason)
+            for reason in _sequence(probe.get('blocking_reasons'))
+            if _text(reason)
+        ],
+        'capital_authority': _text(probe.get('capital_authority'), 'none'),
+    }
+
+
 def evaluate_trading_readiness(
     status: Mapping[str, Any],
     *,
@@ -163,6 +210,7 @@ def evaluate_trading_readiness(
     min_orders: int = 0,
     require_market_open: bool = True,
     require_quant_fresh: bool = True,
+    require_paper_route_probe_candidate: bool = False,
 ) -> dict[str, Any]:
     """Return a strict readiness verdict from a Torghut trading status payload."""
 
@@ -170,6 +218,7 @@ def evaluate_trading_readiness(
     metrics = _mapping(status.get('metrics'))
     proof_floor = _mapping(status.get('proof_floor'))
     dimensions = _dimension_by_name(proof_floor)
+    paper_route_probe = _paper_route_probe_summary(status, proof_floor)
 
     mode = _text(status.get('mode') or status.get('trading_mode')).lower()
     if profile in {'paper', 'live'}:
@@ -276,7 +325,9 @@ def evaluate_trading_readiness(
     quant_reason = _text(quant_dimension.get('reason'))
     quant_required = _dimension_is_required(quant_dimension)
     quant_passed = quant_state == 'pass' or (
-        not require_quant_fresh and not quant_required and quant_state == 'informational'
+        not require_quant_fresh
+        and not quant_required
+        and quant_state == 'informational'
     )
     if require_quant_fresh and quant_reason in _MISSING_QUANT_REASONS:
         quant_passed = False
@@ -284,7 +335,11 @@ def evaluate_trading_readiness(
         checks,
         'quant_ingestion_ready',
         passed=quant_passed,
-        observed={'state': quant_state, 'reason': quant_reason, 'required': quant_required},
+        observed={
+            'state': quant_state,
+            'reason': quant_reason,
+            'required': quant_required,
+        },
         expected={'state': 'pass'}
         if require_quant_fresh or quant_required
         else {'state': 'pass|optional_informational'},
@@ -382,6 +437,68 @@ def evaluate_trading_readiness(
         detail=route_board_summary,
     )
 
+    if require_paper_route_probe_candidate:
+        allowed_probe_blockers = (
+            set() if require_market_open else {'market_session_closed'}
+        )
+        unexpected_probe_blockers = [
+            reason
+            for reason in paper_route_probe['blocking_reasons']
+            if reason not in allowed_probe_blockers
+        ]
+        _add_check(
+            checks,
+            'paper_route_probe_book_present',
+            passed=paper_route_probe['route_book_present'],
+            observed=paper_route_probe['route_book_present'],
+            expected=True,
+        )
+        _add_check(
+            checks,
+            'paper_route_probe_book_schema_version',
+            passed=paper_route_probe['route_book_schema_version']
+            == ROUTE_REACQUISITION_BOOK_SCHEMA_VERSION,
+            observed=paper_route_probe['route_book_schema_version'],
+            expected=ROUTE_REACQUISITION_BOOK_SCHEMA_VERSION,
+        )
+        _add_check(
+            checks,
+            'paper_route_probe_configured',
+            passed=paper_route_probe['configured_enabled'],
+            observed=paper_route_probe['configured_enabled'],
+            expected=True,
+        )
+        _add_check(
+            checks,
+            'paper_route_probe_candidate_symbols',
+            passed=paper_route_probe['eligible_symbol_count'] > 0,
+            observed={
+                'eligible_symbol_count': paper_route_probe['eligible_symbol_count'],
+                'eligible_symbols': paper_route_probe['eligible_symbols'],
+            },
+            expected='>=1',
+        )
+        _add_check(
+            checks,
+            'paper_route_probe_notional_positive',
+            passed=_decimal_positive(paper_route_probe['effective_max_notional'])
+            or _decimal_positive(paper_route_probe['next_session_max_notional']),
+            observed={
+                'effective_max_notional': paper_route_probe['effective_max_notional'],
+                'next_session_max_notional': paper_route_probe[
+                    'next_session_max_notional'
+                ],
+            },
+            expected='effective_or_next_session_>0',
+        )
+        _add_check(
+            checks,
+            'paper_route_probe_blockers',
+            passed=not unexpected_probe_blockers,
+            observed=paper_route_probe['blocking_reasons'],
+            expected=sorted(allowed_probe_blockers),
+        )
+
     decisions_total = _int(metrics.get('decisions_total'))
     orders_submitted_total = _int(metrics.get('orders_submitted_total'))
     _add_check(
@@ -406,20 +523,32 @@ def evaluate_trading_readiness(
         'profile': profile,
         'failed_checks': failed_checks,
         'checks': checks,
+        'paper_route_probe': paper_route_probe,
     }
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     source = parser.add_mutually_exclusive_group(required=True)
-    source.add_argument('--status-file', type=Path, help='Path to a /trading/status JSON payload.')
-    source.add_argument('--status-url', help='URL returning a /trading/status JSON payload.')
-    parser.add_argument('--profile', choices=('paper', 'live', 'either'), default='paper')
+    source.add_argument(
+        '--status-file', type=Path, help='Path to a /trading/status JSON payload.'
+    )
+    source.add_argument(
+        '--status-url', help='URL returning a /trading/status JSON payload.'
+    )
+    parser.add_argument(
+        '--profile', choices=('paper', 'live', 'either'), default='paper'
+    )
     parser.add_argument('--min-routeable-symbols', type=int, default=2)
     parser.add_argument('--min-decisions', type=int, default=0)
     parser.add_argument('--min-orders', type=int, default=0)
     parser.add_argument('--allow-closed-session', action='store_true')
     parser.add_argument('--allow-informational-quant', action='store_true')
+    parser.add_argument(
+        '--require-paper-route-probe-candidate',
+        action='store_true',
+        help='Require a bounded paper-route probe candidate in route_reacquisition_book.',
+    )
     parser.add_argument('--timeout-seconds', type=float, default=10.0)
     return parser
 
@@ -429,7 +558,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     status = (
         _load_json_object(args.status_file)
         if args.status_file is not None
-        else _load_status_url(str(args.status_url), timeout_seconds=args.timeout_seconds)
+        else _load_status_url(
+            str(args.status_url), timeout_seconds=args.timeout_seconds
+        )
     )
     result = evaluate_trading_readiness(
         status,
@@ -439,6 +570,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         min_orders=max(0, int(args.min_orders)),
         require_market_open=not bool(args.allow_closed_session),
         require_quant_fresh=not bool(args.allow_informational_quant),
+        require_paper_route_probe_candidate=bool(
+            args.require_paper_route_probe_candidate
+        ),
     )
     result['evaluated_at'] = datetime.now(timezone.utc).isoformat()
     print(json.dumps(result, indent=2, sort_keys=True))

--- a/services/torghut/tests/test_build_revenue_repair_digest.py
+++ b/services/torghut/tests/test_build_revenue_repair_digest.py
@@ -154,6 +154,18 @@ def _repair_only_status() -> dict[str, object]:
                 "schema_version": "torghut.route-reacquisition-book.v1",
                 "state": "repair_only",
                 "capital_rule": "live_zero_notional_unchanged",
+                "paper_route_probe": {
+                    "configured_enabled": True,
+                    "configured_max_notional": "25.0",
+                    "active": False,
+                    "effective_max_notional": "0",
+                    "next_session_max_notional": "25.0",
+                    "eligible_symbol_count": 1,
+                    "eligible_symbols": ["AAPL"],
+                    "active_symbols": [],
+                    "blocking_reasons": ["market_session_closed"],
+                    "capital_authority": "none",
+                },
                 "summary": {
                     "routeable_symbol_count": 0,
                     "probing_symbol_count": 0,
@@ -169,8 +181,18 @@ def _repair_only_status() -> dict[str, object]:
                             "state": "blocked",
                             "next_repair_action": "repair_route_evidence_before_paper_probe",
                             "paper_probe_notional_limit": "0",
+                            "paper_route_probe": {
+                                "eligible": True,
+                                "active": False,
+                                "notional_limit": "0",
+                                "next_session_notional_limit": "25.0",
+                                "blocking_reasons": ["market_session_closed"],
+                                "capital_authority": "none",
+                            },
                         }
                     ],
+                    "paper_route_probe_eligible_symbols": ["AAPL"],
+                    "paper_route_probe_active_symbols": [],
                     "expected_unblock_value": 13,
                 },
             },
@@ -405,6 +427,24 @@ class TestBuildRevenueRepairDigest(TestCase):
             digest["repair_bid_settlement_held_lot_ids"],
             ["compacted-repair-lot:promotion"],
         )
+        evidence = digest["evidence"]
+        self.assertIsInstance(evidence, dict)
+        route_reacquisition = evidence["route_reacquisition"]
+        self.assertIsInstance(route_reacquisition, dict)
+        self.assertEqual(
+            route_reacquisition["paper_route_probe_eligible_symbols"], ["AAPL"]
+        )
+        self.assertEqual(route_reacquisition["paper_route_probe_active_symbols"], [])
+        paper_route_probe = route_reacquisition["paper_route_probe"]
+        self.assertIsInstance(paper_route_probe, dict)
+        self.assertTrue(paper_route_probe["configured_enabled"])
+        self.assertFalse(paper_route_probe["active"])
+        self.assertEqual(paper_route_probe["next_session_max_notional"], "25.0")
+        self.assertEqual(paper_route_probe["eligible_symbols"], ["AAPL"])
+        self.assertEqual(
+            paper_route_probe["blocking_reasons"], ["market_session_closed"]
+        )
+        self.assertEqual(paper_route_probe["capital_authority"], "none")
         self.assertIn(
             "jangar_material_evidence_settlement_ref_unavailable",
             digest["field_unavailable_reason_codes"],
@@ -689,6 +729,14 @@ class TestBuildRevenueRepairDigest(TestCase):
                     "state": "blocked",
                     "next_repair_action": "repair_route_evidence_before_paper_probe",
                     "paper_probe_notional_limit": "0",
+                    "paper_route_probe": {
+                        "eligible": True,
+                        "active": False,
+                        "notional_limit": "0",
+                        "next_session_notional_limit": "25.0",
+                        "blocking_reasons": ["market_session_closed"],
+                        "capital_authority": "none",
+                    },
                 }
             ],
         )

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -97,6 +97,26 @@ def _ready_status() -> dict[str, object]:
                 },
             ],
         },
+        'route_reacquisition_book': {
+            'schema_version': 'torghut.route-reacquisition-book.v1',
+            'state': 'paper_candidate',
+            'summary': {
+                'paper_route_probe_eligible_symbols': ['NVDA'],
+                'paper_route_probe_active_symbols': ['NVDA'],
+            },
+            'paper_route_probe': {
+                'configured_enabled': True,
+                'configured_max_notional': '25',
+                'active': True,
+                'effective_max_notional': '25',
+                'next_session_max_notional': '25',
+                'eligible_symbol_count': 1,
+                'eligible_symbols': ['NVDA'],
+                'active_symbols': ['NVDA'],
+                'blocking_reasons': [],
+                'capital_authority': 'none',
+            },
+        },
     }
 
 
@@ -126,7 +146,9 @@ def _load_from_test_server(payload: object) -> dict[str, object]:
     thread.start()
     try:
         host, port = server.server_address
-        return verifier._load_status_url(f'http://{host}:{port}/status', timeout_seconds=2.0)
+        return verifier._load_status_url(
+            f'http://{host}:{port}/status', timeout_seconds=2.0
+        )
     finally:
         server.shutdown()
         server.server_close()
@@ -146,7 +168,9 @@ class TestVerifyTradingReadiness(TestCase):
         self.assertTrue(result['ok'])
         self.assertEqual(result['failed_checks'], [])
 
-    def test_live_and_either_profiles_use_live_floor_states_and_market_window(self) -> None:
+    def test_live_and_either_profiles_use_live_floor_states_and_market_window(
+        self,
+    ) -> None:
         status = _ready_status()
         status['mode'] = 'live'
         metrics = status['metrics']
@@ -163,8 +187,12 @@ class TestVerifyTradingReadiness(TestCase):
             }
         )
 
-        live = evaluate_trading_readiness(status, profile='live', min_routeable_symbols=2)
-        either = evaluate_trading_readiness(status, profile='either', min_routeable_symbols=2)
+        live = evaluate_trading_readiness(
+            status, profile='live', min_routeable_symbols=2
+        )
+        either = evaluate_trading_readiness(
+            status, profile='either', min_routeable_symbols=2
+        )
 
         self.assertTrue(live['ok'], live)
         self.assertTrue(either['ok'], either)
@@ -254,14 +282,19 @@ class TestVerifyTradingReadiness(TestCase):
         self.assertIn('route_board_capital_eligible_symbols', result['failed_checks'])
         self.assertIn('route_board_zero_notional_rows', result['failed_checks'])
 
-    def test_optional_quant_empty_fails_unless_informational_quant_is_allowed(self) -> None:
+    def test_optional_quant_empty_fails_unless_informational_quant_is_allowed(
+        self,
+    ) -> None:
         status = _ready_status()
         proof_floor = status['proof_floor']
         assert isinstance(proof_floor, dict)
         dimensions = proof_floor['proof_dimensions']
         assert isinstance(dimensions, list)
         for dimension in dimensions:
-            if isinstance(dimension, dict) and dimension.get('dimension') == 'quant_ingestion':
+            if (
+                isinstance(dimension, dict)
+                and dimension.get('dimension') == 'quant_ingestion'
+            ):
                 dimension['state'] = 'informational'
                 dimension['reason'] = 'quant_latest_metrics_empty'
                 dimension['source_ref'] = {'required': False}
@@ -273,14 +306,19 @@ class TestVerifyTradingReadiness(TestCase):
         self.assertIn('quant_ingestion_ready', strict['failed_checks'])
         self.assertTrue(permissive['ok'])
 
-    def test_required_quant_empty_fails_even_when_informational_quant_is_allowed(self) -> None:
+    def test_required_quant_empty_fails_even_when_informational_quant_is_allowed(
+        self,
+    ) -> None:
         status = _ready_status()
         proof_floor = status['proof_floor']
         assert isinstance(proof_floor, dict)
         dimensions = proof_floor['proof_dimensions']
         assert isinstance(dimensions, list)
         for dimension in dimensions:
-            if isinstance(dimension, dict) and dimension.get('dimension') == 'quant_ingestion':
+            if (
+                isinstance(dimension, dict)
+                and dimension.get('dimension') == 'quant_ingestion'
+            ):
                 dimension['state'] = 'informational'
                 dimension['reason'] = 'quant_latest_metrics_empty'
                 dimension['source_ref'] = {'required': True}
@@ -290,14 +328,19 @@ class TestVerifyTradingReadiness(TestCase):
         self.assertFalse(result['ok'])
         self.assertIn('quant_ingestion_ready', result['failed_checks'])
 
-    def test_legacy_evidence_required_quant_empty_fails_when_informational_quant_is_allowed(self) -> None:
+    def test_legacy_evidence_required_quant_empty_fails_when_informational_quant_is_allowed(
+        self,
+    ) -> None:
         status = _ready_status()
         proof_floor = status['proof_floor']
         assert isinstance(proof_floor, dict)
         dimensions = proof_floor['proof_dimensions']
         assert isinstance(dimensions, list)
         for dimension in dimensions:
-            if isinstance(dimension, dict) and dimension.get('dimension') == 'quant_ingestion':
+            if (
+                isinstance(dimension, dict)
+                and dimension.get('dimension') == 'quant_ingestion'
+            ):
                 dimension['state'] = 'informational'
                 dimension['reason'] = 'quant_latest_metrics_empty'
                 dimension['source_ref'] = {'evidence_required': True}
@@ -306,6 +349,76 @@ class TestVerifyTradingReadiness(TestCase):
 
         self.assertFalse(result['ok'])
         self.assertIn('quant_ingestion_ready', result['failed_checks'])
+
+    def test_closed_session_paper_route_probe_candidate_can_be_required_for_next_session(
+        self,
+    ) -> None:
+        status = _ready_status()
+        metrics = status['metrics']
+        assert isinstance(metrics, dict)
+        metrics['market_session_open'] = 0
+        route_book = status['route_reacquisition_book']
+        assert isinstance(route_book, dict)
+        probe = route_book['paper_route_probe']
+        assert isinstance(probe, dict)
+        probe.update(
+            {
+                'active': False,
+                'effective_max_notional': '0',
+                'next_session_max_notional': '25',
+                'active_symbols': [],
+                'blocking_reasons': ['market_session_closed'],
+            }
+        )
+        summary = route_book['summary']
+        assert isinstance(summary, dict)
+        summary['paper_route_probe_active_symbols'] = []
+
+        result = evaluate_trading_readiness(
+            status,
+            require_market_open=False,
+            require_paper_route_probe_candidate=True,
+        )
+
+        self.assertTrue(result['ok'], result)
+        self.assertEqual(result['paper_route_probe']['eligible_symbols'], ['NVDA'])
+        self.assertEqual(
+            result['paper_route_probe']['blocking_reasons'], ['market_session_closed']
+        )
+
+    def test_required_paper_route_probe_candidate_fails_without_bounded_candidate(
+        self,
+    ) -> None:
+        status = _ready_status()
+        route_book = status['route_reacquisition_book']
+        assert isinstance(route_book, dict)
+        probe = route_book['paper_route_probe']
+        assert isinstance(probe, dict)
+        probe.update(
+            {
+                'configured_enabled': False,
+                'effective_max_notional': '0',
+                'next_session_max_notional': '0',
+                'eligible_symbol_count': 0,
+                'eligible_symbols': [],
+                'active_symbols': [],
+                'blocking_reasons': ['paper_route_probe_disabled'],
+            }
+        )
+        summary = route_book['summary']
+        assert isinstance(summary, dict)
+        summary['paper_route_probe_eligible_symbols'] = []
+        summary['paper_route_probe_active_symbols'] = []
+
+        result = evaluate_trading_readiness(
+            status, require_paper_route_probe_candidate=True
+        )
+
+        self.assertFalse(result['ok'])
+        self.assertIn('paper_route_probe_configured', result['failed_checks'])
+        self.assertIn('paper_route_probe_candidate_symbols', result['failed_checks'])
+        self.assertIn('paper_route_probe_notional_positive', result['failed_checks'])
+        self.assertIn('paper_route_probe_blockers', result['failed_checks'])
 
     def test_payload_helpers_handle_runtime_payload_shapes(self) -> None:
         self.assertTrue(verifier._bool('open'))
@@ -323,7 +436,9 @@ class TestVerifyTradingReadiness(TestCase):
     def test_status_loaders_require_json_objects(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             status_path = Path(tmp_dir) / 'status.json'
-            status_path.write_text(json.dumps(['not', 'an', 'object']), encoding='utf-8')
+            status_path.write_text(
+                json.dumps(['not', 'an', 'object']), encoding='utf-8'
+            )
 
             with self.assertRaisesRegex(ValueError, 'json_object_required'):
                 verifier._load_json_object(status_path)


### PR DESCRIPTION
## Summary

- Adds paper-route probe fields to the revenue-repair digest so bounded next-session probe readiness is visible in saved evidence artifacts.
- Extends `verify_trading_readiness.py` with `--require-paper-route-probe-candidate` to fail closed when the route book is missing, disabled, unbounded, or blocked for reasons other than a tolerated closed session.
- Adds regression coverage for digest preservation and readiness verification of both closed-session next-session probes and unbounded disabled probes.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_verify_trading_readiness.py tests/test_build_revenue_repair_digest.py -q`
- `uv run --frozen ruff check scripts/verify_trading_readiness.py tests/test_verify_trading_readiness.py app/trading/revenue_repair.py tests/test_build_revenue_repair_digest.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
