### PR TITLE
fix(torghut): schedule runtime proof packet assembly

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -39,6 +39,8 @@ spec:
                 - |
                   set -euo pipefail
                   cd /app
+                  RENEWAL_OUTPUT=/tmp/torghut-empirical-renewal/runtime-window-renewal.json
+                  PROOF_PACKET_OUTPUT=/tmp/torghut-empirical-renewal/runtime-ledger-proof-packet.json
                   /opt/venv/bin/python scripts/renew_latest_empirical_promotion_jobs.py \
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref intraday_tsmom_v2@research \
@@ -58,7 +60,15 @@ spec:
                     --runtime-window-source-dsn-env SIM_DB_DSN \
                     --runtime-window-dataset-snapshot-ref portfolio-profit-autoresearch-500-v1 \
                     --runtime-window-source-manifest-ref config/trading/hypotheses/h-tsmom-01.json \
-                    --json
+                    --json \
+                    | tee "${RENEWAL_OUTPUT}"
+                  /opt/venv/bin/python scripts/assemble_runtime_ledger_proof_packet.py \
+                    --status-service-base-url http://torghut.torghut.svc.cluster.local \
+                    --paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local \
+                    --completion-service-base-url http://torghut.torghut.svc.cluster.local \
+                    --runtime-window-import-file "${RENEWAL_OUTPUT}" \
+                    --output-file "${PROOF_PACKET_OUTPUT}" \
+                    --allow-blocked-exit-zero
               env:
                 - name: DB_DSN
                   valueFrom:

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -830,6 +830,15 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--generated-at", default=None)
     parser.add_argument("--timeout-seconds", type=float, default=10.0)
     parser.add_argument("--output-file", type=Path, default=None)
+    parser.add_argument(
+        "--allow-blocked-exit-zero",
+        action="store_true",
+        help=(
+            "Exit 0 after writing a blocked/waiting packet. Source load and "
+            "schema errors still fail; this is for scheduled evidence collection "
+            "where a blocked verdict is expected proof state, not job failure."
+        ),
+    )
     return parser
 
 
@@ -924,7 +933,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.output_file.parent.mkdir(parents=True, exist_ok=True)
         args.output_file.write_text(body + "\n", encoding="utf-8")
     print(body)
-    return 0 if packet["ok"] else 1
+    return 0 if packet["ok"] or args.allow_blocked_exit_zero else 1
 
 
 if __name__ == "__main__":

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -453,6 +453,50 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 payload["promotion_authority"]["blocking_reasons"],
             )
 
+    def test_cli_can_write_blocked_packet_without_failing_scheduled_collection(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            status_path = tmp_path / "status.json"
+            paper_path = tmp_path / "paper.json"
+            import_path = tmp_path / "import.json"
+            completion_path = tmp_path / "completion.json"
+            output_path = tmp_path / "packet.json"
+            status_path.write_text(json.dumps(_status()), encoding="utf-8")
+            paper_path.write_text(json.dumps(_paper_route_evidence()), encoding="utf-8")
+            import_path.write_text(
+                json.dumps(
+                    _runtime_import(
+                        proof_status="blocked",
+                        proof_blockers=["runtime_ledger_pnl_basis_missing"],
+                    )
+                ),
+                encoding="utf-8",
+            )
+            completion_path.write_text(json.dumps(_completion()), encoding="utf-8")
+
+            exit_code = packet.main(
+                [
+                    "--status-file",
+                    str(status_path),
+                    "--paper-route-evidence-file",
+                    str(paper_path),
+                    "--runtime-window-import-file",
+                    str(import_path),
+                    "--completion-file",
+                    str(completion_path),
+                    "--output-file",
+                    str(output_path),
+                    "--allow-blocked-exit-zero",
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["verdict"], "blocked")
+            self.assertFalse(payload["promotion_authority"]["allowed"])
+
     def test_cli_can_emit_waiting_packet_before_import_outputs_exist(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -864,6 +864,30 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--runtime-window-observed-stage paper", args)
         self.assertIn("--runtime-window-source-dsn-env SIM_DB_DSN", args)
         self.assertNotIn("--runtime-window-source-dsn-env DB_DSN", args)
+        self.assertIn(
+            "RENEWAL_OUTPUT=/tmp/torghut-empirical-renewal/runtime-window-renewal.json",
+            args,
+        )
+        self.assertIn(
+            "PROOF_PACKET_OUTPUT=/tmp/torghut-empirical-renewal/runtime-ledger-proof-packet.json",
+            args,
+        )
+        self.assertIn("scripts/assemble_runtime_ledger_proof_packet.py", args)
+        self.assertIn(
+            "--status-service-base-url http://torghut.torghut.svc.cluster.local",
+            args,
+        )
+        self.assertIn(
+            "--paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local",
+            args,
+        )
+        self.assertIn(
+            "--completion-service-base-url http://torghut.torghut.svc.cluster.local",
+            args,
+        )
+        self.assertIn('--runtime-window-import-file "${RENEWAL_OUTPUT}"', args)
+        self.assertIn('--output-file "${PROOF_PACKET_OUTPUT}"', args)
+        self.assertIn("--allow-blocked-exit-zero", args)
 
     def test_migration_job_prepares_sim_database_before_sim_upgrade(self) -> None:
         manifest = _load_yaml_mapping(


### PR DESCRIPTION
## Summary

- Add `--allow-blocked-exit-zero` to the runtime-ledger proof packet assembler so scheduled evidence collection can write blocked/waiting packets without retry churn.
- Extend the Torghut empirical promotion renewal CronJob to tee the runtime-window renewal output and immediately assemble a live/sim runtime-ledger proof packet.
- Lock the GitOps command contract in tests so live status/completion come from `torghut` and paper-route evidence comes from `torghut-sim`.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py tests/test_live_config_manifest_contract.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
