### PR TITLE
fix(torghut): prefer authoritative runtime evidence

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -981,6 +981,18 @@ def _runtime_ledger_selection_score(payload: Mapping[str, object] | None) -> int
     return score
 
 
+def _certificate_evidence_authority_score(
+    *,
+    observed_stage: str | None,
+    runtime_ledger_bucket: Mapping[str, object] | None,
+) -> int:
+    if observed_stage == "live":
+        return 2 if _runtime_ledger_selection_score(runtime_ledger_bucket) >= 9 else 0
+    if observed_stage == "paper":
+        return 1
+    return 0
+
+
 def _runtime_ledger_target_reason_codes(
     payload: Mapping[str, object],
     *,
@@ -1464,7 +1476,7 @@ def _certificate_evidence_selection_key(
     *,
     now: datetime | None,
     max_age_seconds: int | None,
-) -> tuple[int, int, int, int, int, int, int, Decimal, float]:
+) -> tuple[int, int, int, int, int, int, int, int, Decimal, float]:
     metric_window = cast(
         StrategyHypothesisMetricWindow | None, row.get("metric_window")
     )
@@ -1475,7 +1487,7 @@ def _certificate_evidence_selection_key(
         Mapping[str, object] | None, row.get("runtime_ledger_bucket")
     )
     if metric_window is None:
