### PR TITLE
fix(torghut): surface replay coverage gaps

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -2633,6 +2633,37 @@ def _candidate_search_remediation(
     recent_day_shortfall = _recent_trading_days_shortfall(failure_reason)
     recent_day_diagnostics: dict[str, Any] | None = None
     if recent_day_shortfall is not None:
+        signal_recent_days_query = (
+            "SELECT toDate(event_ts) AS trading_day, count() AS rows, "
+            "min(event_ts) AS first_event_ts, max(event_ts) AS last_event_ts "
+            "FROM torghut.ta_signals WHERE source = 'ta' AND window_size = 'PT1S' "
+            "GROUP BY trading_day ORDER BY trading_day DESC LIMIT 20"
+        )
+        signal_microbar_coverage_query = (
+            "SELECT table_name, countDistinct(trading_day) AS days, "
+            "min(trading_day) AS first_day, max(trading_day) AS last_day, sum(rows) AS rows "
+            "FROM ("
+            "SELECT 'ta_signals' AS table_name, toDate(event_ts) AS trading_day, count() AS rows "
+            "FROM torghut.ta_signals WHERE source = 'ta' AND window_size = 'PT1S' "
+            "GROUP BY trading_day UNION ALL "
+            "SELECT 'ta_microbars' AS table_name, toDate(event_ts) AS trading_day, count() AS rows "
+            "FROM torghut.ta_microbars WHERE source = 'ta' AND window_size = 'PT1S' "
+            "GROUP BY trading_day"
+            ") GROUP BY table_name ORDER BY table_name"
+        )
+        signal_microbar_day_gap_query = (
+            "SELECT trading_day, "
+            "sumIf(rows, table_name = 'ta_signals') AS signal_rows, "
+            "sumIf(rows, table_name = 'ta_microbars') AS microbar_rows "
+            "FROM ("
+            "SELECT 'ta_signals' AS table_name, toDate(event_ts) AS trading_day, count() AS rows "
+            "FROM torghut.ta_signals WHERE source = 'ta' AND window_size = 'PT1S' "
+            "GROUP BY trading_day UNION ALL "
+            "SELECT 'ta_microbars' AS table_name, toDate(event_ts) AS trading_day, count() AS rows "
+            "FROM torghut.ta_microbars WHERE source = 'ta' AND window_size = 'PT1S' "
+            "GROUP BY trading_day"
+            ") GROUP BY trading_day ORDER BY trading_day DESC LIMIT 40"
+        )
         recent_day_diagnostics = {
             **recent_day_shortfall,
             "required_window": {
@@ -2640,12 +2671,14 @@ def _candidate_search_remediation(
                 "holdout_days": max(1, int(current_holdout_days)),
                 "second_oos_days": max(0, int(current_second_oos_days)),
             },
-            "clickhouse_recent_days_query": (
-                "SELECT toDate(event_ts) AS trading_day, count() AS rows, "
-                "min(event_ts) AS first_event_ts, max(event_ts) AS last_event_ts "
-                "FROM torghut.ta_signals WHERE source = 'ta' AND window_size = 'PT1S' "
-                "GROUP BY trading_day ORDER BY trading_day DESC LIMIT 20"
-            ),
+            "clickhouse_recent_days_query": signal_recent_days_query,
+            "clickhouse_signal_microbar_coverage_query": signal_microbar_coverage_query,
+            "clickhouse_signal_microbar_day_gap_query": signal_microbar_day_gap_query,
+            "clickhouse_coverage_probe_queries": {
+                "ta_signals_recent_days": signal_recent_days_query,
+                "signal_microbar_coverage": signal_microbar_coverage_query,
+                "signal_microbar_day_gap": signal_microbar_day_gap_query,
+            },
         }
         next_actions.append(
             {
@@ -2658,6 +2691,12 @@ def _candidate_search_remediation(
                 "recent_trading_days": recent_day_diagnostics,
                 "recommended_operator_probe": recent_day_diagnostics[
                     "clickhouse_recent_days_query"
+                ],
+                "recommended_coverage_probe": recent_day_diagnostics[
+                    "clickhouse_signal_microbar_coverage_query"
+                ],
+                "recommended_day_gap_probe": recent_day_diagnostics[
+                    "clickhouse_signal_microbar_day_gap_query"
                 ],
                 "recommended_archive_probe": (
                     "python services/torghut/scripts/archive_recent_kafka_trading_days.py "

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -8997,6 +8997,30 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             day_action["action"], "inspect_or_backfill_recent_ta_signal_days"
         )
         self.assertIn("torghut.ta_signals", day_action["recommended_operator_probe"])
+        self.assertIn(
+            "torghut.ta_microbars",
+            remediation["recent_trading_days"][
+                "clickhouse_signal_microbar_coverage_query"
+            ],
+        )
+        self.assertIn(
+            "torghut.ta_microbars",
+            remediation["recent_trading_days"][
+                "clickhouse_signal_microbar_day_gap_query"
+            ],
+        )
+        self.assertEqual(
+            day_action["recommended_coverage_probe"],
+            remediation["recent_trading_days"][
+                "clickhouse_coverage_probe_queries"
+            ]["signal_microbar_coverage"],
+        )
+        self.assertEqual(
+            day_action["recommended_day_gap_probe"],
+            remediation["recent_trading_days"][
+                "clickhouse_coverage_probe_queries"
+            ]["signal_microbar_day_gap"],
+        )
 
     def test_remediation_surfaces_stale_tape_shortfall(self) -> None:
         remediation = runner._candidate_search_remediation(


### PR DESCRIPTION
## Summary

- Adds paired `ta_signals` and `ta_microbars` coverage probes to recent trading-day shortfall remediation.
- Keeps the existing `inspect_or_backfill_recent_ta_signal_days` action and signal-only probe for compatibility.
- Extends the whitepaper autoresearch regression test so future insufficient-window reports expose table-level and per-day coverage gaps.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k "recent_trading_day_shortfall or stale_tape_shortfall"`
- `uv run --frozen python -m py_compile scripts/run_whitepaper_autoresearch_profit_target.py`
- `git diff --check`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
