### PR TITLE
fix(torghut): expose paper route session readiness

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -5334,20 +5334,24 @@ def _build_live_submission_gate_payload(
             cast(TradingScheduler | None, getattr(app.state, "trading_scheduler", None))
         )
     if settings.trading_pipeline_mode == "simple":
+        gate = build_live_submission_gate_payload(
+            state,
+            session=session,
+            hypothesis_summary=hypothesis_summary,
+            empirical_jobs_status=empirical_jobs_status,
+            dspy_runtime_status=dspy_runtime_status,
+            quant_health_status=quant_health_status,
+            clickhouse_ta_status=resolved_clickhouse_ta_status,
+        )
         if settings.trading_mode != "live":
-            return {
-                "allowed": True,
-                "reason": "non_live_mode",
+            gate["pipeline_mode"] = "simple"
+            gate["configured_live_promotion"] = settings.trading_simple_submit_enabled
+            gate["simple_lane"] = {
+                "submit_enabled": settings.trading_simple_submit_enabled,
+                "shared_gate_enforced": True,
                 "blocked_reasons": [],
-                "capital_stage": settings.trading_mode,
-                "configured_live_promotion": settings.trading_simple_submit_enabled,
-                "autonomy_promotion_eligible": False,
-                "drift_live_promotion_eligible": False,
-                "promotion_eligible_total": 0,
-                "dependency_quorum_decision": "informational_only",
-                "empirical_jobs_ready": None,
-                "dspy_live_ready": None,
             }
+            return gate
         blocked_reasons: list[str] = []
         if not settings.trading_enabled:
             blocked_reasons.append("trading_disabled")
@@ -5364,15 +5368,6 @@ def _build_live_submission_gate_payload(
                     or "emergency_stop_active"
                 )
             )