-        return (0, 0, 0, 0, 0, 0, 0, Decimal("0"), 0.0)
+        return (0, 0, 0, 0, 0, 0, 0, 0, Decimal("0"), 0.0)
 
     issued_at = _coerce_aware_datetime(
         getattr(metric_window, "window_ended_at", None)
@@ -1489,6 +1501,11 @@ def _certificate_evidence_selection_key(
         )
     observed_stage = _safe_text(getattr(metric_window, "observed_stage", None))
     stage_score = {"live": 2, "paper": 1}.get(observed_stage or "", 0)
+    runtime_ledger_score = _runtime_ledger_selection_score(runtime_ledger_bucket)
+    authority_score = _certificate_evidence_authority_score(
+        observed_stage=observed_stage,
+        runtime_ledger_bucket=runtime_ledger_bucket,
+    )
     decision_score = 0
     if promotion_decision is not None:
         decision_score = int(
@@ -1510,11 +1527,12 @@ def _certificate_evidence_selection_key(
     issued_ts = issued_at.timestamp() if issued_at is not None else 0.0
     return (
         fresh_score,
-        stage_score,
         decision_score,
         activity_score,
         continuity_score,
-        _runtime_ledger_selection_score(runtime_ledger_bucket),
+        authority_score,
+        stage_score,
+        runtime_ledger_score,
         capital_rank + sample_count,
         expectancy_bps,
         issued_ts,

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -28,6 +28,8 @@ from app.models import (
 from app.trading.hypotheses import JangarDependencyQuorumStatus
 from app.trading.submission_council import (
     _QUANT_HEALTH_CACHE,
+    _certificate_evidence_authority_score,
+    _certificate_evidence_selection_key,
     _coerce_aware_datetime,
     _load_latest_certificate_evidence,
     _load_latest_runtime_ledger_summary,
@@ -1664,6 +1666,177 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(item["candidate_id"], "cand-good")
         self.assertEqual(item["capital_stage"], "0.10x canary")
         self.assertEqual(item["reasons"], [])
+
+    def test_hypothesis_runtime_summary_keeps_paper_probation_when_newer_live_lacks_ledger(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        now = datetime.now(timezone.utc)
+        settings.trading_drift_live_promotion_max_evidence_age_seconds = 3600
+        registry = SimpleNamespace(
+            loaded=True,
+            path="test-registry",
+            errors=[],
+            items=[SimpleNamespace(hypothesis_id="H-CONT-01")],
+        )
+        runtime_items = [
+            {
+                "hypothesis_id": "H-CONT-01",
+                "candidate_id": None,
+                "strategy_id": "intraday_continuation",
+                "lane_id": "continuation",
+                "strategy_family": "intraday_continuation",
+                "state": "shadow",
+                "capital_stage": "shadow",
+                "capital_multiplier": "0",
+                "promotion_eligible": False,
+                "rollback_required": False,
+                "reasons": ["drift_checks_missing"],
+                "informational_reasons": [],
+                "observed": {},
+            }
+        ]
+
+        with session_local() as session:
+            session.add(
+                StrategyHypothesisMetricWindow(
+                    run_id="runtime-proof-paper",
+                    candidate_id="cand-paper",
+                    hypothesis_id="H-CONT-01",
+                    observed_stage="paper",
+                    window_started_at=now - timedelta(minutes=30),
+                    window_ended_at=now - timedelta(minutes=20),
+                    market_session_count=3,
+                    decision_count=42,
+                    trade_count=42,
+                    order_count=42,
+                    avg_abs_slippage_bps="4.2",
+                    slippage_budget_bps="12",
+                    post_cost_expectancy_bps="8.5",
+                    continuity_ok=True,
+                    drift_ok=True,
+                    dependency_quorum_decision="allow",
+                    capital_stage="shadow",
+                )
+            )
+            session.add(
+                StrategyPromotionDecision(
+                    run_id="runtime-proof-paper",
+                    candidate_id="cand-paper",
+                    hypothesis_id="H-CONT-01",
+                    promotion_target="paper",
+                    state="shadow",
+                    allowed=True,
+                    reason_summary="paper_runtime_evidence_thresholds_satisfied",
+                )
+            )
+            session.add(
+                StrategyHypothesisMetricWindow(
+                    run_id="runtime-proof-live-missing-ledger",
+                    candidate_id="cand-live-missing-ledger",
+                    hypothesis_id="H-CONT-01",
+                    observed_stage="live",
+                    window_started_at=now - timedelta(minutes=10),
+                    window_ended_at=now,
+                    market_session_count=3,
+                    decision_count=42,
+                    trade_count=42,
+                    order_count=42,
+                    avg_abs_slippage_bps="4.2",
+                    slippage_budget_bps="12",
+                    post_cost_expectancy_bps="8.5",
+                    continuity_ok=True,
+                    drift_ok=True,
+                    dependency_quorum_decision="allow",
+                    capital_stage="0.10x canary",
+                    payload_json={
+                        "post_cost_promotion_sample_count": 42,
+                        "post_cost_basis_counts": {
+                            "realized_strategy_pnl_after_explicit_costs": 42
+                        },
+                        "post_cost_expectancy_aggregation": "runtime_ledger_notional_weighted",
+                        "runtime_ledger_notional_weighted_sample_count": 42,
+                    },
+                )
+            )
+            session.add(
+                StrategyPromotionDecision(
+                    run_id="runtime-proof-live-missing-ledger",
+                    candidate_id="cand-live-missing-ledger",
+                    hypothesis_id="H-CONT-01",
+                    promotion_target="live",
+                    state="0.10x canary",
+                    allowed=True,
+                    reason_summary="runtime_evidence_thresholds_satisfied",
+                )
+            )
+            session.commit()
+
+            with (
+                patch(
+                    "app.trading.submission_council.load_hypothesis_registry",
+                    return_value=registry,
+                ),
+                patch(
+                    "app.trading.submission_council.resolve_hypothesis_dependency_quorum",
+                    return_value=JangarDependencyQuorumStatus(
+                        decision="allow",
+                        reasons=[],
+                        message="ready",
+                    ),
+                ),
+                patch(
+                    "app.trading.submission_council.compile_hypothesis_runtime_statuses",
+                    return_value=runtime_items,
+                ),
+                patch(
+                    "app.trading.submission_council.build_tca_gate_inputs",
+                    return_value={},
+                ),
+            ):
+                result = build_hypothesis_runtime_summary(
+                    session,
+                    state=SimpleNamespace(market_session_open=True),
+                    market_context_status={"last_freshness_seconds": 10},
+                )
+
+        self.assertEqual(result["promotion_eligible_total"], 0)
+        self.assertEqual(result["paper_probation_eligible_total"], 1)
+        item = result["items"][0]
+        self.assertEqual(item["candidate_id"], "cand-paper")
+        self.assertFalse(item["promotion_eligible"])
+        self.assertTrue(item["paper_probation_eligible"])
+        self.assertEqual(item["reasons"], ["paper_probation_evidence_collection_only"])
+        self.assertNotIn(
+            "runtime_ledger_proof_missing",
+            item["observed"].get("runtime_window_rejection_reasons", []),
+        )
+
+    def test_certificate_evidence_selection_key_handles_unknown_or_missing_window(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _certificate_evidence_authority_score(
+                observed_stage="shadow",
+                runtime_ledger_bucket=None,
+            ),
+            0,
+        )
+        self.assertEqual(
+            _certificate_evidence_selection_key(
+                {},
+                now=datetime.now(timezone.utc),
+                max_age_seconds=3600,
+            ),
+            (0, 0, 0, 0, 0, 0, 0, 0, Decimal("0"), 0.0),
+        )
 
     def test_build_live_submission_gate_payload_rescues_stale_summary_with_session_live_runtime_evidence(
         self,


### PR DESCRIPTION
## Summary

- Prefer certificate evidence with real stage authority before raw live/paper stage rank.
- Keep valid paper-probation evidence visible when a newer live window lacks runtime-ledger authority.
- Add regression coverage for the hidden paper-probation target failure mode.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_submission_council.py -k 'prefers_stronger_runtime_certificate_candidate or keeps_paper_probation_when_newer_live_lacks_ledger' -q`
- `uv run --frozen pytest tests/test_submission_council.py -q`
- `uv run --frozen pytest tests/test_trading_api.py -k 'hypothesis_runtime_payload_uses_certificate_evidence_merge or trading_paper_route_evidence' -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'runtime_summary or runtime_window_certificate or paper_probation' -q`
- `uv run --frozen ruff format --check app/trading/submission_council.py tests/test_submission_council.py`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
