### PR TITLE
fix(torghut): normalize nested runtime ledger evidence

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 from datetime import date, datetime, time, timedelta, timezone
@@ -162,11 +163,20 @@ def _text_or_none(value: Any) -> str | None:
 
 
 def _row_payloads(row: Mapping[str, object]) -> list[Mapping[str, object]]:
-    payloads: list[Mapping[str, object]] = [row]
-    for key in ("execution_audit_json", "raw_order"):
-        payload = row.get(key)
-        if isinstance(payload, Mapping):
-            payloads.append({str(item_key): item for item_key, item in payload.items()})
+    payloads: list[Mapping[str, object]] = []
+
+    def append_payload(value: object, *, depth: int) -> None:
+        if not isinstance(value, Mapping):
+            return
+        payload = {str(item_key): item for item_key, item in value.items()}
+        payloads.append(payload)
+        if depth <= 0:
+            return
+        for nested in payload.values():
+            if isinstance(nested, Mapping):
+                append_payload(nested, depth=depth - 1)
+
+    append_payload(row, depth=4)
     return payloads
 
 
@@ -185,6 +195,66 @@ def _first_text(row: Mapping[str, object], *keys: str) -> str | None:
             text = str(payload.get(key) or "").strip()
             if text:
                 return text
+    return None
+
+
+def _json_default(value: object) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return str(value)
+    return str(value)
+
+
+def _stable_payload_digest(value: object) -> str | None:
+    if not isinstance(value, Mapping):
+        return None
+    payload = {str(item_key): item for item_key, item in value.items()}
+    if not payload:
+        return None
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_json_default,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _first_payload_digest(row: Mapping[str, object], *keys: str) -> str | None:
+    for payload in _row_payloads(row):
+        for key in keys:
+            if digest := _stable_payload_digest(payload.get(key)):
+                return digest
+    return None
+
+
+_LINEAGE_CONTEXT_KEYS = (
+    "simulation_run_id",
+    "dataset_id",
+    "dataset_snapshot_ref",
+    "dataset_snapshot_hash",
+    "replay_data_hash",
+    "replay_tape_content_sha256",
+    "source_query_digest",
+    "source_topic",
+    "source_partition",
+)
+
+
+def _first_lineage_digest(row: Mapping[str, object]) -> str | None:
+    if digest := _first_payload_digest(
+        row, "lineage", "candidate_lineage", "source_lineage"
+    ):
+        return digest
+    for payload in _row_payloads(row):
+        lineage_payload = {
+            key: value
+            for key in _LINEAGE_CONTEXT_KEYS
+            if (value := payload.get(key)) is not None
+        }
+        if digest := _stable_payload_digest(lineage_payload):
+            return digest
     return None
 
 
