### PR TITLE
fix(torghut): import paper route plans from live service

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -45,7 +45,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref intraday_tsmom_v2@research \
                     --runtime-window-import \
-                    --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence \
+                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence \
                     --runtime-window-target-plan-exclusive \
                     --runtime-window-target-plan-required \
                     --runtime-window-target-plan-settlement-seconds 3600 \
@@ -64,7 +64,7 @@ spec:
                     | tee "${RENEWAL_OUTPUT}"
                   /opt/venv/bin/python scripts/assemble_runtime_ledger_proof_packet.py \
                     --status-service-base-url http://torghut.torghut.svc.cluster.local \
-                    --paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local \
+                    --paper-route-service-base-url http://torghut.torghut.svc.cluster.local \
                     --completion-service-base-url http://torghut.torghut.svc.cluster.local \
                     --runtime-window-import-file "${RENEWAL_OUTPUT}" \
                     --output-file "${PROOF_PACKET_OUTPUT}" \

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -44,7 +44,7 @@ PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL = "TORGHUT_SIM"
 PAPER_ROUTE_RUNTIME_IMPORT_SETTLEMENT_SECONDS = 3600
 DEFAULT_TORGHUT_LIVE_SERVICE_BASE_URL = "http://torghut.torghut.svc.cluster.local"
 DEFAULT_TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL = (
-    "http://torghut-sim.torghut.svc.cluster.local"
+    "http://torghut.torghut.svc.cluster.local"
 )
 RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE = "artifacts/runtime-ledger-proof-packet.json"
 RUNTIME_WINDOW_IMPORT_OUTPUT_FILE = "artifacts/runtime-window-import.json"
@@ -1355,7 +1355,7 @@ def _runtime_ledger_proof_packet_handoff(
         ),
         "source_service_authority": {
             "status": "live_torghut_service",
-            "paper_route_evidence": "paper_route_sim_service",
+            "paper_route_evidence": "live_torghut_service",
             "completion_doc29": "live_torghut_service",
         },
         "source_endpoints": {

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -783,7 +783,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--max-batches 1", args)
         self.assertIn("--apply", args)
 
-    def test_empirical_promotion_renewal_imports_live_paper_plan_from_sim_service_and_db(
+    def test_empirical_promotion_renewal_imports_authoritative_live_paper_plan_and_sim_db(
         self,
     ) -> None:
         spec, container = _load_cronjob_container(
@@ -845,12 +845,12 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn(
             "--runtime-window-target-plan-url "
-            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
         self.assertNotIn(
             "--runtime-window-target-plan-url "
-            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
         self.assertIn("--runtime-window-target-plan-exclusive", args)
@@ -878,6 +878,10 @@ class TestLiveConfigManifestContract(TestCase):
             args,
         )
         self.assertIn(
+            "--paper-route-service-base-url http://torghut.torghut.svc.cluster.local",
+            args,
+        )
+        self.assertNotIn(
             "--paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local",
             args,
         )

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -380,13 +380,13 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertEqual(
             proof_handoff["default_paper_route_service_base_url"],
-            "http://torghut-sim.torghut.svc.cluster.local",
+            "http://torghut.torghut.svc.cluster.local",
         )
         self.assertEqual(
             proof_handoff["source_service_authority"],
             {
                 "status": "live_torghut_service",
-                "paper_route_evidence": "paper_route_sim_service",
+                "paper_route_evidence": "live_torghut_service",
                 "completion_doc29": "live_torghut_service",
             },
         )


### PR DESCRIPTION
## Summary

- Points empirical promotion renewal at the live `torghut` `/trading/paper-route-evidence` plan instead of the `torghut-sim` proxy hop.
- Aligns runtime-ledger proof-packet handoff defaults so status, paper-route evidence, and completion inputs all come from the live authoritative Torghut service.
- Keeps paper execution import scoped to the sim database via `SIM_DB_DSN`; this changes proof-plan sourcing, not live capital authorization.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_live_config_manifest_contract.py -k 'runtime_ledger_proof_packet_handoff or empirical_promotion_renewal' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py -k empirical_promotion_renewal -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `bun test packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
