### PR TITLE
fix(torghut): scope paper route ledger evidence

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -790,6 +790,10 @@ def _runtime_ledger_summary(
     *,
     hypothesis_id: str | None,
     candidate_id: str | None,
+    observed_stage: str | None,
+    account_label: str | None,
+    strategy_name: str | None,
+    strategy_family: str | None,
     window_start: datetime,
     window_end: datetime,
 ) -> dict[str, object]:
@@ -805,6 +809,16 @@ def _runtime_ledger_summary(
     )
     stmt = stmt.where(StrategyRuntimeLedgerBucket.bucket_started_at <= window_end)
     stmt = stmt.where(StrategyRuntimeLedgerBucket.bucket_ended_at >= window_start)
+    if observed_stage:
+        stmt = stmt.where(StrategyRuntimeLedgerBucket.observed_stage == observed_stage)
+    if account_label:
+        stmt = stmt.where(StrategyRuntimeLedgerBucket.account_label == account_label)
+    if strategy_name:
+        stmt = stmt.where(
+            StrategyRuntimeLedgerBucket.runtime_strategy_name == strategy_name
+        )
+    if strategy_family:
+        stmt = stmt.where(StrategyRuntimeLedgerBucket.strategy_family == strategy_family)
     rows = list(session.execute(stmt.limit(50)).scalars())
     filled_notional = sum((row.filled_notional for row in rows), Decimal("0"))
     net_pnl = sum((row.net_strategy_pnl_after_costs for row in rows), Decimal("0"))
@@ -831,6 +845,14 @@ def _runtime_ledger_summary(
             if filled_notional > 0
             else Decimal("0")
         ),
+        "filters": {
+            "hypothesis_id": hypothesis_id,
+            "candidate_id": candidate_id,
+            "observed_stage": observed_stage,
+            "account_label": account_label,
+            "strategy_name": strategy_name,
+            "strategy_family": strategy_family,
+        },
         "latest_bucket_ended_at": _isoformat(rows[0].bucket_ended_at if rows else None),
         "db_row_refs": [str(row.id) for row in rows],
         "blockers": sorted(
@@ -1005,6 +1027,10 @@ def _target_audit(
         session,
         hypothesis_id=hypothesis_id,
         candidate_id=candidate_id,
+        observed_stage=cast(str | None, target.get("observed_stage")),
+        account_label=cast(str | None, target.get("account_label")),
+        strategy_name=cast(str | None, target.get("strategy_name")),
+        strategy_family=cast(str | None, target.get("strategy_family")),
         window_start=window_start,
         window_end=window_end,
     )

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -923,3 +923,115 @@ class TestPaperRouteEvidenceAudit(TestCase):
             payload["summary"]["promotion_authority"]["reason"],
             "paper_route_evidence_audit_observability_only",
         )
+
+    def test_runtime_ledger_summary_is_scoped_to_target_stage_account_and_strategy(
+        self,
+    ) -> None:
+        now = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        window_start = now - timedelta(hours=6)
+        strategy_name = "paper-route-scoped-ledger"
+        with Session(self.engine) as session:
+            for suffix, observed_stage, account_label, runtime_strategy_name in (
+                ("wrong-stage", "live", "paper", strategy_name),
+                ("wrong-account", "paper", "other-paper", strategy_name),
+                ("wrong-strategy", "paper", "paper", "different-paper-route"),
+            ):
+                session.add(
+                    StrategyRuntimeLedgerBucket(
+                        run_id=f"paper-route-{suffix}",
+                        candidate_id="candidate-scoped-ledger",
+                        hypothesis_id="H-SCOPED-LEDGER",
+                        observed_stage=observed_stage,
+                        bucket_started_at=window_start,
+                        bucket_ended_at=now,
+                        account_label=account_label,
+                        runtime_strategy_name=runtime_strategy_name,
+                        strategy_family="microbar_pairs",
+                        fill_count=2,
+                        decision_count=1,
+                        submitted_order_count=1,
+                        closed_trade_count=1,
+                        open_position_count=0,
+                        filled_notional=Decimal("200"),
+                        gross_strategy_pnl=Decimal("12"),
+                        cost_amount=Decimal("2"),
+                        net_strategy_pnl_after_costs=Decimal("10"),
+                        post_cost_expectancy_bps=Decimal("500"),
+                        ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={"policy-a": 1},
+                        cost_model_hash_counts={"cost-a": 1},
+                        lineage_hash_counts={"lineage-a": 1},
+                        blockers_json=[],
+                    )
+                )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-SCOPED-LEDGER",
+                                "candidate_id": "candidate-scoped-ledger",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": strategy_name,
+                                "account_label": "paper",
+                                "window_start": window_start.isoformat(),
+                                "window_end": now.isoformat(),
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": [],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": False,
+                        "next_session_max_notional": "25",
+                        "eligible_symbol_count": 1,
+                        "blocking_reasons": ["market_session_closed"],
+                    },
+                },
+                generated_at=now,
+            )
+
+        runtime_ledger = payload["targets"][0]["runtime_ledger"]
+        self.assertEqual(
+            runtime_ledger["filters"],
+            {
+                "hypothesis_id": "H-SCOPED-LEDGER",
+                "candidate_id": "candidate-scoped-ledger",
+                "observed_stage": "paper",
+                "account_label": "paper",
+                "strategy_name": strategy_name,
+                "strategy_family": "microbar_pairs",
+            },
+        )
+        self.assertEqual(runtime_ledger["bucket_count"], 0)
+        self.assertEqual(runtime_ledger["evidence_grade_bucket_count"], 0)
+        self.assertIn(
+            "runtime_ledger_bucket_missing",
+            payload["targets"][0]["readiness"]["evidence_collection_blockers"],
+        )
+        self.assertIn(
+            "runtime_ledger_evidence_grade_bucket_missing",
+            payload["targets"][0]["readiness"]["evidence_collection_blockers"],
+        )


### PR DESCRIPTION
## Summary

- Scope paper-route runtime-ledger evidence lookup to the target's observed stage, account label, runtime strategy name, and strategy family.
- Expose the runtime-ledger filters in the audit payload so proof reviewers can see which identity constrained each bucket query.
- Add a regression that wrong-stage, wrong-account, and wrong-strategy buckets cannot satisfy a paper-route target.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_verify_trading_readiness.py tests/test_run_empirical_promotion_jobs.py -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
