### PR TITLE
fix(torghut): allow dependency-blocked paper probes

### DIFF
--- a/services/torghut/app/trading/route_reacquisition.py
+++ b/services/torghut/app/trading/route_reacquisition.py
@@ -10,6 +10,7 @@ SCHEMA_VERSION = "torghut.route-reacquisition-book.v1"
 _PAPER_ROUTE_PROBE_REASONS = {
     "execution_tca_route_universe_empty",
     "execution_tca_symbol_missing",
+    "route_tca_passed_but_dependency_receipts_block_capital",
     "tca_evidence_stale",
 }
 _PAPER_ROUTE_PROBE_STATES = {"missing", "probing"}
@@ -114,6 +115,8 @@ def _next_action(*, state: str, reason: str) -> str:
     if state == "blocked":
         return "repair_route_evidence_before_paper_probe"
     if state == "probing":
+        if reason == "route_tca_passed_but_dependency_receipts_block_capital":
+            return "collect_paper_runtime_ledger_receipts_before_capital"
         return "settle_market_context_quant_and_alpha_receipts_before_paper_probe"
     if state == "routeable":
         return "maintain_route_tca_and_wait_for_capital_gate"

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -52,6 +52,7 @@ _SIMPLE_ALLOWED_REJECT_REASONS = {
 _PAPER_ROUTE_PROBE_REASONS = {
     "execution_tca_route_universe_empty",
     "execution_tca_symbol_missing",
+    "route_tca_passed_but_dependency_receipts_block_capital",
     "tca_evidence_stale",
 }
 _PROFITABILITY_PROOF_FLOOR_TCA_MAX_AGE_SECONDS = 86_400
@@ -571,6 +572,40 @@ class SimpleTradingPipeline(TradingPipeline):
         return repair_symbols
 
     @staticmethod
+    def _proof_floor_paper_route_probe_symbols(
+        proof_floor: Mapping[str, object],
+    ) -> set[str]:
+        route_book = proof_floor.get("route_reacquisition_book")
+        if not isinstance(route_book, Mapping):
+            return set()
+        route_book_mapping = cast(Mapping[str, Any], route_book)
+        probe = route_book_mapping.get("paper_route_probe")
+        summary = route_book_mapping.get("summary")
+        symbols: set[str] = set()
+        for source, keys in (
+            (probe, ("active_symbols", "eligible_symbols")),
+            (
+                summary,
+                (
+                    "paper_route_probe_active_symbols",
+                    "paper_route_probe_eligible_symbols",
+                ),
+            ),
+        ):
+            if not isinstance(source, Mapping):
+                continue
+            source_mapping = cast(Mapping[str, Any], source)
+            for key in keys:
+                raw_symbols = source_mapping.get(key)
+                if not isinstance(raw_symbols, list):
+                    continue
+                for raw_symbol in cast(list[object], raw_symbols):
+                    symbol = str(raw_symbol).strip().upper()
+                    if symbol:
+                        symbols.add(symbol)
+        return symbols
+
+    @staticmethod
     def _proof_floor_symbol_route_probe_reasons(
         proof_floor: Mapping[str, object],
         symbol: str,
@@ -578,28 +613,35 @@ class SimpleTradingPipeline(TradingPipeline):
         route_book = proof_floor.get("route_reacquisition_book")
         if not isinstance(route_book, Mapping):
             return set()
-        summary = cast(Mapping[str, Any], route_book).get("summary")
-        if not isinstance(summary, Mapping):
-            return set()
-        repair_candidates = cast(Mapping[str, Any], summary).get("repair_candidates")
-        if not isinstance(repair_candidates, list):
-            return set()
-
+        raw_summary = cast(Mapping[str, Any], route_book).get("summary")
+        summary: Mapping[str, Any]
+        if isinstance(raw_summary, Mapping):
+            summary = cast(Mapping[str, Any], raw_summary)
+        else:
+            summary = {}
         normalized_symbol = symbol.strip().upper()
         reasons: set[str] = set()
-        for raw_candidate in cast(list[object], repair_candidates):
-            if not isinstance(raw_candidate, Mapping):
+        route_book_mapping = cast(Mapping[str, Any], route_book)
+        candidate_sources: list[object] = [
+            summary.get("repair_candidates"),
+            route_book_mapping.get("records"),
+        ]
+        for raw_candidates in candidate_sources:
+            if not isinstance(raw_candidates, list):
                 continue
-            candidate = cast(Mapping[str, Any], raw_candidate)
-            candidate_symbol = str(candidate.get("symbol") or "").strip().upper()
-            if not candidate_symbol or candidate_symbol != normalized_symbol:
-                continue
-            state = str(candidate.get("state") or "").strip()
-            if state not in {"missing", "probing"}:
-                continue
-            reason = str(candidate.get("reason") or "").strip()
-            if reason in _PAPER_ROUTE_PROBE_REASONS:
-                reasons.add(reason)
+            for raw_candidate in cast(list[object], raw_candidates):
+                if not isinstance(raw_candidate, Mapping):
+                    continue
+                candidate = cast(Mapping[str, Any], raw_candidate)
+                candidate_symbol = str(candidate.get("symbol") or "").strip().upper()
+                if not candidate_symbol or candidate_symbol != normalized_symbol:
+                    continue
+                state = str(candidate.get("state") or "").strip()
+                if state not in {"missing", "probing"}:
+                    continue
+                reason = str(candidate.get("reason") or "").strip()
+                if reason in _PAPER_ROUTE_PROBE_REASONS:
+                    reasons.add(reason)
         return reasons
 
     @staticmethod
@@ -691,14 +733,23 @@ class SimpleTradingPipeline(TradingPipeline):
             proof_floor,
             symbol,
         )
+        paper_route_probe_symbols = self._proof_floor_paper_route_probe_symbols(
+            proof_floor
+        )
+        symbol_paper_route_probe_eligible = symbol in paper_route_probe_symbols
         if not (
             (blocking_reasons & _PAPER_ROUTE_PROBE_REASONS)
             or symbol_route_probe_reasons
+            or symbol_paper_route_probe_eligible
         ):
             return None
 
         repair_symbols = self._proof_floor_route_repair_symbols(proof_floor)
-        if repair_symbols and symbol not in repair_symbols:
+        if (
+            repair_symbols
+            and symbol not in repair_symbols
+            and not symbol_paper_route_probe_eligible
+        ):
             return None
 
         return {
@@ -709,6 +760,7 @@ class SimpleTradingPipeline(TradingPipeline):
             "side": decision.action,
             "blocking_reasons": sorted(blocking_reasons | symbol_route_probe_reasons),
             "route_repair_symbols": sorted(repair_symbols),
+            "paper_route_probe_symbols": sorted(paper_route_probe_symbols),
         }
 
     def _apply_paper_route_probe_cap(

--- a/services/torghut/tests/test_profitability_proof_floor.py
+++ b/services/torghut/tests/test_profitability_proof_floor.py
@@ -1018,9 +1018,9 @@ def test_paper_route_probe_config_flows_into_proof_floor_route_book() -> None:
     assert probe["configured_enabled"] is True
     assert probe["active"] is False
     assert probe["next_session_max_notional"] == "25"
-    assert probe["eligible_symbols"] == ["AAPL"]
+    assert probe["eligible_symbols"] == ["AMZN", "AAPL"]
     assert probe["capital_authority"] == "none"
-    assert summary["paper_route_probe_eligible_symbols"] == ["AAPL"]
+    assert summary["paper_route_probe_eligible_symbols"] == ["AMZN", "AAPL"]
 
 
 def test_settled_old_tca_exposes_execution_quality_instead_of_staleness() -> None:

--- a/services/torghut/tests/test_route_reacquisition.py
+++ b/services/torghut/tests/test_route_reacquisition.py
@@ -344,17 +344,30 @@ def test_route_book_surfaces_paper_route_probe_readiness_without_capital_authori
     assert probe["active"] is False
     assert probe["effective_max_notional"] == "0"
     assert probe["next_session_max_notional"] == "25.0"
-    assert probe["eligible_symbols"] == ["AAPL", "INTC"]
+    assert probe["eligible_symbols"] == ["AMZN", "AAPL", "INTC"]
     assert probe["active_symbols"] == []
     assert probe["blocking_reasons"] == ["market_session_closed"]
     assert probe["capital_authority"] == "none"
 
     summary = cast(Mapping[str, Any], book["summary"])
-    assert summary["paper_route_probe_eligible_symbols"] == ["AAPL", "INTC"]
+    assert summary["paper_route_probe_eligible_symbols"] == ["AMZN", "AAPL", "INTC"]
     assert summary["paper_route_probe_active_symbols"] == []
     assert summary["repair_candidate_symbols"] == ["NVDA", "AAPL", "INTC"]
 
     records = cast(list[Mapping[str, Any]], book["records"])
+    amzn = next(item for item in records if item["symbol"] == "AMZN")
+    amzn_probe = cast(Mapping[str, Any], amzn["paper_route_probe"])
+    assert amzn["state"] == "probing"
+    assert amzn["reason"] == "route_tca_passed_but_dependency_receipts_block_capital"
+    assert (
+        amzn["next_repair_action"]
+        == "collect_paper_runtime_ledger_receipts_before_capital"
+    )
+    assert amzn_probe["eligible"] is True
+    assert amzn_probe["active"] is False
+    assert amzn_probe["notional_limit"] == "0"
+    assert amzn_probe["next_session_notional_limit"] == "25.0"
+
     aapl = next(item for item in records if item["symbol"] == "AAPL")
     aapl_probe = cast(Mapping[str, Any], aapl["paper_route_probe"])
     assert aapl["paper_probe_notional_limit"] == "0"

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -3084,6 +3084,9 @@ class TestTradingPipeline(TestCase):
             SimpleTradingPipeline._proof_floor_route_repair_symbols({}), set()
         )
         self.assertEqual(
+            SimpleTradingPipeline._proof_floor_paper_route_probe_symbols({}), set()
+        )
+        self.assertEqual(
             SimpleTradingPipeline._proof_floor_symbol_route_probe_reasons({}, "NVDA"),
             set(),
         )
@@ -3112,6 +3115,27 @@ class TestTradingPipeline(TestCase):
                 }
             ),
             {"NVDA", "MU"},
