### PR TITLE
fix(torghut): import paper route plan from live service

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -34,7 +34,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref intraday_tsmom_v2@research \
                     --runtime-window-import \
-                    --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence \
+                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence \
                     --runtime-window-target-plan-exclusive \
                     --runtime-window-target-plan-required \
                     --runtime-window-target-plan-settlement-seconds 3600 \

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -783,7 +783,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--max-batches 1", args)
         self.assertIn("--apply", args)
 
-    def test_empirical_promotion_renewal_imports_paper_windows_from_sim_db(
+    def test_empirical_promotion_renewal_imports_live_paper_plan_from_sim_db(
         self,
     ) -> None:
         spec, container = _load_cronjob_container(
@@ -820,12 +820,12 @@ class TestLiveConfigManifestContract(TestCase):
 
         args = "\n".join(str(item) for item in container.get("args", []))
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
-        self.assertIn(
+        self.assertNotIn(
             "--runtime-window-target-plan-url "
             "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
-        self.assertNotIn(
+        self.assertIn(
             "--runtime-window-target-plan-url "
             "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,


### PR DESCRIPTION
## Summary

- Point the empirical promotion renewal CronJob at the authoritative live Torghut `/trading/paper-route-evidence` target plan.
- Keep runtime-window imports bound to the sim database via `SIM_DB_DSN` and `TORGHUT_SIM`, so the job imports paper-route fills without relying on the sim service to mirror the live target plan.
- Update the manifest contract test to fail if the CronJob regresses back to the sim-hop target-plan URL.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k empirical_promotion_renewal_imports_live_paper_plan_from_sim_db -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k 'sim_manifest_runs_paper_live_signal_profile or empirical_promotion_renewal_imports_live_paper_plan_from_sim_db' -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- Read-only cluster check: Argo `torghut` is currently `Synced Healthy Succeeded` at `1e27e8120`; live CronJob still uses the sim-hop URL, so this change is not yet deployed.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
