### PR TITLE
fix(torghut): target exact candidate spec replays

### DIFF
--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -28,6 +28,12 @@ spec:
         value: /tmp/torghut-whitepaper-autoresearch
       - name: sourceJsonlB64
         value: ''
+      - name: candidateSpecsJsonlB64
+        value: ''
+      - name: candidateSpecsConfigMapName
+        value: torghut-whitepaper-autoresearch-candidate-specs
+      - name: candidateSpecsConfigMapKey
+        value: candidate-specs.jsonl
       - name: feedbackEvidenceJsonlB64
         value: ''
       - name: feedbackEvidenceConfigMapName
@@ -102,6 +108,9 @@ spec:
           - name: runId
           - name: outputRoot
           - name: sourceJsonlB64
+          - name: candidateSpecsJsonlB64
+          - name: candidateSpecsConfigMapName
+          - name: candidateSpecsConfigMapKey
           - name: feedbackEvidenceJsonlB64
           - name: feedbackEvidenceConfigMapName
           - name: feedbackEvidenceConfigMapKey
@@ -159,6 +168,10 @@ spec:
             value: /etc/torghut/strategies.yaml
           - name: TORGHUT_WHITEPAPER_SOURCE_JSONL_B64
             value: "{{inputs.parameters.sourceJsonlB64}}"
+          - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64
+            value: "{{inputs.parameters.candidateSpecsJsonlB64}}"
+          - name: TORGHUT_WHITEPAPER_CANDIDATE_SPECS_CONFIGMAP_PATH
+            value: /var/run/torghut-candidate-specs/candidate-specs.jsonl
           - name: TORGHUT_WHITEPAPER_FEEDBACK_EVIDENCE_JSONL_B64
             value: "{{inputs.parameters.feedbackEvidenceJsonlB64}}"
           - name: TORGHUT_WHITEPAPER_FEEDBACK_EVIDENCE_CONFIGMAP_PATH
@@ -169,6 +182,9 @@ spec:
             readOnly: true
           - name: feedback-evidence
             mountPath: /var/run/torghut-feedback
+            readOnly: true
+          - name: candidate-specs
+            mountPath: /var/run/torghut-candidate-specs
             readOnly: true
         resources:
           requests:
@@ -191,6 +207,7 @@ spec:
             OUTPUT_DIR="${OUTPUT_ROOT%/}/${RUN_ID}"
             WORKDIR=/tmp/torghut-whitepaper-autoresearch-workflow
             SOURCE_JSONL="${WORKDIR}/sources.jsonl"
+            CANDIDATE_SPECS_JSONL="${WORKDIR}/candidate-specs.jsonl"
             FEEDBACK_EVIDENCE_JSONL="${WORKDIR}/feedback-evidence.jsonl"
             mkdir -p "${WORKDIR}" "${OUTPUT_DIR}"
 
@@ -231,6 +248,13 @@ spec:
             if [ -n "${TORGHUT_WHITEPAPER_SOURCE_JSONL_B64}" ]; then
               printf '%s' "${TORGHUT_WHITEPAPER_SOURCE_JSONL_B64}" | base64 -d > "${SOURCE_JSONL}"
               SCRIPT_ARGS+=(--source-jsonl "${SOURCE_JSONL}")
+            fi
+            if [ -s "${TORGHUT_WHITEPAPER_CANDIDATE_SPECS_CONFIGMAP_PATH:-}" ]; then
+              cp "${TORGHUT_WHITEPAPER_CANDIDATE_SPECS_CONFIGMAP_PATH}" "${CANDIDATE_SPECS_JSONL}"
+              SCRIPT_ARGS+=(--candidate-specs "${CANDIDATE_SPECS_JSONL}")
+            elif [ -n "${TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64}" ]; then
+              printf '%s' "${TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64}" | base64 -d > "${CANDIDATE_SPECS_JSONL}"
+              SCRIPT_ARGS+=(--candidate-specs "${CANDIDATE_SPECS_JSONL}")
             fi
             if [ -s "${TORGHUT_WHITEPAPER_FEEDBACK_EVIDENCE_CONFIGMAP_PATH:-}" ]; then
               cp "${TORGHUT_WHITEPAPER_FEEDBACK_EVIDENCE_CONFIGMAP_PATH}" "${FEEDBACK_EVIDENCE_JSONL}"
