### PR TITLE
fix(torghut): scope paper probation gate blockers

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -2325,6 +2325,38 @@ def _evaluate_certificate_candidates(
     return evaluated, valid
 
 
+def _runtime_hypothesis_ids_for_gate_scope(
+    runtime_items: Sequence[Mapping[str, Any]],
+    *,
+    eligibility_key: str,
+) -> set[str]:
+    return {
+        hypothesis_id
+        for item in runtime_items
+        if bool(item.get(eligibility_key))
+        for hypothesis_id in [str(item.get("hypothesis_id") or "").strip()]
+        if hypothesis_id
+    }
+
+
+def _candidate_reason_codes_for_gate_scope(
+    evaluated_tuples: Sequence[Mapping[str, object]],
+    *,
+    hypothesis_ids: set[str],
+) -> list[str]:
+    scoped_tuples = [
+        item
+        for item in evaluated_tuples
+        if str(item.get("hypothesis_id") or "").strip() in hypothesis_ids
+    ]
+    source_tuples = scoped_tuples if scoped_tuples else list(evaluated_tuples)
+    return [
+        reason
+        for item in source_tuples
+        for reason in cast(Sequence[str], item.get("reason_codes") or [])
+    ]
+
+
 def _default_lineage_ref(
     *,
     status: str = "unverified",
@@ -3029,11 +3061,14 @@ def build_live_submission_gate_payload(
             item for item in evaluated_tuples if not item.get("reason_codes")
         ]
 
-    candidate_reason_codes = [
-        reason
-        for item in evaluated_tuples
-        for reason in cast(Sequence[str], item.get("reason_codes") or [])
-    ]
+    promotion_scope_hypothesis_ids = _runtime_hypothesis_ids_for_gate_scope(
+        runtime_items,
+        eligibility_key="promotion_eligible",
+    )
+    paper_probation_scope_hypothesis_ids = _runtime_hypothesis_ids_for_gate_scope(
+        runtime_items,
+        eligibility_key="paper_probation_eligible",
+    )
     if (
         promotion_eligible_total > 0 or claimed_promotion_eligible_total > 0
     ) and not valid_candidates:
@@ -3041,10 +3076,20 @@ def build_live_submission_gate_payload(
             blocked_reasons.append("promotion_certificate_missing")
             blocked_reasons.append("hypothesis_window_evidence_missing")
         else:
-            blocked_reasons.extend(candidate_reason_codes)
+            blocked_reasons.extend(
+                _candidate_reason_codes_for_gate_scope(
+                    evaluated_tuples,
+                    hypothesis_ids=promotion_scope_hypothesis_ids,
+                )
+            )
             blocked_reasons.append("promotion_certificate_missing")
     elif paper_probation_eligible_total > 0 and evaluated_tuples:
-        blocked_reasons.extend(candidate_reason_codes)
+        blocked_reasons.extend(
+            _candidate_reason_codes_for_gate_scope(
+                evaluated_tuples,
+                hypothesis_ids=paper_probation_scope_hypothesis_ids,
+            )
+        )
 
     blocked_reasons = _normalize_reason_codes(blocked_reasons)
 

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -3295,6 +3295,108 @@ class TestSubmissionCouncil(TestCase):
             result["reason_codes"],
         )
 
+    def test_build_live_submission_gate_payload_scopes_paper_probation_blockers_to_runtime_candidate(
+        self,
+    ) -> None:
+        result = build_live_submission_gate_payload(
+            SimpleNamespace(
+                last_autonomy_promotion_eligible=False,
+                last_autonomy_promotion_action=None,
+                drift_live_promotion_eligible=False,
+                last_market_context_freshness_seconds=900,
+                last_market_context_domain_states={"news": "stale"},
+                market_context_alert_active=True,
+                market_context_alert_reason="market_context_stale",
+            ),
+            hypothesis_summary={
+                "summary": {
+                    "promotion_eligible_total": 0,
+                    "paper_probation_eligible_total": 1,
+                    "capital_stage_totals": {"shadow": 2},
+                    "dependency_quorum": {
+                        "decision": "allow",
+                        "reasons": [],
+                        "message": "ready",
+                    },
+                },
+                "items": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "lane_id": "microbar-cross-sectional-pairs",
+                        "strategy_family": "microbar_cross_sectional_pairs",
+                        "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                        "promotion_eligible": False,
+                        "paper_probation_eligible": True,
+                        "capital_stage": "shadow",
+                        "reasons": ["paper_probation_evidence_collection_only"],
+                        "segment_dependencies": ["execution", "empirical", "ta-core"],
+                    },
+                    {
+                        "hypothesis_id": "H-REV-01",
+                        "candidate_id": "rev-candidate",
+                        "lane_id": "event-reversion",
+                        "strategy_family": "event_reversion",
+                        "strategy_id": "microbar_prev_day_open45_reversal_long_top1_chip_v1@paper",
+                        "promotion_eligible": False,
+                        "paper_probation_eligible": False,
+                        "capital_stage": "shadow",
+                        "reasons": [],
+                        "segment_dependencies": [
+                            "execution",
+                            "empirical",
+                            "llm-review",
+                            "market-context",
+                            "ta-core",
+                        ],
+                    },
+                ],
+            },
+            empirical_jobs_status={"ready": True, "status": "healthy"},
+            quant_health_status=self._healthy_quant_status(),
+            promotion_certificate_evidence=[
+                {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "metric_window": self._metric_window(
+                        observed_stage="paper",
+                        run_id="pairs-paper-window",
+                        candidate_id="c88421d619759b2cfaa6f4d0",
+                        hypothesis_id="H-PAIRS-01",
+                    ),
+                    "promotion_decision": self._promotion_decision(
+                        run_id="pairs-paper-window",
+                        candidate_id="c88421d619759b2cfaa6f4d0",
+                        hypothesis_id="H-PAIRS-01",
+                    ),
+                },
+                {
+                    "hypothesis_id": "H-REV-01",
+                    "metric_window": self._metric_window(
+                        run_id="rev-live-window",
+                        candidate_id="rev-candidate",
+                        hypothesis_id="H-REV-01",
+                    ),
+                    "promotion_decision": self._promotion_decision(
+                        run_id="rev-live-window",
+                        candidate_id="rev-candidate",
+                        hypothesis_id="H-REV-01",
+                    ),
+                },
+            ],
+        )
+
+        self.assertFalse(result["allowed"])
+        self.assertIn(
+            "promotion_certificate_not_live_runtime",
+            result["blocked_reasons"],
+        )
+        self.assertNotIn("segment_market-context_blocked", result["blocked_reasons"])
+        self.assertNotIn("market_context_stale", result["blocked_reasons"])
+        self.assertNotIn(
+            "market_context_domain_news_stale",
+            result["blocked_reasons"],
+        )
+
     def test_build_live_submission_gate_payload_blocks_without_certificate_evidence(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Scoped live-submission certificate blocker aggregation to the runtime candidate that is promotion-eligible or paper-probation-eligible.
- Prevented unrelated evaluated hypotheses from polluting a paper-probation candidate gate with their segment blockers.
- Added a regression covering H-PAIRS paper probation alongside unrelated H-REV market-context staleness.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen pytest tests/test_submission_council.py -k 'scopes_paper_probation_blockers_to_runtime_candidate or hypothesis_runtime_summary_uses_fresh_imported_runtime_proof or build_live_submission_gate_payload_requires_valid_certificate_evidence or build_live_submission_gate_payload_blocks_paper_runtime_certificate_for_live_submission or build_live_submission_gate_payload_blocks_when_hypothesis_runtime_item_is_shadow' -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_submission_council.py -q`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
