### PR TITLE
fix(torghut): scope paper route audit source activity

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -13,7 +13,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any, cast
 from zoneinfo import ZoneInfo
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from ..models import (
@@ -274,6 +274,20 @@ def _paper_route_probe_symbols(probe: Mapping[str, object]) -> list[str]:
     return symbols
 
 
+def _target_probe_symbols(
+    target: Mapping[str, object],
+    probe: Mapping[str, object],
+) -> list[str]:
+    symbols: list[str] = []
+    for item in _as_sequence(target.get("paper_route_probe_symbols")):
+        symbol = str(item).strip().upper()
+        if symbol and symbol not in symbols:
+            symbols.append(symbol)
+    if symbols:
+        return symbols
+    return _paper_route_probe_symbols(probe)
+
+
 def _next_session_probe_notional(probe: Mapping[str, object]) -> str:
     next_notional = _safe_decimal(probe.get("next_session_max_notional"))
     if next_notional > 0:
@@ -300,6 +314,11 @@ def _target_identity(target: Mapping[str, Any]) -> dict[str, object]:
         "dataset_snapshot_ref": _safe_text(target.get("dataset_snapshot_ref")),
         "window_start": _safe_text(target.get("window_start")),
         "window_end": _safe_text(target.get("window_end")),
+        "paper_route_probe_symbols": [
+            str(item).strip()
+            for item in _as_sequence(target.get("paper_route_probe_symbols"))
+            if str(item).strip()
+        ],
         "runtime_ledger_bucket_ref": _safe_text(
             target.get("runtime_ledger_bucket_ref")
         ),
@@ -511,11 +530,19 @@ def _strategy_source_activity(
     session: Session,
     *,
     strategy_name: str | None,
+    account_label: str | None,
+    symbols: Sequence[str],
     window_start: datetime,
+    window_end: datetime,
 ) -> dict[str, object]:
+    symbol_filters = [
+        str(item).strip().upper() for item in symbols if str(item).strip()
+    ]
     if strategy_name is None:
         return {
             "strategy_name": None,
+            "account_label": account_label,
+            "symbols": symbol_filters,
             "decision_count": 0,
             "execution_count": 0,
             "filled_execution_count": 0,
@@ -527,37 +554,73 @@ def _strategy_source_activity(
             "missing_reasons": ["strategy_name_missing"],
         }
 
+    decision_stmt = (
+        select(TradeDecision)
+        .join(Strategy, TradeDecision.strategy_id == Strategy.id)
+        .where(Strategy.name == strategy_name)
+        .where(TradeDecision.created_at >= window_start)
+        .where(TradeDecision.created_at <= window_end)
+    )
+    if account_label:
+        decision_stmt = decision_stmt.where(
+            TradeDecision.alpaca_account_label == account_label
+        )
+    if symbol_filters:
+        decision_stmt = decision_stmt.where(
+            func.upper(TradeDecision.symbol).in_(symbol_filters)
+        )
     decision_rows = list(
         session.execute(
-            select(TradeDecision)
-            .join(Strategy, TradeDecision.strategy_id == Strategy.id)
-            .where(Strategy.name == strategy_name)
-            .where(TradeDecision.created_at >= window_start)
-            .order_by(TradeDecision.created_at.desc())
-            .limit(500)
+            decision_stmt.order_by(TradeDecision.created_at.desc()).limit(500)
         ).scalars()
     )
     decision_ids = [row.id for row in decision_rows]
     execution_rows: list[Execution] = []
     if decision_ids:
+        execution_stmt = (
+            select(Execution)
+            .where(Execution.trade_decision_id.in_(decision_ids))
+            .where(Execution.created_at >= window_start)
+            .where(Execution.created_at <= window_end)
+        )
+        if account_label:
+            execution_stmt = execution_stmt.where(
+                Execution.alpaca_account_label == account_label
+            )
+        if symbol_filters:
+            execution_stmt = execution_stmt.where(
+                func.upper(Execution.symbol).in_(symbol_filters)
+            )
         execution_rows = list(
             session.execute(
-                select(Execution)
-                .where(Execution.trade_decision_id.in_(decision_ids))
-                .order_by(Execution.created_at.desc())
-                .limit(500)
+                execution_stmt.order_by(Execution.created_at.desc()).limit(500)
             ).scalars()
         )
-    tca_rows = list(
-        session.execute(
+    tca_rows: list[ExecutionTCAMetric] = []
+    if decision_ids:
+        tca_stmt = (
             select(ExecutionTCAMetric)
             .join(Strategy, ExecutionTCAMetric.strategy_id == Strategy.id)
             .where(Strategy.name == strategy_name)
             .where(ExecutionTCAMetric.computed_at >= window_start)
-            .order_by(ExecutionTCAMetric.computed_at.desc())
-            .limit(500)
-        ).scalars()
-    )
+            .where(ExecutionTCAMetric.computed_at <= window_end)
+        )
+        tca_stmt = tca_stmt.where(
+            ExecutionTCAMetric.trade_decision_id.in_(decision_ids)
+        )
+        if account_label:
+            tca_stmt = tca_stmt.where(
+                ExecutionTCAMetric.alpaca_account_label == account_label
+            )
+        if symbol_filters:
+            tca_stmt = tca_stmt.where(
+                func.upper(ExecutionTCAMetric.symbol).in_(symbol_filters)
+            )
+        tca_rows = list(
+            session.execute(
+                tca_stmt.order_by(ExecutionTCAMetric.computed_at.desc()).limit(500)
+            ).scalars()
+        )
     decision_count = len(decision_rows)
     execution_count = len(execution_rows)
     tca_sample_count = len(tca_rows)
@@ -573,6 +636,8 @@ def _strategy_source_activity(
         missing_reasons.append("source_tca_missing")
     return {
         "strategy_name": strategy_name,
+        "account_label": account_label,
+        "symbols": symbol_filters,
         "decision_count": decision_count,
         "execution_count": execution_count,
         "filled_execution_count": filled_execution_count,
@@ -840,7 +905,10 @@ def _target_audit(
     source_activity = _strategy_source_activity(
         session,
         strategy_name=cast(str | None, target.get("strategy_name")),
+        account_label=cast(str | None, target.get("account_label")),
+        symbols=_target_probe_symbols(target, probe),
         window_start=window_start,
+        window_end=window_end,
     )
     runtime_ledger = _runtime_ledger_summary(
         session,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -279,6 +279,284 @@ class TestPaperRouteEvidenceAudit(TestCase):
             target["runtime_ledger_target_metadata_blockers"],
         )
 
+    def test_source_activity_is_bound_to_target_window_end(self) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        strategy_name = "post-window-paper-route"
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="post-window paper route source activity",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={"action": "buy", "qty": "1"},
+                rationale="post window fixture",
+                status="executed",
+                created_at=window_end + timedelta(minutes=5),
+                executed_at=window_end + timedelta(minutes=6),
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="paper",
+                alpaca_order_id="post-window-order-1",
+                client_order_id="post-window-client-1",
+                symbol="AAPL",
+                side="buy",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=window_end + timedelta(minutes=6),
+                updated_at=window_end + timedelta(minutes=6),
+                last_update_at=window_end + timedelta(minutes=6),
+            )
+            session.add(execution)
+            session.flush()
+            session.add(
+                ExecutionTCAMetric(
+                    execution_id=execution.id,
+                    trade_decision_id=decision.id,
+                    strategy_id=strategy.id,
+                    alpaca_account_label="paper",
+                    symbol="AAPL",
+                    side="buy",
+                    arrival_price=Decimal("99"),
+                    avg_fill_price=Decimal("100"),
+                    filled_qty=Decimal("1"),
+                    signed_qty=Decimal("1"),
+                    slippage_bps=Decimal("5"),
+                    shortfall_notional=Decimal("1"),
+                    realized_shortfall_bps=Decimal("5"),
+                    churn_qty=Decimal("0"),
+                    churn_ratio=Decimal("0"),
+                    computed_at=window_end + timedelta(minutes=7),
+                    created_at=window_end + timedelta(minutes=7),
+                    updated_at=window_end + timedelta(minutes=7),
+                )
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-POST-WINDOW",
+                                "candidate_id": "candidate-post-window",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": strategy_name,
+                                "account_label": "paper",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_route_probe_symbols": [" aapl ", "AAPL"],
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL", "MSFT"],
+                        "paper_route_probe_active_symbols": [],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": False,
+                        "next_session_max_notional": "25",
+                        "eligible_symbol_count": 1,
+                        "blocking_reasons": ["market_session_closed"],
+                    },
+                },
+                generated_at=window_start - timedelta(days=2),
+            )
+
+        source_activity = payload["targets"][0]["source_activity"]
+        self.assertEqual(source_activity["symbols"], ["AAPL"])
+        self.assertTrue(source_activity["missing"])
+        self.assertEqual(source_activity["decision_count"], 0)
+        self.assertEqual(source_activity["execution_count"], 0)
+        self.assertEqual(source_activity["tca_sample_count"], 0)
+        self.assertEqual(
+            source_activity["missing_reasons"],
+            [
+                "source_decisions_missing",
+                "source_executions_missing",
+                "source_tca_missing",
+            ],
+        )
+        self.assertIn(
+            "source_decisions_missing",
+            payload["targets"][0]["readiness"]["evidence_collection_blockers"],
+        )
+
+    def test_source_activity_is_scoped_to_target_account_and_probe_symbols(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        strategy_name = "wrong-account-or-symbol-paper-route"
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="wrong account and symbol paper route source activity",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL", "MSFT"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            for suffix, account_label, symbol in (
+                ("wrong-account", "other-paper", "AAPL"),
+                ("wrong-symbol", "paper", "MSFT"),
+            ):
+                decision = TradeDecision(
+                    strategy_id=strategy.id,
+                    alpaca_account_label=account_label,
+                    symbol=symbol,
+                    timeframe="1Min",
+                    decision_json={"action": "buy", "qty": "1"},
+                    rationale=f"{suffix} fixture",
+                    status="executed",
+                    created_at=window_start + timedelta(minutes=5),
+                    executed_at=window_start + timedelta(minutes=6),
+                )
+                session.add(decision)
+                session.flush()
+                execution = Execution(
+                    trade_decision_id=decision.id,
+                    alpaca_account_label=account_label,
+                    alpaca_order_id=f"{suffix}-order-1",
+                    client_order_id=f"{suffix}-client-1",
+                    symbol=symbol,
+                    side="buy",
+                    order_type="limit",
+                    time_in_force="day",
+                    submitted_qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("100"),
+                    status="filled",
+                    raw_order={},
+                    created_at=window_start + timedelta(minutes=6),
+                    updated_at=window_start + timedelta(minutes=6),
+                    last_update_at=window_start + timedelta(minutes=6),
+                )
+                session.add(execution)
+                session.flush()
+                session.add(
+                    ExecutionTCAMetric(
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        strategy_id=strategy.id,
+                        alpaca_account_label=account_label,
+                        symbol=symbol,
+                        side="buy",
+                        arrival_price=Decimal("99"),
+                        avg_fill_price=Decimal("100"),
+                        filled_qty=Decimal("1"),
+                        signed_qty=Decimal("1"),
+                        slippage_bps=Decimal("5"),
+                        shortfall_notional=Decimal("1"),
+                        realized_shortfall_bps=Decimal("5"),
+                        churn_qty=Decimal("0"),
+                        churn_ratio=Decimal("0"),
+                        computed_at=window_start + timedelta(minutes=7),
+                        created_at=window_start + timedelta(minutes=7),
+                        updated_at=window_start + timedelta(minutes=7),
+                    )
+                )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-SCOPED-SOURCE",
+                                "candidate_id": "candidate-scoped-source",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": strategy_name,
+                                "account_label": "paper",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": [],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": False,
+                        "next_session_max_notional": "25",
+                        "eligible_symbol_count": 1,
+                        "blocking_reasons": ["market_session_closed"],
+                    },
+                },
+                generated_at=window_start - timedelta(days=2),
+            )
+
+        source_activity = payload["targets"][0]["source_activity"]
+        self.assertEqual(source_activity["account_label"], "paper")
+        self.assertEqual(source_activity["symbols"], ["AAPL"])
+        self.assertTrue(source_activity["missing"])
+        self.assertEqual(source_activity["decision_count"], 0)
+        self.assertEqual(source_activity["execution_count"], 0)
+        self.assertEqual(source_activity["tca_sample_count"], 0)
+        self.assertIn(
+            "source_decisions_missing",
+            payload["targets"][0]["readiness"]["evidence_collection_blockers"],
+        )
+
     def test_builder_joins_source_activity_runtime_ledger_and_decisions(self) -> None:
         now = datetime(2026, 5, 24, 12, tzinfo=timezone.utc)
         window_start = now - timedelta(hours=2)


### PR DESCRIPTION
## Summary

- Bind paper-route source activity auditing to each target window's start and end time.
- Scope paper-route source activity to the target account, probed symbols, and matching decision IDs before counting decisions, executions, or TCA samples.
- Add regression coverage for both post-window activity and wrong-account/wrong-symbol activity so the May 26 runtime-ledger proof path stays target-specific.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen python -m pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen python -m pytest tests/test_trading_api.py -k paper_route_evidence -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
