### PR TITLE
fix(torghut): bind readiness proof to daily ledger window

### DIFF
--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -17,6 +17,14 @@ SCHEMA_VERSION = 'torghut.trading-readiness-verification.v1'
 ROUTE_REACQUISITION_BOARD_SCHEMA_VERSION = 'torghut.route-reacquisition-board.v1'
 ROUTE_REACQUISITION_BOOK_SCHEMA_VERSION = 'torghut.route-reacquisition-book.v1'
 DOC29_LIVE_SCALE_GATE = 'live_scale_observed'
+_RUNTIME_LEDGER_TRADING_DAY_KEYS = (
+    'runtime_ledger_observed_trading_day_count',
+    'runtime_ledger_trading_day_count',
+    'observed_trading_day_count',
+    'trading_day_count',
+    'runtime_ledger_session_count',
+    'session_count',
+)
 _MISSING_QUANT_REASONS = {
     'quant_health_fetch_failed',
     'quant_health_missing',
@@ -234,11 +242,22 @@ def _runtime_ledger_refs(gate: Mapping[str, Any], key: str) -> Sequence[object]:
     return _sequence(refs.get(key))
 
 
+def _runtime_ledger_trading_day_count(
+    summary: Mapping[str, Any],
+) -> tuple[int, str | None]:
+    for key in _RUNTIME_LEDGER_TRADING_DAY_KEYS:
+        if key in summary:
+            return _int(summary.get(key)), key
+    return 0, None
+
+
 def _add_runtime_ledger_profit_proof_checks(
     checks: dict[str, dict[str, Any]],
     *,
     completion_status: Mapping[str, Any] | None,
     min_runtime_ledger_net_pnl: Decimal,
+    min_runtime_ledger_trading_days: int,
+    min_runtime_ledger_daily_net_pnl: Decimal,
 ) -> None:
     completion_present = completion_status is not None
     _add_check(
@@ -304,6 +323,17 @@ def _add_runtime_ledger_profit_proof_checks(
         observed=summary.get('runtime_ledger_closed_trade_count'),
         expected='>0',
     )
+    trading_day_count, trading_day_count_key = _runtime_ledger_trading_day_count(
+        summary
+    )
+    _add_check(
+        checks,
+        'runtime_ledger_observed_trading_days',
+        passed=trading_day_count >= min_runtime_ledger_trading_days,
+        observed=trading_day_count,
+        expected=f'>={min_runtime_ledger_trading_days}',
+        detail={'source_key': trading_day_count_key},
+    )
     _add_check(
         checks,
         'runtime_ledger_filled_notional',
@@ -318,6 +348,24 @@ def _add_runtime_ledger_profit_proof_checks(
         passed=net_pnl is not None and net_pnl >= min_runtime_ledger_net_pnl,
         observed=str(net_pnl) if net_pnl is not None else None,
         expected=f'>={min_runtime_ledger_net_pnl}',
+    )
+    daily_net_pnl = (
+        net_pnl / Decimal(trading_day_count)
+        if net_pnl is not None and trading_day_count > 0
+        else None
+    )
+    daily_net_pnl_required = min_runtime_ledger_daily_net_pnl > 0
+    _add_check(
+        checks,
+        'runtime_ledger_daily_net_pnl_target',
+        passed=not daily_net_pnl_required
+        or (
+            daily_net_pnl is not None
+            and daily_net_pnl >= min_runtime_ledger_daily_net_pnl
+        ),
+        observed=str(daily_net_pnl) if daily_net_pnl is not None else None,
+        expected=f'>={min_runtime_ledger_daily_net_pnl}',
+        detail={'trading_day_count': trading_day_count},
     )
     _add_check(
         checks,
@@ -339,6 +387,8 @@ def evaluate_trading_readiness(
     min_decisions: int = 0,
     min_orders: int = 0,
     min_runtime_ledger_net_pnl: Decimal = Decimal('0'),
+    min_runtime_ledger_trading_days: int = 0,
+    min_runtime_ledger_daily_net_pnl: Decimal = Decimal('0'),
     require_market_open: bool = True,
     require_quant_fresh: bool = True,
     require_paper_route_probe_candidate: bool = False,
@@ -653,6 +703,8 @@ def evaluate_trading_readiness(
             checks,
             completion_status=completion_status,
             min_runtime_ledger_net_pnl=min_runtime_ledger_net_pnl,
+            min_runtime_ledger_trading_days=min_runtime_ledger_trading_days,
+            min_runtime_ledger_daily_net_pnl=min_runtime_ledger_daily_net_pnl,
         )
 
     failed_checks = [key for key, value in checks.items() if not value['passed']]
@@ -667,6 +719,8 @@ def evaluate_trading_readiness(
             'required': require_runtime_ledger_profit_proof,
             'gate_id': DOC29_LIVE_SCALE_GATE,
             'min_runtime_ledger_net_pnl': str(min_runtime_ledger_net_pnl),
+            'min_runtime_ledger_trading_days': min_runtime_ledger_trading_days,
+            'min_runtime_ledger_daily_net_pnl': str(min_runtime_ledger_daily_net_pnl),
         },
     }
 
@@ -700,6 +754,17 @@ def _parser() -> argparse.ArgumentParser:
         '--min-runtime-ledger-net-pnl',
         default='0',
         help='Minimum runtime-ledger net strategy PnL after costs required when runtime proof is required.',
+    )
+    parser.add_argument(
+        '--min-runtime-ledger-trading-days',
+        type=int,
+        default=0,
+        help='Minimum observed runtime-ledger trading days required when runtime proof is required.',
+    )
+    parser.add_argument(
+        '--min-runtime-ledger-daily-net-pnl',
+        default='0',
+        help='Minimum runtime-ledger net strategy PnL after costs per observed trading day.',
     )
     parser.add_argument('--allow-closed-session', action='store_true')
     parser.add_argument('--allow-informational-quant', action='store_true')
@@ -736,6 +801,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise SystemExit(
             f'--min-runtime-ledger-net-pnl must be decimal, got {args.min_runtime_ledger_net_pnl!r}'
         )
+    min_runtime_ledger_daily_net_pnl = _decimal(args.min_runtime_ledger_daily_net_pnl)
+    if min_runtime_ledger_daily_net_pnl is None:
+        raise SystemExit(
+            '--min-runtime-ledger-daily-net-pnl must be decimal, '
+            f'got {args.min_runtime_ledger_daily_net_pnl!r}'
+        )
     result = evaluate_trading_readiness(
         status,
         completion_status=completion_status,
@@ -744,6 +815,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         min_decisions=max(0, int(args.min_decisions)),
         min_orders=max(0, int(args.min_orders)),
         min_runtime_ledger_net_pnl=min_runtime_ledger_net_pnl,
+        min_runtime_ledger_trading_days=max(
+            0, int(args.min_runtime_ledger_trading_days)
+        ),
+        min_runtime_ledger_daily_net_pnl=min_runtime_ledger_daily_net_pnl,
         require_market_open=not bool(args.allow_closed_session),
         require_quant_fresh=not bool(args.allow_informational_quant),
         require_paper_route_probe_candidate=bool(

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -127,9 +127,22 @@ def _completion_status(
     blocked_reason: str | None = None,
     net_pnl: str = '600',
     expectancy_bps: str = '12.5',
+    trading_day_count: int | None = 25,
     ledger_refs: list[str] | None = None,
     unbacked_refs: list[str] | None = None,
 ) -> dict[str, object]:
+    runtime_ledger_summary: dict[str, object] = {
+        'runtime_ledger_bucket_count': 1,
+        'runtime_ledger_fill_count': 4,
+        'runtime_ledger_closed_trade_count': 2,
+        'runtime_ledger_filled_notional': '50000',
+        'runtime_ledger_net_strategy_pnl_after_costs': net_pnl,
+        'runtime_ledger_post_cost_expectancy_bps': expectancy_bps,
+    }
+    if trading_day_count is not None:
+        runtime_ledger_summary['runtime_ledger_observed_trading_day_count'] = (
+            trading_day_count
+        )
     return {
         'doc_id': 'doc29',
         'summary': {'all_satisfied': gate_status == 'satisfied'},
@@ -147,14 +160,7 @@ def _completion_status(
                     if unbacked_refs is not None
                     else [],
                 },
-                'runtime_ledger_summary': {
-                    'runtime_ledger_bucket_count': 1,
-                    'runtime_ledger_fill_count': 4,
-                    'runtime_ledger_closed_trade_count': 2,
-                    'runtime_ledger_filled_notional': '50000',
-                    'runtime_ledger_net_strategy_pnl_after_costs': net_pnl,
-                    'runtime_ledger_post_cost_expectancy_bps': expectancy_bps,
-                },
+                'runtime_ledger_summary': runtime_ledger_summary,
             }
         ],
     }
@@ -217,6 +223,8 @@ class TestVerifyTradingReadiness(TestCase):
             profile='paper',
             min_routeable_symbols=2,
             min_runtime_ledger_net_pnl=Decimal('500'),
+            min_runtime_ledger_trading_days=25,
+            min_runtime_ledger_daily_net_pnl=Decimal('20'),
             require_runtime_ledger_profit_proof=True,
         )
 
@@ -245,10 +253,13 @@ class TestVerifyTradingReadiness(TestCase):
                 blocked_reason='runtime_ledger_profit_proof_missing',
                 net_pnl='499.99',
                 expectancy_bps='0',
+                trading_day_count=2,
                 ledger_refs=[],
                 unbacked_refs=['window-1'],
             ),
             min_runtime_ledger_net_pnl=Decimal('500'),
+            min_runtime_ledger_trading_days=25,
+            min_runtime_ledger_daily_net_pnl=Decimal('500'),
             require_runtime_ledger_profit_proof=True,
         )
 