@@ -575,9 +645,25 @@ def _build_realized_strategy_pnl_rows(
                 "execution_policy_sha256",
                 "policy_hash",
                 "execution_idempotency_key",
+            )
+            or _first_payload_digest(
+                row,
+                "execution_policy",
+                "execution_policy_context",
+                "execution_advisor",
+                "_execution_advice_provenance",
             ),
             "cost_model_hash": _first_text(
                 row, "cost_model_hash", "fee_model_hash", "cost_model_sha256"
+            )
+            or _first_payload_digest(
+                row,
+                "cost_model",
+                "cost_model_config",
+                "transaction_cost_model",
+                "fee_model",
+                "fees_model",
+                "model",
             ),
             "lineage_hash": _first_text(
                 row,
@@ -585,7 +671,8 @@ def _build_realized_strategy_pnl_rows(
                 "candidate_lineage_hash",
                 "replay_lineage_hash",
                 "candidate_evaluation_key",
-            ),
+            )
+            or _first_lineage_digest(row),
             "replay_data_hash": _first_text(
                 row,
                 "replay_data_hash",

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -20,6 +20,7 @@ from scripts.import_hypothesis_runtime_windows import (
     POST_COST_BASIS_SIMULATION_REPORT,
     POST_COST_BASIS_TCA_PROXY,
     _build_realized_strategy_pnl_rows,
+    _first_lineage_digest,
     _load_json_artifact,
     _load_report_post_cost_expectancy_bps,
     _nonnegative_int,
@@ -27,6 +28,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _parse_dt_or_none,
     _parse_target_metadata,
     _query_timestamps,
+    _row_payloads,
     _runtime_ledger_bucket_profit_proof_present,
     _runtime_ledger_event_type,
     _runtime_ledger_profit_proof_present,
@@ -34,6 +36,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _runtime_ledger_target_metadata_blockers,
     _runtime_ledger_tca_rows_from_durable_buckets,
     _runtime_ledger_tca_rows_from_artifacts,
+    _stable_payload_digest,
     _strategy_name_candidates,
     main,
 )
@@ -693,6 +696,63 @@ class TestImportHypothesisRuntimeWindows(TestCase):
     def test_strategy_name_candidates_drop_blank_values(self) -> None:
         self.assertEqual(_strategy_name_candidates("", "   ", None), [])
 
+    def test_row_payloads_recurses_to_limit_and_ignores_non_mappings(self) -> None:
+        self.assertEqual(_row_payloads("not-a-row"), [])
+
+        payloads = _row_payloads(
+            {
+                "level_1": {
+                    "level_2": {
+                        "level_3": {
+                            "level_4": {
+                                "level_5": {"ignored": True},
+                            },
+                        },
+                    },
+                },
+                "scalar": "ignored",
+            }
+        )
+
+        self.assertEqual(len(payloads), 5)
+        self.assertIn("level_5", payloads[-1])
+        self.assertNotIn({"ignored": True}, payloads)
+
+    def test_stable_payload_digest_normalizes_runtime_payload_values(self) -> None:
+        class CustomValue:
+            def __str__(self) -> str:
+                return "custom-value"
+
+        payload = {
+            "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+            "notional": Decimal("100.25"),
+            "custom": CustomValue(),
+        }
+
+        self.assertEqual(
+            _stable_payload_digest(payload),
+            _stable_payload_digest(
+                {
+                    "custom": CustomValue(),
+                    "notional": Decimal("100.25"),
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                }
+            ),
+        )
+
+    def test_first_lineage_digest_prefers_explicit_lineage_payload(self) -> None:
+        lineage_payload = {"source": "runtime-ledger", "snapshot": "sim-run-1"}
+
+        self.assertEqual(
+            _first_lineage_digest(
+                {
+                    "source_lineage": lineage_payload,
+                    "simulation_context": {"simulation_run_id": "ignored-context"},
+                }
+            ),
+            _stable_payload_digest(lineage_payload),
+        )
+
     def test_build_realized_strategy_pnl_rows_requires_costed_round_trip(
         self,
     ) -> None:
@@ -742,6 +802,77 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             rows[0]["post_cost_expectancy_bps"],
             Decimal("34.82587064676616915422885572"),
         )
+
+    def test_build_realized_strategy_pnl_rows_normalizes_nested_runtime_payloads(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_audit_json": {
+                        "fees": {
+                            "cost_amount": "0.20",
+                            "cost_basis": "broker_reported_commission_and_fees",
+                        },
+                        "simulation_context": {
+                            "simulation_run_id": "sim-run-1",
+                            "dataset_event_id": "evt-buy",
+                        },
+                    },
+                    "raw_order": {
+                        "execution_policy": {
+                            "selected_order_type": "limit",
+                            "adaptive": {"max_participation_rate": "0.05"},
+                        },
+                        "cost_model": {"commission_bps": "0", "min_commission": "0"},
+                    },
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_audit_json": {
+                        "fees": {
+                            "cost_amount": "0.10",
+                            "cost_basis": "broker_reported_commission_and_fees",
+                        },
+                        "simulation_context": {
+                            "simulation_run_id": "sim-run-1",
+                            "dataset_event_id": "evt-sell",
+                        },
+                    },
+                    "raw_order": {
+                        "execution_policy": {
+                            "selected_order_type": "limit",
+                            "adaptive": {"max_participation_rate": "0.05"},
+                        },
+                        "cost_model": {"commission_bps": "0", "min_commission": "0"},
+                    },
+                },
+            ]
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], True)
+        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.70"))
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["blockers"], [])
+        self.assertGreaterEqual(len(bucket["execution_policy_hash_counts"]), 1)
+        self.assertGreaterEqual(len(bucket["cost_model_hash_counts"]), 1)
+        self.assertGreaterEqual(len(bucket["lineage_hash_counts"]), 1)
 
     def test_build_realized_strategy_pnl_rows_rejects_shortfall_only_costs(
         self,


### PR DESCRIPTION
## Summary

- Normalize nested execution audit/raw-order payloads when building runtime-ledger proof rows.
- Derive stable content hashes for nested execution policy, cost model, and source-lineage payloads when explicit hash fields are absent.
- Keep TCA shortfall and simulation-report PnL non-authoritative; the importer still requires explicit costed closed-trip runtime-ledger proof.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'nested_runtime_payloads or costed_round_trip or shortfall_only_costs or query_timestamps_filters_to_execution_eligible_decisions' -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
