### PR TITLE
fix(torghut): expose paper route import audit state

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -32,6 +32,9 @@ PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION = "torghut.paper-route-evidence.v1"
 NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION = (
     "torghut.next-paper-route-runtime-window-targets.v1"
 )
+PAPER_ROUTE_RUNTIME_WINDOW_IMPORT_AUDIT_SCHEMA_VERSION = (
+    "torghut.paper-route-runtime-window-import-audit.v1"
+)
 DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS = 72
 DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT = 20
 PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL = "TORGHUT_SIM"
@@ -1136,6 +1139,132 @@ def _target_audit(
     }
 
 
+def _runtime_window_import_audit(
+    *,
+    next_targets: Mapping[str, object],
+    target_audits: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    session_readiness = _as_mapping(next_targets.get("session_readiness"))
+    import_blockers = _unique_text_items(session_readiness.get("import_blockers"))
+    source_missing_reasons = sorted(
+        {
+            str(reason).strip()
+            for audit in target_audits
+            for reason in _as_sequence(
+                _as_mapping(audit.get("source_activity")).get("missing_reasons")
+            )
+            if str(reason).strip()
+        }
+    )
+    runtime_ledger_blockers = sorted(
+        {
+            str(blocker).strip()
+            for audit in target_audits
+            for blocker in _as_sequence(
+                _as_mapping(audit.get("runtime_ledger")).get("blockers")
+            )
+            if str(blocker).strip()
+        }
+    )
+    current_target_count = len(target_audits)
+    targets_with_source_activity = sum(
+        int(not bool(_as_mapping(audit.get("source_activity")).get("missing")))
+        for audit in target_audits
+    )
+    targets_with_runtime_ledger = sum(
+        int(_safe_int(_as_mapping(audit.get("runtime_ledger")).get("bucket_count")) > 0)
+        for audit in target_audits
+    )
+    targets_with_evidence_grade_runtime_ledger = sum(
+        int(
+            _safe_int(
+                _as_mapping(audit.get("runtime_ledger")).get(
+                    "evidence_grade_bucket_count"
+                )
+            )
+            > 0
+        )
+        for audit in target_audits
+    )
+    targets_with_promotion_decision = sum(
+        int(
+            _safe_int(
+                _as_mapping(audit.get("promotion_decisions")).get("decision_count")
+            )
+            > 0
+        )
+        for audit in target_audits
+    )
+    import_ready = bool(session_readiness.get("import_ready"))
+    session_state = _safe_text(session_readiness.get("state")) or "unknown"
+    blockers: list[str]
+    if current_target_count <= 0:
+        state = "paper_probation_import_plan_missing"
+        next_action = "repair_runtime_ledger_paper_probation_import_plan"
+        blockers = ["paper_probation_import_plan_missing"]
+    elif not import_ready:
+        state = session_state
+        next_action = {
+            "waiting_for_session_open": "wait_for_regular_session_open",
+            "collecting_session_evidence": "collect_paper_route_activity_until_close",
+            "window_closed_settlement_pending": "wait_for_settlement_before_import",
+            "window_closed_import_blocked": "repair_paper_route_probe_before_import",
+        }.get(session_state, "wait_for_runtime_window_import_readiness")
+        blockers = import_blockers
+    elif targets_with_source_activity < current_target_count:
+        state = "import_due_source_activity_missing"
+        next_action = "inspect_paper_route_source_activity_before_import"
+        blockers = ["paper_route_source_activity_missing", *source_missing_reasons]
+    elif targets_with_runtime_ledger < current_target_count:
+        state = "import_due_runtime_ledger_missing"
+        next_action = "run_or_inspect_runtime_window_import"
+        blockers = ["runtime_ledger_bucket_missing"]
+    elif targets_with_evidence_grade_runtime_ledger < current_target_count:
+        state = "runtime_ledger_imported_but_not_evidence_grade"
+        next_action = "repair_runtime_ledger_bucket_authority_or_candidate"
+        blockers = [
+            "runtime_ledger_evidence_grade_bucket_missing",
+            *runtime_ledger_blockers,
+        ]
+    else:
+        state = "runtime_ledger_ready_for_gate_review"
+        next_action = "review_runtime_ledger_profit_gates"
+        blockers = []
+    return {
+        "schema_version": PAPER_ROUTE_RUNTIME_WINDOW_IMPORT_AUDIT_SCHEMA_VERSION,
+        "state": state,
+        "next_action": next_action,
+        "session_state": session_state,
+        "session_window": _as_mapping(next_targets.get("session_window")),
+        "settlement_ready_at": session_readiness.get("settlement_ready_at"),
+        "import_ready": import_ready,
+        "blockers": sorted(dict.fromkeys(blockers)),
+        "counts": {
+            "source_plan_target_count": current_target_count,
+            "next_runtime_window_target_count": _safe_int(
+                next_targets.get("target_count")
+            ),
+            "targets_with_source_activity": targets_with_source_activity,
+            "targets_with_runtime_ledger": targets_with_runtime_ledger,
+            "targets_with_evidence_grade_runtime_ledger": (
+                targets_with_evidence_grade_runtime_ledger
+            ),
+            "targets_with_promotion_decision": targets_with_promotion_decision,
+        },
+        "promotion_authority": {
+            "allowed": False,
+            "reason": "runtime_window_import_audit_observability_only",
+            "requires": [
+                "runtime_ledger_live_or_live_paper_required",
+                "post_cost_pnl_basis_required",
+                "filled_notional_required",
+                "closed_round_trips_required",
+                "lineage_hashes_required",
+            ],
+        },
+    }
+
+
 def build_paper_route_evidence_audit(
     session: Session,
     *,
@@ -1163,6 +1292,15 @@ def build_paper_route_evidence_audit(
         )
         for target in targets
     ]
+    next_targets = _next_paper_route_runtime_window_targets(
+        targets=targets,
+        probe=probe,
+        generated_at=resolved_generated_at,
+    )
+    runtime_window_import_audit = _runtime_window_import_audit(
+        next_targets=next_targets,
+        target_audits=target_audits,
+    )
     summary_blockers = sorted(
         {
             str(blocker)
@@ -1206,13 +1344,8 @@ def build_paper_route_evidence_audit(
             },
         },
         "paper_route_probe": probe,
-        "next_paper_route_runtime_window_targets": (
-            _next_paper_route_runtime_window_targets(
-                targets=targets,
-                probe=probe,
-                generated_at=resolved_generated_at,
-            )
-        ),
+        "next_paper_route_runtime_window_targets": next_targets,
+        "runtime_window_import_audit": runtime_window_import_audit,
         "summary": {
             "target_count": len(targets),
             "target_with_source_activity_count": sum(
@@ -1223,6 +1356,17 @@ def build_paper_route_evidence_audit(
                 int(
                     _safe_int(
                         _as_mapping(audit.get("runtime_ledger")).get("bucket_count")
+                    )
+                    > 0
+                )
+                for audit in target_audits
+            ),
+            "target_with_evidence_grade_runtime_ledger_count": sum(
+                int(
+                    _safe_int(
+                        _as_mapping(audit.get("runtime_ledger")).get(
+                            "evidence_grade_bucket_count"
+                        )
                     )
                     > 0
                 )
@@ -1284,6 +1428,7 @@ def build_paper_route_evidence_audit(
                 "reason": "paper_route_evidence_audit_observability_only",
                 "blockers": summary_blockers,
             },
+            "runtime_window_import_audit_state": runtime_window_import_audit["state"],
             "blockers": summary_blockers,
         },
         "targets": target_audits,
@@ -1294,5 +1439,6 @@ __all__ = [
     "DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS",
     "NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION",
     "PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION",
+    "PAPER_ROUTE_RUNTIME_WINDOW_IMPORT_AUDIT_SCHEMA_VERSION",
     "build_paper_route_evidence_audit",
 ]

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -327,6 +327,21 @@ class TestPaperRouteEvidenceAudit(TestCase):
             target["paper_route_runtime_import_handoff"]["target_plan_endpoint"],
             "/trading/paper-route-evidence",
         )
+        import_audit = payload["runtime_window_import_audit"]
+        self.assertEqual(
+            import_audit["schema_version"],
+            "torghut.paper-route-runtime-window-import-audit.v1",
+        )
+        self.assertEqual(import_audit["state"], "waiting_for_session_open")
+        self.assertEqual(import_audit["next_action"], "wait_for_regular_session_open")
+        self.assertFalse(import_audit["import_ready"])
+        self.assertEqual(
+            import_audit["blockers"],
+            ["paper_route_session_window_not_open"],
+        )
+        self.assertEqual(import_audit["counts"]["source_plan_target_count"], 2)
+        self.assertEqual(import_audit["counts"]["next_runtime_window_target_count"], 1)
+        self.assertFalse(import_audit["promotion_authority"]["allowed"])
         self.assertFalse(target["promotion_allowed"])
         self.assertFalse(target["final_promotion_authorized"])
         self.assertEqual(
@@ -452,6 +467,222 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertTrue(import_target["paper_route_session_import_ready"])
         self.assertEqual(import_target["paper_route_session_import_blockers"], [])
+        import_audit = import_payload["runtime_window_import_audit"]
+        self.assertEqual(import_audit["state"], "import_due_source_activity_missing")
+        self.assertEqual(
+            import_audit["next_action"],
+            "inspect_paper_route_source_activity_before_import",
+        )
+        self.assertTrue(import_audit["import_ready"])
+        self.assertEqual(
+            import_audit["blockers"],
+            [
+                "paper_route_source_activity_missing",
+                "source_decisions_missing",
+                "source_executions_missing",
+                "source_tca_missing",
+            ],
+        )
+
+    def test_runtime_window_import_audit_tracks_missing_and_non_grade_ledger(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        now = datetime(2026, 5, 26, 21, tzinfo=timezone.utc)
+        strategy_name = "ledger-audit-paper-route"
+
+        def build(session: Session) -> dict[str, object]:
+            return build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-LEDGER-AUDIT",
+                                "candidate_id": "candidate-ledger-audit",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": strategy_name,
+                                "account_label": "paper",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_route_probe_symbols": ["AAPL"],
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": ["AAPL"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "next_session_max_notional": "25",
+                        "eligible_symbol_count": 1,
+                    },
+                },
+                generated_at=now,
+            )
+
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="paper route ledger audit fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={"action": "buy", "qty": "2"},
+                rationale="paper route ledger audit fixture",
+                status="executed",
+                created_at=window_start + timedelta(minutes=10),
+                executed_at=window_start + timedelta(minutes=11),
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="paper",
+                alpaca_order_id="ledger-audit-order-1",
+                client_order_id="ledger-audit-client-1",
+                symbol="AAPL",
+                side="buy",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("2"),
+                filled_qty=Decimal("2"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=window_start + timedelta(minutes=12),
+                updated_at=window_start + timedelta(minutes=12),
+                last_update_at=window_start + timedelta(minutes=12),
+            )
+            session.add(execution)
+            session.flush()
+            session.add(
+                ExecutionTCAMetric(
+                    execution_id=execution.id,
+                    trade_decision_id=decision.id,
+                    strategy_id=strategy.id,
+                    alpaca_account_label="paper",
+                    symbol="AAPL",
+                    side="buy",
+                    arrival_price=Decimal("99"),
+                    avg_fill_price=Decimal("100"),
+                    filled_qty=Decimal("2"),
+                    signed_qty=Decimal("2"),
+                    slippage_bps=Decimal("5"),
+                    shortfall_notional=Decimal("1"),
+                    realized_shortfall_bps=Decimal("5"),
+                    churn_qty=Decimal("0"),
+                    churn_ratio=Decimal("0"),
+                    computed_at=window_start + timedelta(minutes=13),
+                    created_at=window_start + timedelta(minutes=13),
+                    updated_at=window_start + timedelta(minutes=13),
+                )
+            )
+            session.commit()
+
+            missing_ledger_payload = build(session)
+            missing_ledger_audit = missing_ledger_payload["runtime_window_import_audit"]
+            self.assertEqual(
+                missing_ledger_audit["state"], "import_due_runtime_ledger_missing"
+            )
+            self.assertEqual(
+                missing_ledger_audit["next_action"],
+                "run_or_inspect_runtime_window_import",
+            )
+            self.assertEqual(
+                missing_ledger_audit["blockers"], ["runtime_ledger_bucket_missing"]
+            )
+            self.assertEqual(
+                missing_ledger_audit["counts"]["targets_with_source_activity"], 1
+            )
+            self.assertEqual(
+                missing_ledger_audit["counts"]["targets_with_runtime_ledger"], 0
+            )
+
+            session.add(
+                StrategyRuntimeLedgerBucket(
+                    run_id="paper-route-ledger-audit",
+                    candidate_id="candidate-ledger-audit",
+                    hypothesis_id="H-LEDGER-AUDIT",
+                    observed_stage="paper",
+                    bucket_started_at=window_start,
+                    bucket_ended_at=window_end,
+                    account_label="paper",
+                    runtime_strategy_name=strategy_name,
+                    strategy_family="microbar_pairs",
+                    fill_count=2,
+                    decision_count=1,
+                    submitted_order_count=1,
+                    closed_trade_count=0,
+                    open_position_count=1,
+                    filled_notional=Decimal("200"),
+                    gross_strategy_pnl=Decimal("12"),
+                    cost_amount=Decimal("2"),
+                    net_strategy_pnl_after_costs=Decimal("10"),
+                    post_cost_expectancy_bps=Decimal("500"),
+                    ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                    pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                    execution_policy_hash_counts={"policy-a": 1},
+                    cost_model_hash_counts={"cost-a": 1},
+                    lineage_hash_counts={"lineage-a": 1},
+                    blockers_json=["open_position_count_nonzero"],
+                )
+            )
+            session.commit()
+
+            non_grade_payload = build(session)
+            non_grade_audit = non_grade_payload["runtime_window_import_audit"]
+            self.assertEqual(
+                non_grade_audit["state"],
+                "runtime_ledger_imported_but_not_evidence_grade",
+            )
+            self.assertEqual(
+                non_grade_audit["next_action"],
+                "repair_runtime_ledger_bucket_authority_or_candidate",
+            )
+            self.assertEqual(
+                non_grade_audit["blockers"],
+                [
+                    "open_position_count_nonzero",
+                    "runtime_ledger_evidence_grade_bucket_missing",
+                ],
+            )
+            self.assertEqual(
+                non_grade_audit["counts"]["targets_with_runtime_ledger"], 1
+            )
+            self.assertEqual(
+                non_grade_audit["counts"]["targets_with_evidence_grade_runtime_ledger"],
+                0,
+            )
 
     def test_source_activity_is_bound_to_target_window_end(self) -> None:
         window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
@@ -864,8 +1095,9 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
 
     def test_builder_joins_source_activity_runtime_ledger_and_decisions(self) -> None:
-        now = datetime(2026, 5, 24, 12, tzinfo=timezone.utc)
-        window_start = now - timedelta(hours=2)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        now = datetime(2026, 5, 26, 21, tzinfo=timezone.utc)
         strategy_name = "active-paper-route"
         with Session(self.engine) as session:
             strategy = Strategy(
@@ -941,7 +1173,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         hypothesis_id="H-ACTIVE-ROUTE",
                         observed_stage="paper",
                         bucket_started_at=window_start,
-                        bucket_ended_at=now,
+                        bucket_ended_at=window_end,
                         account_label="paper",
                         runtime_strategy_name=strategy_name,
                         strategy_family="microbar_pairs",
@@ -1010,7 +1242,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                                 "strategy_name": strategy_name,
                                 "account_label": "paper",
                                 "window_start": window_start.isoformat(),
-                                "window_end": now.isoformat(),
+                                "window_end": window_end.isoformat(),
                                 "paper_probation_authorized": True,
                                 "promotion_allowed": True,
                                 "final_promotion_authorized": True,
@@ -1082,6 +1314,9 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertEqual(payload["summary"]["target_with_source_activity_count"], 1)
         self.assertEqual(payload["summary"]["target_with_runtime_ledger_count"], 1)
+        self.assertEqual(
+            payload["summary"]["target_with_evidence_grade_runtime_ledger_count"], 1
+        )
         self.assertEqual(payload["summary"]["target_with_promotion_decision_count"], 1)
         self.assertEqual(payload["summary"]["promotion_allowed_count"], 0)
         self.assertEqual(payload["summary"]["final_promotion_allowed_count"], 0)
@@ -1091,6 +1326,24 @@ class TestPaperRouteEvidenceAudit(TestCase):
             payload["summary"]["promotion_authority"]["reason"],
             "paper_route_evidence_audit_observability_only",
         )
+        self.assertEqual(
+            payload["summary"]["runtime_window_import_audit_state"],
+            "runtime_ledger_ready_for_gate_review",
+        )
+        import_audit = payload["runtime_window_import_audit"]
+        self.assertEqual(import_audit["state"], "runtime_ledger_ready_for_gate_review")
+        self.assertEqual(
+            import_audit["next_action"], "review_runtime_ledger_profit_gates"
+        )
+        self.assertTrue(import_audit["import_ready"])
+        self.assertEqual(import_audit["blockers"], [])
+        self.assertEqual(import_audit["counts"]["source_plan_target_count"], 1)
+        self.assertEqual(import_audit["counts"]["targets_with_source_activity"], 1)
+        self.assertEqual(import_audit["counts"]["targets_with_runtime_ledger"], 1)
+        self.assertEqual(
+            import_audit["counts"]["targets_with_evidence_grade_runtime_ledger"], 1
+        )
+        self.assertFalse(import_audit["promotion_authority"]["allowed"])
 
     def test_runtime_ledger_summary_is_scoped_to_target_stage_account_and_strategy(
         self,


### PR DESCRIPTION
## Summary

- Adds a first-class `runtime_window_import_audit` block to Torghut paper-route evidence output.
- Classifies the proof handoff as waiting, collecting, settlement pending, source activity missing, runtime ledger missing, non-evidence-grade ledger, or ready for gate review.
- Keeps the new audit surface observability-only and explicitly blocks promotion authority.
- Extends focused paper-route evidence tests for pre-session, import-due, and ledger-ready states.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
