### PR TITLE
fix(torghut): harden paper route import readiness

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -34,7 +34,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref intraday_tsmom_v2@research \
                     --runtime-window-import \
-                    --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence \
+                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence \
                     --runtime-window-target-plan-exclusive \
                     --runtime-window-target-plan-required \
                     --runtime-window-target-plan-settlement-seconds 3600 \

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -433,6 +433,31 @@ def _next_paper_route_runtime_window_targets(
         window_end=window_end,
         probe_ready=probe_ready,
     )
+    import_ready = bool(session_readiness.get("import_ready"))
+    import_blockers = [
+        str(item).strip()
+        for item in _as_sequence(session_readiness.get("import_blockers"))
+        if str(item).strip()
+    ]
+    import_handoff = {
+        "runner": "scripts/renew_latest_empirical_promotion_jobs.py",
+        "target_plan_endpoint": "/trading/paper-route-evidence",
+        "required_flags": [
+            "--runtime-window-import",
+            "--runtime-window-target-plan-url",
+            "--runtime-window-target-plan-exclusive",
+            "--runtime-window-target-plan-required",
+            "--runtime-window-target-plan-settlement-seconds",
+        ],
+        "source_dsn_env": "SIM_DB_DSN",
+        "account_label": PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
+        "observed_stage": "paper",
+        "import_ready": import_ready,
+        "import_blockers": import_blockers,
+        "promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "promotion_gate": "runtime_ledger_live_or_live_paper_required",
+    }
     planned_targets: list[dict[str, object]] = []
     skipped_targets: list[dict[str, object]] = []
     planned_keys: set[tuple[object, ...]] = set()
