### PR TITLE
feat(torghut): assemble runtime ledger proof packets

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1,0 +1,830 @@
+#!/usr/bin/env python
+"""Assemble the Torghut runtime-ledger promotion proof packet.
+
+The packet is deliberately stricter than a research scorecard. It only grants
+promotion authority when live status, paper-route runtime-window import output,
+and doc29 runtime-ledger completion evidence all agree on post-cost ledger
+proof. Discovery/replay artifacts can be included as lineage, but they do not
+make the packet promotable by themselves.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, cast
+from urllib.request import urlopen
+
+
+SCHEMA_VERSION = 'torghut.runtime-ledger-live-paper-proof-packet.v1'
+DOC29_LIVE_SCALE_GATE = 'live_scale_observed'
+DEFAULT_MIN_RUNTIME_LEDGER_NET_PNL = Decimal('500')
+DEFAULT_MIN_RUNTIME_LEDGER_DAILY_NET_PNL = Decimal('500')
+DEFAULT_MIN_RUNTIME_LEDGER_TRADING_DAYS = 1
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _text(value: object, default: str = '') -> str:
+    if value is None:
+        return default
+    normalized = str(value).strip()
+    return normalized or default
+
+
+def _bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float, Decimal)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {
+            '1',
+            'true',
+            'yes',
+            'y',
+            'ok',
+            'pass',
+            'passed',
+            'allowed',
+            'satisfied',
+        }
+    return False
+
+
+def _int(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, Decimal):
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(Decimal(value.strip()))
+        except (InvalidOperation, ValueError):
+            return default
+    return default
+
+
+def _decimal(value: object) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value).strip())
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _decimal_text(value: Decimal | None) -> str | None:
+    if value is None:
+        return None
+    text = format(value, 'f')
+    return text.rstrip('0').rstrip('.') if '.' in text else text
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value)
+    return {}
+
+
+def _sequence(value: object) -> Sequence[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return cast(Sequence[object], value)
+    return []
+
+
+def _text_list(value: object) -> list[str]:
+    items: list[str] = []
+    for item in _sequence(value):
+        text = _text(item)
+        if text and text not in items:
+            items.append(text)
+    return items
+
+
+def _extend_unique(items: list[str], additions: Sequence[str]) -> None:
+    for item in additions:
+        text = _text(item)
+        if text and text not in items:
+            items.append(text)
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding='utf-8'))
+    if not isinstance(payload, Mapping):
+        raise ValueError(f'json_object_required:{path}')
+    return {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
+
+
+def _load_json_url(url: str, *, timeout_seconds: float) -> dict[str, Any]:
+    with urlopen(url, timeout=timeout_seconds) as response:
+        payload = json.loads(response.read().decode('utf-8'))
+    if not isinstance(payload, Mapping):
+        raise ValueError(f'json_object_required:{url}')
+    return {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
+
+
+def _load_optional_json_object(
+    *,
+    path: Path | None,
+    url: str | None,
+    timeout_seconds: float,
+) -> dict[str, Any] | None:
+    if path is not None:
+        return _load_json_object(path)
+    if url:
+        return _load_json_url(url, timeout_seconds=timeout_seconds)
+    return None
+
+
+def _check(
+    checks: dict[str, dict[str, Any]],
+    key: str,
+    *,
+    passed: bool,
+    observed: object,
+    expected: object,
+    blockers: Sequence[str] = (),
+    detail: object | None = None,
+) -> None:
+    payload: dict[str, Any] = {
+        'passed': bool(passed),
+        'observed': observed,
+        'expected': expected,
+    }
+    if blockers:
+        payload['blockers'] = list(blockers)
+    if detail is not None:
+        payload['detail'] = detail
+    checks[key] = payload
+
+
+def _completion_live_scale_gate(
+    completion_status: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    for raw_gate in _sequence(completion_status.get('gates')):
+        gate = _mapping(raw_gate)
+        if _text(gate.get('gate_id')) == DOC29_LIVE_SCALE_GATE:
+            return gate
+    gates_by_id = _mapping(completion_status.get('gates_by_id'))
+    return _mapping(gates_by_id.get(DOC29_LIVE_SCALE_GATE))
+
+
+def _runtime_ledger_refs(gate: Mapping[str, Any], key: str) -> list[str]:
+    db_refs = _mapping(gate.get('db_row_refs'))
+    refs = _text_list(db_refs.get(key))
+    if refs:
+        return refs
+    return _text_list(gate.get(key))
+
+
+def _runtime_ledger_trading_day_count(summary: Mapping[str, Any]) -> int:
+    for key in (
+        'runtime_ledger_observed_trading_day_count',
+        'runtime_ledger_trading_day_count',
+        'observed_trading_day_count',
+        'trading_day_count',
+        'runtime_ledger_session_count',
+        'session_count',
+    ):
+        if key in summary:
+            return _int(summary.get(key))
+    return 0
+
+
+def _paper_route_target_plan(
+    paper_route_evidence: Mapping[str, Any] | None,
+) -> Mapping[str, Any]:
+    evidence = paper_route_evidence or {}
+    plan = _mapping(evidence.get('next_paper_route_runtime_window_targets'))
+    if plan:
+        return plan
+    return _mapping(evidence.get('runtime_window_import_plan'))
+
+
+def _paper_route_import_blockers(plan: Mapping[str, Any]) -> list[str]:
+    session_readiness = _mapping(plan.get('session_readiness'))
+    handoff = _mapping(plan.get('runtime_window_import_handoff'))
+    blockers = _text_list(session_readiness.get('import_blockers'))
+    _extend_unique(blockers, _text_list(handoff.get('import_blockers')))
+    for raw_target in _sequence(plan.get('targets')):
+        target = _mapping(raw_target)
+        _extend_unique(
+            blockers, _text_list(target.get('paper_route_session_import_blockers'))
+        )
+    return blockers
+
+
+def _paper_route_targets(plan: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [_mapping(item) for item in _sequence(plan.get('targets')) if _mapping(item)]
+
+
+def _missing_target_identity_count(targets: Sequence[Mapping[str, Any]]) -> int:
+    required = (
+        'hypothesis_id',
+        'candidate_id',
+        'strategy_family',
+        'strategy_name',
+        'source_manifest_ref',
+        'window_start',
+        'window_end',
+    )
+    missing_count = 0
+    for target in targets:
+        if any(not _text(target.get(key)) for key in required):
+            missing_count += 1
+    return missing_count
+
+
+def _runtime_window_import_payload(
+    runtime_window_import: Mapping[str, Any] | None,
+) -> Mapping[str, Any]:
+    payload = runtime_window_import or {}
+    nested = _mapping(payload.get('runtime_window_import'))
+    return nested if nested else payload
+
+
+def _runtime_window_import_items(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    imports = [
+        _mapping(item) for item in _sequence(payload.get('imports')) if _mapping(item)
+    ]
+    if imports:
+        return imports
+    return [payload] if payload else []
+
+
+def _runtime_import_blockers(payload: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    for raw_blocker in _sequence(payload.get('proof_blockers')):
+        blocker = _mapping(raw_blocker)
+        if blocker:
+            _extend_unique(
+                blockers, [_text(blocker.get('blocker') or blocker.get('type'))]
+            )
+        else:
+            text = _text(raw_blocker)
+            if text:
+                _extend_unique(blockers, [text])
+    for item in _runtime_window_import_items(payload):
+        if item is payload:
+            continue
+        _extend_unique(blockers, _runtime_import_blockers(item))
+    return blockers
+
+
+def _runtime_import_authoritative_observation_count(payload: Mapping[str, Any]) -> int:
+    count = 0
+    for item in _runtime_window_import_items(payload):
+        summary = _mapping(item.get('summary'))
+        observation = _mapping(summary.get('runtime_observation'))
+        if observation and observation.get('authoritative') is True:
+            count += 1
+    return count
+
+
+def _first_identity(
+    *,
+    paper_targets: Sequence[Mapping[str, Any]],
+    runtime_import: Mapping[str, Any],
+    completion_gate: Mapping[str, Any],
+) -> dict[str, object]:
+    candidates: list[Mapping[str, Any]] = []
+    candidates.extend(paper_targets)
+    candidates.extend(_runtime_window_import_items(runtime_import))
+    if completion_gate:
+        candidates.append(completion_gate)
+    identity: dict[str, object] = {}
+    for key in (
+        'candidate_id',
+        'hypothesis_id',
+        'observed_stage',
+        'strategy_family',
+        'strategy_name',
+        'account_label',
+        'window_start',
+        'window_end',
+    ):
+        for candidate in candidates:
+            value = _text(candidate.get(key))
+            if value:
+                identity[key] = value
+                break
+    return identity
+
+
+def _status_blockers(status: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    gate = (
+        _mapping(status.get('live_submission_gate'))
+        or _mapping(status.get('live_gate'))
+        or _mapping(status.get('submission_gate'))
+    )
+    if gate:
+        _extend_unique(blockers, _text_list(gate.get('blocked_reasons')))
+        _extend_unique(blockers, _text_list(gate.get('blocking_reasons')))
+        if gate.get('allowed') is False:
+            _extend_unique(
+                blockers,
+                [_text(gate.get('reason'), 'live_submission_gate_not_allowed')],
+            )
+    proof_floor = _mapping(status.get('proof_floor'))
+    _extend_unique(blockers, _text_list(proof_floor.get('blocking_reasons')))
+    return blockers
+
+
+def _completion_blockers(gate: Mapping[str, Any]) -> list[str]:
+    blockers = _text_list(gate.get('blocking_reasons'))
+    blocked_reason = _text(gate.get('blocked_reason'))
+    if blocked_reason:
+        _extend_unique(blockers, [blocked_reason])
+    return blockers
+
+
+def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
+    actions: list[str] = []
+    for blocker in blockers:
+        if blocker in {
+            'paper_route_session_window_not_open',
+            'paper_route_session_window_not_closed',
+        }:
+            _extend_unique(actions, ['wait_for_regular_session_runtime_window'])
+        elif blocker == 'paper_route_session_settlement_pending':
+            _extend_unique(actions, ['wait_for_paper_route_settlement_grace'])
+        elif blocker in {
+            'runtime_window_import_missing',
+            'runtime_ledger_bucket_missing',
+            'paper_route_runtime_ledger_import_pending',
+        }:
+            _extend_unique(
+                actions, ['run_runtime_window_import_from_paper_route_target_plan']
+            )
+        elif blocker.startswith('runtime_ledger_') or blocker in {
+            'filled_notional_missing',
+            'closed_round_trip_missing',
+            'submitted_order_lifecycle_missing',
+            'runtime_decision_lifecycle_missing',
+        }:
+            _extend_unique(
+                actions, ['repair_runtime_ledger_lifecycle_cost_or_lineage_evidence']
+            )
+        elif blocker in {
+            'runtime_ledger_net_pnl_below_target',
+            'runtime_ledger_daily_net_pnl_below_target',
+        }:
+            _extend_unique(
+                actions, ['collect_or_improve_post_cost_runtime_profit_evidence']
+            )
+        elif blocker in {'simple_submit_disabled', 'live_submission_gate_not_allowed'}:
+            _extend_unique(
+                actions, ['keep_promotion_blocked_until_live_gate_and_proof_floor_pass']
+            )
+    if not actions and verdict != 'promotion_authority_allowed':
+        actions.append('inspect_packet_checks_and_repair_failed_proof_dimension')
+    return actions
+
+
+def build_runtime_ledger_proof_packet(
+    status: Mapping[str, Any],
+    *,
+    paper_route_evidence: Mapping[str, Any] | None = None,
+    runtime_window_import: Mapping[str, Any] | None = None,
+    completion_status: Mapping[str, Any] | None = None,
+    min_runtime_ledger_net_pnl: Decimal = DEFAULT_MIN_RUNTIME_LEDGER_NET_PNL,
+    min_runtime_ledger_daily_net_pnl: Decimal = DEFAULT_MIN_RUNTIME_LEDGER_DAILY_NET_PNL,
+    min_runtime_ledger_trading_days: int = DEFAULT_MIN_RUNTIME_LEDGER_TRADING_DAYS,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    checks: dict[str, dict[str, Any]] = {}
+    blockers: list[str] = []
+    generated_at = generated_at or _utc_now()
+
+    live_blockers = _status_blockers(status)
+    _check(
+        checks,
+        'live_status_gate',
+        passed=not live_blockers,
+        observed=live_blockers,
+        expected='no live submission gate or proof-floor blockers',
+        blockers=live_blockers,
+    )
+    _extend_unique(blockers, live_blockers)
+
+    plan = _paper_route_target_plan(paper_route_evidence)
+    paper_targets = _paper_route_targets(plan)
+    paper_import_blockers = _paper_route_import_blockers(plan)
+    handoff = _mapping(plan.get('runtime_window_import_handoff'))
+    session_readiness = _mapping(plan.get('session_readiness'))
+    import_ready = _bool(session_readiness.get('import_ready')) or _bool(
+        handoff.get('import_ready')
+    )
+    missing_identity_count = _missing_target_identity_count(paper_targets)
+    _check(
+        checks,
+        'paper_route_target_plan_present',
+        passed=bool(plan) and bool(paper_targets),
+        observed={'plan_present': bool(plan), 'target_count': len(paper_targets)},
+        expected='paper-route runtime-window target plan with at least one target',
+        blockers=[]
+        if bool(plan) and bool(paper_targets)
+        else ['paper_route_target_plan_missing'],
+    )
+    if not plan or not paper_targets:
+        _extend_unique(blockers, ['paper_route_target_plan_missing'])
+    _check(
+        checks,
+        'paper_route_target_identity',
+        passed=bool(paper_targets) and missing_identity_count == 0,
+        observed={'missing_identity_count': missing_identity_count},
+        expected='all targets carry candidate, hypothesis, strategy, source manifest, and window identity',
+        blockers=[]
+        if missing_identity_count == 0
+        else ['paper_route_target_identity_incomplete'],
+    )
+    if missing_identity_count:
+        _extend_unique(blockers, ['paper_route_target_identity_incomplete'])
+    _check(
+        checks,
+        'paper_route_import_ready',
+        passed=import_ready and not paper_import_blockers,
+        observed={
+            'import_ready': import_ready,
+            'import_blockers': paper_import_blockers,
+        },
+        expected='paper-route target window closed, settled, and import-ready',
+        blockers=paper_import_blockers
+        or ([] if import_ready else ['paper_route_import_not_ready']),
+    )
+    if paper_import_blockers:
+        _extend_unique(blockers, paper_import_blockers)
+    elif not import_ready:
+        _extend_unique(blockers, ['paper_route_import_not_ready'])
+
+    runtime_import_due = import_ready and not paper_import_blockers
+    runtime_import = _runtime_window_import_payload(runtime_window_import)
+    runtime_import_items = _runtime_window_import_items(runtime_import)
+    runtime_import_blockers = _runtime_import_blockers(runtime_import)
+    authoritative_observation_count = _runtime_import_authoritative_observation_count(
+        runtime_import
+    )
+    runtime_import_ok = (
+        runtime_import_due
+        and bool(runtime_import)
+        and _text(runtime_import.get('proof_status'), 'blocked') == 'ok'
+        and not runtime_import_blockers
+        and authoritative_observation_count > 0
+        and all(
+            _text(item.get('proof_status'), 'blocked') == 'ok'
+            for item in runtime_import_items
+        )
+    )
+    _check(
+        checks,
+        'runtime_window_import_proof',
+        passed=runtime_import_ok,
+        observed={
+            'present': bool(runtime_import),
+            'proof_status': _text(runtime_import.get('proof_status'), 'missing'),
+            'target_count': len(runtime_import_items),
+            'runtime_import_due': runtime_import_due,
+            'authoritative_observation_count': authoritative_observation_count,
+            'proof_blockers': runtime_import_blockers,
+        },
+        expected='runtime-window import proof_status ok with authoritative runtime observations and no proof blockers',
+        blockers=runtime_import_blockers
+        or (
+            []
+            if runtime_import_ok or not runtime_import_due
+            else ['runtime_window_import_missing']
+        ),
+    )
+    if runtime_import_blockers:
+        _extend_unique(blockers, runtime_import_blockers)
+    elif runtime_import_due and not runtime_import_ok:
+        _extend_unique(blockers, ['runtime_window_import_missing'])
+
+    completion = completion_status or {}
+    live_scale_gate = _completion_live_scale_gate(completion)
+    completion_gate_blockers = _completion_blockers(live_scale_gate)
+    runtime_summary = _mapping(live_scale_gate.get('runtime_ledger_summary'))
+    ledger_refs = _runtime_ledger_refs(
+        live_scale_gate, 'strategy_runtime_ledger_buckets'
+    )
+    unbacked_refs = _runtime_ledger_refs(
+        live_scale_gate, 'runtime_ledger_unbacked_hypothesis_metric_windows'
+    )
+    gate_satisfied = _text(live_scale_gate.get('status')) == 'satisfied'
+    _check(
+        checks,
+        'doc29_live_scale_gate',
+        passed=(not runtime_import_due)
+        or (gate_satisfied and not completion_gate_blockers),
+        observed={
+            'gate_present': bool(live_scale_gate),
+            'status': _text(live_scale_gate.get('status'), 'missing'),
+            'runtime_import_due': runtime_import_due,
+            'blockers': completion_gate_blockers,
+        },
+        expected='doc29 live_scale_observed gate satisfied',
+        blockers=completion_gate_blockers
+        or (
+            []
+            if gate_satisfied or not runtime_import_due
+            else ['doc29_live_scale_gate_not_satisfied']
+        ),
+    )
+    if completion_gate_blockers:
+        _extend_unique(blockers, completion_gate_blockers)
+    elif runtime_import_due and not gate_satisfied:
+        _extend_unique(blockers, ['doc29_live_scale_gate_not_satisfied'])
+
+    bucket_count = _int(runtime_summary.get('runtime_ledger_bucket_count'))
+    fill_count = _int(runtime_summary.get('runtime_ledger_fill_count'))
+    closed_trade_count = _int(runtime_summary.get('runtime_ledger_closed_trade_count'))
+    filled_notional = _decimal(runtime_summary.get('runtime_ledger_filled_notional'))
+    net_pnl = _decimal(
+        runtime_summary.get('runtime_ledger_net_strategy_pnl_after_costs')
+    )
+    expectancy_bps = _decimal(
+        runtime_summary.get('runtime_ledger_post_cost_expectancy_bps')
+    )
+    trading_days = _runtime_ledger_trading_day_count(runtime_summary)
+    daily_net_pnl = (
+        net_pnl / Decimal(trading_days)
+        if net_pnl is not None and trading_days > 0
+        else None
+    )
+    _check(
+        checks,
+        'runtime_ledger_db_refs',
+        passed=(not runtime_import_due) or (bool(ledger_refs) and not unbacked_refs),
+        observed={
+            'strategy_runtime_ledger_buckets': ledger_refs,
+            'unbacked_metric_windows': unbacked_refs,
+        },
+        expected='runtime ledger bucket db refs present and unbacked windows empty',
+        blockers=[]
+        if (bool(ledger_refs) and not unbacked_refs) or not runtime_import_due
+        else ['runtime_ledger_db_refs_missing_or_unbacked'],
+    )
+    if runtime_import_due and (not ledger_refs or unbacked_refs):
+        _extend_unique(blockers, ['runtime_ledger_db_refs_missing_or_unbacked'])
+    lifecycle_blockers: list[str] = []
+    if runtime_import_due and bucket_count <= 0:
+        lifecycle_blockers.append('runtime_ledger_bucket_count_zero')
+    if runtime_import_due and fill_count <= 0:
+        lifecycle_blockers.append('runtime_ledger_fill_count_zero')
+    if runtime_import_due and closed_trade_count <= 0:
+        lifecycle_blockers.append('runtime_ledger_closed_trade_count_zero')
+    if runtime_import_due and (filled_notional is None or filled_notional <= 0):
+        lifecycle_blockers.append('runtime_ledger_filled_notional_missing')
+    if runtime_import_due and (expectancy_bps is None or expectancy_bps <= 0):
+        lifecycle_blockers.append('runtime_ledger_post_cost_expectancy_not_positive')
+    _check(
+        checks,
+        'runtime_ledger_lifecycle_counts',
+        passed=not lifecycle_blockers,
+        observed={
+            'bucket_count': bucket_count,
+            'fill_count': fill_count,
+            'closed_trade_count': closed_trade_count,
+            'filled_notional': _decimal_text(filled_notional),
+            'post_cost_expectancy_bps': _decimal_text(expectancy_bps),
+        },
+        expected='positive buckets, fills, closed trips, filled notional, and post-cost expectancy',
+        blockers=lifecycle_blockers,
+    )
+    _extend_unique(blockers, lifecycle_blockers)
+    pnl_blockers: list[str] = []
+    if runtime_import_due and (net_pnl is None or net_pnl < min_runtime_ledger_net_pnl):
+        pnl_blockers.append('runtime_ledger_net_pnl_below_target')
+    if runtime_import_due and trading_days < min_runtime_ledger_trading_days:
+        pnl_blockers.append('runtime_ledger_trading_days_below_target')
+    if runtime_import_due and (
+        daily_net_pnl is None or daily_net_pnl < min_runtime_ledger_daily_net_pnl
+    ):
+        pnl_blockers.append('runtime_ledger_daily_net_pnl_below_target')
+    _check(
+        checks,
+        'runtime_ledger_post_cost_profit_target',
+        passed=not pnl_blockers,
+        observed={
+            'net_pnl_after_costs': _decimal_text(net_pnl),
+            'trading_days': trading_days,
+            'daily_net_pnl_after_costs': _decimal_text(daily_net_pnl),
+        },
+        expected={
+            'min_net_pnl_after_costs': _decimal_text(min_runtime_ledger_net_pnl),
+            'min_trading_days': min_runtime_ledger_trading_days,
+            'min_daily_net_pnl_after_costs': _decimal_text(
+                min_runtime_ledger_daily_net_pnl
+            ),
+        },
+        blockers=pnl_blockers,
+    )
+    _extend_unique(blockers, pnl_blockers)
+
+    failed_checks = [key for key, value in checks.items() if not value['passed']]
+    waiting_blockers = {
+        'paper_route_session_window_not_open',
+        'paper_route_session_window_not_closed',
+        'paper_route_session_settlement_pending',
+        'paper_route_import_not_ready',
+    }
+    if not failed_checks:
+        verdict = 'promotion_authority_allowed'
+        reason = 'runtime_ledger_live_paper_post_cost_proof_satisfied'
+    elif set(blockers).issubset(waiting_blockers):
+        verdict = 'waiting_for_runtime_window'
+        reason = 'paper_route_runtime_window_not_importable_yet'
+    else:
+        verdict = 'blocked'
+        reason = 'runtime_ledger_live_paper_post_cost_proof_blocked'
+
+    return {
+        'schema_version': SCHEMA_VERSION,
+        'generated_at': generated_at,
+        'verdict': verdict,
+        'ok': verdict == 'promotion_authority_allowed',
+        'promotion_authority': {
+            'allowed': verdict == 'promotion_authority_allowed',
+            'reason': reason,
+            'blocking_reasons': blockers,
+            'failed_checks': failed_checks,
+        },
+        'target': {
+            'min_runtime_ledger_net_pnl_after_costs': _decimal_text(
+                min_runtime_ledger_net_pnl
+            ),
+            'min_runtime_ledger_daily_net_pnl_after_costs': _decimal_text(
+                min_runtime_ledger_daily_net_pnl
+            ),
+            'min_runtime_ledger_trading_days': min_runtime_ledger_trading_days,
+        },
+        'candidate': _first_identity(
+            paper_targets=paper_targets,
+            runtime_import=runtime_import,
+            completion_gate=live_scale_gate,
+        ),
+        'required_actions': _required_actions(blockers, verdict=verdict),
+        'checks': checks,
+        'evidence': {
+            'status': {
+                'mode': status.get('mode'),
+                'running': status.get('running'),
+                'live_status_blockers': live_blockers,
+            },
+            'paper_route_target_plan': {
+                'schema_version': plan.get('schema_version'),
+                'target_count': len(paper_targets),
+                'import_ready': import_ready,
+                'import_blockers': paper_import_blockers,
+                'session_window': _mapping(plan.get('session_window')),
+            },
+            'runtime_window_import': {
+                'present': bool(runtime_import),
+                'proof_status': runtime_import.get('proof_status'),
+                'target_count': len(runtime_import_items),
+                'proof_blockers': runtime_import_blockers,
+                'authoritative_observation_count': authoritative_observation_count,
+            },
+            'completion_live_scale': {
+                'gate_status': live_scale_gate.get('status'),
+                'runtime_ledger_summary': dict(runtime_summary),
+                'strategy_runtime_ledger_bucket_refs': ledger_refs,
+                'unbacked_metric_window_refs': unbacked_refs,
+            },
+        },
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--status-file', type=Path, help='Path to a /trading/status JSON payload.'
+    )
+    parser.add_argument(
+        '--status-url', help='URL returning a /trading/status JSON payload.'
+    )
+    parser.add_argument(
+        '--paper-route-evidence-file',
+        type=Path,
+        help='Path to a /trading/paper-route-evidence JSON payload.',
+    )
+    parser.add_argument(
+        '--paper-route-evidence-url',
+        help='URL returning a /trading/paper-route-evidence JSON payload.',
+    )
+    parser.add_argument(
+        '--runtime-window-import-file',
+        type=Path,
+        help='Path to renew_latest_empirical_promotion_jobs.py runtime_window_import JSON output.',
+    )
+    parser.add_argument(
+        '--runtime-window-import-url',
+        help='URL returning runtime-window import JSON output.',
+    )
+    parser.add_argument(
+        '--completion-file',
+        type=Path,
+        help='Path to a /trading/completion/doc29 JSON payload.',
+    )
+    parser.add_argument(
+        '--completion-url', help='URL returning /trading/completion/doc29 JSON.'
+    )
+    parser.add_argument(
+        '--min-runtime-ledger-net-pnl',
+        default=str(DEFAULT_MIN_RUNTIME_LEDGER_NET_PNL),
+        help='Minimum total runtime-ledger net strategy PnL after costs.',
+    )
+    parser.add_argument(
+        '--min-runtime-ledger-daily-net-pnl',
+        default=str(DEFAULT_MIN_RUNTIME_LEDGER_DAILY_NET_PNL),
+        help='Minimum runtime-ledger net strategy PnL after costs per observed trading day.',
+    )
+    parser.add_argument(
+        '--min-runtime-ledger-trading-days',
+        type=int,
+        default=DEFAULT_MIN_RUNTIME_LEDGER_TRADING_DAYS,
+        help='Minimum observed runtime-ledger trading days.',
+    )
+    parser.add_argument('--generated-at', default=None)
+    parser.add_argument('--timeout-seconds', type=float, default=10.0)
+    parser.add_argument('--output-file', type=Path, default=None)
+    return parser
+
+
+def _required_source_args(args: argparse.Namespace) -> None:
+    if (args.status_file is None) == (not args.status_url):
+        raise SystemExit('exactly_one_status_source_required')
+    if (args.paper_route_evidence_file is None) == (not args.paper_route_evidence_url):
+        raise SystemExit('exactly_one_paper_route_evidence_source_required')
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    _required_source_args(args)
+    min_net_pnl = _decimal(args.min_runtime_ledger_net_pnl)
+    if min_net_pnl is None:
+        raise SystemExit(
+            f'--min-runtime-ledger-net-pnl must be decimal: {args.min_runtime_ledger_net_pnl!r}'
+        )
+    min_daily_net_pnl = _decimal(args.min_runtime_ledger_daily_net_pnl)
+    if min_daily_net_pnl is None:
+        raise SystemExit(
+            f'--min-runtime-ledger-daily-net-pnl must be decimal: {args.min_runtime_ledger_daily_net_pnl!r}'
+        )
+    status = _load_optional_json_object(
+        path=args.status_file,
+        url=args.status_url,
+        timeout_seconds=args.timeout_seconds,
+    )
+    paper_route_evidence = _load_optional_json_object(
+        path=args.paper_route_evidence_file,
+        url=args.paper_route_evidence_url,
+        timeout_seconds=args.timeout_seconds,
+    )
+    runtime_window_import = _load_optional_json_object(
+        path=args.runtime_window_import_file,
+        url=args.runtime_window_import_url,
+        timeout_seconds=args.timeout_seconds,
+    )
+    completion_status = _load_optional_json_object(
+        path=args.completion_file,
+        url=args.completion_url,
+        timeout_seconds=args.timeout_seconds,
+    )
+    assert status is not None
+    packet = build_runtime_ledger_proof_packet(
+        status,
+        paper_route_evidence=paper_route_evidence,
+        runtime_window_import=runtime_window_import,
+        completion_status=completion_status,
+        min_runtime_ledger_net_pnl=min_net_pnl,
+        min_runtime_ledger_daily_net_pnl=min_daily_net_pnl,
+        min_runtime_ledger_trading_days=max(
+            0, int(args.min_runtime_ledger_trading_days)
+        ),
+        generated_at=args.generated_at,
+    )
+    body = json.dumps(packet, indent=2, sort_keys=True)
+    if args.output_file is not None:
+        args.output_file.parent.mkdir(parents=True, exist_ok=True)
+        args.output_file.write_text(body + '\n', encoding='utf-8')
+    print(body)
+    return 0 if packet['ok'] else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -370,6 +370,13 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
             _extend_unique(
                 actions, ['run_runtime_window_import_from_paper_route_target_plan']
             )
+        elif blocker in {
+            'runtime_ledger_net_pnl_below_target',
+            'runtime_ledger_daily_net_pnl_below_target',
+        }:
+            _extend_unique(
+                actions, ['collect_or_improve_post_cost_runtime_profit_evidence']
+            )
         elif blocker.startswith('runtime_ledger_') or blocker in {
             'filled_notional_missing',
             'closed_round_trip_missing',
@@ -380,12 +387,9 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
                 actions, ['repair_runtime_ledger_lifecycle_cost_or_lineage_evidence']
             )
         elif blocker in {
-            'runtime_ledger_net_pnl_below_target',
-            'runtime_ledger_daily_net_pnl_below_target',
+            'runtime_ledger_trading_days_below_target',
         }:
-            _extend_unique(
-                actions, ['collect_or_improve_post_cost_runtime_profit_evidence']
-            )
+            _extend_unique(actions, ['collect_more_runtime_ledger_trading_days'])
         elif blocker in {'simple_submit_disabled', 'live_submission_gate_not_allowed'}:
             _extend_unique(
                 actions, ['keep_promotion_blocked_until_live_gate_and_proof_floor_pass']

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -19,6 +19,9 @@ ROUTE_REACQUISITION_BOOK_SCHEMA_VERSION = 'torghut.route-reacquisition-book.v1'
 NEXT_PAPER_ROUTE_TARGET_PLAN_SCHEMA_VERSION = (
     'torghut.next-paper-route-runtime-window-targets.v1'
 )
+RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION = (
+    'torghut.runtime-ledger-live-paper-proof-packet.v1'
+)
 DOC29_LIVE_SCALE_GATE = 'live_scale_observed'
 REQUIRED_RUNTIME_WINDOW_TARGET_PLAN_FLAGS = (
     '--runtime-window-import',
@@ -366,6 +369,46 @@ def _runtime_ledger_trading_day_count(
     return 0, None
 
 
+def _add_runtime_ledger_proof_packet_check(
+    checks: dict[str, dict[str, Any]],
+    runtime_ledger_proof_packet: Mapping[str, Any] | None,
+) -> None:
+    packet = _mapping(runtime_ledger_proof_packet)
+    authority = _mapping(packet.get('promotion_authority'))
+    schema_version = _text(packet.get('schema_version'))
+    allowed = authority.get('allowed') is True
+    packet_ok = packet.get('ok') is True and allowed
+    expected_schema = schema_version == RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION
+    _add_check(
+        checks,
+        'runtime_ledger_proof_packet_authority',
+        passed=bool(packet) and expected_schema and packet_ok,
+        observed={
+            'present': bool(packet),
+            'schema_version': schema_version,
+            'ok': packet.get('ok'),
+            'verdict': _text(packet.get('verdict')),
+            'authority_allowed': authority.get('allowed'),
+            'authority_reason': _text(authority.get('reason')),
+            'blocking_reasons': [
+                _text(reason)
+                for reason in _sequence(authority.get('blocking_reasons'))
+                if _text(reason)
+            ],
+            'failed_checks': [
+                _text(check)
+                for check in _sequence(authority.get('failed_checks'))
+                if _text(check)
+            ],
+        },
+        expected={
+            'schema_version': RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
+            'ok': True,
+            'promotion_authority.allowed': True,
+        },
+    )
+
+
 def _add_runtime_ledger_profit_proof_checks(
     checks: dict[str, dict[str, Any]],
     *,
@@ -498,6 +541,7 @@ def evaluate_trading_readiness(
     *,
     completion_status: Mapping[str, Any] | None = None,
     paper_route_evidence: Mapping[str, Any] | None = None,
+    runtime_ledger_proof_packet: Mapping[str, Any] | None = None,
     profile: str = 'paper',
     min_routeable_symbols: int = 2,
     min_decisions: int = 0,
@@ -511,6 +555,7 @@ def evaluate_trading_readiness(
     require_paper_route_target_plan: bool = False,
     require_paper_route_import_ready: bool = False,
     require_runtime_ledger_profit_proof: bool = False,
+    require_runtime_ledger_proof_packet: bool = False,
 ) -> dict[str, Any]:
     """Return a strict readiness verdict from a Torghut trading status payload."""
 
@@ -922,6 +967,11 @@ def evaluate_trading_readiness(
             min_runtime_ledger_trading_days=min_runtime_ledger_trading_days,
             min_runtime_ledger_daily_net_pnl=min_runtime_ledger_daily_net_pnl,
         )
+    if require_runtime_ledger_proof_packet:
+        _add_runtime_ledger_proof_packet_check(
+            checks,
+            runtime_ledger_proof_packet,
+        )
 
     failed_checks = [key for key, value in checks.items() if not value['passed']]
     return {
@@ -938,6 +988,12 @@ def evaluate_trading_readiness(
             'min_runtime_ledger_net_pnl': str(min_runtime_ledger_net_pnl),
             'min_runtime_ledger_trading_days': min_runtime_ledger_trading_days,
             'min_runtime_ledger_daily_net_pnl': str(min_runtime_ledger_daily_net_pnl),
+        },
+        'runtime_ledger_proof_packet': {
+            'required': require_runtime_ledger_proof_packet,
+            'schema_version': _text(
+                _mapping(runtime_ledger_proof_packet).get('schema_version')
+            ),
         },
     }
 
@@ -970,6 +1026,16 @@ def _parser() -> argparse.ArgumentParser:
     paper_route_evidence_source.add_argument(
         '--paper-route-evidence-url',
         help='URL returning a /trading/paper-route-evidence JSON payload.',
+    )
+    runtime_ledger_packet_source = parser.add_mutually_exclusive_group(required=False)
+    runtime_ledger_packet_source.add_argument(
+        '--runtime-ledger-proof-packet-file',
+        type=Path,
+        help='Path to an assemble_runtime_ledger_proof_packet.py JSON payload.',
+    )
+    runtime_ledger_packet_source.add_argument(
+        '--runtime-ledger-proof-packet-url',
+        help='URL returning an assemble_runtime_ledger_proof_packet.py JSON payload.',
     )
     parser.add_argument(
         '--profile', choices=('paper', 'live', 'either'), default='paper'
@@ -1015,6 +1081,11 @@ def _parser() -> argparse.ArgumentParser:
         action='store_true',
         help='Require doc29 live-scale runtime-ledger proof from /trading/completion/doc29.',
     )
+    parser.add_argument(
+        '--require-runtime-ledger-proof-packet',
+        action='store_true',
+        help='Require canonical runtime-ledger proof packet promotion authority.',
+    )
     parser.add_argument('--timeout-seconds', type=float, default=10.0)
     return parser
 
@@ -1038,6 +1109,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         url=args.paper_route_evidence_url,
         timeout_seconds=args.timeout_seconds,
     )
+    runtime_ledger_proof_packet = _load_optional_json_object(
+        path=args.runtime_ledger_proof_packet_file,
+        url=args.runtime_ledger_proof_packet_url,
+        timeout_seconds=args.timeout_seconds,
+    )
     min_runtime_ledger_net_pnl = _decimal(args.min_runtime_ledger_net_pnl)
     if min_runtime_ledger_net_pnl is None:
         raise SystemExit(
@@ -1053,6 +1129,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         status,
         completion_status=completion_status,
         paper_route_evidence=paper_route_evidence,
+        runtime_ledger_proof_packet=runtime_ledger_proof_packet,
         profile=str(args.profile),
         min_routeable_symbols=max(0, int(args.min_routeable_symbols)),
         min_decisions=max(0, int(args.min_decisions)),
@@ -1071,6 +1148,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         require_paper_route_import_ready=bool(args.require_paper_route_import_ready),
         require_runtime_ledger_profit_proof=bool(
             args.require_runtime_ledger_profit_proof
+        ),
+        require_runtime_ledger_proof_packet=bool(
+            args.require_runtime_ledger_proof_packet
         ),
     )
     result['evaluated_at'] = datetime.now(timezone.utc).isoformat()

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 import tempfile
+from argparse import Namespace
 from decimal import Decimal
 from pathlib import Path
 from unittest import TestCase
+from unittest.mock import patch
 
 from scripts import assemble_runtime_ledger_proof_packet as packet
 
@@ -148,6 +150,21 @@ def _completion(
 
 
 class TestRuntimeLedgerProofPacket(TestCase):
+    def test_scalar_normalizers_handle_runtime_json_variants(self) -> None:
+        self.assertTrue(packet._bool(Decimal('1')))
+        self.assertFalse(packet._bool(0))
+        self.assertTrue(packet._bool('allowed'))
+        self.assertFalse(packet._bool(object()))
+
+        self.assertEqual(packet._int(True), 1)
+        self.assertEqual(packet._int(4.9), 4)
+        self.assertEqual(packet._int(Decimal('7')), 7)
+        self.assertEqual(packet._int('8.0'), 8)
+        self.assertEqual(packet._int('bad', default=-1), -1)
+
+        self.assertEqual(packet._decimal(Decimal('12.5')), Decimal('12.5'))
+        self.assertIsNone(packet._decimal('not-a-number'))
+
     def test_packet_allows_only_complete_post_cost_runtime_ledger_proof(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
@@ -225,6 +242,167 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result['promotion_authority']['blocking_reasons'],
         )
 
+    def test_packet_blocks_incomplete_identity_unbacked_refs_and_lifecycle_gaps(self) -> None:
+        paper = _paper_route_evidence()
+        target = paper['next_paper_route_runtime_window_targets']['targets'][0]
+        assert isinstance(target, dict)
+        target['candidate_id'] = ''
+        completion = _completion(
+            status='blocked',
+            net_pnl='bad',
+            trading_days=0,
+            expectancy_bps='0',
+            ledger_refs=[],
+            unbacked_refs=['hypothesis_metric_windows:H-PAIRS-01:2026-05-26'],
+        )
+        gate = completion['gates'][0]
+        assert isinstance(gate, dict)
+        gate['blocking_reasons'] = ['live_scale_runtime_ledger_summary_incomplete']
+        gate['blocked_reason'] = 'live_canary_not_satisfied'
+        summary = gate['runtime_ledger_summary']
+        assert isinstance(summary, dict)
+        summary['runtime_ledger_bucket_count'] = 0
+        summary['runtime_ledger_fill_count'] = 0
+        summary['runtime_ledger_closed_trade_count'] = 0
+        summary['runtime_ledger_filled_notional'] = '0'
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(blockers=['simple_submit_disabled']),
+            paper_route_evidence=paper,
+            runtime_window_import={'runtime_window_import': _runtime_import()},
+            completion_status=completion,
+            min_runtime_ledger_net_pnl=Decimal('500'),
+            min_runtime_ledger_daily_net_pnl=Decimal('500'),
+            min_runtime_ledger_trading_days=1,
+            generated_at='2026-05-26T21:05:00+00:00',
+        )
+
+        blockers = result['promotion_authority']['blocking_reasons']
+        self.assertEqual(result['verdict'], 'blocked')
+        self.assertIn('simple_submit_disabled', blockers)
+        self.assertIn('paper_route_target_identity_incomplete', blockers)
+        self.assertIn('live_scale_runtime_ledger_summary_incomplete', blockers)
+        self.assertIn('live_canary_not_satisfied', blockers)
+        self.assertIn('runtime_ledger_db_refs_missing_or_unbacked', blockers)
+        self.assertIn('runtime_ledger_bucket_count_zero', blockers)
+        self.assertIn('runtime_ledger_fill_count_zero', blockers)
+        self.assertIn('runtime_ledger_closed_trade_count_zero', blockers)
+        self.assertIn('runtime_ledger_filled_notional_missing', blockers)
+        self.assertIn('runtime_ledger_post_cost_expectancy_not_positive', blockers)
+        self.assertIn('runtime_ledger_net_pnl_below_target', blockers)
+        self.assertIn('runtime_ledger_trading_days_below_target', blockers)
+        self.assertIn('runtime_ledger_daily_net_pnl_below_target', blockers)
+        self.assertIn(
+            'keep_promotion_blocked_until_live_gate_and_proof_floor_pass',
+            result['required_actions'],
+        )
+        self.assertIn(
+            'repair_runtime_ledger_lifecycle_cost_or_lineage_evidence',
+            result['required_actions'],
+        )
+        self.assertIn(
+            'collect_or_improve_post_cost_runtime_profit_evidence',
+            result['required_actions'],
+        )
+
+    def test_packet_waits_on_target_level_settlement_blocker(self) -> None:
+        paper = _paper_route_evidence()
+        target = paper['next_paper_route_runtime_window_targets']['targets'][0]
+        assert isinstance(target, dict)
+        target['paper_route_session_import_blockers'] = [
+            'paper_route_session_settlement_pending'
+        ]
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=paper,
+            generated_at='2026-05-26T20:01:00+00:00',
+        )
+
+        self.assertEqual(result['verdict'], 'waiting_for_runtime_window')
+        self.assertEqual(
+            result['promotion_authority']['blocking_reasons'],
+            ['paper_route_session_settlement_pending'],
+        )
+        self.assertEqual(
+            result['required_actions'],
+            ['wait_for_paper_route_settlement_grace'],
+        )
+
+    def test_packet_accepts_alternate_runtime_plan_and_completion_gate_shapes(self) -> None:
+        paper = _paper_route_evidence()
+        plan = paper.pop('next_paper_route_runtime_window_targets')
+        assert isinstance(plan, dict)
+        paper['runtime_window_import_plan'] = plan
+        completion_gate = _completion()['gates'][0]
+
+        result = packet.build_runtime_ledger_proof_packet(
+            {'mode': 'paper', 'running': True, 'live_gate': {'allowed': True}},
+            paper_route_evidence=paper,
+            runtime_window_import={
+                'status': 'ok',
+                'proof_status': 'ok',
+                'candidate_id': 'c88421d619759b2cfaa6f4d0',
+                'summary': {
+                    'runtime_observation': {
+                        'authoritative': True,
+                    },
+                },
+            },
+            completion_status={
+                'gates_by_id': {
+                    packet.DOC29_LIVE_SCALE_GATE: completion_gate,
+                },
+            },
+            generated_at='2026-05-26T21:05:00+00:00',
+        )
+
+        self.assertTrue(result['ok'], result)
+        self.assertEqual(result['evidence']['paper_route_target_plan']['target_count'], 1)
+        self.assertEqual(
+            result['evidence']['runtime_window_import'][
+                'authoritative_observation_count'
+            ],
+            1,
+        )
+
+    def test_packet_preserves_string_proof_blockers_from_runtime_imports(self) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import={
+                'proof_status': 'blocked',
+                'proof_blockers': ['runtime_ledger_bucket_missing'],
+                'imports': [
+                    {
+                        'proof_status': 'blocked',
+                        'proof_blockers': ['runtime_ledger_pnl_basis_missing'],
+                        'summary': {
+                            'runtime_observation': {
+                                'authoritative': False,
+                            },
+                        },
+                    }
+                ],
+            },
+            completion_status=_completion(),
+            generated_at='2026-05-26T21:05:00+00:00',
+        )
+
+        self.assertFalse(result['ok'])
+        self.assertIn(
+            'runtime_ledger_bucket_missing',
+            result['promotion_authority']['blocking_reasons'],
+        )
+        self.assertIn(
+            'runtime_ledger_pnl_basis_missing',
+            result['promotion_authority']['blocking_reasons'],
+        )
+        self.assertIn(
+            'run_runtime_window_import_from_paper_route_target_plan',
+            result['required_actions'],
+        )
+
     def test_cli_writes_packet_and_returns_nonzero_for_blocked_packet(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
@@ -300,3 +478,84 @@ class TestRuntimeLedgerProofPacket(TestCase):
             self.assertEqual(exit_code, 1)
             payload = json.loads(output_path.read_text(encoding='utf-8'))
             self.assertEqual(payload['verdict'], 'waiting_for_runtime_window')
+
+    def test_cli_rejects_missing_duplicate_and_invalid_sources(self) -> None:
+        with self.assertRaisesRegex(SystemExit, 'exactly_one_status_source_required'):
+            packet.main([])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            status_path = tmp_path / 'status.json'
+            paper_path = tmp_path / 'paper.json'
+            status_path.write_text(json.dumps(_status()), encoding='utf-8')
+            paper_path.write_text(json.dumps(_paper_route_evidence()), encoding='utf-8')
+
+            with self.assertRaisesRegex(
+                SystemExit, '--min-runtime-ledger-net-pnl must be decimal'
+            ):
+                packet.main(
+                    [
+                        '--status-file',
+                        str(status_path),
+                        '--paper-route-evidence-file',
+                        str(paper_path),
+                        '--min-runtime-ledger-net-pnl',
+                        'bad',
+                    ]
+                )
+            with self.assertRaisesRegex(
+                SystemExit, '--min-runtime-ledger-daily-net-pnl must be decimal'
+            ):
+                packet.main(
+                    [
+                        '--status-file',
+                        str(status_path),
+                        '--paper-route-evidence-file',
+                        str(paper_path),
+                        '--min-runtime-ledger-daily-net-pnl',
+                        'bad',
+                    ]
+                )
+            with self.assertRaisesRegex(
+                SystemExit, 'exactly_one_paper_route_evidence_source_required'
+            ):
+                packet._required_source_args(
+                    Namespace(
+                        status_file=status_path,
+                        status_url=None,
+                        paper_route_evidence_file=paper_path,
+                        paper_route_evidence_url='http://example.invalid/paper.json',
+                    )
+                )
+
+    def test_json_loaders_require_objects_and_support_urls(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            bad_path = Path(tmp_dir) / 'bad.json'
+            bad_path.write_text(json.dumps(['not', 'an', 'object']), encoding='utf-8')
+            with self.assertRaisesRegex(ValueError, 'json_object_required'):
+                packet._load_json_object(bad_path)
+
+        class _Response:
+            def __init__(self, body: object) -> None:
+                self.body = body
+
+            def __enter__(self) -> '_Response':
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return json.dumps(self.body).encode('utf-8')
+
+        with patch.object(packet, 'urlopen', return_value=_Response({'ok': True})):
+            self.assertEqual(
+                packet._load_json_url('http://example.invalid/status.json', timeout_seconds=1),
+                {'ok': True},
+            )
+        with patch.object(packet, 'urlopen', return_value=_Response(['bad'])):
+            with self.assertRaisesRegex(ValueError, 'json_object_required'):
+                packet._load_json_url(
+                    'http://example.invalid/status.json',
+                    timeout_seconds=1,
+                )

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+import tempfile
+from decimal import Decimal
+from pathlib import Path
+from unittest import TestCase
+
+from scripts import assemble_runtime_ledger_proof_packet as packet
+
+
+def _status(*, blockers: list[str] | None = None) -> dict[str, object]:
+    return {
+        'mode': 'paper',
+        'running': True,
+        'live_submission_gate': {
+            'allowed': not blockers,
+            'reason': 'allowed' if not blockers else blockers[0],
+            'blocked_reasons': blockers or [],
+        },
+        'proof_floor': {
+            'blocking_reasons': [],
+        },
+    }
+
+
+def _paper_route_evidence(
+    *,
+    import_ready: bool = True,
+    import_blockers: list[str] | None = None,
+) -> dict[str, object]:
+    blockers = import_blockers if import_blockers is not None else []
+    return {
+        'schema_version': 'torghut.paper-route-evidence.v1',
+        'next_paper_route_runtime_window_targets': {
+            'schema_version': 'torghut.next-paper-route-runtime-window-targets.v1',
+            'target_count': 1,
+            'session_window': {
+                'start': '2026-05-26T13:30:00+00:00',
+                'end': '2026-05-26T20:00:00+00:00',
+            },
+            'session_readiness': {
+                'import_ready': import_ready,
+                'import_blockers': blockers,
+            },
+            'runtime_window_import_handoff': {
+                'runner': 'scripts/renew_latest_empirical_promotion_jobs.py',
+                'import_ready': import_ready,
+                'import_blockers': blockers,
+                'promotion_allowed': False,
+                'final_promotion_authorized': False,
+            },
+            'targets': [
+                {
+                    'candidate_id': 'c88421d619759b2cfaa6f4d0',
+                    'hypothesis_id': 'H-PAIRS-01',
+                    'observed_stage': 'paper',
+                    'strategy_family': 'microbar_cross_sectional_pairs',
+                    'strategy_name': 'microbar-pairs-vwap-cap-safe',
+                    'account_label': 'TORGHUT_SIM',
+                    'source_manifest_ref': 'config/trading/hypotheses/h-pairs-01.json',
+                    'window_start': '2026-05-26T13:30:00+00:00',
+                    'window_end': '2026-05-26T20:00:00+00:00',
+                    'promotion_allowed': False,
+                    'final_promotion_authorized': False,
+                }
+            ],
+        },
+    }
+
+
+def _runtime_import(
+    *,
+    proof_status: str = 'ok',
+    proof_blockers: list[str] | None = None,
+    authoritative: bool = True,
+) -> dict[str, object]:
+    blocker_payloads = [{'blocker': blocker} for blocker in proof_blockers or []]
+    return {
+        'status': 'ok',
+        'proof_status': proof_status,
+        'proof_blockers': blocker_payloads,
+        'target_count': 1,
+        'imports': [
+            {
+                'status': 'ok',
+                'proof_status': proof_status,
+                'proof_blockers': blocker_payloads,
+                'candidate_id': 'c88421d619759b2cfaa6f4d0',
+                'hypothesis_id': 'H-PAIRS-01',
+                'observed_stage': 'paper',
+                'strategy_family': 'microbar_cross_sectional_pairs',
+                'strategy_name': 'microbar-pairs-vwap-cap-safe',
+                'account_label': 'TORGHUT_SIM',
+                'window_start': '2026-05-26T13:30:00+00:00',
+                'window_end': '2026-05-26T20:00:00+00:00',
+                'summary': {
+                    'promotion_allowed': authoritative,
+                    'runtime_observation': {
+                        'authoritative': authoritative,
+                        'authority_reason': 'runtime_ledger_profit_proof_present'
+                        if authoritative
+                        else 'runtime_without_runtime_ledger_profit_proof',
+                    },
+                },
+            }
+        ],
+    }
+
+
+def _completion(
+    *,
+    status: str = 'satisfied',
+    net_pnl: str = '650',
+    trading_days: int = 1,
+    expectancy_bps: str = '13',
+    ledger_refs: list[str] | None = None,
+    unbacked_refs: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        'doc_id': 'doc29',
+        'summary': {'all_satisfied': status == 'satisfied'},
+        'gates': [
+            {
+                'gate_id': packet.DOC29_LIVE_SCALE_GATE,
+                'status': status,
+                'candidate_id': 'c88421d619759b2cfaa6f4d0',
+                'runtime_ledger_summary': {
+                    'runtime_ledger_bucket_count': 1,
+                    'runtime_ledger_fill_count': 4,
+                    'runtime_ledger_closed_trade_count': 2,
+                    'runtime_ledger_filled_notional': '50000',
+                    'runtime_ledger_net_strategy_pnl_after_costs': net_pnl,
+                    'runtime_ledger_post_cost_expectancy_bps': expectancy_bps,
+                    'runtime_ledger_observed_trading_day_count': trading_days,
+                },
+                'db_row_refs': {
+                    'strategy_runtime_ledger_buckets': ledger_refs
+                    if ledger_refs is not None
+                    else ['strategy-runtime-ledger-buckets:H-PAIRS-01:2026-05-26'],
+                    'runtime_ledger_unbacked_hypothesis_metric_windows': unbacked_refs
+                    if unbacked_refs is not None
+                    else [],
+                },
+            }
+        ],
+    }
+
+
+class TestRuntimeLedgerProofPacket(TestCase):
+    def test_packet_allows_only_complete_post_cost_runtime_ledger_proof(self) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(),
+            min_runtime_ledger_net_pnl=Decimal('500'),
+            min_runtime_ledger_daily_net_pnl=Decimal('500'),
+            min_runtime_ledger_trading_days=1,
+            generated_at='2026-05-26T21:05:00+00:00',
+        )
+
+        self.assertTrue(result['ok'], result)
+        self.assertEqual(result['schema_version'], packet.SCHEMA_VERSION)
+        self.assertEqual(result['verdict'], 'promotion_authority_allowed')
+        self.assertEqual(result['promotion_authority']['blocking_reasons'], [])
+        self.assertEqual(result['candidate']['hypothesis_id'], 'H-PAIRS-01')
+        self.assertEqual(
+            result['checks']['runtime_ledger_post_cost_profit_target']['observed'][
+                'daily_net_pnl_after_costs'
+            ],
+            '650',
+        )
+
+    def test_packet_waits_before_paper_route_window_is_importable(self) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(
+                import_ready=False,
+                import_blockers=['paper_route_session_window_not_open'],
+            ),
+            generated_at='2026-05-25T21:05:00+00:00',
+        )
+
+        self.assertFalse(result['ok'])
+        self.assertEqual(result['verdict'], 'waiting_for_runtime_window')
+        self.assertEqual(
+            result['promotion_authority']['blocking_reasons'],
+            ['paper_route_session_window_not_open'],
+        )
+        self.assertEqual(
+            result['required_actions'],
+            ['wait_for_regular_session_runtime_window'],
+        )
+        self.assertFalse(
+            result['checks']['runtime_window_import_proof']['observed'][
+                'runtime_import_due'
+            ]
+        )
+
+    def test_packet_blocks_non_authoritative_import_and_weak_daily_profit(self) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(
+                proof_status='blocked',
+                proof_blockers=['runtime_without_runtime_ledger_profit_proof'],
+                authoritative=False,
+            ),
+            completion_status=_completion(net_pnl='600', trading_days=3),
+            min_runtime_ledger_net_pnl=Decimal('500'),
+            min_runtime_ledger_daily_net_pnl=Decimal('500'),
+            min_runtime_ledger_trading_days=1,
+            generated_at='2026-05-26T21:05:00+00:00',
+        )
+
+        self.assertFalse(result['ok'])
+        self.assertEqual(result['verdict'], 'blocked')
+        self.assertIn(
+            'runtime_without_runtime_ledger_profit_proof',
+            result['promotion_authority']['blocking_reasons'],
+        )
+        self.assertIn(
+            'runtime_ledger_daily_net_pnl_below_target',
+            result['promotion_authority']['blocking_reasons'],
+        )
+
+    def test_cli_writes_packet_and_returns_nonzero_for_blocked_packet(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            status_path = tmp_path / 'status.json'
+            paper_path = tmp_path / 'paper.json'
+            import_path = tmp_path / 'import.json'
+            completion_path = tmp_path / 'completion.json'
+            output_path = tmp_path / 'packet.json'
+            status_path.write_text(json.dumps(_status()), encoding='utf-8')
+            paper_path.write_text(json.dumps(_paper_route_evidence()), encoding='utf-8')
+            import_path.write_text(
+                json.dumps(
+                    _runtime_import(
+                        proof_status='blocked',
+                        proof_blockers=['runtime_ledger_pnl_basis_missing'],
+                    )
+                ),
+                encoding='utf-8',
+            )
+            completion_path.write_text(json.dumps(_completion()), encoding='utf-8')
+
+            exit_code = packet.main(
+                [
+                    '--status-file',
+                    str(status_path),
+                    '--paper-route-evidence-file',
+                    str(paper_path),
+                    '--runtime-window-import-file',
+                    str(import_path),
+                    '--completion-file',
+                    str(completion_path),
+                    '--output-file',
+                    str(output_path),
+                ]
+            )
+
+            self.assertEqual(exit_code, 1)
+            payload = json.loads(output_path.read_text(encoding='utf-8'))
+            self.assertEqual(payload['verdict'], 'blocked')
+            self.assertIn(
+                'runtime_ledger_pnl_basis_missing',
+                payload['promotion_authority']['blocking_reasons'],
+            )
+
+    def test_cli_can_emit_waiting_packet_before_import_outputs_exist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            status_path = tmp_path / 'status.json'
+            paper_path = tmp_path / 'paper.json'
+            output_path = tmp_path / 'packet.json'
+            status_path.write_text(json.dumps(_status()), encoding='utf-8')
+            paper_path.write_text(
+                json.dumps(
+                    _paper_route_evidence(
+                        import_ready=False,
+                        import_blockers=['paper_route_session_window_not_open'],
+                    )
+                ),
+                encoding='utf-8',
+            )
+
+            exit_code = packet.main(
+                [
+                    '--status-file',
+                    str(status_path),
+                    '--paper-route-evidence-file',
+                    str(paper_path),
+                    '--output-file',
+                    str(output_path),
+                ]
+            )
+
+            self.assertEqual(exit_code, 1)
+            payload = json.loads(output_path.read_text(encoding='utf-8'))
+            self.assertEqual(payload['verdict'], 'waiting_for_runtime_window')

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -234,6 +234,31 @@ def _paper_route_evidence(
     }
 
 
+def _runtime_ledger_proof_packet(
+    *,
+    allowed: bool = True,
+    blockers: list[str] | None = None,
+) -> dict[str, object]:
+    blocking_reasons = blockers or (
+        [] if allowed else ['runtime_ledger_daily_net_pnl_below_target']
+    )
+    return {
+        'schema_version': verifier.RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
+        'ok': allowed,
+        'verdict': 'promotion_authority_allowed' if allowed else 'blocked',
+        'promotion_authority': {
+            'allowed': allowed,
+            'reason': 'runtime_ledger_live_paper_post_cost_proof_satisfied'
+            if allowed
+            else 'runtime_ledger_live_paper_post_cost_proof_blocked',
+            'blocking_reasons': blocking_reasons,
+            'failed_checks': []
+            if allowed
+            else ['runtime_ledger_post_cost_profit_target'],
+        },
+    }
+
+
 class _JsonHandler(BaseHTTPRequestHandler):
     payload: ClassVar[object] = {}
 
@@ -342,6 +367,44 @@ class TestVerifyTradingReadiness(TestCase):
             'runtime_ledger_post_cost_expectancy_positive',
         ):
             self.assertIn(check_name, weak['failed_checks'])
+
+    def test_runtime_ledger_proof_packet_can_be_required_as_final_authority(
+        self,
+    ) -> None:
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            runtime_ledger_proof_packet=_runtime_ledger_proof_packet(),
+            require_runtime_ledger_proof_packet=True,
+        )
+
+        self.assertTrue(result['ok'], result)
+        self.assertEqual(result['failed_checks'], [])
+        self.assertEqual(
+            result['runtime_ledger_proof_packet']['schema_version'],
+            verifier.RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
+        )
+
+    def test_runtime_ledger_proof_packet_fails_closed_when_blocked(self) -> None:
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            runtime_ledger_proof_packet=_runtime_ledger_proof_packet(
+                allowed=False,
+                blockers=['runtime_ledger_daily_net_pnl_below_target'],
+            ),
+            require_runtime_ledger_proof_packet=True,
+        )
+
+        self.assertFalse(result['ok'])
+        self.assertIn(
+            'runtime_ledger_proof_packet_authority',
+            result['failed_checks'],
+        )
+        self.assertEqual(
+            result['checks']['runtime_ledger_proof_packet_authority']['observed'][
+                'blocking_reasons'
+            ],
+            ['runtime_ledger_daily_net_pnl_below_target'],
+        )
 
     def test_runtime_ledger_profit_proof_requires_observed_days_and_daily_pnl(
         self,


### PR DESCRIPTION
## Summary

- Added a canonical runtime-ledger live-paper proof packet assembler that binds `/trading/status`, `/trading/paper-route-evidence`, runtime-window import output, and `/trading/completion/doc29`.
- Kept the packet promotion authority false until post-cost runtime-ledger proof passes configurable net PnL, daily PnL, lifecycle, lineage, import, and doc29 gates.
- Extended `verify_trading_readiness.py` so readiness checks can require the canonical proof packet as final promotion authority.
- Added regression coverage for allowed, waiting-for-window, blocked, and CLI packet flows.

## Related Issues

None

## Testing

- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Live read-only rollout check: Argo CD `torghut` Healthy/Synced at `63f9761fd717af6caf9788ba091b84b371bdb360`; `torghut-00632` and `torghut-sim-00717` ready on digest `sha256:30a706628edef3808b5283040ce1b9f13068621f228a3ab885793715ff5f12ce`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
