### PR TITLE
fix(torghut): import source runtime ledger buckets

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -36,6 +36,11 @@ PROMOTION_GRADE_POST_COST_BASES = frozenset(
         "realized_strategy_pnl_after_explicit_costs",
     }
 )
+_RUNTIME_LEDGER_PROOF_SATISFIED_METADATA_BLOCKERS = frozenset(
+    {
+        "paper_route_runtime_ledger_import_pending",
+    }
+)
 RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
     {
         EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
@@ -298,12 +303,26 @@ def _runtime_ledger_post_cost_from_rows(
 
 def _paper_probation_blocking_reasons(runtime_payload: Mapping[str, Any]) -> list[str]:
     target_metadata = _mapping(runtime_payload.get("target_metadata"))
+    runtime_ledger_import_satisfied = (
+        runtime_payload.get("runtime_ledger_profit_proof_present") is True
+    )
+
+    def target_blockers(value: Any) -> list[str]:
+        blockers = _string_list(value)
+        if not runtime_ledger_import_satisfied:
+            return blockers
+        return [
+            blocker
+            for blocker in blockers
+            if blocker not in _RUNTIME_LEDGER_PROOF_SATISFIED_METADATA_BLOCKERS
+        ]
+
     reasons: list[str] = []
     reasons.extend(
-        _string_list(runtime_payload.get("runtime_ledger_target_metadata_blockers"))
+        target_blockers(runtime_payload.get("runtime_ledger_target_metadata_blockers"))
     )
     reasons.extend(
-        _string_list(target_metadata.get("runtime_ledger_target_metadata_blockers"))
+        target_blockers(target_metadata.get("runtime_ledger_target_metadata_blockers"))
     )
     if not target_metadata:
         return list(dict.fromkeys(reasons))

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -1165,6 +1165,45 @@ def _runtime_ledger_tca_row_from_payload(
     }
 
 
+def _runtime_ledger_bucket_metadata(
+    *,
+    prefix: str,
+    payloads: Sequence[Mapping[str, object]],
+    tca_rows: Sequence[Mapping[str, object]],
+) -> dict[str, Any]:
+    candidate_ids = sorted(
+        {
+            candidate_id
+            for payload in payloads
+            if (candidate_id := _text_or_none(payload.get("candidate_id"))) is not None
+        }
+    )
+    metadata: dict[str, Any] = {
+        f"runtime_ledger_{prefix}_bucket_count": len(payloads),
+        f"runtime_ledger_{prefix}_bucket_run_ids": sorted(
+            {
+                run_id
+                for payload in payloads
+                if (run_id := _text_or_none(payload.get("run_id"))) is not None
+            }
+        ),
+        f"runtime_ledger_{prefix}_bucket_fill_count": sum(
+            _nonnegative_int(payload.get("fill_count")) for payload in payloads
+        ),
+        f"runtime_ledger_{prefix}_bucket_tca_row_count": len(tca_rows),
+        f"runtime_ledger_{prefix}_bucket_profit_proof_count": sum(
+            1
+            for payload in payloads
+            if _runtime_ledger_bucket_profit_proof_present(payload)
+        ),
+    }
+    if candidate_ids:
+        metadata[f"runtime_ledger_{prefix}_bucket_candidate_ids"] = candidate_ids
+    if len(candidate_ids) == 1:
+        metadata[f"runtime_ledger_{prefix}_bucket_candidate_id"] = candidate_ids[0]
+    return metadata
+
+
 def _runtime_ledger_tca_rows_from_durable_buckets(
     *,
     session: Session,
@@ -1204,26 +1243,135 @@ def _runtime_ledger_tca_rows_from_durable_buckets(
     tca_rows = [
         _runtime_ledger_tca_row_from_payload(payload=payload) for payload in payloads
     ]
-    metadata = {
-        "runtime_ledger_durable_bucket_count": len(payloads),
-        "runtime_ledger_durable_bucket_run_ids": sorted(
-            {
-                run_id
-                for payload in payloads
-                if (run_id := _text_or_none(payload.get("run_id"))) is not None
-            }
-        ),
-        "runtime_ledger_durable_bucket_fill_count": sum(
-            _nonnegative_int(payload.get("fill_count")) for payload in payloads
-        ),
-        "runtime_ledger_durable_bucket_tca_row_count": len(tca_rows),
-        "runtime_ledger_durable_bucket_profit_proof_count": sum(
-            1
-            for payload in payloads
-            if _runtime_ledger_bucket_profit_proof_present(payload)
-        ),
-    }
+    metadata = _runtime_ledger_bucket_metadata(
+        prefix="durable",
+        payloads=payloads,
+        tca_rows=tca_rows,
+    )
     return tca_rows, metadata
+
+
+_SOURCE_RUNTIME_LEDGER_COLUMNS = (
+    "run_id",
+    "candidate_id",
+    "hypothesis_id",
+    "observed_stage",
+    "bucket_started_at",
+    "bucket_ended_at",
+    "account_label",
+    "runtime_strategy_name",
+    "strategy_family",
+    "fill_count",
+    "decision_count",
+    "submitted_order_count",
+    "cancelled_order_count",
+    "rejected_order_count",
+    "unfilled_order_count",
+    "closed_trade_count",
+    "open_position_count",
+    "filled_notional",
+    "gross_strategy_pnl",
+    "cost_amount",
+    "net_strategy_pnl_after_costs",
+    "post_cost_expectancy_bps",
+    "execution_policy_hash_counts",
+    "cost_model_hash_counts",
+    "lineage_hash_counts",
+    "blockers_json",
+    "ledger_schema_version",
+    "pnl_basis",
+)
+
+
+def _source_runtime_ledger_payload_from_row(
+    row: Sequence[object],
+) -> dict[str, object]:
+    payload = dict(zip(_SOURCE_RUNTIME_LEDGER_COLUMNS, row, strict=True))
+    started_at = _parse_dt_or_none(payload.get("bucket_started_at"))
+    ended_at = _parse_dt_or_none(payload.get("bucket_ended_at"))
+    return {
+        **payload,
+        "bucket_started_at": started_at.isoformat()
+        if started_at is not None
+        else payload.get("bucket_started_at"),
+        "bucket_ended_at": ended_at.isoformat()
+        if ended_at is not None
+        else payload.get("bucket_ended_at"),
+        "strategy_id": payload.get("runtime_strategy_name"),
+        "execution_policy_hash_counts": _as_mapping(
+            payload.get("execution_policy_hash_counts")
+        ),
+        "cost_model_hash_counts": _as_mapping(payload.get("cost_model_hash_counts")),
+        "lineage_hash_counts": _as_mapping(payload.get("lineage_hash_counts")),
+        "blockers": _metadata_text_list(payload.get("blockers_json")),
+    }
+
+
+def _runtime_ledger_tca_rows_from_source_dsn(
+    *,
+    dsn: str,
+    candidate_id: str | None,
+    hypothesis_id: str,
+    observed_stage: str,
+    strategy_names: list[str],
+    account_label: str,
+    window_start: datetime,
+    window_end: datetime,
+) -> tuple[list[dict[str, object]], dict[str, Any]]:
+    if not strategy_names:
+        raise RuntimeError("strategy_name_not_configured")
+    where_clauses = [
+        "hypothesis_id = %s",
+        "observed_stage = %s",
+        "bucket_started_at < %s",
+        "bucket_ended_at > %s",
+    ]
+    params: list[object] = [hypothesis_id, observed_stage, window_end, window_start]
+    if candidate_id:
+        where_clauses.append("candidate_id = %s")
+        params.append(candidate_id)
+    if account_label:
+        where_clauses.append("account_label = %s")
+        params.append(account_label)
+    where_clauses.append("runtime_strategy_name = any(%s)")
+    params.append(strategy_names)
+    empty_metadata = _runtime_ledger_bucket_metadata(
+        prefix="source",
+        payloads=[],
+        tca_rows=[],
+    )
+    try:
+        with psycopg.connect(dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    select {", ".join(_SOURCE_RUNTIME_LEDGER_COLUMNS)}
+                    from strategy_runtime_ledger_buckets
+                    where {" and ".join(where_clauses)}
+                    order by bucket_ended_at asc, created_at asc
+                    limit 500
+                    """,
+                    tuple(params),
+                )
+                rows = cur.fetchall()
+    except (
+        psycopg.OperationalError,
+        psycopg.errors.UndefinedTable,
+        psycopg.errors.UndefinedColumn,
+    ) as exc:
+        return [], {
+            **empty_metadata,
+            "runtime_ledger_source_bucket_unavailable": type(exc).__name__,
+        }
+    payloads = [_source_runtime_ledger_payload_from_row(row) for row in rows]
+    tca_rows = [
+        _runtime_ledger_tca_row_from_payload(payload=payload) for payload in payloads
+    ]
+    return tca_rows, _runtime_ledger_bucket_metadata(
+        prefix="source",
+        payloads=payloads,
+        tca_rows=tca_rows,
+    )
 
 
 def _query_timestamps(
@@ -1514,6 +1662,27 @@ def main() -> int:
         "runtime_ledger_durable_bucket_tca_row_count": 0,
         "runtime_ledger_durable_bucket_profit_proof_count": 0,
     }
+    runtime_ledger_source_metadata: dict[str, Any] = {
+        "runtime_ledger_source_bucket_count": 0,
+        "runtime_ledger_source_bucket_run_ids": [],
+        "runtime_ledger_source_bucket_fill_count": 0,
+        "runtime_ledger_source_bucket_tca_row_count": 0,
+        "runtime_ledger_source_bucket_profit_proof_count": 0,
+    }
+    if source_dsn:
+        source_runtime_ledger_tca_rows, runtime_ledger_source_metadata = (
+            _runtime_ledger_tca_rows_from_source_dsn(
+                dsn=source_dsn,
+                candidate_id=args.candidate_id.strip() or None,
+                hypothesis_id=args.hypothesis_id,
+                observed_stage=args.observed_stage,
+                strategy_names=strategy_names,
+                account_label=args.account_label,
+                window_start=window_start,
+                window_end=window_end,
+            )
+        )
+        tca_rows.extend(source_runtime_ledger_tca_rows)
     if artifact_refs:
         bucket_ranges = build_regular_session_buckets(
             window_start=window_start,
@@ -1655,6 +1824,7 @@ def main() -> int:
         "runtime_ledger_target_metadata_blockers": runtime_ledger_target_metadata_blockers,
         **runtime_ledger_artifact_metadata,
         **runtime_ledger_durable_metadata,
+        **runtime_ledger_source_metadata,
         "report_post_cost_expectancy_bps": (
             str(report_post_cost_expectancy_bps)
             if report_post_cost_expectancy_bps is not None

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -36,6 +36,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _runtime_observation_authority_payload,
     _runtime_ledger_target_metadata_blockers,
     _runtime_ledger_tca_rows_from_durable_buckets,
+    _runtime_ledger_tca_rows_from_source_dsn,
     _runtime_ledger_tca_rows_from_artifacts,
     _stable_payload_digest,
     _strategy_name_candidates,
@@ -103,6 +104,71 @@ class _FakeConnection:
         return None
 
     def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+
+class _SourceLedgerCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[object, ...]]] = []
+        self._results = [
+            [
+                (
+                    "runtime-proof-source",
+                    "H-TSMOM-LIQ-01",
+                    "H-TSMOM-LIQ-01",
+                    "paper",
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    "TORGHUT_SIM",
+                    "intraday-tsmom-profit-v3",
+                    "intraday_tsmom_consistent",
+                    2,
+                    2,
+                    2,
+                    0,
+                    0,
+                    0,
+                    1,
+                    0,
+                    Decimal("200"),
+                    Decimal("1"),
+                    Decimal("0.20"),
+                    Decimal("0.80"),
+                    Decimal("40"),
+                    {"policy-sha": 2},
+                    {"cost-sha": 2},
+                    {"lineage-sha": 2},
+                    [],
+                    "torghut.exact_replay_ledger.v1",
+                    POST_COST_BASIS_RUNTIME_LEDGER,
+                )
+            ]
+        ]
+
+    def __enter__(self) -> _SourceLedgerCursor:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def execute(self, query: str, params: tuple[object, ...]) -> None:
+        self.executed.append((query, params))
+
+    def fetchall(self) -> list[tuple[object, ...]]:
+        return self._results.pop(0)
+
+
+class _SourceLedgerConnection:
+    def __init__(self, cursor: _SourceLedgerCursor) -> None:
+        self._cursor = cursor
+
+    def __enter__(self) -> _SourceLedgerConnection:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def cursor(self) -> _SourceLedgerCursor:
         return self._cursor
 
 
@@ -445,6 +511,67 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         assert isinstance(bucket, dict)
         self.assertEqual(bucket["run_id"], "runtime-proof-1")
         self.assertEqual(bucket["closed_trade_count"], 1)
+
+    def test_runtime_ledger_tca_rows_from_source_dsn_queries_matching_proof(
+        self,
+    ) -> None:
+        cursor = _SourceLedgerCursor()
+        connection = _SourceLedgerConnection(cursor)
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+
+        with patch(
+            "scripts.import_hypothesis_runtime_windows.psycopg.connect",
+            return_value=connection,
+        ):
+            rows, metadata = _runtime_ledger_tca_rows_from_source_dsn(
+                dsn="postgresql://source",
+                candidate_id="H-TSMOM-LIQ-01",
+                hypothesis_id="H-TSMOM-LIQ-01",
+                observed_stage="paper",
+                strategy_names=["intraday-tsmom-profit-v3"],
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+                window_end=window_end,
+            )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(metadata["runtime_ledger_source_bucket_count"], 1)
+        self.assertEqual(
+            metadata["runtime_ledger_source_bucket_run_ids"],
+            ["runtime-proof-source"],
+        )
+        self.assertEqual(metadata["runtime_ledger_source_bucket_fill_count"], 2)
+        self.assertEqual(metadata["runtime_ledger_source_bucket_profit_proof_count"], 1)
+        self.assertEqual(
+            metadata["runtime_ledger_source_bucket_candidate_id"],
+            "H-TSMOM-LIQ-01",
+        )
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], True)
+        self.assertEqual(
+            rows[0]["post_cost_expectancy_basis"],
+            POST_COST_BASIS_RUNTIME_LEDGER,
+        )
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["run_id"], "runtime-proof-source")
+        self.assertEqual(bucket["bucket_started_at"], "2026-03-06T14:30:00+00:00")
+        query, params = cursor.executed[0]
+        self.assertIn("from strategy_runtime_ledger_buckets", query)
+        self.assertIn("runtime_strategy_name = any(%s)", query)
+        self.assertEqual(
+            params,
+            (
+                "H-TSMOM-LIQ-01",
+                "paper",
+                window_end,
+                window_start,
+                "H-TSMOM-LIQ-01",
+                "TORGHUT_SIM",
+                ["intraday-tsmom-profit-v3"],
+            ),
+        )
 
     def test_parse_target_metadata_requires_json_mapping(self) -> None:
         self.assertEqual(_parse_target_metadata(""), {})
@@ -1959,6 +2086,136 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertEqual(
             runtime_payload["runtime_ledger_durable_bucket_profit_proof_count"],
+            1,
+        )
+        self.assertEqual(
+            runtime_payload["authority_reason"], "runtime_ledger_profit_proof"
+        )
+        self.assertEqual(runtime_payload["promotion_authority"], "runtime_ledger")
+        self.assertEqual(runtime_payload["runtime_ledger_profit_proof_present"], True)
+
+    def test_main_imports_source_runtime_ledger_bucket_with_source_dsn(
+        self,
+    ) -> None:
+        args = SimpleNamespace(
+            run_id="run-source-ledger",
+            candidate_id="H-TSMOM-LIQ-01",
+            hypothesis_id="H-TSMOM-LIQ-01",
+            observed_stage="paper",
+            strategy_family="intraday_tsmom_consistent",
+            source_dsn="postgresql://source",
+            source_dsn_env="DB_DSN",
+            strategy_name="intraday-tsmom-profit-v3",
+            account_label="TORGHUT_SIM",
+            window_start="2026-03-06T14:30:00Z",
+            window_end="2026-03-06T15:00:00Z",
+            bucket_minutes=30,
+            sample_minutes=5,
+            source_manifest_ref="config/trading/hypotheses/h-tsmom-liq-01.json",
+            source_kind="paper_route_probe_runtime_observed",
+            artifact_ref=[],
+            delay_adjusted_depth_stress_report_ref="",
+            dataset_snapshot_ref="source-runtime-ledger-snapshot",
+            target_metadata_json=json.dumps(
+                {
+                    "runtime_ledger_target_metadata_blockers": [
+                        "paper_route_runtime_ledger_import_pending"
+                    ],
+                }
+            ),
+            dependency_quorum_decision="allow",
+            continuity_ok="true",
+            drift_ok="true",
+            json=False,
+        )
+        fake_session = _FakeSession()
+        manifest = SimpleNamespace(
+            strategy_family="intraday_tsmom_consistent",
+            strategy_id="intraday_tsmom_v2@research",
+            max_allowed_slippage_bps=Decimal("6"),
+        )
+        source_tca_row = {
+            "computed_at": datetime(2026, 3, 6, 14, 59, 59, tzinfo=timezone.utc),
+            "abs_slippage_bps": Decimal("10"),
+            "post_cost_expectancy_bps": Decimal("40"),
+            "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+            "post_cost_promotion_eligible": True,
+            "runtime_ledger_bucket": _complete_runtime_ledger_bucket(
+                run_id="runtime-proof-source",
+                candidate_id="H-TSMOM-LIQ-01",
+                hypothesis_id="H-TSMOM-LIQ-01",
+                observed_stage="paper",
+                account_label="TORGHUT_SIM",
+                strategy_id="intraday-tsmom-profit-v3",
+                bucket_started_at="2026-03-06T14:30:00+00:00",
+                bucket_ended_at="2026-03-06T15:00:00+00:00",
+            ),
+        }
+
+        with (
+            patch(
+                "scripts.import_hypothesis_runtime_windows._parse_args",
+                return_value=args,
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.resolve_hypothesis_manifest",
+                return_value=(
+                    SimpleNamespace(
+                        path="config/trading/hypotheses/h-tsmom-liq-01.json"
+                    ),
+                    manifest,
+                ),
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows._query_timestamps",
+                return_value=([], [], []),
+            ) as query_timestamps,
+            patch(
+                "scripts.import_hypothesis_runtime_windows._runtime_ledger_tca_rows_from_source_dsn",
+                return_value=(
+                    [source_tca_row],
+                    {
+                        "runtime_ledger_source_bucket_count": 1,
+                        "runtime_ledger_source_bucket_run_ids": [
+                            "runtime-proof-source"
+                        ],
+                        "runtime_ledger_source_bucket_fill_count": 2,
+                        "runtime_ledger_source_bucket_tca_row_count": 1,
+                        "runtime_ledger_source_bucket_profit_proof_count": 1,
+                    },
+                ),
+            ) as source_buckets,
+            patch(
+                "scripts.import_hypothesis_runtime_windows.build_observed_runtime_buckets",
+                return_value=[],
+            ) as build_buckets,
+            patch(
+                "scripts.import_hypothesis_runtime_windows.persist_observed_runtime_windows",
+                return_value={"run_id": "run-source-ledger"},
+            ) as persist_windows,
+            patch(
+                "scripts.import_hypothesis_runtime_windows.SessionLocal",
+                return_value=fake_session,
+            ),
+            patch("builtins.print"),
+        ):
+            exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        query_timestamps.assert_called_once()
+        source_buckets.assert_called_once()
+        tca_rows = build_buckets.call_args.kwargs["tca_rows"]
+        self.assertEqual(tca_rows, [source_tca_row])
+        runtime_payload = persist_windows.call_args.kwargs[
+            "runtime_observation_payload"
+        ]
+        self.assertEqual(runtime_payload["runtime_ledger_source_bucket_count"], 1)
+        self.assertEqual(
+            runtime_payload["runtime_ledger_source_bucket_run_ids"],
+            ["runtime-proof-source"],
+        )
+        self.assertEqual(
+            runtime_payload["runtime_ledger_source_bucket_profit_proof_count"],
             1,
         )
         self.assertEqual(

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -1429,6 +1429,75 @@ class TestRuntimeWindowImport(TestCase):
             True,
         )
 
+    def test_persist_observed_runtime_windows_clears_import_pending_after_ledger_proof(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    30,
+                ),
+            ],
+            decision_times=[],
+            execution_times=[],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("4"),
+                    "post_cost_expectancy_bps": Decimal("40"),
+                    **_runtime_pnl_basis(),
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(),
+                },
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        with self.session_local() as session:
+            summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-source-ledger-paper-route",
+                candidate_id="cand-paper-route",
+                hypothesis_id="H-PAIRS-01",
+                observed_stage="paper",
+                strategy_family="microbar_cross_sectional_pairs",
+                source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+                buckets=buckets,
+                runtime_observation_payload={
+                    "runtime_ledger_profit_proof_present": True,
+                    "runtime_ledger_target_metadata_blockers": [
+                        "paper_route_runtime_ledger_import_pending",
+                        "live_runtime_ledger_required",
+                    ],
+                    "target_metadata": {
+                        "paper_probation_authorized": True,
+                        "evidence_collection_stage": "paper",
+                        "runtime_ledger_target_metadata_blockers": [
+                            "paper_route_runtime_ledger_import_pending"
+                        ],
+                        "promotion_allowed": False,
+                        "final_promotion_authorized": False,
+                    },
+                },
+            )
+            session.commit()
+
+        self.assertNotIn(
+            "paper_route_runtime_ledger_import_pending",
+            summary["promotion_blocking_reasons"],
+        )
+        self.assertIn(
+            "live_runtime_ledger_required",
+            summary["promotion_blocking_reasons"],
+        )
+        self.assertIn(
+            "paper_probation_evidence_collection_only",
+            summary["promotion_blocking_reasons"],
+        )
+
     def test_persist_observed_runtime_windows_blocks_zero_activity_evidence(
         self,
     ) -> None:

--- a/services/torghut/tests/test_universe.py
+++ b/services/torghut/tests/test_universe.py
@@ -220,6 +220,8 @@ class TestUniverseResolver(TestCase):
         config.settings.trading_jangar_symbols_url = "http://example"
         config.settings.trading_universe_cache_seconds = 1
         config.settings.trading_universe_max_stale_seconds = 1200
+        config.settings.trading_universe_static_fallback_enabled = False
+        config.settings.trading_universe_static_fallback_symbols_raw = ""
         config.settings.trading_universe_symbol_allowlist_raw = "NVDA,AVGO"
         resolver = UniverseResolver()
         resolver._cache = UniverseCache(
@@ -244,6 +246,8 @@ class TestUniverseResolver(TestCase):
         config.settings.trading_jangar_symbols_url = "http://example"
         config.settings.trading_universe_cache_seconds = 1
         config.settings.trading_universe_max_stale_seconds = 1200
+        config.settings.trading_universe_static_fallback_enabled = False
+        config.settings.trading_universe_static_fallback_symbols_raw = ""
         config.settings.trading_universe_symbol_allowlist_raw = "NVDA,AVGO"
         resolver = UniverseResolver()
         resolver._cache = UniverseCache(


### PR DESCRIPTION
## Summary

- Read runtime-ledger buckets from a configured source DSN during runtime-window imports, so `SIM_DB_DSN` paper-route targets can import real ledger proof instead of relying on execution-reconstructed PnL.
- Preserve separate source-ledger metadata in the runtime observation payload, including bucket count, run ids, fill count, and profit-proof count.
- Clear only the stale `paper_route_runtime_ledger_import_pending` blocker after runtime-ledger proof is present, while keeping paper/live promotion blockers intact.
- Add regressions for source-ledger import authority, post-import paper-route blocker cleanup, and shard-safe universe fallback isolation.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- `uv run --frozen ruff check tests/test_universe.py`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py -k 'source_runtime_ledger or source_dsn or clears_import_pending_after_ledger_proof or durable_runtime_ledger_bucket_without_source_dsn or runtime_ledger_tca_rows_from_source_dsn' -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_run_empirical_promotion_jobs.py -k 'source_runtime_ledger or runtime_ledger_tca_rows_from_source_dsn or clears_import_pending_after_ledger_proof or durable_runtime_ledger_bucket_without_source_dsn or runtime_window_targets_from_plan or target_plan_url or runtime_window_import_payload' -q`
- `uv run --frozen pytest tests/test_universe.py::TestUniverseResolver::test_jangar_failure_with_stale_cache_without_allowed_symbols_fails_closed -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_universe.py -k 'source_runtime_ledger or runtime_ledger_tca_rows_from_source_dsn or clears_import_pending_after_ledger_proof or stale_cache_without_allowed_symbols_fails_closed or stale_allowed_cache_reuses_allowed_subset' -q`
- Local reproduction of CI Pytest shard 2 using `.github/workflows/torghut-ci.yml` shard selection and `uv run --frozen pytest -n auto --dist=worksteal`: 840 passed.
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
