### PR TITLE
fix(torghut): prioritize paper route target plans

### DIFF
--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -431,6 +431,13 @@ def _runtime_window_target_plan_from_payload(
     direct_plan = _as_dict(payload.get("runtime_window_import_plan"))
     if direct_plan:
         return direct_plan
+    paper_route_plan = _as_dict(payload.get("next_paper_route_runtime_window_targets"))
+    if (
+        str(payload.get("schema_version") or "").strip()
+        == "torghut.paper-route-evidence.v1"
+        and paper_route_plan
+    ):
+        return paper_route_plan
     gate = _as_dict(payload.get("live_submission_gate"))
     gate_plan = _as_dict(gate.get("runtime_ledger_paper_probation_import_plan"))
     if gate_plan:
@@ -440,7 +447,6 @@ def _runtime_window_target_plan_from_payload(
     )
     if top_level_gate_plan:
         return top_level_gate_plan
-    paper_route_plan = _as_dict(payload.get("next_paper_route_runtime_window_targets"))
     if paper_route_plan:
         return paper_route_plan
     return _as_dict(payload)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -771,6 +771,56 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual(top_level_plan["targets"][0]["hypothesis_id"], "H-PAIRS-01")
         self.assertEqual(fallback_plan["targets"][0]["hypothesis_id"], "H-FALLBACK-01")
 
+    def test_runtime_window_target_plan_payload_prefers_next_paper_route_plan(
+        self,
+    ) -> None:
+        plan = renewal._runtime_window_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-evidence.v1",
+                "live_submission_gate": {
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "targets": [
+                            {
+                                "candidate_id": "cand-stale-paper",
+                                "hypothesis_id": "H-STALE-PAPER",
+                                "window_start": "2026-05-21T17:00:00+00:00",
+                                "window_end": "2026-05-21T17:30:00+00:00",
+                            }
+                        ],
+                    }
+                },
+                "next_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "candidate_id": "cand-paper-route",
+                            "hypothesis_id": "H-PAPER-ROUTE",
+                            "window_start": "2026-05-26T13:30:00+00:00",
+                            "window_end": "2026-05-26T20:00:00+00:00",
+                        }
+                    ],
+                },
+                "targets": [
+                    {
+                        "candidate_id": "cand-top-level-audit",
+                        "hypothesis_id": "H-TOP-LEVEL-AUDIT",
+                        "window_start": "2026-05-13T17:00:00+00:00",
+                        "window_end": "2026-05-13T17:30:00+00:00",
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(
+            plan["schema_version"], "torghut.next-paper-route-runtime-window-targets.v1"
+        )
+        self.assertEqual(plan["targets"][0]["hypothesis_id"], "H-PAPER-ROUTE")
+        self.assertEqual(
+            plan["targets"][0]["window_start"], "2026-05-26T13:30:00+00:00"
+        )
+
     def test_runtime_window_target_plan_payload_accepts_paper_route_evidence_plan(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Prefer `next_paper_route_runtime_window_targets` when parsing `/trading/paper-route-evidence` runtime-window target plans.
- Prevent the May 26 paper-route renewal path from falling back to stale paper-probation gate buckets when the endpoint contains both plan shapes.
- Add a regression covering the live payload shape with stale gate targets, top-level audit targets, and the next-session paper-route plan.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k 'runtime_window_target_plan_payload' -q`
- `uv run --frozen ruff format --check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -q`
- `git diff --check`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
