### PR TITLE
fix(torghut): preserve paper route proof envelope parity

### DIFF
--- a/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
+++ b/packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts
@@ -27,6 +27,8 @@ const paperRouteTarget = {
   strategy_name: 'paper-route-candidate-v1',
   window_start: '2026-05-26T13:30:00+00:00',
   window_end: '2026-05-26T20:00:00+00:00',
+  paper_route_probe_symbols: ['AAPL', 'AMZN'],
+  paper_route_probe_next_session_max_notional: '25',
 }
 
 const buildPaperRouteEvidence = (targets: Array<Record<string, unknown>>) => ({
@@ -170,6 +172,36 @@ describe('validatePostDeployEvidence', () => {
         simPaperRouteEvidence: buildPaperRouteEvidence([{ ...paperRouteTarget, candidate_id: 'other-candidate' }]),
       }),
     ).toThrow('torghut-sim paper-route target plan missing live target')
+  })
+
+  it('rejects a sim paper-route plan with a broader symbol envelope than live', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '200',
+        readyz: { status: 'ok' },
+        revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+        tradingStatus: baseTradingStatus,
+        paperRouteEvidence: buildPaperRouteEvidence([paperRouteTarget]),
+        simPaperRouteEvidence: buildPaperRouteEvidence([
+          { ...paperRouteTarget, paper_route_probe_symbols: ['AMZN', 'AAPL', 'INTC'] },
+        ]),
+      }),
+    ).toThrow('torghut-sim paper-route target symbols differ from live target')
+  })
+
+  it('rejects a sim paper-route plan with a different notional envelope than live', () => {
+    expect(() =>
+      validatePostDeployEvidence({
+        readyzHttpStatus: '200',
+        readyz: { status: 'ok' },
+        revenueRepairDigest: { ...baseDigest, repair_queue: [] },
+        tradingStatus: baseTradingStatus,
+        paperRouteEvidence: buildPaperRouteEvidence([paperRouteTarget]),
+        simPaperRouteEvidence: buildPaperRouteEvidence([
+          { ...paperRouteTarget, paper_route_probe_next_session_max_notional: '50' },
+        ]),
+      }),
+    ).toThrow('torghut-sim paper-route target notional differs from live target')
   })
 
   it('rejects paper-route target plans that accidentally authorize promotion', () => {

--- a/packages/scripts/src/torghut/post-deploy-evidence.ts
+++ b/packages/scripts/src/torghut/post-deploy-evidence.ts
@@ -143,7 +143,20 @@ const assertRepairOnlyZeroNotionalReadyz = (readyz: JsonObject, digest: JsonObje
   }
 }
 
-const targetIdentity = (target: unknown, label: string): string => {
+type PaperRouteTargetEnvelope = {
+  identity: string
+  probeSymbols: string[]
+  maxNotional: string
+}
+
+const uniqueSortedSymbols = (value: unknown, label: string): string[] => {
+  const symbols = requireArray(value, label)
+    .map((symbol) => formatScalar(symbol, '').trim().toUpperCase())
+    .filter(Boolean)
+  return [...new Set(symbols)].sort()
+}
+
+const targetEnvelope = (target: unknown, label: string): PaperRouteTargetEnvelope => {
   const targetObject = requireObject(target, label)
   const hypothesisId = formatScalar(targetObject.hypothesis_id, '')
   const candidateId = formatScalar(targetObject.candidate_id, '')
@@ -153,7 +166,16 @@ const targetIdentity = (target: unknown, label: string): string => {
   if (!hypothesisId || !candidateId || !strategyName || !windowStart || !windowEnd) {
     throw new Error(`${label} missing target identity fields`)
   }
-  return [hypothesisId, candidateId, strategyName, windowStart, windowEnd].join('|')
+  const identity = [hypothesisId, candidateId, strategyName, windowStart, windowEnd].join('|')
+  const probeSymbols = uniqueSortedSymbols(targetObject.paper_route_probe_symbols, `${label} paper_route_probe_symbols`)
+  if (probeSymbols.length === 0) {
+    throw new Error(`${label} paper_route_probe_symbols must not be empty`)
+  }
+  return {
+    identity,
+    probeSymbols,
+    maxNotional: formatScalar(targetObject.paper_route_probe_next_session_max_notional, '0'),
+  }
 }
 
 const requireNotTrue = (value: unknown, label: string) => {
@@ -162,7 +184,10 @@ const requireNotTrue = (value: unknown, label: string) => {
   }
 }
 
-const parsePaperRouteTargets = (evidence: unknown, label: string): { targetCount: number; identities: Set<string> } => {
+const parsePaperRouteTargets = (
+  evidence: unknown,
+  label: string,
+): { targetCount: number; targetsByIdentity: Map<string, PaperRouteTargetEnvelope> } => {
   const payload = requireObject(evidence, `${label} payload`)
   const schemaVersion = formatScalar(payload.schema_version, 'missing')
   if (schemaVersion !== PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION) {
@@ -192,9 +217,17 @@ const parsePaperRouteTargets = (evidence: unknown, label: string): { targetCount
     requireNotTrue(targetObject.final_promotion_allowed, `${label} target ${index} final_promotion_allowed`)
     requireNotTrue(targetObject.final_promotion_authorized, `${label} target ${index} final_promotion_authorized`)
   })
-  return {
-    targetCount,
-    identities: new Set(targets.map((target, index) => targetIdentity(target, `${label} target ${index}`))),
+  const targetsByIdentity = new Map<string, PaperRouteTargetEnvelope>()
+  targets.forEach((target, index) => {
+    const envelope = targetEnvelope(target, `${label} target ${index}`)
+    targetsByIdentity.set(envelope.identity, envelope)
+  })
+  return { targetCount, targetsByIdentity }
+}
+
+const requireSameList = (left: string[], right: string[], label: string) => {
+  if (left.length !== right.length || left.some((value, index) => value !== right[index])) {
+    throw new Error(`${label}: expected ${left.join(',') || 'none'}, got ${right.join(',') || 'none'}`)
   }
 }
 
@@ -207,9 +240,25 @@ const validatePaperRouteMirror = (
   if (liveTargets.targetCount > 0 && simTargets.targetCount === 0) {
     throw new Error('torghut-sim paper-route target plan is empty while live torghut exposes targets')
   }
-  const missingSimTargets = [...liveTargets.identities].filter((identity) => !simTargets.identities.has(identity))
+  const missingSimTargets = [...liveTargets.targetsByIdentity.keys()].filter(
+    (identity) => !simTargets.targetsByIdentity.has(identity),
+  )
   if (missingSimTargets.length > 0) {
     throw new Error(`torghut-sim paper-route target plan missing live target(s): ${missingSimTargets.join(', ')}`)
+  }
+  for (const [identity, liveEnvelope] of liveTargets.targetsByIdentity) {
+    const simEnvelope = simTargets.targetsByIdentity.get(identity)
+    if (!simEnvelope) continue
+    requireSameList(
+      liveEnvelope.probeSymbols,
+      simEnvelope.probeSymbols,
+      `torghut-sim paper-route target symbols differ from live target ${identity}`,
+    )
+    if (simEnvelope.maxNotional !== liveEnvelope.maxNotional) {
+      throw new Error(
+        `torghut-sim paper-route target notional differs from live target ${identity}: expected ${liveEnvelope.maxNotional}, got ${simEnvelope.maxNotional}`,
+      )
+    }
   }
   return { liveTargetCount: liveTargets.targetCount, simTargetCount: simTargets.targetCount }
 }

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4566,6 +4566,14 @@ def _merge_external_paper_route_target_plan(
         return gate
     if _paper_route_target_plan_targets(external_plan):
         merged_plan = dict(external_plan)
+        merged_targets: list[dict[str, Any]] = []
+        for raw_target in _paper_route_target_plan_targets(external_plan):
+            target = dict(raw_target)
+            target["paper_route_target_plan_source"] = "external_target_plan_url"
+            if target.get("paper_route_probe_symbols"):
+                target["paper_route_probe_scope_authority"] = "external_target_plan"
+            merged_targets.append(target)
+        merged_plan["targets"] = merged_targets
         merged_plan["promotion_allowed"] = False
         merged_plan["final_promotion_allowed"] = False
         merged_plan["final_promotion_authorized"] = False

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -370,6 +370,11 @@ def _declared_target_probe_symbols(target: Mapping[str, object]) -> list[str]:
 
 
 def _target_uses_current_probe_scope(target: Mapping[str, object]) -> bool:
+    if (
+        _safe_text(target.get("paper_route_probe_scope_authority"))
+        == "external_target_plan"
+    ):
+        return False
     source_kind = _safe_text(target.get("source_kind"))
     handoff = _safe_text(target.get("handoff"))
     return (
@@ -513,6 +518,12 @@ def _next_paper_route_runtime_window_targets(
     skipped_targets: list[dict[str, object]] = []
     planned_keys: set[tuple[object, ...]] = set()
     for target in targets:
+        target_probe_symbols = _target_probe_symbols(target, probe)
+        target_probe_ready = (
+            bool(probe.get("configured_enabled"))
+            and _safe_decimal(next_notional) > 0
+            and bool(target_probe_symbols)
+        )
         hypothesis_id = _safe_text(target.get("hypothesis_id"))
         candidate_id = _safe_text(target.get("candidate_id"))
         strategy_family = _safe_text(target.get("strategy_family"))
@@ -529,14 +540,14 @@ def _next_paper_route_runtime_window_targets(
             )
             if value is None
         ]
-        if missing or not probe_ready:
+        if missing or not target_probe_ready:
             reasons = list(missing)
-            if not probe_ready:
+            if not target_probe_ready:
                 if not bool(probe.get("configured_enabled")):
                     reasons.append("paper_route_probe_disabled")
                 if _safe_decimal(next_notional) <= 0:
                     reasons.append("paper_route_probe_notional_missing")
-                if not probe_symbols:
+                if not target_probe_symbols:
                     reasons.append("paper_route_probe_symbol_missing")
             skipped_targets.append(
                 {
@@ -563,8 +574,8 @@ def _next_paper_route_runtime_window_targets(
             "source_kind": "paper_route_probe_runtime_observed",
             "window_start": _isoformat(window_start),
             "window_end": _isoformat(window_end),
-            "paper_route_probe_symbols": probe_symbols,
-            "paper_route_probe_symbol_count": len(probe_symbols),
+            "paper_route_probe_symbols": target_probe_symbols,
+            "paper_route_probe_symbol_count": len(target_probe_symbols),
             "paper_route_probe_next_session_max_notional": next_notional,
             "paper_route_probe_window_start": _isoformat(window_start),
             "paper_route_probe_window_end": _isoformat(window_end),
@@ -617,7 +628,7 @@ def _next_paper_route_runtime_window_targets(
             planned_target["source_manifest_ref"],
             planned_target["window_start"],
             planned_target["window_end"],
-            tuple(probe_symbols),
+            tuple(target_probe_symbols),
         )
         if planned_key in planned_keys:
             skipped_targets.append(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7395,7 +7395,12 @@ class TestTradingApi(TestCase):
                 "promotion_allowed": True,
                 "final_promotion_allowed": True,
                 "final_promotion_authorized": True,
-                "targets": [{"candidate_id": "external"}],
+                "targets": [
+                    {
+                        "candidate_id": "external",
+                        "paper_route_probe_symbols": ["AAPL"],
+                    }
+                ],
             },
         ):
             gate = _merge_external_paper_route_target_plan({})
@@ -7406,6 +7411,111 @@ class TestTradingApi(TestCase):
         self.assertFalse(plan["promotion_allowed"])
         self.assertFalse(plan["final_promotion_allowed"])
         self.assertFalse(plan["final_promotion_authorized"])
+        self.assertEqual(
+            plan["targets"][0]["paper_route_target_plan_source"],
+            "external_target_plan_url",
+        )
+        self.assertEqual(
+            plan["targets"][0]["paper_route_probe_scope_authority"],
+            "external_target_plan",
+        )
+
+    def test_external_paper_route_target_preserves_live_symbol_envelope(
+        self,
+    ) -> None:
+        original_scheduler = getattr(app.state, "trading_scheduler", None)
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        settings.trading_paper_route_target_plan_url = (
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence"
+        )
+        target = {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "observed_stage": "paper",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "strategy_name": "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+            "account_label": "TORGHUT_SIM",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+            "dataset_snapshot_ref": "torghut-chip-full-day-20260505-4c330ce9-r1",
+            "window_start": "2026-05-26T13:30:00+00:00",
+            "window_end": "2026-05-26T20:00:00+00:00",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_probation_authorized": True,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "max_notional": "0",
+        }
+        live_gate = {
+            "allowed": True,
+            "reason": "non_live_mode",
+            "blocked_reasons": [],
+            "promotion_eligible_total": 0,
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 0,
+                "skipped_target_count": 0,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "targets": [],
+            },
+        }
+        proof_floor = {
+            "route_reacquisition_book": {
+                "schema_version": "torghut.route-reacquisition-book.v1",
+                "state": "repair_only",
+                "paper_route_probe": {
+                    "configured_enabled": True,
+                    "active": False,
+                    "effective_max_notional": "0",
+                    "next_session_max_notional": "25",
+                    "eligible_symbol_count": 3,
+                    "eligible_symbols": ["AAPL", "AMZN", "INTC"],
+                    "active_symbols": [],
+                    "blocking_reasons": ["market_session_closed"],
+                },
+            }
+        }
+        external_plan = {
+            "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+            "target_count": 1,
+            "skipped_target_count": 0,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "targets": [target],
+        }
+        try:
+            if hasattr(app.state, "trading_scheduler"):
+                del app.state.trading_scheduler
+            with (
+                patch(
+                    "app.main._build_live_submission_gate_payload",
+                    return_value=live_gate,
+                ),
+                patch(
+                    "app.main._build_profitability_proof_floor_payload",
+                    return_value=proof_floor,
+                ),
+                patch(
+                    "app.main._load_external_paper_route_target_plan",
+                    return_value=external_plan,
+                ),
+            ):
+                response = self.client.get("/trading/paper-route-evidence")
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            next_target = payload["next_paper_route_runtime_window_targets"]["targets"][
+                0
+            ]
+            self.assertEqual(next_target["paper_route_probe_symbols"], ["AAPL", "AMZN"])
+            self.assertNotIn("INTC", next_target["paper_route_probe_symbols"])
+        finally:
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+            if original_scheduler is None:
+                if hasattr(app.state, "trading_scheduler"):
+                    del app.state.trading_scheduler
+            else:
+                app.state.trading_scheduler = original_scheduler
 
     def test_trading_llm_evaluation_endpoint(self) -> None:
         response = self.client.get("/trading/llm-evaluation")


### PR DESCRIPTION
## Summary

- Preserve externally mirrored live paper-route probe symbol envelopes when `torghut-sim` builds next-window runtime import targets.
- Harden post-deploy evidence validation so live and sim paper-route targets must match identity, probe symbols, and next-session notional.
- Add regression coverage for the deployed `AAPL, AMZN` versus `AAPL, AMZN, INTC` drift that would pollute the May 26 runtime-ledger import path.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format app/trading/paper_route_evidence.py app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k 'external_paper_route_target_preserves_live_symbol_envelope or trading_paper_route_evidence_uses_external_plan_when_local_plan_empty or merge_external_paper_route_target_plan_fails_closed or paper_route_target_plan_from_payload' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py -k 'paper_route_probe_symbols_extend_next_window_target_scope or external_paper_route_target_preserves_live_symbol_envelope or trading_paper_route_evidence_uses_external_plan_when_local_plan_empty or merge_external_paper_route_target_plan_fails_closed or paper_route_target_plan_from_payload or trading_paper_route_evidence' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_evidence or paper_route_target_plan or merge_external_paper_route' -q`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun test packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/post-deploy-evidence.ts packages/scripts/src/torghut/__tests__/post-deploy-evidence.test.ts`
- `bun run --filter @proompteng/scripts lint:oxlint`
- `bun run --filter @proompteng/scripts lint:oxlint:type`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- Diagnostic: re-ran the new validator against post-deploy artifact `26407796547`; it now rejects the old live/sim mismatch with `expected AAPL,AMZN, got AAPL,AMZN,INTC`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
