### PR TITLE
fix(torghut): preflight kafka retention for ta replay

### DIFF
--- a/services/torghut/scripts/ta_replay_runner.py
+++ b/services/torghut/scripts/ta_replay_runner.py
@@ -26,6 +26,16 @@ FAILED_RUN_STATES = {
     'FAILED_FINISHED',
     'FAILED_RESTARTING',
 }
+MILLISECONDS_PER_DAY = 86_400_000
+DEFAULT_KAFKA_RETENTION_TOPICS: Mapping[str, str] = {
+    'trades': 'torghut.trades.v1',
+    'quotes': 'torghut.quotes.v1',
+    'bars1m': 'torghut.bars.1m.v1',
+    'ta_microbars': 'torghut.ta.bars.1s.v1',
+    'ta_signals': 'torghut.ta.signals.v1',
+}
+RAW_REPLAY_SOURCE_TOPIC_ROLES = frozenset({'trades', 'quotes', 'bars1m'})
+DERIVED_TA_TOPIC_ROLES = frozenset({'ta_microbars', 'ta_signals'})
 
 
 @dataclass(frozen=True)
@@ -88,6 +98,24 @@ def _kubectl_get_ta_deployment_json() -> dict[str, Any]:
             TA_DEPLOYMENT,
             '-o',
             'json',
+        ]
+    )
+    return json.loads(result.stdout)
+
+
+def _kubectl_get_kafka_topics_json(
+    namespace: str, topic_names: list[str]
+) -> dict[str, Any]:
+    result = _run_kubectl(
+        [
+            '-n',
+            namespace,
+            'get',
+            'kafkatopic',
+            *topic_names,
+            '-o',
+            'json',
+            '--ignore-not-found=true',
         ]
     )
     return json.loads(result.stdout)
