### PR TITLE
feat(torghut): expose selection-only whitepaper autoresearch

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -88,6 +88,8 @@ spec:
         value: '2'
       - name: allowStaleTape
         value: 'false'
+      - name: selectionOnly
+        value: 'false'
       - name: persistResults
         value: 'true'
   templates:
@@ -130,6 +132,7 @@ spec:
           - name: replayTapePreviewTopK
           - name: replayTapePreviewMinRows
           - name: allowStaleTape
+          - name: selectionOnly
           - name: persistResults
       container:
         image: registry.ide-newton.ts.net/lab/torghut@sha256:9ff870b9a1b8514bdd5997bc06ef462b2b089d2aa09898835dd6f80466c20a5b
@@ -263,6 +266,9 @@ spec:
             fi
             if [ "{{inputs.parameters.allowStaleTape}}" = "true" ]; then
               SCRIPT_ARGS+=(--allow-stale-tape)
+            fi
+            if [ "{{inputs.parameters.selectionOnly}}" = "true" ]; then
+              SCRIPT_ARGS+=(--selection-only)
             fi
             if [ "{{inputs.parameters.persistResults}}" = "true" ]; then
               SCRIPT_ARGS+=(--persist-results)

--- a/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
+++ b/packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts
@@ -123,11 +123,13 @@ describe('Torghut manifest scheduling', () => {
     expect(JSON.stringify(template)).toContain('--real-replay-shard-timeout-seconds')
     expect(JSON.stringify(template)).toContain('--real-replay-shard-workers')
     expect(JSON.stringify(template)).toContain('--feedback-block-reaudit-slots')
+    expect(JSON.stringify(template)).toContain('--selection-only')
     expect(parameterValue(manifest, 'maxCandidates')).toBe('128')
     expect(parameterValue(manifest, 'topK')).toBe('64')
     expect(parameterValue(manifest, 'explorationSlots')).toBe('48')
     expect(parameterValue(manifest, 'feedbackBlockReauditSlots')).toBe('32')
     expect(parameterValue(manifest, 'portfolioSizeMin')).toBe('3')
+    expect(parameterValue(manifest, 'selectionOnly')).toBe('false')
   })
 
   it('bounds whitepaper autoresearch real replay so profit runs emit evidence before timeout', () => {

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -869,6 +869,13 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertIn("activeDeadlineSeconds: 9000", template)
         self.assertIn("name: allowStaleTape\n        value: 'false'", template)
+        self.assertIn("name: selectionOnly\n        value: 'false'", template)
+        self.assertIn("name: selectionOnly", template)
+        self.assertIn(
+            'if [ "{{inputs.parameters.selectionOnly}}" = "true" ]; then',
+            template,
+        )
+        self.assertIn("SCRIPT_ARGS+=(--selection-only)", template)
         self.assertNotIn("value: '2026-04-24'", template)
         self.assertNotIn("value: '2026-05-01'", template)
 


### PR DESCRIPTION
## Summary

- Add a `selectionOnly` parameter to the Torghut whitepaper autoresearch WorkflowTemplate.
- Pass `--selection-only` to `run_whitepaper_autoresearch_profit_target.py` when the parameter is enabled, while keeping the default behavior unchanged.
- Cover the GitOps switch in both the manifest scheduling contract test and the Torghut workflow template contract test.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'workflow_template_surfaces_feedback_and_fails_closed_on_stale_tape or selection_only_writes_pre_replay_artifacts_without_replay_or_persistence' -q`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `uv run --frozen ruff format --check tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
