### PR TITLE
fix(torghut): surface paper route evidence audit

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -124,6 +124,7 @@ from .trading.profit_carry_passports import build_profit_carry_passport_ledger
 from .trading.profit_freshness_frontier import build_profit_freshness_frontier
 from .trading.profit_repair_settlement import build_profit_repair_settlement_ledger
 from .trading.profit_signal_quorum import build_profit_signal_quorum
+from .trading.paper_route_evidence import build_paper_route_evidence_audit
 from .trading.proof_floor import build_profitability_proof_floor_receipt
 from .trading.quality_adjusted_profit_frontier import (
     build_quality_adjusted_profit_frontier,
@@ -4388,6 +4389,64 @@ def trading_runtime_profitability(
         "live_submission_gate": live_submission_gate,
         "caveats": caveats,
     }
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+@app.get("/trading/paper-route-evidence")
+def trading_paper_route_evidence(
+    session: Session = Depends(get_session),
+) -> JSONResponse:
+    """Return target-by-target paper-route evidence collection status."""
+
+    scheduler: TradingScheduler | None = getattr(app.state, "trading_scheduler", None)
+    if scheduler is None:
+        scheduler = TradingScheduler()
+        app.state.trading_scheduler = scheduler
+
+    empirical_jobs = _empirical_jobs_status()
+    quant_evidence = load_quant_evidence_status(
+        account_label=settings.trading_account_label,
+    )
+    tca_summary = _load_tca_summary(session, scheduler=scheduler)
+    market_context_status = scheduler.market_context_status()
+    hypothesis_payload, _hypothesis_summary, _dependency_quorum = (
+        _build_hypothesis_runtime_payload(
+            scheduler,
+            tca_summary=tca_summary,
+            market_context_status=market_context_status,
+        )
+    )
+    live_submission_gate = _build_live_submission_gate_payload(
+        scheduler.state,
+        session=session,
+        hypothesis_summary=hypothesis_payload,
+        empirical_jobs_status=empirical_jobs,
+        dspy_runtime_status=cast(
+            dict[str, object],
+            scheduler.llm_status().get("dspy_runtime", {}),
+        ),
+        quant_health_status=quant_evidence,
+    )
+    simple_lane_status = _build_simple_lane_status_payload()
+    proof_floor = _build_profitability_proof_floor_payload(
+        state=scheduler.state,
+        torghut_revision=BUILD_VERSION,
+        live_submission_gate=live_submission_gate,
+        hypothesis_payload=hypothesis_payload,
+        empirical_jobs_status=empirical_jobs,
+        quant_evidence=quant_evidence,
+        market_context_status=market_context_status,
+        tca_summary=tca_summary,
+        simple_lane_status=simple_lane_status,
+    )
+    payload = build_paper_route_evidence_audit(
+        session,
+        live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
+        route_reacquisition_book=cast(
+            Mapping[str, Any],
+            proof_floor.get("route_reacquisition_book") or {},
+        ),
+    )
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 
 

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1,0 +1,736 @@
+"""Paper-route evidence audit helpers.
+
+This module keeps paper-probation observability separate from promotion
+authority. It explains why a target is still evidence collection only instead
+of mutating any live submission gate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Any, cast
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..models import (
+    Execution,
+    ExecutionTCAMetric,
+    Strategy,
+    StrategyHypothesisMetricWindow,
+    StrategyPromotionDecision,
+    StrategyRuntimeLedgerBucket,
+    TradeDecision,
+)
+from .runtime_ledger import POST_COST_PNL_BASIS
+
+
+PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION = "torghut.paper-route-evidence.v1"
+DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS = 72
+DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT = 20
+
+
+def _as_mapping(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[str, Any], value).items()}
+
+
+def _as_sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return ()
+
+
+def _as_mapping_items(value: object) -> list[dict[str, Any]]:
+    return [
+        _as_mapping(cast(object, item))
+        for item in _as_sequence(value)
+        if isinstance(item, Mapping)
+    ]
+
+
+def _safe_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _safe_int(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, Decimal):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return 0
+    return 0
+
+
+def _safe_decimal(value: object) -> Decimal:
+    if value is None:
+        return Decimal("0")
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, bool):
+        return Decimal(int(value))
+    if isinstance(value, (int, float, str)):
+        try:
+            return Decimal(str(value).strip())
+        except (InvalidOperation, ValueError):
+            return Decimal("0")
+    return Decimal("0")
+
+
+def _decimal_text(value: object) -> str:
+    amount = _safe_decimal(value)
+    text = format(amount, "f")
+    if "." not in text:
+        return text
+    return text.rstrip("0").rstrip(".") or "0"
+
+
+def _isoformat(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        text = _safe_text(value)
+        if text is None:
+            return None
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _paper_route_probe_summary(
+    route_reacquisition_book: Mapping[str, Any],
+) -> dict[str, object]:
+    summary = _as_mapping(route_reacquisition_book.get("summary"))
+    probe = _as_mapping(route_reacquisition_book.get("paper_route_probe"))
+    eligible_symbols = [
+        str(item).strip()
+        for item in _as_sequence(
+            probe.get("eligible_symbols")
+            or summary.get("paper_route_probe_eligible_symbols")
+        )
+        if str(item).strip()
+    ]
+    active_symbols = [
+        str(item).strip()
+        for item in _as_sequence(
+            probe.get("active_symbols")
+            or summary.get("paper_route_probe_active_symbols")
+        )
+        if str(item).strip()
+    ]
+    blocking_reasons = [
+        str(item).strip()
+        for item in _as_sequence(probe.get("blocking_reasons"))
+        if str(item).strip()
+    ]
+    return {
+        "schema_version": _safe_text(route_reacquisition_book.get("schema_version"))
+        or "missing",
+        "state": _safe_text(route_reacquisition_book.get("state")) or "unknown",
+        "configured_enabled": bool(probe.get("configured_enabled")),
+        "active": bool(probe.get("active")),
+        "effective_max_notional": _safe_text(probe.get("effective_max_notional"))
+        or "0",
+        "next_session_max_notional": _safe_text(probe.get("next_session_max_notional"))
+        or "0",
+        "eligible_symbol_count": _safe_int(
+            probe.get("eligible_symbol_count") or len(eligible_symbols)
+        ),
+        "eligible_symbols": eligible_symbols,
+        "active_symbols": active_symbols,
+        "blocking_reasons": blocking_reasons,
+    }
+
+
+def _target_identity(target: Mapping[str, Any]) -> dict[str, object]:
+    return {
+        "hypothesis_id": _safe_text(target.get("hypothesis_id")),
+        "candidate_id": _safe_text(target.get("candidate_id")),
+        "observed_stage": _safe_text(target.get("observed_stage")) or "paper",
+        "strategy_family": _safe_text(target.get("strategy_family")),
+        "strategy_name": _safe_text(target.get("strategy_name")),
+        "account_label": _safe_text(target.get("account_label")),
+        "source_kind": _safe_text(target.get("source_kind")),
+        "source_dsn_env": _safe_text(target.get("source_dsn_env")),
+        "source_manifest_ref": _safe_text(target.get("source_manifest_ref")),
+        "dataset_snapshot_ref": _safe_text(target.get("dataset_snapshot_ref")),
+        "window_start": _safe_text(target.get("window_start")),
+        "window_end": _safe_text(target.get("window_end")),
+        "runtime_ledger_bucket_ref": _safe_text(
+            target.get("runtime_ledger_bucket_ref")
+        ),
+        "paper_probation_authorized": bool(target.get("paper_probation_authorized")),
+        "paper_probation_authorization_scope": _safe_text(
+            target.get("paper_probation_authorization_scope")
+        ),
+        "promotion_allowed": bool(target.get("promotion_allowed")),
+        "final_promotion_allowed": bool(
+            target.get("final_promotion_allowed")
+            or target.get("final_promotion_authorized")
+        ),
+        "max_notional": _safe_text(target.get("max_notional")) or "0",
+        "final_promotion_blockers": [
+            str(item).strip()
+            for item in _as_sequence(target.get("final_promotion_blockers"))
+            if str(item).strip()
+        ],
+        "candidate_blockers": [
+            str(item).strip()
+            for item in _as_sequence(target.get("candidate_blockers"))
+            if str(item).strip()
+        ],
+        "runtime_ledger_target_metadata_blockers": [
+            str(item).strip()
+            for item in _as_sequence(
+                target.get("runtime_ledger_target_metadata_blockers")
+            )
+            if str(item).strip()
+        ],
+    }
+
+
+def _target_window(
+    target: Mapping[str, Any],
+    *,
+    generated_at: datetime,
+    lookback_hours: int,
+) -> tuple[datetime, datetime]:
+    fallback_end = generated_at
+    fallback_start = fallback_end - timedelta(hours=max(1, lookback_hours))
+    window_start = _parse_datetime(target.get("window_start")) or fallback_start
+    window_end = _parse_datetime(target.get("window_end")) or fallback_end
+    if window_end < window_start:
+        return fallback_start, fallback_end
+    return window_start, window_end
+
+
+def _strategy_source_activity(
+    session: Session,
+    *,
+    strategy_name: str | None,
+    window_start: datetime,
+) -> dict[str, object]:
+    if strategy_name is None:
+        return {
+            "strategy_name": None,
+            "decision_count": 0,
+            "execution_count": 0,
+            "filled_execution_count": 0,
+            "tca_sample_count": 0,
+            "last_decision_at": None,
+            "last_execution_at": None,
+            "last_tca_at": None,
+            "missing": True,
+            "missing_reasons": ["strategy_name_missing"],
+        }
+
+    decision_rows = list(
+        session.execute(
+            select(TradeDecision)
+            .join(Strategy, TradeDecision.strategy_id == Strategy.id)
+            .where(Strategy.name == strategy_name)
+            .where(TradeDecision.created_at >= window_start)
+            .order_by(TradeDecision.created_at.desc())
+            .limit(500)
+        ).scalars()
+    )
+    decision_ids = [row.id for row in decision_rows]
+    execution_rows: list[Execution] = []
+    if decision_ids:
+        execution_rows = list(
+            session.execute(
+                select(Execution)
+                .where(Execution.trade_decision_id.in_(decision_ids))
+                .order_by(Execution.created_at.desc())
+                .limit(500)
+            ).scalars()
+        )
+    tca_rows = list(
+        session.execute(
+            select(ExecutionTCAMetric)
+            .join(Strategy, ExecutionTCAMetric.strategy_id == Strategy.id)
+            .where(Strategy.name == strategy_name)
+            .where(ExecutionTCAMetric.computed_at >= window_start)
+            .order_by(ExecutionTCAMetric.computed_at.desc())
+            .limit(500)
+        ).scalars()
+    )
+    decision_count = len(decision_rows)
+    execution_count = len(execution_rows)
+    tca_sample_count = len(tca_rows)
+    filled_execution_count = sum(
+        int(_safe_decimal(row.filled_qty) > 0) for row in execution_rows
+    )
+    missing_reasons: list[str] = []
+    if decision_count <= 0:
+        missing_reasons.append("source_decisions_missing")
+    if execution_count <= 0:
+        missing_reasons.append("source_executions_missing")
+    if tca_sample_count <= 0:
+        missing_reasons.append("source_tca_missing")
+    return {
+        "strategy_name": strategy_name,
+        "decision_count": decision_count,
+        "execution_count": execution_count,
+        "filled_execution_count": filled_execution_count,
+        "tca_sample_count": tca_sample_count,
+        "last_decision_at": _isoformat(
+            decision_rows[0].created_at if decision_rows else None
+        ),
+        "last_execution_at": _isoformat(
+            execution_rows[0].created_at if execution_rows else None
+        ),
+        "last_tca_at": _isoformat(tca_rows[0].computed_at if tca_rows else None),
+        "missing": bool(missing_reasons),
+        "missing_reasons": missing_reasons,
+    }
+
+
+def _target_filters(
+    stmt: Any,
+    model: Any,
+    *,
+    hypothesis_id: str | None,
+    candidate_id: str | None,
+) -> Any:
+    if hypothesis_id is None:
+        return stmt.where(model.hypothesis_id == "__missing_paper_route_hypothesis__")
+    stmt = stmt.where(model.hypothesis_id == hypothesis_id)
+    if candidate_id is not None:
+        stmt = stmt.where(model.candidate_id == candidate_id)
+    return stmt
+
+
+def _positive_hash_count(value: object) -> bool:
+    counts = _as_mapping(value)
+    return bool(counts) and any(_safe_int(count) > 0 for count in counts.values())
+
+
+def _runtime_ledger_bucket_evidence_grade(row: StrategyRuntimeLedgerBucket) -> bool:
+    blockers = [
+        str(item).strip()
+        for item in _as_sequence(row.blockers_json)
+        if str(item).strip()
+    ]
+    return (
+        row.pnl_basis == POST_COST_PNL_BASIS
+        and _safe_int(row.fill_count) > 0
+        and _safe_int(row.submitted_order_count) > 0
+        and _safe_int(row.closed_trade_count) > 0
+        and _safe_int(row.open_position_count) == 0
+        and _safe_decimal(row.filled_notional) > 0
+        and _positive_hash_count(row.execution_policy_hash_counts)
+        and _positive_hash_count(row.cost_model_hash_counts)
+        and _positive_hash_count(row.lineage_hash_counts)
+        and not blockers
+    )
+
+
+def _runtime_ledger_summary(
+    session: Session,
+    *,
+    hypothesis_id: str | None,
+    candidate_id: str | None,
+    window_start: datetime,
+    window_end: datetime,
+) -> dict[str, object]:
+    stmt = select(StrategyRuntimeLedgerBucket).order_by(
+        StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
+        StrategyRuntimeLedgerBucket.created_at.desc(),
+    )
+    stmt = _target_filters(
+        stmt,
+        StrategyRuntimeLedgerBucket,
+        hypothesis_id=hypothesis_id,
+        candidate_id=candidate_id,
+    )
+    stmt = stmt.where(StrategyRuntimeLedgerBucket.bucket_started_at <= window_end)
+    stmt = stmt.where(StrategyRuntimeLedgerBucket.bucket_ended_at >= window_start)
+    rows = list(session.execute(stmt.limit(50)).scalars())
+    filled_notional = sum((row.filled_notional for row in rows), Decimal("0"))
+    net_pnl = sum((row.net_strategy_pnl_after_costs for row in rows), Decimal("0"))
+    return {
+        "bucket_count": len(rows),
+        "evidence_grade_bucket_count": sum(
+            int(_runtime_ledger_bucket_evidence_grade(row)) for row in rows
+        ),
+        "fill_count": sum(max(0, _safe_int(row.fill_count)) for row in rows),
+        "decision_count": sum(max(0, _safe_int(row.decision_count)) for row in rows),
+        "submitted_order_count": sum(
+            max(0, _safe_int(row.submitted_order_count)) for row in rows
+        ),
+        "closed_trade_count": sum(
+            max(0, _safe_int(row.closed_trade_count)) for row in rows
+        ),
+        "open_position_count": sum(
+            max(0, _safe_int(row.open_position_count)) for row in rows
+        ),
+        "filled_notional": _decimal_text(filled_notional),
+        "net_strategy_pnl_after_costs": _decimal_text(net_pnl),
+        "post_cost_expectancy_bps": _decimal_text(
+            (net_pnl / filled_notional * Decimal("10000"))
+            if filled_notional > 0
+            else Decimal("0")
+        ),
+        "latest_bucket_ended_at": _isoformat(rows[0].bucket_ended_at if rows else None),
+        "db_row_refs": [str(row.id) for row in rows],
+        "blockers": sorted(
+            {
+                str(item).strip()
+                for row in rows
+                for item in _as_sequence(row.blockers_json)
+                if str(item).strip()
+            }
+        ),
+    }
+
+
+def _hypothesis_window_summary(
+    session: Session,
+    *,
+    hypothesis_id: str | None,
+    candidate_id: str | None,
+    window_start: datetime,
+    window_end: datetime,
+) -> dict[str, object]:
+    stmt = select(StrategyHypothesisMetricWindow).order_by(
+        StrategyHypothesisMetricWindow.window_ended_at.desc().nullslast(),
+        StrategyHypothesisMetricWindow.created_at.desc(),
+    )
+    stmt = _target_filters(
+        stmt,
+        StrategyHypothesisMetricWindow,
+        hypothesis_id=hypothesis_id,
+        candidate_id=candidate_id,
+    )
+    stmt = stmt.where(StrategyHypothesisMetricWindow.window_started_at <= window_end)
+    stmt = stmt.where(StrategyHypothesisMetricWindow.window_ended_at >= window_start)
+    rows = list(session.execute(stmt.limit(50)).scalars())
+    provenance_counts: dict[str, int] = {}
+    maturity_counts: dict[str, int] = {}
+    for row in rows:
+        provenance = row.evidence_provenance or "missing"
+        maturity = row.evidence_maturity or "missing"
+        provenance_counts[provenance] = provenance_counts.get(provenance, 0) + 1
+        maturity_counts[maturity] = maturity_counts.get(maturity, 0) + 1
+    return {
+        "window_count": len(rows),
+        "decision_count": sum(max(0, _safe_int(row.decision_count)) for row in rows),
+        "trade_count": sum(max(0, _safe_int(row.trade_count)) for row in rows),
+        "order_count": sum(max(0, _safe_int(row.order_count)) for row in rows),
+        "market_session_count": sum(
+            max(0, _safe_int(row.market_session_count)) for row in rows
+        ),
+        "latest_window_ended_at": _isoformat(rows[0].window_ended_at if rows else None),
+        "evidence_provenance_counts": provenance_counts,
+        "evidence_maturity_counts": maturity_counts,
+        "db_row_refs": [str(row.id) for row in rows],
+    }
+
+
+def _promotion_decision_summary(
+    session: Session,
+    *,
+    hypothesis_id: str | None,
+    candidate_id: str | None,
+) -> dict[str, object]:
+    stmt = select(StrategyPromotionDecision).order_by(
+        StrategyPromotionDecision.created_at.desc()
+    )
+    stmt = _target_filters(
+        stmt,
+        StrategyPromotionDecision,
+        hypothesis_id=hypothesis_id,
+        candidate_id=candidate_id,
+    )
+    rows = list(session.execute(stmt.limit(20)).scalars())
+    latest = rows[0] if rows else None
+    return {
+        "decision_count": len(rows),
+        "allowed_count": sum(int(bool(row.allowed)) for row in rows),
+        "latest": None
+        if latest is None
+        else {
+            "id": str(latest.id),
+            "run_id": latest.run_id,
+            "promotion_target": latest.promotion_target,
+            "state": latest.state,
+            "allowed": bool(latest.allowed),
+            "reason_summary": latest.reason_summary,
+            "created_at": _isoformat(latest.created_at),
+        },
+        "db_row_refs": [str(row.id) for row in rows],
+    }
+
+
+def _readiness_blockers(
+    *,
+    target: Mapping[str, object],
+    probe: Mapping[str, object],
+    source_activity: Mapping[str, object],
+    runtime_ledger: Mapping[str, object],
+    hypothesis_windows: Mapping[str, object],
+    promotion_decisions: Mapping[str, object],
+) -> list[str]:
+    blockers = {
+        str(item).strip()
+        for key in (
+            "final_promotion_blockers",
+            "candidate_blockers",
+            "runtime_ledger_target_metadata_blockers",
+        )
+        for item in _as_sequence(target.get(key))
+        if str(item).strip()
+    }
+    if not bool(target.get("promotion_allowed")):
+        blockers.add("paper_probation_evidence_collection_only")
+    if not bool(probe.get("configured_enabled")):
+        blockers.add("paper_route_probe_disabled")
+    if _safe_int(probe.get("eligible_symbol_count")) <= 0:
+        blockers.add("paper_route_probe_candidate_missing")
+    probe_blockers = [
+        str(item).strip()
+        for item in _as_sequence(probe.get("blocking_reasons"))
+        if str(item).strip() and str(item).strip() != "market_session_closed"
+    ]
+    blockers.update(probe_blockers)
+    blockers.update(
+        str(item).strip()
+        for item in _as_sequence(source_activity.get("missing_reasons"))
+        if str(item).strip()
+    )
+    if _safe_int(runtime_ledger.get("bucket_count")) <= 0:
+        blockers.add("runtime_ledger_bucket_missing")
+    if _safe_int(runtime_ledger.get("evidence_grade_bucket_count")) <= 0:
+        blockers.add("runtime_ledger_evidence_grade_bucket_missing")
+    if _safe_int(hypothesis_windows.get("window_count")) <= 0:
+        blockers.add("hypothesis_window_missing")
+    if _safe_int(promotion_decisions.get("decision_count")) <= 0:
+        blockers.add("promotion_decision_missing")
+    else:
+        latest = _as_mapping(promotion_decisions.get("latest"))
+        if not bool(latest.get("allowed")):
+            blockers.add("promotion_decision_not_allowed")
+    return sorted(blockers)
+
+
+def _target_audit(
+    session: Session,
+    *,
+    raw_target: Mapping[str, Any],
+    probe: Mapping[str, object],
+    generated_at: datetime,
+    lookback_hours: int,
+) -> dict[str, object]:
+    target = _target_identity(raw_target)
+    window_start, window_end = _target_window(
+        target,
+        generated_at=generated_at,
+        lookback_hours=lookback_hours,
+    )
+    hypothesis_id = cast(str | None, target.get("hypothesis_id"))
+    candidate_id = cast(str | None, target.get("candidate_id"))
+    source_activity = _strategy_source_activity(
+        session,
+        strategy_name=cast(str | None, target.get("strategy_name")),
+        window_start=window_start,
+    )
+    runtime_ledger = _runtime_ledger_summary(
+        session,
+        hypothesis_id=hypothesis_id,
+        candidate_id=candidate_id,
+        window_start=window_start,
+        window_end=window_end,
+    )
+    hypothesis_windows = _hypothesis_window_summary(
+        session,
+        hypothesis_id=hypothesis_id,
+        candidate_id=candidate_id,
+        window_start=window_start,
+        window_end=window_end,
+    )
+    promotion_decisions = _promotion_decision_summary(
+        session,
+        hypothesis_id=hypothesis_id,
+        candidate_id=candidate_id,
+    )
+    blockers = _readiness_blockers(
+        target=target,
+        probe=probe,
+        source_activity=source_activity,
+        runtime_ledger=runtime_ledger,
+        hypothesis_windows=hypothesis_windows,
+        promotion_decisions=promotion_decisions,
+    )
+    return {
+        "target": target,
+        "window": {
+            "start": _isoformat(window_start),
+            "end": _isoformat(window_end),
+        },
+        "source_activity": source_activity,
+        "runtime_ledger": runtime_ledger,
+        "hypothesis_windows": hypothesis_windows,
+        "promotion_decisions": promotion_decisions,
+        "readiness": {
+            "state": "evidence_collection_blocked"
+            if blockers
+            else "paper_evidence_collecting",
+            "promotion_allowed": bool(target.get("promotion_allowed")),
+            "final_promotion_allowed": bool(target.get("final_promotion_allowed")),
+            "blockers": blockers,
+        },
+    }
+
+
+def build_paper_route_evidence_audit(
+    session: Session,
+    *,
+    live_submission_gate: Mapping[str, Any],
+    route_reacquisition_book: Mapping[str, Any],
+    generated_at: datetime | None = None,
+    lookback_hours: int = DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+    target_limit: int = DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
+) -> dict[str, object]:
+    """Build a target-by-target audit for paper-route evidence collection."""
+
+    resolved_generated_at = generated_at or datetime.now(timezone.utc)
+    plan = _as_mapping(
+        live_submission_gate.get("runtime_ledger_paper_probation_import_plan")
+    )
+    targets = _as_mapping_items(plan.get("targets"))[: max(0, target_limit)]
+    probe = _paper_route_probe_summary(route_reacquisition_book)
+    target_audits = [
+        _target_audit(
+            session,
+            raw_target=target,
+            probe=probe,
+            generated_at=resolved_generated_at,
+            lookback_hours=lookback_hours,
+        )
+        for target in targets
+    ]
+    summary_blockers = sorted(
+        {
+            str(blocker)
+            for audit in target_audits
+            for blocker in _as_sequence(
+                _as_mapping(audit.get("readiness")).get("blockers")
+            )
+        }
+    )
+    if not targets:
+        summary_blockers.append("paper_probation_import_plan_missing")
+    return {
+        "schema_version": PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION,
+        "generated_at": _isoformat(resolved_generated_at),
+        "window": {
+            "lookback_hours": lookback_hours,
+            "target_limit": target_limit,
+        },
+        "live_submission_gate": {
+            "allowed": bool(live_submission_gate.get("allowed")),
+            "reason": _safe_text(live_submission_gate.get("reason")),
+            "blocked_reasons": [
+                str(item).strip()
+                for item in _as_sequence(live_submission_gate.get("blocked_reasons"))
+                if str(item).strip()
+            ],
+            "promotion_eligible_total": _safe_int(
+                live_submission_gate.get("promotion_eligible_total")
+            ),
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": _safe_text(plan.get("schema_version")),
+                "target_count": _safe_int(plan.get("target_count") or len(targets)),
+                "skipped_target_count": _safe_int(plan.get("skipped_target_count")),
+                "promotion_allowed": bool(plan.get("promotion_allowed")),
+                "final_promotion_allowed": bool(
+                    plan.get("final_promotion_allowed")
+                    or plan.get("final_promotion_authorized")
+                ),
+            },
+        },
+        "paper_route_probe": probe,
+        "summary": {
+            "target_count": len(targets),
+            "target_with_source_activity_count": sum(
+                int(not bool(_as_mapping(audit.get("source_activity")).get("missing")))
+                for audit in target_audits
+            ),
+            "target_with_runtime_ledger_count": sum(
+                int(
+                    _safe_int(
+                        _as_mapping(audit.get("runtime_ledger")).get("bucket_count")
+                    )
+                    > 0
+                )
+                for audit in target_audits
+            ),
+            "target_with_promotion_decision_count": sum(
+                int(
+                    _safe_int(
+                        _as_mapping(audit.get("promotion_decisions")).get(
+                            "decision_count"
+                        )
+                    )
+                    > 0
+                )
+                for audit in target_audits
+            ),
+            "promotion_allowed_count": sum(
+                int(
+                    bool(
+                        _as_mapping(_as_mapping(audit.get("target"))).get(
+                            "promotion_allowed"
+                        )
+                    )
+                )
+                for audit in target_audits
+            ),
+            "final_promotion_allowed_count": sum(
+                int(
+                    bool(
+                        _as_mapping(_as_mapping(audit.get("target"))).get(
+                            "final_promotion_allowed"
+                        )
+                    )
+                )
+                for audit in target_audits
+            ),
+            "blockers": summary_blockers,
+        },
+        "targets": target_audits,
+    }
+
+
+__all__ = [
+    "DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS",
+    "PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION",
+    "build_paper_route_evidence_audit",
+]

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.models import (
+    Base,
+    Execution,
+    ExecutionTCAMetric,
+    Strategy,
+    StrategyHypothesisMetricWindow,
+    StrategyPromotionDecision,
+    StrategyRuntimeLedgerBucket,
+    TradeDecision,
+)
+from app.trading.paper_route_evidence import build_paper_route_evidence_audit
+
+
+class TestPaperRouteEvidenceAudit(TestCase):
+    def setUp(self) -> None:
+        self.engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(self.engine)
+
+    def test_builder_reports_missing_import_plan_without_promotion_authority(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "runtime_ledger_missing",
+                    "blocked_reasons": "not-a-list",
+                    "promotion_eligible_total": 3.8,
+                },
+                route_reacquisition_book={
+                    "summary": "not-a-dict",
+                    "paper_route_probe": {
+                        "configured_enabled": False,
+                        "eligible_symbol_count": "not-an-int",
+                    },
+                },
+                generated_at=datetime(2026, 5, 24, 12, tzinfo=timezone.utc),
+                target_limit=3,
+            )
+
+        self.assertEqual(payload["summary"]["target_count"], 0)
+        self.assertEqual(
+            payload["summary"]["blockers"],
+            ["paper_probation_import_plan_missing"],
+        )
+        self.assertEqual(payload["paper_route_probe"]["schema_version"], "missing")
+        self.assertEqual(payload["paper_route_probe"]["state"], "unknown")
+        self.assertEqual(
+            payload["live_submission_gate"]["promotion_eligible_total"],
+            3,
+        )
+
+    def test_builder_blocks_target_without_identity_or_probe_candidate(self) -> None:
+        now = datetime(2026, 5, 24, 12, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_probe_disabled",
+                    "blocked_reasons": ["paper_probe_disabled"],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": Decimal("1"),
+                        "skipped_target_count": True,
+                        "promotion_allowed": False,
+                        "final_promotion_authorized": False,
+                        "targets": [
+                            {
+                                "window_start": now.isoformat(),
+                                "window_end": (now - timedelta(hours=1)).isoformat(),
+                                "promotion_allowed": False,
+                                "candidate_blockers": ["manual_review_required"],
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "paper_route_probe": {
+                        "configured_enabled": False,
+                        "active": False,
+                        "effective_max_notional": None,
+                        "next_session_max_notional": None,
+                        "eligible_symbol_count": 0,
+                        "blocking_reasons": ["paper_route_probe_disabled"],
+                    },
+                },
+                generated_at=now,
+                lookback_hours=6,
+            )
+
+        self.assertEqual(payload["summary"]["target_count"], 1)
+        self.assertEqual(
+            payload["live_submission_gate"][
+                "runtime_ledger_paper_probation_import_plan"
+            ]["target_count"],
+            1,
+        )
+        self.assertEqual(
+            payload["live_submission_gate"][
+                "runtime_ledger_paper_probation_import_plan"
+            ]["skipped_target_count"],
+            1,
+        )
+        audit = payload["targets"][0]
+        self.assertIsNone(audit["target"]["hypothesis_id"])
+        self.assertEqual(
+            audit["source_activity"]["missing_reasons"], ["strategy_name_missing"]
+        )
+        blockers = set(audit["readiness"]["blockers"])
+        self.assertIn("manual_review_required", blockers)
+        self.assertIn("paper_probation_evidence_collection_only", blockers)
+        self.assertIn("paper_route_probe_disabled", blockers)
+        self.assertIn("paper_route_probe_candidate_missing", blockers)
+        self.assertIn("runtime_ledger_bucket_missing", blockers)
+        self.assertIn("runtime_ledger_evidence_grade_bucket_missing", blockers)
+        self.assertIn("hypothesis_window_missing", blockers)
+        self.assertIn("promotion_decision_missing", blockers)
+
+    def test_builder_joins_source_activity_runtime_ledger_and_decisions(self) -> None:
+        now = datetime(2026, 5, 24, 12, tzinfo=timezone.utc)
+        window_start = now - timedelta(hours=2)
+        strategy_name = "active-paper-route"
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="paper route source activity",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={"action": "buy", "qty": "2"},
+                rationale="paper route fixture",
+                status="executed",
+                created_at=window_start + timedelta(minutes=10),
+                executed_at=window_start + timedelta(minutes=11),
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="paper",
+                alpaca_order_id="paper-route-order-1",
+                client_order_id="paper-route-client-1",
+                symbol="AAPL",
+                side="buy",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("2"),
+                filled_qty=Decimal("2"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=window_start + timedelta(minutes=12),
+                updated_at=window_start + timedelta(minutes=12),
+                last_update_at=window_start + timedelta(minutes=12),
+            )
+            session.add(execution)
+            session.flush()
+            session.add_all(
+                [
+                    ExecutionTCAMetric(
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        strategy_id=strategy.id,
+                        alpaca_account_label="paper",
+                        symbol="AAPL",
+                        side="buy",
+                        arrival_price=Decimal("99"),
+                        avg_fill_price=Decimal("100"),
+                        filled_qty=Decimal("2"),
+                        signed_qty=Decimal("2"),
+                        slippage_bps=Decimal("5"),
+                        shortfall_notional=Decimal("1"),
+                        realized_shortfall_bps=Decimal("5"),
+                        churn_qty=Decimal("0"),
+                        churn_ratio=Decimal("0"),
+                        computed_at=window_start + timedelta(minutes=13),
+                        created_at=window_start + timedelta(minutes=13),
+                        updated_at=window_start + timedelta(minutes=13),
+                    ),
+                    StrategyRuntimeLedgerBucket(
+                        run_id="paper-route-run-2",
+                        candidate_id="candidate-active-route",
+                        hypothesis_id="H-ACTIVE-ROUTE",
+                        observed_stage="paper",
+                        bucket_started_at=window_start,
+                        bucket_ended_at=now,
+                        account_label="paper",
+                        runtime_strategy_name=strategy_name,
+                        strategy_family="microbar_pairs",
+                        fill_count=2,
+                        decision_count=1,
+                        submitted_order_count=1,
+                        closed_trade_count=1,
+                        open_position_count=0,
+                        filled_notional=Decimal("200"),
+                        gross_strategy_pnl=Decimal("12"),
+                        cost_amount=Decimal("2"),
+                        net_strategy_pnl_after_costs=Decimal("10"),
+                        post_cost_expectancy_bps=Decimal("500"),
+                        ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={"policy-a": 1},
+                        cost_model_hash_counts={"cost-a": 1},
+                        lineage_hash_counts={"lineage-a": 1},
+                        blockers_json=[],
+                    ),
+                    StrategyHypothesisMetricWindow(
+                        run_id="paper-route-run-2",
+                        candidate_id="candidate-active-route",
+                        hypothesis_id="H-ACTIVE-ROUTE",
+                        observed_stage="paper",
+                        window_started_at=window_start,
+                        window_ended_at=now,
+                        market_session_count=1,
+                        decision_count=1,
+                        trade_count=1,
+                        order_count=1,
+                        evidence_provenance=None,
+                        evidence_maturity=None,
+                    ),
+                    StrategyPromotionDecision(
+                        run_id="paper-route-run-2",
+                        candidate_id="candidate-active-route",
+                        hypothesis_id="H-ACTIVE-ROUTE",
+                        promotion_target="paper",
+                        state="allowed",
+                        allowed=True,
+                        reason_summary="paper_evidence_collecting",
+                        created_at=now,
+                        updated_at=now,
+                    ),
+                ]
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 1,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": "1",
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-ACTIVE-ROUTE",
+                                "candidate_id": "candidate-active-route",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": strategy_name,
+                                "account_label": "paper",
+                                "window_start": window_start.isoformat(),
+                                "window_end": now.isoformat(),
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": True,
+                                "final_promotion_authorized": True,
+                                "max_notional": True,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": ["AAPL"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                    },
+                },
+                generated_at=now,
+            )
+
+        audit = payload["targets"][0]
+        self.assertFalse(audit["source_activity"]["missing"])
+        self.assertEqual(audit["source_activity"]["decision_count"], 1)
+        self.assertEqual(audit["source_activity"]["execution_count"], 1)
+        self.assertEqual(audit["source_activity"]["filled_execution_count"], 1)
+        self.assertEqual(audit["source_activity"]["tca_sample_count"], 1)
+        self.assertEqual(audit["runtime_ledger"]["evidence_grade_bucket_count"], 1)
+        self.assertEqual(audit["runtime_ledger"]["post_cost_expectancy_bps"], "500")
+        self.assertEqual(
+            audit["hypothesis_windows"]["evidence_provenance_counts"],
+            {"missing": 1},
+        )
+        self.assertEqual(audit["promotion_decisions"]["allowed_count"], 1)
+        self.assertEqual(audit["readiness"]["state"], "paper_evidence_collecting")
+        self.assertEqual(audit["readiness"]["blockers"], [])
+        self.assertEqual(payload["summary"]["target_with_source_activity_count"], 1)
+        self.assertEqual(payload["summary"]["target_with_runtime_ledger_count"], 1)
+        self.assertEqual(payload["summary"]["target_with_promotion_decision_count"], 1)

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -62,6 +62,7 @@ from app.models import (
     Strategy,
     StrategyHypothesisMetricWindow,
     StrategyPromotionDecision,
+    StrategyRuntimeLedgerBucket,
     TradeDecision,
     VNextEmpiricalJobRun,
 )
@@ -6789,6 +6790,180 @@ class TestTradingApi(TestCase):
             self.assertEqual(payload["realized_pnl_summary"]["tca_sample_count"], 0)
             caveat_codes = {item["code"] for item in payload["caveats"]}
             self.assertIn("empty_window_no_runtime_evidence", caveat_codes)
+        finally:
+            if original_scheduler is None:
+                if hasattr(app.state, "trading_scheduler"):
+                    del app.state.trading_scheduler
+            else:
+                app.state.trading_scheduler = original_scheduler
+
+    def test_trading_paper_route_evidence_endpoint_audits_probation_targets(
+        self,
+    ) -> None:
+        original_scheduler = getattr(app.state, "trading_scheduler", None)
+        now = datetime.now(timezone.utc)
+        window_start = now - timedelta(hours=2)
+        window_end = now
+        with self.session_local() as session:
+            bucket = StrategyRuntimeLedgerBucket(
+                run_id="paper-route-run-1",
+                candidate_id="candidate-paper-route",
+                hypothesis_id="H-PAPER-ROUTE",
+                observed_stage="paper",
+                bucket_started_at=window_start,
+                bucket_ended_at=window_end,
+                account_label="paper",
+                runtime_strategy_name="missing-paper-route-strategy",
+                strategy_family="microbar_pairs",
+                fill_count=4,
+                decision_count=5,
+                submitted_order_count=4,
+                closed_trade_count=2,
+                open_position_count=0,
+                filled_notional=Decimal("12500"),
+                gross_strategy_pnl=Decimal("83"),
+                cost_amount=Decimal("3"),
+                net_strategy_pnl_after_costs=Decimal("80"),
+                post_cost_expectancy_bps=Decimal("64"),
+                ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                execution_policy_hash_counts={"policy-a": 4},
+                cost_model_hash_counts={"cost-a": 4},
+                lineage_hash_counts={"lineage-a": 4},
+                blockers_json=[],
+            )
+            metric_window = StrategyHypothesisMetricWindow(
+                run_id="paper-route-run-1",
+                candidate_id="candidate-paper-route",
+                hypothesis_id="H-PAPER-ROUTE",
+                observed_stage="paper",
+                window_started_at=window_start,
+                window_ended_at=window_end,
+                market_session_count=2,
+                decision_count=5,
+                trade_count=2,
+                order_count=4,
+                evidence_provenance="paper_runtime_observed",
+                evidence_maturity="empirically_validated",
+                decision_alignment_ratio="1",
+                avg_abs_slippage_bps="3",
+                slippage_budget_bps="10",
+                post_cost_expectancy_bps="64",
+                continuity_ok=True,
+                drift_ok=True,
+                dependency_quorum_decision="allow",
+                capital_stage="shadow",
+            )
+            promotion_decision = StrategyPromotionDecision(
+                run_id="paper-route-run-1",
+                candidate_id="candidate-paper-route",
+                hypothesis_id="H-PAPER-ROUTE",
+                promotion_target="paper",
+                state="blocked",
+                allowed=False,
+                reason_summary="paper_probation_evidence_collection_only",
+            )
+            session.add_all([bucket, metric_window, promotion_decision])
+            session.commit()
+
+        target = {
+            "hypothesis_id": "H-PAPER-ROUTE",
+            "candidate_id": "candidate-paper-route",
+            "observed_stage": "paper",
+            "strategy_family": "microbar_pairs",
+            "strategy_name": "missing-paper-route-strategy",
+            "account_label": "paper",
+            "source_kind": "durable_runtime_ledger_bucket",
+            "source_manifest_ref": "config/trading/hypotheses/h-paper-route.json",
+            "dataset_snapshot_ref": "dataset://paper-route",
+            "window_start": window_start.isoformat(),
+            "window_end": window_end.isoformat(),
+            "runtime_ledger_bucket_ref": (
+                "strategy_runtime_ledger_buckets:paper-route-run-1:"
+                f"{window_start.isoformat()}:{window_end.isoformat()}"
+            ),
+            "paper_probation_authorized": True,
+            "paper_probation_authorization_scope": "evidence_collection_only",
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "final_promotion_blockers": [
+                "runtime_ledger_stage_not_live",
+                "paper_probation_evidence_collection_only",
+            ],
+            "max_notional": "0",
+        }
+        live_gate = {
+            "allowed": False,
+            "reason": "alpha_readiness_not_promotion_eligible",
+            "blocked_reasons": ["alpha_readiness_not_promotion_eligible"],
+            "promotion_eligible_total": 0,
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "skipped_target_count": 0,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "targets": [target],
+            },
+        }
+        proof_floor = {
+            "route_reacquisition_book": {
+                "schema_version": "torghut.route-reacquisition-book.v1",
+                "state": "repair_only",
+                "summary": {
+                    "paper_route_probe_eligible_symbols": ["AAPL"],
+                    "paper_route_probe_active_symbols": [],
+                },
+                "paper_route_probe": {
+                    "configured_enabled": True,
+                    "active": False,
+                    "effective_max_notional": "0",
+                    "next_session_max_notional": "25",
+                    "eligible_symbol_count": 1,
+                    "eligible_symbols": ["AAPL"],
+                    "active_symbols": [],
+                    "blocking_reasons": ["market_session_closed"],
+                },
+            }
+        }
+        try:
+            app.state.trading_scheduler = TradingScheduler()
+            with (
+                patch(
+                    "app.main._build_live_submission_gate_payload",
+                    return_value=live_gate,
+                ),
+                patch(
+                    "app.main._build_profitability_proof_floor_payload",
+                    return_value=proof_floor,
+                ),
+            ):
+                response = self.client.get("/trading/paper-route-evidence")
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(
+                payload["schema_version"], "torghut.paper-route-evidence.v1"
+            )
+            self.assertEqual(payload["summary"]["target_count"], 1)
+            self.assertEqual(payload["summary"]["target_with_runtime_ledger_count"], 1)
+            self.assertEqual(payload["summary"]["target_with_source_activity_count"], 0)
+            audit = payload["targets"][0]
+            self.assertFalse(audit["target"]["promotion_allowed"])
+            self.assertFalse(audit["target"]["final_promotion_allowed"])
+            self.assertTrue(audit["source_activity"]["missing"])
+            self.assertEqual(audit["runtime_ledger"]["bucket_count"], 1)
+            self.assertEqual(audit["runtime_ledger"]["fill_count"], 4)
+            self.assertEqual(audit["runtime_ledger"]["filled_notional"], "12500")
+            self.assertEqual(audit["hypothesis_windows"]["window_count"], 1)
+            self.assertEqual(audit["promotion_decisions"]["decision_count"], 1)
+            self.assertFalse(audit["promotion_decisions"]["latest"]["allowed"])
+            self.assertEqual(payload["paper_route_probe"]["eligible_symbols"], ["AAPL"])
+            blockers = set(audit["readiness"]["blockers"])
+            self.assertIn("source_decisions_missing", blockers)
+            self.assertIn("source_executions_missing", blockers)
+            self.assertIn("source_tca_missing", blockers)
+            self.assertIn("paper_probation_evidence_collection_only", blockers)
+            self.assertIn("promotion_decision_not_allowed", blockers)
         finally:
             if original_scheduler is None:
                 if hasattr(app.state, "trading_scheduler"):

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -6927,7 +6927,8 @@ class TestTradingApi(TestCase):
             }
         }
         try:
-            app.state.trading_scheduler = TradingScheduler()
+            if hasattr(app.state, "trading_scheduler"):
+                del app.state.trading_scheduler
             with (
                 patch(
                     "app.main._build_live_submission_gate_payload",


### PR DESCRIPTION
## Summary

- Add a `/trading/paper-route-evidence` operator endpoint for target-by-target paper-probation evidence audits.
- Join live paper-probation import targets with paper-route probe readiness, source activity, runtime ledger buckets, hypothesis windows, and promotion decisions.
- Preserve promotion safety by reporting `promotion_allowed=false` and blockers instead of relaxing live submission gates.
- Add focused coverage for missing import plans, disabled paper-route probes, scheduler creation, and joined source/runtime evidence.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/paper_route_evidence.py app/main.py tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py app/main.py tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py -k 'paper_route_evidence or runtime_profitability' -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py -q`
- `uv run --frozen coverage erase && uv run --frozen coverage run -m pytest tests/test_paper_route_evidence.py tests/test_trading_api.py -k 'paper_route_evidence or runtime_profitability' -q && uv run --frozen coverage xml -o coverage.xml --fail-under=0 && GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
