### PR TITLE
chore(sag): disable runtime

### DIFF
--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -229,7 +229,7 @@ spec:
                 renderWithLovely: false
                 annotations:
                   argocd.argoproj.io/sync-wave: "6"
-                automation: auto
+                automation: manual
                 enabled: "true"
               - name: torghut
                 path: argocd/applications/torghut

--- a/argocd/sag/deployment.yaml
+++ b/argocd/sag/deployment.yaml
@@ -7,7 +7,8 @@ metadata:
     app.kubernetes.io/name: sag
     app.kubernetes.io/part-of: lab
 spec:
-  replicas: 1
+  # Disable the SAG runtime while keeping the Argo application and CNPG state intact.
+  replicas: 0
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
## Summary

- Disable the SAG Argo application automation so Argo does not self-heal the runtime back up.
- Scale the SAG deployment to zero replicas while keeping the Argo application, namespace, and CNPG database resources intact.
- Preserve the live SAG database state for a reversible future re-enable.

## Related Issues

None

## Testing

- `git diff --check -- argocd/applicationsets/product.yaml argocd/sag/deployment.yaml`
- `kubectl apply --dry-run=server -f argocd/applicationsets/product.yaml`
- `kubectl apply --dry-run=server -f argocd/sag/deployment.yaml`
- `bun run lint:argocd`
- Live verification on `galactic-tailscale`: `deployment/sag` desired replicas is `0`, no SAG runtime pods remain, and CNPG `sag-db` is healthy.

## Screenshots (if applicable)

N/A

## Breaking Changes

SAG web runtime is intentionally unavailable until the deployment is scaled back up and automation is restored.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
