### PR TITLE
fix(torghut): resolve replay paths in container layout

### DIFF
--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -78,10 +78,28 @@ _EXACT_REPLAY_LEDGER_ROWS_SCHEMA_VERSION = "torghut.exact_replay_ledger.rows.v1"
 _REPLAY_LEDGER_ACCOUNT_LABEL = "TORGHUT_REPLAY"
 _REPLAY_COST_BASIS = "local_replay_transaction_cost_model"
 _REPLAY_LEDGER_SOURCE = "local_intraday_tsmom_replay"
-_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _resolve_repo_root(script_path: Path) -> Path:
+    resolved = script_path.resolve()
+    for candidate in (resolved.parent, *resolved.parents):
+        if (candidate / "argocd").is_dir() and (
+            candidate / "services" / "torghut"
+        ).is_dir():
+            return candidate
+    for candidate in (resolved.parent, *resolved.parents):
+        if (candidate / "app").is_dir() and (candidate / "scripts").is_dir():
+            return candidate
+    parents = resolved.parents
+    return parents[3] if len(parents) > 3 else parents[-1]
+
+
+_REPO_ROOT = _resolve_repo_root(Path(__file__))
 
 
 def default_strategy_configmap_path() -> Path:
+    if strategy_config_path := os.environ.get("TRADING_STRATEGY_CONFIG_PATH"):
+        return Path(strategy_config_path)
     return _REPO_ROOT / "argocd/applications/torghut/strategy-configmap.yaml"
 
 

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -48,6 +48,7 @@ from scripts.local_intraday_tsmom_replay import (
     _quote_quality_status,
     _record_capital_snapshot,
     _record_trace_for_funnel,
+    _resolve_repo_root,
     _reconcile_pending_order_before_immediate_fill,
     _resolve_passed_trace_block_reason,
     _resolve_pending_fill_price,
@@ -61,6 +62,39 @@ from scripts.local_intraday_tsmom_replay import (
 
 
 class TestLocalIntradayTsmomReplay(TestCase):
+    def test_resolve_repo_root_accepts_container_app_layout(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "app"
+            (root / "app").mkdir(parents=True)
+            (root / "scripts").mkdir()
+            script_path = root / "scripts" / "local_intraday_tsmom_replay.py"
+            script_path.touch()
+
+            self.assertEqual(_resolve_repo_root(script_path), root.resolve())
+
+    def test_resolve_repo_root_keeps_legacy_parent_fallback(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            script_path = root / "one" / "two" / "three" / "four" / "script.py"
+            script_path.parent.mkdir(parents=True)
+            script_path.touch()
+
+            self.assertEqual(
+                _resolve_repo_root(script_path), script_path.resolve().parents[3]
+            )
+
+    def test_default_strategy_configmap_prefers_runtime_env_path(self) -> None:
+        from scripts import local_intraday_tsmom_replay as replay
+
+        with patch.dict(
+            os.environ,
+            {"TRADING_STRATEGY_CONFIG_PATH": "/etc/torghut/strategies.yaml"},
+        ):
+            self.assertEqual(
+                replay.default_strategy_configmap_path(),
+                Path("/etc/torghut/strategies.yaml"),
+            )
+
     def _signal(self, *, bid: str, ask: str, price: str) -> SignalEnvelope:
         return SignalEnvelope(
             event_ts=datetime(2026, 3, 27, 17, 30, 24, tzinfo=timezone.utc),


### PR DESCRIPTION
## Summary

- Fix Torghut replay repo-root discovery so imports work in both the monorepo checkout and the `/app/{app,scripts}` container layout.
- Prefer `TRADING_STRATEGY_CONFIG_PATH` for the replay strategy config default, matching the runtime container environment.
- Add regression coverage for the container layout and runtime strategy-config env override.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_local_intraday_tsmom_replay.py -k 'repo_root or runtime_env_path' -q`
- `uv run --frozen python -c 'import scripts.local_intraday_tsmom_replay as r; import scripts.run_whitepaper_autoresearch_profit_target as w; print(r._REPO_ROOT); print(r.default_strategy_configmap_path())'`
- `uv run --frozen ruff format --check scripts/local_intraday_tsmom_replay.py tests/test_local_intraday_tsmom_replay.py`
- `uv run --frozen ruff check scripts/local_intraday_tsmom_replay.py tests/test_local_intraday_tsmom_replay.py`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k selection_only_writes_pre_replay_artifacts_without_replay_or_persistence -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
