### PR TITLE
fix(torghut): let bounded paper route probes repair excluded symbols

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -813,6 +813,7 @@ class SimpleTradingPipeline(TradingPipeline):
         proof_floor_block_reason = self._proof_floor_submission_block_reason(
             proof_floor
         )
+        paper_route_probe_applied = False
         if proof_floor_block_reason is not None:
             probe_context = self._paper_route_probe_context(
                 proof_floor=proof_floor,
@@ -837,9 +838,14 @@ class SimpleTradingPipeline(TradingPipeline):
                     extra_metadata={"profitability_proof_floor": dict(proof_floor)},
                 )
                 return False
-        proof_floor_symbol_block_reason = self._proof_floor_symbol_block_reason(
-            proof_floor,
-            decision.symbol,
+            paper_route_probe_applied = True
+        proof_floor_symbol_block_reason = (
+            self._proof_floor_symbol_block_reason(
+                proof_floor,
+                decision.symbol,
+            )
+            if not paper_route_probe_applied
+            else None
         )
         if proof_floor_symbol_block_reason is not None:
             self._block_decision_submission(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -2901,6 +2901,110 @@ class TestTradingPipeline(TestCase):
             self.assertEqual(paper_route_probe.get("capped_qty"), "0.2500")
             self.assertEqual(simple_lane.get("paper_route_probe_cap_applied"), True)
 
+    def test_simple_pipeline_paper_route_probe_can_repair_symbol_outside_candidates(
+        self,
+    ) -> None:
+        from app import config
+
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_pipeline_mode = "simple"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_max_notional = 25.0
+        config.settings.trading_universe_source = "jangar"
+        config.settings.trading_universe_static_fallback_enabled = True
+        config.settings.trading_universe_static_fallback_symbols_raw = "NVDA"
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="simple-paper-route-probe-repair-symbol",
+                description="simple paper lane route probe repair symbol",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["NVDA"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
+            ingest_ts=datetime(2026, 3, 26, 13, 30, 5, tzinfo=timezone.utc),
+            symbol="NVDA",
+            timeframe="1Min",
+            seq=1,
+            payload={
+                "feature_schema_version": "3.0.0",
+                "macd": {"macd": 1.2, "signal": 0.5},
+                "rsi14": 25,
+                "price": 100,
+            },
+        )
+
+        alpaca_client = FakeAlpacaClient()
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=FakeIngestor([signal]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+        proof_floor = {
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "market_window": {"session_open": True},
+            "blocking_reasons": [
+                "alpha_readiness_not_promotion_eligible",
+                "execution_tca_symbol_missing",
+            ],
+            "route_reacquisition_book": {
+                "summary": {
+                    "candidate_symbols": ["AAPL"],
+                    "repair_candidate_symbols": ["NVDA"],
+                    "repair_candidates": [
+                        {
+                            "symbol": "NVDA",
+                            "state": "missing",
+                            "reason": "execution_tca_symbol_missing",
+                        }
+                    ],
+                }
+            },
+        }
+        with patch.object(
+            SimpleTradingPipeline,
+            "_profitability_proof_floor",
+            return_value=proof_floor,
+        ):
+            pipeline.run_once()
+
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        with self.session_local() as session:
+            decision = session.execute(select(TradeDecision)).scalar_one()
+            decision_json = cast(dict[str, Any], decision.decision_json)
+            params = cast(dict[str, Any], decision_json.get("params"))
+            paper_route_probe = cast(dict[str, Any], params.get("paper_route_probe"))
+            simple_lane = cast(dict[str, Any], params.get("simple_lane"))
+
+            self.assertEqual(decision.status, "submitted")
+            self.assertEqual(paper_route_probe.get("symbol"), "NVDA")
+            self.assertEqual(paper_route_probe.get("mode"), "paper_route_acquisition")
+            self.assertEqual(simple_lane.get("paper_route_probe_cap_applied"), True)
+
     def test_paper_route_probe_helpers_handle_missing_repair_metadata(self) -> None:
         self.assertFalse(SimpleTradingPipeline._proof_floor_market_session_open({}))
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Allows a successfully bounded paper-route probe to pass the later route-symbol exclusion check.
- Keeps the exception narrow: it only applies after paper mode, probe enablement, session-open, route-repair reason, and max-notional cap checks succeed.
- Adds a regression test for repair symbols outside the current candidate-symbol set so missing-route symbols can produce paper fills for runtime-ledger evidence.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen python -m pytest tests/test_trading_pipeline.py -k 'paper_route_probe' -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
