### PR TITLE
chore(symphony): promote image c8acae03

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-25T07:03:19Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-25T17:52:32Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "739c7a71"
-    digest: sha256:7e047eaac0bb6124966fb764c0bb52de172715ef99da8582afb09831fdfb0e1a
+    newTag: "c8acae03"
+    digest: sha256:b0613f9fb125068471fd9cea5275d6c8032701d7b9670dac9cfa0fd7623f53ba

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-25T07:03:19Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-25T17:52:32Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "739c7a71"
-    digest: sha256:7e047eaac0bb6124966fb764c0bb52de172715ef99da8582afb09831fdfb0e1a
+    newTag: "c8acae03"
+    digest: sha256:b0613f9fb125068471fd9cea5275d6c8032701d7b9670dac9cfa0fd7623f53ba

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-25T07:03:19Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-25T17:52:32Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "739c7a71"
-    digest: sha256:7e047eaac0bb6124966fb764c0bb52de172715ef99da8582afb09831fdfb0e1a
+    newTag: "c8acae03"
+    digest: sha256:b0613f9fb125068471fd9cea5275d6c8032701d7b9670dac9cfa0fd7623f53ba


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `c8acae03fa2451fe0f28e7540e8f61b1c67d28a0`
- Image tag: `c8acae03`
- Image digest: `sha256:b0613f9fb125068471fd9cea5275d6c8032701d7b9670dac9cfa0fd7623f53ba`