### PR TITLE
ci(torghut): wait for registry before build push

### DIFF
--- a/.github/workflows/torghut-build-push.yaml
+++ b/.github/workflows/torghut-build-push.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   build-and-push:
     runs-on: arc-arm64
-    timeout-minutes: 60
+    timeout-minutes: 180
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -41,6 +41,41 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Wait for private registry
+        shell: bash
+        env:
+          REGISTRY_URL: https://registry.ide-newton.ts.net/v2/
+          REGISTRY_WAIT_TIMEOUT_SECONDS: 7200
+          REGISTRY_WAIT_INTERVAL_SECONDS: 60
+        run: |
+          set -euo pipefail
+
+          deadline=$((SECONDS + REGISTRY_WAIT_TIMEOUT_SECONDS))
+
+          while true; do
+            status="$(curl -sS -o /tmp/torghut-registry-health.txt -w '%{http_code}' "${REGISTRY_URL}" || true)"
+
+            case "${status}" in
+              200|401)
+                echo "Registry is reachable at ${REGISTRY_URL} (HTTP ${status})."
+                exit 0
+                ;;
+              502|503|504|000)
+                if (( SECONDS >= deadline )); then
+                  echo "Timed out waiting for ${REGISTRY_URL}; last HTTP status was ${status}."
+                  exit 1
+                fi
+
+                echo "Registry is temporarily unavailable at ${REGISTRY_URL} (HTTP ${status}); retrying in ${REGISTRY_WAIT_INTERVAL_SECONDS}s."
+                sleep "${REGISTRY_WAIT_INTERVAL_SECONDS}"
+                ;;
+              *)
+                echo "Registry returned unexpected HTTP status ${status} for ${REGISTRY_URL}."
+                exit 1
+                ;;
+            esac
+          done
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -30,6 +30,18 @@ describe('torghut build-push workflow', () => {
     expect(cacheStep).toBe(-1)
   })
 
+  it('waits for the private registry before building the release image', () => {
+    const buildJob = workflow.indexOf('build-and-push:')
+    const registryWaitStep = workflow.indexOf('name: Wait for private registry', buildJob)
+    const buildStep = workflow.indexOf('name: Build and push torghut image', buildJob)
+
+    expect(workflow).toContain('timeout-minutes: 180')
+    expect(registryWaitStep).toBeGreaterThan(buildJob)
+    expect(buildStep).toBeGreaterThan(registryWaitStep)
+    expect(workflow).toContain('REGISTRY_URL: https://registry.ide-newton.ts.net/v2/')
+    expect(workflow).toContain('REGISTRY_WAIT_TIMEOUT_SECONDS: 7200')
+  })
+
   it('caches Bun downloads before manifest-only CI installs script dependencies', () => {
     const releaseManifestJob = ciWorkflow.indexOf('release-manifests:')
     const cacheStep = ciWorkflow.indexOf('name: Cache Bun downloads', releaseManifestJob)


### PR DESCRIPTION
## Summary

- Add a Torghut build-push preflight that waits for the private registry `/v2/` API before starting the image build.
- Extend the Torghut build-push job timeout so scheduled registry GC can finish before buildx spends work on an image push.
- Cover the workflow contract with a targeted test that verifies the registry wait happens before the build step.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts`
- `git diff --check`
- `bunx actionlint -ignore 'label "arc-arm64" is unknown' .github/workflows/torghut-build-push.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
