### PR TITLE
fix(torghut): verify sim paper route mirror after deploy

### DIFF
--- a/.github/workflows/torghut-post-deploy-verify.yml
+++ b/.github/workflows/torghut-post-deploy-verify.yml
@@ -213,6 +213,24 @@ jobs:
             echo "Knative Service torghut is not Ready"
             exit 1
           fi
+          set +e
+          SIM_KNSVC_READY="$(kubectl get ksvc torghut-sim -n torghut -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2> /tmp/torghut-sim-ksvc-ready.err)"
+          SIM_KNSVC_READY_STATUS=$?
+          set -e
+          if [ "${SIM_KNSVC_READY_STATUS}" -ne 0 ]; then
+            if grep -qi 'not found' /tmp/torghut-sim-ksvc-ready.err; then
+              echo "Knative Service torghut-sim was not found"
+              cat /tmp/torghut-sim-ksvc-ready.err
+              exit 1
+            else
+              echo "Failed to read Knative Service torghut-sim"
+              cat /tmp/torghut-sim-ksvc-ready.err
+              exit 1
+            fi
+          elif [ "${SIM_KNSVC_READY}" != 'True' ]; then
+            echo "Knative Service torghut-sim is not Ready"
+            exit 1
+          fi
 
           EVIDENCE_DIR="${RUNNER_TEMP}/torghut-post-deploy"
           mkdir -p "${EVIDENCE_DIR}"
@@ -235,6 +253,10 @@ jobs:
             >"${EVIDENCE_DIR}/torghut-status.json"
           curl -fsS http://torghut.torghut.svc.cluster.local/trading/revenue-repair \
             >"${EVIDENCE_DIR}/torghut-revenue-repair-digest.json"
+          curl -fsS http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence \
+            >"${EVIDENCE_DIR}/torghut-paper-route-evidence.json"
+          curl -fsS http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence \
+            >"${EVIDENCE_DIR}/torghut-sim-paper-route-evidence.json"
           curl -fsS http://torghut-ws.torghut.svc.cluster.local/readyz \
             >"${EVIDENCE_DIR}/torghut-ws-ready.json"
 
@@ -242,6 +264,8 @@ jobs:
           export TORGHUT_STATUS_PAYLOAD="${EVIDENCE_DIR}/torghut-status.json"
           export TORGHUT_READYZ_HTTP_STATUS
           export TORGHUT_READYZ_PAYLOAD="${EVIDENCE_DIR}/torghut-readyz.json"
+          export TORGHUT_PAPER_ROUTE_EVIDENCE="${EVIDENCE_DIR}/torghut-paper-route-evidence.json"
+          export TORGHUT_SIM_PAPER_ROUTE_EVIDENCE="${EVIDENCE_DIR}/torghut-sim-paper-route-evidence.json"
           bun run packages/scripts/src/torghut/post-deploy-evidence.ts
 
       - name: Close superseded Torghut rollback pull requests

--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -21,6 +21,26 @@ const baseTradingStatus = {
   route_reacquisition_board: baseRouteBoard,
 }
 
+const paperRouteTarget = {
+  hypothesis_id: 'H-PAIRS-01',
+  candidate_id: 'candidate-paper-route',
+  strategy_name: 'paper-route-candidate-v1',
+  window_start: '2026-05-26T13:30:00+00:00',
+  window_end: '2026-05-26T20:00:00+00:00',
+}
+
+const buildPaperRouteEvidence = (targets: Array<Record<string, unknown>>) => ({
+  schema_version: 'torghut.paper-route-evidence.v1',
+  next_paper_route_runtime_window_targets: {
+    schema_version: 'torghut.next-paper-route-runtime-window-targets.v1',
+    promotion_allowed: false,
+    final_promotion_allowed: false,
+    final_promotion_authorized: false,
+    target_count: targets.length,
+    targets,
+  },
+})
+
 const baseDigest = {
   business_state: 'repair_only',
   revenue_ready: false,
@@ -109,5 +129,78 @@ describe('validatePostDeployEvidence', () => {
         tradingStatus: baseTradingStatus,
       }),
     ).toThrow('max_notional=0')
