### PR TITLE
fix(torghut): advertise paper probe target budget

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -90,7 +90,9 @@ spec:
             - name: TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED
               value: "false"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
-              value: "false"
+              value: "true"
+            - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
+              value: "25"
             - name: TRADING_MARKET_CONTEXT_URL
               value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context
             - name: TRADING_JANGAR_CONTROL_PLANE_STATUS_URL

--- a/services/torghut/app/trading/route_reacquisition.py
+++ b/services/torghut/app/trading/route_reacquisition.py
@@ -365,9 +365,7 @@ def build_route_reacquisition_book(
     effective_probe_limit = configured_probe_limit if probe_active else "0"
     next_session_probe_limit = (
         configured_probe_limit
-        if paper_route_probe_enabled
-        and trading_mode == "paper"
-        and configured_probe_limit is not None
+        if paper_route_probe_enabled and configured_probe_limit is not None
         else "0"
     )
     active_probe_symbols = eligible_probe_symbols if probe_active else []

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1011,9 +1011,8 @@ class TestLiveConfigManifestContract(TestCase):
             context="live static universe",
         )
         self.assertFalse(_manifest_bool(env, "TRADING_SIMPLE_SUBMIT_ENABLED"))
-        self.assertFalse(
-            _manifest_bool(env, "TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED")
-        )
+        self.assertTrue(_manifest_bool(env, "TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED"))
+        self.assertEqual(env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"), "25")
         self.assertFalse(_manifest_bool(env, "TRADING_ALPACA_QUOTE_FALLBACK_ENABLED"))
         self.assertFalse(_manifest_bool(env, "TRADING_AUTONOMY_ENABLED"))
         self.assertFalse(_manifest_bool(env, "TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION"))

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -180,7 +180,10 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         "active": False,
                         "next_session_max_notional": "25",
                         "eligible_symbol_count": 1,
-                        "blocking_reasons": ["market_session_closed"],
+                        "blocking_reasons": [
+                            "not_paper_mode",
+                            "market_session_closed",
+                        ],
                     },
                 },
                 generated_at=generated_at,
@@ -205,6 +208,10 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(target["max_notional"], "0")
         self.assertEqual(target["paper_route_probe_symbols"], ["AAPL"])
         self.assertEqual(target["paper_route_probe_next_session_max_notional"], "25")
+        self.assertEqual(
+            plan["paper_route_probe"]["blocking_reasons"],
+            ["not_paper_mode", "market_session_closed"],
+        )
         self.assertFalse(target["promotion_allowed"])
         self.assertFalse(target["final_promotion_authorized"])
         self.assertIn(

--- a/services/torghut/tests/test_route_reacquisition.py
+++ b/services/torghut/tests/test_route_reacquisition.py
@@ -371,6 +371,61 @@ def test_route_book_surfaces_paper_route_probe_readiness_without_capital_authori
     assert candidate_probe["next_session_notional_limit"] == "25.0"
 
 
+def test_live_route_book_can_advertise_next_session_paper_probe_without_capital_authority() -> (
+    None
+):
+    book = build_route_reacquisition_book(
+        proof_floor_receipt={
+            "generated_at": "2026-05-24T06:42:27.532861+00:00",
+            "account_label": "PA3SX7FYNUTF",
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "proof_dimensions": [
+                {
+                    "dimension": "execution_tca",
+                    "state": "pass",
+                    "source_ref": {
+                        "symbol_routes": {
+                            "scope_symbols": ["AAPL"],
+                            "scope_symbol_count": 1,
+                            "routeable_symbols": [],
+                            "blocked_symbols": [],
+                            "missing_symbols": ["AAPL"],
+                        }
+                    },
+                },
+                {"dimension": "market_context", "state": "pass"},
+                {"dimension": "quant_ingestion", "state": "pass"},
+                {"dimension": "alpha_readiness", "state": "fail"},
+            ],
+        },
+        trading_mode="live",
+        market_session_open=False,
+        paper_route_probe_enabled=True,
+        paper_route_probe_max_notional="25",
+    )
+
+    probe = cast(Mapping[str, Any], book["paper_route_probe"])
+    assert probe["configured_enabled"] is True
+    assert probe["active"] is False
+    assert probe["effective_max_notional"] == "0"
+    assert probe["next_session_max_notional"] == "25"
+    assert probe["eligible_symbols"] == ["AAPL"]
+    assert probe["active_symbols"] == []
+    assert probe["blocking_reasons"] == ["not_paper_mode", "market_session_closed"]
+    assert probe["capital_authority"] == "none"
+    assert book["capital_rule"] == "live_zero_notional_unchanged"
+
+    records = cast(list[Mapping[str, Any]], book["records"])
+    aapl = next(item for item in records if item["symbol"] == "AAPL")
+    aapl_probe = cast(Mapping[str, Any], aapl["paper_route_probe"])
+    assert aapl["paper_probe_notional_limit"] == "0"
+    assert aapl_probe["active"] is False
+    assert aapl_probe["notional_limit"] == "0"
+    assert aapl_probe["next_session_notional_limit"] == "25"
+    assert aapl_probe["capital_authority"] == "none"
+
+
 def test_route_book_marks_paper_route_probe_active_only_when_market_open() -> None:
     book = build_route_reacquisition_book(
         proof_floor_receipt={


### PR DESCRIPTION
## Summary

- Allows the route-reacquisition book to advertise a configured next-session paper-probe budget even when the live service itself remains non-paper and zero-submit.
- Enables the live Torghut GitOps manifest to expose the same bounded `25` paper-route probe budget used by `torghut-sim`, while keeping `TRADING_SIMPLE_SUBMIT_ENABLED=false`.
- Covers the live diagnostic contract so `/trading/paper-route-evidence` can emit next-session paper-route runtime-window targets instead of skipping H-PAIRS on missing probe notional.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/route_reacquisition.py tests/test_route_reacquisition.py tests/test_paper_route_evidence.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check app/trading/route_reacquisition.py tests/test_route_reacquisition.py tests/test_paper_route_evidence.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest tests/test_route_reacquisition.py tests/test_paper_route_evidence.py tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_evidence_endpoint' -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k 'paper_route_evidence_plan or runtime_window_target_plan_payload_accepts_paper_route_evidence_plan' -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
