### PR TITLE
fix(torghut): use sim paper route target plan

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -34,7 +34,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref intraday_tsmom_v2@research \
                     --runtime-window-import \
-                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence \
+                    --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence \
                     --runtime-window-target-plan-exclusive \
                     --runtime-window-target-plan-required \
                     --runtime-window-target-plan-settlement-seconds 3600 \

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4469,11 +4469,20 @@ def _paper_route_target_plan_targets(plan: Mapping[str, Any]) -> list[dict[str, 
 
 def _paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
     live_gate = _to_str_map(payload.get("live_submission_gate"))
+    runtime_window_plan = _to_str_map(payload.get("runtime_window_import_plan"))
+    next_paper_route_plan = _to_str_map(
+        payload.get("next_paper_route_runtime_window_targets")
+    )
+    paper_route_payload = (
+        payload.get("schema_version") == "torghut.paper-route-evidence.v1"
+    )
+    paper_route_plans = [next_paper_route_plan] if paper_route_payload else []
     candidate_plans = [
-        _to_str_map(payload.get("runtime_window_import_plan")),
+        runtime_window_plan,
+        *paper_route_plans,
         _to_str_map(live_gate.get("runtime_ledger_paper_probation_import_plan")),
         _to_str_map(payload.get("runtime_ledger_paper_probation_import_plan")),
-        _to_str_map(payload.get("next_paper_route_runtime_window_targets")),
+        *([] if paper_route_payload else [next_paper_route_plan]),
         dict(payload) if _paper_route_target_plan_targets(payload) else {},
     ]
     for plan in candidate_plans:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -822,12 +822,12 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn(
             "--runtime-window-target-plan-url "
-            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
         self.assertNotIn(
             "--runtime-window-target-plan-url "
-            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
         self.assertIn("--runtime-window-target-plan-exclusive", args)

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7176,10 +7176,17 @@ class TestTradingApi(TestCase):
     ) -> None:
         plan = _paper_route_target_plan_from_payload(
             {
+                "schema_version": "torghut.paper-route-evidence.v1",
                 "live_submission_gate": {
                     "runtime_ledger_paper_probation_import_plan": {
                         "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
                         "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-OLD",
+                                "candidate_id": "stale-probation-target",
+                            }
+                        ],
                     }
                 },
                 "next_paper_route_runtime_window_targets": {


### PR DESCRIPTION
## Summary

- Point the empirical promotion renewal CronJob at `torghut-sim` for paper-route target plans so `SIM_DB_DSN` imports use `TORGHUT_SIM` target metadata.
- Make paper-route evidence payload parsing prefer `next_paper_route_runtime_window_targets` over stale runtime-ledger probation plans while preserving direct `runtime_window_import_plan` precedence.
- Tighten regression coverage for stale gate-plan precedence and the GitOps manifest contract.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k empirical_promotion_renewal_imports_paper_windows_from_sim_db -q`
- `uv run --frozen pytest tests/test_trading_api.py -k paper_route_target_plan_from_payload -q`
- `uv run --frozen ruff format --check app/main.py tests/test_live_config_manifest_contract.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/main.py tests/test_live_config_manifest_contract.py tests/test_trading_api.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
