### PR TITLE
feat(torghut): export paper route window targets

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -34,7 +34,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref intraday_tsmom_v2@research \
                     --runtime-window-import \
-                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/status \
+                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence \
                     --runtime-window-target-plan-exclusive \
                     --runtime-window-targets-from-latest-autoresearch \
                     --runtime-window-targets-from-registry \

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -8,9 +8,10 @@ of mutating any live submission gate.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 from typing import Any, cast
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -28,8 +29,14 @@ from .runtime_ledger import POST_COST_PNL_BASIS
 
 
 PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION = "torghut.paper-route-evidence.v1"
+NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION = (
+    "torghut.next-paper-route-runtime-window-targets.v1"
+)
 DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS = 72
 DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT = 20
+US_EQUITIES_TIMEZONE = "America/New_York"
+US_EQUITIES_OPEN = time(hour=9, minute=30)
+US_EQUITIES_CLOSE = time(hour=16, minute=0)
 
 
 def _as_mapping(value: object) -> dict[str, Any]:
@@ -123,6 +130,81 @@ def _parse_datetime(value: object) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
+def _easter_date(year: int) -> date:
+    a = year % 19
+    b = year // 100
+    c = year % 100
+    d = b // 4
+    e = b % 4
+    f = (b + 8) // 25
+    g = (b - f + 1) // 3
+    h = (19 * a + b - d - g + 15) % 30
+    i = c // 4
+    k = c % 4
+    correction = (32 + 2 * e + 2 * i - h - k) % 7
+    m = (a + 11 * h + 22 * correction) // 451
+    month = (h + correction - 7 * m + 114) // 31
+    day = ((h + correction - 7 * m + 114) % 31) + 1
+    return date(year, month, day)
+
+
+def _nth_weekday(year: int, month: int, weekday: int, nth: int) -> date:
+    value = date(year, month, 1)
+    offset = (weekday - value.weekday()) % 7
+    return value + timedelta(days=offset + (nth - 1) * 7)
+
+
+def _last_weekday(year: int, month: int, weekday: int) -> date:
+    value = date(year + int(month == 12), 1 if month == 12 else month + 1, 1)
+    value -= timedelta(days=1)
+    return value - timedelta(days=(value.weekday() - weekday) % 7)
+
+
+def _observed_fixed_holiday(year: int, month: int, day: int) -> date | None:
+    value = date(year, month, day)
+    if value.weekday() == 5:
+        return None if month == 1 and day == 1 else value - timedelta(days=1)
+    if value.weekday() == 6:
+        return value + timedelta(days=1)
+    return value
+
+
+def _nyse_full_day_holidays(year: int) -> set[date]:
+    holidays = {
+        _nth_weekday(year, 1, 0, 3),
+        _nth_weekday(year, 2, 0, 3),
+        _easter_date(year) - timedelta(days=2),
+        _last_weekday(year, 5, 0),
+        _nth_weekday(year, 9, 0, 1),
+        _nth_weekday(year, 11, 3, 4),
+    }
+    for month, day in ((1, 1), (6, 19), (7, 4), (12, 25)):
+        observed = _observed_fixed_holiday(year, month, day)
+        if observed is not None:
+            holidays.add(observed)
+    return holidays
+
+
+def _regular_equities_session_date(value: date) -> bool:
+    return value.weekday() < 5 and value not in _nyse_full_day_holidays(value.year)
+
+
+def _next_regular_equities_session_window(
+    generated_at: datetime,
+) -> tuple[datetime, datetime]:
+    zone = ZoneInfo(US_EQUITIES_TIMEZONE)
+    local_generated_at = generated_at.astimezone(zone)
+    candidate_date = local_generated_at.date()
+    session_open = datetime.combine(candidate_date, US_EQUITIES_OPEN, tzinfo=zone)
+    if local_generated_at >= session_open:
+        candidate_date += timedelta(days=1)
+    while not _regular_equities_session_date(candidate_date):
+        candidate_date += timedelta(days=1)
+    start = datetime.combine(candidate_date, US_EQUITIES_OPEN, tzinfo=zone)
+    end = datetime.combine(candidate_date, US_EQUITIES_CLOSE, tzinfo=zone)
+    return start.astimezone(timezone.utc), end.astimezone(timezone.utc)
+
+
 def _paper_route_probe_summary(
     route_reacquisition_book: Mapping[str, Any],
 ) -> dict[str, object]:
