### PR TITLE
fix(torghut): defer future paper route imports

### DIFF
--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -1188,6 +1188,7 @@ def _run_runtime_window_import(
                 manifest_path=manifest_path,
                 window_start=default_window_start,
                 window_end=default_window_end,
+                now=now,
                 allow_source_activity_window=explicit_window is None,
             )
         )
@@ -1217,6 +1218,7 @@ def _run_runtime_window_import_target(
     manifest_path: Path,
     window_start: datetime,
     window_end: datetime,
+    now: datetime,
     allow_source_activity_window: bool = False,
 ) -> dict[str, Any]:
     runtime_manifest = _read_runtime_window_manifest(target.source_manifest_ref)
@@ -1235,11 +1237,49 @@ def _run_runtime_window_import_target(
             window_selection = "source_execution_activity_span"
         else:
             window_selection = "latest_completed_regular_session_no_source_activity"
+    proof_blockers: list[dict[str, Any]] = []
+    candidate_id = (
+        _as_text(target.candidate_id)
+        or _as_text(runtime_manifest.get("candidate_id"))
+        or _as_text(manifest.get("candidate_id"))
+    )
+    if candidate_id is None:
+        raise RuntimeError("runtime_window_candidate_id_missing")
+    if target_plan_window is not None and window_end > now:
+        proof_blockers.append(
+            {
+                "type": "runtime_window_target_plan_window_not_closed",
+                "hypothesis_id": target.hypothesis_id,
+                "candidate_id": candidate_id,
+                "window_start": _utc_iso(window_start),
+                "window_end": _utc_iso(window_end),
+                "now": _utc_iso(now),
+                "remediation": (
+                    "wait_until_target_plan_window_closes_before_runtime_import"
+                ),
+            }
+        )
+        return {
+            "status": "deferred",
+            "reason": "runtime_window_target_plan_window_not_closed",
+            "window_start": _utc_iso(window_start),
+            "window_end": _utc_iso(window_end),
+            "window_selection": window_selection,
+            "hypothesis_id": target.hypothesis_id,
+            "candidate_id": candidate_id,
+            "strategy_name": target.strategy_name,
+            "account_label": target.account_label,
+            "source_kind": target.source_kind,
+            "artifact_refs": [str(manifest_path), *target.artifact_refs],
+            "target_metadata": dict(target.target_metadata or {}),
+            "proof_status": "deferred",
+            "proof_blockers": proof_blockers,
+            "summary": None,
+        }
     delay_depth_report_ref = _runtime_manifest_delay_depth_stress_report_ref(
         target=target,
         runtime_manifest=runtime_manifest,
     )
-    proof_blockers: list[dict[str, Any]] = []
     if (
         _runtime_manifest_requires_delay_depth_stress(runtime_manifest)
         and delay_depth_report_ref is None
@@ -1250,13 +1290,6 @@ def _run_runtime_window_import_target(
                 runtime_manifest=runtime_manifest,
             )
         )
-    candidate_id = (
-        _as_text(target.candidate_id)
-        or _as_text(runtime_manifest.get("candidate_id"))
-        or _as_text(manifest.get("candidate_id"))
-    )
-    if candidate_id is None:
-        raise RuntimeError("runtime_window_candidate_id_missing")
     command = [
         sys.executable,
         "scripts/import_hypothesis_runtime_windows.py",

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -2153,6 +2153,153 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         )
         self.assertIn("proof/exact-replay-ledger.json", command)
 
+    def test_runtime_window_import_defers_future_target_plan_window(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-pairs-01.json"
+        hypothesis_path.write_text(
+            json.dumps({"candidate_id": "cand-paper-route"}),
+            encoding="utf-8",
+        )
+        plan_path = self.tmp_dir / "paper-route-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "next_paper_route_runtime_window_targets": {
+                        "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                        "targets": [
+                            {
+                                "candidate_id": "cand-paper-route",
+                                "hypothesis_id": "H-PAIRS-01",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "paper-route-candidate-v1",
+                                "source_manifest_ref": str(hypothesis_path),
+                                "source_dsn_env": "SIM_DB_DSN",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "window_start": "2026-05-26T13:30:00Z",
+                                "window_end": "2026-05-26T20:00:00Z",
+                                "paper_route_probe_next_session_max_notional": "25",
+                            }
+                        ],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        args = SimpleNamespace(
+            runtime_window_import=True,
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_target_plan_url=[],
+            runtime_window_target_plan_url_timeout_seconds=2.0,
+            runtime_window_target_plan_exclusive=True,
+            runtime_window_target_plan_required=True,
+            runtime_window_targets_from_latest_autoresearch=True,
+            runtime_window_targets_from_registry=True,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_start="",
+            runtime_window_end="",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with (
+            patch.object(
+                renewal.subprocess,
+                "run",
+                side_effect=AssertionError("future target window should not import"),
+            ),
+            patch.object(
+                renewal,
+                "_latest_autoresearch_runtime_window_targets",
+                side_effect=AssertionError("autoresearch fallback should not run"),
+            ),
+            patch.object(
+                renewal,
+                "_registry_runtime_window_targets",
+                side_effect=AssertionError("registry fallback should not run"),
+            ),
+        ):
+            payload = renewal._run_runtime_window_import(
+                args=args,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                now=datetime(2026, 5, 24, 20, 23, tzinfo=timezone.utc),
+            )
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertEqual(payload["status"], "deferred")
+        self.assertEqual(
+            payload["reason"], "runtime_window_target_plan_window_not_closed"
+        )
+        self.assertEqual(payload["window_selection"], "target_plan_window")
+        self.assertEqual(payload["window_start"], "2026-05-26T13:30:00Z")
+        self.assertEqual(payload["window_end"], "2026-05-26T20:00:00Z")
+        self.assertEqual(payload["proof_status"], "deferred")
+        self.assertEqual(
+            payload["proof_blockers"][0]["type"],
+            "runtime_window_target_plan_window_not_closed",
+        )
+        self.assertEqual(
+            payload["target_metadata"]["paper_route_probe_next_session_max_notional"],
+            "25",
+        )
+
+    def test_runtime_window_import_future_target_plan_requires_candidate_id(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-pairs-01.json"
+        hypothesis_path.write_text(
+            json.dumps({"strategy_name": "paper-route-candidate-v1"}),
+            encoding="utf-8",
+        )
+        target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            strategy_name="paper-route-candidate-v1",
+            account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="",
+            source_manifest_ref=str(hypothesis_path),
+            source_kind="paper_route_probe_runtime_observed",
+            delay_adjusted_depth_stress_report_ref="",
+            window_start="2026-05-26T13:30:00Z",
+            window_end="2026-05-26T20:00:00Z",
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "runtime_window_candidate_id_missing",
+        ):
+            renewal._run_runtime_window_import_target(
+                args=SimpleNamespace(),
+                target=target,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                window_start=datetime(2026, 5, 18, 13, 30, tzinfo=timezone.utc),
+                window_end=datetime(2026, 5, 18, 20, 0, tzinfo=timezone.utc),
+                now=datetime(2026, 5, 24, 20, 23, tzinfo=timezone.utc),
+            )
+
     def test_runtime_window_target_plan_bounds_fail_closed(self) -> None:
         base = {
             "hypothesis_id": "H-PAIRS-01",


### PR DESCRIPTION
## Summary

- Defer target-plan runtime imports when the plan window has not closed yet.
- Return an explicit `runtime_window_target_plan_window_not_closed` blocker instead of importing empty future paper-route windows.
- Add a regression test proving future paper-route targets do not invoke the importer or fallback targets.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q`
- `uv run --frozen ruff format scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py --check`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
