### PR TITLE
fix(synthesis): use published main image tag

### DIFF
--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -9,5 +9,5 @@ resources:
   - networkpolicy.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: latest
+    newTag: main
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary\n- point the synthesis deployment at the Docker workflow's published main tag instead of latest\n\n## Validation\n- kubectl kustomize argocd/applications/synthesis\n- scripts/kubeconform.sh argocd/applications/synthesis