### PR TITLE
fix(torghut): split live and paper proof sources

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -42,7 +42,10 @@ DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS = 72
 DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT = 20
 PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL = "TORGHUT_SIM"
 PAPER_ROUTE_RUNTIME_IMPORT_SETTLEMENT_SECONDS = 3600
-DEFAULT_TORGHUT_SERVICE_BASE_URL = "http://torghut.torghut.svc.cluster.local"
+DEFAULT_TORGHUT_LIVE_SERVICE_BASE_URL = "http://torghut.torghut.svc.cluster.local"
+DEFAULT_TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL = (
+    "http://torghut-sim.torghut.svc.cluster.local"
+)
 RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE = "artifacts/runtime-ledger-proof-packet.json"
 RUNTIME_WINDOW_IMPORT_OUTPUT_FILE = "artifacts/runtime-window-import.json"
 MIN_RUNTIME_LEDGER_PROOF_NET_PNL = "500"
@@ -1299,8 +1302,12 @@ def _runtime_ledger_proof_packet_handoff(
         "--frozen",
         "python",
         "scripts/assemble_runtime_ledger_proof_packet.py",
-        "--service-base-url",
-        "$TORGHUT_SERVICE_BASE_URL",
+        "--status-service-base-url",
+        "$TORGHUT_LIVE_SERVICE_BASE_URL",
+        "--paper-route-service-base-url",
+        "$TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL",
+        "--completion-service-base-url",
+        "$TORGHUT_LIVE_SERVICE_BASE_URL",
         "--min-runtime-ledger-net-pnl",
         MIN_RUNTIME_LEDGER_PROOF_NET_PNL,
         "--min-runtime-ledger-daily-net-pnl",
@@ -1314,8 +1321,6 @@ def _runtime_ledger_proof_packet_handoff(
         *base_args[:-2],
         "--runtime-window-import-file",
         RUNTIME_WINDOW_IMPORT_OUTPUT_FILE,
-        "--completion-url",
-        "$TORGHUT_SERVICE_BASE_URL/trading/completion/doc29",
         "--output-file",
         RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE,
     ]
@@ -1326,8 +1331,18 @@ def _runtime_ledger_proof_packet_handoff(
         "promotion_allowed": False,
         "final_promotion_authorized": False,
         "promotion_gate": "runtime_ledger_live_or_live_paper_required",
-        "service_base_url_env": "TORGHUT_SERVICE_BASE_URL",
-        "default_service_base_url": DEFAULT_TORGHUT_SERVICE_BASE_URL,
+        "service_base_url_env": "TORGHUT_LIVE_SERVICE_BASE_URL",
+        "paper_route_service_base_url_env": "TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL",
+        "default_service_base_url": DEFAULT_TORGHUT_LIVE_SERVICE_BASE_URL,
+        "default_live_service_base_url": DEFAULT_TORGHUT_LIVE_SERVICE_BASE_URL,
+        "default_paper_route_service_base_url": (
+            DEFAULT_TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL
+        ),
+        "source_service_authority": {
+            "status": "live_torghut_service",
+            "paper_route_evidence": "paper_route_sim_service",
+            "completion_doc29": "live_torghut_service",
+        },
         "source_endpoints": {
             "status": "/trading/status",
             "paper_route_evidence": "/trading/paper-route-evidence",

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -161,27 +161,39 @@ def _service_endpoint_url(service_base_url: str, endpoint: str) -> str:
 
 
 def _apply_service_base_url_defaults(args: argparse.Namespace) -> dict[str, str]:
-    service_base_url = _text(getattr(args, "service_base_url", None))
-    if not service_base_url:
-        return {}
-
-    defaults = {
-        "status_url": _service_endpoint_url(service_base_url, STATUS_ENDPOINT),
-        "paper_route_evidence_url": _service_endpoint_url(
-            service_base_url,
+    shared_service_base_url = _text(getattr(args, "service_base_url", None))
+    status_service_base_url = (
+        _text(getattr(args, "status_service_base_url", None)) or shared_service_base_url
+    )
+    paper_route_service_base_url = (
+        _text(getattr(args, "paper_route_service_base_url", None))
+        or shared_service_base_url
+    )
+    completion_service_base_url = (
+        _text(getattr(args, "completion_service_base_url", None))
+        or shared_service_base_url
+    )
+    defaults = {}
+    if status_service_base_url:
+        defaults["status_url"] = _service_endpoint_url(
+            status_service_base_url, STATUS_ENDPOINT
+        )
+    if paper_route_service_base_url:
+        defaults["paper_route_evidence_url"] = _service_endpoint_url(
+            paper_route_service_base_url,
             PAPER_ROUTE_EVIDENCE_ENDPOINT,
-        ),
-        "completion_url": _service_endpoint_url(
-            service_base_url,
+        )
+    if completion_service_base_url:
+        defaults["completion_url"] = _service_endpoint_url(
+            completion_service_base_url,
             COMPLETION_DOC29_ENDPOINT,
-        ),
-    }
+        )
     if args.status_file is None and not args.status_url:
-        args.status_url = defaults["status_url"]
+        args.status_url = defaults.get("status_url")
     if args.paper_route_evidence_file is None and not args.paper_route_evidence_url:
-        args.paper_route_evidence_url = defaults["paper_route_evidence_url"]
+        args.paper_route_evidence_url = defaults.get("paper_route_evidence_url")
     if args.completion_file is None and not args.completion_url:
-        args.completion_url = defaults["completion_url"]
+        args.completion_url = defaults.get("completion_url")
     return defaults
 
 
@@ -753,7 +765,19 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--service-base-url",
-        help="Base Torghut service URL used to fetch /trading/status, /trading/paper-route-evidence, and /trading/completion/doc29.",
+        help="Base Torghut service URL used for any source endpoint without a more specific service base URL.",
+    )
+    parser.add_argument(
+        "--status-service-base-url",
+        help="Base Torghut live service URL used to fetch /trading/status.",
+    )
+    parser.add_argument(
+        "--paper-route-service-base-url",
+        help="Base Torghut paper/sim service URL used to fetch /trading/paper-route-evidence.",
+    )
+    parser.add_argument(
+        "--completion-service-base-url",
+        help="Base Torghut live service URL used to fetch /trading/completion/doc29.",
     )
     parser.add_argument(
         "--status-file", type=Path, help="Path to a /trading/status JSON payload."
@@ -874,6 +898,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     if service_default_urls:
         packet["assembly"] = {
             "service_base_url": args.service_base_url,
+            "service_base_urls": {
+                "status": args.status_service_base_url or args.service_base_url,
+                "paper_route_evidence": (
+                    args.paper_route_service_base_url or args.service_base_url
+                ),
+                "completion": args.completion_service_base_url or args.service_base_url,
+            },
             "defaulted_urls": service_default_urls,
             "status_source": _source_kind(args.status_file, args.status_url),
             "paper_route_evidence_source": _source_kind(

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -547,6 +547,77 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 "file",
             )
 
+    def test_cli_can_assemble_from_split_live_and_paper_route_services(self) -> None:
+        class _Response:
+            def __init__(self, body: object) -> None:
+                self.body = body
+
+            def __enter__(self) -> "_Response":
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return json.dumps(self.body).encode("utf-8")
+
+        def open_url(url: str, *, timeout: float) -> _Response:
+            self.assertEqual(timeout, 10.0)
+            payloads = {
+                "http://torghut-live.local/trading/status": _status(),
+                "http://torghut-sim.local/trading/paper-route-evidence": (
+                    _paper_route_evidence()
+                ),
+                "http://torghut-live.local/trading/completion/doc29": _completion(),
+            }
+            return _Response(payloads[url])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            import_path = tmp_path / "import.json"
+            output_path = tmp_path / "packet.json"
+            import_path.write_text(json.dumps(_runtime_import()), encoding="utf-8")
+
+            with patch.object(packet, "urlopen", side_effect=open_url):
+                exit_code = packet.main(
+                    [
+                        "--status-service-base-url",
+                        "http://torghut-live.local/",
+                        "--paper-route-service-base-url",
+                        "http://torghut-sim.local/",
+                        "--completion-service-base-url",
+                        "http://torghut-live.local/",
+                        "--runtime-window-import-file",
+                        str(import_path),
+                        "--output-file",
+                        str(output_path),
+                    ]
+                )
+
+            self.assertEqual(exit_code, 0)
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["verdict"], "promotion_authority_allowed")
+            self.assertEqual(
+                payload["assembly"]["service_base_urls"],
+                {
+                    "status": "http://torghut-live.local/",
+                    "paper_route_evidence": "http://torghut-sim.local/",
+                    "completion": "http://torghut-live.local/",
+                },
+            )
+            self.assertEqual(
+                payload["assembly"]["defaulted_urls"],
+                {
+                    "status_url": "http://torghut-live.local/trading/status",
+                    "paper_route_evidence_url": (
+                        "http://torghut-sim.local/trading/paper-route-evidence"
+                    ),
+                    "completion_url": (
+                        "http://torghut-live.local/trading/completion/doc29"
+                    ),
+                },
+            )
+
     def test_cli_rejects_missing_duplicate_and_invalid_sources(self) -> None:
         with self.assertRaisesRegex(SystemExit, "exactly_one_status_source_required"):
             packet.main([])

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -374,8 +374,28 @@ class TestPaperRouteEvidenceAudit(TestCase):
             proof_handoff["runtime_window"]["import_blockers"],
             ["paper_route_session_window_not_open"],
         )
+        self.assertEqual(
+            proof_handoff["default_live_service_base_url"],
+            "http://torghut.torghut.svc.cluster.local",
+        )
+        self.assertEqual(
+            proof_handoff["default_paper_route_service_base_url"],
+            "http://torghut-sim.torghut.svc.cluster.local",
+        )
+        self.assertEqual(
+            proof_handoff["source_service_authority"],
+            {
+                "status": "live_torghut_service",
+                "paper_route_evidence": "paper_route_sim_service",
+                "completion_doc29": "live_torghut_service",
+            },
+        )
         waiting_argv = proof_handoff["commands"]["waiting_packet"]["argv"]
-        self.assertIn("--service-base-url", waiting_argv)
+        self.assertIn("--status-service-base-url", waiting_argv)
+        self.assertIn("--paper-route-service-base-url", waiting_argv)
+        self.assertIn("--completion-service-base-url", waiting_argv)
+        self.assertIn("$TORGHUT_LIVE_SERVICE_BASE_URL", waiting_argv)
+        self.assertIn("$TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL", waiting_argv)
         self.assertIn("--min-runtime-ledger-net-pnl", waiting_argv)
         authority_argv = proof_handoff["commands"]["authority_packet_after_import"][
             "argv"


### PR DESCRIPTION
## Summary

- Splits runtime proof-packet source selection so live Torghut remains the authority for `/trading/status` and `/trading/completion/doc29`.
- Routes paper-route evidence assembly to the `torghut-sim` service by default, matching the bounded paper-route source that should collect the May 26 paper session.
- Extends the proof-packet CLI with per-source service base URLs while preserving the shared `--service-base-url` fallback.
- Adds focused coverage for split live/paper service assembly and the handoff contract.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_evidence.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_paper_route_evidence.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_paper_route_evidence.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
