### PR TITLE
fix(torghut): settle paper route imports before ingest

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -4,7 +4,7 @@ metadata:
   name: torghut-empirical-promotion-renewal
   namespace: torghut
 spec:
-  schedule: "23 8,20 * * *"
+  schedule: "23 8,21 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3
@@ -37,6 +37,7 @@ spec:
                     --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence \
                     --runtime-window-target-plan-exclusive \
                     --runtime-window-target-plan-required \
+                    --runtime-window-target-plan-settlement-seconds 3600 \
                     --runtime-window-targets-from-latest-autoresearch \
                     --runtime-window-targets-from-registry \
                     --runtime-window-hypothesis-id H-TSMOM-01 \

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -180,6 +180,16 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--runtime-window-target-plan-settlement-seconds",
+        type=int,
+        default=0,
+        help=(
+            "For target-plan windows, defer runtime-window import until this many "
+            "seconds after the target window end so fills, costs, and order lifecycle "
+            "rows can land before proof import."
+        ),
+    )
+    parser.add_argument(
         "--runtime-window-targets-from-latest-autoresearch",
         action="store_true",
         help=(
@@ -1245,23 +1255,39 @@ def _run_runtime_window_import_target(
     )
     if candidate_id is None:
         raise RuntimeError("runtime_window_candidate_id_missing")
-    if target_plan_window is not None and window_end > now:
+    target_plan_settlement_seconds = int(
+        getattr(args, "runtime_window_target_plan_settlement_seconds", 0) or 0
+    )
+    if target_plan_settlement_seconds < 0:
+        raise RuntimeError("runtime_window_target_plan_settlement_seconds_negative")
+    target_plan_ready_at = window_end + timedelta(
+        seconds=target_plan_settlement_seconds
+    )
+    if target_plan_window is not None and (
+        window_end > now or target_plan_ready_at > now
+    ):
+        if window_end > now:
+            blocker_type = "runtime_window_target_plan_window_not_closed"
+            remediation = "wait_until_target_plan_window_closes_before_runtime_import"
+        else:
+            blocker_type = "runtime_window_target_plan_window_settlement_pending"
+            remediation = "wait_until_target_plan_window_settlement_grace_elapses_before_runtime_import"
         proof_blockers.append(
             {
-                "type": "runtime_window_target_plan_window_not_closed",
+                "type": blocker_type,
                 "hypothesis_id": target.hypothesis_id,
                 "candidate_id": candidate_id,
                 "window_start": _utc_iso(window_start),
                 "window_end": _utc_iso(window_end),
                 "now": _utc_iso(now),
-                "remediation": (
-                    "wait_until_target_plan_window_closes_before_runtime_import"
-                ),
+                "settlement_seconds": target_plan_settlement_seconds,
+                "settlement_ready_at": _utc_iso(target_plan_ready_at),
+                "remediation": remediation,
             }
         )
         return {
             "status": "deferred",
-            "reason": "runtime_window_target_plan_window_not_closed",
+            "reason": blocker_type,
             "window_start": _utc_iso(window_start),
             "window_end": _utc_iso(window_end),
             "window_selection": window_selection,

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -782,7 +782,7 @@ class TestLiveConfigManifestContract(TestCase):
             "argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml"
         )
 
-        self.assertEqual(spec.get("schedule"), "23 8,20 * * *")
+        self.assertEqual(spec.get("schedule"), "23 8,21 * * *")
         env = {
             item.get("name"): item
             for item in cast(list[Mapping[str, object]], container.get("env", []))
@@ -819,6 +819,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertIn("--runtime-window-target-plan-exclusive", args)
         self.assertIn("--runtime-window-target-plan-required", args)
+        self.assertIn("--runtime-window-target-plan-settlement-seconds 3600", args)
         self.assertIn("--runtime-window-targets-from-latest-autoresearch", args)
         self.assertIn("--runtime-window-targets-from-registry", args)
         self.assertIn("--runtime-window-hypothesis-id H-TSMOM-01", args)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -2300,6 +2300,167 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                 now=datetime(2026, 5, 24, 20, 23, tzinfo=timezone.utc),
             )
 
+    def test_runtime_window_import_defers_target_plan_settlement_grace(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-pairs-01.json"
+        hypothesis_path.write_text(
+            json.dumps({"candidate_id": "cand-paper-route"}),
+            encoding="utf-8",
+        )
+        plan_path = self.tmp_dir / "paper-route-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "runtime_window_import_plan": {
+                        "targets": [
+                            {
+                                "candidate_id": "cand-paper-route",
+                                "hypothesis_id": "H-PAIRS-01",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "paper-route-candidate-v1",
+                                "source_manifest_ref": str(hypothesis_path),
+                                "source_dsn_env": "SIM_DB_DSN",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "window_start": "2026-05-26T13:30:00Z",
+                                "window_end": "2026-05-26T20:00:00Z",
+                            }
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        args = SimpleNamespace(
+            runtime_window_import=True,
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_target_plan_url=[],
+            runtime_window_target_plan_url_timeout_seconds=2.0,
+            runtime_window_target_plan_exclusive=True,
+            runtime_window_target_plan_required=True,
+            runtime_window_target_plan_settlement_seconds=3600,
+            runtime_window_targets_from_latest_autoresearch=False,
+            runtime_window_targets_from_registry=False,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_start="",
+            runtime_window_end="",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with patch.object(
+            renewal.subprocess,
+            "run",
+            side_effect=AssertionError("settlement grace should defer import"),
+        ):
+            payload = renewal._run_runtime_window_import(
+                args=args,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                now=datetime(2026, 5, 26, 20, 23, tzinfo=timezone.utc),
+            )
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertEqual(payload["status"], "deferred")
+        self.assertEqual(
+            payload["reason"], "runtime_window_target_plan_window_settlement_pending"
+        )
+        self.assertEqual(payload["proof_status"], "deferred")
+        self.assertEqual(
+            payload["proof_blockers"][0]["type"],
+            "runtime_window_target_plan_window_settlement_pending",
+        )
+        self.assertEqual(payload["proof_blockers"][0]["settlement_seconds"], 3600)
+        self.assertEqual(
+            payload["proof_blockers"][0]["settlement_ready_at"],
+            "2026-05-26T21:00:00Z",
+        )
+        completed = SimpleNamespace(
+            stdout=json.dumps({"inserted_windows": 1, "promotion_decision": "blocked"})
+        )
+
+        with patch.object(
+            renewal.subprocess, "run", return_value=completed
+        ) as run_mock:
+            imported = renewal._run_runtime_window_import(
+                args=args,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                now=datetime(2026, 5, 26, 21, 23, tzinfo=timezone.utc),
+            )
+
+        self.assertIsNotNone(imported)
+        assert imported is not None
+        self.assertEqual(imported["status"], "ok")
+        command = run_mock.call_args.args[0]
+        self.assertEqual(
+            command[command.index("--window-start") + 1],
+            "2026-05-26T13:30:00Z",
+        )
+        self.assertEqual(
+            command[command.index("--window-end") + 1],
+            "2026-05-26T20:00:00Z",
+        )
+
+    def test_runtime_window_import_rejects_negative_target_plan_settlement_grace(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-pairs-01.json"
+        hypothesis_path.write_text(
+            json.dumps({"candidate_id": "cand-paper-route"}),
+            encoding="utf-8",
+        )
+        target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="cand-paper-route",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            strategy_name="paper-route-candidate-v1",
+            account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="",
+            source_manifest_ref=str(hypothesis_path),
+            source_kind="paper_route_probe_runtime_observed",
+            delay_adjusted_depth_stress_report_ref="",
+            window_start="2026-05-26T13:30:00Z",
+            window_end="2026-05-26T20:00:00Z",
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "runtime_window_target_plan_settlement_seconds_negative",
+        ):
+            renewal._run_runtime_window_import_target(
+                args=SimpleNamespace(
+                    runtime_window_target_plan_settlement_seconds=-1,
+                ),
+                target=target,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                window_start=datetime(2026, 5, 18, 13, 30, tzinfo=timezone.utc),
+                window_end=datetime(2026, 5, 18, 20, 0, tzinfo=timezone.utc),
+                now=datetime(2026, 5, 26, 20, 23, tzinfo=timezone.utc),
+            )
+
     def test_runtime_window_target_plan_bounds_fail_closed(self) -> None:
         base = {
             "hypothesis_id": "H-PAIRS-01",


### PR DESCRIPTION
## Summary

- Adds `--runtime-window-target-plan-settlement-seconds` so target-plan runtime imports defer until a configurable post-window grace has elapsed.
- Emits explicit `runtime_window_target_plan_window_settlement_pending` blockers with settlement metadata instead of importing immediately after the close.
- Moves the Torghut empirical renewal CronJob from `20:23Z` to `21:23Z` with a 3600-second grace, preserving two runs per day while avoiding premature paper-route proof ingestion.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q`
- `uv run --frozen ruff format tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_empirical_promotion_renewal_imports_paper_windows_from_sim_db -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `git diff --check`
- `bun run lint:argocd`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
