### PR TITLE
fix(torghut): dedupe runtime ledger import targets

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -1219,6 +1219,7 @@ def _runtime_ledger_paper_probation_import_plan(
 ) -> dict[str, object]:
     targets: list[dict[str, object]] = []
     skipped_targets: list[dict[str, object]] = []
+    seen_target_keys: set[tuple[str, ...]] = set()
     for candidate in candidates:
         hypothesis_id = _safe_text(candidate.get("hypothesis_id"))
         candidate_id = _safe_text(candidate.get("candidate_id"))
@@ -1254,6 +1255,35 @@ def _runtime_ledger_paper_probation_import_plan(
                 }
             )
             continue
+
+        target_key = (
+            hypothesis_id or "",
+            candidate_id or "",
+            strategy_family or "",
+            strategy_name or "",
+            account_label,
+            dataset_snapshot_ref or "",
+            source_manifest_ref or "",
+            _RUNTIME_LEDGER_PAPER_PROBATION_SOURCE_KIND,
+            window_start or "",
+            window_end or "",
+        )
+        bucket_ref = _runtime_ledger_paper_probation_bucket_ref(candidate)
+        if target_key in seen_target_keys:
+            skipped_targets.append(
+                {
+                    "hypothesis_id": hypothesis_id,
+                    "candidate_id": candidate_id,
+                    "strategy_family": strategy_family,
+                    "strategy_name": strategy_name,
+                    "window_start": window_start,
+                    "window_end": window_end,
+                    "runtime_ledger_bucket_ref": bucket_ref,
+                    "reason": "duplicate_runtime_ledger_paper_probation_target",
+                }
+            )
+            continue
+        seen_target_keys.add(target_key)
 
         reason_codes = _normalize_reason_codes(
             [
@@ -1298,7 +1328,7 @@ def _runtime_ledger_paper_probation_import_plan(
             "selection_reason": "positive_post_cost_runtime_ledger_bucket",
             "max_notional": "0",
         }
-        if bucket_ref := _runtime_ledger_paper_probation_bucket_ref(candidate):
+        if bucket_ref:
             target["runtime_ledger_bucket_ref"] = bucket_ref
         targets.append(target)
 

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -755,6 +755,47 @@ class TestSubmissionCouncil(TestCase):
         self.assertIn("strategy_name", skipped_target["missing_fields"])
         self.assertIn("source_manifest_ref", skipped_target["missing_fields"])
 
+    def test_runtime_ledger_paper_probation_import_plan_dedupes_same_window_targets(
+        self,
+    ) -> None:
+        base_candidate = {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "candidate-pairs",
+            "runtime_strategy_name": "microbar-pairs-vwap-cap-safe",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "account": "TORGHUT_REPLAY",
+            "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+            "bucket_started_at": "2026-05-21T17:00:00+00:00",
+            "bucket_ended_at": "2026-05-21T17:30:00+00:00",
+            "reason_codes": ["runtime_ledger_stage_not_live"],
+        }
+
+        plan = _runtime_ledger_paper_probation_import_plan(
+            [
+                {**base_candidate, "run_id": "better-runtime-ledger"},
+                {**base_candidate, "run_id": "duplicate-runtime-ledger"},
+            ]
+        )
+
+        self.assertEqual(plan["target_count"], 1)
+        self.assertEqual(plan["skipped_target_count"], 1)
+        self.assertEqual(
+            plan["targets"][0]["runtime_ledger_bucket_ref"],
+            "strategy_runtime_ledger_buckets:better-runtime-ledger:"
+            "2026-05-21T17:00:00+00:00:2026-05-21T17:30:00+00:00",
+        )
+        skipped_target = plan["skipped_targets"][0]
+        self.assertEqual(
+            skipped_target["reason"],
+            "duplicate_runtime_ledger_paper_probation_target",
+        )
+        self.assertEqual(
+            skipped_target["runtime_ledger_bucket_ref"],
+            "strategy_runtime_ledger_buckets:duplicate-runtime-ledger:"
+            "2026-05-21T17:00:00+00:00:2026-05-21T17:30:00+00:00",
+        )
+
     def test_metric_window_activity_rejects_tca_proxy_expectancy(self) -> None:
         metric_window = SimpleNamespace(
             market_session_count=3,


### PR DESCRIPTION
## Summary

- Dedupes runtime-ledger paper-probation import targets by candidate, strategy, account, dataset, source, and window before exposing them in the live submission gate.
- Records duplicate same-window runtime-ledger buckets as skipped targets with `duplicate_runtime_ledger_paper_probation_target` instead of advertising duplicate import work.
- Adds a regression test covering duplicate same-window H-PAIRS-style targets while preserving the first ranked bucket reference.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_submission_council.py -k 'runtime_ledger_paper_probation_import_plan' -q`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen ruff format --check app/trading/submission_council.py tests/test_submission_council.py`
- `git diff --check`
- `uv run --frozen pytest tests/test_submission_council.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
