### PR TITLE
fix(torghut): fail closed runtime window proof gates

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -330,15 +330,34 @@ def _paper_route_probe_symbols(probe: Mapping[str, object]) -> list[str]:
     return symbols
 
 
-def _target_probe_symbols(
-    target: Mapping[str, object],
-    probe: Mapping[str, object],
-) -> list[str]:
+def _declared_target_probe_symbols(target: Mapping[str, object]) -> list[str]:
     symbols: list[str] = []
     for item in _as_sequence(target.get("paper_route_probe_symbols")):
         symbol = str(item).strip().upper()
         if symbol and symbol not in symbols:
             symbols.append(symbol)
+    return symbols
+
+
+def _target_uses_current_probe_scope(target: Mapping[str, object]) -> bool:
+    source_kind = _safe_text(target.get("source_kind"))
+    handoff = _safe_text(target.get("handoff"))
+    return (
+        source_kind == "paper_route_probe_runtime_observed"
+        or handoff == "next_paper_route_runtime_window_import"
+        or bool(_as_mapping(target.get("paper_route_runtime_import_handoff")))
+    )
+
+
+def _target_probe_symbols(
+    target: Mapping[str, object],
+    probe: Mapping[str, object],
+) -> list[str]:
+    symbols = _declared_target_probe_symbols(target)
+    if _target_uses_current_probe_scope(target):
+        for symbol in _paper_route_probe_symbols(probe):
+            if symbol not in symbols:
+                symbols.append(symbol)
     if symbols:
         return symbols
     return _paper_route_probe_symbols(probe)
@@ -351,7 +370,11 @@ def _next_session_probe_notional(probe: Mapping[str, object]) -> str:
     return _decimal_text(probe.get("effective_max_notional"))
 
 
