### PR TITLE
fix(torghut): require paper route target plan

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -36,6 +36,7 @@ spec:
                     --runtime-window-import \
                     --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence \
                     --runtime-window-target-plan-exclusive \
+                    --runtime-window-target-plan-required \
                     --runtime-window-targets-from-latest-autoresearch \
                     --runtime-window-targets-from-registry \
                     --runtime-window-hypothesis-id H-TSMOM-01 \

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -171,6 +171,15 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--runtime-window-target-plan-required",
+        action="store_true",
+        help=(
+            "Fail closed when runtime-window target plan refs/urls are missing or "
+            "produce no targets instead of falling back to autoresearch or registry "
+            "targets."
+        ),
+    )
+    parser.add_argument(
         "--runtime-window-targets-from-latest-autoresearch",
         action="store_true",
         help=(
@@ -571,6 +580,20 @@ def _runtime_window_plan_targets(
     return targets
 
 
+def _runtime_window_target_plan_ref_count(args: argparse.Namespace) -> int:
+    file_refs = [
+        str(item).strip()
+        for item in getattr(args, "runtime_window_target_plan_ref", []) or []
+        if str(item).strip()
+    ]
+    url_refs = [
+        str(item).strip()
+        for item in getattr(args, "runtime_window_target_plan_url", []) or []
+        if str(item).strip()
+    ]
+    return len(file_refs) + len(url_refs)
+
+
 def _runtime_window_targets_from_plan(
     *,
     plan: Mapping[str, Any],
@@ -785,6 +808,13 @@ def _runtime_window_targets(
 ) -> list[RuntimeWindowImportTarget]:
     specs = [str(item) for item in getattr(args, "runtime_window_target", []) or []]
     plan_targets = _runtime_window_plan_targets(args)
+    plan_required = bool(getattr(args, "runtime_window_target_plan_required", False))
+    if plan_required:
+        plan_ref_count = _runtime_window_target_plan_ref_count(args)
+        if plan_ref_count <= 0:
+            raise RuntimeError("runtime_window_target_plan_required_without_ref")
+        if not plan_targets:
+            raise RuntimeError("runtime_window_target_plan_required_but_empty")
     plan_exclusive = bool(getattr(args, "runtime_window_target_plan_exclusive", False))
     fallback_enabled = not (plan_exclusive and plan_targets)
     autoresearch_targets = (

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -818,6 +818,7 @@ class TestLiveConfigManifestContract(TestCase):
             args,
         )
         self.assertIn("--runtime-window-target-plan-exclusive", args)
+        self.assertIn("--runtime-window-target-plan-required", args)
         self.assertIn("--runtime-window-targets-from-latest-autoresearch", args)
         self.assertIn("--runtime-window-targets-from-registry", args)
         self.assertIn("--runtime-window-hypothesis-id H-TSMOM-01", args)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -673,6 +673,87 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             ["H-FALLBACK-01"],
         )
 
+    def test_runtime_window_target_plan_required_fails_closed_when_plan_empty(
+        self,
+    ) -> None:
+        plan_path = Path(self.tmp_dir) / "empty-paper-route-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "next_paper_route_runtime_window_targets": {
+                        "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                        "target_count": 0,
+                        "targets": [],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        args = SimpleNamespace(
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_target_plan_url=[],
+            runtime_window_target_plan_url_timeout_seconds=2.0,
+            runtime_window_target_plan_exclusive=True,
+            runtime_window_target_plan_required=True,
+            runtime_window_targets_from_latest_autoresearch=True,
+            runtime_window_targets_from_registry=True,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with (
+            patch.object(
+                renewal,
+                "_latest_autoresearch_runtime_window_targets",
+                side_effect=AssertionError("autoresearch fallback should not run"),
+            ),
+            patch.object(
+                renewal,
+                "_registry_runtime_window_targets",
+                side_effect=AssertionError("registry fallback should not run"),
+            ),
+            self.assertRaisesRegex(
+                RuntimeError, "runtime_window_target_plan_required_but_empty"
+            ),
+        ):
+            renewal._runtime_window_targets(args)
+
+    def test_runtime_window_target_plan_required_requires_ref(self) -> None:
+        args = SimpleNamespace(
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[],
+            runtime_window_target_plan_url=[],
+            runtime_window_target_plan_url_timeout_seconds=2.0,
+            runtime_window_target_plan_exclusive=True,
+            runtime_window_target_plan_required=True,
+            runtime_window_targets_from_latest_autoresearch=True,
+            runtime_window_targets_from_registry=True,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError, "runtime_window_target_plan_required_without_ref"
+        ):
+            renewal._runtime_window_targets(args)
+
     def test_runtime_window_target_plan_payload_accepts_top_level_gate_plan_and_fallback(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Add `--runtime-window-target-plan-required` to make renewal imports fail closed when configured plan refs/URLs are missing or empty.
- Enable the required-plan gate for the Torghut empirical promotion renewal CronJob that consumes `/trading/paper-route-evidence`.
- Cover the new fail-closed behavior and the GitOps manifest contract with focused tests.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff format scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py --check`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
