### PR TITLE
feat(torghut): automate runtime proof packet handoff

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -35,10 +35,19 @@ NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION = (
 PAPER_ROUTE_RUNTIME_WINDOW_IMPORT_AUDIT_SCHEMA_VERSION = (
     "torghut.paper-route-runtime-window-import-audit.v1"
 )
+RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION = (
+    "torghut.runtime-ledger-proof-packet-handoff.v1"
+)
 DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS = 72
 DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT = 20
 PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL = "TORGHUT_SIM"
 PAPER_ROUTE_RUNTIME_IMPORT_SETTLEMENT_SECONDS = 3600
+DEFAULT_TORGHUT_SERVICE_BASE_URL = "http://torghut.torghut.svc.cluster.local"
+RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE = "artifacts/runtime-ledger-proof-packet.json"
+RUNTIME_WINDOW_IMPORT_OUTPUT_FILE = "artifacts/runtime-window-import.json"
+MIN_RUNTIME_LEDGER_PROOF_NET_PNL = "500"
+MIN_RUNTIME_LEDGER_PROOF_DAILY_NET_PNL = "500"
+MIN_RUNTIME_LEDGER_PROOF_TRADING_DAYS = 1
 US_EQUITIES_TIMEZONE = "America/New_York"
 US_EQUITIES_OPEN = time(hour=9, minute=30)
 US_EQUITIES_CLOSE = time(hour=16, minute=0)
@@ -1265,6 +1274,121 @@ def _runtime_window_import_audit(
     }
 
 
+def _runtime_ledger_proof_packet_handoff(
+    *,
+    next_targets: Mapping[str, object],
+    runtime_window_import_audit: Mapping[str, object],
+) -> dict[str, object]:
+    runtime_import_handoff = _as_mapping(
+        next_targets.get("runtime_window_import_handoff")
+    )
+    session_readiness = _as_mapping(next_targets.get("session_readiness"))
+    import_ready = bool(
+        session_readiness.get("import_ready")
+        or runtime_import_handoff.get("import_ready")
+        or runtime_window_import_audit.get("import_ready")
+    )
+    import_blockers = _unique_text_items(session_readiness.get("import_blockers")) + [
+        blocker
+        for blocker in _unique_text_items(runtime_import_handoff.get("import_blockers"))
+        if blocker not in _unique_text_items(session_readiness.get("import_blockers"))
+    ]
+    base_args = [
+        "uv",
+        "run",
+        "--frozen",
+        "python",
+        "scripts/assemble_runtime_ledger_proof_packet.py",
+        "--service-base-url",
+        "$TORGHUT_SERVICE_BASE_URL",
+        "--min-runtime-ledger-net-pnl",
+        MIN_RUNTIME_LEDGER_PROOF_NET_PNL,
+        "--min-runtime-ledger-daily-net-pnl",
+        MIN_RUNTIME_LEDGER_PROOF_DAILY_NET_PNL,
+        "--min-runtime-ledger-trading-days",
+        str(MIN_RUNTIME_LEDGER_PROOF_TRADING_DAYS),
+        "--output-file",
+        RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE,
+    ]
+    authority_args = [
+        *base_args[:-2],
+        "--runtime-window-import-file",
+        RUNTIME_WINDOW_IMPORT_OUTPUT_FILE,
+        "--completion-url",
+        "$TORGHUT_SERVICE_BASE_URL/trading/completion/doc29",
+        "--output-file",
+        RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE,
+    ]
+    return {
+        "schema_version": RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION,
+        "source": "paper_route_evidence_audit",
+        "purpose": "assemble_runtime_ledger_live_paper_proof_packet",
+        "promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "promotion_gate": "runtime_ledger_live_or_live_paper_required",
+        "service_base_url_env": "TORGHUT_SERVICE_BASE_URL",
+        "default_service_base_url": DEFAULT_TORGHUT_SERVICE_BASE_URL,
+        "source_endpoints": {
+            "status": "/trading/status",
+            "paper_route_evidence": "/trading/paper-route-evidence",
+            "completion_doc29": "/trading/completion/doc29",
+        },
+        "targets": {
+            "min_runtime_ledger_net_pnl_after_costs": (
+                MIN_RUNTIME_LEDGER_PROOF_NET_PNL
+            ),
+            "min_runtime_ledger_daily_net_pnl_after_costs": (
+                MIN_RUNTIME_LEDGER_PROOF_DAILY_NET_PNL
+            ),
+            "min_runtime_ledger_trading_days": MIN_RUNTIME_LEDGER_PROOF_TRADING_DAYS,
+        },
+        "runtime_window": {
+            "import_ready": import_ready,
+            "import_blockers": sorted(dict.fromkeys(import_blockers)),
+            "session_window": _as_mapping(next_targets.get("session_window")),
+            "settlement_ready_at": session_readiness.get("settlement_ready_at"),
+            "target_count": _safe_int(next_targets.get("target_count")),
+            "import_audit_state": _safe_text(runtime_window_import_audit.get("state"))
+            or "unknown",
+            "import_audit_next_action": _safe_text(
+                runtime_window_import_audit.get("next_action")
+            )
+            or "inspect_packet_checks_and_repair_failed_proof_dimension",
+        },
+        "required_inputs": {
+            "status": {
+                "endpoint": "/trading/status",
+                "required": True,
+            },
+            "paper_route_evidence": {
+                "endpoint": "/trading/paper-route-evidence",
+                "required": True,
+            },
+            "runtime_window_import": {
+                "output_file": RUNTIME_WINDOW_IMPORT_OUTPUT_FILE,
+                "required_when": "runtime_window.import_ready",
+                "producer": "scripts/renew_latest_empirical_promotion_jobs.py",
+            },
+            "completion_doc29": {
+                "endpoint": "/trading/completion/doc29",
+                "required_when": "runtime_window.import_ready",
+            },
+        },
+        "commands": {
+            "waiting_packet": {
+                "argv": base_args,
+                "expected_verdict": "waiting_for_runtime_window",
+            },
+            "authority_packet_after_import": {
+                "argv": authority_args,
+                "expected_verdict": "promotion_authority_allowed",
+                "allowed_only_if_packet_ok": True,
+            },
+        },
+        "runtime_window_import_handoff": runtime_import_handoff,
+    }
+
+
 def build_paper_route_evidence_audit(
     session: Session,
     *,
@@ -1300,6 +1424,10 @@ def build_paper_route_evidence_audit(
     runtime_window_import_audit = _runtime_window_import_audit(
         next_targets=next_targets,
         target_audits=target_audits,
+    )
+    proof_packet_handoff = _runtime_ledger_proof_packet_handoff(
+        next_targets=next_targets,
+        runtime_window_import_audit=runtime_window_import_audit,
     )
     summary_blockers = sorted(
         {
@@ -1346,6 +1474,7 @@ def build_paper_route_evidence_audit(
         "paper_route_probe": probe,
         "next_paper_route_runtime_window_targets": next_targets,
         "runtime_window_import_audit": runtime_window_import_audit,
+        "runtime_ledger_proof_packet_handoff": proof_packet_handoff,
         "summary": {
             "target_count": len(targets),
             "target_with_source_activity_count": sum(
@@ -1440,5 +1569,6 @@ __all__ = [
     "NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION",
     "PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION",
     "PAPER_ROUTE_RUNTIME_WINDOW_IMPORT_AUDIT_SCHEMA_VERSION",
+    "RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION",
     "build_paper_route_evidence_audit",
 ]

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -17,21 +17,25 @@ from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import urljoin
 from urllib.request import urlopen
 
 
-SCHEMA_VERSION = 'torghut.runtime-ledger-live-paper-proof-packet.v1'
-DOC29_LIVE_SCALE_GATE = 'live_scale_observed'
-DEFAULT_MIN_RUNTIME_LEDGER_NET_PNL = Decimal('500')
-DEFAULT_MIN_RUNTIME_LEDGER_DAILY_NET_PNL = Decimal('500')
+SCHEMA_VERSION = "torghut.runtime-ledger-live-paper-proof-packet.v1"
+DOC29_LIVE_SCALE_GATE = "live_scale_observed"
+DEFAULT_MIN_RUNTIME_LEDGER_NET_PNL = Decimal("500")
+DEFAULT_MIN_RUNTIME_LEDGER_DAILY_NET_PNL = Decimal("500")
 DEFAULT_MIN_RUNTIME_LEDGER_TRADING_DAYS = 1
+STATUS_ENDPOINT = "/trading/status"
+PAPER_ROUTE_EVIDENCE_ENDPOINT = "/trading/paper-route-evidence"
+COMPLETION_DOC29_ENDPOINT = "/trading/completion/doc29"
 
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _text(value: object, default: str = '') -> str:
+def _text(value: object, default: str = "") -> str:
     if value is None:
         return default
     normalized = str(value).strip()
@@ -45,15 +49,15 @@ def _bool(value: object) -> bool:
         return value != 0
     if isinstance(value, str):
         return value.strip().lower() in {
-            '1',
-            'true',
-            'yes',
-            'y',
-            'ok',
-            'pass',
-            'passed',
-            'allowed',
-            'satisfied',
+            "1",
+            "true",
+            "yes",
+            "y",
+            "ok",
+            "pass",
+            "passed",
+            "allowed",
+            "satisfied",
         }
     return False
 
@@ -89,8 +93,8 @@ def _decimal(value: object) -> Decimal | None:
 def _decimal_text(value: Decimal | None) -> str | None:
     if value is None:
         return None
-    text = format(value, 'f')
-    return text.rstrip('0').rstrip('.') if '.' in text else text
+    text = format(value, "f")
+    return text.rstrip("0").rstrip(".") if "." in text else text
 
 
 def _mapping(value: object) -> Mapping[str, Any]:
@@ -122,17 +126,17 @@ def _extend_unique(items: list[str], additions: Sequence[str]) -> None:
 
 
 def _load_json_object(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding='utf-8'))
+    payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, Mapping):
-        raise ValueError(f'json_object_required:{path}')
+        raise ValueError(f"json_object_required:{path}")
     return {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
 
 
 def _load_json_url(url: str, *, timeout_seconds: float) -> dict[str, Any]:
     with urlopen(url, timeout=timeout_seconds) as response:
-        payload = json.loads(response.read().decode('utf-8'))
+        payload = json.loads(response.read().decode("utf-8"))
     if not isinstance(payload, Mapping):
-        raise ValueError(f'json_object_required:{url}')
+        raise ValueError(f"json_object_required:{url}")
     return {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
 
 
@@ -149,6 +153,38 @@ def _load_optional_json_object(
     return None
 
 
+def _service_endpoint_url(service_base_url: str, endpoint: str) -> str:
+    base = service_base_url.strip()
+    if not base:
+        raise SystemExit("--service-base-url must not be empty")
+    return urljoin(f"{base.rstrip('/')}/", endpoint.lstrip("/"))
+
+
+def _apply_service_base_url_defaults(args: argparse.Namespace) -> dict[str, str]:
+    service_base_url = _text(getattr(args, "service_base_url", None))
+    if not service_base_url:
+        return {}
+
+    defaults = {
+        "status_url": _service_endpoint_url(service_base_url, STATUS_ENDPOINT),
+        "paper_route_evidence_url": _service_endpoint_url(
+            service_base_url,
+            PAPER_ROUTE_EVIDENCE_ENDPOINT,
+        ),
+        "completion_url": _service_endpoint_url(
+            service_base_url,
+            COMPLETION_DOC29_ENDPOINT,
+        ),
+    }
+    if args.status_file is None and not args.status_url:
+        args.status_url = defaults["status_url"]
+    if args.paper_route_evidence_file is None and not args.paper_route_evidence_url:
+        args.paper_route_evidence_url = defaults["paper_route_evidence_url"]
+    if args.completion_file is None and not args.completion_url:
+        args.completion_url = defaults["completion_url"]
+    return defaults
+
+
 def _check(
     checks: dict[str, dict[str, Any]],
     key: str,
@@ -160,30 +196,30 @@ def _check(
     detail: object | None = None,
 ) -> None:
     payload: dict[str, Any] = {
-        'passed': bool(passed),
-        'observed': observed,
-        'expected': expected,
+        "passed": bool(passed),
+        "observed": observed,
+        "expected": expected,
     }
     if blockers:
-        payload['blockers'] = list(blockers)
+        payload["blockers"] = list(blockers)
     if detail is not None:
-        payload['detail'] = detail
+        payload["detail"] = detail
     checks[key] = payload
 
 
 def _completion_live_scale_gate(
     completion_status: Mapping[str, Any],
 ) -> Mapping[str, Any]:
-    for raw_gate in _sequence(completion_status.get('gates')):
+    for raw_gate in _sequence(completion_status.get("gates")):
         gate = _mapping(raw_gate)
-        if _text(gate.get('gate_id')) == DOC29_LIVE_SCALE_GATE:
+        if _text(gate.get("gate_id")) == DOC29_LIVE_SCALE_GATE:
             return gate
-    gates_by_id = _mapping(completion_status.get('gates_by_id'))
+    gates_by_id = _mapping(completion_status.get("gates_by_id"))
     return _mapping(gates_by_id.get(DOC29_LIVE_SCALE_GATE))
 
 
 def _runtime_ledger_refs(gate: Mapping[str, Any], key: str) -> list[str]:
-    db_refs = _mapping(gate.get('db_row_refs'))
+    db_refs = _mapping(gate.get("db_row_refs"))
     refs = _text_list(db_refs.get(key))
     if refs:
         return refs
@@ -192,12 +228,12 @@ def _runtime_ledger_refs(gate: Mapping[str, Any], key: str) -> list[str]:
 
 def _runtime_ledger_trading_day_count(summary: Mapping[str, Any]) -> int:
     for key in (
-        'runtime_ledger_observed_trading_day_count',
-        'runtime_ledger_trading_day_count',
-        'observed_trading_day_count',
-        'trading_day_count',
-        'runtime_ledger_session_count',
-        'session_count',
+        "runtime_ledger_observed_trading_day_count",
+        "runtime_ledger_trading_day_count",
+        "observed_trading_day_count",
+        "trading_day_count",
+        "runtime_ledger_session_count",
+        "session_count",
     ):
         if key in summary:
             return _int(summary.get(key))
@@ -208,38 +244,38 @@ def _paper_route_target_plan(
     paper_route_evidence: Mapping[str, Any] | None,
 ) -> Mapping[str, Any]:
     evidence = paper_route_evidence or {}
-    plan = _mapping(evidence.get('next_paper_route_runtime_window_targets'))
+    plan = _mapping(evidence.get("next_paper_route_runtime_window_targets"))
     if plan:
         return plan
-    return _mapping(evidence.get('runtime_window_import_plan'))
+    return _mapping(evidence.get("runtime_window_import_plan"))
 
 
 def _paper_route_import_blockers(plan: Mapping[str, Any]) -> list[str]:
-    session_readiness = _mapping(plan.get('session_readiness'))
-    handoff = _mapping(plan.get('runtime_window_import_handoff'))
-    blockers = _text_list(session_readiness.get('import_blockers'))
-    _extend_unique(blockers, _text_list(handoff.get('import_blockers')))
-    for raw_target in _sequence(plan.get('targets')):
+    session_readiness = _mapping(plan.get("session_readiness"))
+    handoff = _mapping(plan.get("runtime_window_import_handoff"))
+    blockers = _text_list(session_readiness.get("import_blockers"))
+    _extend_unique(blockers, _text_list(handoff.get("import_blockers")))
+    for raw_target in _sequence(plan.get("targets")):
         target = _mapping(raw_target)
         _extend_unique(
-            blockers, _text_list(target.get('paper_route_session_import_blockers'))
+            blockers, _text_list(target.get("paper_route_session_import_blockers"))
         )
     return blockers
 
 
 def _paper_route_targets(plan: Mapping[str, Any]) -> list[Mapping[str, Any]]:
-    return [_mapping(item) for item in _sequence(plan.get('targets')) if _mapping(item)]
+    return [_mapping(item) for item in _sequence(plan.get("targets")) if _mapping(item)]
 
 
 def _missing_target_identity_count(targets: Sequence[Mapping[str, Any]]) -> int:
     required = (
-        'hypothesis_id',
-        'candidate_id',
-        'strategy_family',
-        'strategy_name',
-        'source_manifest_ref',
-        'window_start',
-        'window_end',
+        "hypothesis_id",
+        "candidate_id",
+        "strategy_family",
+        "strategy_name",
+        "source_manifest_ref",
+        "window_start",
+        "window_end",
     )
     missing_count = 0
     for target in targets:
@@ -252,13 +288,13 @@ def _runtime_window_import_payload(
     runtime_window_import: Mapping[str, Any] | None,
 ) -> Mapping[str, Any]:
     payload = runtime_window_import or {}
-    nested = _mapping(payload.get('runtime_window_import'))
+    nested = _mapping(payload.get("runtime_window_import"))
     return nested if nested else payload
 
 
 def _runtime_window_import_items(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     imports = [
-        _mapping(item) for item in _sequence(payload.get('imports')) if _mapping(item)
+        _mapping(item) for item in _sequence(payload.get("imports")) if _mapping(item)
     ]
     if imports:
         return imports
@@ -267,11 +303,11 @@ def _runtime_window_import_items(payload: Mapping[str, Any]) -> list[Mapping[str
 
 def _runtime_import_blockers(payload: Mapping[str, Any]) -> list[str]:
     blockers: list[str] = []
-    for raw_blocker in _sequence(payload.get('proof_blockers')):
+    for raw_blocker in _sequence(payload.get("proof_blockers")):
         blocker = _mapping(raw_blocker)
         if blocker:
             _extend_unique(
-                blockers, [_text(blocker.get('blocker') or blocker.get('type'))]
+                blockers, [_text(blocker.get("blocker") or blocker.get("type"))]
             )
         else:
             text = _text(raw_blocker)
@@ -287,9 +323,9 @@ def _runtime_import_blockers(payload: Mapping[str, Any]) -> list[str]:
 def _runtime_import_authoritative_observation_count(payload: Mapping[str, Any]) -> int:
     count = 0
     for item in _runtime_window_import_items(payload):
-        summary = _mapping(item.get('summary'))
-        observation = _mapping(summary.get('runtime_observation'))
-        if observation and observation.get('authoritative') is True:
+        summary = _mapping(item.get("summary"))
+        observation = _mapping(summary.get("runtime_observation"))
+        if observation and observation.get("authoritative") is True:
             count += 1
     return count
 
@@ -307,14 +343,14 @@ def _first_identity(
         candidates.append(completion_gate)
     identity: dict[str, object] = {}
     for key in (
-        'candidate_id',
-        'hypothesis_id',
-        'observed_stage',
-        'strategy_family',
-        'strategy_name',
-        'account_label',
-        'window_start',
-        'window_end',
+        "candidate_id",
+        "hypothesis_id",
+        "observed_stage",
+        "strategy_family",
+        "strategy_name",
+        "account_label",
+        "window_start",
+        "window_end",
     ):
         for candidate in candidates:
             value = _text(candidate.get(key))
@@ -327,26 +363,26 @@ def _first_identity(
 def _status_blockers(status: Mapping[str, Any]) -> list[str]:
     blockers: list[str] = []
     gate = (
-        _mapping(status.get('live_submission_gate'))
-        or _mapping(status.get('live_gate'))
-        or _mapping(status.get('submission_gate'))
+        _mapping(status.get("live_submission_gate"))
+        or _mapping(status.get("live_gate"))
+        or _mapping(status.get("submission_gate"))
     )
     if gate:
-        _extend_unique(blockers, _text_list(gate.get('blocked_reasons')))
-        _extend_unique(blockers, _text_list(gate.get('blocking_reasons')))
-        if gate.get('allowed') is False:
+        _extend_unique(blockers, _text_list(gate.get("blocked_reasons")))
+        _extend_unique(blockers, _text_list(gate.get("blocking_reasons")))
+        if gate.get("allowed") is False:
             _extend_unique(
                 blockers,
-                [_text(gate.get('reason'), 'live_submission_gate_not_allowed')],
+                [_text(gate.get("reason"), "live_submission_gate_not_allowed")],
             )
-    proof_floor = _mapping(status.get('proof_floor'))
-    _extend_unique(blockers, _text_list(proof_floor.get('blocking_reasons')))
+    proof_floor = _mapping(status.get("proof_floor"))
+    _extend_unique(blockers, _text_list(proof_floor.get("blocking_reasons")))
     return blockers
 
 
 def _completion_blockers(gate: Mapping[str, Any]) -> list[str]:
-    blockers = _text_list(gate.get('blocking_reasons'))
-    blocked_reason = _text(gate.get('blocked_reason'))
+    blockers = _text_list(gate.get("blocking_reasons"))
+    blocked_reason = _text(gate.get("blocked_reason"))
     if blocked_reason:
         _extend_unique(blockers, [blocked_reason])
     return blockers
@@ -356,46 +392,46 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
     actions: list[str] = []
     for blocker in blockers:
         if blocker in {
-            'paper_route_session_window_not_open',
-            'paper_route_session_window_not_closed',
+            "paper_route_session_window_not_open",
+            "paper_route_session_window_not_closed",
         }:
-            _extend_unique(actions, ['wait_for_regular_session_runtime_window'])
-        elif blocker == 'paper_route_session_settlement_pending':
-            _extend_unique(actions, ['wait_for_paper_route_settlement_grace'])
+            _extend_unique(actions, ["wait_for_regular_session_runtime_window"])
+        elif blocker == "paper_route_session_settlement_pending":
+            _extend_unique(actions, ["wait_for_paper_route_settlement_grace"])
         elif blocker in {
-            'runtime_window_import_missing',
-            'runtime_ledger_bucket_missing',
-            'paper_route_runtime_ledger_import_pending',
+            "runtime_window_import_missing",
+            "runtime_ledger_bucket_missing",
+            "paper_route_runtime_ledger_import_pending",
         }:
             _extend_unique(
-                actions, ['run_runtime_window_import_from_paper_route_target_plan']
-            )
-        elif blocker in {
-            'runtime_ledger_net_pnl_below_target',
-            'runtime_ledger_daily_net_pnl_below_target',
-        }:
-            _extend_unique(
-                actions, ['collect_or_improve_post_cost_runtime_profit_evidence']
-            )
-        elif blocker.startswith('runtime_ledger_') or blocker in {
-            'filled_notional_missing',
-            'closed_round_trip_missing',
-            'submitted_order_lifecycle_missing',
-            'runtime_decision_lifecycle_missing',
-        }:
-            _extend_unique(
-                actions, ['repair_runtime_ledger_lifecycle_cost_or_lineage_evidence']
+                actions, ["run_runtime_window_import_from_paper_route_target_plan"]
             )
         elif blocker in {
-            'runtime_ledger_trading_days_below_target',
+            "runtime_ledger_net_pnl_below_target",
+            "runtime_ledger_daily_net_pnl_below_target",
         }:
-            _extend_unique(actions, ['collect_more_runtime_ledger_trading_days'])
-        elif blocker in {'simple_submit_disabled', 'live_submission_gate_not_allowed'}:
             _extend_unique(
-                actions, ['keep_promotion_blocked_until_live_gate_and_proof_floor_pass']
+                actions, ["collect_or_improve_post_cost_runtime_profit_evidence"]
             )
-    if not actions and verdict != 'promotion_authority_allowed':
-        actions.append('inspect_packet_checks_and_repair_failed_proof_dimension')
+        elif blocker.startswith("runtime_ledger_") or blocker in {
+            "filled_notional_missing",
+            "closed_round_trip_missing",
+            "submitted_order_lifecycle_missing",
+            "runtime_decision_lifecycle_missing",
+        }:
+            _extend_unique(
+                actions, ["repair_runtime_ledger_lifecycle_cost_or_lineage_evidence"]
+            )
+        elif blocker in {
+            "runtime_ledger_trading_days_below_target",
+        }:
+            _extend_unique(actions, ["collect_more_runtime_ledger_trading_days"])
+        elif blocker in {"simple_submit_disabled", "live_submission_gate_not_allowed"}:
+            _extend_unique(
+                actions, ["keep_promotion_blocked_until_live_gate_and_proof_floor_pass"]
+            )
+    if not actions and verdict != "promotion_authority_allowed":
+        actions.append("inspect_packet_checks_and_repair_failed_proof_dimension")
     return actions
 
 
@@ -417,10 +453,10 @@ def build_runtime_ledger_proof_packet(
     live_blockers = _status_blockers(status)
     _check(
         checks,
-        'live_status_gate',
+        "live_status_gate",
         passed=not live_blockers,
         observed=live_blockers,
-        expected='no live submission gate or proof-floor blockers',
+        expected="no live submission gate or proof-floor blockers",
         blockers=live_blockers,
     )
     _extend_unique(blockers, live_blockers)
@@ -428,52 +464,52 @@ def build_runtime_ledger_proof_packet(
     plan = _paper_route_target_plan(paper_route_evidence)
     paper_targets = _paper_route_targets(plan)
     paper_import_blockers = _paper_route_import_blockers(plan)
-    handoff = _mapping(plan.get('runtime_window_import_handoff'))
-    session_readiness = _mapping(plan.get('session_readiness'))
-    import_ready = _bool(session_readiness.get('import_ready')) or _bool(
-        handoff.get('import_ready')
+    handoff = _mapping(plan.get("runtime_window_import_handoff"))
+    session_readiness = _mapping(plan.get("session_readiness"))
+    import_ready = _bool(session_readiness.get("import_ready")) or _bool(
+        handoff.get("import_ready")
     )
     missing_identity_count = _missing_target_identity_count(paper_targets)
     _check(
         checks,
-        'paper_route_target_plan_present',
+        "paper_route_target_plan_present",
         passed=bool(plan) and bool(paper_targets),
-        observed={'plan_present': bool(plan), 'target_count': len(paper_targets)},
-        expected='paper-route runtime-window target plan with at least one target',
+        observed={"plan_present": bool(plan), "target_count": len(paper_targets)},
+        expected="paper-route runtime-window target plan with at least one target",
         blockers=[]
         if bool(plan) and bool(paper_targets)
-        else ['paper_route_target_plan_missing'],
+        else ["paper_route_target_plan_missing"],
     )
     if not plan or not paper_targets:
-        _extend_unique(blockers, ['paper_route_target_plan_missing'])
+        _extend_unique(blockers, ["paper_route_target_plan_missing"])
     _check(
         checks,
-        'paper_route_target_identity',
+        "paper_route_target_identity",
         passed=bool(paper_targets) and missing_identity_count == 0,
-        observed={'missing_identity_count': missing_identity_count},
-        expected='all targets carry candidate, hypothesis, strategy, source manifest, and window identity',
+        observed={"missing_identity_count": missing_identity_count},
+        expected="all targets carry candidate, hypothesis, strategy, source manifest, and window identity",
         blockers=[]
         if missing_identity_count == 0
-        else ['paper_route_target_identity_incomplete'],
+        else ["paper_route_target_identity_incomplete"],
     )
     if missing_identity_count:
-        _extend_unique(blockers, ['paper_route_target_identity_incomplete'])
+        _extend_unique(blockers, ["paper_route_target_identity_incomplete"])
     _check(
         checks,
-        'paper_route_import_ready',
+        "paper_route_import_ready",
         passed=import_ready and not paper_import_blockers,
         observed={
-            'import_ready': import_ready,
-            'import_blockers': paper_import_blockers,
+            "import_ready": import_ready,
+            "import_blockers": paper_import_blockers,
         },
-        expected='paper-route target window closed, settled, and import-ready',
+        expected="paper-route target window closed, settled, and import-ready",
         blockers=paper_import_blockers
-        or ([] if import_ready else ['paper_route_import_not_ready']),
+        or ([] if import_ready else ["paper_route_import_not_ready"]),
     )
     if paper_import_blockers:
         _extend_unique(blockers, paper_import_blockers)
     elif not import_ready:
-        _extend_unique(blockers, ['paper_route_import_not_ready'])
+        _extend_unique(blockers, ["paper_route_import_not_ready"])
 
     runtime_import_due = import_ready and not paper_import_blockers
     runtime_import = _runtime_window_import_payload(runtime_window_import)
@@ -485,83 +521,83 @@ def build_runtime_ledger_proof_packet(
     runtime_import_ok = (
         runtime_import_due
         and bool(runtime_import)
-        and _text(runtime_import.get('proof_status'), 'blocked') == 'ok'
+        and _text(runtime_import.get("proof_status"), "blocked") == "ok"
         and not runtime_import_blockers
         and authoritative_observation_count > 0
         and all(
-            _text(item.get('proof_status'), 'blocked') == 'ok'
+            _text(item.get("proof_status"), "blocked") == "ok"
             for item in runtime_import_items
         )
     )
     _check(
         checks,
-        'runtime_window_import_proof',
+        "runtime_window_import_proof",
         passed=runtime_import_ok,
         observed={
-            'present': bool(runtime_import),
-            'proof_status': _text(runtime_import.get('proof_status'), 'missing'),
-            'target_count': len(runtime_import_items),
-            'runtime_import_due': runtime_import_due,
-            'authoritative_observation_count': authoritative_observation_count,
-            'proof_blockers': runtime_import_blockers,
+            "present": bool(runtime_import),
+            "proof_status": _text(runtime_import.get("proof_status"), "missing"),
+            "target_count": len(runtime_import_items),
+            "runtime_import_due": runtime_import_due,
+            "authoritative_observation_count": authoritative_observation_count,
+            "proof_blockers": runtime_import_blockers,
         },
-        expected='runtime-window import proof_status ok with authoritative runtime observations and no proof blockers',
+        expected="runtime-window import proof_status ok with authoritative runtime observations and no proof blockers",
         blockers=runtime_import_blockers
         or (
             []
             if runtime_import_ok or not runtime_import_due
-            else ['runtime_window_import_missing']
+            else ["runtime_window_import_missing"]
         ),
     )
     if runtime_import_blockers:
         _extend_unique(blockers, runtime_import_blockers)
     elif runtime_import_due and not runtime_import_ok:
-        _extend_unique(blockers, ['runtime_window_import_missing'])
+        _extend_unique(blockers, ["runtime_window_import_missing"])
 
     completion = completion_status or {}
     live_scale_gate = _completion_live_scale_gate(completion)
     completion_gate_blockers = _completion_blockers(live_scale_gate)
-    runtime_summary = _mapping(live_scale_gate.get('runtime_ledger_summary'))
+    runtime_summary = _mapping(live_scale_gate.get("runtime_ledger_summary"))
     ledger_refs = _runtime_ledger_refs(
-        live_scale_gate, 'strategy_runtime_ledger_buckets'
+        live_scale_gate, "strategy_runtime_ledger_buckets"
     )
     unbacked_refs = _runtime_ledger_refs(
-        live_scale_gate, 'runtime_ledger_unbacked_hypothesis_metric_windows'
+        live_scale_gate, "runtime_ledger_unbacked_hypothesis_metric_windows"
     )
-    gate_satisfied = _text(live_scale_gate.get('status')) == 'satisfied'
+    gate_satisfied = _text(live_scale_gate.get("status")) == "satisfied"
     _check(
         checks,
-        'doc29_live_scale_gate',
+        "doc29_live_scale_gate",
         passed=(not runtime_import_due)
         or (gate_satisfied and not completion_gate_blockers),
         observed={
-            'gate_present': bool(live_scale_gate),
-            'status': _text(live_scale_gate.get('status'), 'missing'),
-            'runtime_import_due': runtime_import_due,
-            'blockers': completion_gate_blockers,
+            "gate_present": bool(live_scale_gate),
+            "status": _text(live_scale_gate.get("status"), "missing"),
+            "runtime_import_due": runtime_import_due,
+            "blockers": completion_gate_blockers,
         },
-        expected='doc29 live_scale_observed gate satisfied',
+        expected="doc29 live_scale_observed gate satisfied",
         blockers=completion_gate_blockers
         or (
             []
             if gate_satisfied or not runtime_import_due
-            else ['doc29_live_scale_gate_not_satisfied']
+            else ["doc29_live_scale_gate_not_satisfied"]
         ),
     )
     if completion_gate_blockers:
         _extend_unique(blockers, completion_gate_blockers)
     elif runtime_import_due and not gate_satisfied:
-        _extend_unique(blockers, ['doc29_live_scale_gate_not_satisfied'])
+        _extend_unique(blockers, ["doc29_live_scale_gate_not_satisfied"])
 
-    bucket_count = _int(runtime_summary.get('runtime_ledger_bucket_count'))
-    fill_count = _int(runtime_summary.get('runtime_ledger_fill_count'))
-    closed_trade_count = _int(runtime_summary.get('runtime_ledger_closed_trade_count'))
-    filled_notional = _decimal(runtime_summary.get('runtime_ledger_filled_notional'))
+    bucket_count = _int(runtime_summary.get("runtime_ledger_bucket_count"))
+    fill_count = _int(runtime_summary.get("runtime_ledger_fill_count"))
+    closed_trade_count = _int(runtime_summary.get("runtime_ledger_closed_trade_count"))
+    filled_notional = _decimal(runtime_summary.get("runtime_ledger_filled_notional"))
     net_pnl = _decimal(
-        runtime_summary.get('runtime_ledger_net_strategy_pnl_after_costs')
+        runtime_summary.get("runtime_ledger_net_strategy_pnl_after_costs")
     )
     expectancy_bps = _decimal(
-        runtime_summary.get('runtime_ledger_post_cost_expectancy_bps')
+        runtime_summary.get("runtime_ledger_post_cost_expectancy_bps")
     )
     trading_days = _runtime_ledger_trading_day_count(runtime_summary)
     daily_net_pnl = (
@@ -571,67 +607,67 @@ def build_runtime_ledger_proof_packet(
     )
     _check(
         checks,
-        'runtime_ledger_db_refs',
+        "runtime_ledger_db_refs",
         passed=(not runtime_import_due) or (bool(ledger_refs) and not unbacked_refs),
         observed={
-            'strategy_runtime_ledger_buckets': ledger_refs,
-            'unbacked_metric_windows': unbacked_refs,
+            "strategy_runtime_ledger_buckets": ledger_refs,
+            "unbacked_metric_windows": unbacked_refs,
         },
-        expected='runtime ledger bucket db refs present and unbacked windows empty',
+        expected="runtime ledger bucket db refs present and unbacked windows empty",
         blockers=[]
         if (bool(ledger_refs) and not unbacked_refs) or not runtime_import_due
-        else ['runtime_ledger_db_refs_missing_or_unbacked'],
+        else ["runtime_ledger_db_refs_missing_or_unbacked"],
     )
     if runtime_import_due and (not ledger_refs or unbacked_refs):
-        _extend_unique(blockers, ['runtime_ledger_db_refs_missing_or_unbacked'])
+        _extend_unique(blockers, ["runtime_ledger_db_refs_missing_or_unbacked"])
     lifecycle_blockers: list[str] = []
     if runtime_import_due and bucket_count <= 0:
-        lifecycle_blockers.append('runtime_ledger_bucket_count_zero')
+        lifecycle_blockers.append("runtime_ledger_bucket_count_zero")
     if runtime_import_due and fill_count <= 0:
-        lifecycle_blockers.append('runtime_ledger_fill_count_zero')
+        lifecycle_blockers.append("runtime_ledger_fill_count_zero")
     if runtime_import_due and closed_trade_count <= 0:
-        lifecycle_blockers.append('runtime_ledger_closed_trade_count_zero')
+        lifecycle_blockers.append("runtime_ledger_closed_trade_count_zero")
     if runtime_import_due and (filled_notional is None or filled_notional <= 0):
-        lifecycle_blockers.append('runtime_ledger_filled_notional_missing')
+        lifecycle_blockers.append("runtime_ledger_filled_notional_missing")
     if runtime_import_due and (expectancy_bps is None or expectancy_bps <= 0):
-        lifecycle_blockers.append('runtime_ledger_post_cost_expectancy_not_positive')
+        lifecycle_blockers.append("runtime_ledger_post_cost_expectancy_not_positive")
     _check(
         checks,
-        'runtime_ledger_lifecycle_counts',
+        "runtime_ledger_lifecycle_counts",
         passed=not lifecycle_blockers,
         observed={
-            'bucket_count': bucket_count,
-            'fill_count': fill_count,
-            'closed_trade_count': closed_trade_count,
-            'filled_notional': _decimal_text(filled_notional),
-            'post_cost_expectancy_bps': _decimal_text(expectancy_bps),
+            "bucket_count": bucket_count,
+            "fill_count": fill_count,
+            "closed_trade_count": closed_trade_count,
+            "filled_notional": _decimal_text(filled_notional),
+            "post_cost_expectancy_bps": _decimal_text(expectancy_bps),
         },
-        expected='positive buckets, fills, closed trips, filled notional, and post-cost expectancy',
+        expected="positive buckets, fills, closed trips, filled notional, and post-cost expectancy",
         blockers=lifecycle_blockers,
     )
     _extend_unique(blockers, lifecycle_blockers)
     pnl_blockers: list[str] = []
     if runtime_import_due and (net_pnl is None or net_pnl < min_runtime_ledger_net_pnl):
-        pnl_blockers.append('runtime_ledger_net_pnl_below_target')
+        pnl_blockers.append("runtime_ledger_net_pnl_below_target")
     if runtime_import_due and trading_days < min_runtime_ledger_trading_days:
-        pnl_blockers.append('runtime_ledger_trading_days_below_target')
+        pnl_blockers.append("runtime_ledger_trading_days_below_target")
     if runtime_import_due and (
         daily_net_pnl is None or daily_net_pnl < min_runtime_ledger_daily_net_pnl
     ):
-        pnl_blockers.append('runtime_ledger_daily_net_pnl_below_target')
+        pnl_blockers.append("runtime_ledger_daily_net_pnl_below_target")
     _check(
         checks,
-        'runtime_ledger_post_cost_profit_target',
+        "runtime_ledger_post_cost_profit_target",
         passed=not pnl_blockers,
         observed={
-            'net_pnl_after_costs': _decimal_text(net_pnl),
-            'trading_days': trading_days,
-            'daily_net_pnl_after_costs': _decimal_text(daily_net_pnl),
+            "net_pnl_after_costs": _decimal_text(net_pnl),
+            "trading_days": trading_days,
+            "daily_net_pnl_after_costs": _decimal_text(daily_net_pnl),
         },
         expected={
-            'min_net_pnl_after_costs': _decimal_text(min_runtime_ledger_net_pnl),
-            'min_trading_days': min_runtime_ledger_trading_days,
-            'min_daily_net_pnl_after_costs': _decimal_text(
+            "min_net_pnl_after_costs": _decimal_text(min_runtime_ledger_net_pnl),
+            "min_trading_days": min_runtime_ledger_trading_days,
+            "min_daily_net_pnl_after_costs": _decimal_text(
                 min_runtime_ledger_daily_net_pnl
             ),
         },
@@ -639,75 +675,75 @@ def build_runtime_ledger_proof_packet(
     )
     _extend_unique(blockers, pnl_blockers)
 
-    failed_checks = [key for key, value in checks.items() if not value['passed']]
+    failed_checks = [key for key, value in checks.items() if not value["passed"]]
     waiting_blockers = {
-        'paper_route_session_window_not_open',
-        'paper_route_session_window_not_closed',
-        'paper_route_session_settlement_pending',
-        'paper_route_import_not_ready',
+        "paper_route_session_window_not_open",
+        "paper_route_session_window_not_closed",
+        "paper_route_session_settlement_pending",
+        "paper_route_import_not_ready",
     }
     if not failed_checks:
-        verdict = 'promotion_authority_allowed'
-        reason = 'runtime_ledger_live_paper_post_cost_proof_satisfied'
+        verdict = "promotion_authority_allowed"
+        reason = "runtime_ledger_live_paper_post_cost_proof_satisfied"
     elif set(blockers).issubset(waiting_blockers):
-        verdict = 'waiting_for_runtime_window'
-        reason = 'paper_route_runtime_window_not_importable_yet'
+        verdict = "waiting_for_runtime_window"
+        reason = "paper_route_runtime_window_not_importable_yet"
     else:
-        verdict = 'blocked'
-        reason = 'runtime_ledger_live_paper_post_cost_proof_blocked'
+        verdict = "blocked"
+        reason = "runtime_ledger_live_paper_post_cost_proof_blocked"
 
     return {
-        'schema_version': SCHEMA_VERSION,
-        'generated_at': generated_at,
-        'verdict': verdict,
-        'ok': verdict == 'promotion_authority_allowed',
-        'promotion_authority': {
-            'allowed': verdict == 'promotion_authority_allowed',
-            'reason': reason,
-            'blocking_reasons': blockers,
-            'failed_checks': failed_checks,
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": generated_at,
+        "verdict": verdict,
+        "ok": verdict == "promotion_authority_allowed",
+        "promotion_authority": {
+            "allowed": verdict == "promotion_authority_allowed",
+            "reason": reason,
+            "blocking_reasons": blockers,
+            "failed_checks": failed_checks,
         },
-        'target': {
-            'min_runtime_ledger_net_pnl_after_costs': _decimal_text(
+        "target": {
+            "min_runtime_ledger_net_pnl_after_costs": _decimal_text(
                 min_runtime_ledger_net_pnl
             ),
-            'min_runtime_ledger_daily_net_pnl_after_costs': _decimal_text(
+            "min_runtime_ledger_daily_net_pnl_after_costs": _decimal_text(
                 min_runtime_ledger_daily_net_pnl
             ),
-            'min_runtime_ledger_trading_days': min_runtime_ledger_trading_days,
+            "min_runtime_ledger_trading_days": min_runtime_ledger_trading_days,
         },
-        'candidate': _first_identity(
+        "candidate": _first_identity(
             paper_targets=paper_targets,
             runtime_import=runtime_import,
             completion_gate=live_scale_gate,
         ),
-        'required_actions': _required_actions(blockers, verdict=verdict),
-        'checks': checks,
-        'evidence': {
-            'status': {
-                'mode': status.get('mode'),
-                'running': status.get('running'),
-                'live_status_blockers': live_blockers,
+        "required_actions": _required_actions(blockers, verdict=verdict),
+        "checks": checks,
+        "evidence": {
+            "status": {
+                "mode": status.get("mode"),
+                "running": status.get("running"),
+                "live_status_blockers": live_blockers,
             },
-            'paper_route_target_plan': {
-                'schema_version': plan.get('schema_version'),
-                'target_count': len(paper_targets),
-                'import_ready': import_ready,
-                'import_blockers': paper_import_blockers,
-                'session_window': _mapping(plan.get('session_window')),
+            "paper_route_target_plan": {
+                "schema_version": plan.get("schema_version"),
+                "target_count": len(paper_targets),
+                "import_ready": import_ready,
+                "import_blockers": paper_import_blockers,
+                "session_window": _mapping(plan.get("session_window")),
             },
-            'runtime_window_import': {
-                'present': bool(runtime_import),
-                'proof_status': runtime_import.get('proof_status'),
-                'target_count': len(runtime_import_items),
-                'proof_blockers': runtime_import_blockers,
-                'authoritative_observation_count': authoritative_observation_count,
+            "runtime_window_import": {
+                "present": bool(runtime_import),
+                "proof_status": runtime_import.get("proof_status"),
+                "target_count": len(runtime_import_items),
+                "proof_blockers": runtime_import_blockers,
+                "authoritative_observation_count": authoritative_observation_count,
             },
-            'completion_live_scale': {
-                'gate_status': live_scale_gate.get('status'),
-                'runtime_ledger_summary': dict(runtime_summary),
-                'strategy_runtime_ledger_bucket_refs': ledger_refs,
-                'unbacked_metric_window_refs': unbacked_refs,
+            "completion_live_scale": {
+                "gate_status": live_scale_gate.get("status"),
+                "runtime_ledger_summary": dict(runtime_summary),
+                "strategy_runtime_ledger_bucket_refs": ledger_refs,
+                "unbacked_metric_window_refs": unbacked_refs,
             },
         },
     }
@@ -716,78 +752,91 @@ def build_runtime_ledger_proof_packet(
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        '--status-file', type=Path, help='Path to a /trading/status JSON payload.'
+        "--service-base-url",
+        help="Base Torghut service URL used to fetch /trading/status, /trading/paper-route-evidence, and /trading/completion/doc29.",
     )
     parser.add_argument(
-        '--status-url', help='URL returning a /trading/status JSON payload.'
+        "--status-file", type=Path, help="Path to a /trading/status JSON payload."
     )
     parser.add_argument(
-        '--paper-route-evidence-file',
+        "--status-url", help="URL returning a /trading/status JSON payload."
+    )
+    parser.add_argument(
+        "--paper-route-evidence-file",
         type=Path,
-        help='Path to a /trading/paper-route-evidence JSON payload.',
+        help="Path to a /trading/paper-route-evidence JSON payload.",
     )
     parser.add_argument(
-        '--paper-route-evidence-url',
-        help='URL returning a /trading/paper-route-evidence JSON payload.',
+        "--paper-route-evidence-url",
+        help="URL returning a /trading/paper-route-evidence JSON payload.",
     )
     parser.add_argument(
-        '--runtime-window-import-file',
+        "--runtime-window-import-file",
         type=Path,
-        help='Path to renew_latest_empirical_promotion_jobs.py runtime_window_import JSON output.',
+        help="Path to renew_latest_empirical_promotion_jobs.py runtime_window_import JSON output.",
     )
     parser.add_argument(
-        '--runtime-window-import-url',
-        help='URL returning runtime-window import JSON output.',
+        "--runtime-window-import-url",
+        help="URL returning runtime-window import JSON output.",
     )
     parser.add_argument(
-        '--completion-file',
+        "--completion-file",
         type=Path,
-        help='Path to a /trading/completion/doc29 JSON payload.',
+        help="Path to a /trading/completion/doc29 JSON payload.",
     )
     parser.add_argument(
-        '--completion-url', help='URL returning /trading/completion/doc29 JSON.'
+        "--completion-url", help="URL returning /trading/completion/doc29 JSON."
     )
     parser.add_argument(
-        '--min-runtime-ledger-net-pnl',
+        "--min-runtime-ledger-net-pnl",
         default=str(DEFAULT_MIN_RUNTIME_LEDGER_NET_PNL),
-        help='Minimum total runtime-ledger net strategy PnL after costs.',
+        help="Minimum total runtime-ledger net strategy PnL after costs.",
     )
     parser.add_argument(
-        '--min-runtime-ledger-daily-net-pnl',
+        "--min-runtime-ledger-daily-net-pnl",
         default=str(DEFAULT_MIN_RUNTIME_LEDGER_DAILY_NET_PNL),
-        help='Minimum runtime-ledger net strategy PnL after costs per observed trading day.',
+        help="Minimum runtime-ledger net strategy PnL after costs per observed trading day.",
     )
     parser.add_argument(
-        '--min-runtime-ledger-trading-days',
+        "--min-runtime-ledger-trading-days",
         type=int,
         default=DEFAULT_MIN_RUNTIME_LEDGER_TRADING_DAYS,
-        help='Minimum observed runtime-ledger trading days.',
+        help="Minimum observed runtime-ledger trading days.",
     )
-    parser.add_argument('--generated-at', default=None)
-    parser.add_argument('--timeout-seconds', type=float, default=10.0)
-    parser.add_argument('--output-file', type=Path, default=None)
+    parser.add_argument("--generated-at", default=None)
+    parser.add_argument("--timeout-seconds", type=float, default=10.0)
+    parser.add_argument("--output-file", type=Path, default=None)
     return parser
 
 
 def _required_source_args(args: argparse.Namespace) -> None:
     if (args.status_file is None) == (not args.status_url):
-        raise SystemExit('exactly_one_status_source_required')
+        raise SystemExit("exactly_one_status_source_required")
     if (args.paper_route_evidence_file is None) == (not args.paper_route_evidence_url):
-        raise SystemExit('exactly_one_paper_route_evidence_source_required')
+        raise SystemExit("exactly_one_paper_route_evidence_source_required")
+
+
+def _source_kind(path: Path | None, url: str | None) -> str:
+    if path is not None:
+        return "file"
+    if url:
+        return "url"
+    return "missing"
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
+    service_default_urls = _apply_service_base_url_defaults(args)
     _required_source_args(args)
     min_net_pnl = _decimal(args.min_runtime_ledger_net_pnl)
     if min_net_pnl is None:
         raise SystemExit(
-            f'--min-runtime-ledger-net-pnl must be decimal: {args.min_runtime_ledger_net_pnl!r}'
+            f"--min-runtime-ledger-net-pnl must be decimal: {args.min_runtime_ledger_net_pnl!r}"
         )
     min_daily_net_pnl = _decimal(args.min_runtime_ledger_daily_net_pnl)
     if min_daily_net_pnl is None:
         raise SystemExit(
-            f'--min-runtime-ledger-daily-net-pnl must be decimal: {args.min_runtime_ledger_daily_net_pnl!r}'
+            f"--min-runtime-ledger-daily-net-pnl must be decimal: {args.min_runtime_ledger_daily_net_pnl!r}"
         )
     status = _load_optional_json_object(
         path=args.status_file,
@@ -822,13 +871,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
         generated_at=args.generated_at,
     )
+    if service_default_urls:
+        packet["assembly"] = {
+            "service_base_url": args.service_base_url,
+            "defaulted_urls": service_default_urls,
+            "status_source": _source_kind(args.status_file, args.status_url),
+            "paper_route_evidence_source": _source_kind(
+                args.paper_route_evidence_file,
+                args.paper_route_evidence_url,
+            ),
+            "runtime_window_import_source": _source_kind(
+                args.runtime_window_import_file,
+                args.runtime_window_import_url,
+            ),
+            "completion_source": _source_kind(
+                args.completion_file, args.completion_url
+            ),
+        }
     body = json.dumps(packet, indent=2, sort_keys=True)
     if args.output_file is not None:
         args.output_file.parent.mkdir(parents=True, exist_ok=True)
-        args.output_file.write_text(body + '\n', encoding='utf-8')
+        args.output_file.write_text(body + "\n", encoding="utf-8")
     print(body)
-    return 0 if packet['ok'] else 1
+    return 0 if packet["ok"] else 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -13,15 +13,15 @@ from scripts import assemble_runtime_ledger_proof_packet as packet
 
 def _status(*, blockers: list[str] | None = None) -> dict[str, object]:
     return {
-        'mode': 'paper',
-        'running': True,
-        'live_submission_gate': {
-            'allowed': not blockers,
-            'reason': 'allowed' if not blockers else blockers[0],
-            'blocked_reasons': blockers or [],
+        "mode": "paper",
+        "running": True,
+        "live_submission_gate": {
+            "allowed": not blockers,
+            "reason": "allowed" if not blockers else blockers[0],
+            "blocked_reasons": blockers or [],
         },
-        'proof_floor': {
-            'blocking_reasons': [],
+        "proof_floor": {
+            "blocking_reasons": [],
         },
     }
 
@@ -33,38 +33,38 @@ def _paper_route_evidence(
 ) -> dict[str, object]:
     blockers = import_blockers if import_blockers is not None else []
     return {
-        'schema_version': 'torghut.paper-route-evidence.v1',
-        'next_paper_route_runtime_window_targets': {
-            'schema_version': 'torghut.next-paper-route-runtime-window-targets.v1',
-            'target_count': 1,
-            'session_window': {
-                'start': '2026-05-26T13:30:00+00:00',
-                'end': '2026-05-26T20:00:00+00:00',
+        "schema_version": "torghut.paper-route-evidence.v1",
+        "next_paper_route_runtime_window_targets": {
+            "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+            "target_count": 1,
+            "session_window": {
+                "start": "2026-05-26T13:30:00+00:00",
+                "end": "2026-05-26T20:00:00+00:00",
             },
-            'session_readiness': {
-                'import_ready': import_ready,
-                'import_blockers': blockers,
+            "session_readiness": {
+                "import_ready": import_ready,
+                "import_blockers": blockers,
             },
-            'runtime_window_import_handoff': {
-                'runner': 'scripts/renew_latest_empirical_promotion_jobs.py',
-                'import_ready': import_ready,
-                'import_blockers': blockers,
-                'promotion_allowed': False,
-                'final_promotion_authorized': False,
+            "runtime_window_import_handoff": {
+                "runner": "scripts/renew_latest_empirical_promotion_jobs.py",
+                "import_ready": import_ready,
+                "import_blockers": blockers,
+                "promotion_allowed": False,
+                "final_promotion_authorized": False,
             },
-            'targets': [
+            "targets": [
                 {
-                    'candidate_id': 'c88421d619759b2cfaa6f4d0',
-                    'hypothesis_id': 'H-PAIRS-01',
-                    'observed_stage': 'paper',
-                    'strategy_family': 'microbar_cross_sectional_pairs',
-                    'strategy_name': 'microbar-pairs-vwap-cap-safe',
-                    'account_label': 'TORGHUT_SIM',
-                    'source_manifest_ref': 'config/trading/hypotheses/h-pairs-01.json',
-                    'window_start': '2026-05-26T13:30:00+00:00',
-                    'window_end': '2026-05-26T20:00:00+00:00',
-                    'promotion_allowed': False,
-                    'final_promotion_authorized': False,
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "hypothesis_id": "H-PAIRS-01",
+                    "observed_stage": "paper",
+                    "strategy_family": "microbar_cross_sectional_pairs",
+                    "strategy_name": "microbar-pairs-vwap-cap-safe",
+                    "account_label": "TORGHUT_SIM",
+                    "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                    "window_start": "2026-05-26T13:30:00+00:00",
+                    "window_end": "2026-05-26T20:00:00+00:00",
+                    "promotion_allowed": False,
+                    "final_promotion_authorized": False,
                 }
             ],
         },
@@ -73,36 +73,36 @@ def _paper_route_evidence(
 
 def _runtime_import(
     *,
-    proof_status: str = 'ok',
+    proof_status: str = "ok",
     proof_blockers: list[str] | None = None,
     authoritative: bool = True,
 ) -> dict[str, object]:
-    blocker_payloads = [{'blocker': blocker} for blocker in proof_blockers or []]
+    blocker_payloads = [{"blocker": blocker} for blocker in proof_blockers or []]
     return {
-        'status': 'ok',
-        'proof_status': proof_status,
-        'proof_blockers': blocker_payloads,
-        'target_count': 1,
-        'imports': [
+        "status": "ok",
+        "proof_status": proof_status,
+        "proof_blockers": blocker_payloads,
+        "target_count": 1,
+        "imports": [
             {
-                'status': 'ok',
-                'proof_status': proof_status,
-                'proof_blockers': blocker_payloads,
-                'candidate_id': 'c88421d619759b2cfaa6f4d0',
-                'hypothesis_id': 'H-PAIRS-01',
-                'observed_stage': 'paper',
-                'strategy_family': 'microbar_cross_sectional_pairs',
-                'strategy_name': 'microbar-pairs-vwap-cap-safe',
-                'account_label': 'TORGHUT_SIM',
-                'window_start': '2026-05-26T13:30:00+00:00',
-                'window_end': '2026-05-26T20:00:00+00:00',
-                'summary': {
-                    'promotion_allowed': authoritative,
-                    'runtime_observation': {
-                        'authoritative': authoritative,
-                        'authority_reason': 'runtime_ledger_profit_proof_present'
+                "status": "ok",
+                "proof_status": proof_status,
+                "proof_blockers": blocker_payloads,
+                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                "hypothesis_id": "H-PAIRS-01",
+                "observed_stage": "paper",
+                "strategy_family": "microbar_cross_sectional_pairs",
+                "strategy_name": "microbar-pairs-vwap-cap-safe",
+                "account_label": "TORGHUT_SIM",
+                "window_start": "2026-05-26T13:30:00+00:00",
+                "window_end": "2026-05-26T20:00:00+00:00",
+                "summary": {
+                    "promotion_allowed": authoritative,
+                    "runtime_observation": {
+                        "authoritative": authoritative,
+                        "authority_reason": "runtime_ledger_profit_proof_present"
                         if authoritative
-                        else 'runtime_without_runtime_ledger_profit_proof',
+                        else "runtime_without_runtime_ledger_profit_proof",
                     },
                 },
             }
@@ -112,35 +112,35 @@ def _runtime_import(
 
 def _completion(
     *,
-    status: str = 'satisfied',
-    net_pnl: str = '650',
+    status: str = "satisfied",
+    net_pnl: str = "650",
     trading_days: int = 1,
-    expectancy_bps: str = '13',
+    expectancy_bps: str = "13",
     ledger_refs: list[str] | None = None,
     unbacked_refs: list[str] | None = None,
 ) -> dict[str, object]:
     return {
-        'doc_id': 'doc29',
-        'summary': {'all_satisfied': status == 'satisfied'},
-        'gates': [
+        "doc_id": "doc29",
+        "summary": {"all_satisfied": status == "satisfied"},
+        "gates": [
             {
-                'gate_id': packet.DOC29_LIVE_SCALE_GATE,
-                'status': status,
-                'candidate_id': 'c88421d619759b2cfaa6f4d0',
-                'runtime_ledger_summary': {
-                    'runtime_ledger_bucket_count': 1,
-                    'runtime_ledger_fill_count': 4,
-                    'runtime_ledger_closed_trade_count': 2,
-                    'runtime_ledger_filled_notional': '50000',
-                    'runtime_ledger_net_strategy_pnl_after_costs': net_pnl,
-                    'runtime_ledger_post_cost_expectancy_bps': expectancy_bps,
-                    'runtime_ledger_observed_trading_day_count': trading_days,
+                "gate_id": packet.DOC29_LIVE_SCALE_GATE,
+                "status": status,
+                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                "runtime_ledger_summary": {
+                    "runtime_ledger_bucket_count": 1,
+                    "runtime_ledger_fill_count": 4,
+                    "runtime_ledger_closed_trade_count": 2,
+                    "runtime_ledger_filled_notional": "50000",
+                    "runtime_ledger_net_strategy_pnl_after_costs": net_pnl,
+                    "runtime_ledger_post_cost_expectancy_bps": expectancy_bps,
+                    "runtime_ledger_observed_trading_day_count": trading_days,
                 },
-                'db_row_refs': {
-                    'strategy_runtime_ledger_buckets': ledger_refs
+                "db_row_refs": {
+                    "strategy_runtime_ledger_buckets": ledger_refs
                     if ledger_refs is not None
-                    else ['strategy-runtime-ledger-buckets:H-PAIRS-01:2026-05-26'],
-                    'runtime_ledger_unbacked_hypothesis_metric_windows': unbacked_refs
+                    else ["strategy-runtime-ledger-buckets:H-PAIRS-01:2026-05-26"],
+                    "runtime_ledger_unbacked_hypothesis_metric_windows": unbacked_refs
                     if unbacked_refs is not None
                     else [],
                 },
@@ -151,19 +151,19 @@ def _completion(
 
 class TestRuntimeLedgerProofPacket(TestCase):
     def test_scalar_normalizers_handle_runtime_json_variants(self) -> None:
-        self.assertTrue(packet._bool(Decimal('1')))
+        self.assertTrue(packet._bool(Decimal("1")))
         self.assertFalse(packet._bool(0))
-        self.assertTrue(packet._bool('allowed'))
+        self.assertTrue(packet._bool("allowed"))
         self.assertFalse(packet._bool(object()))
 
         self.assertEqual(packet._int(True), 1)
         self.assertEqual(packet._int(4.9), 4)
-        self.assertEqual(packet._int(Decimal('7')), 7)
-        self.assertEqual(packet._int('8.0'), 8)
-        self.assertEqual(packet._int('bad', default=-1), -1)
+        self.assertEqual(packet._int(Decimal("7")), 7)
+        self.assertEqual(packet._int("8.0"), 8)
+        self.assertEqual(packet._int("bad", default=-1), -1)
 
-        self.assertEqual(packet._decimal(Decimal('12.5')), Decimal('12.5'))
-        self.assertIsNone(packet._decimal('not-a-number'))
+        self.assertEqual(packet._decimal(Decimal("12.5")), Decimal("12.5"))
+        self.assertIsNone(packet._decimal("not-a-number"))
 
     def test_packet_allows_only_complete_post_cost_runtime_ledger_proof(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(
@@ -171,22 +171,22 @@ class TestRuntimeLedgerProofPacket(TestCase):
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=_runtime_import(),
             completion_status=_completion(),
-            min_runtime_ledger_net_pnl=Decimal('500'),
-            min_runtime_ledger_daily_net_pnl=Decimal('500'),
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
             min_runtime_ledger_trading_days=1,
-            generated_at='2026-05-26T21:05:00+00:00',
+            generated_at="2026-05-26T21:05:00+00:00",
         )
 
-        self.assertTrue(result['ok'], result)
-        self.assertEqual(result['schema_version'], packet.SCHEMA_VERSION)
-        self.assertEqual(result['verdict'], 'promotion_authority_allowed')
-        self.assertEqual(result['promotion_authority']['blocking_reasons'], [])
-        self.assertEqual(result['candidate']['hypothesis_id'], 'H-PAIRS-01')
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["schema_version"], packet.SCHEMA_VERSION)
+        self.assertEqual(result["verdict"], "promotion_authority_allowed")
+        self.assertEqual(result["promotion_authority"]["blocking_reasons"], [])
+        self.assertEqual(result["candidate"]["hypothesis_id"], "H-PAIRS-01")
         self.assertEqual(
-            result['checks']['runtime_ledger_post_cost_profit_target']['observed'][
-                'daily_net_pnl_after_costs'
+            result["checks"]["runtime_ledger_post_cost_profit_target"]["observed"][
+                "daily_net_pnl_after_costs"
             ],
-            '650',
+            "650",
         )
 
     def test_packet_waits_before_paper_route_window_is_importable(self) -> None:
@@ -194,24 +194,24 @@ class TestRuntimeLedgerProofPacket(TestCase):
             _status(),
             paper_route_evidence=_paper_route_evidence(
                 import_ready=False,
-                import_blockers=['paper_route_session_window_not_open'],
+                import_blockers=["paper_route_session_window_not_open"],
             ),
-            generated_at='2026-05-25T21:05:00+00:00',
+            generated_at="2026-05-25T21:05:00+00:00",
         )
 
-        self.assertFalse(result['ok'])
-        self.assertEqual(result['verdict'], 'waiting_for_runtime_window')
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["verdict"], "waiting_for_runtime_window")
         self.assertEqual(
-            result['promotion_authority']['blocking_reasons'],
-            ['paper_route_session_window_not_open'],
+            result["promotion_authority"]["blocking_reasons"],
+            ["paper_route_session_window_not_open"],
         )
         self.assertEqual(
-            result['required_actions'],
-            ['wait_for_regular_session_runtime_window'],
+            result["required_actions"],
+            ["wait_for_regular_session_runtime_window"],
         )
         self.assertFalse(
-            result['checks']['runtime_window_import_proof']['observed'][
-                'runtime_import_due'
+            result["checks"]["runtime_window_import_proof"]["observed"][
+                "runtime_import_due"
             ]
         )
 
@@ -220,148 +220,154 @@ class TestRuntimeLedgerProofPacket(TestCase):
             _status(),
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import=_runtime_import(
-                proof_status='blocked',
-                proof_blockers=['runtime_without_runtime_ledger_profit_proof'],
+                proof_status="blocked",
+                proof_blockers=["runtime_without_runtime_ledger_profit_proof"],
                 authoritative=False,
             ),
-            completion_status=_completion(net_pnl='600', trading_days=3),
-            min_runtime_ledger_net_pnl=Decimal('500'),
-            min_runtime_ledger_daily_net_pnl=Decimal('500'),
+            completion_status=_completion(net_pnl="600", trading_days=3),
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
             min_runtime_ledger_trading_days=1,
-            generated_at='2026-05-26T21:05:00+00:00',
+            generated_at="2026-05-26T21:05:00+00:00",
         )
 
-        self.assertFalse(result['ok'])
-        self.assertEqual(result['verdict'], 'blocked')
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["verdict"], "blocked")
         self.assertIn(
-            'runtime_without_runtime_ledger_profit_proof',
-            result['promotion_authority']['blocking_reasons'],
+            "runtime_without_runtime_ledger_profit_proof",
+            result["promotion_authority"]["blocking_reasons"],
         )
         self.assertIn(
-            'runtime_ledger_daily_net_pnl_below_target',
-            result['promotion_authority']['blocking_reasons'],
+            "runtime_ledger_daily_net_pnl_below_target",
+            result["promotion_authority"]["blocking_reasons"],
         )
 
-    def test_packet_blocks_incomplete_identity_unbacked_refs_and_lifecycle_gaps(self) -> None:
+    def test_packet_blocks_incomplete_identity_unbacked_refs_and_lifecycle_gaps(
+        self,
+    ) -> None:
         paper = _paper_route_evidence()
-        target = paper['next_paper_route_runtime_window_targets']['targets'][0]
+        target = paper["next_paper_route_runtime_window_targets"]["targets"][0]
         assert isinstance(target, dict)
-        target['candidate_id'] = ''
+        target["candidate_id"] = ""
         completion = _completion(
-            status='blocked',
-            net_pnl='bad',
+            status="blocked",
+            net_pnl="bad",
             trading_days=0,
-            expectancy_bps='0',
+            expectancy_bps="0",
             ledger_refs=[],
-            unbacked_refs=['hypothesis_metric_windows:H-PAIRS-01:2026-05-26'],
+            unbacked_refs=["hypothesis_metric_windows:H-PAIRS-01:2026-05-26"],
         )
-        gate = completion['gates'][0]
+        gate = completion["gates"][0]
         assert isinstance(gate, dict)
-        gate['blocking_reasons'] = ['live_scale_runtime_ledger_summary_incomplete']
-        gate['blocked_reason'] = 'live_canary_not_satisfied'
-        summary = gate['runtime_ledger_summary']
+        gate["blocking_reasons"] = ["live_scale_runtime_ledger_summary_incomplete"]
+        gate["blocked_reason"] = "live_canary_not_satisfied"
+        summary = gate["runtime_ledger_summary"]
         assert isinstance(summary, dict)
-        summary['runtime_ledger_bucket_count'] = 0
-        summary['runtime_ledger_fill_count'] = 0
-        summary['runtime_ledger_closed_trade_count'] = 0
-        summary['runtime_ledger_filled_notional'] = '0'
+        summary["runtime_ledger_bucket_count"] = 0
+        summary["runtime_ledger_fill_count"] = 0
+        summary["runtime_ledger_closed_trade_count"] = 0
+        summary["runtime_ledger_filled_notional"] = "0"
 
         result = packet.build_runtime_ledger_proof_packet(
-            _status(blockers=['simple_submit_disabled']),
+            _status(blockers=["simple_submit_disabled"]),
             paper_route_evidence=paper,
-            runtime_window_import={'runtime_window_import': _runtime_import()},
+            runtime_window_import={"runtime_window_import": _runtime_import()},
             completion_status=completion,
-            min_runtime_ledger_net_pnl=Decimal('500'),
-            min_runtime_ledger_daily_net_pnl=Decimal('500'),
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
             min_runtime_ledger_trading_days=1,
-            generated_at='2026-05-26T21:05:00+00:00',
+            generated_at="2026-05-26T21:05:00+00:00",
         )
 
-        blockers = result['promotion_authority']['blocking_reasons']
-        self.assertEqual(result['verdict'], 'blocked')
-        self.assertIn('simple_submit_disabled', blockers)
-        self.assertIn('paper_route_target_identity_incomplete', blockers)
-        self.assertIn('live_scale_runtime_ledger_summary_incomplete', blockers)
-        self.assertIn('live_canary_not_satisfied', blockers)
-        self.assertIn('runtime_ledger_db_refs_missing_or_unbacked', blockers)
-        self.assertIn('runtime_ledger_bucket_count_zero', blockers)
-        self.assertIn('runtime_ledger_fill_count_zero', blockers)
-        self.assertIn('runtime_ledger_closed_trade_count_zero', blockers)
-        self.assertIn('runtime_ledger_filled_notional_missing', blockers)
-        self.assertIn('runtime_ledger_post_cost_expectancy_not_positive', blockers)
-        self.assertIn('runtime_ledger_net_pnl_below_target', blockers)
-        self.assertIn('runtime_ledger_trading_days_below_target', blockers)
-        self.assertIn('runtime_ledger_daily_net_pnl_below_target', blockers)
+        blockers = result["promotion_authority"]["blocking_reasons"]
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn("simple_submit_disabled", blockers)
+        self.assertIn("paper_route_target_identity_incomplete", blockers)
+        self.assertIn("live_scale_runtime_ledger_summary_incomplete", blockers)
+        self.assertIn("live_canary_not_satisfied", blockers)
+        self.assertIn("runtime_ledger_db_refs_missing_or_unbacked", blockers)
+        self.assertIn("runtime_ledger_bucket_count_zero", blockers)
+        self.assertIn("runtime_ledger_fill_count_zero", blockers)
+        self.assertIn("runtime_ledger_closed_trade_count_zero", blockers)
+        self.assertIn("runtime_ledger_filled_notional_missing", blockers)
+        self.assertIn("runtime_ledger_post_cost_expectancy_not_positive", blockers)
+        self.assertIn("runtime_ledger_net_pnl_below_target", blockers)
+        self.assertIn("runtime_ledger_trading_days_below_target", blockers)
+        self.assertIn("runtime_ledger_daily_net_pnl_below_target", blockers)
         self.assertIn(
-            'keep_promotion_blocked_until_live_gate_and_proof_floor_pass',
-            result['required_actions'],
+            "keep_promotion_blocked_until_live_gate_and_proof_floor_pass",
+            result["required_actions"],
         )
         self.assertIn(
-            'repair_runtime_ledger_lifecycle_cost_or_lineage_evidence',
-            result['required_actions'],
+            "repair_runtime_ledger_lifecycle_cost_or_lineage_evidence",
+            result["required_actions"],
         )
         self.assertIn(
-            'collect_or_improve_post_cost_runtime_profit_evidence',
-            result['required_actions'],
+            "collect_or_improve_post_cost_runtime_profit_evidence",
+            result["required_actions"],
         )
 
     def test_packet_waits_on_target_level_settlement_blocker(self) -> None:
         paper = _paper_route_evidence()
-        target = paper['next_paper_route_runtime_window_targets']['targets'][0]
+        target = paper["next_paper_route_runtime_window_targets"]["targets"][0]
         assert isinstance(target, dict)
-        target['paper_route_session_import_blockers'] = [
-            'paper_route_session_settlement_pending'
+        target["paper_route_session_import_blockers"] = [
+            "paper_route_session_settlement_pending"
         ]
 
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
             paper_route_evidence=paper,
-            generated_at='2026-05-26T20:01:00+00:00',
+            generated_at="2026-05-26T20:01:00+00:00",
         )
 
-        self.assertEqual(result['verdict'], 'waiting_for_runtime_window')
+        self.assertEqual(result["verdict"], "waiting_for_runtime_window")
         self.assertEqual(
-            result['promotion_authority']['blocking_reasons'],
-            ['paper_route_session_settlement_pending'],
+            result["promotion_authority"]["blocking_reasons"],
+            ["paper_route_session_settlement_pending"],
         )
         self.assertEqual(
-            result['required_actions'],
-            ['wait_for_paper_route_settlement_grace'],
+            result["required_actions"],
+            ["wait_for_paper_route_settlement_grace"],
         )
 
-    def test_packet_accepts_alternate_runtime_plan_and_completion_gate_shapes(self) -> None:
+    def test_packet_accepts_alternate_runtime_plan_and_completion_gate_shapes(
+        self,
+    ) -> None:
         paper = _paper_route_evidence()
-        plan = paper.pop('next_paper_route_runtime_window_targets')
+        plan = paper.pop("next_paper_route_runtime_window_targets")
         assert isinstance(plan, dict)
-        paper['runtime_window_import_plan'] = plan
-        completion_gate = _completion()['gates'][0]
+        paper["runtime_window_import_plan"] = plan
+        completion_gate = _completion()["gates"][0]
 
         result = packet.build_runtime_ledger_proof_packet(
-            {'mode': 'paper', 'running': True, 'live_gate': {'allowed': True}},
+            {"mode": "paper", "running": True, "live_gate": {"allowed": True}},
             paper_route_evidence=paper,
             runtime_window_import={
-                'status': 'ok',
-                'proof_status': 'ok',
-                'candidate_id': 'c88421d619759b2cfaa6f4d0',
-                'summary': {
-                    'runtime_observation': {
-                        'authoritative': True,
+                "status": "ok",
+                "proof_status": "ok",
+                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                "summary": {
+                    "runtime_observation": {
+                        "authoritative": True,
                     },
                 },
             },
             completion_status={
-                'gates_by_id': {
+                "gates_by_id": {
                     packet.DOC29_LIVE_SCALE_GATE: completion_gate,
                 },
             },
-            generated_at='2026-05-26T21:05:00+00:00',
+            generated_at="2026-05-26T21:05:00+00:00",
         )
 
-        self.assertTrue(result['ok'], result)
-        self.assertEqual(result['evidence']['paper_route_target_plan']['target_count'], 1)
+        self.assertTrue(result["ok"], result)
         self.assertEqual(
-            result['evidence']['runtime_window_import'][
-                'authoritative_observation_count'
+            result["evidence"]["paper_route_target_plan"]["target_count"], 1
+        )
+        self.assertEqual(
+            result["evidence"]["runtime_window_import"][
+                "authoritative_observation_count"
             ],
             1,
         )
@@ -371,191 +377,258 @@ class TestRuntimeLedgerProofPacket(TestCase):
             _status(),
             paper_route_evidence=_paper_route_evidence(),
             runtime_window_import={
-                'proof_status': 'blocked',
-                'proof_blockers': ['runtime_ledger_bucket_missing'],
-                'imports': [
+                "proof_status": "blocked",
+                "proof_blockers": ["runtime_ledger_bucket_missing"],
+                "imports": [
                     {
-                        'proof_status': 'blocked',
-                        'proof_blockers': ['runtime_ledger_pnl_basis_missing'],
-                        'summary': {
-                            'runtime_observation': {
-                                'authoritative': False,
+                        "proof_status": "blocked",
+                        "proof_blockers": ["runtime_ledger_pnl_basis_missing"],
+                        "summary": {
+                            "runtime_observation": {
+                                "authoritative": False,
                             },
                         },
                     }
                 ],
             },
             completion_status=_completion(),
-            generated_at='2026-05-26T21:05:00+00:00',
+            generated_at="2026-05-26T21:05:00+00:00",
         )
 
-        self.assertFalse(result['ok'])
+        self.assertFalse(result["ok"])
         self.assertIn(
-            'runtime_ledger_bucket_missing',
-            result['promotion_authority']['blocking_reasons'],
+            "runtime_ledger_bucket_missing",
+            result["promotion_authority"]["blocking_reasons"],
         )
         self.assertIn(
-            'runtime_ledger_pnl_basis_missing',
-            result['promotion_authority']['blocking_reasons'],
+            "runtime_ledger_pnl_basis_missing",
+            result["promotion_authority"]["blocking_reasons"],
         )
         self.assertIn(
-            'run_runtime_window_import_from_paper_route_target_plan',
-            result['required_actions'],
+            "run_runtime_window_import_from_paper_route_target_plan",
+            result["required_actions"],
         )
 
     def test_cli_writes_packet_and_returns_nonzero_for_blocked_packet(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
-            status_path = tmp_path / 'status.json'
-            paper_path = tmp_path / 'paper.json'
-            import_path = tmp_path / 'import.json'
-            completion_path = tmp_path / 'completion.json'
-            output_path = tmp_path / 'packet.json'
-            status_path.write_text(json.dumps(_status()), encoding='utf-8')
-            paper_path.write_text(json.dumps(_paper_route_evidence()), encoding='utf-8')
+            status_path = tmp_path / "status.json"
+            paper_path = tmp_path / "paper.json"
+            import_path = tmp_path / "import.json"
+            completion_path = tmp_path / "completion.json"
+            output_path = tmp_path / "packet.json"
+            status_path.write_text(json.dumps(_status()), encoding="utf-8")
+            paper_path.write_text(json.dumps(_paper_route_evidence()), encoding="utf-8")
             import_path.write_text(
                 json.dumps(
                     _runtime_import(
-                        proof_status='blocked',
-                        proof_blockers=['runtime_ledger_pnl_basis_missing'],
+                        proof_status="blocked",
+                        proof_blockers=["runtime_ledger_pnl_basis_missing"],
                     )
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
-            completion_path.write_text(json.dumps(_completion()), encoding='utf-8')
+            completion_path.write_text(json.dumps(_completion()), encoding="utf-8")
 
             exit_code = packet.main(
                 [
-                    '--status-file',
+                    "--status-file",
                     str(status_path),
-                    '--paper-route-evidence-file',
+                    "--paper-route-evidence-file",
                     str(paper_path),
-                    '--runtime-window-import-file',
+                    "--runtime-window-import-file",
                     str(import_path),
-                    '--completion-file',
+                    "--completion-file",
                     str(completion_path),
-                    '--output-file',
+                    "--output-file",
                     str(output_path),
                 ]
             )
 
             self.assertEqual(exit_code, 1)
-            payload = json.loads(output_path.read_text(encoding='utf-8'))
-            self.assertEqual(payload['verdict'], 'blocked')
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["verdict"], "blocked")
             self.assertIn(
-                'runtime_ledger_pnl_basis_missing',
-                payload['promotion_authority']['blocking_reasons'],
+                "runtime_ledger_pnl_basis_missing",
+                payload["promotion_authority"]["blocking_reasons"],
             )
 
     def test_cli_can_emit_waiting_packet_before_import_outputs_exist(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
-            status_path = tmp_path / 'status.json'
-            paper_path = tmp_path / 'paper.json'
-            output_path = tmp_path / 'packet.json'
-            status_path.write_text(json.dumps(_status()), encoding='utf-8')
+            status_path = tmp_path / "status.json"
+            paper_path = tmp_path / "paper.json"
+            output_path = tmp_path / "packet.json"
+            status_path.write_text(json.dumps(_status()), encoding="utf-8")
             paper_path.write_text(
                 json.dumps(
                     _paper_route_evidence(
                         import_ready=False,
-                        import_blockers=['paper_route_session_window_not_open'],
+                        import_blockers=["paper_route_session_window_not_open"],
                     )
                 ),
-                encoding='utf-8',
+                encoding="utf-8",
             )
 
             exit_code = packet.main(
                 [
-                    '--status-file',
+                    "--status-file",
                     str(status_path),
-                    '--paper-route-evidence-file',
+                    "--paper-route-evidence-file",
                     str(paper_path),
-                    '--output-file',
+                    "--output-file",
                     str(output_path),
                 ]
             )
 
             self.assertEqual(exit_code, 1)
-            payload = json.loads(output_path.read_text(encoding='utf-8'))
-            self.assertEqual(payload['verdict'], 'waiting_for_runtime_window')
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["verdict"], "waiting_for_runtime_window")
 
-    def test_cli_rejects_missing_duplicate_and_invalid_sources(self) -> None:
-        with self.assertRaisesRegex(SystemExit, 'exactly_one_status_source_required'):
-            packet.main([])
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            status_path = tmp_path / 'status.json'
-            paper_path = tmp_path / 'paper.json'
-            status_path.write_text(json.dumps(_status()), encoding='utf-8')
-            paper_path.write_text(json.dumps(_paper_route_evidence()), encoding='utf-8')
-
-            with self.assertRaisesRegex(
-                SystemExit, '--min-runtime-ledger-net-pnl must be decimal'
-            ):
-                packet.main(
-                    [
-                        '--status-file',
-                        str(status_path),
-                        '--paper-route-evidence-file',
-                        str(paper_path),
-                        '--min-runtime-ledger-net-pnl',
-                        'bad',
-                    ]
-                )
-            with self.assertRaisesRegex(
-                SystemExit, '--min-runtime-ledger-daily-net-pnl must be decimal'
-            ):
-                packet.main(
-                    [
-                        '--status-file',
-                        str(status_path),
-                        '--paper-route-evidence-file',
-                        str(paper_path),
-                        '--min-runtime-ledger-daily-net-pnl',
-                        'bad',
-                    ]
-                )
-            with self.assertRaisesRegex(
-                SystemExit, 'exactly_one_paper_route_evidence_source_required'
-            ):
-                packet._required_source_args(
-                    Namespace(
-                        status_file=status_path,
-                        status_url=None,
-                        paper_route_evidence_file=paper_path,
-                        paper_route_evidence_url='http://example.invalid/paper.json',
-                    )
-                )
-
-    def test_json_loaders_require_objects_and_support_urls(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            bad_path = Path(tmp_dir) / 'bad.json'
-            bad_path.write_text(json.dumps(['not', 'an', 'object']), encoding='utf-8')
-            with self.assertRaisesRegex(ValueError, 'json_object_required'):
-                packet._load_json_object(bad_path)
-
+    def test_cli_can_assemble_from_service_base_url(self) -> None:
         class _Response:
             def __init__(self, body: object) -> None:
                 self.body = body
 
-            def __enter__(self) -> '_Response':
+            def __enter__(self) -> "_Response":
                 return self
 
             def __exit__(self, *_args: object) -> None:
                 return None
 
             def read(self) -> bytes:
-                return json.dumps(self.body).encode('utf-8')
+                return json.dumps(self.body).encode("utf-8")
 
-        with patch.object(packet, 'urlopen', return_value=_Response({'ok': True})):
+        def open_url(url: str, *, timeout: float) -> _Response:
+            self.assertEqual(timeout, 10.0)
+            payloads = {
+                "http://torghut.local/trading/status": _status(),
+                "http://torghut.local/trading/paper-route-evidence": (
+                    _paper_route_evidence()
+                ),
+                "http://torghut.local/trading/completion/doc29": _completion(),
+            }
+            return _Response(payloads[url])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            import_path = tmp_path / "import.json"
+            output_path = tmp_path / "packet.json"
+            import_path.write_text(json.dumps(_runtime_import()), encoding="utf-8")
+
+            with patch.object(packet, "urlopen", side_effect=open_url):
+                exit_code = packet.main(
+                    [
+                        "--service-base-url",
+                        "http://torghut.local/",
+                        "--runtime-window-import-file",
+                        str(import_path),
+                        "--output-file",
+                        str(output_path),
+                    ]
+                )
+
+            self.assertEqual(exit_code, 0)
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["verdict"], "promotion_authority_allowed")
             self.assertEqual(
-                packet._load_json_url('http://example.invalid/status.json', timeout_seconds=1),
-                {'ok': True},
+                payload["assembly"]["defaulted_urls"],
+                {
+                    "status_url": "http://torghut.local/trading/status",
+                    "paper_route_evidence_url": (
+                        "http://torghut.local/trading/paper-route-evidence"
+                    ),
+                    "completion_url": ("http://torghut.local/trading/completion/doc29"),
+                },
             )
-        with patch.object(packet, 'urlopen', return_value=_Response(['bad'])):
-            with self.assertRaisesRegex(ValueError, 'json_object_required'):
+            self.assertEqual(payload["assembly"]["status_source"], "url")
+            self.assertEqual(
+                payload["assembly"]["runtime_window_import_source"],
+                "file",
+            )
+
+    def test_cli_rejects_missing_duplicate_and_invalid_sources(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "exactly_one_status_source_required"):
+            packet.main([])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            status_path = tmp_path / "status.json"
+            paper_path = tmp_path / "paper.json"
+            status_path.write_text(json.dumps(_status()), encoding="utf-8")
+            paper_path.write_text(json.dumps(_paper_route_evidence()), encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                SystemExit, "--min-runtime-ledger-net-pnl must be decimal"
+            ):
+                packet.main(
+                    [
+                        "--status-file",
+                        str(status_path),
+                        "--paper-route-evidence-file",
+                        str(paper_path),
+                        "--min-runtime-ledger-net-pnl",
+                        "bad",
+                    ]
+                )
+            with self.assertRaisesRegex(
+                SystemExit, "--min-runtime-ledger-daily-net-pnl must be decimal"
+            ):
+                packet.main(
+                    [
+                        "--status-file",
+                        str(status_path),
+                        "--paper-route-evidence-file",
+                        str(paper_path),
+                        "--min-runtime-ledger-daily-net-pnl",
+                        "bad",
+                    ]
+                )
+            with self.assertRaisesRegex(
+                SystemExit, "exactly_one_paper_route_evidence_source_required"
+            ):
+                packet._required_source_args(
+                    Namespace(
+                        service_base_url=None,
+                        status_file=status_path,
+                        status_url=None,
+                        paper_route_evidence_file=paper_path,
+                        paper_route_evidence_url="http://example.invalid/paper.json",
+                        completion_file=None,
+                        completion_url=None,
+                    )
+                )
+
+    def test_json_loaders_require_objects_and_support_urls(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            bad_path = Path(tmp_dir) / "bad.json"
+            bad_path.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "json_object_required"):
+                packet._load_json_object(bad_path)
+
+        class _Response:
+            def __init__(self, body: object) -> None:
+                self.body = body
+
+            def __enter__(self) -> "_Response":
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return json.dumps(self.body).encode("utf-8")
+
+        with patch.object(packet, "urlopen", return_value=_Response({"ok": True})):
+            self.assertEqual(
                 packet._load_json_url(
-                    'http://example.invalid/status.json',
+                    "http://example.invalid/status.json", timeout_seconds=1
+                ),
+                {"ok": True},
+            )
+        with patch.object(packet, "urlopen", return_value=_Response(["bad"])):
+            with self.assertRaisesRegex(ValueError, "json_object_required"):
+                packet._load_json_url(
+                    "http://example.invalid/status.json",
                     timeout_seconds=1,
                 )

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -19,6 +19,7 @@ from app.models import (
     TradeDecision,
 )
 from app.trading.paper_route_evidence import (
+    RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION,
     _next_regular_equities_session_window,
     build_paper_route_evidence_audit,
 )
@@ -342,6 +343,49 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(import_audit["counts"]["source_plan_target_count"], 2)
         self.assertEqual(import_audit["counts"]["next_runtime_window_target_count"], 1)
         self.assertFalse(import_audit["promotion_authority"]["allowed"])
+        proof_handoff = payload["runtime_ledger_proof_packet_handoff"]
+        self.assertEqual(
+            proof_handoff["schema_version"],
+            RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION,
+        )
+        self.assertFalse(proof_handoff["promotion_allowed"])
+        self.assertFalse(proof_handoff["final_promotion_authorized"])
+        self.assertEqual(
+            proof_handoff["source_endpoints"],
+            {
+                "status": "/trading/status",
+                "paper_route_evidence": "/trading/paper-route-evidence",
+                "completion_doc29": "/trading/completion/doc29",
+            },
+        )
+        self.assertEqual(
+            proof_handoff["targets"],
+            {
+                "min_runtime_ledger_net_pnl_after_costs": "500",
+                "min_runtime_ledger_daily_net_pnl_after_costs": "500",
+                "min_runtime_ledger_trading_days": 1,
+            },
+        )
+        self.assertEqual(
+            proof_handoff["runtime_window"]["import_audit_state"],
+            "waiting_for_session_open",
+        )
+        self.assertEqual(
+            proof_handoff["runtime_window"]["import_blockers"],
+            ["paper_route_session_window_not_open"],
+        )
+        waiting_argv = proof_handoff["commands"]["waiting_packet"]["argv"]
+        self.assertIn("--service-base-url", waiting_argv)
+        self.assertIn("--min-runtime-ledger-net-pnl", waiting_argv)
+        authority_argv = proof_handoff["commands"]["authority_packet_after_import"][
+            "argv"
+        ]
+        self.assertIn("--runtime-window-import-file", authority_argv)
+        self.assertIn("artifacts/runtime-window-import.json", authority_argv)
+        self.assertEqual(
+            proof_handoff["required_inputs"]["runtime_window_import"]["required_when"],
+            "runtime_window.import_ready",
+        )
         self.assertFalse(target["promotion_allowed"])
         self.assertFalse(target["final_promotion_authorized"])
         self.assertEqual(
@@ -482,6 +526,23 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 "source_executions_missing",
                 "source_tca_missing",
             ],
+        )
+        import_handoff = import_payload["runtime_ledger_proof_packet_handoff"]
+        self.assertTrue(import_handoff["runtime_window"]["import_ready"])
+        self.assertEqual(
+            import_handoff["runtime_window"]["import_audit_state"],
+            "import_due_source_activity_missing",
+        )
+        self.assertEqual(
+            import_handoff["commands"]["authority_packet_after_import"][
+                "expected_verdict"
+            ],
+            "promotion_authority_allowed",
+        )
+        self.assertTrue(
+            import_handoff["commands"]["authority_packet_after_import"][
+                "allowed_only_if_packet_ok"
+            ]
         )
 
     def test_runtime_window_import_audit_tracks_missing_and_non_grade_ledger(


### PR DESCRIPTION
## Summary

- Add a runtime-ledger proof-packet handoff to `/trading/paper-route-evidence` so the live evidence surface publishes canonical service endpoints, `$500` post-cost targets, required inputs, and waiting/authority packet commands.
- Add `--service-base-url` support to `scripts/assemble_runtime_ledger_proof_packet.py` so packet assembly can fetch `/trading/status`, `/trading/paper-route-evidence`, and `/trading/completion/doc29` from one Torghut base URL while preserving explicit file/URL overrides.
- Extend paper-route and proof-packet tests to cover the new handoff, import-ready state, promotion-authority safety flags, and service-base URL assembly.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_evidence.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_paper_route_evidence.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_paper_route_evidence.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
