### PR TITLE
chore(symphony): promote image 739c7a71

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-24T06:13:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-25T07:03:19Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "5562f77b"
-    digest: sha256:a742058a50896af4ec59684a497eec97c5354d6309c659eb838a4775a4772646
+    newTag: "739c7a71"
+    digest: sha256:7e047eaac0bb6124966fb764c0bb52de172715ef99da8582afb09831fdfb0e1a

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-24T06:13:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-25T07:03:19Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "5562f77b"
-    digest: sha256:a742058a50896af4ec59684a497eec97c5354d6309c659eb838a4775a4772646
+    newTag: "739c7a71"
+    digest: sha256:7e047eaac0bb6124966fb764c0bb52de172715ef99da8582afb09831fdfb0e1a

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-24T06:13:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-25T07:03:19Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "5562f77b"
-    digest: sha256:a742058a50896af4ec59684a497eec97c5354d6309c659eb838a4775a4772646
+    newTag: "739c7a71"
+    digest: sha256:7e047eaac0bb6124966fb764c0bb52de172715ef99da8582afb09831fdfb0e1a


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `739c7a71acf67902c6cba6c015fd282855961869`
- Image tag: `739c7a71`
- Image digest: `sha256:7e047eaac0bb6124966fb764c0bb52de172715ef99da8582afb09831fdfb0e1a`