### PR TITLE
fix(agents): build control plane with production jsx

### DIFF
--- a/services/agents/Dockerfile
+++ b/services/agents/Dockerfile
@@ -134,6 +134,7 @@ RUN bun --cwd=packages/cx-tools run build
 
 FROM agents-workspace-deps AS agents-build
 WORKDIR /app
+ENV NODE_ENV=production
 RUN rm -rf /app/packages /app/services
 COPY full/ .
 COPY --from=agent-contracts-build /app/packages/agent-contracts /app/packages/agent-contracts


### PR DESCRIPTION
## Summary

- Sets `NODE_ENV=production` in the Agents Docker `agents-build` stage so Vite/TanStack Start emits production SSR JSX.
- Keeps dependency installation in the development stage so build tooling remains available, then switches only the build stage environment.
- Fixes the live `/primitives` 500 caused by `jsxDEV` leaking into the production server bundle.

## Related Issues

None

## Testing

- `bun run --cwd services/agents tsc`
- `bun run --cwd services/agents build` with `NODE_ENV=production`, then verified the emitted server bundle has no `jsxDEV` or `jsx-dev-runtime` references.
- `PORT=3088 NODE_ENV=production bun run --cwd services/agents start`, then `curl -fsS -D - http://127.0.0.1:3088/primitives` returned `200 OK`.
- Docker `agents-build` target with the pruned Agents context, `--platform linux/arm64`, and `--load`; then inspected the built image output for `jsxDEV|jsx-dev-runtime` and found no matches.
- Docker `control-plane` target with the pruned Agents context, `--platform linux/arm64`, and `--load`; then ran the image locally and `curl -fsS -D - http://127.0.0.1:3091/primitives` returned `200 OK`.
- `bun run --cwd services/agents lint`
- `bun run --cwd services/agents test` passed 105 files / 581 tests.

## Screenshots (if applicable)

N/A. This is a Docker build/runtime fix validated with local HTTP and Docker image checks.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