@@ -492,6 +517,14 @@ def _next_paper_route_runtime_window_targets(
             "paper_route_probe_next_session_max_notional": next_notional,
             "paper_route_probe_window_start": _isoformat(window_start),
             "paper_route_probe_window_end": _isoformat(window_end),
+            "paper_route_session_readiness_state": _safe_text(
+                session_readiness.get("state")
+            )
+            or "unknown",
+            "paper_route_session_import_ready": import_ready,
+            "paper_route_session_import_blockers": import_blockers,
+            "paper_route_runtime_window_import_not_before": _isoformat(window_end),
+            "paper_route_runtime_import_handoff": import_handoff,
             "paper_probation_authorized": True,
             "paper_probation_authorization_scope": "evidence_collection_only",
             "evidence_collection_stage": "paper",
@@ -561,6 +594,13 @@ def _next_paper_route_runtime_window_targets(
             "end": _isoformat(window_end),
         },
         "session_readiness": session_readiness,
+        "runtime_window_import_handoff": {
+            **import_handoff,
+            "target_count": len(planned_targets),
+            "skipped_target_count": len(skipped_targets),
+            "window_start": _isoformat(window_start),
+            "window_end": _isoformat(window_end),
+        },
         "paper_route_probe": {
             "configured_enabled": bool(probe.get("configured_enabled")),
             "active": bool(probe.get("active")),

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -578,6 +578,58 @@ def _capital_multiplier_for_stage(stage: str) -> str:
     }.get(stage, "0")
 
 
+def _runtime_window_import_proof_blockers(
+    *,
+    promotion_blocking_reasons: Sequence[str],
+    runtime_payload: Mapping[str, Any],
+    candidate_id: str | None,
+    hypothesis_id: str,
+    observed_stage: str,
+    window_start: datetime,
+    window_end: datetime,
+) -> list[dict[str, Any]]:
+    blockers: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def add_blocker(reason: str) -> None:
+        code = _text(reason)
+        if not code or code in seen:
+            return
+        seen.add(code)
+        blockers.append(
+            {
+                "blocker": code,
+                "hypothesis_id": hypothesis_id,
+                "candidate_id": candidate_id,
+                "observed_stage": observed_stage,
+                "window_start": window_start.isoformat(),
+                "window_end": window_end.isoformat(),
+                "promotion_authority": _text(runtime_payload.get("promotion_authority"))
+                or "unknown",
+                "authority_reason": _text(runtime_payload.get("authority_reason")),
+                "runtime_ledger_profit_proof_present": bool(
+                    runtime_payload.get("runtime_ledger_profit_proof_present")
+                ),
+                "remediation": (
+                    "Inspect the imported runtime-window ledger rows and repair route, "
+                    "TCA, fill, cost, or lineage evidence before treating this target as "
+                    "promotion proof."
+                ),
+            }
+        )
+
+    for reason in promotion_blocking_reasons:
+        add_blocker(reason)
+
+    if runtime_payload and runtime_payload.get("authoritative") is False:
+        add_blocker(
+            _text(runtime_payload.get("authority_reason"))
+            or "runtime_observation_not_authoritative"
+        )
+
+    return blockers
+
+
 def _runtime_promotion_blocking_reasons(
     *,
     observed_stage: str,
@@ -1098,6 +1150,14 @@ def persist_observed_runtime_windows(
             default=datetime.now(timezone.utc),
         ),
     )
+    import_window_start = min(
+        (bucket.window_started_at for bucket in raw_buckets),
+        default=latest_observation_at,
+    )
+    import_window_end = max(
+        (bucket.window_ended_at for bucket in raw_buckets),
+        default=latest_observation_at,
+    )
     promotion_blocking_reasons = list(
         dict.fromkeys(
             [
@@ -1112,6 +1172,16 @@ def persist_observed_runtime_windows(
         )
     )
     promotion_allowed = not promotion_blocking_reasons
+    proof_blockers = _runtime_window_import_proof_blockers(
+        promotion_blocking_reasons=promotion_blocking_reasons,
+        runtime_payload=runtime_payload,
+        candidate_id=candidate_id,
+        hypothesis_id=hypothesis_id,
+        observed_stage=observed_stage,
+        window_start=import_window_start,
+        window_end=import_window_end,
+    )
+    proof_status = "blocked" if proof_blockers else "ok"
     running_session_samples = 0
     for bucket in sorted_buckets:
         running_session_samples += bucket.market_session_count
@@ -1338,6 +1408,9 @@ def persist_observed_runtime_windows(
         "slippage_budget_bps": str(budget),
         "promotion_allowed": promotion_allowed,
         "promotion_blocking_reasons": promotion_blocking_reasons,
+        "proof_status": proof_status,
+        "proof_blockers": proof_blockers,
+        "runtime_observation": runtime_payload,
         "delay_adjusted_depth_stress": delay_depth_stress_summary,
     }
 

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -84,6 +84,11 @@ RUNTIME_WINDOW_TARGET_METADATA_KEYS = (
     "paper_route_probe_next_session_max_notional",
     "paper_route_probe_window_start",
     "paper_route_probe_window_end",
+    "paper_route_session_readiness_state",
+    "paper_route_session_import_ready",
+    "paper_route_session_import_blockers",
+    "paper_route_runtime_window_import_not_before",
+    "paper_route_runtime_import_handoff",
     "handoff",
     "promotion_gate",
 )
@@ -257,6 +262,12 @@ def _as_text(value: Any) -> str | None:
         return None
     text = str(value).strip()
     return text or None
+
+
+def _as_text_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [text for item in value if (text := str(item).strip())]
 
 
 def _runtime_version_ref() -> str:
@@ -1219,6 +1230,59 @@ def _run_runtime_window_import(
     }
 
 
+def _runtime_window_import_payload_proof_blockers(
+    *,
+    payload: Mapping[str, Any],
+    target: RuntimeWindowImportTarget,
+    candidate_id: str,
+    window_start: datetime,
+    window_end: datetime,
+) -> list[dict[str, Any]]:
+    blockers = [
+        dict(blocker)
+        for blocker in payload.get("proof_blockers", [])
+        if isinstance(blocker, Mapping)
+    ]
+    if blockers:
+        return blockers
+
+    seen: set[str] = set()
+
+    def add_blocker(reason: str) -> None:
+        code = str(reason or "").strip()
+        if not code or code in seen:
+            return
+        seen.add(code)
+        blockers.append(
+            {
+                "blocker": code,
+                "hypothesis_id": target.hypothesis_id,
+                "candidate_id": candidate_id,
+                "observed_stage": target.observed_stage,
+                "window_start": _utc_iso(window_start),
+                "window_end": _utc_iso(window_end),
+                "remediation": (
+                    "Inspect the runtime-window import summary and repair route, TCA, "
+                    "fill, cost, lineage, or post-cost ledger evidence before promotion."
+                ),
+            }
+        )
+
+    if payload.get("promotion_allowed") is False:
+        reasons = _as_text_list(payload.get("promotion_blocking_reasons"))
+        for reason in reasons or ["runtime_window_import_not_promotion_allowed"]:
+            add_blocker(reason)
+
+    runtime_observation = _as_dict(payload.get("runtime_observation"))
+    if runtime_observation.get("authoritative") is False:
+        add_blocker(
+            _as_text(runtime_observation.get("authority_reason"))
+            or "runtime_observation_not_authoritative"
+        )
+
+    return blockers
+
+
 def _run_runtime_window_import_target(
     *,
     args: argparse.Namespace,
@@ -1379,11 +1443,16 @@ def _run_runtime_window_import_target(
         )
     result = subprocess.run(command, check=True, capture_output=True, text=True)
     payload = json.loads(result.stdout)
-    payload_proof_blockers = [
-        blocker
-        for blocker in payload.get("proof_blockers", [])
-        if isinstance(blocker, Mapping)
-    ]
+    if not isinstance(payload, Mapping):
+        raise RuntimeError("runtime_window_import_payload_not_mapping")
+    payload = dict(payload)
+    payload_proof_blockers = _runtime_window_import_payload_proof_blockers(
+        payload=payload,
+        target=target,
+        candidate_id=candidate_id,
+        window_start=window_start,
+        window_end=window_end,
+    )
     proof_blockers.extend(payload_proof_blockers)
     return {
         "status": "ok",

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -822,6 +822,11 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn(
             "--runtime-window-target-plan-url "
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
+            args,
+        )
+        self.assertNotIn(
+            "--runtime-window-target-plan-url "
             "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -268,6 +268,25 @@ class TestPaperRouteEvidenceAudit(TestCase):
             plan["session_readiness"]["import_blockers"],
             ["paper_route_session_window_not_open"],
         )
+        handoff = plan["runtime_window_import_handoff"]
+        self.assertEqual(
+            handoff["runner"], "scripts/renew_latest_empirical_promotion_jobs.py"
+        )
+        self.assertEqual(
+            handoff["target_plan_endpoint"], "/trading/paper-route-evidence"
+        )
+        self.assertIn("--runtime-window-import", handoff["required_flags"])
+        self.assertIn(
+            "--runtime-window-target-plan-settlement-seconds",
+            handoff["required_flags"],
+        )
+        self.assertFalse(handoff["import_ready"])
+        self.assertEqual(
+            handoff["import_blockers"],
+            ["paper_route_session_window_not_open"],
+        )
+        self.assertFalse(handoff["promotion_allowed"])
+        self.assertFalse(handoff["final_promotion_authorized"])
         target = plan["targets"][0]
         self.assertEqual(target["account_label"], "TORGHUT_SIM")
         self.assertEqual(target["source_account_label"], "TORGHUT_REPLAY")
@@ -279,6 +298,22 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(
             plan["paper_route_probe"]["blocking_reasons"],
             ["not_paper_mode", "market_session_closed"],
+        )
+        self.assertEqual(
+            target["paper_route_session_readiness_state"], "waiting_for_session_open"
+        )
+        self.assertFalse(target["paper_route_session_import_ready"])
+        self.assertEqual(
+            target["paper_route_session_import_blockers"],
+            ["paper_route_session_window_not_open"],
+        )
+        self.assertEqual(
+            target["paper_route_runtime_window_import_not_before"],
+            "2026-05-26T20:00:00+00:00",
+        )
+        self.assertEqual(
+            target["paper_route_runtime_import_handoff"]["target_plan_endpoint"],
+            "/trading/paper-route-evidence",
         )
         self.assertFalse(target["promotion_allowed"])
         self.assertFalse(target["final_promotion_authorized"])
@@ -360,6 +395,15 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertTrue(import_readiness["probe_ready"])
         self.assertTrue(import_readiness["import_ready"])
         self.assertEqual(import_readiness["import_blockers"], [])
+        import_target = import_payload["next_paper_route_runtime_window_targets"][
+            "targets"
+        ][0]
+        self.assertEqual(
+            import_target["paper_route_session_readiness_state"],
+            "window_closed_import_ready",
+        )
+        self.assertTrue(import_target["paper_route_session_import_ready"])
+        self.assertEqual(import_target["paper_route_session_import_blockers"], [])
 
     def test_source_activity_is_bound_to_target_window_end(self) -> None:
         window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -796,6 +796,29 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                             "paper_route_probe_next_session_max_notional": "25",
                             "paper_route_probe_window_start": "2026-05-26T13:30:00+00:00",
                             "paper_route_probe_window_end": "2026-05-26T20:00:00+00:00",
+                            "paper_route_session_readiness_state": "waiting_for_session_open",
+                            "paper_route_session_import_ready": False,
+                            "paper_route_session_import_blockers": [
+                                "paper_route_session_window_not_open"
+                            ],
+                            "paper_route_runtime_window_import_not_before": "2026-05-26T20:00:00+00:00",
+                            "paper_route_runtime_import_handoff": {
+                                "runner": "scripts/renew_latest_empirical_promotion_jobs.py",
+                                "target_plan_endpoint": "/trading/paper-route-evidence",
+                                "required_flags": [
+                                    "--runtime-window-import",
+                                    "--runtime-window-target-plan-url",
+                                    "--runtime-window-target-plan-exclusive",
+                                    "--runtime-window-target-plan-required",
+                                    "--runtime-window-target-plan-settlement-seconds",
+                                ],
+                                "source_dsn_env": "SIM_DB_DSN",
+                                "account_label": "TORGHUT_SIM",
+                                "import_ready": False,
+                                "import_blockers": [
+                                    "paper_route_session_window_not_open"
+                                ],
+                            },
                             "paper_probation_authorized": True,
                             "promotion_allowed": False,
                             "final_promotion_authorized": False,
@@ -863,6 +886,25 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual(
             targets[0].target_metadata["paper_route_probe_next_session_max_notional"],
             "25",
+        )
+        self.assertEqual(
+            targets[0].target_metadata["paper_route_session_readiness_state"],
+            "waiting_for_session_open",
+        )
+        self.assertFalse(targets[0].target_metadata["paper_route_session_import_ready"])
+        self.assertEqual(
+            targets[0].target_metadata["paper_route_session_import_blockers"],
+            ["paper_route_session_window_not_open"],
+        )
+        self.assertEqual(
+            targets[0].target_metadata["paper_route_runtime_window_import_not_before"],
+            "2026-05-26T20:00:00+00:00",
+        )
+        self.assertEqual(
+            targets[0].target_metadata["paper_route_runtime_import_handoff"][
+                "target_plan_endpoint"
+            ],
+            "/trading/paper-route-evidence",
         )
         self.assertFalse(targets[0].target_metadata["promotion_allowed"])
         self.assertFalse(targets[0].target_metadata["final_promotion_allowed"])
@@ -2417,6 +2459,249 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             command[command.index("--window-end") + 1],
             "2026-05-26T20:00:00Z",
         )
+
+    def test_runtime_window_import_blocks_non_authoritative_import_summary(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-pairs-01.json"
+        hypothesis_path.write_text(
+            json.dumps({"candidate_id": "cand-paper-route"}),
+            encoding="utf-8",
+        )
+        plan_path = self.tmp_dir / "paper-route-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "runtime_window_import_plan": {
+                        "targets": [
+                            {
+                                "candidate_id": "cand-paper-route",
+                                "hypothesis_id": "H-PAIRS-01",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "paper-route-candidate-v1",
+                                "source_manifest_ref": str(hypothesis_path),
+                                "source_dsn_env": "SIM_DB_DSN",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "window_start": "2026-05-26T13:30:00Z",
+                                "window_end": "2026-05-26T20:00:00Z",
+                            }
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        completed = SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "status": "ok",
+                    "promotion_allowed": False,
+                    "promotion_blocking_reasons": [
+                        "paper_stage_evidence_collection_only",
+                        "runtime_ledger_pnl_basis_missing",
+                    ],
+                    "runtime_observation": {
+                        "authoritative": False,
+                        "authority_reason": "runtime_without_runtime_ledger_profit_proof",
+                        "promotion_authority": "blocked",
+                        "runtime_ledger_profit_proof_present": False,
+                    },
+                }
+            )
+        )
+        args = SimpleNamespace(
+            runtime_window_import=True,
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_target_plan_url=[],
+            runtime_window_target_plan_url_timeout_seconds=2.0,
+            runtime_window_target_plan_exclusive=True,
+            runtime_window_target_plan_required=True,
+            runtime_window_target_plan_settlement_seconds=3600,
+            runtime_window_targets_from_latest_autoresearch=False,
+            runtime_window_targets_from_registry=False,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_start="",
+            runtime_window_end="",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with patch.object(renewal.subprocess, "run", return_value=completed):
+            payload = renewal._run_runtime_window_import(
+                args=args,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                now=datetime(2026, 5, 26, 21, 23, tzinfo=timezone.utc),
+            )
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertEqual(payload["proof_status"], "blocked")
+        blocker_codes = [item["blocker"] for item in payload["proof_blockers"]]
+        self.assertEqual(
+            blocker_codes,
+            [
+                "paper_stage_evidence_collection_only",
+                "runtime_ledger_pnl_basis_missing",
+                "runtime_without_runtime_ledger_profit_proof",
+            ],
+        )
+
+    def test_runtime_window_import_payload_keeps_existing_proof_blockers(
+        self,
+    ) -> None:
+        target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="cand-paper-route",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            strategy_name="paper-route-candidate-v1",
+            account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="",
+            source_manifest_ref="manifest.json",
+            source_kind="paper_route_probe_runtime_observed",
+            delay_adjusted_depth_stress_report_ref="",
+        )
+
+        blockers = renewal._runtime_window_import_payload_proof_blockers(
+            payload={
+                "proof_blockers": [
+                    {
+                        "blocker": "runtime_ledger_pnl_basis_missing",
+                        "candidate_id": "cand-paper-route",
+                    }
+                ],
+                "promotion_allowed": False,
+                "promotion_blocking_reasons": ["ignored_when_blockers_exist"],
+            },
+            target=target,
+            candidate_id="cand-paper-route",
+            window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(
+            blockers,
+            [
+                {
+                    "blocker": "runtime_ledger_pnl_basis_missing",
+                    "candidate_id": "cand-paper-route",
+                }
+            ],
+        )
+
+    def test_runtime_window_import_payload_deduplicates_fallback_blockers(
+        self,
+    ) -> None:
+        target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="cand-paper-route",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            strategy_name="paper-route-candidate-v1",
+            account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="",
+            source_manifest_ref="manifest.json",
+            source_kind="paper_route_probe_runtime_observed",
+            delay_adjusted_depth_stress_report_ref="",
+        )
+
+        blockers = renewal._runtime_window_import_payload_proof_blockers(
+            payload={
+                "promotion_allowed": False,
+                "promotion_blocking_reasons": [
+                    "",
+                    "paper_stage_evidence_collection_only",
+                    "paper_stage_evidence_collection_only",
+                ],
+                "runtime_observation": {
+                    "authoritative": False,
+                    "authority_reason": "",
+                    "promotion_authority": "blocked",
+                    "runtime_ledger_profit_proof_present": False,
+                },
+            },
+            target=target,
+            candidate_id="cand-paper-route",
+            window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(
+            [item["blocker"] for item in blockers],
+            [
+                "paper_stage_evidence_collection_only",
+                "runtime_observation_not_authoritative",
+            ],
+        )
+
+    def test_runtime_window_import_rejects_non_mapping_import_payload(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-pairs-01.json"
+        hypothesis_path.write_text(
+            json.dumps({"candidate_id": "cand-paper-route"}),
+            encoding="utf-8",
+        )
+        target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="cand-paper-route",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            strategy_name="paper-route-candidate-v1",
+            account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="",
+            source_manifest_ref=str(hypothesis_path),
+            source_kind="paper_route_probe_runtime_observed",
+            delay_adjusted_depth_stress_report_ref="",
+        )
+        completed = SimpleNamespace(stdout=json.dumps(["not", "a", "mapping"]))
+        args = SimpleNamespace(
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_target_plan_settlement_seconds=0,
+        )
+
+        with (
+            patch.object(renewal.subprocess, "run", return_value=completed),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "runtime_window_import_payload_not_mapping",
+            ),
+        ):
+            renewal._run_runtime_window_import_target(
+                args=args,
+                target=target,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+                window_end=datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc),
+                now=datetime(2026, 5, 26, 21, 23, tzinfo=timezone.utc),
+            )
+
+    def test_as_text_list_rejects_scalar_values(self) -> None:
+        self.assertEqual(renewal._as_text_list("single-reason"), [])
+        self.assertEqual(renewal._as_text_list({"reason": "value"}), [])
 
     def test_runtime_window_import_rejects_negative_target_plan_settlement_grace(
         self,

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -26,6 +26,7 @@ from app.trading.runtime_window_import import (
     _parse_observation_datetime,
     _runtime_ledger_bucket_blockers,
     _runtime_ledger_bucket_payloads,
+    _runtime_window_import_proof_blockers,
     build_observed_runtime_buckets,
     build_regular_session_buckets,
     persist_observed_runtime_windows,
@@ -82,6 +83,38 @@ class TestRuntimeWindowImport(TestCase):
         self.session_local = sessionmaker(
             bind=engine, expire_on_commit=False, future=True
         )
+
+    def test_runtime_window_import_proof_blockers_dedupe_blank_and_authority_reason(
+        self,
+    ) -> None:
+        blockers = _runtime_window_import_proof_blockers(
+            promotion_blocking_reasons=[
+                "",
+                "paper_stage_evidence_collection_only",
+                "paper_stage_evidence_collection_only",
+            ],
+            runtime_payload={
+                "authoritative": False,
+                "authority_reason": "runtime_without_runtime_ledger_profit_proof",
+                "promotion_authority": "blocked",
+                "runtime_ledger_profit_proof_present": False,
+            },
+            candidate_id="cand-paper-route",
+            hypothesis_id="H-PAIRS-01",
+            observed_stage="paper",
+            window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(
+            [item["blocker"] for item in blockers],
+            [
+                "paper_stage_evidence_collection_only",
+                "runtime_without_runtime_ledger_profit_proof",
+            ],
+        )
+        self.assertEqual(blockers[0]["promotion_authority"], "blocked")
+        self.assertFalse(blockers[0]["runtime_ledger_profit_proof_present"])
 
     def test_build_regular_session_buckets_counts_session_samples(self) -> None:
         buckets = build_regular_session_buckets(
@@ -552,6 +585,11 @@ class TestRuntimeWindowImport(TestCase):
         self.assertIn(
             "runtime_ledger_pnl_basis_missing",
             summary["promotion_blocking_reasons"],
+        )
+        self.assertEqual(summary["proof_status"], "blocked")
+        self.assertIn(
+            "sample_count_below_canary_minimum",
+            [item["blocker"] for item in summary["proof_blockers"]],
         )
         self.assertEqual(decisions[0].allowed, False)
         self.assertEqual(decisions[0].state, "shadow")
@@ -1196,6 +1234,11 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(summary["promotion_allowed"], False)
         self.assertEqual(
             summary["promotion_blocking_reasons"],
+            ["paper_stage_evidence_collection_only"],
+        )
+        self.assertEqual(summary["proof_status"], "blocked")
+        self.assertEqual(
+            [item["blocker"] for item in summary["proof_blockers"]],
             ["paper_stage_evidence_collection_only"],
         )
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Routes empirical-promotion renewal target-plan fetches to the authoritative live `/trading/paper-route-evidence` endpoint while keeping paper-window imports on `SIM_DB_DSN` and `TORGHUT_SIM`.
- Adds explicit paper-route import handoff/readiness metadata to paper-route target plans and preserves it through runtime-window target metadata.
- Adds runtime-window import proof blockers so non-authoritative paper/live import summaries stay visibly blocked until real runtime-ledger proof exists.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_runtime_window_import.py -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k 'runtime_window_target_plan_payload_accepts_paper_route_evidence_plan or runtime_window_import_defers_future_target_plan_window or runtime_window_import_defers_target_plan_settlement_grace or runtime_window_import_blocks_non_authoritative_import_summary' -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k empirical_promotion_renewal_imports_paper_windows_from_sim_db -q`
- `uv run --frozen pytest tests/test_whitepaper_candidate_compiler.py -k double_selection -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py app/trading/runtime_window_import.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_runtime_window_import.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
