### PR TITLE
fix(torghut): persist runtime proof packets

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -68,6 +68,8 @@ spec:
                     --completion-service-base-url http://torghut.torghut.svc.cluster.local \
                     --runtime-window-import-file "${RENEWAL_OUTPUT}" \
                     --output-file "${PROOF_PACKET_OUTPUT}" \
+                    --artifact-prefix 'runtime-ledger-proof-packets/{run_id}' \
+                    --require-artifact-upload \
                     --allow-blocked-exit-zero
               env:
                 - name: DB_DSN

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -48,6 +48,7 @@ DEFAULT_TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL = (
 )
 RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE = "artifacts/runtime-ledger-proof-packet.json"
 RUNTIME_WINDOW_IMPORT_OUTPUT_FILE = "artifacts/runtime-window-import.json"
+RUNTIME_LEDGER_PROOF_PACKET_ARTIFACT_PREFIX = "runtime-ledger-proof-packets/{run_id}"
 MIN_RUNTIME_LEDGER_PROOF_NET_PNL = "500"
 MIN_RUNTIME_LEDGER_PROOF_DAILY_NET_PNL = "500"
 MIN_RUNTIME_LEDGER_PROOF_TRADING_DAYS = 1
@@ -1334,6 +1335,9 @@ def _runtime_ledger_proof_packet_handoff(
         RUNTIME_WINDOW_IMPORT_OUTPUT_FILE,
         "--output-file",
         RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE,
+        "--artifact-prefix",
+        RUNTIME_LEDGER_PROOF_PACKET_ARTIFACT_PREFIX,
+        "--require-artifact-upload",
     ]
     return {
         "schema_version": RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION,
@@ -1399,6 +1403,12 @@ def _runtime_ledger_proof_packet_handoff(
                 "endpoint": "/trading/completion/doc29",
                 "required_when": "runtime_window.import_ready",
             },
+            "durable_artifact_upload": {
+                "artifact_prefix": RUNTIME_LEDGER_PROOF_PACKET_ARTIFACT_PREFIX,
+                "artifact_name": "runtime-ledger-proof-packet.json",
+                "bucket_env": "TORGHUT_EMPIRICAL_CEPH_BUCKET",
+                "required_when": "runtime_window_import file is provided",
+            },
         },
         "commands": {
             "waiting_packet": {
@@ -1409,6 +1419,7 @@ def _runtime_ledger_proof_packet_handoff(
                 "argv": authority_args,
                 "expected_verdict": "promotion_authority_allowed",
                 "allowed_only_if_packet_ok": True,
+                "requires_durable_artifact_upload": True,
             },
         },
         "runtime_window_import_handoff": runtime_import_handoff,

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -11,12 +11,13 @@ make the packet promotable by themselves.
 from __future__ import annotations
 
 import argparse
+import os
 import json
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Protocol, cast
 from urllib.parse import urljoin
 from urllib.request import urlopen
 
@@ -29,6 +30,18 @@ DEFAULT_MIN_RUNTIME_LEDGER_TRADING_DAYS = 1
 STATUS_ENDPOINT = "/trading/status"
 PAPER_ROUTE_EVIDENCE_ENDPOINT = "/trading/paper-route-evidence"
 COMPLETION_DOC29_ENDPOINT = "/trading/completion/doc29"
+ARTIFACT_SCHEMA_VERSION = "torghut.runtime-ledger-proof-packet-artifact.v1"
+
+
+class _ObjectStoreClient(Protocol):
+    def put_object(
+        self,
+        *,
+        bucket: str,
+        key: str,
+        body: bytes,
+        content_type: str,
+    ) -> Mapping[str, Any]: ...
 
 
 def _utc_now() -> str:
@@ -138,6 +151,148 @@ def _load_json_url(url: str, *, timeout_seconds: float) -> dict[str, Any]:
     if not isinstance(payload, Mapping):
         raise ValueError(f"json_object_required:{url}")
     return {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
+
+
+def _ceph_client_from_env() -> tuple[_ObjectStoreClient | None, str]:
+    endpoint = os.getenv("TORGHUT_EMPIRICAL_CEPH_ENDPOINT", "").strip()
+    bucket_host = os.getenv("TORGHUT_EMPIRICAL_CEPH_BUCKET_HOST", "").strip()
+    bucket_port = os.getenv("TORGHUT_EMPIRICAL_CEPH_BUCKET_PORT", "").strip()
+    access_key = (
+        os.getenv("TORGHUT_EMPIRICAL_CEPH_ACCESS_KEY", "").strip()
+        or os.getenv(
+            "AWS_ACCESS_KEY_ID",
+            "",
+        ).strip()
+    )
+    secret_key = (
+        os.getenv(
+            "TORGHUT_EMPIRICAL_CEPH_SECRET_KEY",
+            "",
+        ).strip()
+        or os.getenv(
+            "AWS_SECRET_ACCESS_KEY",
+            "",
+        ).strip()
+    )
+    bucket = (
+        os.getenv("TORGHUT_EMPIRICAL_CEPH_BUCKET", "").strip()
+        or os.getenv(
+            "BUCKET_NAME",
+            "",
+        ).strip()
+        or "torghut-empirical-artifacts"
+    )
+    if not endpoint and bucket_host:
+        scheme = (
+            "https"
+            if os.getenv("TORGHUT_EMPIRICAL_CEPH_USE_TLS", "").strip() == "true"
+            else "http"
+        )
+        endpoint = f"{scheme}://{bucket_host}"
+        if bucket_port:
+            endpoint = f"{endpoint}:{bucket_port}"
+    if not endpoint or not access_key or not secret_key:
+        return None, bucket
+    from app.whitepapers.workflow import CephS3Client
+
+    return (
+        CephS3Client(
+            endpoint=endpoint,
+            access_key=access_key,
+            secret_key=secret_key,
+            region=os.getenv("TORGHUT_EMPIRICAL_CEPH_REGION", "us-east-1").strip()
+            or "us-east-1",
+            timeout_seconds=max(
+                int(os.getenv("TORGHUT_EMPIRICAL_CEPH_TIMEOUT_SECONDS", "20") or "20"),
+                1,
+            ),
+        ),
+        bucket,
+    )
+
+
+def _safe_artifact_path_part(value: object, *, default: str) -> str:
+    text = _text(value, default)
+    cleaned = "".join(
+        char if char.isalnum() or char in {"-", "_", "."} else "-" for char in text
+    ).strip("-._")
+    return cleaned or default
+
+
+def _runtime_window_import_run_id(raw_payload: Mapping[str, Any] | None) -> str:
+    payload = _mapping(raw_payload)
+    candidates = [
+        payload.get("run_id"),
+        _mapping(payload.get("runtime_window_import")).get("run_id"),
+        _mapping(payload.get("runtime_window_import")).get(
+            "runtime_window_import_run_id"
+        ),
+    ]
+    for candidate in candidates:
+        text = _text(candidate)
+        if text:
+            return _safe_artifact_path_part(text, default="unknown-run")
+    return "unknown-run"
+
+
+def _resolve_artifact_prefix(
+    raw_prefix: str,
+    *,
+    runtime_window_import: Mapping[str, Any] | None,
+    generated_at: str,
+) -> str:
+    run_id = _runtime_window_import_run_id(runtime_window_import)
+    generated_at_part = _safe_artifact_path_part(generated_at, default="unknown-time")
+    prefix = raw_prefix.format(run_id=run_id, generated_at=generated_at_part)
+    return "/".join(
+        _safe_artifact_path_part(part, default="artifact")
+        for part in prefix.split("/")
+        if part.strip("/")
+    )
+
+
+def _artifact_key(*, prefix: str, artifact_name: str) -> str:
+    name = _safe_artifact_path_part(
+        artifact_name, default="runtime-ledger-proof-packet.json"
+    )
+    return "/".join(part.strip("/") for part in (prefix, name) if part.strip("/"))
+
+
+def _attach_and_upload_artifact(
+    packet: dict[str, Any],
+    *,
+    artifact_prefix: str,
+    artifact_name: str,
+    require_artifact_upload: bool,
+    runtime_window_import: Mapping[str, Any] | None,
+) -> bytes:
+    client, bucket = _ceph_client_from_env()
+    if client is None and require_artifact_upload:
+        raise SystemExit("runtime_ledger_proof_artifact_upload_not_configured")
+    prefix = _resolve_artifact_prefix(
+        artifact_prefix,
+        runtime_window_import=runtime_window_import,
+        generated_at=_text(packet.get("generated_at"), _utc_now()),
+    )
+    key = _artifact_key(prefix=prefix, artifact_name=artifact_name)
+    packet["artifact"] = {
+        "schema_version": ARTIFACT_SCHEMA_VERSION,
+        "uri": f"s3://{bucket}/{key}" if client is not None else None,
+        "bucket": bucket,
+        "key": key,
+        "content_type": "application/json",
+        "uploaded": client is not None,
+        "upload_required": require_artifact_upload,
+    }
+    encoded = json.dumps(packet, indent=2, sort_keys=True).encode("utf-8")
+    if client is not None:
+        client.put_object(
+            bucket=bucket,
+            key=key,
+            body=encoded,
+            content_type="application/json",
+        )
+    return encoded
 
 
 def _load_optional_json_object(
@@ -831,6 +986,28 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--timeout-seconds", type=float, default=10.0)
     parser.add_argument("--output-file", type=Path, default=None)
     parser.add_argument(
+        "--artifact-prefix",
+        default="",
+        help=(
+            "Optional object-store prefix for durable proof packet upload. "
+            "Supports {run_id} from the runtime-window import payload and "
+            "{generated_at} from the packet timestamp."
+        ),
+    )
+    parser.add_argument(
+        "--artifact-name",
+        default="runtime-ledger-proof-packet.json",
+        help="Object-store file name for --artifact-prefix uploads.",
+    )
+    parser.add_argument(
+        "--require-artifact-upload",
+        action="store_true",
+        help=(
+            "Fail closed when --artifact-prefix is set but empirical artifact "
+            "object-store credentials are unavailable."
+        ),
+    )
+    parser.add_argument(
         "--allow-blocked-exit-zero",
         action="store_true",
         help=(
@@ -928,11 +1105,25 @@ def main(argv: Sequence[str] | None = None) -> int:
                 args.completion_file, args.completion_url
             ),
         }
-    body = json.dumps(packet, indent=2, sort_keys=True)
+    artifact_prefix = _text(args.artifact_prefix)
+    encoded_body = (
+        _attach_and_upload_artifact(
+            packet,
+            artifact_prefix=artifact_prefix,
+            artifact_name=_text(
+                args.artifact_name,
+                "runtime-ledger-proof-packet.json",
+            ),
+            require_artifact_upload=bool(args.require_artifact_upload),
+            runtime_window_import=runtime_window_import,
+        )
+        if artifact_prefix
+        else json.dumps(packet, indent=2, sort_keys=True).encode("utf-8")
+    )
     if args.output_file is not None:
         args.output_file.parent.mkdir(parents=True, exist_ok=True)
-        args.output_file.write_text(body + "\n", encoding="utf-8")
-    print(body)
+        args.output_file.write_bytes(encoded_body + b"\n")
+    print(encoded_body.decode("utf-8"))
     return 0 if packet["ok"] or args.allow_blocked_exit_zero else 1
 
 

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -1,14 +1,43 @@
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 from argparse import Namespace
 from decimal import Decimal
 from pathlib import Path
+from typing import Any, cast
 from unittest import TestCase
 from unittest.mock import patch
 
 from scripts import assemble_runtime_ledger_proof_packet as packet
+
+
+class _FakeObjectStoreClient:
+    def __init__(self) -> None:
+        self.uploads: list[dict[str, object]] = []
+
+    def put_object(
+        self,
+        *,
+        bucket: str,
+        key: str,
+        body: bytes,
+        content_type: str,
+    ) -> dict[str, object]:
+        self.uploads.append(
+            {
+                "bucket": bucket,
+                "key": key,
+                "body": body,
+                "content_type": content_type,
+            }
+        )
+        return {
+            "bucket": bucket,
+            "key": key,
+            "uri": f"s3://{bucket}/{key}",
+        }
 
 
 def _status(*, blockers: list[str] | None = None) -> dict[str, object]:
@@ -165,6 +194,81 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertEqual(packet._decimal(Decimal("12.5")), Decimal("12.5"))
         self.assertIsNone(packet._decimal("not-a-number"))
 
+    def test_ceph_client_from_env_uses_direct_empirical_endpoint(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "TORGHUT_EMPIRICAL_CEPH_ENDPOINT": "https://rgw.torghut.internal/",
+                "TORGHUT_EMPIRICAL_CEPH_ACCESS_KEY": "direct-access",
+                "TORGHUT_EMPIRICAL_CEPH_SECRET_KEY": "direct-secret",
+                "TORGHUT_EMPIRICAL_CEPH_BUCKET": "direct-bucket",
+                "TORGHUT_EMPIRICAL_CEPH_REGION": "us-west-2",
+                "TORGHUT_EMPIRICAL_CEPH_TIMEOUT_SECONDS": "35",
+            },
+            clear=True,
+        ):
+            client, bucket = packet._ceph_client_from_env()
+
+        self.assertEqual(bucket, "direct-bucket")
+        self.assertIsNotNone(client)
+        assert client is not None
+        concrete_client = cast(Any, client)
+        self.assertEqual(concrete_client.endpoint, "https://rgw.torghut.internal")
+        self.assertEqual(concrete_client.access_key, "direct-access")
+        self.assertEqual(concrete_client.secret_key, "direct-secret")
+        self.assertEqual(concrete_client.region, "us-west-2")
+        self.assertEqual(concrete_client.timeout_seconds, 35)
+
+    def test_ceph_client_from_env_uses_bucket_host_fallbacks(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "TORGHUT_EMPIRICAL_CEPH_BUCKET_HOST": "rook-ceph-rgw",
+                "TORGHUT_EMPIRICAL_CEPH_BUCKET_PORT": "8080",
+                "TORGHUT_EMPIRICAL_CEPH_USE_TLS": "true",
+                "AWS_ACCESS_KEY_ID": "aws-access",
+                "AWS_SECRET_ACCESS_KEY": "aws-secret",
+                "BUCKET_NAME": "fallback-bucket",
+                "TORGHUT_EMPIRICAL_CEPH_TIMEOUT_SECONDS": "0",
+            },
+            clear=True,
+        ):
+            client, bucket = packet._ceph_client_from_env()
+
+        self.assertEqual(bucket, "fallback-bucket")
+        self.assertIsNotNone(client)
+        assert client is not None
+        concrete_client = cast(Any, client)
+        self.assertEqual(concrete_client.endpoint, "https://rook-ceph-rgw:8080")
+        self.assertEqual(concrete_client.access_key, "aws-access")
+        self.assertEqual(concrete_client.secret_key, "aws-secret")
+        self.assertEqual(concrete_client.region, "us-east-1")
+        self.assertEqual(concrete_client.timeout_seconds, 1)
+
+    def test_ceph_client_from_env_returns_bucket_without_credentials(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "TORGHUT_EMPIRICAL_CEPH_BUCKET_HOST": "rook-ceph-rgw",
+                "TORGHUT_EMPIRICAL_CEPH_BUCKET": "configured-bucket",
+            },
+            clear=True,
+        ):
+            client, bucket = packet._ceph_client_from_env()
+
+        self.assertIsNone(client)
+        self.assertEqual(bucket, "configured-bucket")
+
+    def test_resolve_artifact_prefix_defaults_missing_runtime_run_id(self) -> None:
+        self.assertEqual(
+            packet._resolve_artifact_prefix(
+                "runtime-ledger-proof-packets/{run_id}/{generated_at}",
+                runtime_window_import=None,
+                generated_at="2026-05-26T21:30:00+00:00",
+            ),
+            "runtime-ledger-proof-packets/unknown-run/2026-05-26T21-30-00-00-00",
+        )
+
     def test_packet_allows_only_complete_post_cost_runtime_ledger_proof(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(),
@@ -188,6 +292,125 @@ class TestRuntimeLedgerProofPacket(TestCase):
             ],
             "650",
         )
