### PR TITLE
fix(torghut): preflight ta replay coverage

### DIFF
--- a/services/torghut/scripts/ta_replay_runner.py
+++ b/services/torghut/scripts/ta_replay_runner.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
+from base64 import b64encode
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Mapping
+from urllib.error import URLError
+from urllib.request import Request, urlopen
 
 import yaml
 
@@ -41,7 +45,9 @@ def _require_kubectl() -> None:
 
 def _require_supported_namespace(namespace: str) -> None:
     if namespace != SUPPORTED_NAMESPACE:
-        raise SystemExit(f'unsupported namespace {namespace!r}; only {SUPPORTED_NAMESPACE!r} is allowed')
+        raise SystemExit(
+            f'unsupported namespace {namespace!r}; only {SUPPORTED_NAMESPACE!r} is allowed'
+        )
 
 
 def _kubectl_binary() -> str:
@@ -66,12 +72,24 @@ def _run_kubectl(
 
 
 def _kubectl_get_ta_config_json() -> dict[str, Any]:
-    result = _run_kubectl(['-n', SUPPORTED_NAMESPACE, 'get', 'configmap', TA_CONFIGMAP, '-o', 'json'])
+    result = _run_kubectl(
+        ['-n', SUPPORTED_NAMESPACE, 'get', 'configmap', TA_CONFIGMAP, '-o', 'json']
+    )
     return json.loads(result.stdout)
 
 
 def _kubectl_get_ta_deployment_json() -> dict[str, Any]:
-    result = _run_kubectl(['-n', SUPPORTED_NAMESPACE, 'get', 'flinkdeployment', TA_DEPLOYMENT, '-o', 'json'])
+    result = _run_kubectl(
+        [
+            '-n',
+            SUPPORTED_NAMESPACE,
+            'get',
+            'flinkdeployment',
+            TA_DEPLOYMENT,
+            '-o',
+            'json',
+        ]
+    )
     return json.loads(result.stdout)
 
 
@@ -148,7 +166,9 @@ def _load_state(namespace: str) -> ReplayState:
     )
 
 
-def _plan_command(replay_id: str, group_prefix: str, auto_offset_reset: str) -> dict[str, str]:
+def _plan_command(
+    replay_id: str, group_prefix: str, auto_offset_reset: str
+) -> dict[str, str]:
     if not replay_id:
         raise SystemExit('replay-id must be provided')
     normalized_prefix = group_prefix.strip().replace('__', '-').strip('-')
