### PR TITLE
test(agents): remove prompt parameter fixtures

### DIFF
--- a/services/agents/src/server/orchestration-controller.test.ts
+++ b/services/agents/src/server/orchestration-controller.test.ts
@@ -185,7 +185,7 @@ describe('orchestration controller', () => {
                 with: {
                   implementation: JSON.stringify({
                     summary: 'Codex rerun',
-                    text: '{{prompt}}',
+                    text: '{{codexPrompt}}',
                     source: { provider: 'github', externalId: '{{repository}}#{{issueNumber}}' },
                   }),
                   runtime: JSON.stringify({ type: 'job', config: { serviceAccountName: 'agents-sa' } }),
@@ -194,7 +194,7 @@ describe('orchestration controller', () => {
                   policy: JSON.stringify({ secretBindingRef: 'codex-github-token' }),
                   vcsRef: 'github',
                   vcsPolicy: JSON.stringify({ required: true, mode: 'read-write' }),
-                  goal: JSON.stringify({ objective: '{{prompt}}', tokenBudget: 250000 }),
+                  goal: JSON.stringify({ objective: '{{codexPrompt}}', tokenBudget: 250000 }),
                   ttlSecondsAfterFinished: '86400',
                 },
               },
@@ -212,7 +212,7 @@ describe('orchestration controller', () => {
       metadata: { name: 'codex-rerun-run', namespace: 'agents', generation: 1 },
       spec: {
         orchestrationRef: { name: 'codex-rerun' },
-        parameters: { repository: 'proompteng/lab', issueNumber: '7152', prompt: 'fix it' },
+        parameters: { repository: 'proompteng/lab', issueNumber: '7152', codexPrompt: 'fix it' },
       },
     }
 
@@ -224,7 +224,7 @@ describe('orchestration controller', () => {
     expect(spec.agentRef).toEqual({ name: 'codex-agent' })
     expect(spec.implementation).toEqual({
       summary: 'Codex rerun',
-      text: '{{prompt}}',
+      text: '{{codexPrompt}}',
       source: { provider: 'github', externalId: '{{repository}}#{{issueNumber}}' },
     })
     expect(spec.runtime).toEqual({ type: 'job', config: { serviceAccountName: 'agents-sa' } })
@@ -233,7 +233,7 @@ describe('orchestration controller', () => {
     expect(spec.policy).toEqual({ secretBindingRef: 'codex-github-token' })
     expect(spec.vcsRef).toEqual({ name: 'github' })
     expect(spec.vcsPolicy).toEqual({ required: true, mode: 'read-write' })
-    expect(spec.goal).toEqual({ objective: '{{prompt}}', tokenBudget: 250000 })
+    expect(spec.goal).toEqual({ objective: '{{codexPrompt}}', tokenBudget: 250000 })
     expect(spec.ttlSecondsAfterFinished).toBe(86400)
   })
 

--- a/services/agents/src/server/supporting-primitives-controller.test.ts
+++ b/services/agents/src/server/supporting-primitives-controller.test.ts
@@ -190,7 +190,7 @@ describe('supporting primitives controller', () => {
         spec: {
           agentRef: { name: 'demo-agent' },
           runtime: { type: 'job' },
-          parameters: { prompt: 'ship it' },
+          parameters: { objective: 'ship it' },
         },
       },
     })


### PR DESCRIPTION
## Summary

- Removed stale non-validation `parameters.prompt` fixtures from Agents controller tests.
- Switched the orchestration fixture to the explicit `codexPrompt` parameter used by current Codex orchestration resources.
- Kept the negative validation tests that prove `spec.parameters.prompt` and workflow-step prompt overrides are still rejected.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/agents test -- src/server/orchestration-controller.test.ts src/server/supporting-primitives-controller.test.ts`
- `bunx oxfmt --check services/agents/src/server/orchestration-controller.test.ts services/agents/src/server/supporting-primitives-controller.test.ts`
- `bun run --filter @proompteng/agents tsc`

## Screenshots (if applicable)

N/A (test fixture cleanup only).

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