+  })
+
+  it('accepts matching live and sim paper-route target plans', () => {
+    const result = validatePostDeployEvidence({
+      readyzHttpStatus: '200',
+      readyz: { status: 'ok' },
+      revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+      tradingStatus: baseTradingStatus,
+      paperRouteEvidence: buildPaperRouteEvidence([paperRouteTarget]),
+      simPaperRouteEvidence: buildPaperRouteEvidence([{ ...paperRouteTarget, source_account_label: 'TORGHUT_SIM' }]),
+    })
+
+    expect(result.summaryLines.join('\n')).toContain('Torghut Paper Route Target Mirror')
+    expect(result.summaryLines.join('\n')).toContain('Live target count: `1`')
+    expect(result.summaryLines.join('\n')).toContain('Sim target count: `1`')
+  })
+
+  it('rejects an empty sim paper-route plan when live torghut exposes a target', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '200',
+        readyz: { status: 'ok' },
+        revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+        tradingStatus: baseTradingStatus,
+        paperRouteEvidence: buildPaperRouteEvidence([paperRouteTarget]),
+        simPaperRouteEvidence: buildPaperRouteEvidence([]),
+      }),
+    ).toThrow('torghut-sim paper-route target plan is empty while live torghut exposes targets')
+  })
+
+  it('rejects a sim paper-route plan missing the live target identity', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '200',
+        readyz: { status: 'ok' },
+        revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+        tradingStatus: baseTradingStatus,
+        paperRouteEvidence: buildPaperRouteEvidence([paperRouteTarget]),
+        simPaperRouteEvidence: buildPaperRouteEvidence([{ ...paperRouteTarget, candidate_id: 'other-candidate' }]),
+      }),
+    ).toThrow('torghut-sim paper-route target plan missing live target')
+  })
+
+  it('rejects paper-route target plans that accidentally authorize promotion', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '200',
+        readyz: { status: 'ok' },
+        revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+        tradingStatus: baseTradingStatus,
+        paperRouteEvidence: {
+          ...buildPaperRouteEvidence([paperRouteTarget]),
+          next_paper_route_runtime_window_targets: {
+            ...buildPaperRouteEvidence([paperRouteTarget]).next_paper_route_runtime_window_targets,
+            final_promotion_authorized: true,
+          },
+        },
+        simPaperRouteEvidence: buildPaperRouteEvidence([paperRouteTarget]),
+      }),
+    ).toThrow('final_promotion_authorized must not be true')
+  })
+
+  it('rejects paper-route targets that accidentally authorize promotion', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '200',
+        readyz: { status: 'ok' },
+        revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+        tradingStatus: baseTradingStatus,
+        paperRouteEvidence: buildPaperRouteEvidence([{ ...paperRouteTarget, promotion_allowed: true }]),
+        simPaperRouteEvidence: buildPaperRouteEvidence([paperRouteTarget]),
+      }),
+    ).toThrow('target 0 promotion_allowed must not be true')
   })
 })

--- a/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts
@@ -53,6 +53,13 @@ describe('torghut post-deploy verifier workflow', () => {
     expect(workflow).not.toContain('expected 2xx')
   })
 
