### PR TITLE
feat(torghut): rank friction-aware regime contracts

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -3562,6 +3562,78 @@ def _mechanism_overlays_for_card(card: HypothesisCard) -> dict[str, Any]:
 
     if has_any(
         (
+            "fr-lux",
+            "friction-aware",
+            "friction aware",
+            "regime-conditioned",
+            "regime conditioned",
+            "volatility-liquidity regime",
+            "volatility liquidity regime",
+            "trade-space trust region",
+            "trade space trust region",
+            "inventory flow trust region",
+            "turnover budget",
+            "turnover bounds",
+            "inaction band",
+            "convex frictions",
+            "cost misspecification",
+            "liquidity proxy",
+            "liquidity proxies",
+        )
+    ):
+        overlay_ids.append("friction_aware_regime_conditioned_policy")
+        overlay_contracts.append(
+            {
+                "overlay_id": "friction_aware_regime_conditioned_policy",
+                "required_evidence": [
+                    "regime_state",
+                    "regime_conditioned_policy",
+                    "proportional_cost_model",
+                    "impact_cost_model",
+                    "liquidity_proxy_cost_calibration",
+                    "trade_space_trust_region",
+                    "turnover_budget",
+                    "cost_misspecification_stress",
+                    "scenario_level_inference",
+                    "post_cost_net_pnl",
+                    "live_paper_parity",
+                ],
+                "rank_metric": "post_cost_net_pnl_after_regime_conditioned_friction_stress",
+                "evidence_policy": (
+                    "friction_aware_regime_conditioned_policy_is_replay_ranking_not_promotion_proof"
+                ),
+            }
+        )
+        hard_vetoes.update(
+            {
+                "required_friction_aware_regime_conditioning": True,
+                "required_proportional_and_impact_cost_model": True,
+                "required_liquidity_proxy_cost_calibration": True,
+                "required_trade_space_trust_region": True,
+                "required_turnover_budget": True,
+                "required_cost_misspecification_stress": True,
+                "required_scenario_level_inference": True,
+                "required_live_paper_parity": True,
+            }
+        )
+        promotion_contract.update(
+            {
+                "requires_regime_conditioned_policy": True,
+                "requires_proportional_and_impact_cost_model": True,
+                "requires_liquidity_proxy_cost_calibration": True,
+                "requires_trade_space_trust_region": True,
+                "requires_turnover_budget": True,
+                "requires_cost_misspecification_stress": True,
+                "requires_scenario_level_inference": True,
+                "requires_live_paper_parity": True,
+                "rejects_cost_blind_policy_optimization": True,
+                "rejects_single_regime_cost_backtest": True,
+                "risk_policy": "friction_aware_regime_conditioned_policy_validation_only",
+            }
+        )
+
+    if has_any(
+        (
             "regime-weighted conformal",
             "regime weighted conformal",
             "regime_weighted_conformal",
@@ -4334,6 +4406,7 @@ def _apply_mechanism_overlay_strategy_params(
         {
             "mixed_market_limit_execution_policy",
             "crumbling_quote_liquidity_erosion",
+            "friction_aware_regime_conditioned_policy",
         }
         & overlay_ids
     ):
@@ -4348,6 +4421,10 @@ def _apply_mechanism_overlay_strategy_params(
         params.setdefault("market_order_spread_bps_max", "6")
         params.setdefault("max_recent_quote_invalid_ratio", "0.12")
         params.setdefault("max_recent_quote_jump_bps", "40")
+    if "friction_aware_regime_conditioned_policy" in overlay_ids:
+        params.setdefault("cost_model_profile", "proportional_plus_impact")
+        params.setdefault("turnover_budget_profile", "trade_space_trust_region")
+        params.setdefault("regime_conditioning_profile", "volatility_liquidity")
     next_overrides["params"] = params
     return next_overrides
 

--- a/services/torghut/app/trading/discovery/mlx_training_data.py
+++ b/services/torghut/app/trading/discovery/mlx_training_data.py
@@ -17,7 +17,7 @@ from app.trading.discovery.objectives import (
     deployable_proof_failed_gate_count,
 )
 
-MLX_RANKER_SCHEMA_VERSION = "torghut.mlx-ranker.v4"
+MLX_RANKER_SCHEMA_VERSION = "torghut.mlx-ranker.v5"
 
 _MECHANISM_OVERLAY_IDS = (
     "cluster_lob_event_clustering",
@@ -25,6 +25,7 @@ _MECHANISM_OVERLAY_IDS = (
     "queue_position_survival_fill_curve",
     "mpc_dynamic_execution_schedule",
     "alpha_decay_predictability_stress",
+    "friction_aware_regime_conditioned_policy",
     "regime_weighted_conformal_cost_buffer",
     "crumbling_quote_liquidity_erosion",
     "nonlinear_market_impact_tca",
@@ -66,6 +67,12 @@ _PAPER_CONTRACT_FEATURE_NAMES = (
     "paper_requires_regime_tail_exceedance",
     "paper_requires_breakeven_cost_buffer",
     "paper_requires_seed_model_family_robustness",
+    "paper_requires_regime_conditioning",
+    "paper_requires_trade_space_trust_region",
+    "paper_requires_turnover_budget",
+    "paper_requires_cost_misspecification_stress",
+    "paper_requires_liquidity_proxy_cost_calibration",
+    "paper_requires_scenario_level_inference",
     "paper_requires_crumbling_quote_probability",
     "paper_requires_mechanical_liquidity_erosion",
     "paper_promotion_requires_count",
@@ -473,6 +480,52 @@ def _paper_contract_feature_values(spec: CandidateSpec) -> Mapping[str, float]:
                 "multi_seed_replay",
                 "model_family_robustness",
                 "seed_model_family_robustness",
+            ),
+        ),
+        "paper_requires_regime_conditioning": _requirement_present(
+            contract_requirements,
+            (
+                "regime_state",
+                "regime_conditioned_policy",
+                "regime_conditioning",
+                "volatility_liquidity_regime",
+            ),
+        ),
+        "paper_requires_trade_space_trust_region": _requirement_present(
+            contract_requirements,
+            (
+                "trade_space_trust_region",
+                "inventory_flow_trust_region",
+                "kl_trust_region",
+            ),
+        ),
+        "paper_requires_turnover_budget": _requirement_present(
+            contract_requirements,
+            ("turnover_budget", "turnover_bounds", "inaction_bands"),
+        ),
+        "paper_requires_cost_misspecification_stress": _requirement_present(
+            contract_requirements,
+            (
+                "cost_misspecification_stress",
+                "cost_level_grid",
+                "transaction_cost_stress",
+            ),
+        ),
+        "paper_requires_liquidity_proxy_cost_calibration": _requirement_present(
+            contract_requirements,
+            (
+                "liquidity_proxy_cost_calibration",
+                "liquidity_proxy",
+                "proportional_cost_model",
+                "impact_cost_model",
+            ),
+        ),
+        "paper_requires_scenario_level_inference": _requirement_present(
+            contract_requirements,
+            (
+                "scenario_level_inference",
+                "multiple_testing_correction",
+                "bootstrap_confidence_interval",
             ),
         ),
         "paper_requires_crumbling_quote_probability": _requirement_present(

--- a/services/torghut/app/whitepapers/claim_compiler.py
+++ b/services/torghut/app/whitepapers/claim_compiler.py
@@ -1092,6 +1092,87 @@ RECENT_WHITEPAPER_SEEDS: tuple[WhitepaperResearchSource, ...] = (
         ),
     ),
     WhitepaperResearchSource(
+        run_id="seed-arxiv-2510-02986",
+        title="FR-LUX: Friction-Aware, Regime-Conditioned Policy Optimization for Implementable Portfolio Management",
+        source_url="https://arxiv.org/abs/2510.02986",
+        published_at="2025-10-03",
+        claims=(
+            {
+                "claim_id": "friction-aware-regime-conditioned-policy",
+                "claim_type": "feature_recipe",
+                "claim_text": (
+                    "FR-LUX uses friction-aware, regime-conditioned policy optimization to learn "
+                    "after-cost trading policies across volatility-liquidity regimes."
+                ),
+                "asset_scope": "us_equities_portfolio",
+                "horizon_scope": "portfolio_execution",
+                "expected_direction": "positive",
+                "data_requirements": [
+                    "regime_state",
+                    "regime_conditioned_policy",
+                    "volatility_liquidity_regime",
+                    "proportional_cost_model",
+                    "impact_cost_model",
+                    "post_cost_net_pnl",
+                ],
+                "confidence": "0.76",
+            },
+            {
+                "claim_id": "trade-space-trust-region-turnover-budget",
+                "claim_type": "risk_constraint",
+                "claim_text": (
+                    "Trade-space trust regions, inaction bands, and turnover budgets are needed "
+                    "to avoid cost-blind inventory churn under convex frictions."
+                ),
+                "asset_scope": "us_equities_portfolio",
+                "horizon_scope": "portfolio_execution",
+                "expected_direction": "neutral",
+                "data_requirements": [
+                    "trade_space_trust_region",
+                    "turnover_budget",
+                    "turnover_bounds",
+                    "cost_misspecification_stress",
+                    "transaction_cost_stress",
+                ],
+                "confidence": "0.75",
+            },
+            {
+                "claim_id": "scenario-level-cost-calibration-validation",
+                "claim_type": "validation_requirement",
+                "claim_text": (
+                    "Promotion candidates should prove liquidity-proxy cost calibration, "
+                    "scenario-level inference, and live-paper parity before a regime-conditioned "
+                    "friction model affects capital."
+                ),
+                "asset_scope": "us_equities_portfolio",
+                "horizon_scope": "portfolio_execution",
+                "expected_direction": "neutral",
+                "data_requirements": [
+                    "liquidity_proxy_cost_calibration",
+                    "scenario_level_inference",
+                    "bootstrap_confidence_interval",
+                    "multiple_testing_correction",
+                    "live_paper_parity",
+                ],
+                "confidence": "0.74",
+            },
+        ),
+        claim_relations=(
+            {
+                "relation_id": "frlux-policy-requires-turnover-and-cost-validation",
+                "relation_type": "requires_validation",
+                "source_claim_id": "trade-space-trust-region-turnover-budget",
+                "target_claim_id": "friction-aware-regime-conditioned-policy",
+            },
+            {
+                "relation_id": "frlux-policy-requires-scenario-cost-calibration",
+                "relation_type": "requires_validation",
+                "source_claim_id": "scenario-level-cost-calibration-validation",
+                "target_claim_id": "friction-aware-regime-conditioned-policy",
+            },
+        ),
+    ),
+    WhitepaperResearchSource(
         run_id="seed-arxiv-2603-16365",
         title="FactorEngine: A Program-level Knowledge-Infused Factor Mining Framework for Quantitative Investment",
         source_url="https://arxiv.org/abs/2603.16365",

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -712,6 +712,80 @@ class TestCandidateSpecs(TestCase):
             "mpc_dynamic_schedule_validation_only",
         )
 
+    def test_friction_aware_regime_claim_adds_policy_overlay(self) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-frlux-regime-friction",
+            claims=[
+                {
+                    "claim_id": "frlux-regime-conditioned-policy",
+                    "claim_type": "feature_recipe",
+                    "claim_text": (
+                        "FR-LUX friction-aware, regime-conditioned policy optimization "
+                        "uses proportional and impact costs across volatility-liquidity regimes."
+                    ),
+                    "data_requirements": [
+                        "regime_state",
+                        "regime_conditioned_policy",
+                        "proportional_cost_model",
+                        "impact_cost_model",
+                    ],
+                    "confidence": "0.76",
+                },
+                {
+                    "claim_id": "frlux-turnover-budget-validation",
+                    "claim_type": "validation_requirement",
+                    "claim_text": (
+                        "Trade-space trust region, turnover budget, cost misspecification stress, "
+                        "scenario-level inference, and live-paper parity must validate the policy."
+                    ),
+                    "data_requirements": [
+                        "trade_space_trust_region",
+                        "turnover_budget",
+                        "cost_misspecification_stress",
+                        "scenario_level_inference",
+                        "live_paper_parity",
+                    ],
+                    "confidence": "0.74",
+                },
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+        first = specs[0]
+
+        self.assertIn(
+            "friction_aware_regime_conditioned_policy",
+            first.parameter_space["mechanism_overlay_ids"],
+        )
+        params = first.strategy_overrides["params"]
+        self.assertEqual(params["cost_model_profile"], "proportional_plus_impact")
+        self.assertEqual(params["turnover_budget_profile"], "trade_space_trust_region")
+        self.assertEqual(params["regime_conditioning_profile"], "volatility_liquidity")
+        self.assertTrue(first.hard_vetoes["required_trade_space_trust_region"])
+        self.assertTrue(first.hard_vetoes["required_cost_misspecification_stress"])
+        self.assertTrue(first.promotion_contract["requires_turnover_budget"])
+        self.assertTrue(
+            first.promotion_contract["rejects_cost_blind_policy_optimization"]
+        )
+        mechanism_overlays = candidate_specs_module._mechanism_overlays_for_card(
+            cards[0]
+        )
+        friction_contract = next(
+            contract
+            for contract in mechanism_overlays["feature_contract"]["mechanism_overlays"]
+            if contract["overlay_id"] == "friction_aware_regime_conditioned_policy"
+        )
+        self.assertEqual(
+            friction_contract["rank_metric"],
+            "post_cost_net_pnl_after_regime_conditioned_friction_stress",
+        )
+        self.assertEqual(
+            friction_contract["evidence_policy"],
+            "friction_aware_regime_conditioned_policy_is_replay_ranking_not_promotion_proof",
+        )
+
     def test_alpha_decay_claim_adds_predictability_stress_contract(self) -> None:
         cards = build_hypothesis_cards(
             source_run_id="paper-tkan-alpha-decay",

--- a/services/torghut/tests/test_mlx_training_data.py
+++ b/services/torghut/tests/test_mlx_training_data.py
@@ -565,6 +565,99 @@ class TestMlxTrainingData(TestCase):
             0.0,
         )
 
+    def test_training_rows_encode_friction_aware_regime_contract(self) -> None:
+        spec = CandidateSpec(
+            schema_version="torghut.candidate-spec.v1",
+            candidate_spec_id="spec-frlux",
+            hypothesis_id="H-FRLUX",
+            family_template_id="intraday_tsmom_v2",
+            candidate_kind="configuration",
+            runtime_family="intraday_tsmom_consistent",
+            runtime_strategy_name="intraday-tsmom-profit-v3",
+            feature_contract={
+                "source_claims": [
+                    {
+                        "claim_id": "friction-aware-regime-conditioned-policy",
+                        "claim_type": "feature_recipe",
+                        "confidence": "0.76",
+                        "data_requirements": [
+                            "regime_state",
+                            "regime_conditioned_policy",
+                            "proportional_cost_model",
+                            "impact_cost_model",
+                        ],
+                    }
+                ],
+                "validation_requirements": [
+                    {
+                        "claim_id": "frlux-validation",
+                        "data_requirements": [
+                            "trade_space_trust_region",
+                            "turnover_budget",
+                            "cost_misspecification_stress",
+                            "liquidity_proxy_cost_calibration",
+                            "scenario_level_inference",
+                        ],
+                    }
+                ],
+                "mechanism_overlays": [
+                    {
+                        "overlay_id": "friction_aware_regime_conditioned_policy",
+                        "required_evidence": [
+                            "regime_state",
+                            "regime_conditioned_policy",
+                            "trade_space_trust_region",
+                            "turnover_budget",
+                            "cost_misspecification_stress",
+                            "liquidity_proxy_cost_calibration",
+                            "scenario_level_inference",
+                            "live_paper_parity",
+                        ],
+                    }
+                ],
+            },
+            parameter_space={
+                "mechanism_overlay_ids": ["friction_aware_regime_conditioned_policy"]
+            },
+            strategy_overrides={
+                "max_notional_per_trade": "25000",
+                "max_position_pct_equity": "0.25",
+                "params": {
+                    "capital_profile": "initial_equity_cash_constrained_1x",
+                    "max_entries_per_session": "2",
+                    "max_gross_exposure_pct_equity": "1.0",
+                },
+            },
+            objective={"target_net_pnl_per_day": "500"},
+            hard_vetoes={"required_min_daily_notional": "250000"},
+            expected_failure_modes=(),
+            promotion_contract={
+                "requires_regime_conditioned_policy": True,
+                "requires_turnover_budget": True,
+                "requires_cost_misspecification_stress": True,
+                "rejects_cost_blind_policy_optimization": True,
+            },
+        )
+
+        rows = build_mlx_training_rows(candidate_specs=[spec], evidence_bundles=[])
+        features = rows[0].to_payload()["features"]
+
+        self.assertEqual(
+            features["paper_overlay_friction_aware_regime_conditioned_policy"],
+            1.0,
+        )
+        self.assertEqual(features["paper_requires_regime_conditioning"], 1.0)
+        self.assertEqual(features["paper_requires_trade_space_trust_region"], 1.0)
+        self.assertEqual(features["paper_requires_turnover_budget"], 1.0)
+        self.assertEqual(features["paper_requires_cost_misspecification_stress"], 1.0)
+        self.assertEqual(
+            features["paper_requires_liquidity_proxy_cost_calibration"], 1.0
+        )
+        self.assertEqual(features["paper_requires_scenario_level_inference"], 1.0)
+        self.assertEqual(features["paper_requires_live_paper_parity"], 1.0)
+        self.assertEqual(features["paper_promotion_requires_count"], 3.0)
+        self.assertEqual(features["paper_promotion_rejects_count"], 1.0)
+
     def test_training_rows_encode_crumbling_quote_overlay_contract(self) -> None:
         spec = CandidateSpec(
             schema_version="torghut.candidate-spec.v1",

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -4075,7 +4075,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             self.assertEqual(
                 pre_replay_model_payload["row_count"], payload["candidate_spec_count"]
             )
-            self.assertEqual(model_payload["schema_version"], "torghut.mlx-ranker.v4")
+            self.assertEqual(model_payload["schema_version"], "torghut.mlx-ranker.v5")
             self.assertEqual(
                 model_payload["row_count"], payload["candidate_spec_count"]
             )
@@ -8824,7 +8824,7 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 backend_preference="numpy-fallback",
             )
 
-        self.assertEqual(model_payload["schema_version"], "torghut.mlx-ranker.v4")
+        self.assertEqual(model_payload["schema_version"], "torghut.mlx-ranker.v5")
         self.assertEqual(model_payload["backend"], "numpy-fallback")
         self.assertIn("rank_bucket_lift", model_payload)
         self.assertIn(model_payload["model_status"], {"active", "demoted_to_heuristic"})

--- a/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
+++ b/services/torghut/tests/test_whitepaper_autoresearch_artifacts.py
@@ -230,7 +230,7 @@ class TestWhitepaperAutoresearchArtifacts(TestCase):
         model = train_mlx_ranker(rows, backend_preference="numpy-fallback", steps=128)
         ranked = rank_training_rows(model=model, rows=rows)
 
-        self.assertEqual(model.schema_version, "torghut.mlx-ranker.v4")
+        self.assertEqual(model.schema_version, "torghut.mlx-ranker.v5")
         self.assertEqual(model.backend, "numpy-fallback")
         self.assertEqual(model.row_count, 2)
         self.assertEqual(ranked[0].candidate_spec_id, high_spec.candidate_spec_id)

--- a/services/torghut/tests/test_whitepaper_claim_compiler.py
+++ b/services/torghut/tests/test_whitepaper_claim_compiler.py
@@ -46,6 +46,7 @@ class TestWhitepaperClaimCompiler(TestCase):
                 "seed-arxiv-2604-10402",
                 "seed-arxiv-2604-09060",
                 "seed-arxiv-2603-29086",
+                "seed-arxiv-2510-02986",
                 "seed-arxiv-2603-16365",
                 "seed-arxiv-2602-07085",
                 "seed-arxiv-2505-17388",


### PR DESCRIPTION
## Summary

- Add FR-LUX as a recent whitepaper seed for friction-aware, regime-conditioned portfolio execution.
- Compile FR-LUX-style claims into a validation-only `friction_aware_regime_conditioned_policy` mechanism overlay with hard evidence requirements and no promotion-gate relaxation.
- Extend MLX ranker paper-contract features to encode regime conditioning, trust-region turnover control, cost-misspecification stress, liquidity-proxy cost calibration, and scenario-level inference.

## Related Issues

None.

## Testing

- `uv run --frozen ruff format app/trading/discovery/mlx_training_data.py app/trading/discovery/candidate_specs.py app/whitepapers/claim_compiler.py tests/test_mlx_training_data.py tests/test_candidate_specs.py tests/test_whitepaper_claim_compiler.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_whitepaper_autoresearch_artifacts.py`
- `uv run --frozen ruff check app/trading/discovery/mlx_training_data.py app/trading/discovery/candidate_specs.py app/whitepapers/claim_compiler.py tests/test_mlx_training_data.py tests/test_candidate_specs.py tests/test_whitepaper_claim_compiler.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_whitepaper_autoresearch_artifacts.py`
- `uv run --frozen python -m pytest tests/test_whitepaper_claim_compiler.py tests/test_candidate_specs.py tests/test_mlx_training_data.py -k 'friction_aware or recent_seed_sources or mechanism_contract_features or conformal_cost_buffer' -q`
- `uv run --frozen python -m pytest tests/test_mlx_training_data.py tests/test_candidate_specs.py tests/test_whitepaper_claim_compiler.py tests/test_whitepaper_autoresearch_artifacts.py -q`
- `uv run --frozen python -m pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'candidate_specs_replay_skips_compiler_and_replays_selected_specs or candidate_sleeve_goal_rows_carry_order_type_proof_refs or train_ranker_script_helper_reads_runner_artifacts' -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A.

## Breaking Changes

The MLX ranker schema version changes from `torghut.mlx-ranker.v4` to `torghut.mlx-ranker.v5` because the feature vector adds FR-LUX paper-contract features.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
