### PR TITLE
fix(torghut): classify paper route proof audit blockers

### DIFF
--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -21,6 +21,15 @@ The empirical workflow depends on the namespace-local sealed secret
 `rook-ceph-rgw-argo-workflows` for Argo archive-log uploads. Keep that secret managed here so
 workflow submissions in `torghut` do not rely on manual secret copies from `argo-workflows`.
 
+The `torghut-empirical-promotion-renewal` CronJob is also the scheduled runtime-ledger proof packet conductor for the
+paper-route proof lane. It first runs `renew_latest_empirical_promotion_jobs.py` with the live
+`/trading/paper-route-evidence` target plan, then runs `assemble_runtime_ledger_proof_packet.py` and uploads the packet
+under `runtime-ledger-proof-packets/{run_id}`. When the paper-route window is import-ready, the packet now requires the
+live `runtime_window_import_audit` from `/trading/paper-route-evidence` and carries source-activity blockers such as
+`paper_route_source_activity_missing`, `source_decisions_missing`, `source_executions_missing`, and `source_tca_missing`
+into the final verdict. Treat those as the next repair target before rerunning import; do not collapse them into a
+generic runtime-ledger-missing diagnosis.
+
 Trigger a simulation run via Argo:
 
 ```bash

--- a/docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
+++ b/docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
@@ -232,6 +232,26 @@ The helper prints:
 - exact sequence for non-destructive replay mode,
 - optional coverage, retention, and replay-feasibility verdicts.
 
+## Runtime-ledger proof packet after the paper-route window
+
+The scheduled `torghut-empirical-promotion-renewal` CronJob is the canonical post-window proof conductor. It runs after
+the live paper-route target plan says the session is closed and settled, then writes a durable
+`runtime-ledger-proof-packet.json`.
+
+Read these fields before deciding the next action:
+
+- `checks.paper_route_runtime_window_import_audit`: proves `/trading/paper-route-evidence` included the current
+  `runtime_window_import_audit` when import was due.
+- `checks.paper_route_source_activity`: distinguishes missing paper-route decisions/executions/TCA from a later
+  runtime-ledger import failure.
+- `evidence.paper_route_runtime_window_import_audit`: carries the audit state, next action, blockers, and source/ledger
+  counts from the live service.
+
+If the packet reports `paper_route_source_activity_missing`, `source_decisions_missing`, `source_executions_missing`, or
+`source_tca_missing`, repair the paper-route source activity before replaying or rerunning ledger import. If source
+activity is present but runtime ledger counts are missing, then inspect `renew_latest_empirical_promotion_jobs.py`
+runtime-window import output and the DB-backed runtime-ledger buckets. Neither case authorizes promotion by itself.
+
 Execute the planned sequence with explicit human confirmation:
 
 ```bash

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -434,6 +434,41 @@ def _paper_route_targets(plan: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     return [_mapping(item) for item in _sequence(plan.get("targets")) if _mapping(item)]
 
 
+def _paper_route_runtime_window_import_audit(
+    paper_route_evidence: Mapping[str, Any] | None,
+) -> Mapping[str, Any]:
+    return _mapping((paper_route_evidence or {}).get("runtime_window_import_audit"))
+
+
+def _paper_route_runtime_window_import_audit_counts(
+    audit: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    return _mapping(audit.get("counts"))
+
+
+def _paper_route_runtime_window_import_audit_blockers(
+    audit: Mapping[str, Any],
+) -> list[str]:
+    return _text_list(audit.get("blockers"))
+
+
+def _paper_route_source_activity_blockers(
+    audit_blockers: Sequence[str],
+) -> list[str]:
+    source_blocker_names = {
+        "paper_route_source_activity_missing",
+        "strategy_name_missing",
+        "source_decisions_missing",
+        "source_executions_missing",
+        "source_tca_missing",
+    }
+    return [
+        blocker
+        for blocker in audit_blockers
+        if blocker in source_blocker_names or blocker.startswith("source_")
+    ]
+
+
 def _health_gate_bool(value: object) -> bool:
     if isinstance(value, bool):
         return value
@@ -659,6 +694,18 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
             "runtime_ledger_trading_days_below_target",
         }:
             _extend_unique(actions, ["collect_more_runtime_ledger_trading_days"])
+        elif blocker in {
+            "paper_route_source_activity_missing",
+            "strategy_name_missing",
+            "source_decisions_missing",
+            "source_executions_missing",
+            "source_tca_missing",
+        } or blocker.startswith("source_"):
+            _extend_unique(
+                actions, ["inspect_paper_route_source_activity_before_import"]
+            )
+        elif blocker == "runtime_window_import_audit_missing":
+            _extend_unique(actions, ["inspect_paper_route_evidence_audit"])
         elif blocker in {"simple_submit_disabled", "live_submission_gate_not_allowed"}:
             _extend_unique(
                 actions, ["keep_promotion_blocked_until_live_gate_and_proof_floor_pass"]
@@ -704,6 +751,14 @@ def build_runtime_ledger_proof_packet(
     plan = _paper_route_target_plan(paper_route_evidence)
     paper_targets = _paper_route_targets(plan)
     paper_import_blockers = _paper_route_import_blockers(plan)
+    import_audit = _paper_route_runtime_window_import_audit(paper_route_evidence)
+    import_audit_counts = _paper_route_runtime_window_import_audit_counts(import_audit)
+    import_audit_blockers = _paper_route_runtime_window_import_audit_blockers(
+        import_audit
+    )
+    source_activity_blockers = _paper_route_source_activity_blockers(
+        import_audit_blockers
+    )
     health_gate_summary = _runtime_window_import_health_gate_summary(
         plan=plan,
         targets=paper_targets,
@@ -778,9 +833,69 @@ def build_runtime_ledger_proof_packet(
     runtime_import_due = (
         import_ready and not paper_import_blockers and not health_gate_blockers
     )
+    _check(
+        checks,
+        "paper_route_runtime_window_import_audit",
+        passed=not runtime_import_due or bool(import_audit),
+        observed={
+            "present": bool(import_audit),
+            "state": _text(import_audit.get("state"), "missing"),
+            "next_action": _text(import_audit.get("next_action")),
+            "import_ready": import_audit.get("import_ready"),
+            "blockers": import_audit_blockers,
+        },
+        expected="paper-route evidence includes runtime_window_import_audit when import is due",
+        blockers=[]
+        if (not runtime_import_due or bool(import_audit))
+        else ["runtime_window_import_audit_missing"],
+    )
+    if runtime_import_due and not import_audit:
+        _extend_unique(blockers, ["runtime_window_import_audit_missing"])
+
+    source_target_count = _int(import_audit_counts.get("source_plan_target_count"))
+    targets_with_source_activity = _int(
+        import_audit_counts.get("targets_with_source_activity")
+    )
+    source_activity_ok = (
+        not runtime_import_due
+        or not import_audit
+        or (
+            source_target_count > 0
+            and targets_with_source_activity >= source_target_count
+            and not source_activity_blockers
+        )
+    )
+    _check(
+        checks,
+        "paper_route_source_activity",
+        passed=source_activity_ok,
+        observed={
+            "runtime_import_due": runtime_import_due,
+            "source_plan_target_count": source_target_count,
+            "targets_with_source_activity": targets_with_source_activity,
+            "blockers": source_activity_blockers,
+        },
+        expected="paper-route source decisions, executions, and TCA exist for every import target when runtime import is due",
+        blockers=source_activity_blockers
+        or ([] if source_activity_ok else ["paper_route_source_activity_missing"]),
+    )
+    if not source_activity_ok:
+        _extend_unique(
+            blockers,
+            source_activity_blockers or ["paper_route_source_activity_missing"],
+        )
+
     runtime_import = _runtime_window_import_payload(runtime_window_import)
     runtime_import_items = _runtime_window_import_items(runtime_import)
     runtime_import_blockers = _runtime_import_blockers(runtime_import)
+    runtime_import_check_blockers = list(runtime_import_blockers)
+    if (
+        runtime_import_due
+        and import_audit
+        and not runtime_import_check_blockers
+        and import_audit_blockers
+    ):
+        runtime_import_check_blockers = list(import_audit_blockers)
     authoritative_observation_count = _runtime_import_authoritative_observation_count(
         runtime_import
     )
@@ -806,9 +921,11 @@ def build_runtime_ledger_proof_packet(
             "runtime_import_due": runtime_import_due,
             "authoritative_observation_count": authoritative_observation_count,
             "proof_blockers": runtime_import_blockers,
+            "import_audit_state": _text(import_audit.get("state"), "missing"),
+            "import_audit_blockers": import_audit_blockers,
         },
         expected="runtime-window import proof_status ok with authoritative runtime observations and no proof blockers",
-        blockers=runtime_import_blockers
+        blockers=runtime_import_check_blockers
         or (
             []
             if runtime_import_ok or not runtime_import_due
@@ -817,6 +934,8 @@ def build_runtime_ledger_proof_packet(
     )
     if runtime_import_blockers:
         _extend_unique(blockers, runtime_import_blockers)
+    elif runtime_import_due and import_audit_blockers:
+        _extend_unique(blockers, import_audit_blockers)
     elif runtime_import_due and not runtime_import_ok:
         _extend_unique(blockers, ["runtime_window_import_missing"])
 
@@ -998,6 +1117,14 @@ def build_runtime_ledger_proof_packet(
                 "import_blockers": paper_import_blockers,
                 "session_window": _mapping(plan.get("session_window")),
                 "runtime_window_import_health_gate": health_gate_summary,
+            },
+            "paper_route_runtime_window_import_audit": {
+                "present": bool(import_audit),
+                "state": import_audit.get("state"),
+                "next_action": import_audit.get("next_action"),
+                "import_ready": import_audit.get("import_ready"),
+                "blockers": import_audit_blockers,
+                "counts": dict(import_audit_counts),
             },
             "runtime_window_import": {
                 "present": bool(runtime_import),

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -59,9 +59,10 @@ def _paper_route_evidence(
     *,
     import_ready: bool = True,
     import_blockers: list[str] | None = None,
+    import_audit: dict[str, object] | None = None,
 ) -> dict[str, object]:
     blockers = import_blockers if import_blockers is not None else []
-    return {
+    payload: dict[str, object] = {
         "schema_version": "torghut.paper-route-evidence.v1",
         "next_paper_route_runtime_window_targets": {
             "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
@@ -109,6 +110,33 @@ def _paper_route_evidence(
             ],
         },
     }
+    if import_audit is not None:
+        payload["runtime_window_import_audit"] = import_audit
+    else:
+        payload["runtime_window_import_audit"] = {
+            "schema_version": "torghut.paper-route-runtime-window-import-audit.v1",
+            "state": "runtime_ledger_ready_for_gate_review"
+            if import_ready
+            else "waiting_for_session_open",
+            "next_action": "review_runtime_ledger_profit_gates"
+            if import_ready
+            else "wait_for_regular_session_open",
+            "import_ready": import_ready,
+            "blockers": blockers,
+            "counts": {
+                "source_plan_target_count": 1,
+                "next_runtime_window_target_count": 1,
+                "targets_with_source_activity": 1 if import_ready else 0,
+                "targets_with_runtime_ledger": 1 if import_ready else 0,
+                "targets_with_evidence_grade_runtime_ledger": 1 if import_ready else 0,
+                "targets_with_promotion_decision": 1 if import_ready else 0,
+            },
+            "promotion_authority": {
+                "allowed": False,
+                "reason": "runtime_window_import_audit_observability_only",
+            },
+        }
+    return payload
 
 
 def _runtime_import(
@@ -447,6 +475,94 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result["checks"]["runtime_window_import_proof"]["observed"][
                 "runtime_import_due"
             ]
+        )
+
+    def test_packet_blocks_with_source_activity_audit_before_generic_import_missing(
+        self,
+    ) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(
+                import_ready=True,
+                import_audit={
+                    "schema_version": (
+                        "torghut.paper-route-runtime-window-import-audit.v1"
+                    ),
+                    "state": "import_due_source_activity_missing",
+                    "next_action": "inspect_paper_route_source_activity_before_import",
+                    "import_ready": True,
+                    "blockers": [
+                        "paper_route_source_activity_missing",
+                        "source_decisions_missing",
+                        "source_executions_missing",
+                        "source_tca_missing",
+                    ],
+                    "counts": {
+                        "source_plan_target_count": 1,
+                        "next_runtime_window_target_count": 1,
+                        "targets_with_source_activity": 0,
+                        "targets_with_runtime_ledger": 0,
+                        "targets_with_evidence_grade_runtime_ledger": 0,
+                        "targets_with_promotion_decision": 0,
+                    },
+                },
+            ),
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn(
+            "paper_route_source_activity",
+            result["promotion_authority"]["failed_checks"],
+        )
+        self.assertIn(
+            "paper_route_source_activity_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "source_decisions_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "inspect_paper_route_source_activity_before_import",
+            result["required_actions"],
+        )
+        self.assertEqual(
+            result["checks"]["runtime_window_import_proof"]["observed"][
+                "import_audit_state"
+            ],
+            "import_due_source_activity_missing",
+        )
+        self.assertEqual(
+            result["evidence"]["paper_route_runtime_window_import_audit"]["state"],
+            "import_due_source_activity_missing",
+        )
+
+    def test_packet_requires_import_audit_when_paper_route_import_is_due(
+        self,
+    ) -> None:
+        paper = _paper_route_evidence(import_ready=True)
+        paper.pop("runtime_window_import_audit")
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=paper,
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn(
+            "runtime_window_import_audit_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "inspect_paper_route_evidence_audit",
+            result["required_actions"],
         )
 
     def test_packet_blocks_when_paper_route_import_health_gate_is_not_ready(


### PR DESCRIPTION
## Summary

- Require the runtime-ledger proof packet to consume `/trading/paper-route-evidence` runtime-window import audit data whenever paper-route import is due.
- Surface source-activity blockers such as `paper_route_source_activity_missing`, `source_decisions_missing`, `source_executions_missing`, and `source_tca_missing` before generic runtime-import-missing verdicts.
- Document the scheduled renewal CronJob as the post-window proof packet conductor and how to interpret source-activity versus ledger-import blockers.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