@@ -292,6 +316,13 @@ spec:
             items:
               - key: "{{inputs.parameters.feedbackEvidenceConfigMapKey}}"
                 path: feedback-evidence.jsonl
+        - name: candidate-specs
+          configMap:
+            name: "{{inputs.parameters.candidateSpecsConfigMapName}}"
+            optional: true
+            items:
+              - key: "{{inputs.parameters.candidateSpecsConfigMapKey}}"
+                path: candidate-specs.jsonl
       outputs:
         artifacts:
           - name: whitepaper-autoresearch-output

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -803,6 +803,12 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         template = template_path.read_text()
 
         self.assertIn("name: feedbackEvidenceJsonlB64", template)
+        self.assertIn("name: candidateSpecsJsonlB64", template)
+        self.assertIn("name: candidateSpecsConfigMapName", template)
+        self.assertIn("name: candidateSpecsConfigMapKey", template)
+        self.assertIn("--candidate-specs", template)
+        self.assertIn("TORGHUT_WHITEPAPER_CANDIDATE_SPECS_JSONL_B64", template)
+        self.assertIn("TORGHUT_WHITEPAPER_CANDIDATE_SPECS_CONFIGMAP_PATH", template)
         self.assertIn("name: feedbackEvidenceConfigMapName", template)
         self.assertIn("name: feedbackEvidenceConfigMapKey", template)
         self.assertIn("--feedback-evidence-jsonl", template)
@@ -811,8 +817,13 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn("TORGHUT_WHITEPAPER_SOURCE_JSONL_B64", template)
         self.assertIn('--epoch-id "${RUN_ID}"', template)
         self.assertIn("name: feedback-evidence", template)
+        self.assertIn("name: candidate-specs", template)
         self.assertNotIn(
             "printf '%s' \"{{inputs.parameters.feedbackEvidenceJsonlB64}}\"",
+            template,
+        )
+        self.assertNotIn(
+            "printf '%s' \"{{inputs.parameters.candidateSpecsJsonlB64}}\"",
             template,
         )
         self.assertNotIn(
@@ -9011,15 +9022,15 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         )
         self.assertEqual(
             day_action["recommended_coverage_probe"],
-            remediation["recent_trading_days"][
-                "clickhouse_coverage_probe_queries"
-            ]["signal_microbar_coverage"],
+            remediation["recent_trading_days"]["clickhouse_coverage_probe_queries"][
+                "signal_microbar_coverage"
+            ],
         )
         self.assertEqual(
             day_action["recommended_day_gap_probe"],
-            remediation["recent_trading_days"][
-                "clickhouse_coverage_probe_queries"
-            ]["signal_microbar_day_gap"],
+            remediation["recent_trading_days"]["clickhouse_coverage_probe_queries"][
+                "signal_microbar_day_gap"
+            ],
         )
 
     def test_remediation_surfaces_stale_tape_shortfall(self) -> None:


### PR DESCRIPTION
## Summary

- Adds optional `candidateSpecsJsonlB64` and ConfigMap parameters to the Torghut whitepaper autoresearch WorkflowTemplate.
- Wires supplied candidate-spec JSONL into the existing `--candidate-specs` direct replay path so cluster runs can target a selected shortlist instead of rerunning broad source compilation and selection.
- Extends the WorkflowTemplate regression test to cover the new input path and keep base64 handling environment-variable based.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k workflow_template_surfaces_feedback_and_fails_closed_on_stale_tape -q`
- `uv run --frozen ruff check tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff format --check tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