+
+    def test_cli_uploads_durable_proof_packet_artifact_with_runtime_run_id(
+        self,
+    ) -> None:
+        fake_client = _FakeObjectStoreClient()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            status_path = root / "status.json"
+            paper_path = root / "paper.json"
+            runtime_path = root / "runtime.json"
+            completion_path = root / "completion.json"
+            output_path = root / "packet.json"
+            status_path.write_text(json.dumps(_status()), encoding="utf-8")
+            paper_path.write_text(json.dumps(_paper_route_evidence()), encoding="utf-8")
+            runtime_path.write_text(
+                json.dumps(
+                    {
+                        "run_id": "sim-2026-05-05-chip-renew-20260526T212300Z",
+                        "runtime_window_import": _runtime_import(),
+                    }
+                ),
+                encoding="utf-8",
+            )
+            completion_path.write_text(json.dumps(_completion()), encoding="utf-8")
+
+            with patch.object(
+                packet,
+                "_ceph_client_from_env",
+                return_value=(fake_client, "torghut-empirical-artifacts"),
+            ):
+                exit_code = packet.main(
+                    [
+                        "--status-file",
+                        str(status_path),
+                        "--paper-route-evidence-file",
+                        str(paper_path),
+                        "--runtime-window-import-file",
+                        str(runtime_path),
+                        "--completion-file",
+                        str(completion_path),
+                        "--output-file",
+                        str(output_path),
+                        "--generated-at",
+                        "2026-05-26T21:30:00+00:00",
+                        "--artifact-prefix",
+                        "runtime-ledger-proof-packets/{run_id}",
+                        "--artifact-name",
+                        "authority-packet.json",
+                        "--require-artifact-upload",
+                    ]
+                )
+
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(len(fake_client.uploads), 1)
+            upload = fake_client.uploads[0]
+            self.assertEqual(upload["bucket"], "torghut-empirical-artifacts")
+            self.assertEqual(
+                upload["key"],
+                "runtime-ledger-proof-packets/"
+                "sim-2026-05-05-chip-renew-20260526T212300Z/"
+                "authority-packet.json",
+            )
+            uploaded_payload = json.loads(cast(bytes, upload["body"]).decode("utf-8"))
+            local_payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(uploaded_payload, local_payload)
+            self.assertEqual(
+                local_payload["artifact"]["uri"],
+                "s3://torghut-empirical-artifacts/"
+                "runtime-ledger-proof-packets/"
+                "sim-2026-05-05-chip-renew-20260526T212300Z/"
+                "authority-packet.json",
+            )
+            self.assertTrue(local_payload["artifact"]["uploaded"])
+            self.assertTrue(local_payload["artifact"]["upload_required"])
+
+    def test_cli_fails_closed_when_required_artifact_upload_is_not_configured(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            status_path = root / "status.json"
+            paper_path = root / "paper.json"
+            output_path = root / "packet.json"
+            status_path.write_text(json.dumps(_status()), encoding="utf-8")
+            paper_path.write_text(
+                json.dumps(
+                    _paper_route_evidence(
+                        import_ready=False,
+                        import_blockers=["paper_route_session_window_not_open"],
+                    )
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.object(
+                packet,
+                "_ceph_client_from_env",
+                return_value=(None, "torghut-empirical-artifacts"),
+            ):
+                with self.assertRaisesRegex(
+                    SystemExit,
+                    "runtime_ledger_proof_artifact_upload_not_configured",
+                ):
+                    packet.main(
+                        [
+                            "--status-file",
+                            str(status_path),
+                            "--paper-route-evidence-file",
+                            str(paper_path),
+                            "--output-file",
+                            str(output_path),
+                            "--artifact-prefix",
+                            "runtime-ledger-proof-packets/{run_id}",
+                            "--require-artifact-upload",
+                            "--allow-blocked-exit-zero",
+                        ]
+                    )
+
+            self.assertFalse(output_path.exists())
 
     def test_packet_waits_before_paper_route_window_is_importable(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -887,6 +887,11 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertIn('--runtime-window-import-file "${RENEWAL_OUTPUT}"', args)
         self.assertIn('--output-file "${PROOF_PACKET_OUTPUT}"', args)
+        self.assertIn(
+            "--artifact-prefix 'runtime-ledger-proof-packets/{run_id}'",
+            args,
+        )
+        self.assertIn("--require-artifact-upload", args)
         self.assertIn("--allow-blocked-exit-zero", args)
 
     def test_migration_job_prepares_sim_database_before_sim_upgrade(self) -> None:

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -402,6 +402,20 @@ class TestPaperRouteEvidenceAudit(TestCase):
         ]
         self.assertIn("--runtime-window-import-file", authority_argv)
         self.assertIn("artifacts/runtime-window-import.json", authority_argv)
+        self.assertIn("--artifact-prefix", authority_argv)
+        self.assertIn("runtime-ledger-proof-packets/{run_id}", authority_argv)
+        self.assertIn("--require-artifact-upload", authority_argv)
+        self.assertTrue(
+            proof_handoff["commands"]["authority_packet_after_import"][
+                "requires_durable_artifact_upload"
+            ]
+        )
+        self.assertEqual(
+            proof_handoff["required_inputs"]["durable_artifact_upload"][
+                "artifact_prefix"
+            ],
+            "runtime-ledger-proof-packets/{run_id}",
+        )
         self.assertEqual(
             proof_handoff["required_inputs"]["runtime_window_import"]["required_when"],
             "runtime_window.import_ready",
@@ -562,6 +576,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertTrue(
             import_handoff["commands"]["authority_packet_after_import"][
                 "allowed_only_if_packet_ok"
+            ]
+        )
+        self.assertTrue(
+            import_handoff["commands"]["authority_packet_after_import"][
+                "requires_durable_artifact_upload"
             ]
         )
 


### PR DESCRIPTION
## Summary

- Adds durable object-store metadata and upload support to the runtime-ledger proof packet assembler.
- Wires the empirical promotion renewal CronJob to require proof packet upload under `runtime-ledger-proof-packets/{run_id}`.
- Extends paper-route evidence handoff metadata so authority packets explicitly require durable artifact upload before promotion-grade use.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py app/trading/paper_route_evidence.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_live_config_manifest_contract.py tests/test_paper_route_evidence.py`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k empirical_promotion_renewal -q`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

The empirical promotion renewal proof-packet assembly now fails closed when empirical artifact object-store credentials are unavailable.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