+        )
+        self.assertEqual(
+            SimpleTradingPipeline._proof_floor_paper_route_probe_symbols(
+                {
+                    "route_reacquisition_book": {
+                        "summary": {
+                            "paper_route_probe_eligible_symbols": [
+                                " nvda ",
+                                "",
+                                "MU",
+                            ],
+                            "paper_route_probe_active_symbols": ["aapl"],
+                        },
+                        "paper_route_probe": {
+                            "eligible_symbols": ["INTC"],
+                            "active_symbols": ["AMZN"],
+                        },
+                    }
+                }
+            ),
+            {"AAPL", "AMZN", "INTC", "MU", "NVDA"},
         )
         self.assertEqual(
             SimpleTradingPipeline._proof_floor_symbol_route_probe_reasons(
@@ -3281,6 +3305,33 @@ class TestTradingPipeline(TestCase):
             )
         )
 
+        record_level_route_repair_floor = {
+            **proof_floor,
+            "blocking_reasons": ["alpha_readiness_not_promotion_eligible"],
+            "route_reacquisition_book": {
+                "summary": {"candidate_symbols": ["NVDA"]},
+                "records": [
+                    {
+                        "symbol": "NVDA",
+                        "state": "probing",
+                        "reason": (
+                            "route_tca_passed_but_dependency_receipts_block_capital"
+                        ),
+                    }
+                ],
+            },
+        }
+        record_level_probe_context = pipeline._paper_route_probe_context(
+            proof_floor=record_level_route_repair_floor,
+            decision=decision,
+        )
+        self.assertIsNotNone(record_level_probe_context)
+        assert record_level_probe_context is not None
+        self.assertIn(
+            "route_tca_passed_but_dependency_receipts_block_capital",
+            cast(list[str], record_level_probe_context.get("blocking_reasons")),
+        )
+
         symbol_level_route_repair_floor = {
             **proof_floor,
             "blocking_reasons": ["alpha_readiness_not_promotion_eligible"],
@@ -3309,6 +3360,29 @@ class TestTradingPipeline(TestCase):
         self.assertIn(
             "execution_tca_symbol_missing",
             cast(list[str], symbol_level_probe_context.get("blocking_reasons")),
+        )
+
+        paper_route_probe_symbol_floor = {
+            **proof_floor,
+            "blocking_reasons": ["alpha_readiness_not_promotion_eligible"],
+            "route_reacquisition_book": {
+                "summary": {
+                    "repair_candidate_symbols": ["MU"],
+                    "paper_route_probe_eligible_symbols": ["NVDA"],
+                }
+            },
+        }
+        eligible_symbol_probe_context = pipeline._paper_route_probe_context(
+            proof_floor=paper_route_probe_symbol_floor,
+            decision=decision,
+        )
+        self.assertIsNotNone(eligible_symbol_probe_context)
+        assert eligible_symbol_probe_context is not None
+        self.assertEqual(
+            eligible_symbol_probe_context.get("paper_route_probe_symbols"), ["NVDA"]
+        )
+        self.assertEqual(
+            eligible_symbol_probe_context.get("route_repair_symbols"), ["MU"]
         )
 
         wrong_symbol_floor = {


### PR DESCRIPTION
## Summary

- Treat `route_tca_passed_but_dependency_receipts_block_capital` as a bounded paper-route probe reason so routeable symbols like AMZN can collect runtime-ledger receipts before capital.
- Let the simple paper submit lane honor formal `paper_route_probe` eligible symbols and route-book records, while keeping live submit and promotion authority unchanged.
- Add regression coverage for route-book eligibility, proof-floor summaries, and simple-pipeline probe context behavior.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/route_reacquisition.py app/trading/scheduler/simple_pipeline.py tests/test_route_reacquisition.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff check app/trading/route_reacquisition.py app/trading/scheduler/simple_pipeline.py tests/test_route_reacquisition.py tests/test_trading_pipeline.py`
- `uv run --frozen python -m pytest tests/test_route_reacquisition.py tests/test_trading_pipeline.py -k 'paper_route_probe' -q`
- `uv run --frozen python -m pytest tests/test_profitability_proof_floor.py tests/test_verify_trading_readiness.py tests/test_build_revenue_repair_digest.py -k 'paper_route_probe' -q`
- `uv run --frozen python -m pytest tests/test_route_reacquisition.py tests/test_trading_pipeline.py tests/test_profitability_proof_floor.py tests/test_verify_trading_readiness.py tests/test_build_revenue_repair_digest.py -k 'paper_route_probe' -q`
- `uv run --frozen python -m pytest tests/test_route_reacquisition.py tests/test_profitability_proof_floor.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