@@ -166,6 +248,23 @@ def _paper_route_probe_summary(
         "active_symbols": active_symbols,
         "blocking_reasons": blocking_reasons,
     }
+
+
+def _paper_route_probe_symbols(probe: Mapping[str, object]) -> list[str]:
+    symbols: list[str] = []
+    for key in ("active_symbols", "eligible_symbols"):
+        for item in _as_sequence(probe.get(key)):
+            symbol = str(item).strip().upper()
+            if symbol and symbol not in symbols:
+                symbols.append(symbol)
+    return symbols
+
+
+def _next_session_probe_notional(probe: Mapping[str, object]) -> str:
+    next_notional = _safe_decimal(probe.get("next_session_max_notional"))
+    if next_notional > 0:
+        return _decimal_text(next_notional)
+    return _decimal_text(probe.get("effective_max_notional"))
 
 
 def _target_identity(target: Mapping[str, Any]) -> dict[str, object]:
@@ -228,6 +327,141 @@ def _target_window(
     if window_end < window_start:
         return fallback_start, fallback_end
     return window_start, window_end
+
+
+def _next_paper_route_runtime_window_targets(
+    *,
+    targets: Sequence[Mapping[str, Any]],
+    probe: Mapping[str, object],
+    generated_at: datetime,
+) -> dict[str, object]:
+    window_start, window_end = _next_regular_equities_session_window(generated_at)
+    probe_symbols = _paper_route_probe_symbols(probe)
+    next_notional = _next_session_probe_notional(probe)
+    probe_ready = (
+        bool(probe.get("configured_enabled"))
+        and _safe_decimal(next_notional) > 0
+        and bool(probe_symbols)
+    )
+    planned_targets: list[dict[str, object]] = []
+    skipped_targets: list[dict[str, object]] = []
+    for target in targets:
+        hypothesis_id = _safe_text(target.get("hypothesis_id"))
+        candidate_id = _safe_text(target.get("candidate_id"))
+        strategy_family = _safe_text(target.get("strategy_family"))
+        strategy_name = _safe_text(target.get("strategy_name"))
+        source_manifest_ref = _safe_text(target.get("source_manifest_ref"))
+        missing = [
+            field
+            for field, value in (
+                ("hypothesis_id", hypothesis_id),
+                ("candidate_id", candidate_id),
+                ("strategy_family", strategy_family),
+                ("strategy_name", strategy_name),
+                ("source_manifest_ref", source_manifest_ref),
+            )
+            if value is None
+        ]
+        if missing or not probe_ready:
+            reasons = list(missing)
+            if not probe_ready:
+                if not bool(probe.get("configured_enabled")):
+                    reasons.append("paper_route_probe_disabled")
+                if _safe_decimal(next_notional) <= 0:
+                    reasons.append("paper_route_probe_notional_missing")
+                if not probe_symbols:
+                    reasons.append("paper_route_probe_symbol_missing")
+            skipped_targets.append(
+                {
+                    "hypothesis_id": hypothesis_id,
+                    "candidate_id": candidate_id,
+                    "reason": "next_paper_route_runtime_window_target_not_ready",
+                    "missing_or_blocking_fields": reasons,
+                }
+            )
+            continue
+        planned_targets.append(
+            {
+                "hypothesis_id": hypothesis_id,
+                "candidate_id": candidate_id,
+                "observed_stage": "paper",
+                "strategy_family": strategy_family,
+                "strategy_name": strategy_name,
+                "account_label": _safe_text(target.get("account_label"))
+                or "TORGHUT_SIM",
+                "source_dsn_env": "SIM_DB_DSN",
+                "dataset_snapshot_ref": _safe_text(target.get("dataset_snapshot_ref"))
+                or "",
+                "source_manifest_ref": source_manifest_ref,
+                "source_kind": "paper_route_probe_runtime_observed",
+                "window_start": _isoformat(window_start),
+                "window_end": _isoformat(window_end),
+                "paper_route_probe_symbols": probe_symbols,
+                "paper_route_probe_symbol_count": len(probe_symbols),
+                "paper_route_probe_next_session_max_notional": next_notional,
+                "paper_route_probe_window_start": _isoformat(window_start),
+                "paper_route_probe_window_end": _isoformat(window_end),
+                "paper_probation_authorized": True,
+                "paper_probation_authorization_scope": "evidence_collection_only",
+                "evidence_collection_stage": "paper",
+                "probation_allowed": True,
+                "probation_reason": "paper_route_probe_next_session_runtime_window",
+                "selection_reason": "paper_route_probe_next_session_evidence_collection",
+                "selected_by": "paper_route_evidence_audit",
+                "promotion_allowed": False,
+                "final_promotion_authorized": False,
+                "final_promotion_allowed": False,
+                "final_promotion_blockers": [
+                    "paper_probation_evidence_collection_only",
+                    "paper_route_runtime_ledger_import_pending",
+                    "live_runtime_ledger_required",
+                ],
+                "candidate_blockers": [
+                    "paper_route_runtime_ledger_import_pending",
+                    *[
+                        str(item).strip()
+                        for item in _as_sequence(target.get("candidate_blockers"))
+                        if str(item).strip()
+                    ],
+                ],
+                "runtime_ledger_target_metadata_blockers": [
+                    "paper_route_runtime_ledger_import_pending",
+                    "live_runtime_ledger_required",
+                ],
+                "handoff": "next_paper_route_runtime_window_import",
+                "promotion_gate": "runtime_ledger_live_or_live_paper_required",
+                "max_notional": "0",
+            }
+        )
+    return {
+        "schema_version": NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION,
+        "source": "paper_route_evidence_audit",
+        "purpose": "next_session_paper_route_runtime_window_evidence_collection",
+        "promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "final_promotion_allowed": False,
+        "session_timezone": US_EQUITIES_TIMEZONE,
+        "session_window": {
+            "start": _isoformat(window_start),
+            "end": _isoformat(window_end),
+        },
+        "paper_route_probe": {
+            "configured_enabled": bool(probe.get("configured_enabled")),
+            "active": bool(probe.get("active")),
+            "symbols": probe_symbols,
+            "symbol_count": len(probe_symbols),
+            "next_session_max_notional": next_notional,
+            "blocking_reasons": [
+                str(item).strip()
+                for item in _as_sequence(probe.get("blocking_reasons"))
+                if str(item).strip()
+            ],
+        },
+        "target_count": len(planned_targets),
+        "skipped_target_count": len(skipped_targets),
+        "targets": planned_targets,
+        "skipped_targets": skipped_targets,
+    }
 
 
 def _strategy_source_activity(
@@ -677,6 +911,13 @@ def build_paper_route_evidence_audit(
             },
         },
         "paper_route_probe": probe,
+        "next_paper_route_runtime_window_targets": (
+            _next_paper_route_runtime_window_targets(
+                targets=targets,
+                probe=probe,
+                generated_at=resolved_generated_at,
+            )
+        ),
         "summary": {
             "target_count": len(targets),
             "target_with_source_activity_count": sum(
@@ -731,6 +972,7 @@ def build_paper_route_evidence_audit(
 
 __all__ = [
     "DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS",
+    "NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION",
     "PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION",
     "build_paper_route_evidence_audit",
 ]

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -79,6 +79,11 @@ RUNTIME_WINDOW_TARGET_METADATA_KEYS = (
     "final_promotion_allowed",
     "final_promotion_blockers",
     "candidate_blockers",
+    "paper_route_probe_symbols",
+    "paper_route_probe_symbol_count",
+    "paper_route_probe_next_session_max_notional",
+    "paper_route_probe_window_start",
+    "paper_route_probe_window_end",
     "handoff",
     "promotion_gate",
 )
@@ -147,7 +152,9 @@ def _parse_args() -> argparse.Namespace:
         help=(
             "Repeatable URL returning either a runtime-window import plan or a "
             "/trading/status payload with live_submission_gate."
-            "runtime_ledger_paper_probation_import_plan."
+            "runtime_ledger_paper_probation_import_plan, or a "
+            "/trading/paper-route-evidence payload with "
+            "next_paper_route_runtime_window_targets."
         ),
     )
     parser.add_argument(
@@ -403,6 +410,9 @@ def _runtime_window_target_plan_from_payload(
     )
     if top_level_gate_plan:
         return top_level_gate_plan
+    paper_route_plan = _as_dict(payload.get("next_paper_route_runtime_window_targets"))
+    if paper_route_plan:
+        return paper_route_plan
     return _as_dict(payload)
 
 

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -814,7 +814,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn(
             "--runtime-window-target-plan-url "
-            "http://torghut.torghut.svc.cluster.local/trading/status",
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
         self.assertIn("--runtime-window-target-plan-exclusive", args)

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -136,6 +136,82 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertIn("hypothesis_window_missing", blockers)
         self.assertIn("promotion_decision_missing", blockers)
 
+    def test_builder_exports_next_paper_route_runtime_window_targets(self) -> None:
+        generated_at = datetime(2026, 5, 24, 12, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAPER-ROUTE",
+                                "candidate_id": "candidate-paper-route",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": "paper-route-candidate-v1",
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "durable_runtime_ledger_bucket",
+                                "source_manifest_ref": "config/trading/hypotheses/h-paper-route.json",
+                                "dataset_snapshot_ref": "dataset://paper-route",
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["aapl"],
+                        "paper_route_probe_active_symbols": [],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": False,
+                        "next_session_max_notional": "25",
+                        "eligible_symbol_count": 1,
+                        "blocking_reasons": ["market_session_closed"],
+                    },
+                },
+                generated_at=generated_at,
+            )
+
+        plan = payload["next_paper_route_runtime_window_targets"]
+        self.assertEqual(
+            plan["schema_version"], "torghut.next-paper-route-runtime-window-targets.v1"
+        )
+        self.assertEqual(plan["target_count"], 1)
+        self.assertEqual(plan["skipped_target_count"], 0)
+        self.assertEqual(
+            plan["session_window"],
+            {
+                "start": "2026-05-26T13:30:00+00:00",
+                "end": "2026-05-26T20:00:00+00:00",
+            },
+        )
+        target = plan["targets"][0]
+        self.assertEqual(target["source_dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(target["source_kind"], "paper_route_probe_runtime_observed")
+        self.assertEqual(target["max_notional"], "0")
+        self.assertEqual(target["paper_route_probe_symbols"], ["AAPL"])
+        self.assertEqual(target["paper_route_probe_next_session_max_notional"], "25")
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_authorized"])
+        self.assertIn(
+            "paper_route_runtime_ledger_import_pending",
+            target["runtime_ledger_target_metadata_blockers"],
+        )
+
     def test_builder_joins_source_activity_runtime_ledger_and_decisions(self) -> None:
         now = datetime(2026, 5, 24, 12, tzinfo=timezone.utc)
         window_start = now - timedelta(hours=2)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -690,6 +690,80 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual(top_level_plan["targets"][0]["hypothesis_id"], "H-PAIRS-01")
         self.assertEqual(fallback_plan["targets"][0]["hypothesis_id"], "H-FALLBACK-01")
 
+    def test_runtime_window_target_plan_payload_accepts_paper_route_evidence_plan(
+        self,
+    ) -> None:
+        paper_route_plan = renewal._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-evidence.v1",
+                "next_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "targets": [
+                        {
+                            "candidate_id": "cand-paper-route",
+                            "hypothesis_id": "H-PAPER-ROUTE",
+                            "observed_stage": "paper",
+                            "strategy_family": "microbar_pairs",
+                            "strategy_name": "paper-route-candidate-v1",
+                            "source_dsn_env": "SIM_DB_DSN",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                            "source_manifest_ref": "config/trading/hypotheses/h-paper-route.json",
+                            "window_start": "2026-05-26T13:30:00+00:00",
+                            "window_end": "2026-05-26T20:00:00+00:00",
+                            "paper_route_probe_symbols": ["AAPL"],
+                            "paper_route_probe_symbol_count": 1,
+                            "paper_route_probe_next_session_max_notional": "25",
+                            "paper_route_probe_window_start": "2026-05-26T13:30:00+00:00",
+                            "paper_route_probe_window_end": "2026-05-26T20:00:00+00:00",
+                            "paper_probation_authorized": True,
+                            "promotion_allowed": False,
+                            "final_promotion_authorized": False,
+                            "final_promotion_allowed": False,
+                            "max_notional": "0",
+                        }
+                    ],
+                },
+            }
+        )
+        args = SimpleNamespace(
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[],
+            runtime_window_targets_from_registry=False,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        targets = renewal._runtime_window_targets_from_plan(
+            plan=paper_route_plan,
+            ref="paper-route-evidence",
+            args=args,
+        )
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].hypothesis_id, "H-PAPER-ROUTE")
+        self.assertEqual(targets[0].source_dsn_env, "SIM_DB_DSN")
+        self.assertEqual(targets[0].source_kind, "paper_route_probe_runtime_observed")
+        self.assertEqual(targets[0].window_start, "2026-05-26T13:30:00+00:00")
+        assert targets[0].target_metadata is not None
+        self.assertEqual(targets[0].target_metadata["max_notional"], "0")
+        self.assertEqual(
+            targets[0].target_metadata["paper_route_probe_symbols"], ["AAPL"]
+        )
+        self.assertEqual(
+            targets[0].target_metadata["paper_route_probe_next_session_max_notional"],
+            "25",
+        )
+        self.assertFalse(targets[0].target_metadata["promotion_allowed"])
+        self.assertFalse(targets[0].target_metadata["final_promotion_allowed"])
+
     def test_runtime_window_target_plan_url_failures_are_fail_closed(self) -> None:
         with self.assertRaisesRegex(
             RuntimeError, "runtime_window_target_plan_url_empty"

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -6959,6 +6959,21 @@ class TestTradingApi(TestCase):
             self.assertEqual(audit["promotion_decisions"]["decision_count"], 1)
             self.assertFalse(audit["promotion_decisions"]["latest"]["allowed"])
             self.assertEqual(payload["paper_route_probe"]["eligible_symbols"], ["AAPL"])
+            next_plan = payload["next_paper_route_runtime_window_targets"]
+            self.assertEqual(
+                next_plan["schema_version"],
+                "torghut.next-paper-route-runtime-window-targets.v1",
+            )
+            self.assertEqual(next_plan["target_count"], 1)
+            next_target = next_plan["targets"][0]
+            self.assertEqual(next_target["source_dsn_env"], "SIM_DB_DSN")
+            self.assertEqual(
+                next_target["source_kind"], "paper_route_probe_runtime_observed"
+            )
+            self.assertEqual(next_target["paper_route_probe_symbols"], ["AAPL"])
+            self.assertEqual(next_target["max_notional"], "0")
+            self.assertFalse(next_target["promotion_allowed"])
+            self.assertFalse(next_target["final_promotion_allowed"])
             blockers = set(audit["readiness"]["blockers"])
             self.assertIn("source_decisions_missing", blockers)
             self.assertIn("source_executions_missing", blockers)


### PR DESCRIPTION
## Summary

- Adds `next_paper_route_runtime_window_targets` to `/trading/paper-route-evidence` so paper-probation candidates produce zero-notional next-session runtime-window import targets.
- Teaches `renew_latest_empirical_promotion_jobs.py` to consume the new paper-route evidence plan shape and preserve paper-route metadata through target imports.
- Updates the empirical promotion renewal CronJob to use the paper-route evidence endpoint through GitOps, while keeping final promotion blocked until runtime-ledger proof exists.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py tests/test_trading_api.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py tests/test_trading_api.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k 'paper_route_evidence_plan or runtime_window_targets_from_live_gate_plan_url_preserve_window_targets or runtime_window_targets_from_candidate_board_plan' -q`
- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_evidence_endpoint' -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k 'empirical_promotion_renewal_imports_paper_windows_from_sim_db' -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py -q`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