@@ -193,22 +213,24 @@ def _build_plan_report(
     warnings: list[str],
     verify: bool,
     verification: dict[str, bool] | None = None,
+    coverage: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
-        "status": "ok",
-        "mode": mode,
-        "namespace": namespace,
-        "current": {
-            "ta_group_id": state.ta_group_id,
-            "ta_auto_offset_reset": state.ta_auto_offset_reset,
-            "flink_job_state": state.flink_job_state,
-            "flink_restart_nonce": state.flink_restart_nonce,
-            "flink_status_state": state.flink_status_state,
+        'status': 'ok',
+        'mode': mode,
+        'namespace': namespace,
+        'current': {
+            'ta_group_id': state.ta_group_id,
+            'ta_auto_offset_reset': state.ta_auto_offset_reset,
+            'flink_job_state': state.flink_job_state,
+            'flink_restart_nonce': state.flink_restart_nonce,
+            'flink_status_state': state.flink_status_state,
         },
-        "plan": plan,
-        "warnings": warnings,
-        "verify": verification,
-        "verify_requested": verify,
+        'plan': plan,
+        'warnings': warnings,
+        'verify': verification,
+        'verify_requested': verify,
+        'coverage': coverage,
     }
 
 
@@ -218,18 +240,19 @@ def _print_plan_text(
     namespace: str,
     dry_run: bool,
     warnings: list[str],
+    coverage: dict[str, Any] | None = None,
 ) -> None:
     print('Current replay state:')
     print(f'  namespace: {namespace}')
     print(f'  TA_GROUP_ID: {state.ta_group_id}')
     print(f'  TA_AUTO_OFFSET_RESET: {state.ta_auto_offset_reset}')
-    print(f"  TA job state: {state.flink_job_state or 'unknown'}")
+    print(f'  TA job state: {state.flink_job_state or "unknown"}')
     print(f'  TA restartNonce: {state.flink_restart_nonce}')
-    print(f"  TA status state: {state.flink_status_state or 'unknown'}")
+    print(f'  TA status state: {state.flink_status_state or "unknown"}')
     print('')
     print('Planned action:')
-    print(f"  replay-group: {plan['replay_group_id']}")
-    print(f"  ta-auto-offset-reset: {plan['ta_auto_offset_reset']}")
+    print(f'  replay-group: {plan["replay_group_id"]}')
+    print(f'  ta-auto-offset-reset: {plan["ta_auto_offset_reset"]}')
     print('Execution sequence (non-destructive replay mode):')
     print('  1) Set TA_GROUP_ID and TA_AUTO_OFFSET_RESET in torghut-ta-config')
     print('  2) Suspend torghut-ta if currently running')
@@ -240,11 +263,198 @@ def _print_plan_text(
         print('Warnings:')
         for warning in warnings:
             print(f'  - {warning}')
+    if coverage is not None:
+        summary_payload = coverage.get('summary')
+        summary: Mapping[str, Any] = (
+            summary_payload if isinstance(summary_payload, dict) else {}
+        )
+        print('Coverage preflight:')
+        print(f'  status: {coverage.get("status")}')
+        print(f'  required-trading-days: {summary.get("required_trading_days", 0)}')
+        print(f'  signal-days: {summary.get("ta_signals_days", 0)}')
+        print(f'  microbar-days: {summary.get("ta_microbars_days", 0)}')
+        print(
+            f'  missing-signal-days-vs-required: {summary.get("missing_signal_days_vs_required", 0)}'
+        )
+        print(f'  microbar-only-days: {summary.get("microbar_only_day_count", 0)}')
     if dry_run:
-        print(f'Use --mode=apply --confirm {APPLY_CONFIRMATION_PHRASE} to execute the plan.')
+        print(
+            f'Use --mode=apply --confirm {APPLY_CONFIRMATION_PHRASE} to execute the plan.'
+        )
 
 
-def _apply_plan(state: ReplayState, plan: dict[str, str], namespace: str) -> ReplayState:
+def _clickhouse_basic_auth(username: str, password: str) -> str:
+    token = b64encode(f'{username}:{password}'.encode('utf-8')).decode('ascii')
+    return f'Basic {token}'
+
+
+def _clickhouse_query(
+    *,
+    http_url: str,
+    username: str,
+    password: str,
+    query: str,
+    timeout_seconds: int,
+) -> str:
+    request = Request(
+        http_url,
+        data=query.encode('utf-8'),
+        method='POST',
+        headers={'Authorization': _clickhouse_basic_auth(username, password)},
+    )
+    try:
+        with urlopen(request, timeout=max(1, timeout_seconds)) as response:
+            return response.read().decode('utf-8')
+    except URLError as exc:
+        raise RuntimeError(f'clickhouse_coverage_query_failed:{exc}') from exc
+
+
+def _parse_tsv_with_names(raw: str) -> list[dict[str, str]]:
+    lines = [line for line in raw.splitlines() if line.strip()]
+    if not lines:
+        return []
+    header = lines[0].split('\t')
+    rows: list[dict[str, str]] = []
+    for line in lines[1:]:
+        values = line.split('\t')
+        rows.append(
+            {
+                name: values[index] if index < len(values) else ''
+                for index, name in enumerate(header)
+            }
+        )
+    return rows
+
+
+def _parse_int_field(row: Mapping[str, str] | None, name: str) -> int:
+    if row is None:
+        return 0
+    try:
+        return int(row.get(name, '0') or '0')
+    except ValueError:
+        return 0
+
+
+def _table_coverage_query() -> str:
+    return """
+SELECT
+  table_name,
+  countDistinct(trading_day) AS days,
+  min(trading_day) AS first_day,
+  max(trading_day) AS last_day,
+  sum(rows) AS rows
+FROM (
+  SELECT
+    'ta_signals' AS table_name,
+    toDate(event_ts) AS trading_day,
+    count() AS rows
+  FROM torghut.ta_signals
+  WHERE source = 'ta' AND window_size = 'PT1S'
+  GROUP BY trading_day
+  UNION ALL
+  SELECT
+    'ta_microbars' AS table_name,
+    toDate(event_ts) AS trading_day,
+    count() AS rows
+  FROM torghut.ta_microbars
+  WHERE source = 'ta' AND window_size = 'PT1S'
+  GROUP BY trading_day
+)
+GROUP BY table_name ORDER BY table_name FORMAT TSVWithNames
+""".strip()
+
+
+def _day_gap_query(limit: int) -> str:
+    return f"""
+SELECT
+  trading_day,
+  sumIf(rows, table_name = 'ta_signals') AS signal_rows,
+  sumIf(rows, table_name = 'ta_microbars') AS microbar_rows
+FROM (
+  SELECT
+    'ta_signals' AS table_name,
+    toDate(event_ts) AS trading_day,
+    count() AS rows
+  FROM torghut.ta_signals
+  WHERE source = 'ta' AND window_size = 'PT1S'
+  GROUP BY trading_day
+  UNION ALL
+  SELECT
+    'ta_microbars' AS table_name,
+    toDate(event_ts) AS trading_day,
+    count() AS rows
+  FROM torghut.ta_microbars
+  WHERE source = 'ta' AND window_size = 'PT1S'
+  GROUP BY trading_day
+)
+GROUP BY trading_day ORDER BY trading_day DESC LIMIT {max(1, int(limit))} FORMAT TSVWithNames
+""".strip()
+
+
+def _load_clickhouse_coverage(args: argparse.Namespace) -> dict[str, Any] | None:
+    if not bool(getattr(args, 'check_clickhouse_coverage', False)):
+        return None
+    password = str(getattr(args, 'clickhouse_password', '') or '')
+    if not password:
+        password = os.environ.get(
+            str(getattr(args, 'clickhouse_password_env', '') or ''), ''
+        )
+    if not password:
+        raise SystemExit(
+            f'--check-clickhouse-coverage requires --clickhouse-password or ${args.clickhouse_password_env}'
+        )
+    query_args = {
+        'http_url': str(args.clickhouse_http_url),
+        'username': str(args.clickhouse_username),
+        'password': password,
+        'timeout_seconds': int(args.clickhouse_timeout_seconds),
+    }
+    table_rows = _parse_tsv_with_names(
+        _clickhouse_query(query=_table_coverage_query(), **query_args)
+    )
+    day_rows = _parse_tsv_with_names(
+        _clickhouse_query(
+            query=_day_gap_query(int(args.coverage_day_limit)), **query_args
+        )
+    )
+    table_by_name = {row.get('table_name', ''): row for row in table_rows}
+    signal_days = _parse_int_field(table_by_name.get('ta_signals'), 'days')
+    microbar_days = _parse_int_field(table_by_name.get('ta_microbars'), 'days')
+    required_days = max(0, int(args.required_trading_days or 0))
+    microbar_only_days = [
+        row.get('trading_day', '')
+        for row in day_rows
+        if _parse_int_field(row, 'signal_rows') <= 0
+        and _parse_int_field(row, 'microbar_rows') > 0
+    ]
+    missing_signal_days = max(0, required_days - signal_days) if required_days else 0
+    status = 'ok'
+    blockers: list[str] = []
+    if missing_signal_days:
+        status = 'insufficient_ta_signal_days'
+        blockers.append(f'insufficient_ta_signal_days:{signal_days}<{required_days}')
+    if microbar_only_days:
+        blockers.append(f'microbar_only_days:{len(microbar_only_days)}')
+    return {
+        'schema_version': 'torghut.ta-replay-coverage-preflight.v1',
+        'status': status,
+        'blockers': blockers,
+        'summary': {
+            'required_trading_days': required_days,
+            'ta_signals_days': signal_days,
+            'ta_microbars_days': microbar_days,
+            'missing_signal_days_vs_required': missing_signal_days,
+            'microbar_only_day_count': len(microbar_only_days),
+            'microbar_only_days': microbar_only_days,
+        },
+        'tables': table_rows,
+        'day_gaps': day_rows,
+    }
+
+
+def _apply_plan(
+    state: ReplayState, plan: dict[str, str], namespace: str
+) -> ReplayState:
     _require_supported_namespace(namespace)
 
     configmap_patch = {
@@ -272,7 +482,9 @@ def _apply_plan(state: ReplayState, plan: dict[str, str], namespace: str) -> Rep
     return _load_state(namespace)
 
 
-def _verify_state(state: ReplayState, plan: dict[str, str], previous_nonce: int) -> dict[str, bool]:
+def _verify_state(
+    state: ReplayState, plan: dict[str, str], previous_nonce: int
+) -> dict[str, bool]:
     checks: dict[str, bool] = {}
     checks['ta_group_id_applied'] = state.ta_group_id == plan['replay_group_id']
     checks['ta_auto_offset_reset_applied'] = (
@@ -281,8 +493,13 @@ def _verify_state(state: ReplayState, plan: dict[str, str], previous_nonce: int)
     checks['restart_nonce_advanced'] = state.flink_restart_nonce >= previous_nonce + 1
     checks['job_state_not_failed'] = True
     if state.flink_status_state:
-        checks['job_state_not_failed'] = state.flink_status_state not in FAILED_RUN_STATES
-    checks['spec_job_state_running_or_unknown'] = state.flink_job_state in {'running', None}
+        checks['job_state_not_failed'] = (
+            state.flink_status_state not in FAILED_RUN_STATES
+        )
+    checks['spec_job_state_running_or_unknown'] = state.flink_job_state in {
+        'running',
+        None,
+    }
     return checks
 
 
@@ -299,7 +516,10 @@ def _handle_plan_mode(
     plan: dict[str, str],
     warnings: list[str],
 ) -> int:
-    verification = _verify_state(state, plan, state.flink_restart_nonce) if args.verify else None
+    verification = (
+        _verify_state(state, plan, state.flink_restart_nonce) if args.verify else None
+    )
+    coverage = _load_clickhouse_coverage(args)
     report = _build_plan_report(
         namespace=args.namespace,
         mode='plan',
@@ -308,12 +528,15 @@ def _handle_plan_mode(
         warnings=warnings,
         verify=args.verify,
         verification=verification,
+        coverage=coverage,
     )
     if args.json:
         print(json.dumps(report, sort_keys=True, indent=2))
         return _final_status(verification) if verification else 0
 
-    _print_plan_text(state, plan, args.namespace, dry_run=True, warnings=warnings)
+    _print_plan_text(
+        state, plan, args.namespace, dry_run=True, warnings=warnings, coverage=coverage
+    )
     return 0
 
 
@@ -325,6 +548,7 @@ def _handle_verify_mode(
     warnings: list[str],
 ) -> int:
     verification = _verify_state(state, plan, state.flink_restart_nonce)
+    coverage = _load_clickhouse_coverage(args)
     report = _build_plan_report(
         namespace=args.namespace,
         mode='verify',
@@ -333,16 +557,19 @@ def _handle_verify_mode(
         warnings=warnings,
         verify=True,
         verification=verification,
+        coverage=coverage,
     )
     if args.json:
         print(json.dumps(report, sort_keys=True, indent=2))
         return _final_status(verification)
 
-    _print_plan_text(state, plan, args.namespace, dry_run=False, warnings=warnings)
+    _print_plan_text(
+        state, plan, args.namespace, dry_run=False, warnings=warnings, coverage=coverage
+    )
     print('')
     print('Verify results:')
     for check_name, ok in verification.items():
-        print(f"  {check_name}: {'ok' if ok else 'fail'}")
+        print(f'  {check_name}: {"ok" if ok else "fail"}')
     return _final_status(verification)
 
 
@@ -359,7 +586,10 @@ def _handle_apply_mode(
             print(f'  warning: {warning}')
     previous_nonce = state.flink_restart_nonce
     applied_state = _apply_plan(state, plan, args.namespace)
-    verification = _verify_state(applied_state, plan, previous_nonce) if args.verify else None
+    verification = (
+        _verify_state(applied_state, plan, previous_nonce) if args.verify else None
+    )
+    coverage = _load_clickhouse_coverage(args)
 
     report = _build_plan_report(
         namespace=args.namespace,
@@ -369,25 +599,41 @@ def _handle_apply_mode(
         warnings=warnings,
         verify=args.verify,
         verification=verification,
+        coverage=coverage,
     )
     if args.json:
         print(json.dumps(report, sort_keys=True, indent=2))
         return _final_status(verification) if verification else 0
 
     print('Patch complete.')
-    _print_plan_text(applied_state, plan, args.namespace, dry_run=False, warnings=warnings)
+    _print_plan_text(
+        applied_state,
+        plan,
+        args.namespace,
+        dry_run=False,
+        warnings=warnings,
+        coverage=coverage,
+    )
     if args.verify and verification is not None:
         print('Verify results:')
         for check_name, ok in verification.items():
-            print(f"  {check_name}: {'ok' if ok else 'fail'}")
+            print(f'  {check_name}: {"ok" if ok else "fail"}')
         return _final_status(verification)
     return 0
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description='Standardize TA replay rollout actions for torghut.')
-    parser.add_argument('--namespace', default='torghut', help='Kubernetes namespace for torghut resources.')
-    parser.add_argument('--replay-id', required=True, help='Replay id used for group-id isolation.')
+    parser = argparse.ArgumentParser(
+        description='Standardize TA replay rollout actions for torghut.'
+    )
+    parser.add_argument(
+        '--namespace',
+        default='torghut',
+        help='Kubernetes namespace for torghut resources.',
+    )
+    parser.add_argument(
+        '--replay-id', required=True, help='Replay id used for group-id isolation.'
+    )
     parser.add_argument(
         '--group-prefix',
         default='torghut-ta-replay',
@@ -424,6 +670,57 @@ def parse_args() -> argparse.Namespace:
         '--json',
         action='store_true',
         help='Emit machine-readable output for automation.',
+    )
+    parser.add_argument(
+        '--check-clickhouse-coverage',
+        action='store_true',
+        help='Add a read-only ta_signals/ta_microbars coverage preflight to plan/verify/apply reports.',
+    )
+    parser.add_argument(
+        '--clickhouse-http-url',
+        default=os.environ.get(
+            'TA_CLICKHOUSE_HTTP_URL',
+            os.environ.get(
+                'CLICKHOUSE_HTTP_URL',
+                'http://torghut-clickhouse.torghut.svc.cluster.local:8123',
+            ),
+        ),
+        help='ClickHouse HTTP endpoint used by --check-clickhouse-coverage.',
+    )
+    parser.add_argument(
+        '--clickhouse-username',
+        default=os.environ.get(
+            'TA_CLICKHOUSE_USERNAME', os.environ.get('CLICKHOUSE_USERNAME', 'torghut')
+        ),
+        help='ClickHouse username used by --check-clickhouse-coverage.',
+    )
+    parser.add_argument(
+        '--clickhouse-password',
+        default='',
+        help='ClickHouse password used by --check-clickhouse-coverage. Prefer the env var instead.',
+    )
+    parser.add_argument(
+        '--clickhouse-password-env',
+        default='TA_CLICKHOUSE_PASSWORD',
+        help='Environment variable containing the ClickHouse password.',
+    )
+    parser.add_argument(
+        '--clickhouse-timeout-seconds',
+        type=int,
+        default=30,
+        help='Timeout for each read-only ClickHouse coverage query.',
+    )
+    parser.add_argument(
+        '--coverage-day-limit',
+        type=int,
+        default=40,
+        help='Number of recent trading days to include in the coverage day-gap report.',
+    )
+    parser.add_argument(
+        '--required-trading-days',
+        type=int,
+        default=0,
+        help='Required replay proof trading-day count used to compute signal-day shortfall.',
     )
     return parser.parse_args()
 

--- a/services/torghut/tests/test_ta_replay_runner.py
+++ b/services/torghut/tests/test_ta_replay_runner.py
@@ -1,0 +1,96 @@
+import argparse
+import io
+import json
+from contextlib import redirect_stdout
+from unittest import TestCase
+from unittest.mock import patch
+
+from scripts import ta_replay_runner as runner
+
+
+_TABLE_COVERAGE_TSV = """table_name\tdays\tfirst_day\tlast_day\trows
+ta_microbars\t19\t2026-04-27\t2026-05-22\t1281193
+ta_signals\t9\t2026-05-12\t2026-05-22\t632380
+"""
+
+_DAY_GAP_TSV = """trading_day\tsignal_rows\tmicrobar_rows
+2026-05-22\t58446\t58446
+2026-05-08\t0\t68396
+2026-05-07\t0\t66008
+"""
+
+
+class TestTaReplayRunnerCoveragePreflight(TestCase):
+    def _args(self) -> argparse.Namespace:
+        return argparse.Namespace(
+            namespace='torghut',
+            verify=False,
+            json=True,
+            check_clickhouse_coverage=True,
+            clickhouse_http_url='http://clickhouse.test:8123',
+            clickhouse_username='torghut',
+            clickhouse_password='secret',
+            clickhouse_password_env='TA_CLICKHOUSE_PASSWORD',
+            clickhouse_timeout_seconds=5,
+            coverage_day_limit=40,
+            required_trading_days=25,
+        )
+
+    def test_load_clickhouse_coverage_flags_signal_shortfall_and_microbar_only_days(
+        self,
+    ) -> None:
+        with patch.object(
+            runner,
+            '_clickhouse_query',
+            side_effect=[_TABLE_COVERAGE_TSV, _DAY_GAP_TSV],
+        ):
+            coverage = runner._load_clickhouse_coverage(self._args())
+
+        assert coverage is not None
+        self.assertEqual(coverage['status'], 'insufficient_ta_signal_days')
+        self.assertIn('insufficient_ta_signal_days:9<25', coverage['blockers'])
+        self.assertIn('microbar_only_days:2', coverage['blockers'])
+        self.assertEqual(coverage['summary']['ta_signals_days'], 9)
+        self.assertEqual(coverage['summary']['ta_microbars_days'], 19)
+        self.assertEqual(coverage['summary']['missing_signal_days_vs_required'], 16)
+        self.assertEqual(
+            coverage['summary']['microbar_only_days'],
+            ['2026-05-08', '2026-05-07'],
+        )
+
+    def test_plan_json_embeds_coverage_preflight(self) -> None:
+        state = runner.ReplayState(
+            namespace='torghut',
+            ta_group_id='torghut-ta-2025-12-23',
+            ta_auto_offset_reset='latest',
+            flink_job_state='running',
+            flink_restart_nonce=7,
+            flink_status_state='RUNNING',
+        )
+        plan = {
+            'replay_group_id': 'torghut-ta-replay-profit-proof',
+            'ta_auto_offset_reset': 'earliest',
+        }
+        output = io.StringIO()
+        with patch.object(
+            runner,
+            '_clickhouse_query',
+            side_effect=[_TABLE_COVERAGE_TSV, _DAY_GAP_TSV],
+        ):
+            with redirect_stdout(output):
+                exit_code = runner._handle_plan_mode(
+                    args=self._args(),
+                    state=state,
+                    plan=plan,
+                    warnings=[],
+                )
+
+        self.assertEqual(exit_code, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(
+            payload['coverage']['schema_version'],
+            'torghut.ta-replay-coverage-preflight.v1',
+        )
+        self.assertEqual(
+            payload['coverage']['summary']['missing_signal_days_vs_required'], 16
+        )

--- a/services/torghut/tests/test_ta_replay_runner.py
+++ b/services/torghut/tests/test_ta_replay_runner.py
@@ -1,9 +1,12 @@
 import argparse
 import io
 import json
+import os
+import sys
 from contextlib import redirect_stdout
 from unittest import TestCase
 from unittest.mock import patch
+from urllib.error import URLError
 
 from scripts import ta_replay_runner as runner
 
@@ -21,76 +24,292 @@ _DAY_GAP_TSV = """trading_day\tsignal_rows\tmicrobar_rows
 
 
 class TestTaReplayRunnerCoveragePreflight(TestCase):
-    def _args(self) -> argparse.Namespace:
-        return argparse.Namespace(
-            namespace='torghut',
-            verify=False,
-            json=True,
-            check_clickhouse_coverage=True,
-            clickhouse_http_url='http://clickhouse.test:8123',
-            clickhouse_username='torghut',
-            clickhouse_password='secret',
-            clickhouse_password_env='TA_CLICKHOUSE_PASSWORD',
-            clickhouse_timeout_seconds=5,
-            coverage_day_limit=40,
-            required_trading_days=25,
+    def _args(self, **overrides: object) -> argparse.Namespace:
+        values = {
+            "namespace": "torghut",
+            "verify": False,
+            "json": True,
+            "check_clickhouse_coverage": True,
+            "clickhouse_http_url": "http://clickhouse.test:8123",
+            "clickhouse_username": "torghut",
+            "clickhouse_password": "secret",
+            "clickhouse_password_env": "TA_CLICKHOUSE_PASSWORD",
+            "clickhouse_timeout_seconds": 5,
+            "coverage_day_limit": 40,
+            "required_trading_days": 25,
+        }
+        values.update(overrides)
+        return argparse.Namespace(**values)
+
+    def _state(self) -> runner.ReplayState:
+        return runner.ReplayState(
+            namespace="torghut",
+            ta_group_id="torghut-ta-2025-12-23",
+            ta_auto_offset_reset="latest",
+            flink_job_state="running",
+            flink_restart_nonce=7,
+            flink_status_state="RUNNING",
         )
+
+    def _plan(self) -> dict[str, str]:
+        return {
+            "replay_group_id": "torghut-ta-replay-profit-proof",
+            "ta_auto_offset_reset": "earliest",
+        }
+
+    def _coverage(self) -> dict[str, object]:
+        return argparse.Namespace(
+            status="insufficient_ta_signal_days",
+            summary={
+                "required_trading_days": 25,
+                "ta_signals_days": 9,
+                "ta_microbars_days": 19,
+                "missing_signal_days_vs_required": 16,
+                "microbar_only_day_count": 2,
+            },
+        ).__dict__
 
     def test_load_clickhouse_coverage_flags_signal_shortfall_and_microbar_only_days(
         self,
     ) -> None:
         with patch.object(
             runner,
-            '_clickhouse_query',
+            "_clickhouse_query",
             side_effect=[_TABLE_COVERAGE_TSV, _DAY_GAP_TSV],
         ):
             coverage = runner._load_clickhouse_coverage(self._args())
 
         assert coverage is not None
-        self.assertEqual(coverage['status'], 'insufficient_ta_signal_days')
-        self.assertIn('insufficient_ta_signal_days:9<25', coverage['blockers'])
-        self.assertIn('microbar_only_days:2', coverage['blockers'])
-        self.assertEqual(coverage['summary']['ta_signals_days'], 9)
-        self.assertEqual(coverage['summary']['ta_microbars_days'], 19)
-        self.assertEqual(coverage['summary']['missing_signal_days_vs_required'], 16)
+        self.assertEqual(coverage["status"], "insufficient_ta_signal_days")
+        self.assertIn("insufficient_ta_signal_days:9<25", coverage["blockers"])
+        self.assertIn("microbar_only_days:2", coverage["blockers"])
+        self.assertEqual(coverage["summary"]["ta_signals_days"], 9)
+        self.assertEqual(coverage["summary"]["ta_microbars_days"], 19)
+        self.assertEqual(coverage["summary"]["missing_signal_days_vs_required"], 16)
         self.assertEqual(
-            coverage['summary']['microbar_only_days'],
-            ['2026-05-08', '2026-05-07'],
+            coverage["summary"]["microbar_only_days"],
+            ["2026-05-08", "2026-05-07"],
         )
 
     def test_plan_json_embeds_coverage_preflight(self) -> None:
-        state = runner.ReplayState(
-            namespace='torghut',
-            ta_group_id='torghut-ta-2025-12-23',
-            ta_auto_offset_reset='latest',
-            flink_job_state='running',
-            flink_restart_nonce=7,
-            flink_status_state='RUNNING',
-        )
-        plan = {
-            'replay_group_id': 'torghut-ta-replay-profit-proof',
-            'ta_auto_offset_reset': 'earliest',
-        }
         output = io.StringIO()
         with patch.object(
             runner,
-            '_clickhouse_query',
+            "_clickhouse_query",
             side_effect=[_TABLE_COVERAGE_TSV, _DAY_GAP_TSV],
         ):
             with redirect_stdout(output):
                 exit_code = runner._handle_plan_mode(
                     args=self._args(),
-                    state=state,
-                    plan=plan,
+                    state=self._state(),
+                    plan=self._plan(),
                     warnings=[],
                 )
 
         self.assertEqual(exit_code, 0)
         payload = json.loads(output.getvalue())
         self.assertEqual(
-            payload['coverage']['schema_version'],
-            'torghut.ta-replay-coverage-preflight.v1',
+            payload["coverage"]["schema_version"],
+            "torghut.ta-replay-coverage-preflight.v1",
         )
         self.assertEqual(
-            payload['coverage']['summary']['missing_signal_days_vs_required'], 16
+            payload["coverage"]["summary"]["missing_signal_days_vs_required"], 16
         )
+
+    def test_text_plan_renders_coverage_preflight_summary(self) -> None:
+        output = io.StringIO()
+        with redirect_stdout(output):
+            runner._print_plan_text(
+                self._state(),
+                self._plan(),
+                "torghut",
+                dry_run=True,
+                warnings=["TA_AUTO_OFFSET_RESET already matches the replay target"],
+                coverage=self._coverage(),
+            )
+
+        text = output.getvalue()
+        self.assertIn("Coverage preflight:", text)
+        self.assertIn("missing-signal-days-vs-required: 16", text)
+        self.assertIn("Use --mode=apply --confirm REPLAY_TA_CANARY", text)
+
+    def test_verify_text_mode_renders_coverage_and_failed_checks(self) -> None:
+        state = runner.ReplayState(
+            namespace="torghut",
+            ta_group_id="wrong-group",
+            ta_auto_offset_reset="latest",
+            flink_job_state="suspended",
+            flink_restart_nonce=7,
+            flink_status_state="FAILED",
+        )
+        output = io.StringIO()
+        with patch.object(
+            runner,
+            "_clickhouse_query",
+            side_effect=[_TABLE_COVERAGE_TSV, _DAY_GAP_TSV],
+        ):
+            with redirect_stdout(output):
+                exit_code = runner._handle_verify_mode(
+                    args=self._args(json=False),
+                    state=state,
+                    plan=self._plan(),
+                    warnings=[],
+                )
+
+        self.assertEqual(exit_code, 1)
+        text = output.getvalue()
+        self.assertIn("Verify results:", text)
+        self.assertIn("ta_group_id_applied: fail", text)
+        self.assertIn("job_state_not_failed: fail", text)
+
+    def test_apply_text_mode_patches_and_renders_verification(self) -> None:
+        applied_state = runner.ReplayState(
+            namespace="torghut",
+            ta_group_id="torghut-ta-replay-profit-proof",
+            ta_auto_offset_reset="earliest",
+            flink_job_state="running",
+            flink_restart_nonce=8,
+            flink_status_state="RUNNING",
+        )
+        output = io.StringIO()
+        patches: list[tuple[str, str, dict[str, object]]] = []
+
+        def capture_patch(kind: str, name: str, patch: dict[str, object]) -> None:
+            patches.append((kind, name, patch))
+
+        with patch.object(runner, "_kubectl_merge_patch", side_effect=capture_patch):
+            with patch.object(runner, "_load_state", return_value=applied_state):
+                with patch.object(
+                    runner,
+                    "_clickhouse_query",
+                    side_effect=[_TABLE_COVERAGE_TSV, _DAY_GAP_TSV],
+                ):
+                    with redirect_stdout(output):
+                        exit_code = runner._handle_apply_mode(
+                            args=self._args(json=False, verify=True),
+                            state=self._state(),
+                            plan=self._plan(),
+                            warnings=["planned warning"],
+                        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            [patch[0] for patch in patches],
+            ["configmap", "flinkdeployment", "flinkdeployment"],
+        )
+        self.assertIn("Patch complete.", output.getvalue())
+        self.assertIn("restart_nonce_advanced: ok", output.getvalue())
+
+    def test_clickhouse_query_builds_request_and_wraps_url_errors(self) -> None:
+        class FakeResponse:
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return b"ok"
+
+        with patch.object(runner, "urlopen", return_value=FakeResponse()) as urlopen:
+            result = runner._clickhouse_query(
+                http_url="http://clickhouse.test:8123",
+                username="torghut",
+                password="secret",
+                query="SELECT 1",
+                timeout_seconds=0,
+            )
+
+        self.assertEqual(result, "ok")
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.full_url, "http://clickhouse.test:8123")
+        self.assertEqual(request.get_method(), "POST")
+        self.assertEqual(
+            request.headers["Authorization"],
+            runner._clickhouse_basic_auth("torghut", "secret"),
+        )
+        self.assertEqual(urlopen.call_args.kwargs["timeout"], 1)
+
+        with patch.object(runner, "urlopen", side_effect=URLError("refused")):
+            with self.assertRaisesRegex(
+                RuntimeError, "clickhouse_coverage_query_failed"
+            ):
+                runner._clickhouse_query(
+                    http_url="http://clickhouse.test:8123",
+                    username="torghut",
+                    password="secret",
+                    query="SELECT 1",
+                    timeout_seconds=5,
+                )
+
+    def test_coverage_loader_disabled_password_and_env_branches(self) -> None:
+        self.assertIsNone(
+            runner._load_clickhouse_coverage(
+                self._args(check_clickhouse_coverage=False, clickhouse_password="")
+            )
+        )
+
+        with self.assertRaisesRegex(SystemExit, "requires --clickhouse-password"):
+            runner._load_clickhouse_coverage(
+                self._args(
+                    clickhouse_password="",
+                    clickhouse_password_env="MISSING_TA_PASSWORD",
+                )
+            )
+
+        with patch.dict(os.environ, {"TA_CLICKHOUSE_PASSWORD": "from-env"}):
+            with patch.object(
+                runner,
+                "_clickhouse_query",
+                side_effect=[
+                    "table_name\tdays\tfirst_day\tlast_day\trows\nta_signals\tbad\t\t\t0\n",
+                    "trading_day\tsignal_rows\tmicrobar_rows\n2026-05-22\t1\t1\n",
+                ],
+            ):
+                coverage = runner._load_clickhouse_coverage(
+                    self._args(clickhouse_password="", required_trading_days=0)
+                )
+
+        assert coverage is not None
+        self.assertEqual(coverage["status"], "ok")
+        self.assertEqual(coverage["summary"]["ta_signals_days"], 0)
+
+    def test_parse_helpers_and_cli_defaults(self) -> None:
+        self.assertEqual(runner._parse_tsv_with_names(""), [])
+        self.assertEqual(
+            runner._parse_tsv_with_names("a\tb\n1\n"),
+            [{"a": "1", "b": ""}],
+        )
+        self.assertEqual(runner._parse_int_field(None, "days"), 0)
+        self.assertEqual(runner._parse_int_field({"days": "bad"}, "days"), 0)
+        self.assertIn("LIMIT 1 FORMAT TSVWithNames", runner._day_gap_query(0))
+
+        argv = [
+            "ta_replay_runner.py",
+            "--replay-id",
+            "proof",
+            "--check-clickhouse-coverage",
+            "--required-trading-days",
+            "25",
+            "--coverage-day-limit",
+            "12",
+            "--clickhouse-timeout-seconds",
+            "3",
+        ]
+        with patch.object(sys, "argv", argv):
+            with patch.dict(
+                os.environ,
+                {
+                    "TA_CLICKHOUSE_HTTP_URL": "http://env-clickhouse:8123",
+                    "TA_CLICKHOUSE_USERNAME": "env-user",
+                },
+            ):
+                parsed = runner.parse_args()
+
+        self.assertEqual(parsed.replay_id, "proof")
+        self.assertTrue(parsed.check_clickhouse_coverage)
+        self.assertEqual(parsed.required_trading_days, 25)
+        self.assertEqual(parsed.coverage_day_limit, 12)
+        self.assertEqual(parsed.clickhouse_timeout_seconds, 3)
+        self.assertEqual(parsed.clickhouse_http_url, "http://env-clickhouse:8123")
+        self.assertEqual(parsed.clickhouse_username, "env-user")


### PR DESCRIPTION
## Summary

- Adds an optional read-only ClickHouse coverage preflight to `ta_replay_runner.py`.
- Reports `ta_signals` days, `ta_microbars` days, microbar-only days, and required signal-day shortfall before replay actuation.
- Adds regression coverage for the live blocker shape where microbars exist for older days but signal rows are missing.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_ta_replay_runner.py`
- `uv run --frozen python -m py_compile scripts/ta_replay_runner.py tests/test_ta_replay_runner.py`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- Live read-only preflight via `ta_replay_runner.py --mode plan --json --check-clickhouse-coverage --required-trading-days 25` against a ClickHouse port-forward; result showed 9 signal days versus 25 required days and `microbar_only_days:10`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