-        gate = build_live_submission_gate_payload(
-            state,
-            session=session,
-            hypothesis_summary=hypothesis_summary,
-            empirical_jobs_status=empirical_jobs_status,
-            dspy_runtime_status=dspy_runtime_status,
-            quant_health_status=quant_health_status,
-            clickhouse_ta_status=resolved_clickhouse_ta_status,
-        )
         merged_blocked_reasons = list(
             dict.fromkeys(
                 [

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -219,6 +219,53 @@ def _next_regular_equities_session_window(
     return start.astimezone(timezone.utc), end.astimezone(timezone.utc)
 
 
+def _seconds_until(*, generated_at: datetime, target: datetime) -> int:
+    return max(0, int((target - generated_at).total_seconds()))
+
+
+def _paper_route_session_readiness(
+    *,
+    generated_at: datetime,
+    window_start: datetime,
+    window_end: datetime,
+    probe_ready: bool,
+) -> dict[str, object]:
+    window_open = window_start <= generated_at <= window_end
+    window_closed = generated_at > window_end
+    import_blockers: list[str] = []
+    if generated_at < window_start:
+        state = "waiting_for_session_open"
+        import_blockers.append("paper_route_session_window_not_open")
+    elif window_open:
+        state = "collecting_session_evidence"
+        import_blockers.append("paper_route_session_window_not_closed")
+    else:
+        state = "window_closed_import_ready"
+    if not probe_ready:
+        state = "window_closed_import_blocked" if window_closed else state
+        import_blockers.append("paper_route_probe_not_ready")
+    return {
+        "state": state,
+        "session_window": {
+            "start": _isoformat(window_start),
+            "end": _isoformat(window_end),
+        },
+        "window_open": window_open,
+        "window_closed": window_closed,
+        "probe_ready": probe_ready,
+        "import_ready": window_closed and probe_ready,
+        "seconds_until_window_start": _seconds_until(
+            generated_at=generated_at,
+            target=window_start,
+        ),
+        "seconds_until_window_end": _seconds_until(
+            generated_at=generated_at,
+            target=window_end,
+        ),
+        "import_blockers": import_blockers,
+    }
+
+
 def _paper_route_probe_summary(
     route_reacquisition_book: Mapping[str, Any],
 ) -> dict[str, object]:
@@ -380,6 +427,12 @@ def _next_paper_route_runtime_window_targets(
         and _safe_decimal(next_notional) > 0
         and bool(probe_symbols)
     )
+    session_readiness = _paper_route_session_readiness(
+        generated_at=generated_at,
+        window_start=window_start,
+        window_end=window_end,
+        probe_ready=probe_ready,
+    )
     planned_targets: list[dict[str, object]] = []
     skipped_targets: list[dict[str, object]] = []
     planned_keys: set[tuple[object, ...]] = set()
@@ -507,6 +560,7 @@ def _next_paper_route_runtime_window_targets(
             "start": _isoformat(window_start),
             "end": _isoformat(window_end),
         },
+        "session_readiness": session_readiness,
         "paper_route_probe": {
             "configured_enabled": bool(probe.get("configured_enabled")),
             "active": bool(probe.get("active")),

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -260,6 +260,14 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 "end": "2026-05-26T20:00:00+00:00",
             },
         )
+        self.assertEqual(plan["session_readiness"]["state"], "waiting_for_session_open")
+        self.assertFalse(plan["session_readiness"]["window_open"])
+        self.assertFalse(plan["session_readiness"]["window_closed"])
+        self.assertFalse(plan["session_readiness"]["import_ready"])
+        self.assertEqual(
+            plan["session_readiness"]["import_blockers"],
+            ["paper_route_session_window_not_open"],
+        )
         target = plan["targets"][0]
         self.assertEqual(target["account_label"], "TORGHUT_SIM")
         self.assertEqual(target["source_account_label"], "TORGHUT_REPLAY")
@@ -278,6 +286,80 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "paper_route_runtime_ledger_import_pending",
             target["runtime_ledger_target_metadata_blockers"],
         )
+
+    def test_next_paper_route_session_readiness_tracks_collection_and_import(
+        self,
+    ) -> None:
+        def build(generated_at: datetime) -> dict[str, object]:
+            with Session(self.engine) as session:
+                return build_paper_route_evidence_audit(
+                    session,
+                    live_submission_gate={
+                        "allowed": False,
+                        "reason": "paper_route_probe_only",
+                        "blocked_reasons": [],
+                        "promotion_eligible_total": 0,
+                        "runtime_ledger_paper_probation_import_plan": {
+                            "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                            "target_count": 1,
+                            "targets": [
+                                {
+                                    "hypothesis_id": "H-PAPER-ROUTE",
+                                    "candidate_id": "candidate-paper-route",
+                                    "observed_stage": "paper",
+                                    "strategy_family": "microbar_pairs",
+                                    "strategy_name": "paper-route-candidate-v1",
+                                    "account_label": "TORGHUT_REPLAY",
+                                    "source_manifest_ref": "config/trading/hypotheses/h-paper-route.json",
+                                    "dataset_snapshot_ref": "dataset://paper-route",
+                                    "paper_probation_authorized": True,
+                                    "promotion_allowed": False,
+                                    "final_promotion_authorized": False,
+                                    "max_notional": "0",
+                                }
+                            ],
+                        },
+                    },
+                    route_reacquisition_book={
+                        "schema_version": "torghut.route-reacquisition-book.v1",
+                        "state": "repair_only",
+                        "summary": {
+                            "paper_route_probe_eligible_symbols": ["AAPL"],
+                        },
+                        "paper_route_probe": {
+                            "configured_enabled": True,
+                            "active": True,
+                            "next_session_max_notional": "25",
+                            "eligible_symbol_count": 1,
+                            "blocking_reasons": [],
+                        },
+                    },
+                    generated_at=generated_at,
+                )
+
+        collecting_payload = build(datetime(2026, 5, 26, 15, tzinfo=timezone.utc))
+        collecting_readiness = collecting_payload[
+            "next_paper_route_runtime_window_targets"
+        ]["session_readiness"]
+        self.assertEqual(collecting_readiness["state"], "collecting_session_evidence")
+        self.assertTrue(collecting_readiness["window_open"])
+        self.assertFalse(collecting_readiness["window_closed"])
+        self.assertFalse(collecting_readiness["import_ready"])
+        self.assertEqual(
+            collecting_readiness["import_blockers"],
+            ["paper_route_session_window_not_closed"],
+        )
+
+        import_payload = build(datetime(2026, 5, 26, 21, tzinfo=timezone.utc))
+        import_readiness = import_payload["next_paper_route_runtime_window_targets"][
+            "session_readiness"
+        ]
+        self.assertEqual(import_readiness["state"], "window_closed_import_ready")
+        self.assertFalse(import_readiness["window_open"])
+        self.assertTrue(import_readiness["window_closed"])
+        self.assertTrue(import_readiness["probe_ready"])
+        self.assertTrue(import_readiness["import_ready"])
+        self.assertEqual(import_readiness["import_blockers"], [])
 
     def test_source_activity_is_bound_to_target_window_end(self) -> None:
         window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -2122,6 +2122,70 @@ class TestTradingApi(TestCase):
             },
         )
 
