### PR TITLE
chore(symphony): promote image f852e406

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-25T17:52:32Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-25T20:37:39Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c8acae03"
-    digest: sha256:b0613f9fb125068471fd9cea5275d6c8032701d7b9670dac9cfa0fd7623f53ba
+    newTag: "f852e406"
+    digest: sha256:6920ad38219eefd6d3852de078694840fbeb70d3153e9888edf2da9035f52737

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-25T17:52:32Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-25T20:37:39Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c8acae03"
-    digest: sha256:b0613f9fb125068471fd9cea5275d6c8032701d7b9670dac9cfa0fd7623f53ba
+    newTag: "f852e406"
+    digest: sha256:6920ad38219eefd6d3852de078694840fbeb70d3153e9888edf2da9035f52737

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-25T17:52:32Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-25T20:37:39Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c8acae03"
-    digest: sha256:b0613f9fb125068471fd9cea5275d6c8032701d7b9670dac9cfa0fd7623f53ba
+    newTag: "f852e406"
+    digest: sha256:6920ad38219eefd6d3852de078694840fbeb70d3153e9888edf2da9035f52737


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `f852e4067e1aee6fbddb5cf63c330f0e44d3440f`
- Image tag: `f852e406`
- Image digest: `sha256:6920ad38219eefd6d3852de078694840fbeb70d3153e9888edf2da9035f52737`