### PR TITLE
chore(agents): promote images 8a1da949

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: ee5b48c7
-  digest: sha256:a32f5be91b2367d909c81f88fd1079f3c0987e52df0deb40537f6e0e688a5ba6
+  tag: 8a1da949
+  digest: sha256:2dbcb57bc8471d28f05dda0491bd4b37f3f9c6a07679ceb24a5e9ec9c797aaed
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,26 +11,26 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: ee5b48c7
-    digest: sha256:06243c3cb43851b18b4383476234a63406d2e21eaac213ae44aa75139af1673a
+    tag: 8a1da949
+    digest: sha256:95238f1ea23ab5e4a649060beb4757428945e867e740868971effc6bdd6b6cf5
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: ee5b48c7e9c940c1d47418edd855f46c2d251dfe
-      AGENTS_GITOPS_REVISION: ee5b48c7e9c940c1d47418edd855f46c2d251dfe
-      AGENTS_SOURCE_CI_RUN_ID: "26414108420"
+      AGENTS_SOURCE_HEAD_SHA: 8a1da9493d554877c8bad1b568e98896c0b92374
+      AGENTS_GITOPS_REVISION: 8a1da9493d554877c8bad1b568e98896c0b92374
+      AGENTS_SOURCE_CI_RUN_ID: "26415134360"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:06243c3cb43851b18b4383476234a63406d2e21eaac213ae44aa75139af1673a
-      AGENTS_SERVING_BUILD_COMMIT: ee5b48c7e9c940c1d47418edd855f46c2d251dfe
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:06243c3cb43851b18b4383476234a63406d2e21eaac213ae44aa75139af1673a
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:95238f1ea23ab5e4a649060beb4757428945e867e740868971effc6bdd6b6cf5
+      AGENTS_SERVING_BUILD_COMMIT: 8a1da9493d554877c8bad1b568e98896c0b92374
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:95238f1ea23ab5e4a649060beb4757428945e867e740868971effc6bdd6b6cf5
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: ee5b48c7
-    digest: sha256:e170d6c34abc1d7686a7268c3dde9bcca4b1252384f17533820fba1c017f2d37
+    tag: 8a1da949
+    digest: sha256:d3e92318259d397a84afad7c6a9266c000a3b2a0bdf6550cc445060af60bb4ee
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun
@@ -85,8 +85,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: ee5b48c7
-    digest: sha256:a32f5be91b2367d909c81f88fd1079f3c0987e52df0deb40537f6e0e688a5ba6
+    tag: 8a1da949
+    digest: sha256:2dbcb57bc8471d28f05dda0491bd4b37f3f9c6a07679ceb24a5e9ec9c797aaed
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `8a1da9493d554877c8bad1b568e98896c0b92374`
- Image tag: `8a1da949`
- Agents build run: `26415134360`
- Promotion source: `manual_dispatch`