@@ -214,6 +242,7 @@ def _build_plan_report(
     verify: bool,
     verification: dict[str, bool] | None = None,
     coverage: dict[str, Any] | None = None,
+    kafka_retention: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
         'status': 'ok',
@@ -231,6 +260,7 @@ def _build_plan_report(
         'verify': verification,
         'verify_requested': verify,
         'coverage': coverage,
+        'kafka_retention': kafka_retention,
     }
 
 
@@ -241,6 +271,7 @@ def _print_plan_text(
     dry_run: bool,
     warnings: list[str],
     coverage: dict[str, Any] | None = None,
+    kafka_retention: dict[str, Any] | None = None,
 ) -> None:
     print('Current replay state:')
     print(f'  namespace: {namespace}')
@@ -277,6 +308,30 @@ def _print_plan_text(
             f'  missing-signal-days-vs-required: {summary.get("missing_signal_days_vs_required", 0)}'
         )
         print(f'  microbar-only-days: {summary.get("microbar_only_day_count", 0)}')
+    if kafka_retention is not None:
+        summary_payload = kafka_retention.get('summary')
+        summary: Mapping[str, Any] = (
+            summary_payload if isinstance(summary_payload, dict) else {}
+        )
+        print('Kafka retention preflight:')
+        print(f'  status: {kafka_retention.get("status")}')
+        print(f'  required-calendar-days: {summary.get("required_calendar_days", 0)}')
+        topics_payload = kafka_retention.get('topics')
+        topics = topics_payload if isinstance(topics_payload, list) else []
+        for topic in topics:
+            if not isinstance(topic, dict):
+                continue
+            retention_days = topic.get('retention_days')
+            retention_display = (
+                f'{retention_days}d' if retention_days is not None else 'unknown'
+            )
+            print(f'  {topic.get("role")}: {retention_display} ({topic.get("topic")})')
+        blockers_payload = kafka_retention.get('blockers')
+        blockers = blockers_payload if isinstance(blockers_payload, list) else []
+        if blockers:
+            print('  blockers:')
+            for blocker in blockers:
+                print(f'    - {blocker}')
     if dry_run:
         print(
             f'Use --mode=apply --confirm {APPLY_CONFIRMATION_PHRASE} to execute the plan.'
@@ -452,6 +507,206 @@ def _load_clickhouse_coverage(args: argparse.Namespace) -> dict[str, Any] | None
     }
 
 
+def _required_calendar_days_from_trading_days(required_trading_days: int) -> int:
+    if required_trading_days <= 0:
+        return 0
+    return (required_trading_days * 7 + 4) // 5
+
+
+def _parse_kafka_retention_topic_overrides(values: list[str]) -> dict[str, str]:
+    topics = dict(DEFAULT_KAFKA_RETENTION_TOPICS)
+    for raw_value in values:
+        if '=' not in raw_value:
+            raise SystemExit(
+                f'--kafka-retention-topic must be role=topic, got {raw_value!r}'
+            )
+        role, topic = raw_value.split('=', 1)
+        role = role.strip()
+        topic = topic.strip()
+        if role not in topics:
+            valid_roles = ', '.join(sorted(topics))
+            raise SystemExit(
+                f'unknown kafka retention topic role {role!r}; expected one of: {valid_roles}'
+            )
+        if not topic:
+            raise SystemExit(f'kafka retention topic for role {role!r} cannot be empty')
+        topics[role] = topic
+    return topics
+
+
+def _kafka_topic_items_by_name(
+    payload: Mapping[str, Any],
+) -> dict[str, Mapping[str, Any]]:
+    items_payload = payload.get('items')
+    if isinstance(items_payload, list):
+        items = items_payload
+    else:
+        items = [payload]
+    by_name: dict[str, Mapping[str, Any]] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        metadata = item.get('metadata')
+        if not isinstance(metadata, dict):
+            continue
+        name = metadata.get('name')
+        if isinstance(name, str) and name:
+            by_name[name] = item
+    return by_name
+
+
+def _kafka_topic_ready_status(item: Mapping[str, Any]) -> str:
+    status = item.get('status')
+    if not isinstance(status, dict):
+        return 'unknown'
+    conditions = status.get('conditions')
+    if not isinstance(conditions, list):
+        return 'unknown'
+    for condition in conditions:
+        if not isinstance(condition, dict):
+            continue
+        if condition.get('type') == 'Ready':
+            ready = condition.get('status')
+            return str(ready) if ready is not None else 'unknown'
+    return 'unknown'
+
+
+def _kafka_topic_config(item: Mapping[str, Any]) -> Mapping[str, Any]:
+    spec = item.get('spec')
+    if not isinstance(spec, dict):
+        return {}
+    config = spec.get('config')
+    return config if isinstance(config, dict) else {}
+
+
+def _parse_retention_ms(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _retention_days(retention_ms: int | None) -> float | None:
+    if retention_ms is None:
+        return None
+    return round(retention_ms / MILLISECONDS_PER_DAY, 2)
+
+
+def _topic_role_has_blocker(blocker: str, role: str) -> bool:
+    return (
+        (blocker.startswith('retention_') and f':{role}:' in blocker)
+        or blocker.startswith(f'kafka_topic_missing:{role}:')
+        or blocker.startswith(f'kafka_topic_not_ready:{role}:')
+    )
+
+
+def _load_kafka_retention(args: argparse.Namespace) -> dict[str, Any] | None:
+    if not bool(getattr(args, 'check_kafka_retention', False)):
+        return None
+
+    topic_by_role = _parse_kafka_retention_topic_overrides(
+        list(getattr(args, 'kafka_retention_topic', []) or [])
+    )
+    topic_names = list(dict.fromkeys(topic_by_role.values()))
+    payload = _kubectl_get_kafka_topics_json(
+        str(args.kafka_topic_namespace), topic_names
+    )
+    items_by_name = _kafka_topic_items_by_name(payload)
+
+    required_trading_days = max(0, int(getattr(args, 'required_trading_days', 0) or 0))
+    required_calendar_days = max(
+        0,
+        int(getattr(args, 'required_calendar_days', 0) or 0)
+        or _required_calendar_days_from_trading_days(required_trading_days),
+    )
+    blockers: list[str] = []
+    topics: list[dict[str, Any]] = []
+
+    for role, topic_name in topic_by_role.items():
+        item = items_by_name.get(topic_name)
+        if item is None:
+            blockers.append(f'kafka_topic_missing:{role}:{topic_name}')
+            topics.append(
+                {
+                    'role': role,
+                    'topic': topic_name,
+                    'retention_ms': None,
+                    'retention_days': None,
+                    'ready': 'missing',
+                    'partitions': None,
+                    'replicas': None,
+                }
+            )
+            continue
+
+        spec = item.get('spec')
+        spec_mapping = spec if isinstance(spec, dict) else {}
+        config = _kafka_topic_config(item)
+        retention_ms = _parse_retention_ms(config.get('retention.ms'))
+        retention_days = _retention_days(retention_ms)
+        ready = _kafka_topic_ready_status(item)
+        if ready not in {'True', 'unknown'}:
+            blockers.append(f'kafka_topic_not_ready:{role}:{topic_name}:{ready}')
+        if required_calendar_days and retention_days is None:
+            blockers.append(f'retention_missing:{role}:{topic_name}')
+        if (
+            required_calendar_days
+            and retention_days is not None
+            and retention_days < required_calendar_days
+        ):
+            blockers.append(
+                f'retention_shortfall:{role}:{retention_days:g}<{required_calendar_days}'
+            )
+
+        topics.append(
+            {
+                'role': role,
+                'topic': topic_name,
+                'retention_ms': retention_ms,
+                'retention_days': retention_days,
+                'ready': ready,
+                'partitions': spec_mapping.get('partitions'),
+                'replicas': spec_mapping.get('replicas'),
+            }
+        )
+
+    raw_source_blocked = any(
+        _topic_role_has_blocker(blocker, role)
+        for role in RAW_REPLAY_SOURCE_TOPIC_ROLES
+        for blocker in blockers
+    )
+    derived_topic_blocked = any(
+        _topic_role_has_blocker(blocker, role)
+        for role in DERIVED_TA_TOPIC_ROLES
+        for blocker in blockers
+    )
+    if raw_source_blocked:
+        status = 'insufficient_source_retention'
+    elif derived_topic_blocked:
+        status = 'insufficient_derived_topic_retention'
+    elif blockers:
+        status = 'kafka_topic_preflight_blocked'
+    else:
+        status = 'ok'
+
+    return {
+        'schema_version': 'torghut.kafka-retention-preflight.v1',
+        'status': status,
+        'blockers': blockers,
+        'summary': {
+            'required_trading_days': required_trading_days,
+            'required_calendar_days': required_calendar_days,
+            'raw_replay_source_roles': sorted(RAW_REPLAY_SOURCE_TOPIC_ROLES),
+            'derived_ta_topic_roles': sorted(DERIVED_TA_TOPIC_ROLES),
+        },
+        'topics': topics,
+    }
+
+
 def _apply_plan(
     state: ReplayState, plan: dict[str, str], namespace: str
 ) -> ReplayState:
@@ -520,6 +775,7 @@ def _handle_plan_mode(
         _verify_state(state, plan, state.flink_restart_nonce) if args.verify else None
     )
     coverage = _load_clickhouse_coverage(args)
+    kafka_retention = _load_kafka_retention(args)
     report = _build_plan_report(
         namespace=args.namespace,
         mode='plan',
@@ -529,13 +785,20 @@ def _handle_plan_mode(
         verify=args.verify,
         verification=verification,
         coverage=coverage,
+        kafka_retention=kafka_retention,
     )
     if args.json:
         print(json.dumps(report, sort_keys=True, indent=2))
         return _final_status(verification) if verification else 0
 
     _print_plan_text(
-        state, plan, args.namespace, dry_run=True, warnings=warnings, coverage=coverage
+        state,
+        plan,
+        args.namespace,
+        dry_run=True,
+        warnings=warnings,
+        coverage=coverage,
+        kafka_retention=kafka_retention,
     )
     return 0
 
@@ -549,6 +812,7 @@ def _handle_verify_mode(
 ) -> int:
     verification = _verify_state(state, plan, state.flink_restart_nonce)
     coverage = _load_clickhouse_coverage(args)
+    kafka_retention = _load_kafka_retention(args)
     report = _build_plan_report(
         namespace=args.namespace,
         mode='verify',
@@ -558,13 +822,20 @@ def _handle_verify_mode(
         verify=True,
         verification=verification,
         coverage=coverage,
+        kafka_retention=kafka_retention,
     )
     if args.json:
         print(json.dumps(report, sort_keys=True, indent=2))
         return _final_status(verification)
 
     _print_plan_text(
-        state, plan, args.namespace, dry_run=False, warnings=warnings, coverage=coverage
+        state,
+        plan,
+        args.namespace,
+        dry_run=False,
+        warnings=warnings,
+        coverage=coverage,
+        kafka_retention=kafka_retention,
     )
     print('')
     print('Verify results:')
@@ -590,6 +861,7 @@ def _handle_apply_mode(
         _verify_state(applied_state, plan, previous_nonce) if args.verify else None
     )
     coverage = _load_clickhouse_coverage(args)
+    kafka_retention = _load_kafka_retention(args)
 
     report = _build_plan_report(
         namespace=args.namespace,
@@ -600,6 +872,7 @@ def _handle_apply_mode(
         verify=args.verify,
         verification=verification,
         coverage=coverage,
+        kafka_retention=kafka_retention,
     )
     if args.json:
         print(json.dumps(report, sort_keys=True, indent=2))
@@ -613,6 +886,7 @@ def _handle_apply_mode(
         dry_run=False,
         warnings=warnings,
         coverage=coverage,
+        kafka_retention=kafka_retention,
     )
     if args.verify and verification is not None:
         print('Verify results:')
@@ -677,6 +951,22 @@ def parse_args() -> argparse.Namespace:
         help='Add a read-only ta_signals/ta_microbars coverage preflight to plan/verify/apply reports.',
     )
     parser.add_argument(
+        '--check-kafka-retention',
+        action='store_true',
+        help='Add a read-only KafkaTopic retention preflight for raw and derived TA replay topics.',
+    )
+    parser.add_argument(
+        '--kafka-topic-namespace',
+        default='kafka',
+        help='Kubernetes namespace containing Strimzi KafkaTopic resources.',
+    )
+    parser.add_argument(
+        '--kafka-retention-topic',
+        action='append',
+        default=[],
+        help='Override a retention topic by role, for example trades=torghut.trades.v1.',
+    )
+    parser.add_argument(
         '--clickhouse-http-url',
         default=os.environ.get(
             'TA_CLICKHOUSE_HTTP_URL',
@@ -721,6 +1011,12 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=0,
         help='Required replay proof trading-day count used to compute signal-day shortfall.',
+    )
+    parser.add_argument(
+        '--required-calendar-days',
+        type=int,
+        default=0,
+        help='Required source retention calendar-day count. Defaults to ceil(required-trading-days * 7 / 5).',
     )
     return parser.parse_args()
 

--- a/services/torghut/tests/test_ta_replay_runner.py
+++ b/services/torghut/tests/test_ta_replay_runner.py
@@ -408,6 +408,159 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
         self.assertIn("trades: 7.0d (torghut.trades.v1)", text)
         self.assertIn("retention_shortfall:trades:7<35", text)
 
+    def test_replay_state_and_plan_helpers_cover_edge_branches(self) -> None:
+        with patch.object(runner.shutil, "which", return_value=None):
+            with self.assertRaisesRegex(SystemExit, "kubectl not found"):
+                runner._require_kubectl()
+            with self.assertRaisesRegex(SystemExit, "kubectl not found"):
+                runner._kubectl_binary()
+
+        with patch.object(runner.shutil, "which", return_value="/usr/bin/kubectl"):
+            runner._require_kubectl()
+            self.assertEqual(runner._kubectl_binary(), "/usr/bin/kubectl")
+
+        with self.assertRaisesRegex(SystemExit, "unsupported namespace"):
+            runner._require_supported_namespace("agents")
+        with self.assertRaisesRegex(SystemExit, "replay-id must be provided"):
+            runner._plan_command("", "prefix", "earliest")
+        with self.assertRaisesRegex(SystemExit, "replay-id cannot be empty"):
+            runner._validate_plan_args("", "prefix")
+        with self.assertRaisesRegex(SystemExit, "group-prefix cannot be empty"):
+            runner._validate_plan_args("proof", "")
+
+        self.assertEqual(
+            runner._plan_command(" proof__id ", " prefix__ ", ""),
+            {
+                "replay_group_id": "prefix-proof-id",
+                "ta_auto_offset_reset": "earliest",
+            },
+        )
+        replay_state = runner.ReplayState(
+            namespace="torghut",
+            ta_group_id="torghut-ta-replay-profit-proof",
+            ta_auto_offset_reset="earliest",
+            flink_job_state=None,
+            flink_restart_nonce=7,
+            flink_status_state=None,
+        )
+        self.assertEqual(
+            runner._validate_apply_preconditions(
+                state=replay_state,
+                plan=self._plan(),
+                allow_existing_group=False,
+            ),
+            [
+                "planned TA_GROUP_ID already equals current value; pass --allow-existing-group-id to continue",
+                "TA_AUTO_OFFSET_RESET already matches the replay target",
+            ],
+        )
+
+    def test_load_state_parses_kubernetes_payloads_and_error_shapes(self) -> None:
+        config = {
+            "data": {
+                "TA_GROUP_ID": "torghut-ta-2025-12-23",
+                "TA_AUTO_OFFSET_RESET": "latest",
+            }
+        }
+        deployment = {
+            "spec": {
+                "job": {"state": "running"},
+                "restartNonce": "8",
+            },
+            "status": {"jobStatus": {"state": "RUNNING"}},
+        }
+        with patch.object(runner, "_kubectl_get_ta_config_json", return_value=config):
+            with patch.object(
+                runner, "_kubectl_get_ta_deployment_json", return_value=deployment
+            ):
+                state = runner._load_state("torghut")
+
+        self.assertEqual(state.ta_group_id, "torghut-ta-2025-12-23")
+        self.assertEqual(state.ta_auto_offset_reset, "latest")
+        self.assertEqual(state.flink_job_state, "running")
+        self.assertEqual(state.flink_restart_nonce, 8)
+        self.assertEqual(state.flink_status_state, "RUNNING")
+
+        with patch.object(runner, "_kubectl_get_ta_config_json", return_value={}):
+            with self.assertRaisesRegex(SystemExit, "configmap data"):
+                runner._load_state("torghut")
+        with patch.object(
+            runner, "_kubectl_get_ta_config_json", return_value={"data": {}}
+        ):
+            with self.assertRaisesRegex(SystemExit, "TA_GROUP_ID missing"):
+                runner._load_state("torghut")
+        with patch.object(runner, "_kubectl_get_ta_config_json", return_value=config):
+            with patch.object(
+                runner, "_kubectl_get_ta_deployment_json", return_value={}
+            ):
+                with self.assertRaisesRegex(SystemExit, "flinkdeployment spec"):
+                    runner._load_state("torghut")
+
+    def test_main_dispatches_modes_and_requires_apply_confirmation(self) -> None:
+        base_args = self._args(
+            replay_id="proof",
+            group_prefix="torghut-ta-replay",
+            auto_offset_reset="earliest",
+            allow_existing_group_id=False,
+            mode="plan",
+            confirm="",
+        )
+        with patch.object(runner, "parse_args", return_value=base_args):
+            with patch.object(runner, "_require_kubectl"):
+                with patch.object(runner, "_load_state", return_value=self._state()):
+                    with patch.object(
+                        runner, "_handle_plan_mode", return_value=4
+                    ) as handle_plan:
+                        self.assertEqual(runner.main(), 4)
+        handle_plan.assert_called_once()
+
+        verify_args = self._args(
+            replay_id="proof",
+            group_prefix="torghut-ta-replay",
+            auto_offset_reset="earliest",
+            allow_existing_group_id=False,
+            mode="verify",
+            confirm="",
+        )
+        with patch.object(runner, "parse_args", return_value=verify_args):
+            with patch.object(runner, "_require_kubectl"):
+                with patch.object(runner, "_load_state", return_value=self._state()):
+                    with patch.object(
+                        runner, "_handle_verify_mode", return_value=5
+                    ) as handle_verify:
+                        self.assertEqual(runner.main(), 5)
+        handle_verify.assert_called_once()
+
+        apply_args = self._args(
+            replay_id="proof",
+            group_prefix="torghut-ta-replay",
+            auto_offset_reset="earliest",
+            allow_existing_group_id=False,
+            mode="apply",
+            confirm=runner.APPLY_CONFIRMATION_PHRASE,
+        )
+        with patch.object(runner, "parse_args", return_value=apply_args):
+            with patch.object(runner, "_require_kubectl"):
+                with patch.object(runner, "_load_state", return_value=self._state()):
+                    with patch.object(
+                        runner, "_handle_apply_mode", return_value=6
+                    ) as handle_apply:
+                        self.assertEqual(runner.main(), 6)
+        handle_apply.assert_called_once()
+
+        unconfirmed_apply_args = self._args(
+            replay_id="proof",
+            group_prefix="torghut-ta-replay",
+            auto_offset_reset="earliest",
+            allow_existing_group_id=False,
+            mode="apply",
+            confirm="",
+        )
+        with patch.object(runner, "parse_args", return_value=unconfirmed_apply_args):
+            with patch.object(runner, "_require_kubectl"):
+                with self.assertRaisesRegex(SystemExit, "requires --confirm"):
+                    runner.main()
+
     def test_verify_text_mode_renders_coverage_and_failed_checks(self) -> None:
         state = runner.ReplayState(
             namespace="torghut",

--- a/services/torghut/tests/test_ta_replay_runner.py
+++ b/services/torghut/tests/test_ta_replay_runner.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 from contextlib import redirect_stdout
+from subprocess import CompletedProcess
 from unittest import TestCase
 from unittest.mock import patch
 from urllib.error import URLError
@@ -22,6 +23,58 @@ _DAY_GAP_TSV = """trading_day\tsignal_rows\tmicrobar_rows
 2026-05-07\t0\t66008
 """
 
+_KAFKA_TOPICS_JSON = {
+    "apiVersion": "v1",
+    "kind": "List",
+    "items": [
+        {
+            "metadata": {"name": "torghut.trades.v1"},
+            "spec": {
+                "partitions": 3,
+                "replicas": 3,
+                "config": {"retention.ms": 604800000},
+            },
+            "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+        },
+        {
+            "metadata": {"name": "torghut.quotes.v1"},
+            "spec": {
+                "partitions": 3,
+                "replicas": 3,
+                "config": {"retention.ms": "604800000"},
+            },
+            "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+        },
+        {
+            "metadata": {"name": "torghut.bars.1m.v1"},
+            "spec": {
+                "partitions": 3,
+                "replicas": 3,
+                "config": {"retention.ms": 2592000000},
+            },
+            "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+        },
+        {
+            "metadata": {"name": "torghut.ta.bars.1s.v1"},
+            "spec": {
+                "partitions": 1,
+                "replicas": 3,
+                "config": {"retention.ms": 1209600000},
+            },
+            "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+        },
+        {
+            "metadata": {"name": "torghut.ta.signals.v1"},
+            "spec": {
+                "partitions": 1,
+                "replicas": 3,
+                "config": {"retention.ms": 1209600000},
+            },
+            "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+        },
+    ],
+}
+
 
 class TestTaReplayRunnerCoveragePreflight(TestCase):
     def _args(self, **overrides: object) -> argparse.Namespace:
@@ -30,6 +83,7 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
             "verify": False,
             "json": True,
             "check_clickhouse_coverage": True,
+            "check_kafka_retention": False,
             "clickhouse_http_url": "http://clickhouse.test:8123",
             "clickhouse_username": "torghut",
             "clickhouse_password": "secret",
@@ -37,6 +91,9 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
             "clickhouse_timeout_seconds": 5,
             "coverage_day_limit": 40,
             "required_trading_days": 25,
+            "required_calendar_days": 0,
+            "kafka_topic_namespace": "kafka",
+            "kafka_retention_topic": [],
         }
         values.update(overrides)
         return argparse.Namespace(**values)
@@ -69,6 +126,32 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
             },
         ).__dict__
 
+    def _kafka_retention(self) -> dict[str, object]:
+        return {
+            "schema_version": "torghut.kafka-retention-preflight.v1",
+            "status": "insufficient_source_retention",
+            "blockers": [
+                "retention_shortfall:trades:7<35",
+                "retention_shortfall:quotes:7<35",
+            ],
+            "summary": {
+                "required_trading_days": 25,
+                "required_calendar_days": 35,
+            },
+            "topics": [
+                {
+                    "role": "trades",
+                    "topic": "torghut.trades.v1",
+                    "retention_days": 7.0,
+                },
+                {
+                    "role": "quotes",
+                    "topic": "torghut.quotes.v1",
+                    "retention_days": 7.0,
+                },
+            ],
+        }
+
     def test_load_clickhouse_coverage_flags_signal_shortfall_and_microbar_only_days(
         self,
     ) -> None:
@@ -90,6 +173,152 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
             coverage["summary"]["microbar_only_days"],
             ["2026-05-08", "2026-05-07"],
         )
+
+    def test_load_kafka_retention_flags_source_shortfall_for_proof_window(
+        self,
+    ) -> None:
+        with patch.object(
+            runner,
+            "_kubectl_get_kafka_topics_json",
+            return_value=_KAFKA_TOPICS_JSON,
+        ):
+            retention = runner._load_kafka_retention(
+                self._args(
+                    check_clickhouse_coverage=False,
+                    check_kafka_retention=True,
+                )
+            )
+
+        assert retention is not None
+        self.assertEqual(retention["status"], "insufficient_source_retention")
+        self.assertEqual(retention["summary"]["required_calendar_days"], 35)
+        self.assertIn("retention_shortfall:trades:7<35", retention["blockers"])
+        self.assertIn("retention_shortfall:quotes:7<35", retention["blockers"])
+        self.assertIn("retention_shortfall:bars1m:30<35", retention["blockers"])
+        self.assertIn("retention_shortfall:ta_signals:14<35", retention["blockers"])
+        trades = next(
+            topic for topic in retention["topics"] if topic["role"] == "trades"
+        )
+        self.assertEqual(trades["retention_days"], 7.0)
+
+    def test_load_kafka_retention_handles_missing_not_ready_and_overrides(
+        self,
+    ) -> None:
+        payload = {
+            "items": [
+                {
+                    "metadata": {"name": "custom.trades"},
+                    "spec": {"config": {"retention.ms": "bad"}},
+                    "status": {"conditions": [{"type": "Ready", "status": "False"}]},
+                }
+            ]
+        }
+        with patch.object(
+            runner,
+            "_kubectl_get_kafka_topics_json",
+            return_value=payload,
+        ):
+            retention = runner._load_kafka_retention(
+                self._args(
+                    check_clickhouse_coverage=False,
+                    check_kafka_retention=True,
+                    kafka_retention_topic=["trades=custom.trades"],
+                    required_calendar_days=7,
+                )
+            )
+
+        assert retention is not None
+        self.assertEqual(retention["status"], "insufficient_source_retention")
+        self.assertIn(
+            "kafka_topic_not_ready:trades:custom.trades:False", retention["blockers"]
+        )
+        self.assertIn("retention_missing:trades:custom.trades", retention["blockers"])
+        self.assertIn(
+            "kafka_topic_missing:quotes:torghut.quotes.v1", retention["blockers"]
+        )
+
+        self.assertEqual(runner._required_calendar_days_from_trading_days(25), 35)
+        self.assertEqual(
+            runner._parse_kafka_retention_topic_overrides(["trades=custom.trades"])[
+                "trades"
+            ],
+            "custom.trades",
+        )
+        with self.assertRaisesRegex(SystemExit, "role=topic"):
+            runner._parse_kafka_retention_topic_overrides(["bad"])
+        with self.assertRaisesRegex(SystemExit, "unknown kafka retention topic role"):
+            runner._parse_kafka_retention_topic_overrides(["bad=topic"])
+        with self.assertRaisesRegex(SystemExit, "cannot be empty"):
+            runner._parse_kafka_retention_topic_overrides(["trades="])
+
+    def test_kafka_retention_helpers_cover_kubectl_and_json_edges(self) -> None:
+        with patch.object(
+            runner,
+            "_run_kubectl",
+            return_value=CompletedProcess(
+                args=[], returncode=0, stdout='{"items": []}'
+            ),
+        ) as run_kubectl:
+            payload = runner._kubectl_get_kafka_topics_json("kafka", ["topic-a"])
+
+        self.assertEqual(payload, {"items": []})
+        self.assertEqual(
+            run_kubectl.call_args.args[0],
+            [
+                "-n",
+                "kafka",
+                "get",
+                "kafkatopic",
+                "topic-a",
+                "-o",
+                "json",
+                "--ignore-not-found=true",
+            ],
+        )
+        self.assertEqual(
+            runner._kafka_topic_items_by_name(
+                {"metadata": {"name": "single-topic"}, "spec": {}}
+            ),
+            {"single-topic": {"metadata": {"name": "single-topic"}, "spec": {}}},
+        )
+        self.assertEqual(runner._kafka_topic_items_by_name({"items": [None, {}]}), {})
+        self.assertEqual(runner._kafka_topic_ready_status({}), "unknown")
+        self.assertEqual(
+            runner._kafka_topic_ready_status({"status": {"conditions": "bad"}}),
+            "unknown",
+        )
+        self.assertEqual(runner._kafka_topic_config({}), {})
+        self.assertTrue(
+            runner._topic_role_has_blocker(
+                "kafka_topic_not_ready:trades:topic:False", "trades"
+            )
+        )
+        self.assertFalse(
+            runner._topic_role_has_blocker(
+                "kafka_topic_not_ready:quotes:topic:False", "trades"
+            )
+        )
+
+    def test_load_kafka_retention_can_pass_when_required_window_is_available(
+        self,
+    ) -> None:
+        with patch.object(
+            runner,
+            "_kubectl_get_kafka_topics_json",
+            return_value=_KAFKA_TOPICS_JSON,
+        ):
+            retention = runner._load_kafka_retention(
+                self._args(
+                    check_clickhouse_coverage=False,
+                    check_kafka_retention=True,
+                    required_trading_days=1,
+                    required_calendar_days=1,
+                )
+            )
+
+        assert retention is not None
+        self.assertEqual(retention["status"], "ok")
+        self.assertEqual(retention["blockers"], [])
 
     def test_plan_json_embeds_coverage_preflight(self) -> None:
         output = io.StringIO()
@@ -116,6 +345,34 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
             payload["coverage"]["summary"]["missing_signal_days_vs_required"], 16
         )
 
+    def test_plan_json_embeds_kafka_retention_preflight(self) -> None:
+        output = io.StringIO()
+        with patch.object(
+            runner,
+            "_kubectl_get_kafka_topics_json",
+            return_value=_KAFKA_TOPICS_JSON,
+        ):
+            with redirect_stdout(output):
+                exit_code = runner._handle_plan_mode(
+                    args=self._args(
+                        check_clickhouse_coverage=False,
+                        check_kafka_retention=True,
+                    ),
+                    state=self._state(),
+                    plan=self._plan(),
+                    warnings=[],
+                )
+
+        self.assertEqual(exit_code, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(
+            payload["kafka_retention"]["schema_version"],
+            "torghut.kafka-retention-preflight.v1",
+        )
+        self.assertEqual(
+            payload["kafka_retention"]["status"], "insufficient_source_retention"
+        )
+
     def test_text_plan_renders_coverage_preflight_summary(self) -> None:
         output = io.StringIO()
         with redirect_stdout(output):
@@ -132,6 +389,24 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
         self.assertIn("Coverage preflight:", text)
         self.assertIn("missing-signal-days-vs-required: 16", text)
         self.assertIn("Use --mode=apply --confirm REPLAY_TA_CANARY", text)
+
+    def test_text_plan_renders_kafka_retention_preflight_summary(self) -> None:
+        output = io.StringIO()
+        with redirect_stdout(output):
+            runner._print_plan_text(
+                self._state(),
+                self._plan(),
+                "torghut",
+                dry_run=True,
+                warnings=[],
+                kafka_retention=self._kafka_retention(),
+            )
+
+        text = output.getvalue()
+        self.assertIn("Kafka retention preflight:", text)
+        self.assertIn("required-calendar-days: 35", text)
+        self.assertIn("trades: 7.0d (torghut.trades.v1)", text)
+        self.assertIn("retention_shortfall:trades:7<35", text)
 
     def test_verify_text_mode_renders_coverage_and_failed_checks(self) -> None:
         state = runner.ReplayState(
@@ -289,10 +564,17 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
             "--replay-id",
             "proof",
             "--check-clickhouse-coverage",
+            "--check-kafka-retention",
             "--required-trading-days",
             "25",
+            "--required-calendar-days",
+            "35",
             "--coverage-day-limit",
             "12",
+            "--kafka-topic-namespace",
+            "market-data",
+            "--kafka-retention-topic",
+            "trades=torghut.trades.replay",
             "--clickhouse-timeout-seconds",
             "3",
         ]
@@ -309,7 +591,11 @@ class TestTaReplayRunnerCoveragePreflight(TestCase):
         self.assertEqual(parsed.replay_id, "proof")
         self.assertTrue(parsed.check_clickhouse_coverage)
         self.assertEqual(parsed.required_trading_days, 25)
+        self.assertEqual(parsed.required_calendar_days, 35)
         self.assertEqual(parsed.coverage_day_limit, 12)
+        self.assertTrue(parsed.check_kafka_retention)
+        self.assertEqual(parsed.kafka_topic_namespace, "market-data")
+        self.assertEqual(parsed.kafka_retention_topic, ["trades=torghut.trades.replay"])
         self.assertEqual(parsed.clickhouse_timeout_seconds, 3)
         self.assertEqual(parsed.clickhouse_http_url, "http://env-clickhouse:8123")
         self.assertEqual(parsed.clickhouse_username, "env-user")


### PR DESCRIPTION
## Summary

- Add a read-only KafkaTopic retention preflight to the TA replay runner.
- Report raw-source versus derived-TA retention blockers for a requested proof window.
- Cover missing topics, not-ready topics, overrides, JSON/text output, helper edge branches, and successful retention cases in unit tests.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_ta_replay_runner.py --cov=scripts.ta_replay_runner --cov-report=xml --cov-fail-under=0`
- `uv run --frozen ruff check scripts/ta_replay_runner.py tests/test_ta_replay_runner.py`
- `uv run --frozen ruff format --check --config "format.quote-style = 'single'" scripts/ta_replay_runner.py`
- `uv run --frozen ruff format --check tests/test_ta_replay_runner.py`
- `uv run --frozen python -m py_compile scripts/ta_replay_runner.py tests/test_ta_replay_runner.py`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- Read-only live preflight: `uv run --frozen python scripts/ta_replay_runner.py --replay-id profit-proof-retention --mode plan --json --check-kafka-retention --required-trading-days 25`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
