### PR TITLE
fix(torghut): scope ledger probation blockers

### DIFF
--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -2387,6 +2387,17 @@ def _runtime_hypothesis_ids_for_gate_scope(
     }
 
 
+def _runtime_ledger_hypothesis_ids_for_gate_scope(
+    runtime_ledger_candidates: Sequence[Mapping[str, object]],
+) -> set[str]:
+    return {
+        hypothesis_id
+        for candidate in runtime_ledger_candidates
+        for hypothesis_id in [str(candidate.get("hypothesis_id") or "").strip()]
+        if hypothesis_id
+    }
+
+
 def _candidate_reason_codes_for_gate_scope(
     evaluated_tuples: Sequence[Mapping[str, object]],
     *,
@@ -3116,6 +3127,11 @@ def build_live_submission_gate_payload(
     paper_probation_scope_hypothesis_ids = _runtime_hypothesis_ids_for_gate_scope(
         runtime_items,
         eligibility_key="paper_probation_eligible",
+    )
+    paper_probation_scope_hypothesis_ids.update(
+        _runtime_ledger_hypothesis_ids_for_gate_scope(
+            runtime_ledger_paper_probation_candidates
+        )
     )
     if (
         promotion_eligible_total > 0 or claimed_promotion_eligible_total > 0

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -514,6 +514,7 @@ class TestSubmissionCouncil(TestCase):
                 candidate_id: str,
                 strategy_id: str,
                 strategy_family: str,
+                segment_dependencies: list[str] | None = None,
             ) -> None:
                 self.hypothesis_id = hypothesis_id
                 self._payload = {
@@ -523,7 +524,7 @@ class TestSubmissionCouncil(TestCase):
                     "strategy_family": strategy_family,
                     "lane_id": strategy_family,
                     "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
-                    "segment_dependencies": [],
+                    "segment_dependencies": list(segment_dependencies or []),
                 }
 
             def model_dump(self, *, mode: str = "json") -> dict[str, object]:
@@ -545,6 +546,13 @@ class TestSubmissionCouncil(TestCase):
                     candidate_id="c88421d619759b2cfaa6f4d0",
                     strategy_id="microbar_cross_sectional_pairs_v1@research",
                     strategy_family="microbar_cross_sectional_pairs",
+                ),
+                _RegistryItem(
+                    hypothesis_id="H-REV-01",
+                    candidate_id="rev-candidate",
+                    strategy_id="microbar_prev_day_open45_reversal_long_top1_chip_v1@paper",
+                    strategy_family="event_reversion",
+                    segment_dependencies=["market-context"],
                 ),
             ],
         )
@@ -627,6 +635,9 @@ class TestSubmissionCouncil(TestCase):
                         last_autonomy_promotion_action=None,
                         drift_live_promotion_eligible=False,
                         last_market_context_freshness_seconds=45,
+                        last_market_context_domain_states={"news": "stale"},
+                        market_context_alert_active=True,
+                        market_context_alert_reason="market_context_stale",
                         metrics=SimpleNamespace(
                             feature_batch_rows_total=9,
                             feature_null_rate={"price": 0.0},
@@ -650,7 +661,36 @@ class TestSubmissionCouncil(TestCase):
                     empirical_jobs_status={"ready": True, "status": "healthy"},
                     dspy_runtime_status={"mode": "inactive"},
                     quant_health_status=self._healthy_quant_status(),
-                    promotion_certificate_evidence=[],
+                    promotion_certificate_evidence=[
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "metric_window": self._metric_window(
+                                observed_stage="paper",
+                                run_id="pairs-paper-window",
+                                candidate_id="c88421d619759b2cfaa6f4d0",
+                                hypothesis_id="H-PAIRS-01",
+                            ),
+                            "promotion_decision": self._promotion_decision(
+                                run_id="pairs-paper-window",
+                                candidate_id="c88421d619759b2cfaa6f4d0",
+                                hypothesis_id="H-PAIRS-01",
+                            ),
+                        },
+                        {
+                            "hypothesis_id": "H-REV-01",
+                            "metric_window": self._metric_window(
+                                observed_stage="paper",
+                                run_id="rev-paper-window",
+                                candidate_id="rev-candidate",
+                                hypothesis_id="H-REV-01",
+                            ),
+                            "promotion_decision": self._promotion_decision(
+                                run_id="rev-paper-window",
+                                candidate_id="rev-candidate",
+                                hypothesis_id="H-REV-01",
+                            ),
+                        },
+                    ],
                     session=session,
                 )
 
@@ -672,6 +712,9 @@ class TestSubmissionCouncil(TestCase):
         self.assertIn(
             "paper_probation_evidence_collection_only", gate["blocked_reasons"]
         )
+        self.assertNotIn("segment_market-context_blocked", gate["blocked_reasons"])
+        self.assertNotIn("market_context_stale", gate["blocked_reasons"])
+        self.assertNotIn("market_context_domain_news_stale", gate["blocked_reasons"])
         self.assertEqual(len(paper_candidates), 1)
         self.assertEqual(paper_candidates[0]["hypothesis_id"], "H-PAIRS-01")
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Scopes live-submission gate blocker aggregation to runtime-ledger paper-probation hypotheses when durable ledger buckets are the only paper-probation source.
- Prevents unrelated stale market-context candidates from leaking `segment_market-context_blocked` into the active paper-probation gate.
- Adds regression coverage with a stale-news market-context candidate alongside a runtime-ledger H-PAIRS paper-probation candidate.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_submission_council.py -k runtime_ledger_paper_probation -q`
- `uv run --frozen pytest tests/test_submission_council.py -q`
- `uv run --frozen ruff check app/trading/submission_council.py tests/test_submission_council.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
