### PR TITLE
chore(app): promote image 0.572.1

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    newTag: 0.569.1
+    newTag: 0.572.1
     newName: registry.ide-newton.ts.net/lab/app


### PR DESCRIPTION
## Summary

- Promote the enabled `app` Argo CD application to image tag `0.572.1`.
- Align `app` with the already-promoted enabled `proompteng` and `docs` image apps from the scoped Bun 1.3.14 rollout.
- Keep disabled Product ApplicationSet targets untouched.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/app >/tmp/lab-app-kustomize.yaml`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
