### PR TITLE
fix(torghut): gate paper route import on settlement

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -23,6 +23,15 @@ spec:
             - name: renew
               image: registry.ide-newton.ts.net/lab/torghut@sha256:bb431665b4239c89e7650fd797bc94a69421f5f0a0ac5e88fb44b4e06f1f04ea
               imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                  ephemeral-storage: 256Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+                  ephemeral-storage: 2Gi
               command:
                 - /bin/bash
                 - -lc

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -35,6 +35,7 @@ NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION = (
 DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS = 72
 DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT = 20
 PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL = "TORGHUT_SIM"
+PAPER_ROUTE_RUNTIME_IMPORT_SETTLEMENT_SECONDS = 3600
 US_EQUITIES_TIMEZONE = "America/New_York"
 US_EQUITIES_OPEN = time(hour=9, minute=30)
 US_EQUITIES_CLOSE = time(hour=16, minute=0)
@@ -238,9 +239,13 @@ def _paper_route_session_readiness(
     window_start: datetime,
     window_end: datetime,
     probe_ready: bool,
+    settlement_seconds: int,
 ) -> dict[str, object]:
+    settlement_seconds = max(0, int(settlement_seconds))
+    settlement_ready_at = window_end + timedelta(seconds=settlement_seconds)
     window_open = window_start <= generated_at <= window_end
     window_closed = generated_at > window_end
+    settlement_ready = generated_at >= settlement_ready_at
     import_blockers: list[str] = []
     if generated_at < window_start:
         state = "waiting_for_session_open"
@@ -248,6 +253,9 @@ def _paper_route_session_readiness(
     elif window_open:
         state = "collecting_session_evidence"
         import_blockers.append("paper_route_session_window_not_closed")
+    elif not settlement_ready:
+        state = "window_closed_settlement_pending"
+        import_blockers.append("paper_route_session_settlement_pending")
     else:
         state = "window_closed_import_ready"
     if not probe_ready:
@@ -261,8 +269,11 @@ def _paper_route_session_readiness(
         },
         "window_open": window_open,
         "window_closed": window_closed,
+        "settlement_seconds": settlement_seconds,
+        "settlement_ready": settlement_ready,
+        "settlement_ready_at": _isoformat(settlement_ready_at),
         "probe_ready": probe_ready,
-        "import_ready": window_closed and probe_ready,
+        "import_ready": window_closed and settlement_ready and probe_ready,
         "seconds_until_window_start": _seconds_until(
             generated_at=generated_at,
             target=window_start,
@@ -270,6 +281,10 @@ def _paper_route_session_readiness(
         "seconds_until_window_end": _seconds_until(
             generated_at=generated_at,
             target=window_end,
+        ),
+        "seconds_until_import_ready": _seconds_until(
+            generated_at=generated_at,
+            target=settlement_ready_at,
         ),
         "import_blockers": import_blockers,
     }
@@ -450,6 +465,7 @@ def _next_paper_route_runtime_window_targets(
         window_start=window_start,
         window_end=window_end,
         probe_ready=probe_ready,
+        settlement_seconds=PAPER_ROUTE_RUNTIME_IMPORT_SETTLEMENT_SECONDS,
     )
     import_ready = bool(session_readiness.get("import_ready"))
     import_blockers = [
@@ -467,6 +483,8 @@ def _next_paper_route_runtime_window_targets(
             "--runtime-window-target-plan-required",
             "--runtime-window-target-plan-settlement-seconds",
         ],
+        "target_plan_settlement_seconds": PAPER_ROUTE_RUNTIME_IMPORT_SETTLEMENT_SECONDS,
+        "settlement_ready_at": session_readiness.get("settlement_ready_at"),
         "source_dsn_env": "SIM_DB_DSN",
         "account_label": PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
         "observed_stage": "paper",
@@ -541,7 +559,10 @@ def _next_paper_route_runtime_window_targets(
             or "unknown",
             "paper_route_session_import_ready": import_ready,
             "paper_route_session_import_blockers": import_blockers,
-            "paper_route_runtime_window_import_not_before": _isoformat(window_end),
+            "paper_route_runtime_window_import_not_before": _safe_text(
+                session_readiness.get("settlement_ready_at")
+            )
+            or _isoformat(window_end),
             "paper_route_runtime_import_handoff": import_handoff,
             "paper_probation_authorized": True,
             "paper_probation_authorization_scope": "evidence_collection_only",
@@ -837,7 +858,9 @@ def _runtime_ledger_summary(
             StrategyRuntimeLedgerBucket.runtime_strategy_name == strategy_name
         )
     if strategy_family:
-        stmt = stmt.where(StrategyRuntimeLedgerBucket.strategy_family == strategy_family)
+        stmt = stmt.where(
+            StrategyRuntimeLedgerBucket.strategy_family == strategy_family
+        )
     rows = list(session.execute(stmt.limit(50)).scalars())
     filled_notional = sum((row.filled_notional for row in rows), Decimal("0"))
     net_pnl = sum((row.net_strategy_pnl_after_costs for row in rows), Decimal("0"))

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -791,6 +791,29 @@ class TestLiveConfigManifestContract(TestCase):
         )
 
         self.assertEqual(spec.get("schedule"), "23 8,21 * * *")
+        self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
+        self.assertEqual(spec.get("startingDeadlineSeconds"), 900)
+        job_spec = cast(
+            Mapping[str, object],
+            cast(Mapping[str, object], spec.get("jobTemplate", {})).get("spec", {}),
+        )
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 900)
+        resources = cast(Mapping[str, object], container.get("resources", {}))
+        self.assertEqual(
+            resources,
+            {
+                "requests": {
+                    "cpu": "100m",
+                    "memory": "256Mi",
+                    "ephemeral-storage": "256Mi",
+                },
+                "limits": {
+                    "cpu": "1",
+                    "memory": "1Gi",
+                    "ephemeral-storage": "2Gi",
+                },
+            },
+        )
         env = {
             item.get("name"): item
             for item in cast(list[Mapping[str, object]], container.get("env", []))

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -269,6 +269,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertFalse(plan["session_readiness"]["window_open"])
         self.assertFalse(plan["session_readiness"]["window_closed"])
         self.assertFalse(plan["session_readiness"]["import_ready"])
+        self.assertEqual(plan["session_readiness"]["settlement_seconds"], 3600)
+        self.assertEqual(
+            plan["session_readiness"]["settlement_ready_at"],
+            "2026-05-26T21:00:00+00:00",
+        )
         self.assertEqual(
             plan["session_readiness"]["import_blockers"],
             ["paper_route_session_window_not_open"],
@@ -285,6 +290,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "--runtime-window-target-plan-settlement-seconds",
             handoff["required_flags"],
         )
+        self.assertEqual(handoff["target_plan_settlement_seconds"], 3600)
+        self.assertEqual(handoff["settlement_ready_at"], "2026-05-26T21:00:00+00:00")
         self.assertFalse(handoff["import_ready"])
         self.assertEqual(
             handoff["import_blockers"],
@@ -314,7 +321,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertEqual(
             target["paper_route_runtime_window_import_not_before"],
-            "2026-05-26T20:00:00+00:00",
+            "2026-05-26T21:00:00+00:00",
         )
         self.assertEqual(
             target["paper_route_runtime_import_handoff"]["target_plan_endpoint"],
@@ -397,6 +404,34 @@ class TestPaperRouteEvidenceAudit(TestCase):
             ["paper_route_session_window_not_closed"],
         )
 
+        settlement_payload = build(datetime(2026, 5, 26, 20, 30, tzinfo=timezone.utc))
+        settlement_readiness = settlement_payload[
+            "next_paper_route_runtime_window_targets"
+        ]["session_readiness"]
+        self.assertEqual(
+            settlement_readiness["state"], "window_closed_settlement_pending"
+        )
+        self.assertFalse(settlement_readiness["window_open"])
+        self.assertTrue(settlement_readiness["window_closed"])
+        self.assertFalse(settlement_readiness["settlement_ready"])
+        self.assertFalse(settlement_readiness["import_ready"])
+        self.assertEqual(settlement_readiness["seconds_until_import_ready"], 1800)
+        self.assertEqual(
+            settlement_readiness["import_blockers"],
+            ["paper_route_session_settlement_pending"],
+        )
+        settlement_target = settlement_payload[
+            "next_paper_route_runtime_window_targets"
+        ]["targets"][0]
+        self.assertEqual(
+            settlement_target["paper_route_session_readiness_state"],
+            "window_closed_settlement_pending",
+        )
+        self.assertEqual(
+            settlement_target["paper_route_runtime_window_import_not_before"],
+            "2026-05-26T21:00:00+00:00",
+        )
+
         import_payload = build(datetime(2026, 5, 26, 21, tzinfo=timezone.utc))
         import_readiness = import_payload["next_paper_route_runtime_window_targets"][
             "session_readiness"
@@ -404,6 +439,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(import_readiness["state"], "window_closed_import_ready")
         self.assertFalse(import_readiness["window_open"])
         self.assertTrue(import_readiness["window_closed"])
+        self.assertTrue(import_readiness["settlement_ready"])
         self.assertTrue(import_readiness["probe_ready"])
         self.assertTrue(import_readiness["import_ready"])
         self.assertEqual(import_readiness["import_blockers"], [])


### PR DESCRIPTION
## Summary

- Makes `/trading/paper-route-evidence` settlement-aware so paper-route runtime-window import readiness stays false until the existing 3600-second settlement grace has elapsed.
- Exposes `settlement_ready_at`, `settlement_seconds`, and the corrected `paper_route_runtime_window_import_not_before` timestamp in the handoff payload.
- Adds bounded CPU, memory, and ephemeral-storage requests/limits to the empirical promotion renewal CronJob so the proof import path has a tighter cluster footprint.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_verify_trading_readiness.py tests/test_live_config_manifest_contract.py -k 'paper_route or empirical_promotion_renewal' -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_verify_trading_readiness.py tests/test_live_config_manifest_contract.py`
- `uv sync --frozen --extra dev && uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
