### PR TITLE
fix(memories): default to tailscale agents endpoint

### DIFF
--- a/services/memories/README.md
+++ b/services/memories/README.md
@@ -21,7 +21,7 @@ Default base URL selection:
 
 - In Kubernetes namespace `agents`: `http://agents`
 - In any other Kubernetes namespace: `http://agents.agents.svc.cluster.local`
-- Outside Kubernetes: `https://agents.k8s.proompteng.ai`
+- Outside Kubernetes: `http://agents.ide-newton.ts.net`
 
 Override the base URL by setting `MEMORIES_AGENTS_URL` (or `AGENTS_SERVICE_BASE_URL` / `MEMORIES_BASE_URL`).
 For debugging Kubernetes auto-detection, you can set `MEMORIES_K8S_NAMESPACE`.

--- a/services/memories/cli.ts
+++ b/services/memories/cli.ts
@@ -43,7 +43,7 @@ export function parseCliFlags(argv: string[] = []) {
   return flags
 }
 
-export const DEFAULT_AGENTS_BASE_URL = 'https://agents.k8s.proompteng.ai'
+export const DEFAULT_AGENTS_BASE_URL = 'http://agents.ide-newton.ts.net'
 export const DEFAULT_K8S_AGENTS_BASE_URL = 'http://agents.agents.svc.cluster.local'
 export const DEFAULT_K8S_SAME_NAMESPACE_AGENTS_BASE_URL = 'http://agents'
 

--- a/services/memories/tests/cli.test.ts
+++ b/services/memories/tests/cli.test.ts
@@ -75,7 +75,8 @@ describe('resolveAgentsBaseUrl', () => {
     ).toBe(DEFAULT_K8S_AGENTS_BASE_URL)
   })
 
-  it('uses public Agents API default outside Kubernetes', () => {
+  it('uses Tailscale Agents API default outside Kubernetes', () => {
+    expect(DEFAULT_AGENTS_BASE_URL).toBe('http://agents.ide-newton.ts.net')
     expect(
       resolveAgentsBaseUrl({
         env: {},


### PR DESCRIPTION
## Summary

- Change the local/outside-Kubernetes memories CLI default from `https://agents.k8s.proompteng.ai` to `http://agents.ide-newton.ts.net`.
- Keep in-cluster defaults unchanged for the `agents` namespace and cross-namespace Kubernetes callers.
- Update memories docs and tests so the Tailscale default is explicit.

## Related Issues

None

## Testing

- `bun run --filter memories test`
- `bunx oxfmt --check services/memories/cli.ts services/memories/tests/cli.test.ts`
- `bun run --cwd services/memories lint:oxlint`
- `bun run --cwd services/memories lint:oxlint:type`
- `git diff --check`
- `bun run --filter memories retrieve-memory --query "agents memory endpoint script" --limit 1`
- `bun run --filter memories save-memory --task-name memory-default-url-fix-smoke --summary "Memory CLI default URL changed to Tailscale Agents endpoint" --content "Smoke test after changing services/memories/cli.ts DEFAULT_AGENTS_BASE_URL to http://agents.ide-newton.ts.net. This save ran without MEMORIES_AGENTS_URL set, proving the default now reaches Agents /v1/memory-notes from the local machine." --tags agents,memories,tailscale,smoke`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
