### PR TITLE
fix(torghut): keep paper route import on current session

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -201,12 +201,17 @@ def _regular_equities_session_date(value: date) -> bool:
 def _next_regular_equities_session_window(
     generated_at: datetime,
 ) -> tuple[datetime, datetime]:
+    """Return the current local trading date, or the next regular session.
+
+    The empirical renewal job reads this dynamic plan after the close to import
+    the just-finished paper-route window. Keep the current regular session until
+    the New York calendar date rolls over, otherwise the importer chases the
+    following session before it can ledger the one that just closed.
+    """
+
     zone = ZoneInfo(US_EQUITIES_TIMEZONE)
     local_generated_at = generated_at.astimezone(zone)
     candidate_date = local_generated_at.date()
-    session_open = datetime.combine(candidate_date, US_EQUITIES_OPEN, tzinfo=zone)
-    if local_generated_at >= session_open:
-        candidate_date += timedelta(days=1)
     while not _regular_equities_session_date(candidate_date):
         candidate_date += timedelta(days=1)
     start = datetime.combine(candidate_date, US_EQUITIES_OPEN, tzinfo=zone)

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -18,7 +18,10 @@ from app.models import (
     StrategyRuntimeLedgerBucket,
     TradeDecision,
 )
-from app.trading.paper_route_evidence import build_paper_route_evidence_audit
+from app.trading.paper_route_evidence import (
+    _next_regular_equities_session_window,
+    build_paper_route_evidence_audit,
+)
 
 
 class TestPaperRouteEvidenceAudit(TestCase):
@@ -30,6 +33,42 @@ class TestPaperRouteEvidenceAudit(TestCase):
             poolclass=StaticPool,
         )
         Base.metadata.create_all(self.engine)
+
+    def test_next_paper_route_window_stays_on_current_session_for_import(
+        self,
+    ) -> None:
+        cases = [
+            (
+                datetime(2026, 5, 24, 14, 38, tzinfo=timezone.utc),
+                "2026-05-26T13:30:00+00:00",
+                "2026-05-26T20:00:00+00:00",
+            ),
+            (
+                datetime(2026, 5, 26, 12, 0, tzinfo=timezone.utc),
+                "2026-05-26T13:30:00+00:00",
+                "2026-05-26T20:00:00+00:00",
+            ),
+            (
+                datetime(2026, 5, 26, 15, 0, tzinfo=timezone.utc),
+                "2026-05-26T13:30:00+00:00",
+                "2026-05-26T20:00:00+00:00",
+            ),
+            (
+                datetime(2026, 5, 26, 21, 23, tzinfo=timezone.utc),
+                "2026-05-26T13:30:00+00:00",
+                "2026-05-26T20:00:00+00:00",
+            ),
+            (
+                datetime(2026, 5, 27, 4, 1, tzinfo=timezone.utc),
+                "2026-05-27T13:30:00+00:00",
+                "2026-05-27T20:00:00+00:00",
+            ),
+        ]
+        for generated_at, expected_start, expected_end in cases:
+            with self.subTest(generated_at=generated_at):
+                start, end = _next_regular_equities_session_window(generated_at)
+                self.assertEqual(start.isoformat(), expected_start)
+                self.assertEqual(end.isoformat(), expected_end)
 
     def test_builder_reports_missing_import_plan_without_promotion_authority(
         self,


### PR DESCRIPTION
## Summary

- Keeps the paper-route evidence session target on the current New York trading date until the local calendar rolls over.
- Prevents the empirical renewal CronJob from chasing the following session when it reads `/trading/paper-route-evidence` after the close.
- Adds regression coverage for the May 26, 2026 paper-route import checkpoint before, during, and after the session.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen python -m pytest tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
