### PR TITLE
fix(agents): sanitize pruned docker context

### DIFF
--- a/packages/scripts/src/agents/__tests__/build-image.test.ts
+++ b/packages/scripts/src/agents/__tests__/build-image.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, it } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { __private } from '../build-image'
 
@@ -98,5 +101,28 @@ describe('agents build-image helpers', () => {
     expect(() => __private.parsePruneScopes('@proompteng/agents,@proompteng/jangar')).toThrow(
       'Agents images must not prune or package @proompteng/jangar',
     )
+  })
+
+  it('removes nested node_modules from pruned Docker contexts', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agents-prune-node-modules-'))
+    try {
+      const agentsNodeModules = join(dir, 'full/services/agents/node_modules')
+      const nestedNodeModules = join(dir, 'json/packages/cx-tools/node_modules')
+      const sourceDirectory = join(dir, 'full/services/agents/src')
+      mkdirSync(agentsNodeModules, { recursive: true })
+      mkdirSync(nestedNodeModules, { recursive: true })
+      mkdirSync(sourceDirectory, { recursive: true })
+      symlinkSync('../../../node_modules/.bun/yaml@2.9.0/node_modules/yaml', join(agentsNodeModules, 'yaml'))
+      writeFileSync(join(nestedNodeModules, 'placeholder'), '')
+      writeFileSync(join(sourceDirectory, 'index.ts'), 'export {}\n')
+
+      __private.removeNestedNodeModules(dir)
+
+      expect(existsSync(agentsNodeModules)).toBeFalse()
+      expect(existsSync(nestedNodeModules)).toBeFalse()
+      expect(existsSync(sourceDirectory)).toBeTrue()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/scripts/src/agents/build-image.ts
+++ b/packages/scripts/src/agents/build-image.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { copyFileSync, cpSync, existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { copyFileSync, cpSync, existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 
@@ -69,6 +69,28 @@ const parsePruneScopes = (value: string | undefined, target?: string): string[] 
   return normalizedScopes
 }
 
+const removeNestedNodeModules = (root: string) => {
+  if (!existsSync(root)) return
+
+  const directories = [root]
+  while (directories.length > 0) {
+    const current = directories.pop()
+    if (!current) continue
+
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+
+      const entryPath = resolve(current, entry.name)
+      if (entry.name === 'node_modules') {
+        rmSync(entryPath, { recursive: true, force: true })
+        continue
+      }
+
+      directories.push(entryPath)
+    }
+  }
+}
+
 const parseCacheMode = (value: string | undefined): DockerCacheMode | undefined => {
   if (!value) return undefined
   const normalized = value.trim().toLowerCase()
@@ -108,6 +130,9 @@ const createPrunedContext = async (target?: string): Promise<{ dir: string; clea
       cpSync(cxToolsSource, resolve(dir, 'full/packages/cx-tools'), { recursive: true })
       cpSync(cxToolsSource, resolve(dir, 'json/packages/cx-tools'), { recursive: true })
     }
+
+    removeNestedNodeModules(resolve(dir, 'full'))
+    removeNestedNodeModules(resolve(dir, 'json'))
 
     return { dir, cleanup }
   } catch (error) {
@@ -235,4 +260,5 @@ export const __private = {
   parsePlatforms,
   parsePruneScopes,
   resolveBuildConfiguration,
+  removeNestedNodeModules,
 }


### PR DESCRIPTION
## Summary

- Strip nested `node_modules` directories from Agents pruned Docker contexts before image builds.
- Prevent CI checkout-installed workspace symlinks from being copied into Docker `full/` and shadowing in-image dependencies.
- Add a regression test covering broken nested `node_modules` symlinks in pruned contexts.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/build-image.test.ts`
- `bun run --cwd packages/scripts lint`
- `bun run --cwd services/agents tsc`
- `git diff --check`
- `docker buildx build -f /Users/gregkonush/.codex/worktrees/2f33/lab/services/agents/Dockerfile --target agents-build --platform linux/arm64 --build-arg AGENTS_VERSION=local --build-arg AGENTS_COMMIT=local --build-arg AGENTS_BUILD_NODE_OPTIONS=--max-old-space-size=4096 --build-arg AGENTS_BUILD_CI=true /tmp/agents-prune-sanitized-N3PKJl`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
