### PR TITLE
fix(torghut): route sim paper plan through live target

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -34,7 +34,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref intraday_tsmom_v2@research \
                     --runtime-window-import \
-                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence \
+                    --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence \
                     --runtime-window-target-plan-exclusive \
                     --runtime-window-target-plan-required \
                     --runtime-window-target-plan-settlement-seconds 3600 \

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -110,6 +110,10 @@ spec:
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
               value: "25"
+            - name: TRADING_PAPER_ROUTE_TARGET_PLAN_URL
+              value: http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence
+            - name: TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS
+              value: "3"
             - name: TRADING_KILL_SWITCH_ENABLED
               value: "false"
             - name: TRADING_FEATURE_FLAGS_ENABLED

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1404,6 +1404,20 @@ class Settings(BaseSettings):
         alias="TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL",
         description="Maximum notional per paper route-acquisition probe order.",
     )
+    trading_paper_route_target_plan_url: Optional[str] = Field(
+        default=None,
+        alias="TRADING_PAPER_ROUTE_TARGET_PLAN_URL",
+        description=(
+            "Optional paper-route target-plan URL used when this service has no "
+            "local runtime-ledger paper-probation plan. Intended for paper services "
+            "that execute bounded route probes from the live gate's authoritative plan."
+        ),
+    )
+    trading_paper_route_target_plan_timeout_seconds: float = Field(
+        default=3.0,
+        alias="TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS",
+        description="Timeout for fetching TRADING_PAPER_ROUTE_TARGET_PLAN_URL.",
+    )
     trading_emergency_stop_enabled: bool = Field(
         default=False,
         alias="TRADING_EMERGENCY_STOP_ENABLED",
@@ -2308,6 +2322,10 @@ class Settings(BaseSettings):
             (
                 self.trading_simple_paper_route_probe_max_notional,
                 "TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL must be >= 0",
+            ),
+            (
+                self.trading_paper_route_target_plan_timeout_seconds,
+                "TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS must be >= 0",
             ),
             (
                 self.trading_readiness_dependency_cache_stale_tolerance_seconds,

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4427,6 +4427,9 @@ def trading_paper_route_evidence(
         ),
         quant_health_status=quant_evidence,
     )
+    live_submission_gate = _merge_external_paper_route_target_plan(
+        cast(Mapping[str, Any], live_submission_gate)
+    )
     simple_lane_status = _build_simple_lane_status_payload()
     proof_floor = _build_profitability_proof_floor_payload(
         state=scheduler.state,
@@ -4448,6 +4451,123 @@ def trading_paper_route_evidence(
         ),
     )
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+def _mapping_items(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [
+        _to_str_map(cast(object, item))
+        for item in cast(Sequence[object], value)
+        if isinstance(item, Mapping)
+    ]
+
+
+def _paper_route_target_plan_targets(plan: Mapping[str, Any]) -> list[dict[str, Any]]:
+    return _mapping_items(plan.get("targets"))
+
+
+def _paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    live_gate = _to_str_map(payload.get("live_submission_gate"))
+    candidate_plans = [
+        _to_str_map(payload.get("runtime_window_import_plan")),
+        _to_str_map(live_gate.get("runtime_ledger_paper_probation_import_plan")),
+        _to_str_map(payload.get("runtime_ledger_paper_probation_import_plan")),
+        _to_str_map(payload.get("next_paper_route_runtime_window_targets")),
+        dict(payload) if _paper_route_target_plan_targets(payload) else {},
+    ]
+    for plan in candidate_plans:
+        if _paper_route_target_plan_targets(plan):
+            return plan
+    return {}
+
+
+def _fetch_paper_route_target_plan_url(
+    url: str,
+    *,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"}:
+        return {
+            "load_error": f"paper_route_target_plan_invalid_scheme:{scheme or 'missing'}"
+        }
+    if not parsed.hostname:
+        return {"load_error": "paper_route_target_plan_invalid_host"}
+
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    connection_class = HTTPSConnection if scheme == "https" else HTTPConnection
+    connection = connection_class(
+        parsed.hostname,
+        parsed.port,
+        timeout=max(float(timeout_seconds), 0.1),
+    )
+    try:
+        connection.request("GET", path, headers={"Accept": "application/json"})
+        response = connection.getresponse()
+        if response.status < 200 or response.status >= 300:
+            return {
+                "load_error": f"paper_route_target_plan_http_status:{response.status}"
+            }
+        raw = response.read(5_000_001)
+    except Exception as exc:  # pragma: no cover - depends on network
+        return {"load_error": f"paper_route_target_plan_fetch_failed:{exc}"}
+    finally:
+        connection.close()
+
+    if len(raw) > 5_000_000:
+        return {"load_error": "paper_route_target_plan_response_too_large"}
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except Exception as exc:
+        return {"load_error": f"paper_route_target_plan_invalid_json:{exc}"}
+    if not isinstance(payload, Mapping):
+        return {"load_error": "paper_route_target_plan_invalid_payload"}
+    plan = _paper_route_target_plan_from_payload(cast(Mapping[str, Any], payload))
+    if not plan:
+        return {"load_error": "paper_route_target_plan_missing"}
+    plan = dict(plan)
+    plan.setdefault("source", "external_paper_route_target_plan")
+    return plan
+
+
+def _load_external_paper_route_target_plan() -> dict[str, Any]:
+    url = str(settings.trading_paper_route_target_plan_url or "").strip()
+    if not url:
+        return {}
+    return _fetch_paper_route_target_plan_url(
+        url,
+        timeout_seconds=settings.trading_paper_route_target_plan_timeout_seconds,
+    )
+
+
+def _merge_external_paper_route_target_plan(
+    live_submission_gate: Mapping[str, Any],
+) -> dict[str, object]:
+    gate = dict(live_submission_gate)
+    local_plan = _to_str_map(gate.get("runtime_ledger_paper_probation_import_plan"))
+    if _paper_route_target_plan_targets(local_plan):
+        return gate
+
+    external_plan = _load_external_paper_route_target_plan()
+    if not external_plan:
+        return gate
+    if _paper_route_target_plan_targets(external_plan):
+        merged_plan = dict(external_plan)
+        merged_plan["promotion_allowed"] = False
+        merged_plan["final_promotion_allowed"] = False
+        merged_plan["final_promotion_authorized"] = False
+        gate["runtime_ledger_paper_probation_import_plan"] = merged_plan
+        gate["paper_route_target_plan_source"] = "external_target_plan_url"
+        return gate
+
+    load_error = str(external_plan.get("load_error") or "").strip()
+    if load_error:
+        gate["paper_route_target_plan_error"] = load_error
+    return gate
 
 
 @app.get("/trading/tca")

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -560,6 +560,14 @@ class TestLiveConfigManifestContract(TestCase):
             sim_env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
             "25",
         )
+        self.assertEqual(
+            sim_env.get("TRADING_PAPER_ROUTE_TARGET_PLAN_URL"),
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
+        )
+        self.assertEqual(
+            sim_env.get("TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS"),
+            "3",
+        )
         self.assertFalse(_manifest_bool(sim_env, "TRADING_SIMULATION_ENABLED"))
         self.assertEqual(sim_env.get("TRADING_UNIVERSE_SOURCE"), "static")
         self.assertEqual(
@@ -814,7 +822,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn(
             "--runtime-window-target-plan-url "
-            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
         self.assertIn("--runtime-window-target-plan-exclusive", args)

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -27,10 +27,14 @@ from app.main import (
     _build_live_submission_gate_payload,
     _build_route_image_proof_summary,
     _check_alpaca,
+    _fetch_paper_route_target_plan_url,
     _forecast_service_status,
+    _load_external_paper_route_target_plan,
+    _paper_route_target_plan_from_payload,
     _load_rejected_signal_outcome_learning_summary,
     healthz,
     _load_options_catalog_freshness_summary,
+    _merge_external_paper_route_target_plan,
     _readiness_dependency_cache_key,
     _readiness_dependency_checks,
     _route_continuity_packet_for_proof_floor,
@@ -7050,6 +7054,351 @@ class TestTradingApi(TestCase):
                     del app.state.trading_scheduler
             else:
                 app.state.trading_scheduler = original_scheduler
+
+    def test_trading_paper_route_evidence_uses_external_plan_when_local_plan_empty(
+        self,
+    ) -> None:
+        original_scheduler = getattr(app.state, "trading_scheduler", None)
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        settings.trading_paper_route_target_plan_url = (
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence"
+        )
+        target = {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "observed_stage": "paper",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "strategy_name": "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+            "account_label": "TORGHUT_REPLAY",
+            "source_kind": "runtime_ledger_paper_probation_candidates",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+            "dataset_snapshot_ref": "torghut-chip-full-day-20260505-4c330ce9-r1",
+            "window_start": "2026-05-22T13:30:00+00:00",
+            "window_end": "2026-05-22T20:00:00+00:00",
+            "paper_probation_authorized": True,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "max_notional": "0",
+        }
+        live_gate = {
+            "allowed": True,
+            "reason": "non_live_mode",
+            "blocked_reasons": [],
+            "promotion_eligible_total": 0,
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 0,
+                "skipped_target_count": 0,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "targets": [],
+            },
+        }
+        proof_floor = {
+            "route_reacquisition_book": {
+                "schema_version": "torghut.route-reacquisition-book.v1",
+                "state": "repair_only",
+                "paper_route_probe": {
+                    "configured_enabled": True,
+                    "active": False,
+                    "effective_max_notional": "0",
+                    "next_session_max_notional": "25",
+                    "eligible_symbol_count": 2,
+                    "eligible_symbols": ["AAPL", "AMZN"],
+                    "active_symbols": [],
+                    "blocking_reasons": ["market_session_closed"],
+                },
+            }
+        }
+        external_plan = {
+            "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+            "target_count": 1,
+            "skipped_target_count": 0,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "targets": [target],
+        }
+        try:
+            if hasattr(app.state, "trading_scheduler"):
+                del app.state.trading_scheduler
+            with (
+                patch(
+                    "app.main._build_live_submission_gate_payload",
+                    return_value=live_gate,
+                ),
+                patch(
+                    "app.main._build_profitability_proof_floor_payload",
+                    return_value=proof_floor,
+                ),
+                patch(
+                    "app.main._load_external_paper_route_target_plan",
+                    return_value=external_plan,
+                ) as external_loader,
+            ):
+                response = self.client.get("/trading/paper-route-evidence")
+            self.assertEqual(response.status_code, 200)
+            external_loader.assert_called_once()
+            payload = response.json()
+            self.assertEqual(payload["summary"]["target_count"], 1)
+            self.assertEqual(
+                payload["live_submission_gate"][
+                    "runtime_ledger_paper_probation_import_plan"
+                ]["target_count"],
+                1,
+            )
+            self.assertEqual(
+                payload["targets"][0]["target"]["candidate_id"],
+                "c88421d619759b2cfaa6f4d0",
+            )
+            next_plan = payload["next_paper_route_runtime_window_targets"]
+            self.assertEqual(next_plan["target_count"], 1)
+            next_target = next_plan["targets"][0]
+            self.assertEqual(next_target["hypothesis_id"], "H-PAIRS-01")
+            self.assertEqual(next_target["candidate_id"], "c88421d619759b2cfaa6f4d0")
+            self.assertEqual(next_target["source_dsn_env"], "SIM_DB_DSN")
+            self.assertEqual(
+                next_target["source_kind"], "paper_route_probe_runtime_observed"
+            )
+            self.assertEqual(next_target["paper_route_probe_symbols"], ["AAPL", "AMZN"])
+            self.assertEqual(next_target["max_notional"], "0")
+            self.assertFalse(next_target["promotion_allowed"])
+            self.assertFalse(next_target["final_promotion_allowed"])
+        finally:
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+            if original_scheduler is None:
+                if hasattr(app.state, "trading_scheduler"):
+                    del app.state.trading_scheduler
+            else:
+                app.state.trading_scheduler = original_scheduler
+
+    def test_paper_route_target_plan_from_payload_prefers_next_window_targets(
+        self,
+    ) -> None:
+        plan = _paper_route_target_plan_from_payload(
+            {
+                "live_submission_gate": {
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                    }
+                },
+                "next_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertEqual(plan["targets"][0]["candidate_id"], "c88421d619759b2cfaa6f4d0")
+
+    def test_paper_route_target_plan_from_payload_requires_targets(self) -> None:
+        self.assertEqual(
+            _paper_route_target_plan_from_payload(
+                {
+                    "runtime_window_import_plan": {
+                        "target_count": 1,
+                    },
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "targets": "not-a-target-list",
+                    },
+                }
+            ),
+            {},
+        )
+
+    def test_fetch_paper_route_target_plan_url_rejects_invalid_url(self) -> None:
+        self.assertEqual(
+            _fetch_paper_route_target_plan_url(
+                "file:///tmp/plan.json",
+                timeout_seconds=1,
+            ),
+            {"load_error": "paper_route_target_plan_invalid_scheme:file"},
+        )
+        self.assertEqual(
+            _fetch_paper_route_target_plan_url(
+                "http:///missing-host",
+                timeout_seconds=1,
+            ),
+            {"load_error": "paper_route_target_plan_invalid_host"},
+        )
+
+    def test_fetch_paper_route_target_plan_url_validates_response(self) -> None:
+        class FakeResponse:
+            def __init__(self, status: int, raw: bytes) -> None:
+                self.status = status
+                self._raw = raw
+
+            def read(self, size: int) -> bytes:
+                self.read_size = size
+                return self._raw
+
+        def connection_class(status: int, raw: bytes) -> type[Any]:
+            class FakeConnection:
+                instances: list["FakeConnection"] = []
+
+                def __init__(
+                    self,
+                    hostname: str,
+                    port: int | None,
+                    *,
+                    timeout: float,
+                ) -> None:
+                    self.hostname = hostname
+                    self.port = port
+                    self.timeout = timeout
+                    self.request_path: str | None = None
+                    self.closed = False
+                    self.instances.append(self)
+
+                def request(
+                    self,
+                    method: str,
+                    path: str,
+                    *,
+                    headers: dict[str, str],
+                ) -> None:
+                    self.request_method = method
+                    self.request_path = path
+                    self.request_headers = headers
+
+                def getresponse(self) -> FakeResponse:
+                    return FakeResponse(status, raw)
+
+                def close(self) -> None:
+                    self.closed = True
+
+            return FakeConnection
+
+        http_error_connection = connection_class(503, b"{}")
+        with patch("app.main.HTTPConnection", http_error_connection):
+            self.assertEqual(
+                _fetch_paper_route_target_plan_url(
+                    "http://torghut.example/plan?mode=paper",
+                    timeout_seconds=0,
+                ),
+                {"load_error": "paper_route_target_plan_http_status:503"},
+            )
+        self.assertEqual(http_error_connection.instances[0].hostname, "torghut.example")
+        self.assertEqual(
+            http_error_connection.instances[0].request_path, "/plan?mode=paper"
+        )
+        self.assertEqual(http_error_connection.instances[0].timeout, 0.1)
+        self.assertTrue(http_error_connection.instances[0].closed)
+
+        for raw, expected in (
+            (b"{", "paper_route_target_plan_invalid_json:"),
+            (b"[]", "paper_route_target_plan_invalid_payload"),
+            (
+                json.dumps({"runtime_window_import_plan": {"targets": []}}).encode(
+                    "utf-8"
+                ),
+                "paper_route_target_plan_missing",
+            ),
+            (b"x" * 5_000_001, "paper_route_target_plan_response_too_large"),
+        ):
+            fake_connection = connection_class(200, raw)
+            with patch("app.main.HTTPConnection", fake_connection):
+                result = _fetch_paper_route_target_plan_url(
+                    "http://torghut.example",
+                    timeout_seconds=1,
+                )
+            self.assertTrue(str(result["load_error"]).startswith(expected))
+
+        success_connection = connection_class(
+            200,
+            json.dumps(
+                {
+                    "runtime_window_import_plan": {
+                        "targets": [
+                            {
+                                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                            }
+                        ]
+                    }
+                }
+            ).encode("utf-8"),
+        )
+        with patch("app.main.HTTPConnection", success_connection):
+            plan = _fetch_paper_route_target_plan_url(
+                "http://torghut.example",
+                timeout_seconds=3,
+            )
+        self.assertEqual(plan["source"], "external_paper_route_target_plan")
+        self.assertEqual(plan["targets"][0]["candidate_id"], "c88421d619759b2cfaa6f4d0")
+
+    def test_load_external_paper_route_target_plan_uses_configured_url(self) -> None:
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        original_timeout = settings.trading_paper_route_target_plan_timeout_seconds
+        try:
+            settings.trading_paper_route_target_plan_url = "  "
+            self.assertEqual(_load_external_paper_route_target_plan(), {})
+
+            settings.trading_paper_route_target_plan_url = "http://torghut.example/plan"
+            settings.trading_paper_route_target_plan_timeout_seconds = 7
+            with patch(
+                "app.main._fetch_paper_route_target_plan_url",
+                return_value={"targets": [{"candidate_id": "candidate"}]},
+            ) as fetch:
+                plan = _load_external_paper_route_target_plan()
+            self.assertEqual(plan["targets"][0]["candidate_id"], "candidate")
+            fetch.assert_called_once_with(
+                "http://torghut.example/plan",
+                timeout_seconds=7,
+            )
+        finally:
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+            settings.trading_paper_route_target_plan_timeout_seconds = original_timeout
+
+    def test_merge_external_paper_route_target_plan_fails_closed(self) -> None:
+        local_gate = {
+            "runtime_ledger_paper_probation_import_plan": {
+                "targets": [{"candidate_id": "local"}],
+            }
+        }
+        with patch(
+            "app.main._load_external_paper_route_target_plan"
+        ) as external_loader:
+            self.assertEqual(
+                _merge_external_paper_route_target_plan(local_gate), local_gate
+            )
+        external_loader.assert_not_called()
+
+        with patch("app.main._load_external_paper_route_target_plan", return_value={}):
+            self.assertEqual(_merge_external_paper_route_target_plan({}), {})
+
+        with patch(
+            "app.main._load_external_paper_route_target_plan",
+            return_value={"load_error": "paper_route_target_plan_missing"},
+        ):
+            gate = _merge_external_paper_route_target_plan({})
+        self.assertEqual(
+            gate["paper_route_target_plan_error"],
+            "paper_route_target_plan_missing",
+        )
+
+        with patch(
+            "app.main._load_external_paper_route_target_plan",
+            return_value={
+                "promotion_allowed": True,
+                "final_promotion_allowed": True,
+                "final_promotion_authorized": True,
+                "targets": [{"candidate_id": "external"}],
+            },
+        ):
+            gate = _merge_external_paper_route_target_plan({})
+        plan = gate["runtime_ledger_paper_probation_import_plan"]
+        self.assertEqual(
+            gate["paper_route_target_plan_source"], "external_target_plan_url"
+        )
+        self.assertFalse(plan["promotion_allowed"])
+        self.assertFalse(plan["final_promotion_allowed"])
+        self.assertFalse(plan["final_promotion_authorized"])
 
     def test_trading_llm_evaluation_endpoint(self) -> None:
         response = self.client.get("/trading/llm-evaluation")


### PR DESCRIPTION
## Summary

- Adds a fail-closed paper-route target-plan fallback so `torghut-sim` can surface the live gate's authoritative H-PAIRS next-window target when its local sim DB has no runtime-ledger probation plan.
- Configures the sim Knative service to fetch the live paper-route evidence plan and points the bounded empirical renewal CronJob at the sim paper-route endpoint.
- Keeps promotion authority disabled on imported fallback plans: promotion and final promotion remain false, with the path used only for evidence collection.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/main.py app/config.py tests/test_trading_api.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan_from_payload_prefers_next_window_targets or paper_route_evidence_uses_external_plan_when_local_plan_empty or trading_paper_route_evidence_endpoint_audits_probation_targets or simple_lane_paper_mode_preserves_shared_runtime_import_plan' -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k 'sim_manifest_runs_paper_live_signal_profile or empirical_promotion_renewal' -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py -k 'paper_route_evidence or paper_route_target_plan_from_payload or simple_lane_paper_mode_preserves_shared_runtime_import_plan' -q`
- `uv run --frozen ruff check app/main.py app/config.py tests/test_trading_api.py tests/test_live_config_manifest_contract.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
