### PR TITLE
fix(jangar): grant post-deploy access to agents proxy

### DIFF
--- a/argocd/applications/jangar/post-deploy-verifier-rbac.yaml
+++ b/argocd/applications/jangar/post-deploy-verifier-rbac.yaml
@@ -27,3 +27,34 @@ roleRef:
   kind: Role
   name: post-deploy-verifier
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: jangar-post-deploy-verifier-agents-proxy
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services/proxy
+    resourceNames:
+      - agents
+      - agents:80
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: jangar-post-deploy-verifier-agents-proxy
+subjects:
+  - kind: ServiceAccount
+    name: arc-arm64-gha-rs-kube-mode
+    namespace: arc
+  - kind: ServiceAccount
+    name: agents-sa
+    namespace: agents
+roleRef:
+  kind: ClusterRole
+  name: jangar-post-deploy-verifier-agents-proxy
+  apiGroup: rbac.authorization.k8s.io

--- a/packages/scripts/src/jangar/__tests__/post-deploy-verifier-rbac.test.ts
+++ b/packages/scripts/src/jangar/__tests__/post-deploy-verifier-rbac.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'bun:test'
+import { parseAllDocuments } from 'yaml'
+
+type Manifest = {
+  kind?: string
+  metadata?: {
+    name?: string
+    namespace?: string
+  }
+  roleRef?: unknown
+  rules?: unknown
+  subjects?: unknown
+}
+
+const readYamlObjects = (path: string) =>
+  parseAllDocuments(readFileSync(resolve(process.cwd(), path), 'utf8')).map((document) => document.toJSON() as Manifest)
+
+describe('jangar post-deploy verifier RBAC', () => {
+  const manifests = readYamlObjects('argocd/applications/jangar/post-deploy-verifier-rbac.yaml')
+
+  it('keeps the Jangar namespace service proxy grant for local service checks', () => {
+    const role = manifests.find(
+      (manifest) =>
+        manifest?.kind === 'Role' &&
+        manifest?.metadata?.name === 'post-deploy-verifier' &&
+        manifest?.metadata?.namespace === 'jangar',
+    )
+
+    expect(role?.rules).toContainEqual({
+      apiGroups: [''],
+      resources: ['services/proxy'],
+      verbs: ['get'],
+    })
+  })
+
+  it('grants the ARC runner access to the Agents control-plane service proxy used by deployment verification', () => {
+    const clusterRole = manifests.find(
+      (manifest) =>
+        manifest?.kind === 'ClusterRole' && manifest?.metadata?.name === 'jangar-post-deploy-verifier-agents-proxy',
+    )
+    const clusterRoleBinding = manifests.find(
+      (manifest) =>
+        manifest?.kind === 'ClusterRoleBinding' &&
+        manifest?.metadata?.name === 'jangar-post-deploy-verifier-agents-proxy',
+    )
+
+    expect(clusterRole?.rules).toContainEqual({
+      apiGroups: [''],
+      resources: ['services/proxy'],
+      resourceNames: ['agents', 'agents:80'],
+      verbs: ['get'],
+    })
+    expect(clusterRoleBinding?.subjects).toContainEqual({
+      kind: 'ServiceAccount',
+      name: 'arc-arm64-gha-rs-kube-mode',
+      namespace: 'arc',
+    })
+    expect(clusterRoleBinding?.roleRef).toEqual({
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'ClusterRole',
+      name: 'jangar-post-deploy-verifier-agents-proxy',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Grant the Jangar post-deploy verifier a focused ClusterRole/Binding for the Agents control-plane service proxy path used by CI.
- Restrict that grant to `services/proxy` resource names `agents` and `agents:80` for the ARC runner and `agents-sa`.
- Add a YAML-parsing regression test for the post-deploy verifier RBAC contract.

## Related Issues

None.

## Testing

- `bun test packages/scripts/src/jangar/__tests__/verify-deployment.test.ts packages/scripts/src/jangar/__tests__/post-deploy-verifier-rbac.test.ts`
- `bunx oxfmt --check packages/scripts/src/jangar argocd/applications/jangar`
- `git diff --check origin/main...HEAD`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/jangar >/tmp/jangar-post-deploy-rbac-render.yaml`
- `rg -n "jangar-post-deploy-verifier-agents-proxy|resourceNames|agents:80|arc-arm64-gha-rs-kube-mode" /tmp/jangar-post-deploy-rbac-render.yaml`
- `bun run lint:argocd`
- `bunx oxlint --config .oxlintrc.json packages/scripts/src/jangar/__tests__/post-deploy-verifier-rbac.test.ts`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