-def _target_identity(target: Mapping[str, Any]) -> dict[str, object]:
+def _target_identity(
+    target: Mapping[str, Any],
+    *,
+    probe: Mapping[str, object],
+) -> dict[str, object]:
     source_promotion_allowed = bool(target.get("promotion_allowed"))
     source_final_promotion_allowed = bool(
         target.get("final_promotion_allowed")
@@ -370,11 +393,7 @@ def _target_identity(target: Mapping[str, Any]) -> dict[str, object]:
         "dataset_snapshot_ref": _safe_text(target.get("dataset_snapshot_ref")),
         "window_start": _safe_text(target.get("window_start")),
         "window_end": _safe_text(target.get("window_end")),
-        "paper_route_probe_symbols": [
-            str(item).strip()
-            for item in _as_sequence(target.get("paper_route_probe_symbols"))
-            if str(item).strip()
-        ],
+        "paper_route_probe_symbols": _target_probe_symbols(target, probe),
         "runtime_ledger_bucket_ref": _safe_text(
             target.get("runtime_ledger_bucket_ref")
         ),
@@ -1007,7 +1026,7 @@ def _target_audit(
     generated_at: datetime,
     lookback_hours: int,
 ) -> dict[str, object]:
-    target = _target_identity(raw_target)
+    target = _target_identity(raw_target, probe=probe)
     window_start, window_end = _target_window(
         target,
         generated_at=generated_at,

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -644,6 +644,9 @@ def _runtime_promotion_blocking_reasons(
     average_slippage: Decimal,
     average_post_cost: Decimal,
     latest_three_budget_ok: bool,
+    all_continuity_ok: bool,
+    all_drift_ok: bool,
+    dependency_quorum_allowed: bool,
     manifest: HypothesisManifest,
     budget: Decimal,
 ) -> list[str]:
@@ -664,6 +667,12 @@ def _runtime_promotion_blocking_reasons(
         reasons.append("slippage_budget_exceeded")
     if not latest_three_budget_ok:
         reasons.append("recent_slippage_budget_exceeded")
+    if not all_continuity_ok:
+        reasons.append("evidence_continuity_not_ok")
+    if not all_drift_ok:
+        reasons.append("drift_checks_not_ok")
+    if not dependency_quorum_allowed:
+        reasons.append("dependency_quorum_not_allow")
     if total_post_cost_promotion_sample_count <= 0:
         reasons.append("post_cost_pnl_basis_missing")
     if (
@@ -1103,6 +1112,22 @@ def persist_observed_runtime_windows(
         if sorted_buckets
         else False
     )
+    all_continuity_ok = (
+        all(bucket.continuity_ok for bucket in sorted_buckets)
+        if sorted_buckets
+        else False
+    )
+    all_drift_ok = (
+        all(bucket.drift_ok for bucket in sorted_buckets) if sorted_buckets else False
+    )
+    dependency_quorum_allowed = (
+        all(
+            str(bucket.dependency_quorum_decision or "").strip().lower() == "allow"
+            for bucket in sorted_buckets
+        )
+        if sorted_buckets
+        else False
+    )
     (
         runtime_ledger_average_post_cost,
         runtime_ledger_net_strategy_pnl_after_costs,
@@ -1140,6 +1165,9 @@ def persist_observed_runtime_windows(
         average_slippage=average_slippage,
         average_post_cost=average_post_cost,
         latest_three_budget_ok=latest_three_budget_ok,
+        all_continuity_ok=all_continuity_ok,
+        all_drift_ok=all_drift_ok,
+        dependency_quorum_allowed=dependency_quorum_allowed,
         manifest=manifest,
         budget=budget,
     )

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -38,6 +38,9 @@ EXECUTION_ELIGIBLE_DECISION_STATUSES = (
     "partially_filled",
 )
 POST_COST_BASIS_RUNTIME_LEDGER = POST_COST_PNL_BASIS
+POST_COST_BASIS_EXECUTION_RECONSTRUCTION = (
+    "execution_reconstructed_pnl_after_explicit_costs"
+)
 POST_COST_BASIS_SIMULATION_REPORT = "simulation_report_net_pnl"
 POST_COST_BASIS_TCA_PROXY = "tca_shortfall_proxy"
 RUNTIME_LEDGER_ARTIFACT_SCHEMAS = frozenset(
@@ -90,9 +93,9 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument("--delay-adjusted-depth-stress-report-ref", default="")
-    parser.add_argument("--dependency-quorum-decision", default="allow")
-    parser.add_argument("--continuity-ok", default="true")
-    parser.add_argument("--drift-ok", default="true")
+    parser.add_argument("--dependency-quorum-decision", default="")
+    parser.add_argument("--continuity-ok", default="")
+    parser.add_argument("--drift-ok", default="")
     parser.add_argument("--json", action="store_true")
     return parser.parse_args()
 
@@ -738,12 +741,24 @@ def _build_realized_strategy_pnl_rows(
     ):
         if bucket.closed_trade_count <= 0 and not bucket.blockers:
             continue
-        realized_rows.append(
-            _runtime_ledger_tca_row_from_bucket(
-                bucket=bucket,
-                computed_at=unique_times[-1],
-            )
+        row = _runtime_ledger_tca_row_from_bucket(
+            bucket=bucket,
+            computed_at=unique_times[-1],
         )
+        row["post_cost_expectancy_basis"] = POST_COST_BASIS_EXECUTION_RECONSTRUCTION
+        row["post_cost_promotion_eligible"] = False
+        row["promotion_blocker"] = "execution_reconstruction_not_runtime_ledger_proof"
+        blockers = list(row.get("runtime_ledger_blockers") or [])
+        if "execution_reconstruction_not_runtime_ledger_proof" not in blockers:
+            blockers.append("execution_reconstruction_not_runtime_ledger_proof")
+        row["runtime_ledger_blockers"] = blockers
+        bucket_payload = row.get("runtime_ledger_bucket")
+        if isinstance(bucket_payload, Mapping):
+            bucket_payload = dict(bucket_payload)
+            bucket_payload["blockers"] = blockers
+            bucket_payload["pnl_basis"] = POST_COST_BASIS_EXECUTION_RECONSTRUCTION
+            row["runtime_ledger_bucket"] = bucket_payload
+        realized_rows.append(row)
     return realized_rows
 
 
@@ -1609,7 +1624,7 @@ def main() -> int:
         tca_rows=tca_rows,
         continuity_ok=_flag(args.continuity_ok),
         drift_ok=_flag(args.drift_ok),
-        dependency_quorum_decision=args.dependency_quorum_decision.strip() or "allow",
+        dependency_quorum_decision=args.dependency_quorum_decision.strip() or "missing",
     )
     evidence_provenance = (
         "paper_runtime_observed"

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -245,6 +245,9 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--runtime-window-source-kind", default="paper_runtime_observed"
     )
+    parser.add_argument("--runtime-window-dependency-quorum-decision", default="")
+    parser.add_argument("--runtime-window-continuity-ok", default="")
+    parser.add_argument("--runtime-window-drift-ok", default="")
     parser.add_argument("--json", action="store_true")
     return parser.parse_args()
 
@@ -367,6 +370,9 @@ class RuntimeWindowImportTarget:
     source_manifest_ref: str
     source_kind: str
     delay_adjusted_depth_stress_report_ref: str
+    dependency_quorum_decision: str = ""
+    continuity_ok: str = ""
+    drift_ok: str = ""
     window_start: str = ""
     window_end: str = ""
     artifact_refs: tuple[str, ...] = ()
@@ -571,6 +577,15 @@ def _registry_runtime_window_targets(
                 ).strip()
                 or "paper_runtime_observed",
                 delay_adjusted_depth_stress_report_ref="",
+                dependency_quorum_decision=str(
+                    getattr(args, "runtime_window_dependency_quorum_decision", "") or ""
+                ).strip(),
+                continuity_ok=str(
+                    getattr(args, "runtime_window_continuity_ok", "") or ""
+                ).strip(),
+                drift_ok=str(
+                    getattr(args, "runtime_window_drift_ok", "") or ""
+                ).strip(),
                 window_start="",
                 window_end="",
             )
@@ -684,6 +699,12 @@ def _runtime_window_targets_from_plan(
                 "delay_adjusted_depth_stress_report_ref",
                 "runtime_window_delay_adjusted_depth_stress_report_ref",
             ),
+            dependency_quorum_decision=value(
+                "dependency_quorum_decision",
+                "runtime_window_dependency_quorum_decision",
+            ),
+            continuity_ok=value("continuity_ok", "runtime_window_continuity_ok"),
+            drift_ok=value("drift_ok", "runtime_window_drift_ok"),
             window_start=str(payload.get("window_start") or "").strip(),
             window_end=str(payload.get("window_end") or "").strip(),
             artifact_refs=_runtime_window_target_artifact_refs(payload),
@@ -1278,15 +1299,46 @@ def _runtime_window_import_payload_proof_blockers(
         reasons = _as_text_list(payload.get("promotion_blocking_reasons"))
         for reason in reasons or ["runtime_window_import_not_promotion_allowed"]:
             add_blocker(reason)
+    elif "promotion_allowed" not in payload:
+        legacy_decision = _as_text(payload.get("promotion_decision"))
+        if legacy_decision is not None and legacy_decision.lower() != "allowed":
+            add_blocker("runtime_window_import_promotion_decision_not_allowed")
+        else:
+            add_blocker("runtime_window_import_promotion_allowed_missing")
 
     runtime_observation = _as_dict(payload.get("runtime_observation"))
-    if runtime_observation.get("authoritative") is False:
+    if not runtime_observation:
+        add_blocker("runtime_observation_missing")
+    elif runtime_observation.get("authoritative") is not True:
         add_blocker(
             _as_text(runtime_observation.get("authority_reason"))
             or "runtime_observation_not_authoritative"
         )
 
     return blockers
+
+
+def _runtime_window_import_health_gate_args(
+    *,
+    target: RuntimeWindowImportTarget,
+    runtime_manifest: Mapping[str, Any],
+) -> tuple[str, str, str]:
+    dependency_quorum_decision = (
+        _as_text(target.dependency_quorum_decision)
+        or _as_text(runtime_manifest.get("dependency_quorum_decision"))
+        or "missing"
+    )
+    continuity_ok = (
+        _as_text(target.continuity_ok)
+        or _as_text(runtime_manifest.get("continuity_ok"))
+        or "false"
+    )
+    drift_ok = (
+        _as_text(target.drift_ok)
+        or _as_text(runtime_manifest.get("drift_ok"))
+        or "false"
+    )
+    return dependency_quorum_decision, continuity_ok, drift_ok
 
 
 def _run_runtime_window_import_target(
@@ -1386,6 +1438,12 @@ def _run_runtime_window_import_target(
                 runtime_manifest=runtime_manifest,
             )
         )
+    dependency_quorum_decision, continuity_ok, drift_ok = (
+        _runtime_window_import_health_gate_args(
+            target=target,
+            runtime_manifest=runtime_manifest,
+        )
+    )
     command = [
         sys.executable,
         "scripts/import_hypothesis_runtime_windows.py",
@@ -1420,11 +1478,11 @@ def _run_runtime_window_import_target(
         "--artifact-ref",
         str(manifest_path),
         "--dependency-quorum-decision",
-        "allow",
+        dependency_quorum_decision,
         "--continuity-ok",
-        "true",
+        continuity_ok,
         "--drift-ok",
-        "true",
+        drift_ok,
         "--json",
     ]
     for artifact_ref in target.artifact_refs:

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -16,6 +16,7 @@ from sqlalchemy.pool import StaticPool
 from app.models import Base, StrategyRuntimeLedgerBucket
 from scripts.import_hypothesis_runtime_windows import (
     EXECUTION_ELIGIBLE_DECISION_STATUSES,
+    POST_COST_BASIS_EXECUTION_RECONSTRUCTION,
     POST_COST_BASIS_RUNTIME_LEDGER,
     POST_COST_BASIS_SIMULATION_REPORT,
     POST_COST_BASIS_TCA_PROXY,
@@ -794,9 +795,13 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(
             rows[0]["post_cost_expectancy_basis"],
-            POST_COST_BASIS_RUNTIME_LEDGER,
+            POST_COST_BASIS_EXECUTION_RECONSTRUCTION,
         )
-        self.assertEqual(rows[0]["post_cost_promotion_eligible"], True)
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
+        self.assertEqual(
+            rows[0]["promotion_blocker"],
+            "execution_reconstruction_not_runtime_ledger_proof",
+        )
         self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.70"))
         self.assertEqual(
             rows[0]["post_cost_expectancy_bps"],
@@ -864,12 +869,16 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
 
         self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0]["post_cost_promotion_eligible"], True)
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
         self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.70"))
         bucket = rows[0]["runtime_ledger_bucket"]
         self.assertIsInstance(bucket, dict)
         assert isinstance(bucket, dict)
-        self.assertEqual(bucket["blockers"], [])
+        self.assertEqual(
+            bucket["blockers"],
+            ["execution_reconstruction_not_runtime_ledger_proof"],
+        )
+        self.assertEqual(bucket["pnl_basis"], POST_COST_BASIS_EXECUTION_RECONSTRUCTION)
         self.assertGreaterEqual(len(bucket["execution_policy_hash_counts"]), 1)
         self.assertGreaterEqual(len(bucket["cost_model_hash_counts"]), 1)
         self.assertGreaterEqual(len(bucket["lineage_hash_counts"]), 1)
@@ -901,6 +910,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
         self.assertIsNone(rows[0]["post_cost_expectancy_bps"])
+        self.assertEqual(
+            rows[0]["post_cost_expectancy_basis"],
+            POST_COST_BASIS_EXECUTION_RECONSTRUCTION,
+        )
+        self.assertIn(
+            "execution_reconstruction_not_runtime_ledger_proof",
+            rows[0]["runtime_ledger_blockers"],
+        )
         self.assertIn("explicit_cost_missing", rows[0]["runtime_ledger_blockers"])
         self.assertIn("cost_basis_missing", rows[0]["runtime_ledger_blockers"])
 

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -557,6 +557,138 @@ class TestPaperRouteEvidenceAudit(TestCase):
             payload["targets"][0]["readiness"]["evidence_collection_blockers"],
         )
 
+    def test_current_paper_route_probe_symbols_extend_next_window_target_scope(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        strategy_name = "next-window-paper-route-symbol-refresh"
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="paper route source activity from refreshed probe symbols",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN", "INTC"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="paper",
+                symbol="INTC",
+                timeframe="1Min",
+                decision_json={"action": "buy", "qty": "1"},
+                rationale="refreshed probe symbol fixture",
+                status="executed",
+                created_at=window_start + timedelta(minutes=5),
+                executed_at=window_start + timedelta(minutes=6),
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="paper",
+                alpaca_order_id="refreshed-probe-order-1",
+                client_order_id="refreshed-probe-client-1",
+                symbol="INTC",
+                side="buy",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=window_start + timedelta(minutes=6),
+                updated_at=window_start + timedelta(minutes=6),
+                last_update_at=window_start + timedelta(minutes=6),
+            )
+            session.add(execution)
+            session.flush()
+            session.add(
+                ExecutionTCAMetric(
+                    execution_id=execution.id,
+                    trade_decision_id=decision.id,
+                    strategy_id=strategy.id,
+                    alpaca_account_label="paper",
+                    symbol="INTC",
+                    side="buy",
+                    arrival_price=Decimal("99"),
+                    avg_fill_price=Decimal("100"),
+                    filled_qty=Decimal("1"),
+                    signed_qty=Decimal("1"),
+                    slippage_bps=Decimal("5"),
+                    shortfall_notional=Decimal("1"),
+                    realized_shortfall_bps=Decimal("5"),
+                    churn_qty=Decimal("0"),
+                    churn_ratio=Decimal("0"),
+                    computed_at=window_start + timedelta(minutes=7),
+                    created_at=window_start + timedelta(minutes=7),
+                    updated_at=window_start + timedelta(minutes=7),
+                )
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": True,
+                    "reason": "non_live_mode",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-REFRESHED-PROBE",
+                                "candidate_id": "candidate-refreshed-probe",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": strategy_name,
+                                "account_label": "paper",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": False,
+                        "next_session_max_notional": "25",
+                        "eligible_symbol_count": 3,
+                        "eligible_symbols": ["AMZN", "AAPL", "INTC"],
+                        "active_symbols": [],
+                        "blocking_reasons": ["market_session_closed"],
+                    },
+                },
+                generated_at=window_start - timedelta(days=2),
+            )
+
+        target = payload["targets"][0]["target"]
+        source_activity = payload["targets"][0]["source_activity"]
+        self.assertEqual(target["paper_route_probe_symbols"], ["AAPL", "AMZN", "INTC"])
+        self.assertEqual(source_activity["symbols"], ["AAPL", "AMZN", "INTC"])
+        self.assertFalse(source_activity["missing"])
+        self.assertEqual(source_activity["decision_count"], 1)
+        self.assertEqual(source_activity["execution_count"], 1)
+        self.assertEqual(source_activity["filled_execution_count"], 1)
+        self.assertEqual(source_activity["tca_sample_count"], 1)
+
     def test_source_activity_is_scoped_to_target_account_and_probe_symbols(
         self,
     ) -> None:

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -1989,8 +1989,17 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertIsNotNone(payload)
         assert payload is not None
         self.assertEqual(payload["target_count"], 2)
-        self.assertEqual(payload["proof_status"], "ok")
-        self.assertEqual(payload["proof_blockers"], [])
+        self.assertEqual(payload["proof_status"], "blocked")
+        blocker_codes = [item["blocker"] for item in payload["proof_blockers"]]
+        self.assertEqual(
+            blocker_codes,
+            [
+                "runtime_window_import_promotion_decision_not_allowed",
+                "runtime_observation_missing",
+                "runtime_window_import_promotion_decision_not_allowed",
+                "runtime_observation_missing",
+            ],
+        )
         self.assertEqual(
             [item["hypothesis_id"] for item in payload["imports"]],
             ["H-TSMOM-01", "H-MICRO-01"],
@@ -2004,6 +2013,9 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertIn("torghut-chip-full-day-20260505-4c330ce9-r1", joined)
         self.assertIn("--delay-adjusted-depth-stress-report-ref", joined)
         self.assertIn("/proof/h-micro-delay-depth.json", joined)
+        self.assertIn("--dependency-quorum-decision missing", joined)
+        self.assertIn("--continuity-ok false", joined)
+        self.assertIn("--drift-ok false", joined)
 
     def test_runtime_window_import_uses_latest_source_activity_window_when_unpinned(
         self,
@@ -2961,13 +2973,16 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertIsNotNone(payload)
         assert payload is not None
         self.assertEqual(payload["proof_status"], "blocked")
-        self.assertEqual(
-            payload["proof_blockers"][0]["blocker"],
-            "delay_adjusted_depth_stress_report_ref_missing",
+        blocker_codes = [item["blocker"] for item in payload["proof_blockers"]]
+        self.assertIn("delay_adjusted_depth_stress_report_ref_missing", blocker_codes)
+        self.assertIn(
+            "runtime_window_import_promotion_decision_not_allowed",
+            blocker_codes,
         )
+        self.assertIn("runtime_observation_missing", blocker_codes)
         self.assertEqual(
             [item["proof_status"] for item in payload["imports"]],
-            ["ok", "blocked"],
+            ["blocked", "blocked"],
         )
 
     def test_runtime_window_import_reports_missing_required_delay_depth_ref(

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -682,6 +682,60 @@ class TestRuntimeWindowImport(TestCase):
             decision.payload_json["runtime_ledger_filled_notional"], "10100"
         )
 
+    def test_persist_observed_runtime_windows_blocks_missing_health_gate_evidence(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    6,
+                )
+            ],
+            decision_times=[datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+            execution_times=[datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("1"),
+                    "post_cost_expectancy_bps": Decimal("40"),
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(),
+                    **_runtime_pnl_basis(),
+                }
+            ],
+            continuity_ok=False,
+            drift_ok=False,
+            dependency_quorum_decision="missing",
+        )
+
+        with self.session_local() as session:
+            summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-live-health-gates",
+                candidate_id="cand-health-gates",
+                hypothesis_id="H-CONT-01",
+                observed_stage="live",
+                strategy_family="intraday_continuation",
+                source_manifest_ref="config/trading/hypotheses/h-cont-01.json",
+                buckets=buckets,
+                runtime_observation_payload={
+                    "dataset_snapshot_ref": "torghut-runtime-window-health-gates",
+                    "source_kind": "live_runtime_observed",
+                },
+            )
+
+        self.assertFalse(summary["promotion_allowed"])
+        self.assertIn(
+            "evidence_continuity_not_ok",
+            summary["promotion_blocking_reasons"],
+        )
+        self.assertIn("drift_checks_not_ok", summary["promotion_blocking_reasons"])
+        self.assertIn(
+            "dependency_quorum_not_allow",
+            summary["promotion_blocking_reasons"],
+        )
+
     def test_persist_observed_runtime_windows_does_not_promote_bucket_early(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Fail closed runtime-window renewal proof when child import payloads are legacy, missing `promotion_allowed`, missing runtime observation authority, or explicitly blocked.
- Stop defaulting runtime-window import health gates to pass; missing continuity, drift, or dependency quorum evidence now stays false/missing and blocks promotion.
- Quarantine execution-reconstructed PnL rows as diagnostic evidence instead of runtime-ledger promotion proof.
- Extend current paper-route probe symbols into next-window paper-route target audits so source-activity checks follow the active probe scope.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_import_hypothesis_runtime_windows.py tests/test_run_empirical_promotion_jobs.py tests/test_runtime_window_import.py -q` (`126 passed`)
- `uv run --frozen ruff check app/trading/paper_route_evidence.py app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_import_hypothesis_runtime_windows.py tests/test_run_empirical_promotion_jobs.py tests/test_runtime_window_import.py`
- `git diff --check origin/main...HEAD`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