+    def test_simple_lane_paper_mode_preserves_shared_runtime_import_plan(self) -> None:
+        original = {
+            "trading_pipeline_mode": settings.trading_pipeline_mode,
+            "trading_mode": settings.trading_mode,
+            "trading_simple_submit_enabled": settings.trading_simple_submit_enabled,
+        }
+        settings.trading_pipeline_mode = "simple"
+        settings.trading_mode = "paper"
+        settings.trading_simple_submit_enabled = True
+        shared_gate = {
+            "allowed": True,
+            "reason": "non_live_mode",
+            "blocked_reasons": [],
+            "capital_stage": "paper",
+            "promotion_eligible_total": 0,
+            "paper_probation_eligible_total": 1,
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "targets": [
+                    {
+                        "hypothesis_id": "H-PAIRS-01",
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "paper_probation_authorized": True,
+                        "promotion_allowed": False,
+                        "final_promotion_authorized": False,
+                    }
+                ],
+            },
+        }
+        try:
+            with patch(
+                "app.main.build_live_submission_gate_payload",
+                return_value=shared_gate,
+            ) as shared_gate_builder:
+                gate = _build_live_submission_gate_payload(
+                    SimpleNamespace(emergency_stop_active=False),
+                    session=None,
+                    hypothesis_summary={},
+                )
+        finally:
+            settings.trading_pipeline_mode = original["trading_pipeline_mode"]
+            settings.trading_mode = original["trading_mode"]
+            settings.trading_simple_submit_enabled = original[
+                "trading_simple_submit_enabled"
+            ]
+
+        shared_gate_builder.assert_called_once()
+        self.assertTrue(gate["allowed"])
+        self.assertEqual(gate["reason"], "non_live_mode")
+        self.assertEqual(gate["pipeline_mode"], "simple")
+        self.assertEqual(
+            gate["runtime_ledger_paper_probation_import_plan"]["target_count"],
+            1,
+        )
+        self.assertEqual(
+            gate["simple_lane"],
+            {
+                "submit_enabled": True,
+                "shared_gate_enforced": True,
+                "blocked_reasons": [],
+            },
+        )
+
     def test_trading_status_and_health_include_profitability_proof_floor(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds explicit `session_readiness` to `/trading/paper-route-evidence` next-window plans.
- Distinguishes pre-open, in-session evidence collection, and post-close import-ready states for the May 26 paper-route proof window.
- Preserves the shared runtime-ledger paper-probation import plan in simple `paper`/sim mode so the paper service can build H-PAIRS next-session targets instead of reporting `paper_probation_import_plan_missing`.
- Keeps the payload observability-only: no promotion authority, notional, or final gate relaxation changes.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_api.py -k 'simple_lane_paper_mode_preserves_shared_runtime_import_plan or simple_lane_shared_gate_applies_local_block_reason or paper_route_evidence' -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen ruff format app/main.py tests/test_trading_api.py app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/main.py tests/test_trading_api.py app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are not required; the payload contract is covered by tests.