+  it('verifies torghut-sim paper-route target mirroring after deploy', () => {
+    expect(workflow).toContain('Knative Service torghut-sim is not Ready')
+    expect(workflow).toContain('http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence')
+    expect(workflow).toContain('http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence')
+    expect(workflow).toContain('TORGHUT_SIM_PAPER_ROUTE_EVIDENCE')
+  })
+
   it('requests Argo refresh before polling deployed revisions', () => {
     expect(workflow).toContain('argocd.argoproj.io/refresh=hard --overwrite')
     expect(workflow).toContain('for app in torghut torghut-options; do')

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -4,6 +4,8 @@ import { appendFileSync, readFileSync } from 'node:fs'
 import process from 'node:process'
 
 const ROUTE_BOARD_SCHEMA_VERSION = 'torghut.route-reacquisition-board.v1'
+const PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION = 'torghut.paper-route-evidence.v1'
+const PAPER_ROUTE_TARGETS_SCHEMA_VERSION = 'torghut.next-paper-route-runtime-window-targets.v1'
 
 type JsonObject = Record<string, unknown>
 
@@ -12,6 +14,8 @@ type PostDeployEvidenceInput = {
   readyz: unknown
   revenueRepairDigest: unknown
   tradingStatus: unknown
+  paperRouteEvidence?: unknown
+  simPaperRouteEvidence?: unknown
 }
 
 export type PostDeployEvidenceResult = {
@@ -53,6 +57,13 @@ const requireDependencyOk = (dependencies: JsonObject, name: string) => {
   if (dependency.ok !== true) {
     throw new Error(`readyz dependencies.${name}.ok must be true for repair-only rollout acceptance`)
   }
+}
+
+const requireArray = (value: unknown, label: string): unknown[] => {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array`)
+  }
+  return value
 }
 
 const collectDependencyFailureNames = (digest: JsonObject): Set<string> => {
@@ -130,6 +141,77 @@ const assertRepairOnlyZeroNotionalReadyz = (readyz: JsonObject, digest: JsonObje
       throw new Error(`missing expected repair-only dependency failure: ${requiredFailure}`)
     }
   }
+}
+
+const targetIdentity = (target: unknown, label: string): string => {
+  const targetObject = requireObject(target, label)
+  const hypothesisId = formatScalar(targetObject.hypothesis_id, '')
+  const candidateId = formatScalar(targetObject.candidate_id, '')
+  const strategyName = formatScalar(targetObject.strategy_name ?? targetObject.strategy_id, '')
+  const windowStart = formatScalar(targetObject.window_start, '')
+  const windowEnd = formatScalar(targetObject.window_end, '')
+  if (!hypothesisId || !candidateId || !strategyName || !windowStart || !windowEnd) {
+    throw new Error(`${label} missing target identity fields`)
+  }
+  return [hypothesisId, candidateId, strategyName, windowStart, windowEnd].join('|')
+}
+
+const requireNotTrue = (value: unknown, label: string) => {
+  if (value === true || value === 'true') {
+    throw new Error(`${label} must not be true for paper-route evidence collection`)
+  }
+}
+
+const parsePaperRouteTargets = (evidence: unknown, label: string): { targetCount: number; identities: Set<string> } => {
+  const payload = requireObject(evidence, `${label} payload`)
+  const schemaVersion = formatScalar(payload.schema_version, 'missing')
+  if (schemaVersion !== PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION) {
+    throw new Error(`${label} schema mismatch: expected ${PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION}, got ${schemaVersion}`)
+  }
+  const plan = requireObject(
+    payload.next_paper_route_runtime_window_targets,
+    `${label} next_paper_route_runtime_window_targets`,
+  )
+  const planSchemaVersion = formatScalar(plan.schema_version, 'missing')
+  if (planSchemaVersion !== PAPER_ROUTE_TARGETS_SCHEMA_VERSION) {
+    throw new Error(
+      `${label} target plan schema mismatch: expected ${PAPER_ROUTE_TARGETS_SCHEMA_VERSION}, got ${planSchemaVersion}`,
+    )
+  }
+  const targets = requireArray(plan.targets, `${label} target plan targets`)
+  const targetCount = requireNonNegativeInteger(plan.target_count, `${label} target plan target_count`)
+  if (targets.length !== targetCount) {
+    throw new Error(`${label} target_count mismatch: count=${targetCount}, targets=${targets.length}`)
+  }
+  requireNotTrue(plan.promotion_allowed, `${label} target plan promotion_allowed`)
+  requireNotTrue(plan.final_promotion_allowed, `${label} target plan final_promotion_allowed`)
+  requireNotTrue(plan.final_promotion_authorized, `${label} target plan final_promotion_authorized`)
+  targets.forEach((target, index) => {
+    const targetObject = requireObject(target, `${label} target ${index}`)
+    requireNotTrue(targetObject.promotion_allowed, `${label} target ${index} promotion_allowed`)
+    requireNotTrue(targetObject.final_promotion_allowed, `${label} target ${index} final_promotion_allowed`)
+    requireNotTrue(targetObject.final_promotion_authorized, `${label} target ${index} final_promotion_authorized`)
+  })
+  return {
+    targetCount,
+    identities: new Set(targets.map((target, index) => targetIdentity(target, `${label} target ${index}`))),
+  }
+}
+
+const validatePaperRouteMirror = (
+  paperRouteEvidence: unknown,
+  simPaperRouteEvidence: unknown,
+): { liveTargetCount: number; simTargetCount: number } => {
+  const liveTargets = parsePaperRouteTargets(paperRouteEvidence, 'torghut paper-route evidence')
+  const simTargets = parsePaperRouteTargets(simPaperRouteEvidence, 'torghut-sim paper-route evidence')
+  if (liveTargets.targetCount > 0 && simTargets.targetCount === 0) {
+    throw new Error('torghut-sim paper-route target plan is empty while live torghut exposes targets')
+  }
+  const missingSimTargets = [...liveTargets.identities].filter((identity) => !simTargets.identities.has(identity))
+  if (missingSimTargets.length > 0) {
+    throw new Error(`torghut-sim paper-route target plan missing live target(s): ${missingSimTargets.join(', ')}`)
+  }
+  return { liveTargetCount: liveTargets.targetCount, simTargetCount: simTargets.targetCount }
 }
 
 export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): PostDeployEvidenceResult => {
@@ -243,6 +325,20 @@ export const validatePostDeployEvidence = (input: PostDeployEvidenceInput): Post
     lines.push(`- Top repair symbols: ${topRepairSymbols.map((symbol) => `\`${symbol}\``).join(', ')}`)
   }
 
+  if (input.paperRouteEvidence !== undefined || input.simPaperRouteEvidence !== undefined) {
+    if (input.paperRouteEvidence === undefined || input.simPaperRouteEvidence === undefined) {
+      throw new Error('both torghut and torghut-sim paper-route evidence payloads are required for mirror validation')
+    }
+    const mirror = validatePaperRouteMirror(input.paperRouteEvidence, input.simPaperRouteEvidence)
+    lines.push(
+      '',
+      '## Torghut Paper Route Target Mirror',
+      '',
+      `- Live target count: \`${mirror.liveTargetCount}\``,
+      `- Sim target count: \`${mirror.simTargetCount}\``,
+    )
+  }
+
   return { readyzAcceptedReason, readyzStatusCode, summaryLines: lines }
 }
 
@@ -260,6 +356,12 @@ export const runPostDeployEvidenceCli = (env: NodeJS.ProcessEnv = process.env): 
     readyz: loadJsonFile(env.TORGHUT_READYZ_PAYLOAD ?? '', 'TORGHUT_READYZ_PAYLOAD'),
     revenueRepairDigest: loadJsonFile(env.TORGHUT_REVENUE_REPAIR_DIGEST ?? '', 'TORGHUT_REVENUE_REPAIR_DIGEST'),
     tradingStatus: loadJsonFile(env.TORGHUT_STATUS_PAYLOAD ?? '', 'TORGHUT_STATUS_PAYLOAD'),
+    paperRouteEvidence: env.TORGHUT_PAPER_ROUTE_EVIDENCE
+      ? loadJsonFile(env.TORGHUT_PAPER_ROUTE_EVIDENCE, 'TORGHUT_PAPER_ROUTE_EVIDENCE')
+      : undefined,
+    simPaperRouteEvidence: env.TORGHUT_SIM_PAPER_ROUTE_EVIDENCE
+      ? loadJsonFile(env.TORGHUT_SIM_PAPER_ROUTE_EVIDENCE, 'TORGHUT_SIM_PAPER_ROUTE_EVIDENCE')
+      : undefined,
   })
 
   const summaryPath = env.GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Adds post-deploy collection for live and sim `/trading/paper-route-evidence`.
- Fails the verifier when `torghut-sim` does not mirror live paper-route target identities.
- Fails closed if paper-route evidence accidentally reports promotion authorization during evidence collection.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bunx oxfmt --check .github/workflows/torghut-post-deploy-verify.yml packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `bun run --cwd packages/scripts lint`
- `bun run --cwd packages/scripts lint:oxlint:type`
- `git diff --check`
- Read-only live check: both `torghut` and `torghut-sim` return one matching paper-route target, and both report promotion authorization as false.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
