### PR TITLE
chore(jangar): promote image 5ade7d76

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-25T05:52:04Z
+    deploy.knative.dev/rollout: 2026-05-25T07:30:16Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 41c9e32ed8e73281591266e6f8e246b5132d056b
+              value: 5ade7d7663cc27b3fecacbe6f68abc03329a886d
             - name: JANGAR_GITOPS_REVISION
-              value: 41c9e32ed8e73281591266e6f8e246b5132d056b
+              value: 5ade7d7663cc27b3fecacbe6f68abc03329a886d
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -367,15 +367,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26385396803"
+              value: "26388927747"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:26a717479ae47fccd5db31b1c0811269f9794d85412b7bbe7cddcffacd20f83f
+              value: sha256:320a2c7604d498e65812b72c147d3324da6fbc98a0a207e409ed9089e2267794
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 41c9e32ed8e73281591266e6f8e246b5132d056b
+              value: 5ade7d7663cc27b3fecacbe6f68abc03329a886d
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:26a717479ae47fccd5db31b1c0811269f9794d85412b7bbe7cddcffacd20f83f
+              value: sha256:320a2c7604d498e65812b72c147d3324da6fbc98a0a207e409ed9089e2267794
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -38,5 +38,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 41c9e32e
-    digest: sha256:26a717479ae47fccd5db31b1c0811269f9794d85412b7bbe7cddcffacd20f83f
+    newTag: 5ade7d76
+    digest: sha256:320a2c7604d498e65812b72c147d3324da6fbc98a0a207e409ed9089e2267794


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `5ade7d7663cc27b3fecacbe6f68abc03329a886d`
- Image tag: `5ade7d76`
- Image digest: `sha256:320a2c7604d498e65812b72c147d3324da6fbc98a0a207e409ed9089e2267794`
- Source CI run: `26388927747`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates