### PR TITLE
fix(torghut): gate proof packets on import health

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -434,6 +434,72 @@ def _paper_route_targets(plan: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     return [_mapping(item) for item in _sequence(plan.get("targets")) if _mapping(item)]
 
 
+def _health_gate_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    return _text(value).lower() == "true"
+
+
+def _runtime_window_import_health_gate_summary(
+    *,
+    plan: Mapping[str, Any],
+    targets: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    plan_gate = _mapping(plan.get("runtime_window_import_health_gate"))
+    blockers = _text_list(plan_gate.get("blockers"))
+    target_summaries: list[dict[str, Any]] = []
+    ready_count = 0
+    for index, target in enumerate(targets):
+        gate = _mapping(target.get("runtime_window_import_health_gate"))
+        target_blockers = _text_list(
+            target.get("runtime_window_import_health_gate_blockers")
+        )
+        _extend_unique(target_blockers, _text_list(gate.get("blockers")))
+        dependency_quorum_decision = _text(
+            target.get("dependency_quorum_decision")
+            or gate.get("dependency_quorum_decision")
+        )
+        continuity_ok = target.get("continuity_ok", gate.get("continuity_ok"))
+        drift_ok = target.get("drift_ok", gate.get("drift_ok"))
+        if not gate:
+            _extend_unique(
+                target_blockers, ["runtime_window_import_health_gate_missing"]
+            )
+        if dependency_quorum_decision != "allow":
+            _extend_unique(target_blockers, ["dependency_quorum_not_allow"])
+        if not _health_gate_bool(continuity_ok):
+            _extend_unique(target_blockers, ["continuity_not_ok"])
+        if not _health_gate_bool(drift_ok):
+            _extend_unique(target_blockers, ["drift_not_ok"])
+        ready = not target_blockers
+        if ready:
+            ready_count += 1
+        _extend_unique(blockers, target_blockers)
+        target_summaries.append(
+            {
+                "index": index,
+                "hypothesis_id": _text(target.get("hypothesis_id")),
+                "candidate_id": _text(target.get("candidate_id")),
+                "dependency_quorum_decision": dependency_quorum_decision,
+                "continuity_ok": _text(continuity_ok),
+                "drift_ok": _text(drift_ok),
+                "ready": ready,
+                "blockers": target_blockers,
+            }
+        )
+    target_count = len(targets)
+    return {
+        "schema_version": "torghut.runtime-window-import-health-gate-proof-summary.v1",
+        "plan_schema_version": _text(plan_gate.get("schema_version")),
+        "target_count": target_count,
+        "ready_target_count": ready_count,
+        "blocked_target_count": max(0, target_count - ready_count),
+        "ready": target_count > 0 and ready_count == target_count and not blockers,
+        "blockers": blockers,
+        "targets": target_summaries,
+    }
+
+
 def _missing_target_identity_count(targets: Sequence[Mapping[str, Any]]) -> int:
     required = (
         "hypothesis_id",
@@ -597,6 +663,13 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
             _extend_unique(
                 actions, ["keep_promotion_blocked_until_live_gate_and_proof_floor_pass"]
             )
+        elif blocker in {
+            "runtime_window_import_health_gate_missing",
+            "dependency_quorum_not_allow",
+            "continuity_not_ok",
+            "drift_not_ok",
+        } or blocker.startswith("runtime_window_import_health_gate"):
+            _extend_unique(actions, ["repair_runtime_window_import_health_gate"])
     if not actions and verdict != "promotion_authority_allowed":
         actions.append("inspect_packet_checks_and_repair_failed_proof_dimension")
     return actions
@@ -631,6 +704,11 @@ def build_runtime_ledger_proof_packet(
     plan = _paper_route_target_plan(paper_route_evidence)
     paper_targets = _paper_route_targets(plan)
     paper_import_blockers = _paper_route_import_blockers(plan)
+    health_gate_summary = _runtime_window_import_health_gate_summary(
+        plan=plan,
+        targets=paper_targets,
+    )
+    health_gate_blockers = _text_list(health_gate_summary.get("blockers"))
     handoff = _mapping(plan.get("runtime_window_import_handoff"))
     session_readiness = _mapping(plan.get("session_readiness"))
     import_ready = _bool(session_readiness.get("import_ready")) or _bool(
@@ -663,14 +741,33 @@ def build_runtime_ledger_proof_packet(
         _extend_unique(blockers, ["paper_route_target_identity_incomplete"])
     _check(
         checks,
+        "paper_route_import_health_gate",
+        passed=bool(paper_targets) and bool(health_gate_summary.get("ready")),
+        observed=health_gate_summary,
+        expected="every paper-route runtime-window target has allow quorum, continuity_ok true, and drift_ok true",
+        blockers=health_gate_blockers
+        or (
+            []
+            if bool(paper_targets) and bool(health_gate_summary.get("ready"))
+            else ["runtime_window_import_health_gate_missing"]
+        ),
+    )
+    if health_gate_blockers:
+        _extend_unique(blockers, health_gate_blockers)
+    elif paper_targets and not bool(health_gate_summary.get("ready")):
+        _extend_unique(blockers, ["runtime_window_import_health_gate_missing"])
+    _check(
+        checks,
         "paper_route_import_ready",
-        passed=import_ready and not paper_import_blockers,
+        passed=import_ready and not paper_import_blockers and not health_gate_blockers,
         observed={
             "import_ready": import_ready,
             "import_blockers": paper_import_blockers,
+            "health_gate_blockers": health_gate_blockers,
         },
         expected="paper-route target window closed, settled, and import-ready",
         blockers=paper_import_blockers
+        or health_gate_blockers
         or ([] if import_ready else ["paper_route_import_not_ready"]),
     )
     if paper_import_blockers:
@@ -678,7 +775,9 @@ def build_runtime_ledger_proof_packet(
     elif not import_ready:
         _extend_unique(blockers, ["paper_route_import_not_ready"])
 
-    runtime_import_due = import_ready and not paper_import_blockers
+    runtime_import_due = (
+        import_ready and not paper_import_blockers and not health_gate_blockers
+    )
     runtime_import = _runtime_window_import_payload(runtime_window_import)
     runtime_import_items = _runtime_window_import_items(runtime_import)
     runtime_import_blockers = _runtime_import_blockers(runtime_import)
@@ -898,6 +997,7 @@ def build_runtime_ledger_proof_packet(
                 "import_ready": import_ready,
                 "import_blockers": paper_import_blockers,
                 "session_window": _mapping(plan.get("session_window")),
+                "runtime_window_import_health_gate": health_gate_summary,
             },
             "runtime_window_import": {
                 "present": bool(runtime_import),

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -13,41 +13,41 @@ from typing import Any, cast
 from urllib.request import urlopen
 
 
-SCHEMA_VERSION = 'torghut.trading-readiness-verification.v1'
-ROUTE_REACQUISITION_BOARD_SCHEMA_VERSION = 'torghut.route-reacquisition-board.v1'
-ROUTE_REACQUISITION_BOOK_SCHEMA_VERSION = 'torghut.route-reacquisition-book.v1'
+SCHEMA_VERSION = "torghut.trading-readiness-verification.v1"
+ROUTE_REACQUISITION_BOARD_SCHEMA_VERSION = "torghut.route-reacquisition-board.v1"
+ROUTE_REACQUISITION_BOOK_SCHEMA_VERSION = "torghut.route-reacquisition-book.v1"
 NEXT_PAPER_ROUTE_TARGET_PLAN_SCHEMA_VERSION = (
-    'torghut.next-paper-route-runtime-window-targets.v1'
+    "torghut.next-paper-route-runtime-window-targets.v1"
 )
 RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION = (
-    'torghut.runtime-ledger-live-paper-proof-packet.v1'
+    "torghut.runtime-ledger-live-paper-proof-packet.v1"
 )
-DOC29_LIVE_SCALE_GATE = 'live_scale_observed'
+DOC29_LIVE_SCALE_GATE = "live_scale_observed"
 REQUIRED_RUNTIME_WINDOW_TARGET_PLAN_FLAGS = (
-    '--runtime-window-import',
-    '--runtime-window-target-plan-url',
-    '--runtime-window-target-plan-exclusive',
-    '--runtime-window-target-plan-required',
-    '--runtime-window-target-plan-settlement-seconds',
+    "--runtime-window-import",
+    "--runtime-window-target-plan-url",
+    "--runtime-window-target-plan-exclusive",
+    "--runtime-window-target-plan-required",
+    "--runtime-window-target-plan-settlement-seconds",
 )
 _RUNTIME_LEDGER_TRADING_DAY_KEYS = (
-    'runtime_ledger_observed_trading_day_count',
-    'runtime_ledger_trading_day_count',
-    'observed_trading_day_count',
-    'trading_day_count',
-    'runtime_ledger_session_count',
-    'session_count',
+    "runtime_ledger_observed_trading_day_count",
+    "runtime_ledger_trading_day_count",
+    "observed_trading_day_count",
+    "trading_day_count",
+    "runtime_ledger_session_count",
+    "session_count",
 )
 _MISSING_QUANT_REASONS = {
-    'quant_health_fetch_failed',
-    'quant_health_missing',
-    'quant_latest_metrics_empty',
-    'quant_latest_store_alarm',
-    'quant_pipeline_stages_missing',
+    "quant_health_fetch_failed",
+    "quant_health_missing",
+    "quant_latest_metrics_empty",
+    "quant_latest_store_alarm",
+    "quant_pipeline_stages_missing",
 }
 
 
-def _text(value: object, default: str = '') -> str:
+def _text(value: object, default: str = "") -> str:
     if value is None:
         return default
     normalized = str(value).strip()
@@ -60,8 +60,14 @@ def _bool(value: object) -> bool:
     if isinstance(value, (int, float)):
         return value != 0
     if isinstance(value, str):
-        return value.strip().lower() in {'1', 'true', 'yes', 'y', 'open'}
+        return value.strip().lower() in {"1", "true", "yes", "y", "open"}
     return False
+
+
+def _health_gate_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    return _text(value).lower() == "true"
 
 
 def _int(value: object, default: int = 0) -> int:
@@ -106,17 +112,17 @@ def _sequence(value: object) -> Sequence[object]:
 
 
 def _load_json_object(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding='utf-8'))
+    payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, Mapping):
-        raise ValueError(f'json_object_required:{path}')
+        raise ValueError(f"json_object_required:{path}")
     return {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
 
 
 def _load_status_url(url: str, *, timeout_seconds: float) -> dict[str, Any]:
     with urlopen(url, timeout=timeout_seconds) as response:
-        payload = json.loads(response.read().decode('utf-8'))
+        payload = json.loads(response.read().decode("utf-8"))
     if not isinstance(payload, Mapping):
-        raise ValueError(f'json_object_required:{url}')
+        raise ValueError(f"json_object_required:{url}")
     return {str(key): value for key, value in cast(Mapping[str, Any], payload).items()}
 
 
@@ -135,31 +141,31 @@ def _load_optional_json_object(
 
 def _dimension_by_name(proof_floor: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
     dimensions: dict[str, Mapping[str, Any]] = {}
-    for raw_dimension in _sequence(proof_floor.get('proof_dimensions')):
+    for raw_dimension in _sequence(proof_floor.get("proof_dimensions")):
         dimension = _mapping(raw_dimension)
-        name = _text(dimension.get('dimension'))
+        name = _text(dimension.get("dimension"))
         if name:
             dimensions[name] = dimension
     return dimensions
 
 
 def _dimension_is_required(dimension: Mapping[str, Any]) -> bool:
-    source_ref = _mapping(dimension.get('source_ref'))
-    if 'required' in source_ref:
-        return _bool(source_ref.get('required'))
-    if 'evidence_required' in source_ref:
-        return _bool(source_ref.get('evidence_required'))
+    source_ref = _mapping(dimension.get("source_ref"))
+    if "required" in source_ref:
+        return _bool(source_ref.get("required"))
+    if "evidence_required" in source_ref:
+        return _bool(source_ref.get("evidence_required"))
     return True
 
 
 def _market_session_open(
     status: Mapping[str, Any], proof_floor: Mapping[str, Any]
 ) -> bool:
-    metrics = _mapping(status.get('metrics'))
-    if 'market_session_open' in metrics:
-        return _bool(metrics.get('market_session_open'))
-    market_window = _mapping(proof_floor.get('market_window'))
-    return _bool(market_window.get('session_open'))
+    metrics = _mapping(status.get("metrics"))
+    if "market_session_open" in metrics:
+        return _bool(metrics.get("market_session_open"))
+    market_window = _mapping(proof_floor.get("market_window"))
+    return _bool(market_window.get("session_open"))
 
 
 def _add_check(
@@ -172,28 +178,28 @@ def _add_check(
     detail: object | None = None,
 ) -> None:
     payload: dict[str, Any] = {
-        'passed': passed,
-        'observed': observed,
-        'expected': expected,
+        "passed": passed,
+        "observed": observed,
+        "expected": expected,
     }
     if detail is not None:
-        payload['detail'] = detail
+        payload["detail"] = detail
     checks[key] = payload
 
 
 def _expected_floor_states(profile: str) -> tuple[set[str], set[str], set[str]]:
-    if profile == 'paper':
-        return {'paper_ready'}, {'paper_candidate'}, {'paper_allowed'}
-    if profile == 'live':
+    if profile == "paper":
+        return {"paper_ready"}, {"paper_candidate"}, {"paper_allowed"}
+    if profile == "live":
         return (
-            {'live_micro_ready', 'live_scale_ready'},
-            {'live_micro_candidate', 'live_scale_candidate'},
-            {'live_allowed'},
+            {"live_micro_ready", "live_scale_ready"},
+            {"live_micro_candidate", "live_scale_candidate"},
+            {"live_allowed"},
         )
     return (
-        {'paper_ready', 'live_micro_ready', 'live_scale_ready'},
-        {'paper_candidate', 'live_micro_candidate', 'live_scale_candidate'},
-        {'paper_allowed', 'live_allowed'},
+        {"paper_ready", "live_micro_ready", "live_scale_ready"},
+        {"paper_candidate", "live_micro_candidate", "live_scale_candidate"},
+        {"paper_allowed", "live_allowed"},
     )
 
 
@@ -201,38 +207,38 @@ def _paper_route_probe_summary(
     status: Mapping[str, Any],
     proof_floor: Mapping[str, Any],
 ) -> dict[str, Any]:
-    route_book = _mapping(status.get('route_reacquisition_book')) or _mapping(
-        proof_floor.get('route_reacquisition_book')
+    route_book = _mapping(status.get("route_reacquisition_book")) or _mapping(
+        proof_floor.get("route_reacquisition_book")
     )
-    route_summary = _mapping(route_book.get('summary'))
-    probe = _mapping(route_book.get('paper_route_probe'))
-    eligible_symbols = _sequence(probe.get('eligible_symbols')) or _sequence(
-        route_summary.get('paper_route_probe_eligible_symbols')
+    route_summary = _mapping(route_book.get("summary"))
+    probe = _mapping(route_book.get("paper_route_probe"))
+    eligible_symbols = _sequence(probe.get("eligible_symbols")) or _sequence(
+        route_summary.get("paper_route_probe_eligible_symbols")
     )
-    active_symbols = _sequence(probe.get('active_symbols')) or _sequence(
-        route_summary.get('paper_route_probe_active_symbols')
+    active_symbols = _sequence(probe.get("active_symbols")) or _sequence(
+        route_summary.get("paper_route_probe_active_symbols")
     )
     return {
-        'route_book_present': bool(route_book),
-        'route_book_schema_version': _text(route_book.get('schema_version')),
-        'configured_enabled': _bool(probe.get('configured_enabled')),
-        'configured_max_notional': _text(probe.get('configured_max_notional'), '0'),
-        'active': _bool(probe.get('active')),
-        'effective_max_notional': _text(probe.get('effective_max_notional'), '0'),
-        'next_session_max_notional': _text(probe.get('next_session_max_notional'), '0'),
-        'eligible_symbol_count': _int(
-            probe.get('eligible_symbol_count'), default=len(eligible_symbols)
+        "route_book_present": bool(route_book),
+        "route_book_schema_version": _text(route_book.get("schema_version")),
+        "configured_enabled": _bool(probe.get("configured_enabled")),
+        "configured_max_notional": _text(probe.get("configured_max_notional"), "0"),
+        "active": _bool(probe.get("active")),
+        "effective_max_notional": _text(probe.get("effective_max_notional"), "0"),
+        "next_session_max_notional": _text(probe.get("next_session_max_notional"), "0"),
+        "eligible_symbol_count": _int(
+            probe.get("eligible_symbol_count"), default=len(eligible_symbols)
         ),
-        'eligible_symbols': [
+        "eligible_symbols": [
             _text(symbol) for symbol in eligible_symbols if _text(symbol)
         ],
-        'active_symbols': [_text(symbol) for symbol in active_symbols if _text(symbol)],
-        'blocking_reasons': [
+        "active_symbols": [_text(symbol) for symbol in active_symbols if _text(symbol)],
+        "blocking_reasons": [
             _text(reason)
-            for reason in _sequence(probe.get('blocking_reasons'))
+            for reason in _sequence(probe.get("blocking_reasons"))
             if _text(reason)
         ],
-        'capital_authority': _text(probe.get('capital_authority'), 'none'),
+        "capital_authority": _text(probe.get("capital_authority"), "none"),
     }
 
 
@@ -240,12 +246,12 @@ def _paper_route_target_plan_summary(
     paper_route_evidence: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     evidence = paper_route_evidence or {}
-    plan = _mapping(evidence.get('next_paper_route_runtime_window_targets'))
-    targets = [_mapping(target) for target in _sequence(plan.get('targets'))]
-    handoff = _mapping(plan.get('runtime_window_import_handoff'))
-    session_readiness = _mapping(plan.get('session_readiness'))
+    plan = _mapping(evidence.get("next_paper_route_runtime_window_targets"))
+    targets = [_mapping(target) for target in _sequence(plan.get("targets"))]
+    handoff = _mapping(plan.get("runtime_window_import_handoff"))
+    session_readiness = _mapping(plan.get("session_readiness"))
     required_flags = {
-        _text(flag) for flag in _sequence(handoff.get('required_flags')) if _text(flag)
+        _text(flag) for flag in _sequence(handoff.get("required_flags")) if _text(flag)
     }
     missing_required_flags = [
         flag
@@ -255,8 +261,8 @@ def _paper_route_target_plan_summary(
     import_blockers = [
         _text(reason)
         for reason in (
-            _sequence(handoff.get('import_blockers'))
-            or _sequence(session_readiness.get('import_blockers'))
+            _sequence(handoff.get("import_blockers"))
+            or _sequence(session_readiness.get("import_blockers"))
         )
         if _text(reason)
     ]
@@ -264,19 +270,21 @@ def _paper_route_target_plan_summary(
     missing_identity_count = 0
     probe_contract_count = 0
     promotion_blocked_count = 0
+    health_gate_ready_count = 0
+    health_gate_blockers: list[str] = []
     for target in targets:
         missing_identity = [
             field
             for field in (
-                'hypothesis_id',
-                'candidate_id',
-                'strategy_family',
-                'strategy_name',
-                'account_label',
-                'source_dsn_env',
-                'source_kind',
-                'window_start',
-                'window_end',
+                "hypothesis_id",
+                "candidate_id",
+                "strategy_family",
+                "strategy_name",
+                "account_label",
+                "source_dsn_env",
+                "source_kind",
+                "window_start",
+                "window_end",
             )
             if not _text(target.get(field))
         ]
@@ -284,79 +292,124 @@ def _paper_route_target_plan_summary(
             missing_identity_count += 1
         probe_symbols = [
             _text(symbol)
-            for symbol in _sequence(target.get('paper_route_probe_symbols'))
+            for symbol in _sequence(target.get("paper_route_probe_symbols"))
             if _text(symbol)
         ]
         probe_notional_positive = _decimal_positive(
-            target.get('paper_route_probe_next_session_max_notional')
+            target.get("paper_route_probe_next_session_max_notional")
         )
         if probe_symbols and probe_notional_positive:
             probe_contract_count += 1
         promotion_blocked = (
-            not _bool(target.get('promotion_allowed'))
-            and not _bool(target.get('final_promotion_authorized'))
-            and not _bool(target.get('final_promotion_allowed'))
-            and (_decimal(target.get('max_notional')) or Decimal('0')) == 0
+            not _bool(target.get("promotion_allowed"))
+            and not _bool(target.get("final_promotion_authorized"))
+            and not _bool(target.get("final_promotion_allowed"))
+            and (_decimal(target.get("max_notional")) or Decimal("0")) == 0
         )
         if promotion_blocked:
             promotion_blocked_count += 1
+        health_gate = _mapping(target.get("runtime_window_import_health_gate"))
+        target_health_blockers = [
+            _text(reason)
+            for reason in _sequence(
+                target.get("runtime_window_import_health_gate_blockers")
+            )
+            if _text(reason)
+        ]
+        for reason in _sequence(health_gate.get("blockers")):
+            blocker = _text(reason)
+            if blocker and blocker not in target_health_blockers:
+                target_health_blockers.append(blocker)
+        dependency_quorum_decision = _text(
+            target.get("dependency_quorum_decision")
+            or health_gate.get("dependency_quorum_decision")
+        )
+        continuity_ok = target.get("continuity_ok", health_gate.get("continuity_ok"))
+        drift_ok = target.get("drift_ok", health_gate.get("drift_ok"))
+        if not health_gate:
+            target_health_blockers.append("runtime_window_import_health_gate_missing")
+        if dependency_quorum_decision != "allow":
+            target_health_blockers.append("dependency_quorum_not_allow")
+        if not _health_gate_bool(continuity_ok):
+            target_health_blockers.append("continuity_not_ok")
+        if not _health_gate_bool(drift_ok):
+            target_health_blockers.append("drift_not_ok")
+        target_health_blockers = sorted(set(target_health_blockers))
+        if not target_health_blockers:
+            health_gate_ready_count += 1
+        for blocker in target_health_blockers:
+            if blocker not in health_gate_blockers:
+                health_gate_blockers.append(blocker)
         target_summaries.append(
             {
-                'hypothesis_id': _text(target.get('hypothesis_id')),
-                'candidate_id': _text(target.get('candidate_id')),
-                'strategy_name': _text(target.get('strategy_name')),
-                'account_label': _text(target.get('account_label')),
-                'source_dsn_env': _text(target.get('source_dsn_env')),
-                'source_kind': _text(target.get('source_kind')),
-                'window_start': _text(target.get('window_start')),
-                'window_end': _text(target.get('window_end')),
-                'paper_route_probe_symbols': probe_symbols,
-                'paper_route_probe_next_session_max_notional': _text(
-                    target.get('paper_route_probe_next_session_max_notional')
+                "hypothesis_id": _text(target.get("hypothesis_id")),
+                "candidate_id": _text(target.get("candidate_id")),
+                "strategy_name": _text(target.get("strategy_name")),
+                "account_label": _text(target.get("account_label")),
+                "source_dsn_env": _text(target.get("source_dsn_env")),
+                "source_kind": _text(target.get("source_kind")),
+                "window_start": _text(target.get("window_start")),
+                "window_end": _text(target.get("window_end")),
+                "paper_route_probe_symbols": probe_symbols,
+                "paper_route_probe_next_session_max_notional": _text(
+                    target.get("paper_route_probe_next_session_max_notional")
                 ),
-                'promotion_blocked': promotion_blocked,
-                'missing_identity_fields': missing_identity,
+                "promotion_blocked": promotion_blocked,
+                "dependency_quorum_decision": dependency_quorum_decision,
+                "continuity_ok": _text(continuity_ok),
+                "drift_ok": _text(drift_ok),
+                "runtime_window_import_health_gate_blockers": target_health_blockers,
+                "missing_identity_fields": missing_identity,
             }
         )
-    target_count = _int(plan.get('target_count'), default=len(targets))
-    import_ready = _bool(handoff.get('import_ready')) or _bool(
-        session_readiness.get('import_ready')
+    target_count = _int(plan.get("target_count"), default=len(targets))
+    import_ready = _bool(handoff.get("import_ready")) or _bool(
+        session_readiness.get("import_ready")
     )
     return {
-        'present': bool(plan),
-        'schema_version': _text(plan.get('schema_version')),
-        'target_count': target_count,
-        'actual_target_count': len(targets),
-        'skipped_target_count': _int(plan.get('skipped_target_count')),
-        'session_window': _mapping(plan.get('session_window')),
-        'session_readiness_state': _text(session_readiness.get('state')),
-        'import_ready': import_ready,
-        'import_blockers': import_blockers,
-        'required_flags': sorted(required_flags),
-        'missing_required_flags': missing_required_flags,
-        'targets': target_summaries,
-        'missing_identity_count': missing_identity_count,
-        'probe_contract_count': probe_contract_count,
-        'promotion_blocked_count': promotion_blocked_count,
+        "present": bool(plan),
+        "schema_version": _text(plan.get("schema_version")),
+        "target_count": target_count,
+        "actual_target_count": len(targets),
+        "skipped_target_count": _int(plan.get("skipped_target_count")),
+        "session_window": _mapping(plan.get("session_window")),
+        "session_readiness_state": _text(session_readiness.get("state")),
+        "import_ready": import_ready,
+        "import_blockers": import_blockers,
+        "required_flags": sorted(required_flags),
+        "missing_required_flags": missing_required_flags,
+        "targets": target_summaries,
+        "missing_identity_count": missing_identity_count,
+        "probe_contract_count": probe_contract_count,
+        "promotion_blocked_count": promotion_blocked_count,
+        "runtime_window_import_health_gate": {
+            "ready": bool(targets)
+            and health_gate_ready_count == len(targets)
+            and not health_gate_blockers,
+            "target_count": len(targets),
+            "ready_target_count": health_gate_ready_count,
+            "blocked_target_count": max(0, len(targets) - health_gate_ready_count),
+            "blockers": health_gate_blockers,
+        },
     }
 
 
 def _completion_gate(
     completion_status: Mapping[str, Any], gate_id: str
 ) -> Mapping[str, Any]:
-    for raw_gate in _sequence(completion_status.get('gates')):
+    for raw_gate in _sequence(completion_status.get("gates")):
         gate = _mapping(raw_gate)
-        if _text(gate.get('gate_id')) == gate_id:
+        if _text(gate.get("gate_id")) == gate_id:
             return gate
     return {}
 
 
 def _runtime_ledger_summary(gate: Mapping[str, Any]) -> Mapping[str, Any]:
-    return _mapping(gate.get('runtime_ledger_summary'))
+    return _mapping(gate.get("runtime_ledger_summary"))
 
 
 def _runtime_ledger_refs(gate: Mapping[str, Any], key: str) -> Sequence[object]:
-    refs = _mapping(gate.get('db_row_refs'))
+    refs = _mapping(gate.get("db_row_refs"))
     return _sequence(refs.get(key))
 
 
@@ -374,37 +427,37 @@ def _add_runtime_ledger_proof_packet_check(
     runtime_ledger_proof_packet: Mapping[str, Any] | None,
 ) -> None:
     packet = _mapping(runtime_ledger_proof_packet)
-    authority = _mapping(packet.get('promotion_authority'))
-    schema_version = _text(packet.get('schema_version'))
-    allowed = authority.get('allowed') is True
-    packet_ok = packet.get('ok') is True and allowed
+    authority = _mapping(packet.get("promotion_authority"))
+    schema_version = _text(packet.get("schema_version"))
+    allowed = authority.get("allowed") is True
+    packet_ok = packet.get("ok") is True and allowed
     expected_schema = schema_version == RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION
     _add_check(
         checks,
-        'runtime_ledger_proof_packet_authority',
+        "runtime_ledger_proof_packet_authority",
         passed=bool(packet) and expected_schema and packet_ok,
         observed={
-            'present': bool(packet),
-            'schema_version': schema_version,
-            'ok': packet.get('ok'),
-            'verdict': _text(packet.get('verdict')),
-            'authority_allowed': authority.get('allowed'),
-            'authority_reason': _text(authority.get('reason')),
-            'blocking_reasons': [
+            "present": bool(packet),
+            "schema_version": schema_version,
+            "ok": packet.get("ok"),
+            "verdict": _text(packet.get("verdict")),
+            "authority_allowed": authority.get("allowed"),
+            "authority_reason": _text(authority.get("reason")),
+            "blocking_reasons": [
                 _text(reason)
-                for reason in _sequence(authority.get('blocking_reasons'))
+                for reason in _sequence(authority.get("blocking_reasons"))
                 if _text(reason)
             ],
-            'failed_checks': [
+            "failed_checks": [
                 _text(check)
-                for check in _sequence(authority.get('failed_checks'))
+                for check in _sequence(authority.get("failed_checks"))
                 if _text(check)
             ],
         },
         expected={
-            'schema_version': RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
-            'ok': True,
-            'promotion_authority.allowed': True,
+            "schema_version": RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
+            "ok": True,
+            "promotion_authority.allowed": True,
         },
     )
 
@@ -420,7 +473,7 @@ def _add_runtime_ledger_profit_proof_checks(
     completion_present = completion_status is not None
     _add_check(
         checks,
-        'completion_status_present',
+        "completion_status_present",
         passed=completion_present,
         observed=completion_present,
         expected=True,
@@ -430,31 +483,31 @@ def _add_runtime_ledger_profit_proof_checks(
 
     gate = _completion_gate(completion_status, DOC29_LIVE_SCALE_GATE)
     summary = _runtime_ledger_summary(gate)
-    ledger_refs = _runtime_ledger_refs(gate, 'strategy_runtime_ledger_buckets')
+    ledger_refs = _runtime_ledger_refs(gate, "strategy_runtime_ledger_buckets")
     unbacked_refs = _runtime_ledger_refs(
         gate,
-        'runtime_ledger_unbacked_hypothesis_metric_windows',
+        "runtime_ledger_unbacked_hypothesis_metric_windows",
     )
-    gate_status = _text(gate.get('status'))
-    blocked_reason = _text(gate.get('blocked_reason'))
+    gate_status = _text(gate.get("status"))
+    blocked_reason = _text(gate.get("blocked_reason"))
     _add_check(
         checks,
-        'doc29_live_scale_gate_satisfied',
-        passed=gate_status == 'satisfied' and not blocked_reason,
-        observed={'status': gate_status, 'blocked_reason': blocked_reason or None},
-        expected={'status': 'satisfied', 'blocked_reason': None},
+        "doc29_live_scale_gate_satisfied",
+        passed=gate_status == "satisfied" and not blocked_reason,
+        observed={"status": gate_status, "blocked_reason": blocked_reason or None},
+        expected={"status": "satisfied", "blocked_reason": None},
     )
     _add_check(
         checks,
-        'runtime_ledger_db_refs_present',
+        "runtime_ledger_db_refs_present",
         passed=len(ledger_refs) > 0,
         observed=len(ledger_refs),
-        expected='>0',
+        expected=">0",
         detail=list(ledger_refs),
     )
     _add_check(
         checks,
-        'runtime_ledger_unbacked_windows_empty',
+        "runtime_ledger_unbacked_windows_empty",
         passed=len(unbacked_refs) == 0,
         observed=len(unbacked_refs),
         expected=0,
@@ -462,50 +515,50 @@ def _add_runtime_ledger_profit_proof_checks(
     )
     _add_check(
         checks,
-        'runtime_ledger_bucket_count',
-        passed=_int(summary.get('runtime_ledger_bucket_count')) > 0,
-        observed=summary.get('runtime_ledger_bucket_count'),
-        expected='>0',
+        "runtime_ledger_bucket_count",
+        passed=_int(summary.get("runtime_ledger_bucket_count")) > 0,
+        observed=summary.get("runtime_ledger_bucket_count"),
+        expected=">0",
     )
     _add_check(
         checks,
-        'runtime_ledger_fill_count',
-        passed=_int(summary.get('runtime_ledger_fill_count')) > 0,
-        observed=summary.get('runtime_ledger_fill_count'),
-        expected='>0',
+        "runtime_ledger_fill_count",
+        passed=_int(summary.get("runtime_ledger_fill_count")) > 0,
+        observed=summary.get("runtime_ledger_fill_count"),
+        expected=">0",
     )
     _add_check(
         checks,
-        'runtime_ledger_closed_trade_count',
-        passed=_int(summary.get('runtime_ledger_closed_trade_count')) > 0,
-        observed=summary.get('runtime_ledger_closed_trade_count'),
-        expected='>0',
+        "runtime_ledger_closed_trade_count",
+        passed=_int(summary.get("runtime_ledger_closed_trade_count")) > 0,
+        observed=summary.get("runtime_ledger_closed_trade_count"),
+        expected=">0",
     )
     trading_day_count, trading_day_count_key = _runtime_ledger_trading_day_count(
         summary
     )
     _add_check(
         checks,
-        'runtime_ledger_observed_trading_days',
+        "runtime_ledger_observed_trading_days",
         passed=trading_day_count >= min_runtime_ledger_trading_days,
         observed=trading_day_count,
-        expected=f'>={min_runtime_ledger_trading_days}',
-        detail={'source_key': trading_day_count_key},
+        expected=f">={min_runtime_ledger_trading_days}",
+        detail={"source_key": trading_day_count_key},
     )
     _add_check(
         checks,
-        'runtime_ledger_filled_notional',
-        passed=_decimal_positive(summary.get('runtime_ledger_filled_notional')),
-        observed=summary.get('runtime_ledger_filled_notional'),
-        expected='>0',
+        "runtime_ledger_filled_notional",
+        passed=_decimal_positive(summary.get("runtime_ledger_filled_notional")),
+        observed=summary.get("runtime_ledger_filled_notional"),
+        expected=">0",
     )
-    net_pnl = _decimal(summary.get('runtime_ledger_net_strategy_pnl_after_costs'))
+    net_pnl = _decimal(summary.get("runtime_ledger_net_strategy_pnl_after_costs"))
     _add_check(
         checks,
-        'runtime_ledger_net_pnl_target',
+        "runtime_ledger_net_pnl_target",
         passed=net_pnl is not None and net_pnl >= min_runtime_ledger_net_pnl,
         observed=str(net_pnl) if net_pnl is not None else None,
-        expected=f'>={min_runtime_ledger_net_pnl}',
+        expected=f">={min_runtime_ledger_net_pnl}",
     )
     daily_net_pnl = (
         net_pnl / Decimal(trading_day_count)
@@ -515,24 +568,24 @@ def _add_runtime_ledger_profit_proof_checks(
     daily_net_pnl_required = min_runtime_ledger_daily_net_pnl > 0
     _add_check(
         checks,
-        'runtime_ledger_daily_net_pnl_target',
+        "runtime_ledger_daily_net_pnl_target",
         passed=not daily_net_pnl_required
         or (
             daily_net_pnl is not None
             and daily_net_pnl >= min_runtime_ledger_daily_net_pnl
         ),
         observed=str(daily_net_pnl) if daily_net_pnl is not None else None,
-        expected=f'>={min_runtime_ledger_daily_net_pnl}',
-        detail={'trading_day_count': trading_day_count},
+        expected=f">={min_runtime_ledger_daily_net_pnl}",
+        detail={"trading_day_count": trading_day_count},
     )
     _add_check(
         checks,
-        'runtime_ledger_post_cost_expectancy_positive',
+        "runtime_ledger_post_cost_expectancy_positive",
         passed=_decimal_positive(
-            summary.get('runtime_ledger_post_cost_expectancy_bps')
+            summary.get("runtime_ledger_post_cost_expectancy_bps")
         ),
-        observed=summary.get('runtime_ledger_post_cost_expectancy_bps'),
-        expected='>0',
+        observed=summary.get("runtime_ledger_post_cost_expectancy_bps"),
+        expected=">0",
     )
 
 
@@ -542,13 +595,13 @@ def evaluate_trading_readiness(
     completion_status: Mapping[str, Any] | None = None,
     paper_route_evidence: Mapping[str, Any] | None = None,
     runtime_ledger_proof_packet: Mapping[str, Any] | None = None,
-    profile: str = 'paper',
+    profile: str = "paper",
     min_routeable_symbols: int = 2,
     min_decisions: int = 0,
     min_orders: int = 0,
-    min_runtime_ledger_net_pnl: Decimal = Decimal('0'),
+    min_runtime_ledger_net_pnl: Decimal = Decimal("0"),
     min_runtime_ledger_trading_days: int = 0,
-    min_runtime_ledger_daily_net_pnl: Decimal = Decimal('0'),
+    min_runtime_ledger_daily_net_pnl: Decimal = Decimal("0"),
     require_market_open: bool = True,
     require_quant_fresh: bool = True,
     require_paper_route_probe_candidate: bool = False,
@@ -560,17 +613,17 @@ def evaluate_trading_readiness(
     """Return a strict readiness verdict from a Torghut trading status payload."""
 
     checks: dict[str, dict[str, Any]] = {}
-    metrics = _mapping(status.get('metrics'))
-    proof_floor = _mapping(status.get('proof_floor'))
+    metrics = _mapping(status.get("metrics"))
+    proof_floor = _mapping(status.get("proof_floor"))
     dimensions = _dimension_by_name(proof_floor)
     paper_route_probe = _paper_route_probe_summary(status, proof_floor)
     paper_route_target_plan = _paper_route_target_plan_summary(paper_route_evidence)
 
-    mode = _text(status.get('mode') or status.get('trading_mode')).lower()
-    if profile in {'paper', 'live'}:
+    mode = _text(status.get("mode") or status.get("trading_mode")).lower()
+    if profile in {"paper", "live"}:
         _add_check(
             checks,
-            'trading_mode',
+            "trading_mode",
             passed=mode == profile,
             observed=mode,
             expected=profile,
@@ -578,22 +631,22 @@ def evaluate_trading_readiness(
 
     _add_check(
         checks,
-        'scheduler_running',
-        passed=_bool(status.get('running')),
-        observed=status.get('running'),
+        "scheduler_running",
+        passed=_bool(status.get("running")),
+        observed=status.get("running"),
         expected=True,
     )
-    last_error = _text(status.get('last_error'))
+    last_error = _text(status.get("last_error"))
     _add_check(
         checks,
-        'last_error_clear',
+        "last_error_clear",
         passed=not last_error,
         observed=last_error or None,
         expected=None,
     )
     _add_check(
         checks,
-        'proof_floor_present',
+        "proof_floor_present",
         passed=bool(proof_floor),
         observed=bool(proof_floor),
         expected=True,
@@ -603,180 +656,180 @@ def evaluate_trading_readiness(
     if require_market_open:
         _add_check(
             checks,
-            'market_session_open',
+            "market_session_open",
             passed=market_open,
             observed=market_open,
             expected=True,
         )
 
     floor_states, route_states, capital_states = _expected_floor_states(profile)
-    floor_state = _text(proof_floor.get('floor_state'))
-    route_state = _text(proof_floor.get('route_state'))
-    capital_state = _text(proof_floor.get('capital_state'))
-    max_notional = _decimal(proof_floor.get('max_notional'))
+    floor_state = _text(proof_floor.get("floor_state"))
+    route_state = _text(proof_floor.get("route_state"))
+    capital_state = _text(proof_floor.get("capital_state"))
+    max_notional = _decimal(proof_floor.get("max_notional"))
     blocking_reasons = [
         _text(reason)
-        for reason in _sequence(proof_floor.get('blocking_reasons'))
+        for reason in _sequence(proof_floor.get("blocking_reasons"))
         if _text(reason)
     ]
     _add_check(
         checks,
-        'proof_floor_state',
+        "proof_floor_state",
         passed=floor_state in floor_states,
         observed=floor_state,
         expected=sorted(floor_states),
     )
     _add_check(
         checks,
-        'route_state',
+        "route_state",
         passed=route_state in route_states,
         observed=route_state,
         expected=sorted(route_states),
     )
     _add_check(
         checks,
-        'capital_state',
+        "capital_state",
         passed=capital_state in capital_states,
         observed=capital_state,
         expected=sorted(capital_states),
     )
     _add_check(
         checks,
-        'max_notional_positive',
+        "max_notional_positive",
         passed=max_notional is not None and max_notional > 0,
-        observed=str(proof_floor.get('max_notional')),
-        expected='>0',
+        observed=str(proof_floor.get("max_notional")),
+        expected=">0",
     )
     _add_check(
         checks,
-        'blocking_reasons_empty',
+        "blocking_reasons_empty",
         passed=not blocking_reasons,
         observed=blocking_reasons,
         expected=[],
     )
 
-    for dimension_name in ('alpha_readiness', 'execution_tca', 'market_context'):
+    for dimension_name in ("alpha_readiness", "execution_tca", "market_context"):
         dimension = dimensions.get(dimension_name, {})
-        state = _text(dimension.get('state'))
+        state = _text(dimension.get("state"))
         _add_check(
             checks,
-            f'{dimension_name}_pass',
-            passed=state == 'pass',
-            observed={'state': state, 'reason': dimension.get('reason')},
-            expected={'state': 'pass'},
+            f"{dimension_name}_pass",
+            passed=state == "pass",
+            observed={"state": state, "reason": dimension.get("reason")},
+            expected={"state": "pass"},
         )
 
-    quant_dimension = dimensions.get('quant_ingestion', {})
-    quant_state = _text(quant_dimension.get('state'))
-    quant_reason = _text(quant_dimension.get('reason'))
+    quant_dimension = dimensions.get("quant_ingestion", {})
+    quant_state = _text(quant_dimension.get("state"))
+    quant_reason = _text(quant_dimension.get("reason"))
     quant_required = _dimension_is_required(quant_dimension)
-    quant_passed = quant_state == 'pass' or (
+    quant_passed = quant_state == "pass" or (
         not require_quant_fresh
         and not quant_required
-        and quant_state == 'informational'
+        and quant_state == "informational"
     )
     if require_quant_fresh and quant_reason in _MISSING_QUANT_REASONS:
         quant_passed = False
     _add_check(
         checks,
-        'quant_ingestion_ready',
+        "quant_ingestion_ready",
         passed=quant_passed,
         observed={
-            'state': quant_state,
-            'reason': quant_reason,
-            'required': quant_required,
+            "state": quant_state,
+            "reason": quant_reason,
+            "required": quant_required,
         },
-        expected={'state': 'pass'}
+        expected={"state": "pass"}
         if require_quant_fresh or quant_required
-        else {'state': 'pass|optional_informational'},
+        else {"state": "pass|optional_informational"},
     )
 
-    tca_source_ref = _mapping(dimensions.get('execution_tca', {}).get('source_ref'))
-    symbol_routes = _mapping(tca_source_ref.get('symbol_routes'))
-    routeable_symbol_count = _int(symbol_routes.get('routeable_symbol_count'))
-    blocked_symbol_count = _int(symbol_routes.get('blocked_symbol_count'))
-    missing_symbol_count = _int(symbol_routes.get('missing_symbol_count'))
+    tca_source_ref = _mapping(dimensions.get("execution_tca", {}).get("source_ref"))
+    symbol_routes = _mapping(tca_source_ref.get("symbol_routes"))
+    routeable_symbol_count = _int(symbol_routes.get("routeable_symbol_count"))
+    blocked_symbol_count = _int(symbol_routes.get("blocked_symbol_count"))
+    missing_symbol_count = _int(symbol_routes.get("missing_symbol_count"))
     _add_check(
         checks,
-        'routeable_symbol_count',
+        "routeable_symbol_count",
         passed=routeable_symbol_count >= min_routeable_symbols,
         observed=routeable_symbol_count,
-        expected=f'>={min_routeable_symbols}',
+        expected=f">={min_routeable_symbols}",
         detail={
-            'routeable_symbols': symbol_routes.get('routeable_symbols') or [],
-            'scope_symbols': symbol_routes.get('scope_symbols') or [],
+            "routeable_symbols": symbol_routes.get("routeable_symbols") or [],
+            "scope_symbols": symbol_routes.get("scope_symbols") or [],
         },
     )
     _add_check(
         checks,
-        'blocked_symbol_count',
+        "blocked_symbol_count",
         passed=blocked_symbol_count == 0,
         observed=blocked_symbol_count,
         expected=0,
-        detail=symbol_routes.get('blocked_symbols') or [],
+        detail=symbol_routes.get("blocked_symbols") or [],
     )
     _add_check(
         checks,
-        'missing_symbol_count',
+        "missing_symbol_count",
         passed=missing_symbol_count == 0,
         observed=missing_symbol_count,
         expected=0,
-        detail=symbol_routes.get('missing_symbols') or [],
+        detail=symbol_routes.get("missing_symbols") or [],
     )
 
-    route_board = _mapping(status.get('route_reacquisition_board'))
-    route_board_summary = _mapping(route_board.get('summary'))
-    route_board_continuity = _mapping(route_board.get('jangar_continuity'))
+    route_board = _mapping(status.get("route_reacquisition_board"))
+    route_board_summary = _mapping(route_board.get("summary"))
+    route_board_continuity = _mapping(route_board.get("jangar_continuity"))
     route_board_capital_eligible_symbols = _int(
-        route_board_summary.get('capital_eligible_symbol_count')
+        route_board_summary.get("capital_eligible_symbol_count")
     )
     route_board_zero_notional_rows = _int(
-        route_board_summary.get('zero_notional_row_count')
+        route_board_summary.get("zero_notional_row_count")
     )
     _add_check(
         checks,
-        'route_reacquisition_board_present',
+        "route_reacquisition_board_present",
         passed=bool(route_board),
         observed=bool(route_board),
         expected=True,
     )
     _add_check(
         checks,
-        'route_board_schema_version',
-        passed=_text(route_board.get('schema_version'))
+        "route_board_schema_version",
+        passed=_text(route_board.get("schema_version"))
         == ROUTE_REACQUISITION_BOARD_SCHEMA_VERSION,
-        observed=_text(route_board.get('schema_version')),
+        observed=_text(route_board.get("schema_version")),
         expected=ROUTE_REACQUISITION_BOARD_SCHEMA_VERSION,
     )
-    route_board_continuity_decision = _text(route_board_continuity.get('decision'))
-    route_board_continuity_state = _text(route_board_continuity.get('state'))
+    route_board_continuity_decision = _text(route_board_continuity.get("decision"))
+    route_board_continuity_state = _text(route_board_continuity.get("state"))
     route_board_continuity_ready = (
-        route_board_continuity_state == 'present'
-        and route_board_continuity_decision == 'allow'
+        route_board_continuity_state == "present"
+        and route_board_continuity_decision == "allow"
     )
     _add_check(
         checks,
-        'route_board_jangar_continuity_ready',
+        "route_board_jangar_continuity_ready",
         passed=route_board_continuity_ready,
         observed={
-            'state': route_board_continuity_state,
-            'decision': route_board_continuity_decision,
-            'epoch_id': route_board_continuity.get('epoch_id'),
-            'blocking_reasons': route_board_continuity.get('blocking_reasons') or [],
+            "state": route_board_continuity_state,
+            "decision": route_board_continuity_decision,
+            "epoch_id": route_board_continuity.get("epoch_id"),
+            "blocking_reasons": route_board_continuity.get("blocking_reasons") or [],
         },
-        expected={'state': 'present', 'decision': 'allow'},
+        expected={"state": "present", "decision": "allow"},
     )
     _add_check(
         checks,
-        'route_board_capital_eligible_symbols',
+        "route_board_capital_eligible_symbols",
         passed=route_board_capital_eligible_symbols >= min_routeable_symbols,
         observed=route_board_capital_eligible_symbols,
-        expected=f'>={min_routeable_symbols}',
+        expected=f">={min_routeable_symbols}",
         detail=route_board_summary,
     )
     _add_check(
         checks,
-        'route_board_zero_notional_rows',
+        "route_board_zero_notional_rows",
         passed=route_board_zero_notional_rows == 0,
         observed=route_board_zero_notional_rows,
         expected=0,
@@ -785,178 +838,193 @@ def evaluate_trading_readiness(
 
     if require_paper_route_probe_candidate:
         allowed_probe_blockers = (
-            set() if require_market_open else {'market_session_closed'}
+            set() if require_market_open else {"market_session_closed"}
         )
         unexpected_probe_blockers = [
             reason
-            for reason in paper_route_probe['blocking_reasons']
+            for reason in paper_route_probe["blocking_reasons"]
             if reason not in allowed_probe_blockers
         ]
         _add_check(
             checks,
-            'paper_route_probe_book_present',
-            passed=paper_route_probe['route_book_present'],
-            observed=paper_route_probe['route_book_present'],
+            "paper_route_probe_book_present",
+            passed=paper_route_probe["route_book_present"],
+            observed=paper_route_probe["route_book_present"],
             expected=True,
         )
         _add_check(
             checks,
-            'paper_route_probe_book_schema_version',
-            passed=paper_route_probe['route_book_schema_version']
+            "paper_route_probe_book_schema_version",
+            passed=paper_route_probe["route_book_schema_version"]
             == ROUTE_REACQUISITION_BOOK_SCHEMA_VERSION,
-            observed=paper_route_probe['route_book_schema_version'],
+            observed=paper_route_probe["route_book_schema_version"],
             expected=ROUTE_REACQUISITION_BOOK_SCHEMA_VERSION,
         )
         _add_check(
             checks,
-            'paper_route_probe_configured',
-            passed=paper_route_probe['configured_enabled'],
-            observed=paper_route_probe['configured_enabled'],
+            "paper_route_probe_configured",
+            passed=paper_route_probe["configured_enabled"],
+            observed=paper_route_probe["configured_enabled"],
             expected=True,
         )
         _add_check(
             checks,
-            'paper_route_probe_candidate_symbols',
-            passed=paper_route_probe['eligible_symbol_count'] > 0,
+            "paper_route_probe_candidate_symbols",
+            passed=paper_route_probe["eligible_symbol_count"] > 0,
             observed={
-                'eligible_symbol_count': paper_route_probe['eligible_symbol_count'],
-                'eligible_symbols': paper_route_probe['eligible_symbols'],
+                "eligible_symbol_count": paper_route_probe["eligible_symbol_count"],
+                "eligible_symbols": paper_route_probe["eligible_symbols"],
             },
-            expected='>=1',
+            expected=">=1",
         )
         _add_check(
             checks,
-            'paper_route_probe_notional_positive',
-            passed=_decimal_positive(paper_route_probe['effective_max_notional'])
-            or _decimal_positive(paper_route_probe['next_session_max_notional']),
+            "paper_route_probe_notional_positive",
+            passed=_decimal_positive(paper_route_probe["effective_max_notional"])
+            or _decimal_positive(paper_route_probe["next_session_max_notional"]),
             observed={
-                'effective_max_notional': paper_route_probe['effective_max_notional'],
-                'next_session_max_notional': paper_route_probe[
-                    'next_session_max_notional'
+                "effective_max_notional": paper_route_probe["effective_max_notional"],
+                "next_session_max_notional": paper_route_probe[
+                    "next_session_max_notional"
                 ],
             },
-            expected='effective_or_next_session_>0',
+            expected="effective_or_next_session_>0",
         )
         _add_check(
             checks,
-            'paper_route_probe_blockers',
+            "paper_route_probe_blockers",
             passed=not unexpected_probe_blockers,
-            observed=paper_route_probe['blocking_reasons'],
+            observed=paper_route_probe["blocking_reasons"],
             expected=sorted(allowed_probe_blockers),
         )
 
     if require_paper_route_target_plan or require_paper_route_import_ready:
         _add_check(
             checks,
-            'paper_route_target_plan_present',
-            passed=paper_route_target_plan['present'],
-            observed=paper_route_target_plan['present'],
+            "paper_route_target_plan_present",
+            passed=paper_route_target_plan["present"],
+            observed=paper_route_target_plan["present"],
             expected=True,
         )
         _add_check(
             checks,
-            'paper_route_target_plan_schema_version',
-            passed=paper_route_target_plan['schema_version']
+            "paper_route_target_plan_schema_version",
+            passed=paper_route_target_plan["schema_version"]
             == NEXT_PAPER_ROUTE_TARGET_PLAN_SCHEMA_VERSION,
-            observed=paper_route_target_plan['schema_version'],
+            observed=paper_route_target_plan["schema_version"],
             expected=NEXT_PAPER_ROUTE_TARGET_PLAN_SCHEMA_VERSION,
         )
         _add_check(
             checks,
-            'paper_route_target_plan_targets_present',
-            passed=paper_route_target_plan['target_count'] > 0
-            and paper_route_target_plan['actual_target_count'] > 0,
+            "paper_route_target_plan_targets_present",
+            passed=paper_route_target_plan["target_count"] > 0
+            and paper_route_target_plan["actual_target_count"] > 0,
             observed={
-                'target_count': paper_route_target_plan['target_count'],
-                'actual_target_count': paper_route_target_plan['actual_target_count'],
-                'skipped_target_count': paper_route_target_plan['skipped_target_count'],
+                "target_count": paper_route_target_plan["target_count"],
+                "actual_target_count": paper_route_target_plan["actual_target_count"],
+                "skipped_target_count": paper_route_target_plan["skipped_target_count"],
             },
-            expected={'target_count': '>0', 'actual_target_count': '>0'},
+            expected={"target_count": ">0", "actual_target_count": ">0"},
         )
         _add_check(
             checks,
-            'paper_route_target_plan_handoff_flags',
-            passed=not paper_route_target_plan['missing_required_flags'],
-            observed=paper_route_target_plan['required_flags'],
+            "paper_route_target_plan_handoff_flags",
+            passed=not paper_route_target_plan["missing_required_flags"],
+            observed=paper_route_target_plan["required_flags"],
             expected=list(REQUIRED_RUNTIME_WINDOW_TARGET_PLAN_FLAGS),
             detail={
-                'missing_required_flags': paper_route_target_plan[
-                    'missing_required_flags'
+                "missing_required_flags": paper_route_target_plan[
+                    "missing_required_flags"
                 ]
             },
         )
         _add_check(
             checks,
-            'paper_route_target_plan_target_identity',
-            passed=paper_route_target_plan['missing_identity_count'] == 0
-            and paper_route_target_plan['actual_target_count'] > 0,
+            "paper_route_target_plan_target_identity",
+            passed=paper_route_target_plan["missing_identity_count"] == 0
+            and paper_route_target_plan["actual_target_count"] > 0,
             observed={
-                'missing_identity_count': paper_route_target_plan[
-                    'missing_identity_count'
+                "missing_identity_count": paper_route_target_plan[
+                    "missing_identity_count"
                 ],
-                'targets': paper_route_target_plan['targets'],
+                "targets": paper_route_target_plan["targets"],
             },
-            expected={'missing_identity_count': 0},
+            expected={"missing_identity_count": 0},
         )
         _add_check(
             checks,
-            'paper_route_target_plan_probe_contract',
-            passed=paper_route_target_plan['probe_contract_count']
-            == paper_route_target_plan['actual_target_count']
-            and paper_route_target_plan['actual_target_count'] > 0,
+            "paper_route_target_plan_probe_contract",
+            passed=paper_route_target_plan["probe_contract_count"]
+            == paper_route_target_plan["actual_target_count"]
+            and paper_route_target_plan["actual_target_count"] > 0,
             observed={
-                'probe_contract_count': paper_route_target_plan['probe_contract_count'],
-                'targets': paper_route_target_plan['targets'],
+                "probe_contract_count": paper_route_target_plan["probe_contract_count"],
+                "targets": paper_route_target_plan["targets"],
             },
-            expected='every_target_has_probe_symbols_and_positive_next_notional',
+            expected="every_target_has_probe_symbols_and_positive_next_notional",
         )
         _add_check(
             checks,
-            'paper_route_target_plan_promotion_blocked',
-            passed=paper_route_target_plan['promotion_blocked_count']
-            == paper_route_target_plan['actual_target_count']
-            and paper_route_target_plan['actual_target_count'] > 0,
+            "paper_route_target_plan_promotion_blocked",
+            passed=paper_route_target_plan["promotion_blocked_count"]
+            == paper_route_target_plan["actual_target_count"]
+            and paper_route_target_plan["actual_target_count"] > 0,
             observed={
-                'promotion_blocked_count': paper_route_target_plan[
-                    'promotion_blocked_count'
+                "promotion_blocked_count": paper_route_target_plan[
+                    "promotion_blocked_count"
                 ],
-                'targets': paper_route_target_plan['targets'],
+                "targets": paper_route_target_plan["targets"],
             },
-            expected='every_target_zero_notional_and_not_final_promotion',
+            expected="every_target_zero_notional_and_not_final_promotion",
+        )
+        import_health_gate = _mapping(
+            paper_route_target_plan["runtime_window_import_health_gate"]
+        )
+        _add_check(
+            checks,
+            "paper_route_target_plan_import_health_gate",
+            passed=bool(import_health_gate.get("ready")),
+            observed=import_health_gate,
+            expected={
+                "ready": True,
+                "dependency_quorum_decision": "allow",
+                "continuity_ok": "true",
+                "drift_ok": "true",
+            },
         )
 
     if require_paper_route_import_ready:
         _add_check(
             checks,
-            'paper_route_target_plan_import_ready',
-            passed=paper_route_target_plan['import_ready']
-            and not paper_route_target_plan['import_blockers'],
+            "paper_route_target_plan_import_ready",
+            passed=paper_route_target_plan["import_ready"]
+            and not paper_route_target_plan["import_blockers"],
             observed={
-                'import_ready': paper_route_target_plan['import_ready'],
-                'import_blockers': paper_route_target_plan['import_blockers'],
-                'session_readiness_state': paper_route_target_plan[
-                    'session_readiness_state'
+                "import_ready": paper_route_target_plan["import_ready"],
+                "import_blockers": paper_route_target_plan["import_blockers"],
+                "session_readiness_state": paper_route_target_plan[
+                    "session_readiness_state"
                 ],
-                'session_window': paper_route_target_plan['session_window'],
+                "session_window": paper_route_target_plan["session_window"],
             },
-            expected={'import_ready': True, 'import_blockers': []},
+            expected={"import_ready": True, "import_blockers": []},
         )
 
-    decisions_total = _int(metrics.get('decisions_total'))
-    orders_submitted_total = _int(metrics.get('orders_submitted_total'))
+    decisions_total = _int(metrics.get("decisions_total"))
+    orders_submitted_total = _int(metrics.get("orders_submitted_total"))
     _add_check(
         checks,
-        'decisions_total',
+        "decisions_total",
         passed=decisions_total >= min_decisions,
         observed=decisions_total,
-        expected=f'>={min_decisions}',
+        expected=f">={min_decisions}",
     )
     _add_check(
         checks,
-        'orders_submitted_total',
+        "orders_submitted_total",
         passed=orders_submitted_total >= min_orders,
         observed=orders_submitted_total,
-        expected=f'>={min_orders}',
+        expected=f">={min_orders}",
     )
 
     if require_runtime_ledger_profit_proof:
@@ -973,26 +1041,26 @@ def evaluate_trading_readiness(
             runtime_ledger_proof_packet,
         )
 
-    failed_checks = [key for key, value in checks.items() if not value['passed']]
+    failed_checks = [key for key, value in checks.items() if not value["passed"]]
     return {
-        'schema_version': SCHEMA_VERSION,
-        'ok': not failed_checks,
-        'profile': profile,
-        'failed_checks': failed_checks,
-        'checks': checks,
-        'paper_route_probe': paper_route_probe,
-        'paper_route_target_plan': paper_route_target_plan,
-        'completion_profit_proof': {
-            'required': require_runtime_ledger_profit_proof,
-            'gate_id': DOC29_LIVE_SCALE_GATE,
-            'min_runtime_ledger_net_pnl': str(min_runtime_ledger_net_pnl),
-            'min_runtime_ledger_trading_days': min_runtime_ledger_trading_days,
-            'min_runtime_ledger_daily_net_pnl': str(min_runtime_ledger_daily_net_pnl),
+        "schema_version": SCHEMA_VERSION,
+        "ok": not failed_checks,
+        "profile": profile,
+        "failed_checks": failed_checks,
+        "checks": checks,
+        "paper_route_probe": paper_route_probe,
+        "paper_route_target_plan": paper_route_target_plan,
+        "completion_profit_proof": {
+            "required": require_runtime_ledger_profit_proof,
+            "gate_id": DOC29_LIVE_SCALE_GATE,
+            "min_runtime_ledger_net_pnl": str(min_runtime_ledger_net_pnl),
+            "min_runtime_ledger_trading_days": min_runtime_ledger_trading_days,
+            "min_runtime_ledger_daily_net_pnl": str(min_runtime_ledger_daily_net_pnl),
         },
-        'runtime_ledger_proof_packet': {
-            'required': require_runtime_ledger_proof_packet,
-            'schema_version': _text(
-                _mapping(runtime_ledger_proof_packet).get('schema_version')
+        "runtime_ledger_proof_packet": {
+            "required": require_runtime_ledger_proof_packet,
+            "schema_version": _text(
+                _mapping(runtime_ledger_proof_packet).get("schema_version")
             ),
         },
     }
@@ -1002,91 +1070,91 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument(
-        '--status-file', type=Path, help='Path to a /trading/status JSON payload.'
+        "--status-file", type=Path, help="Path to a /trading/status JSON payload."
     )
     source.add_argument(
-        '--status-url', help='URL returning a /trading/status JSON payload.'
+        "--status-url", help="URL returning a /trading/status JSON payload."
     )
     completion_source = parser.add_mutually_exclusive_group(required=False)
     completion_source.add_argument(
-        '--completion-file',
+        "--completion-file",
         type=Path,
-        help='Path to a /trading/completion/doc29 JSON payload.',
+        help="Path to a /trading/completion/doc29 JSON payload.",
     )
     completion_source.add_argument(
-        '--completion-url',
-        help='URL returning a /trading/completion/doc29 JSON payload.',
+        "--completion-url",
+        help="URL returning a /trading/completion/doc29 JSON payload.",
     )
     paper_route_evidence_source = parser.add_mutually_exclusive_group(required=False)
     paper_route_evidence_source.add_argument(
-        '--paper-route-evidence-file',
+        "--paper-route-evidence-file",
         type=Path,
-        help='Path to a /trading/paper-route-evidence JSON payload.',
+        help="Path to a /trading/paper-route-evidence JSON payload.",
     )
     paper_route_evidence_source.add_argument(
-        '--paper-route-evidence-url',
-        help='URL returning a /trading/paper-route-evidence JSON payload.',
+        "--paper-route-evidence-url",
+        help="URL returning a /trading/paper-route-evidence JSON payload.",
     )
     runtime_ledger_packet_source = parser.add_mutually_exclusive_group(required=False)
     runtime_ledger_packet_source.add_argument(
-        '--runtime-ledger-proof-packet-file',
+        "--runtime-ledger-proof-packet-file",
         type=Path,
-        help='Path to an assemble_runtime_ledger_proof_packet.py JSON payload.',
+        help="Path to an assemble_runtime_ledger_proof_packet.py JSON payload.",
     )
     runtime_ledger_packet_source.add_argument(
-        '--runtime-ledger-proof-packet-url',
-        help='URL returning an assemble_runtime_ledger_proof_packet.py JSON payload.',
+        "--runtime-ledger-proof-packet-url",
+        help="URL returning an assemble_runtime_ledger_proof_packet.py JSON payload.",
     )
     parser.add_argument(
-        '--profile', choices=('paper', 'live', 'either'), default='paper'
+        "--profile", choices=("paper", "live", "either"), default="paper"
     )
-    parser.add_argument('--min-routeable-symbols', type=int, default=2)
-    parser.add_argument('--min-decisions', type=int, default=0)
-    parser.add_argument('--min-orders', type=int, default=0)
+    parser.add_argument("--min-routeable-symbols", type=int, default=2)
+    parser.add_argument("--min-decisions", type=int, default=0)
+    parser.add_argument("--min-orders", type=int, default=0)
     parser.add_argument(
-        '--min-runtime-ledger-net-pnl',
-        default='0',
-        help='Minimum runtime-ledger net strategy PnL after costs required when runtime proof is required.',
+        "--min-runtime-ledger-net-pnl",
+        default="0",
+        help="Minimum runtime-ledger net strategy PnL after costs required when runtime proof is required.",
     )
     parser.add_argument(
-        '--min-runtime-ledger-trading-days',
+        "--min-runtime-ledger-trading-days",
         type=int,
         default=0,
-        help='Minimum observed runtime-ledger trading days required when runtime proof is required.',
+        help="Minimum observed runtime-ledger trading days required when runtime proof is required.",
     )
     parser.add_argument(
-        '--min-runtime-ledger-daily-net-pnl',
-        default='0',
-        help='Minimum runtime-ledger net strategy PnL after costs per observed trading day.',
+        "--min-runtime-ledger-daily-net-pnl",
+        default="0",
+        help="Minimum runtime-ledger net strategy PnL after costs per observed trading day.",
     )
-    parser.add_argument('--allow-closed-session', action='store_true')
-    parser.add_argument('--allow-informational-quant', action='store_true')
+    parser.add_argument("--allow-closed-session", action="store_true")
+    parser.add_argument("--allow-informational-quant", action="store_true")
     parser.add_argument(
-        '--require-paper-route-probe-candidate',
-        action='store_true',
-        help='Require a bounded paper-route probe candidate in route_reacquisition_book.',
-    )
-    parser.add_argument(
-        '--require-paper-route-target-plan',
-        action='store_true',
-        help='Require /trading/paper-route-evidence to expose a next-session runtime-window target plan.',
+        "--require-paper-route-probe-candidate",
+        action="store_true",
+        help="Require a bounded paper-route probe candidate in route_reacquisition_book.",
     )
     parser.add_argument(
-        '--require-paper-route-import-ready',
-        action='store_true',
-        help='Require the paper-route target plan to be settlement-ready for runtime-window import.',
+        "--require-paper-route-target-plan",
+        action="store_true",
+        help="Require /trading/paper-route-evidence to expose a next-session runtime-window target plan.",
     )
     parser.add_argument(
-        '--require-runtime-ledger-profit-proof',
-        action='store_true',
-        help='Require doc29 live-scale runtime-ledger proof from /trading/completion/doc29.',
+        "--require-paper-route-import-ready",
+        action="store_true",
+        help="Require the paper-route target plan to be settlement-ready for runtime-window import.",
     )
     parser.add_argument(
-        '--require-runtime-ledger-proof-packet',
-        action='store_true',
-        help='Require canonical runtime-ledger proof packet promotion authority.',
+        "--require-runtime-ledger-profit-proof",
+        action="store_true",
+        help="Require doc29 live-scale runtime-ledger proof from /trading/completion/doc29.",
     )
-    parser.add_argument('--timeout-seconds', type=float, default=10.0)
+    parser.add_argument(
+        "--require-runtime-ledger-proof-packet",
+        action="store_true",
+        help="Require canonical runtime-ledger proof packet promotion authority.",
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=10.0)
     return parser
 
 
@@ -1117,13 +1185,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     min_runtime_ledger_net_pnl = _decimal(args.min_runtime_ledger_net_pnl)
     if min_runtime_ledger_net_pnl is None:
         raise SystemExit(
-            f'--min-runtime-ledger-net-pnl must be decimal, got {args.min_runtime_ledger_net_pnl!r}'
+            f"--min-runtime-ledger-net-pnl must be decimal, got {args.min_runtime_ledger_net_pnl!r}"
         )
     min_runtime_ledger_daily_net_pnl = _decimal(args.min_runtime_ledger_daily_net_pnl)
     if min_runtime_ledger_daily_net_pnl is None:
         raise SystemExit(
-            '--min-runtime-ledger-daily-net-pnl must be decimal, '
-            f'got {args.min_runtime_ledger_daily_net_pnl!r}'
+            "--min-runtime-ledger-daily-net-pnl must be decimal, "
+            f"got {args.min_runtime_ledger_daily_net_pnl!r}"
         )
     result = evaluate_trading_readiness(
         status,
@@ -1153,10 +1221,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             args.require_runtime_ledger_proof_packet
         ),
     )
-    result['evaluated_at'] = datetime.now(timezone.utc).isoformat()
+    result["evaluated_at"] = datetime.now(timezone.utc).isoformat()
     print(json.dumps(result, indent=2, sort_keys=True))
-    return 0 if result['ok'] else 1
+    return 0 if result["ok"] else 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -94,6 +94,17 @@ def _paper_route_evidence(
                     "window_end": "2026-05-26T20:00:00+00:00",
                     "promotion_allowed": False,
                     "final_promotion_authorized": False,
+                    "dependency_quorum_decision": "allow",
+                    "continuity_ok": "true",
+                    "drift_ok": "true",
+                    "runtime_window_import_health_gate": {
+                        "schema_version": "torghut.runtime-window-import-health-gate.v1",
+                        "dependency_quorum_decision": "allow",
+                        "continuity_ok": "true",
+                        "drift_ok": "true",
+                        "blockers": [],
+                    },
+                    "runtime_window_import_health_gate_blockers": [],
                 }
             ],
         },
@@ -437,6 +448,56 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 "runtime_import_due"
             ]
         )
+
+    def test_packet_blocks_when_paper_route_import_health_gate_is_not_ready(
+        self,
+    ) -> None:
+        evidence = _paper_route_evidence(import_ready=True)
+        plan = evidence["next_paper_route_runtime_window_targets"]
+        assert isinstance(plan, dict)
+        target = plan["targets"][0]
+        assert isinstance(target, dict)
+        target["dependency_quorum_decision"] = "missing"
+        target["continuity_ok"] = "false"
+        target["runtime_window_import_health_gate"] = {
+            "schema_version": "torghut.runtime-window-import-health-gate.v1",
+            "dependency_quorum_decision": "missing",
+            "continuity_ok": "false",
+            "drift_ok": "true",
+            "blockers": ["dependency_quorum_not_allow", "continuity_not_ok"],
+        }
+        target["runtime_window_import_health_gate_blockers"] = [
+            "dependency_quorum_not_allow",
+            "continuity_not_ok",
+        ]
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=evidence,
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn(
+            "paper_route_import_health_gate",
+            result["promotion_authority"]["failed_checks"],
+        )
+        self.assertIn(
+            "dependency_quorum_not_allow",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "repair_runtime_window_import_health_gate",
+            result["required_actions"],
+        )
+        health_gate = result["evidence"]["paper_route_target_plan"][
+            "runtime_window_import_health_gate"
+        ]
+        self.assertEqual(health_gate["ready_target_count"], 0)
+        self.assertEqual(health_gate["blocked_target_count"], 1)
 
     def test_packet_blocks_non_authoritative_import_and_weak_daily_profit(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -15,107 +15,107 @@ from scripts.verify_trading_readiness import evaluate_trading_readiness, main
 
 def _ready_status() -> dict[str, object]:
     return {
-        'mode': 'paper',
-        'running': True,
-        'last_error': None,
-        'metrics': {
-            'market_session_open': 1,
-            'decisions_total': 3,
-            'orders_submitted_total': 2,
+        "mode": "paper",
+        "running": True,
+        "last_error": None,
+        "metrics": {
+            "market_session_open": 1,
+            "decisions_total": 3,
+            "orders_submitted_total": 2,
         },
-        'proof_floor': {
-            'floor_state': 'paper_ready',
-            'route_state': 'paper_candidate',
-            'capital_state': 'paper_allowed',
-            'max_notional': '250',
-            'blocking_reasons': [],
-            'proof_dimensions': [
+        "proof_floor": {
+            "floor_state": "paper_ready",
+            "route_state": "paper_candidate",
+            "capital_state": "paper_allowed",
+            "max_notional": "250",
+            "blocking_reasons": [],
+            "proof_dimensions": [
                 {
-                    'dimension': 'alpha_readiness',
-                    'state': 'pass',
-                    'reason': 'promotion_eligible',
+                    "dimension": "alpha_readiness",
+                    "state": "pass",
+                    "reason": "promotion_eligible",
                 },
                 {
-                    'dimension': 'market_context',
-                    'state': 'pass',
-                    'reason': 'fresh',
+                    "dimension": "market_context",
+                    "state": "pass",
+                    "reason": "fresh",
                 },
                 {
-                    'dimension': 'quant_ingestion',
-                    'state': 'pass',
-                    'reason': 'fresh',
+                    "dimension": "quant_ingestion",
+                    "state": "pass",
+                    "reason": "fresh",
                 },
                 {
-                    'dimension': 'execution_tca',
-                    'state': 'pass',
-                    'reason': 'fresh',
-                    'source_ref': {
-                        'symbol_routes': {
-                            'scope_symbols': ['NVDA', 'AVGO'],
-                            'routeable_symbol_count': 2,
-                            'blocked_symbol_count': 0,
-                            'missing_symbol_count': 0,
-                            'routeable_symbols': [
-                                {'symbol': 'NVDA', 'avg_abs_slippage_bps': '4.2'},
-                                {'symbol': 'AVGO', 'avg_abs_slippage_bps': '5.1'},
+                    "dimension": "execution_tca",
+                    "state": "pass",
+                    "reason": "fresh",
+                    "source_ref": {
+                        "symbol_routes": {
+                            "scope_symbols": ["NVDA", "AVGO"],
+                            "routeable_symbol_count": 2,
+                            "blocked_symbol_count": 0,
+                            "missing_symbol_count": 0,
+                            "routeable_symbols": [
+                                {"symbol": "NVDA", "avg_abs_slippage_bps": "4.2"},
+                                {"symbol": "AVGO", "avg_abs_slippage_bps": "5.1"},
                             ],
-                            'blocked_symbols': [],
-                            'missing_symbols': [],
+                            "blocked_symbols": [],
+                            "missing_symbols": [],
                         }
                     },
                 },
             ],
         },
-        'route_reacquisition_board': {
-            'schema_version': 'torghut.route-reacquisition-board.v1',
-            'state': 'candidate',
-            'capital_state': 'paper_allowed',
-            'jangar_continuity': {
-                'epoch_id': 'truth-settlement:paper_canary:ready',
-                'state': 'present',
-                'decision': 'allow',
-                'fresh_until': '2026-05-08T12:00:00+00:00',
-                'blocking_reasons': [],
+        "route_reacquisition_board": {
+            "schema_version": "torghut.route-reacquisition-board.v1",
+            "state": "candidate",
+            "capital_state": "paper_allowed",
+            "jangar_continuity": {
+                "epoch_id": "truth-settlement:paper_canary:ready",
+                "state": "present",
+                "decision": "allow",
+                "fresh_until": "2026-05-08T12:00:00+00:00",
+                "blocking_reasons": [],
             },
-            'summary': {
-                'row_count': 2,
-                'state_counts': {'routeable': 2},
-                'zero_notional_row_count': 0,
-                'expected_unblock_value': 8,
-                'top_repair_symbols': [],
-                'capital_eligible_symbol_count': 2,
+            "summary": {
+                "row_count": 2,
+                "state_counts": {"routeable": 2},
+                "zero_notional_row_count": 0,
+                "expected_unblock_value": 8,
+                "top_repair_symbols": [],
+                "capital_eligible_symbol_count": 2,
             },
-            'rows': [
+            "rows": [
                 {
-                    'symbol': 'NVDA',
-                    'state': 'routeable',
-                    'max_notional': '250',
+                    "symbol": "NVDA",
+                    "state": "routeable",
+                    "max_notional": "250",
                 },
                 {
-                    'symbol': 'AVGO',
-                    'state': 'routeable',
-                    'max_notional': '250',
+                    "symbol": "AVGO",
+                    "state": "routeable",
+                    "max_notional": "250",
                 },
             ],
         },
-        'route_reacquisition_book': {
-            'schema_version': 'torghut.route-reacquisition-book.v1',
-            'state': 'paper_candidate',
-            'summary': {
-                'paper_route_probe_eligible_symbols': ['NVDA'],
-                'paper_route_probe_active_symbols': ['NVDA'],
+        "route_reacquisition_book": {
+            "schema_version": "torghut.route-reacquisition-book.v1",
+            "state": "paper_candidate",
+            "summary": {
+                "paper_route_probe_eligible_symbols": ["NVDA"],
+                "paper_route_probe_active_symbols": ["NVDA"],
             },
-            'paper_route_probe': {
-                'configured_enabled': True,
-                'configured_max_notional': '25',
-                'active': True,
-                'effective_max_notional': '25',
-                'next_session_max_notional': '25',
-                'eligible_symbol_count': 1,
-                'eligible_symbols': ['NVDA'],
-                'active_symbols': ['NVDA'],
-                'blocking_reasons': [],
-                'capital_authority': 'none',
+            "paper_route_probe": {
+                "configured_enabled": True,
+                "configured_max_notional": "25",
+                "active": True,
+                "effective_max_notional": "25",
+                "next_session_max_notional": "25",
+                "eligible_symbol_count": 1,
+                "eligible_symbols": ["NVDA"],
+                "active_symbols": ["NVDA"],
+                "blocking_reasons": [],
+                "capital_authority": "none",
             },
         },
     }
@@ -123,44 +123,44 @@ def _ready_status() -> dict[str, object]:
 
 def _completion_status(
     *,
-    gate_status: str = 'satisfied',
+    gate_status: str = "satisfied",
     blocked_reason: str | None = None,
-    net_pnl: str = '600',
-    expectancy_bps: str = '12.5',
+    net_pnl: str = "600",
+    expectancy_bps: str = "12.5",
     trading_day_count: int | None = 25,
     ledger_refs: list[str] | None = None,
     unbacked_refs: list[str] | None = None,
 ) -> dict[str, object]:
     runtime_ledger_summary: dict[str, object] = {
-        'runtime_ledger_bucket_count': 1,
-        'runtime_ledger_fill_count': 4,
-        'runtime_ledger_closed_trade_count': 2,
-        'runtime_ledger_filled_notional': '50000',
-        'runtime_ledger_net_strategy_pnl_after_costs': net_pnl,
-        'runtime_ledger_post_cost_expectancy_bps': expectancy_bps,
+        "runtime_ledger_bucket_count": 1,
+        "runtime_ledger_fill_count": 4,
+        "runtime_ledger_closed_trade_count": 2,
+        "runtime_ledger_filled_notional": "50000",
+        "runtime_ledger_net_strategy_pnl_after_costs": net_pnl,
+        "runtime_ledger_post_cost_expectancy_bps": expectancy_bps,
     }
     if trading_day_count is not None:
-        runtime_ledger_summary['runtime_ledger_observed_trading_day_count'] = (
+        runtime_ledger_summary["runtime_ledger_observed_trading_day_count"] = (
             trading_day_count
         )
     return {
-        'doc_id': 'doc29',
-        'summary': {'all_satisfied': gate_status == 'satisfied'},
-        'gates': [
+        "doc_id": "doc29",
+        "summary": {"all_satisfied": gate_status == "satisfied"},
+        "gates": [
             {
-                'gate_id': verifier.DOC29_LIVE_SCALE_GATE,
-                'status': gate_status,
-                'blocked_reason': blocked_reason,
-                'candidate_id': 'cand-1',
-                'db_row_refs': {
-                    'strategy_runtime_ledger_buckets': ledger_refs
+                "gate_id": verifier.DOC29_LIVE_SCALE_GATE,
+                "status": gate_status,
+                "blocked_reason": blocked_reason,
+                "candidate_id": "cand-1",
+                "db_row_refs": {
+                    "strategy_runtime_ledger_buckets": ledger_refs
                     if ledger_refs is not None
-                    else ['bucket-1'],
-                    'runtime_ledger_unbacked_hypothesis_metric_windows': unbacked_refs
+                    else ["bucket-1"],
+                    "runtime_ledger_unbacked_hypothesis_metric_windows": unbacked_refs
                     if unbacked_refs is not None
                     else [],
                 },
-                'runtime_ledger_summary': runtime_ledger_summary,
+                "runtime_ledger_summary": runtime_ledger_summary,
             }
         ],
     }
@@ -176,60 +176,71 @@ def _paper_route_evidence(
     blockers = (
         import_blockers
         if import_blockers is not None
-        else ([] if import_ready else ['paper_route_session_window_not_open'])
+        else ([] if import_ready else ["paper_route_session_window_not_open"])
     )
     target = {
-        'hypothesis_id': 'H-PAIRS-01',
-        'candidate_id': 'c88421d619759b2cfaa6f4d0',
-        'observed_stage': 'paper',
-        'strategy_family': 'microbar_cross_sectional_pairs',
-        'strategy_name': 'microbar-pairs-vwap-cap-safe',
-        'account_label': 'TORGHUT_SIM',
-        'source_account_label': 'TORGHUT_REPLAY',
-        'source_dsn_env': 'SIM_DB_DSN',
-        'source_kind': 'paper_route_probe_runtime_observed',
-        'dataset_snapshot_ref': 'portfolio-profit-autoresearch-500-v1',
-        'source_manifest_ref': 'config/trading/hypotheses/h-pairs-01.json',
-        'window_start': '2026-05-26T13:30:00+00:00',
-        'window_end': '2026-05-26T20:00:00+00:00',
-        'paper_route_probe_symbols': ['AAPL', 'AMZN'],
-        'paper_route_probe_next_session_max_notional': '25',
-        'promotion_allowed': False,
-        'final_promotion_authorized': False,
-        'final_promotion_allowed': False,
-        'max_notional': '0',
+        "hypothesis_id": "H-PAIRS-01",
+        "candidate_id": "c88421d619759b2cfaa6f4d0",
+        "observed_stage": "paper",
+        "strategy_family": "microbar_cross_sectional_pairs",
+        "strategy_name": "microbar-pairs-vwap-cap-safe",
+        "account_label": "TORGHUT_SIM",
+        "source_account_label": "TORGHUT_REPLAY",
+        "source_dsn_env": "SIM_DB_DSN",
+        "source_kind": "paper_route_probe_runtime_observed",
+        "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+        "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+        "window_start": "2026-05-26T13:30:00+00:00",
+        "window_end": "2026-05-26T20:00:00+00:00",
+        "paper_route_probe_symbols": ["AAPL", "AMZN"],
+        "paper_route_probe_next_session_max_notional": "25",
+        "promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "final_promotion_allowed": False,
+        "max_notional": "0",
+        "dependency_quorum_decision": "allow",
+        "continuity_ok": "true",
+        "drift_ok": "true",
+        "runtime_window_import_health_gate": {
+            "schema_version": "torghut.runtime-window-import-health-gate.v1",
+            "dependency_quorum_decision": "allow",
+            "continuity_ok": "true",
+            "drift_ok": "true",
+            "blockers": [],
+        },
+        "runtime_window_import_health_gate_blockers": [],
     }
     if target_overrides:
         target.update(target_overrides)
     flags = required_flags or list(verifier.REQUIRED_RUNTIME_WINDOW_TARGET_PLAN_FLAGS)
     return {
-        'schema_version': 'torghut.paper-route-evidence.v1',
-        'next_paper_route_runtime_window_targets': {
-            'schema_version': verifier.NEXT_PAPER_ROUTE_TARGET_PLAN_SCHEMA_VERSION,
-            'target_count': 1,
-            'skipped_target_count': 0,
-            'session_window': {
-                'start': '2026-05-26T13:30:00+00:00',
-                'end': '2026-05-26T20:00:00+00:00',
+        "schema_version": "torghut.paper-route-evidence.v1",
+        "next_paper_route_runtime_window_targets": {
+            "schema_version": verifier.NEXT_PAPER_ROUTE_TARGET_PLAN_SCHEMA_VERSION,
+            "target_count": 1,
+            "skipped_target_count": 0,
+            "session_window": {
+                "start": "2026-05-26T13:30:00+00:00",
+                "end": "2026-05-26T20:00:00+00:00",
             },
-            'session_readiness': {
-                'state': 'import_ready' if import_ready else 'waiting_for_session_open',
-                'import_ready': import_ready,
-                'import_blockers': blockers,
+            "session_readiness": {
+                "state": "import_ready" if import_ready else "waiting_for_session_open",
+                "import_ready": import_ready,
+                "import_blockers": blockers,
             },
-            'runtime_window_import_handoff': {
-                'runner': 'scripts/renew_latest_empirical_promotion_jobs.py',
-                'target_plan_endpoint': '/trading/paper-route-evidence',
-                'required_flags': flags,
-                'source_dsn_env': 'SIM_DB_DSN',
-                'account_label': 'TORGHUT_SIM',
-                'observed_stage': 'paper',
-                'import_ready': import_ready,
-                'import_blockers': blockers,
-                'promotion_allowed': False,
-                'final_promotion_authorized': False,
+            "runtime_window_import_handoff": {
+                "runner": "scripts/renew_latest_empirical_promotion_jobs.py",
+                "target_plan_endpoint": "/trading/paper-route-evidence",
+                "required_flags": flags,
+                "source_dsn_env": "SIM_DB_DSN",
+                "account_label": "TORGHUT_SIM",
+                "observed_stage": "paper",
+                "import_ready": import_ready,
+                "import_blockers": blockers,
+                "promotion_allowed": False,
+                "final_promotion_authorized": False,
             },
-            'targets': [target],
+            "targets": [target],
         },
     }
 
@@ -240,21 +251,21 @@ def _runtime_ledger_proof_packet(
     blockers: list[str] | None = None,
 ) -> dict[str, object]:
     blocking_reasons = blockers or (
-        [] if allowed else ['runtime_ledger_daily_net_pnl_below_target']
+        [] if allowed else ["runtime_ledger_daily_net_pnl_below_target"]
     )
     return {
-        'schema_version': verifier.RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
-        'ok': allowed,
-        'verdict': 'promotion_authority_allowed' if allowed else 'blocked',
-        'promotion_authority': {
-            'allowed': allowed,
-            'reason': 'runtime_ledger_live_paper_post_cost_proof_satisfied'
+        "schema_version": verifier.RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
+        "ok": allowed,
+        "verdict": "promotion_authority_allowed" if allowed else "blocked",
+        "promotion_authority": {
+            "allowed": allowed,
+            "reason": "runtime_ledger_live_paper_post_cost_proof_satisfied"
             if allowed
-            else 'runtime_ledger_live_paper_post_cost_proof_blocked',
-            'blocking_reasons': blocking_reasons,
-            'failed_checks': []
+            else "runtime_ledger_live_paper_post_cost_proof_blocked",
+            "blocking_reasons": blocking_reasons,
+            "failed_checks": []
             if allowed
-            else ['runtime_ledger_post_cost_profit_target'],
+            else ["runtime_ledger_post_cost_profit_target"],
         },
     }
 
@@ -263,10 +274,10 @@ class _JsonHandler(BaseHTTPRequestHandler):
     payload: ClassVar[object] = {}
 
     def do_GET(self) -> None:
-        body = json.dumps(self.payload).encode('utf-8')
+        body = json.dumps(self.payload).encode("utf-8")
         self.send_response(200)
-        self.send_header('Content-Type', 'application/json')
-        self.send_header('Content-Length', str(len(body)))
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
 
@@ -280,13 +291,13 @@ def _load_from_test_server(payload: object) -> dict[str, object]:
     class Handler(_JsonHandler):
         payload: ClassVar[object] = response_payload
 
-    server = HTTPServer(('127.0.0.1', 0), Handler)
+    server = HTTPServer(("127.0.0.1", 0), Handler)
     thread = Thread(target=server.serve_forever)
     thread.start()
     try:
         host, port = server.server_address
         return verifier._load_status_url(
-            f'http://{host}:{port}/status', timeout_seconds=2.0
+            f"http://{host}:{port}/status", timeout_seconds=2.0
         )
     finally:
         server.shutdown()
@@ -298,14 +309,14 @@ class TestVerifyTradingReadiness(TestCase):
     def test_ready_paper_status_passes_strict_gate(self) -> None:
         result = evaluate_trading_readiness(
             _ready_status(),
-            profile='paper',
+            profile="paper",
             min_routeable_symbols=2,
             min_decisions=1,
             min_orders=1,
         )
 
-        self.assertTrue(result['ok'])
-        self.assertEqual(result['failed_checks'], [])
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["failed_checks"], [])
 
     def test_runtime_ledger_profit_proof_can_be_required_from_completion_status(
         self,
@@ -313,18 +324,18 @@ class TestVerifyTradingReadiness(TestCase):
         result = evaluate_trading_readiness(
             _ready_status(),
             completion_status=_completion_status(),
-            profile='paper',
+            profile="paper",
             min_routeable_symbols=2,
-            min_runtime_ledger_net_pnl=Decimal('500'),
+            min_runtime_ledger_net_pnl=Decimal("500"),
             min_runtime_ledger_trading_days=25,
-            min_runtime_ledger_daily_net_pnl=Decimal('20'),
+            min_runtime_ledger_daily_net_pnl=Decimal("20"),
             require_runtime_ledger_profit_proof=True,
         )
 
-        self.assertTrue(result['ok'], result)
-        self.assertEqual(result['failed_checks'], [])
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["failed_checks"], [])
         self.assertEqual(
-            result['completion_profit_proof']['gate_id'],
+            result["completion_profit_proof"]["gate_id"],
             verifier.DOC29_LIVE_SCALE_GATE,
         )
 
@@ -333,40 +344,40 @@ class TestVerifyTradingReadiness(TestCase):
     ) -> None:
         missing = evaluate_trading_readiness(
             _ready_status(),
-            min_runtime_ledger_net_pnl=Decimal('500'),
+            min_runtime_ledger_net_pnl=Decimal("500"),
             require_runtime_ledger_profit_proof=True,
         )
-        self.assertFalse(missing['ok'])
-        self.assertIn('completion_status_present', missing['failed_checks'])
+        self.assertFalse(missing["ok"])
+        self.assertIn("completion_status_present", missing["failed_checks"])
 
         weak = evaluate_trading_readiness(
             _ready_status(),
             completion_status=_completion_status(
-                gate_status='blocked',
-                blocked_reason='runtime_ledger_profit_proof_missing',
-                net_pnl='499.99',
-                expectancy_bps='0',
+                gate_status="blocked",
+                blocked_reason="runtime_ledger_profit_proof_missing",
+                net_pnl="499.99",
+                expectancy_bps="0",
                 trading_day_count=2,
                 ledger_refs=[],
-                unbacked_refs=['window-1'],
+                unbacked_refs=["window-1"],
             ),
-            min_runtime_ledger_net_pnl=Decimal('500'),
+            min_runtime_ledger_net_pnl=Decimal("500"),
             min_runtime_ledger_trading_days=25,
-            min_runtime_ledger_daily_net_pnl=Decimal('500'),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
             require_runtime_ledger_profit_proof=True,
         )
 
-        self.assertFalse(weak['ok'])
+        self.assertFalse(weak["ok"])
         for check_name in (
-            'doc29_live_scale_gate_satisfied',
-            'runtime_ledger_db_refs_present',
-            'runtime_ledger_unbacked_windows_empty',
-            'runtime_ledger_observed_trading_days',
-            'runtime_ledger_net_pnl_target',
-            'runtime_ledger_daily_net_pnl_target',
-            'runtime_ledger_post_cost_expectancy_positive',
+            "doc29_live_scale_gate_satisfied",
+            "runtime_ledger_db_refs_present",
+            "runtime_ledger_unbacked_windows_empty",
+            "runtime_ledger_observed_trading_days",
+            "runtime_ledger_net_pnl_target",
+            "runtime_ledger_daily_net_pnl_target",
+            "runtime_ledger_post_cost_expectancy_positive",
         ):
-            self.assertIn(check_name, weak['failed_checks'])
+            self.assertIn(check_name, weak["failed_checks"])
 
     def test_runtime_ledger_proof_packet_can_be_required_as_final_authority(
         self,
@@ -377,10 +388,10 @@ class TestVerifyTradingReadiness(TestCase):
             require_runtime_ledger_proof_packet=True,
         )
 
-        self.assertTrue(result['ok'], result)
-        self.assertEqual(result['failed_checks'], [])
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["failed_checks"], [])
         self.assertEqual(
-            result['runtime_ledger_proof_packet']['schema_version'],
+            result["runtime_ledger_proof_packet"]["schema_version"],
             verifier.RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
         )
 
@@ -389,21 +400,21 @@ class TestVerifyTradingReadiness(TestCase):
             _ready_status(),
             runtime_ledger_proof_packet=_runtime_ledger_proof_packet(
                 allowed=False,
-                blockers=['runtime_ledger_daily_net_pnl_below_target'],
+                blockers=["runtime_ledger_daily_net_pnl_below_target"],
             ),
             require_runtime_ledger_proof_packet=True,
         )
 
-        self.assertFalse(result['ok'])
+        self.assertFalse(result["ok"])
         self.assertIn(
-            'runtime_ledger_proof_packet_authority',
-            result['failed_checks'],
+            "runtime_ledger_proof_packet_authority",
+            result["failed_checks"],
         )
         self.assertEqual(
-            result['checks']['runtime_ledger_proof_packet_authority']['observed'][
-                'blocking_reasons'
+            result["checks"]["runtime_ledger_proof_packet_authority"]["observed"][
+                "blocking_reasons"
             ],
-            ['runtime_ledger_daily_net_pnl_below_target'],
+            ["runtime_ledger_daily_net_pnl_below_target"],
         )
 
     def test_runtime_ledger_profit_proof_requires_observed_days_and_daily_pnl(
@@ -412,242 +423,242 @@ class TestVerifyTradingReadiness(TestCase):
         short_window = evaluate_trading_readiness(
             _ready_status(),
             completion_status=_completion_status(
-                net_pnl='15000',
+                net_pnl="15000",
                 trading_day_count=3,
             ),
-            min_runtime_ledger_net_pnl=Decimal('12500'),
+            min_runtime_ledger_net_pnl=Decimal("12500"),
             min_runtime_ledger_trading_days=25,
-            min_runtime_ledger_daily_net_pnl=Decimal('500'),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
             require_runtime_ledger_profit_proof=True,
         )
-        self.assertFalse(short_window['ok'])
+        self.assertFalse(short_window["ok"])
         self.assertIn(
-            'runtime_ledger_observed_trading_days',
-            short_window['failed_checks'],
+            "runtime_ledger_observed_trading_days",
+            short_window["failed_checks"],
         )
 
         weak_daily = evaluate_trading_readiness(
             _ready_status(),
             completion_status=_completion_status(
-                net_pnl='600',
+                net_pnl="600",
                 trading_day_count=25,
             ),
-            min_runtime_ledger_net_pnl=Decimal('500'),
+            min_runtime_ledger_net_pnl=Decimal("500"),
             min_runtime_ledger_trading_days=25,
-            min_runtime_ledger_daily_net_pnl=Decimal('500'),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
             require_runtime_ledger_profit_proof=True,
         )
-        self.assertFalse(weak_daily['ok'])
+        self.assertFalse(weak_daily["ok"])
         self.assertIn(
-            'runtime_ledger_daily_net_pnl_target',
-            weak_daily['failed_checks'],
+            "runtime_ledger_daily_net_pnl_target",
+            weak_daily["failed_checks"],
         )
 
     def test_live_and_either_profiles_use_live_floor_states_and_market_window(
         self,
     ) -> None:
         status = _ready_status()
-        status['mode'] = 'live'
-        metrics = status['metrics']
+        status["mode"] = "live"
+        metrics = status["metrics"]
         assert isinstance(metrics, dict)
-        metrics.pop('market_session_open')
-        proof_floor = status['proof_floor']
+        metrics.pop("market_session_open")
+        proof_floor = status["proof_floor"]
         assert isinstance(proof_floor, dict)
         proof_floor.update(
             {
-                'floor_state': 'live_micro_ready',
-                'route_state': 'live_micro_candidate',
-                'capital_state': 'live_allowed',
-                'market_window': {'session_open': 'open'},
+                "floor_state": "live_micro_ready",
+                "route_state": "live_micro_candidate",
+                "capital_state": "live_allowed",
+                "market_window": {"session_open": "open"},
             }
         )
 
         live = evaluate_trading_readiness(
-            status, profile='live', min_routeable_symbols=2
+            status, profile="live", min_routeable_symbols=2
         )
         either = evaluate_trading_readiness(
-            status, profile='either', min_routeable_symbols=2
+            status, profile="either", min_routeable_symbols=2
         )
 
-        self.assertTrue(live['ok'], live)
-        self.assertTrue(either['ok'], either)
+        self.assertTrue(live["ok"], live)
+        self.assertTrue(either["ok"], either)
 
     def test_repair_only_route_universe_fails_with_actionable_checks(self) -> None:
         status = _ready_status()
-        proof_floor = status['proof_floor']
+        proof_floor = status["proof_floor"]
         assert isinstance(proof_floor, dict)
         proof_floor.update(
             {
-                'floor_state': 'repair_only',
-                'route_state': 'repair_only',
-                'capital_state': 'zero_notional',
-                'max_notional': '0',
-                'blocking_reasons': [
-                    'alpha_readiness_not_promotion_eligible',
-                    'execution_tca_route_universe_empty',
-                    'market_context_stale',
+                "floor_state": "repair_only",
+                "route_state": "repair_only",
+                "capital_state": "zero_notional",
+                "max_notional": "0",
+                "blocking_reasons": [
+                    "alpha_readiness_not_promotion_eligible",
+                    "execution_tca_route_universe_empty",
+                    "market_context_stale",
                 ],
             }
         )
-        dimensions = proof_floor['proof_dimensions']
+        dimensions = proof_floor["proof_dimensions"]
         assert isinstance(dimensions, list)
         for dimension in dimensions:
             if not isinstance(dimension, dict):
                 continue
-            if dimension.get('dimension') == 'alpha_readiness':
-                dimension['state'] = 'fail'
-                dimension['reason'] = 'alpha_readiness_not_promotion_eligible'
-            if dimension.get('dimension') == 'market_context':
-                dimension['state'] = 'stale'
-                dimension['reason'] = 'market_context_stale'
-            if dimension.get('dimension') == 'execution_tca':
-                dimension['state'] = 'fail'
-                dimension['reason'] = 'execution_tca_route_universe_empty'
-                source_ref = dimension['source_ref']
+            if dimension.get("dimension") == "alpha_readiness":
+                dimension["state"] = "fail"
+                dimension["reason"] = "alpha_readiness_not_promotion_eligible"
+            if dimension.get("dimension") == "market_context":
+                dimension["state"] = "stale"
+                dimension["reason"] = "market_context_stale"
+            if dimension.get("dimension") == "execution_tca":
+                dimension["state"] = "fail"
+                dimension["reason"] = "execution_tca_route_universe_empty"
+                source_ref = dimension["source_ref"]
                 assert isinstance(source_ref, dict)
-                symbol_routes = source_ref['symbol_routes']
+                symbol_routes = source_ref["symbol_routes"]
                 assert isinstance(symbol_routes, dict)
                 symbol_routes.update(
                     {
-                        'routeable_symbol_count': 0,
-                        'blocked_symbol_count': 1,
-                        'missing_symbol_count': 1,
-                        'routeable_symbols': [],
-                        'blocked_symbols': [{'symbol': 'NVDA'}],
-                        'missing_symbols': ['AVGO'],
+                        "routeable_symbol_count": 0,
+                        "blocked_symbol_count": 1,
+                        "missing_symbol_count": 1,
+                        "routeable_symbols": [],
+                        "blocked_symbols": [{"symbol": "NVDA"}],
+                        "missing_symbols": ["AVGO"],
                     }
                 )
 
-        status['route_reacquisition_board'] = {
-            'schema_version': 'torghut.route-reacquisition-board.v1',
-            'state': 'repair_only',
-            'capital_state': 'zero_notional',
-            'summary': {
-                'row_count': 2,
-                'state_counts': {'blocked': 1, 'missing': 1},
-                'zero_notional_row_count': 2,
-                'expected_unblock_value': 3,
-                'top_repair_symbols': ['NVDA', 'AVGO'],
-                'capital_eligible_symbol_count': 0,
+        status["route_reacquisition_board"] = {
+            "schema_version": "torghut.route-reacquisition-board.v1",
+            "state": "repair_only",
+            "capital_state": "zero_notional",
+            "summary": {
+                "row_count": 2,
+                "state_counts": {"blocked": 1, "missing": 1},
+                "zero_notional_row_count": 2,
+                "expected_unblock_value": 3,
+                "top_repair_symbols": ["NVDA", "AVGO"],
+                "capital_eligible_symbol_count": 0,
             },
-            'rows': [
-                {'symbol': 'NVDA', 'state': 'blocked', 'max_notional': '0'},
-                {'symbol': 'AVGO', 'state': 'missing', 'max_notional': '0'},
+            "rows": [
+                {"symbol": "NVDA", "state": "blocked", "max_notional": "0"},
+                {"symbol": "AVGO", "state": "missing", "max_notional": "0"},
             ],
         }
 
         result = evaluate_trading_readiness(
             status,
-            profile='paper',
+            profile="paper",
             min_routeable_symbols=2,
             min_decisions=1,
             min_orders=1,
         )
 
-        self.assertFalse(result['ok'])
-        self.assertIn('proof_floor_state', result['failed_checks'])
-        self.assertIn('capital_state', result['failed_checks'])
-        self.assertIn('alpha_readiness_pass', result['failed_checks'])
-        self.assertIn('market_context_pass', result['failed_checks'])
-        self.assertIn('execution_tca_pass', result['failed_checks'])
-        self.assertIn('routeable_symbol_count', result['failed_checks'])
-        self.assertIn('blocked_symbol_count', result['failed_checks'])
-        self.assertIn('missing_symbol_count', result['failed_checks'])
-        self.assertIn('route_board_jangar_continuity_ready', result['failed_checks'])
-        self.assertIn('route_board_capital_eligible_symbols', result['failed_checks'])
-        self.assertIn('route_board_zero_notional_rows', result['failed_checks'])
+        self.assertFalse(result["ok"])
+        self.assertIn("proof_floor_state", result["failed_checks"])
+        self.assertIn("capital_state", result["failed_checks"])
+        self.assertIn("alpha_readiness_pass", result["failed_checks"])
+        self.assertIn("market_context_pass", result["failed_checks"])
+        self.assertIn("execution_tca_pass", result["failed_checks"])
+        self.assertIn("routeable_symbol_count", result["failed_checks"])
+        self.assertIn("blocked_symbol_count", result["failed_checks"])
+        self.assertIn("missing_symbol_count", result["failed_checks"])
+        self.assertIn("route_board_jangar_continuity_ready", result["failed_checks"])
+        self.assertIn("route_board_capital_eligible_symbols", result["failed_checks"])
+        self.assertIn("route_board_zero_notional_rows", result["failed_checks"])
 
     def test_optional_quant_empty_fails_unless_informational_quant_is_allowed(
         self,
     ) -> None:
         status = _ready_status()
-        proof_floor = status['proof_floor']
+        proof_floor = status["proof_floor"]
         assert isinstance(proof_floor, dict)
-        dimensions = proof_floor['proof_dimensions']
+        dimensions = proof_floor["proof_dimensions"]
         assert isinstance(dimensions, list)
         for dimension in dimensions:
             if (
                 isinstance(dimension, dict)
-                and dimension.get('dimension') == 'quant_ingestion'
+                and dimension.get("dimension") == "quant_ingestion"
             ):
-                dimension['state'] = 'informational'
-                dimension['reason'] = 'quant_latest_metrics_empty'
-                dimension['source_ref'] = {'required': False}
+                dimension["state"] = "informational"
+                dimension["reason"] = "quant_latest_metrics_empty"
+                dimension["source_ref"] = {"required": False}
 
         strict = evaluate_trading_readiness(status, require_quant_fresh=True)
         permissive = evaluate_trading_readiness(status, require_quant_fresh=False)
 
-        self.assertFalse(strict['ok'])
-        self.assertIn('quant_ingestion_ready', strict['failed_checks'])
-        self.assertTrue(permissive['ok'])
+        self.assertFalse(strict["ok"])
+        self.assertIn("quant_ingestion_ready", strict["failed_checks"])
+        self.assertTrue(permissive["ok"])
 
     def test_required_quant_empty_fails_even_when_informational_quant_is_allowed(
         self,
     ) -> None:
         status = _ready_status()
-        proof_floor = status['proof_floor']
+        proof_floor = status["proof_floor"]
         assert isinstance(proof_floor, dict)
-        dimensions = proof_floor['proof_dimensions']
+        dimensions = proof_floor["proof_dimensions"]
         assert isinstance(dimensions, list)
         for dimension in dimensions:
             if (
                 isinstance(dimension, dict)
-                and dimension.get('dimension') == 'quant_ingestion'
+                and dimension.get("dimension") == "quant_ingestion"
             ):
-                dimension['state'] = 'informational'
-                dimension['reason'] = 'quant_latest_metrics_empty'
-                dimension['source_ref'] = {'required': True}
+                dimension["state"] = "informational"
+                dimension["reason"] = "quant_latest_metrics_empty"
+                dimension["source_ref"] = {"required": True}
 
         result = evaluate_trading_readiness(status, require_quant_fresh=False)
 
-        self.assertFalse(result['ok'])
-        self.assertIn('quant_ingestion_ready', result['failed_checks'])
+        self.assertFalse(result["ok"])
+        self.assertIn("quant_ingestion_ready", result["failed_checks"])
 
     def test_legacy_evidence_required_quant_empty_fails_when_informational_quant_is_allowed(
         self,
     ) -> None:
         status = _ready_status()
-        proof_floor = status['proof_floor']
+        proof_floor = status["proof_floor"]
         assert isinstance(proof_floor, dict)
-        dimensions = proof_floor['proof_dimensions']
+        dimensions = proof_floor["proof_dimensions"]
         assert isinstance(dimensions, list)
         for dimension in dimensions:
             if (
                 isinstance(dimension, dict)
-                and dimension.get('dimension') == 'quant_ingestion'
+                and dimension.get("dimension") == "quant_ingestion"
             ):
-                dimension['state'] = 'informational'
-                dimension['reason'] = 'quant_latest_metrics_empty'
-                dimension['source_ref'] = {'evidence_required': True}
+                dimension["state"] = "informational"
+                dimension["reason"] = "quant_latest_metrics_empty"
+                dimension["source_ref"] = {"evidence_required": True}
 
         result = evaluate_trading_readiness(status, require_quant_fresh=False)
 
-        self.assertFalse(result['ok'])
-        self.assertIn('quant_ingestion_ready', result['failed_checks'])
+        self.assertFalse(result["ok"])
+        self.assertIn("quant_ingestion_ready", result["failed_checks"])
 
     def test_closed_session_paper_route_probe_candidate_can_be_required_for_next_session(
         self,
     ) -> None:
         status = _ready_status()
-        metrics = status['metrics']
+        metrics = status["metrics"]
         assert isinstance(metrics, dict)
-        metrics['market_session_open'] = 0
-        route_book = status['route_reacquisition_book']
+        metrics["market_session_open"] = 0
+        route_book = status["route_reacquisition_book"]
         assert isinstance(route_book, dict)
-        probe = route_book['paper_route_probe']
+        probe = route_book["paper_route_probe"]
         assert isinstance(probe, dict)
         probe.update(
             {
-                'active': False,
-                'effective_max_notional': '0',
-                'next_session_max_notional': '25',
-                'active_symbols': [],
-                'blocking_reasons': ['market_session_closed'],
+                "active": False,
+                "effective_max_notional": "0",
+                "next_session_max_notional": "25",
+                "active_symbols": [],
+                "blocking_reasons": ["market_session_closed"],
             }
         )
-        summary = route_book['summary']
+        summary = route_book["summary"]
         assert isinstance(summary, dict)
-        summary['paper_route_probe_active_symbols'] = []
+        summary["paper_route_probe_active_symbols"] = []
 
         result = evaluate_trading_readiness(
             status,
@@ -655,17 +666,17 @@ class TestVerifyTradingReadiness(TestCase):
             require_paper_route_probe_candidate=True,
         )
 
-        self.assertTrue(result['ok'], result)
-        self.assertEqual(result['paper_route_probe']['eligible_symbols'], ['NVDA'])
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["paper_route_probe"]["eligible_symbols"], ["NVDA"])
         self.assertEqual(
-            result['paper_route_probe']['blocking_reasons'], ['market_session_closed']
+            result["paper_route_probe"]["blocking_reasons"], ["market_session_closed"]
         )
 
     def test_paper_route_target_plan_can_be_required_before_session_open(self) -> None:
         status = _ready_status()
-        metrics = status['metrics']
+        metrics = status["metrics"]
         assert isinstance(metrics, dict)
-        metrics['market_session_open'] = 0
+        metrics["market_session_open"] = 0
 
         result = evaluate_trading_readiness(
             status,
@@ -674,16 +685,16 @@ class TestVerifyTradingReadiness(TestCase):
             require_paper_route_target_plan=True,
         )
 
-        self.assertTrue(result['ok'], result)
-        self.assertEqual(result['paper_route_target_plan']['target_count'], 1)
+        self.assertTrue(result["ok"], result)
+        self.assertEqual(result["paper_route_target_plan"]["target_count"], 1)
         self.assertEqual(
-            result['paper_route_target_plan']['import_blockers'],
-            ['paper_route_session_window_not_open'],
+            result["paper_route_target_plan"]["import_blockers"],
+            ["paper_route_session_window_not_open"],
         )
         self.assertEqual(
-            result['paper_route_target_plan']['missing_required_flags'], []
+            result["paper_route_target_plan"]["missing_required_flags"], []
         )
-        self.assertEqual(result['paper_route_target_plan']['missing_identity_count'], 0)
+        self.assertEqual(result["paper_route_target_plan"]["missing_identity_count"], 0)
 
     def test_paper_route_target_plan_fails_closed_on_missing_handoff_or_identity(
         self,
@@ -691,25 +702,25 @@ class TestVerifyTradingReadiness(TestCase):
         result = evaluate_trading_readiness(
             _ready_status(),
             paper_route_evidence=_paper_route_evidence(
-                required_flags=['--runtime-window-import'],
+                required_flags=["--runtime-window-import"],
                 target_overrides={
-                    'strategy_name': '',
-                    'paper_route_probe_symbols': [],
-                    'promotion_allowed': True,
-                    'max_notional': '25',
+                    "strategy_name": "",
+                    "paper_route_probe_symbols": [],
+                    "promotion_allowed": True,
+                    "max_notional": "25",
                 },
             ),
             require_paper_route_target_plan=True,
         )
 
-        self.assertFalse(result['ok'])
-        self.assertIn('paper_route_target_plan_handoff_flags', result['failed_checks'])
+        self.assertFalse(result["ok"])
+        self.assertIn("paper_route_target_plan_handoff_flags", result["failed_checks"])
         self.assertIn(
-            'paper_route_target_plan_target_identity', result['failed_checks']
+            "paper_route_target_plan_target_identity", result["failed_checks"]
         )
-        self.assertIn('paper_route_target_plan_probe_contract', result['failed_checks'])
+        self.assertIn("paper_route_target_plan_probe_contract", result["failed_checks"])
         self.assertIn(
-            'paper_route_target_plan_promotion_blocked', result['failed_checks']
+            "paper_route_target_plan_promotion_blocked", result["failed_checks"]
         )
 
     def test_paper_route_import_ready_is_separate_from_target_plan_presence(
@@ -721,8 +732,8 @@ class TestVerifyTradingReadiness(TestCase):
             require_paper_route_target_plan=True,
             require_paper_route_import_ready=True,
         )
-        self.assertFalse(waiting['ok'])
-        self.assertIn('paper_route_target_plan_import_ready', waiting['failed_checks'])
+        self.assertFalse(waiting["ok"])
+        self.assertIn("paper_route_target_plan_import_ready", waiting["failed_checks"])
 
         ready = evaluate_trading_readiness(
             _ready_status(),
@@ -730,102 +741,146 @@ class TestVerifyTradingReadiness(TestCase):
             require_paper_route_target_plan=True,
             require_paper_route_import_ready=True,
         )
-        self.assertTrue(ready['ok'], ready)
+        self.assertTrue(ready["ok"], ready)
+
+    def test_paper_route_target_plan_requires_runtime_import_health_gate(
+        self,
+    ) -> None:
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            paper_route_evidence=_paper_route_evidence(
+                import_ready=True,
+                target_overrides={
+                    "dependency_quorum_decision": "missing",
+                    "continuity_ok": "false",
+                    "runtime_window_import_health_gate": {
+                        "schema_version": "torghut.runtime-window-import-health-gate.v1",
+                        "dependency_quorum_decision": "missing",
+                        "continuity_ok": "false",
+                        "drift_ok": "true",
+                        "blockers": [
+                            "dependency_quorum_not_allow",
+                            "continuity_not_ok",
+                        ],
+                    },
+                    "runtime_window_import_health_gate_blockers": [
+                        "dependency_quorum_not_allow",
+                        "continuity_not_ok",
+                    ],
+                },
+            ),
+            require_paper_route_target_plan=True,
+            require_paper_route_import_ready=True,
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertIn(
+            "paper_route_target_plan_import_health_gate", result["failed_checks"]
+        )
+        health_gate = result["paper_route_target_plan"][
+            "runtime_window_import_health_gate"
+        ]
+        self.assertEqual(health_gate["ready_target_count"], 0)
+        self.assertEqual(health_gate["blocked_target_count"], 1)
+        self.assertEqual(
+            health_gate["blockers"],
+            ["continuity_not_ok", "dependency_quorum_not_allow"],
+        )
 
     def test_required_paper_route_probe_candidate_fails_without_bounded_candidate(
         self,
     ) -> None:
         status = _ready_status()
-        route_book = status['route_reacquisition_book']
+        route_book = status["route_reacquisition_book"]
         assert isinstance(route_book, dict)
-        probe = route_book['paper_route_probe']
+        probe = route_book["paper_route_probe"]
         assert isinstance(probe, dict)
         probe.update(
             {
-                'configured_enabled': False,
-                'effective_max_notional': '0',
-                'next_session_max_notional': '0',
-                'eligible_symbol_count': 0,
-                'eligible_symbols': [],
-                'active_symbols': [],
-                'blocking_reasons': ['paper_route_probe_disabled'],
+                "configured_enabled": False,
+                "effective_max_notional": "0",
+                "next_session_max_notional": "0",
+                "eligible_symbol_count": 0,
+                "eligible_symbols": [],
+                "active_symbols": [],
+                "blocking_reasons": ["paper_route_probe_disabled"],
             }
         )
-        summary = route_book['summary']
+        summary = route_book["summary"]
         assert isinstance(summary, dict)
-        summary['paper_route_probe_eligible_symbols'] = []
-        summary['paper_route_probe_active_symbols'] = []
+        summary["paper_route_probe_eligible_symbols"] = []
+        summary["paper_route_probe_active_symbols"] = []
 
         result = evaluate_trading_readiness(
             status, require_paper_route_probe_candidate=True
         )
 
-        self.assertFalse(result['ok'])
-        self.assertIn('paper_route_probe_configured', result['failed_checks'])
-        self.assertIn('paper_route_probe_candidate_symbols', result['failed_checks'])
-        self.assertIn('paper_route_probe_notional_positive', result['failed_checks'])
-        self.assertIn('paper_route_probe_blockers', result['failed_checks'])
+        self.assertFalse(result["ok"])
+        self.assertIn("paper_route_probe_configured", result["failed_checks"])
+        self.assertIn("paper_route_probe_candidate_symbols", result["failed_checks"])
+        self.assertIn("paper_route_probe_notional_positive", result["failed_checks"])
+        self.assertIn("paper_route_probe_blockers", result["failed_checks"])
 
     def test_payload_helpers_handle_runtime_payload_shapes(self) -> None:
-        self.assertTrue(verifier._bool('open'))
+        self.assertTrue(verifier._bool("open"))
         self.assertFalse(verifier._bool(object()))
         self.assertEqual(verifier._int(True), 1)
         self.assertEqual(verifier._int(3.8), 3)
-        self.assertEqual(verifier._int('7.9'), 7)
-        self.assertEqual(verifier._int('not-a-number', default=4), 4)
-        self.assertEqual(verifier._int('', default=4), 4)
+        self.assertEqual(verifier._int("7.9"), 7)
+        self.assertEqual(verifier._int("not-a-number", default=4), 4)
+        self.assertEqual(verifier._int("", default=4), 4)
         self.assertIsNone(verifier._decimal(None))
-        self.assertIsNone(verifier._decimal('not-a-number'))
+        self.assertIsNone(verifier._decimal("not-a-number"))
         self.assertEqual(verifier._mapping(object()), {})
-        self.assertEqual(verifier._sequence('NVDA'), [])
+        self.assertEqual(verifier._sequence("NVDA"), [])
 
     def test_status_loaders_require_json_objects(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            status_path = Path(tmp_dir) / 'status.json'
+            status_path = Path(tmp_dir) / "status.json"
             status_path.write_text(
-                json.dumps(['not', 'an', 'object']), encoding='utf-8'
+                json.dumps(["not", "an", "object"]), encoding="utf-8"
             )
 
-            with self.assertRaisesRegex(ValueError, 'json_object_required'):
+            with self.assertRaisesRegex(ValueError, "json_object_required"):
                 verifier._load_json_object(status_path)
 
-        self.assertEqual(_load_from_test_server({'ok': True}), {'ok': True})
-        with self.assertRaisesRegex(ValueError, 'json_object_required'):
-            _load_from_test_server(['not', 'an', 'object'])
+        self.assertEqual(_load_from_test_server({"ok": True}), {"ok": True})
+        with self.assertRaisesRegex(ValueError, "json_object_required"):
+            _load_from_test_server(["not", "an", "object"])
 
     def test_cli_returns_nonzero_for_failed_status_file(self) -> None:
         status = _ready_status()
-        status['running'] = False
+        status["running"] = False
         with tempfile.TemporaryDirectory() as tmp_dir:
-            status_path = Path(tmp_dir) / 'status.json'
-            status_path.write_text(json.dumps(status), encoding='utf-8')
+            status_path = Path(tmp_dir) / "status.json"
+            status_path.write_text(json.dumps(status), encoding="utf-8")
 
-            exit_code = main(['--status-file', str(status_path)])
+            exit_code = main(["--status-file", str(status_path)])
 
         self.assertEqual(exit_code, 1)
 
     def test_cli_accepts_completion_file_for_runtime_ledger_profit_proof(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            status_path = Path(tmp_dir) / 'status.json'
-            completion_path = Path(tmp_dir) / 'completion.json'
-            status_path.write_text(json.dumps(_ready_status()), encoding='utf-8')
+            status_path = Path(tmp_dir) / "status.json"
+            completion_path = Path(tmp_dir) / "completion.json"
+            status_path.write_text(json.dumps(_ready_status()), encoding="utf-8")
             completion_path.write_text(
-                json.dumps(_completion_status()), encoding='utf-8'
+                json.dumps(_completion_status()), encoding="utf-8"
             )
 
             exit_code = main(
                 [
-                    '--status-file',
+                    "--status-file",
                     str(status_path),
-                    '--completion-file',
+                    "--completion-file",
                     str(completion_path),
-                    '--require-runtime-ledger-profit-proof',
-                    '--min-runtime-ledger-net-pnl',
-                    '500',
-                    '--min-runtime-ledger-trading-days',
-                    '25',
-                    '--min-runtime-ledger-daily-net-pnl',
-                    '20',
+                    "--require-runtime-ledger-profit-proof",
+                    "--min-runtime-ledger-net-pnl",
+                    "500",
+                    "--min-runtime-ledger-trading-days",
+                    "25",
+                    "--min-runtime-ledger-daily-net-pnl",
+                    "20",
                 ]
             )
 
@@ -833,27 +888,27 @@ class TestVerifyTradingReadiness(TestCase):
 
     def test_cli_rejects_non_decimal_runtime_ledger_profit_target(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            status_path = Path(tmp_dir) / 'status.json'
-            status_path.write_text(json.dumps(_ready_status()), encoding='utf-8')
+            status_path = Path(tmp_dir) / "status.json"
+            status_path.write_text(json.dumps(_ready_status()), encoding="utf-8")
 
-            with self.assertRaisesRegex(SystemExit, 'must be decimal'):
+            with self.assertRaisesRegex(SystemExit, "must be decimal"):
                 main(
                     [
-                        '--status-file',
+                        "--status-file",
                         str(status_path),
-                        '--require-runtime-ledger-profit-proof',
-                        '--min-runtime-ledger-net-pnl',
-                        'not-a-number',
+                        "--require-runtime-ledger-profit-proof",
+                        "--min-runtime-ledger-net-pnl",
+                        "not-a-number",
                     ]
                 )
 
-            with self.assertRaisesRegex(SystemExit, 'daily-net-pnl must be decimal'):
+            with self.assertRaisesRegex(SystemExit, "daily-net-pnl must be decimal"):
                 main(
                     [
-                        '--status-file',
+                        "--status-file",
                         str(status_path),
-                        '--require-runtime-ledger-profit-proof',
-                        '--min-runtime-ledger-daily-net-pnl',
-                        'not-a-number',
+                        "--require-runtime-ledger-profit-proof",
+                        "--min-runtime-ledger-daily-net-pnl",
+                        "not-a-number",
                     ]
                 )


### PR DESCRIPTION
## Summary

- Adds runtime-window import health-gate validation to the runtime-ledger proof packet so promotion proof fails closed when the live paper-route target plan lacks allow quorum, continuity, or drift approval.
- Surfaces the same health-gate summary in trading readiness checks, including per-target blockers and ready/blocked target counts.
- Extends proof-packet and readiness regression coverage for blocked health-gate targets.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py`
- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