@@ -257,10 +268,49 @@ class TestVerifyTradingReadiness(TestCase):
             'doc29_live_scale_gate_satisfied',
             'runtime_ledger_db_refs_present',
             'runtime_ledger_unbacked_windows_empty',
+            'runtime_ledger_observed_trading_days',
             'runtime_ledger_net_pnl_target',
+            'runtime_ledger_daily_net_pnl_target',
             'runtime_ledger_post_cost_expectancy_positive',
         ):
             self.assertIn(check_name, weak['failed_checks'])
+
+    def test_runtime_ledger_profit_proof_requires_observed_days_and_daily_pnl(
+        self,
+    ) -> None:
+        short_window = evaluate_trading_readiness(
+            _ready_status(),
+            completion_status=_completion_status(
+                net_pnl='15000',
+                trading_day_count=3,
+            ),
+            min_runtime_ledger_net_pnl=Decimal('12500'),
+            min_runtime_ledger_trading_days=25,
+            min_runtime_ledger_daily_net_pnl=Decimal('500'),
+            require_runtime_ledger_profit_proof=True,
+        )
+        self.assertFalse(short_window['ok'])
+        self.assertIn(
+            'runtime_ledger_observed_trading_days',
+            short_window['failed_checks'],
+        )
+
+        weak_daily = evaluate_trading_readiness(
+            _ready_status(),
+            completion_status=_completion_status(
+                net_pnl='600',
+                trading_day_count=25,
+            ),
+            min_runtime_ledger_net_pnl=Decimal('500'),
+            min_runtime_ledger_trading_days=25,
+            min_runtime_ledger_daily_net_pnl=Decimal('500'),
+            require_runtime_ledger_profit_proof=True,
+        )
+        self.assertFalse(weak_daily['ok'])
+        self.assertIn(
+            'runtime_ledger_daily_net_pnl_target',
+            weak_daily['failed_checks'],
+        )
 
     def test_live_and_either_profiles_use_live_floor_states_and_market_window(
         self,
@@ -570,6 +620,10 @@ class TestVerifyTradingReadiness(TestCase):
                     '--require-runtime-ledger-profit-proof',
                     '--min-runtime-ledger-net-pnl',
                     '500',
+                    '--min-runtime-ledger-trading-days',
+                    '25',
+                    '--min-runtime-ledger-daily-net-pnl',
+                    '20',
                 ]
             )
 
@@ -587,6 +641,17 @@ class TestVerifyTradingReadiness(TestCase):
                         str(status_path),
                         '--require-runtime-ledger-profit-proof',
                         '--min-runtime-ledger-net-pnl',
+                        'not-a-number',
+                    ]
+                )
+
+            with self.assertRaisesRegex(SystemExit, 'daily-net-pnl must be decimal'):
+                main(
+                    [
+                        '--status-file',
+                        str(status_path),
+                        '--require-runtime-ledger-profit-proof',
+                        '--min-runtime-ledger-daily-net-pnl',
                         'not-a-number',
                     ]
                 )


### PR DESCRIPTION
## Summary

- Adds runtime-ledger observed trading-day proof to the Torghut readiness verifier.
- Adds a per-observed-trading-day post-cost net PnL floor so a large short-window total cannot satisfy a `$500/day` proof contract.
- Extends CLI flags and regression coverage for daily/window proof thresholds.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/verify_trading_readiness.py tests/test_verify_trading_readiness.py --check --config "format.quote-style='single'"`
- `uv run --frozen ruff check scripts/verify_trading_readiness.py tests/test_verify_trading_readiness.py`
- `git diff --check`
- `uv run --frozen pytest tests/test_verify_trading_readiness.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
