### PR TITLE
fix(torghut): use paper account for route imports

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -34,6 +34,7 @@ NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION = (
 )
 DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS = 72
 DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT = 20
+PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL = "TORGHUT_SIM"
 US_EQUITIES_TIMEZONE = "America/New_York"
 US_EQUITIES_OPEN = time(hour=9, minute=30)
 US_EQUITIES_CLOSE = time(hour=16, minute=0)
@@ -393,13 +394,15 @@ def _next_paper_route_runtime_window_targets(
                 }
             )
             continue
+        source_account_label = _safe_text(target.get("account_label"))
         planned_target: dict[str, object] = {
             "hypothesis_id": hypothesis_id,
             "candidate_id": candidate_id,
             "observed_stage": "paper",
             "strategy_family": strategy_family,
             "strategy_name": strategy_name,
-            "account_label": _safe_text(target.get("account_label")) or "TORGHUT_SIM",
+            "account_label": PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
+            "source_account_label": source_account_label or "",
             "source_dsn_env": "SIM_DB_DSN",
             "dataset_snapshot_ref": _safe_text(target.get("dataset_snapshot_ref"))
             or "",

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -156,7 +156,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                                 "observed_stage": "paper",
                                 "strategy_family": "microbar_pairs",
                                 "strategy_name": "paper-route-candidate-v1",
-                                "account_label": "TORGHUT_SIM",
+                                "account_label": "TORGHUT_REPLAY",
                                 "source_kind": "durable_runtime_ledger_bucket",
                                 "source_manifest_ref": "config/trading/hypotheses/h-paper-route.json",
                                 "dataset_snapshot_ref": "dataset://paper-route",
@@ -171,7 +171,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                                 "observed_stage": "paper",
                                 "strategy_family": "microbar_pairs",
                                 "strategy_name": "paper-route-candidate-v1",
-                                "account_label": "TORGHUT_SIM",
+                                "account_label": "TORGHUT_REPLAY",
                                 "source_kind": "durable_runtime_ledger_bucket",
                                 "source_manifest_ref": "config/trading/hypotheses/h-paper-route.json",
                                 "dataset_snapshot_ref": "dataset://paper-route",
@@ -222,6 +222,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
             },
         )
         target = plan["targets"][0]
+        self.assertEqual(target["account_label"], "TORGHUT_SIM")
+        self.assertEqual(target["source_account_label"], "TORGHUT_REPLAY")
         self.assertEqual(target["source_dsn_env"], "SIM_DB_DSN")
         self.assertEqual(target["source_kind"], "paper_route_probe_runtime_observed")
         self.assertEqual(target["max_notional"], "0")


### PR DESCRIPTION
## Summary

- Make next-session paper-route runtime-window targets import from the sim paper account label instead of inheriting replay-source account labels.
- Preserve the original source account label separately as lineage metadata for auditability.
- Add regression coverage for replay-backed paper-route targets so the import plan stays pointed at `TORGHUT_SIM`.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py tests/test_paper_route_evidence.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
