### PR TITLE
fix(torghut): import paper route plan from sim service

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -34,7 +34,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref intraday_tsmom_v2@research \
                     --runtime-window-import \
-                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence \
+                    --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence \
                     --runtime-window-target-plan-exclusive \
                     --runtime-window-target-plan-required \
                     --runtime-window-target-plan-settlement-seconds 3600 \

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -783,7 +783,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--max-batches 1", args)
         self.assertIn("--apply", args)
 
-    def test_empirical_promotion_renewal_imports_live_paper_plan_from_sim_db(
+    def test_empirical_promotion_renewal_imports_live_paper_plan_from_sim_service_and_db(
         self,
     ) -> None:
         spec, container = _load_cronjob_container(
@@ -820,12 +820,12 @@ class TestLiveConfigManifestContract(TestCase):
 
         args = "\n".join(str(item) for item in container.get("args", []))
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
-        self.assertNotIn(
+        self.assertIn(
             "--runtime-window-target-plan-url "
             "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
-        self.assertIn(
+        self.assertNotIn(
             "--runtime-window-target-plan-url "
             "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,


### PR DESCRIPTION
## Summary

- Point `torghut-empirical-promotion-renewal` at the paper/sim Torghut service for `/trading/paper-route-evidence`.
- Keep the runtime-window import destination on `TORGHUT_SIM` / `SIM_DB_DSN` while sourcing the target plan from the service that actually exposes the paper-route probe symbols.
- Update the manifest contract test so this cannot drift back to the live service plan source.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k 'empirical_promotion_renewal_imports_live_paper_plan_from_sim_service_and_db or sim_manifest_runs_paper_live_signal_profile' -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py -k 'empirical_promotion_renewal_imports_live_paper_plan_from_sim_service_and_db or paper_route or runtime_window_target_plan' -q`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
