### PR TITLE
fix(synthesis): simplify feed UI and page infinitely

### DIFF
--- a/apps/synthesis/src/routes/__root.tsx
+++ b/apps/synthesis/src/routes/__root.tsx
@@ -28,7 +28,7 @@ function RootDocument({ children }: { children: ReactNode }) {
       <head>
         <HeadContent />
       </head>
-      <body className="h-dvh overflow-hidden bg-[#f4f1ea] text-[#201c18]">
+      <body className="h-dvh overflow-hidden bg-black text-[#e7e9ea]">
         {children}
         <Scripts />
       </body>

--- a/apps/synthesis/src/routes/index.tsx
+++ b/apps/synthesis/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import {
   ArrowUpRight,
@@ -6,14 +6,23 @@ import {
   Clock3,
   ExternalLink,
   Filter,
+  Home,
   MessageCircle,
   RefreshCw,
   Search,
+  Sparkles,
   ThumbsUp,
   X,
 } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import type { AnchorHTMLAttributes, ButtonHTMLAttributes, HTMLAttributes, InputHTMLAttributes, ReactNode } from 'react'
+import type {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  InputHTMLAttributes,
+  ReactNode,
+  UIEvent,
+} from 'react'
 import type { FeedResponse, SynthesisItem } from '~/server/schema'
 
 export const Route = createFileRoute('/')({
@@ -24,17 +33,16 @@ const defaultTags = ['semis', 'devtools', 'ai agents', 'quant', 'options', 'ml',
 
 const cx = (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(' ')
 
-type ButtonVariant = 'primary' | 'outline' | 'ghost' | 'soft'
+type ButtonVariant = 'primary' | 'ghost' | 'subtle'
 type ButtonSize = 'default' | 'sm' | 'icon'
 
 const buttonClass = (variant: ButtonVariant = 'primary', size: ButtonSize = 'default', className?: string) =>
   cx(
-    'inline-flex shrink-0 items-center justify-center gap-1.5 rounded-md border text-sm font-medium tracking-normal transition-colors outline-none focus-visible:ring-2 focus-visible:ring-[#1f7a6f]/25 disabled:pointer-events-none disabled:opacity-50',
-    variant === 'primary' && 'border-[#1f7a6f] bg-[#1f7a6f] text-white hover:bg-[#17665e]',
-    variant === 'outline' && 'border-[#d8d2c6] bg-white text-[#201c18] hover:border-[#bfb6a8] hover:bg-[#f8f6f1]',
-    variant === 'ghost' && 'border-transparent bg-transparent text-[#625b50] hover:bg-[#eee8dd] hover:text-[#201c18]',
-    variant === 'soft' && 'border-[#d9efe9] bg-[#e8f5f1] text-[#17665e] hover:bg-[#d7ede7]',
-    size === 'default' && 'h-9 px-3',
+    'inline-flex shrink-0 items-center justify-center gap-2 rounded-full text-sm font-semibold tracking-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-[#1d9bf0]/40 disabled:pointer-events-none disabled:opacity-50',
+    variant === 'primary' && 'bg-[#eff3f4] text-black hover:bg-[#d7dbdc]',
+    variant === 'ghost' && 'bg-transparent text-[#e7e9ea] hover:bg-[#181818]',
+    variant === 'subtle' && 'border border-[#2f3336] bg-transparent text-[#e7e9ea] hover:bg-[#080808]',
+    size === 'default' && 'h-10 px-4',
     size === 'sm' && 'h-8 px-3 text-xs',
     size === 'icon' && 'size-9',
     className,
@@ -51,7 +59,7 @@ function Button({
 
 function AnchorButton({
   className,
-  variant = 'primary',
+  variant = 'ghost',
   size = 'default',
   ...props
 }: AnchorHTMLAttributes<HTMLAnchorElement> & { variant?: ButtonVariant; size?: ButtonSize }) {
@@ -62,27 +70,7 @@ function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
   return (
     <input
       className={cx(
-        'h-10 w-full min-w-0 rounded-md border border-[#d8d2c6] bg-white px-3 text-sm text-[#201c18] outline-none transition-colors placeholder:text-[#8b8378] focus:border-[#1f7a6f] focus:ring-2 focus:ring-[#1f7a6f]/15',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
-
-function Badge({
-  className,
-  variant = 'neutral',
-  ...props
-}: HTMLAttributes<HTMLSpanElement> & { variant?: 'neutral' | 'teal' | 'amber' | 'rose' }) {
-  return (
-    <span
-      className={cx(
-        'inline-flex h-6 w-fit shrink-0 items-center justify-center gap-1 rounded-md border px-2 text-xs font-medium',
-        variant === 'neutral' && 'border-[#ddd6ca] bg-[#f7f4ee] text-[#5d554b]',
-        variant === 'teal' && 'border-[#cfe8e1] bg-[#edf8f4] text-[#17665e]',
-        variant === 'amber' && 'border-[#ead8af] bg-[#fff7df] text-[#8a5a09]',
-        variant === 'rose' && 'border-[#f0c7c7] bg-[#fff0ef] text-[#9a3412]',
+        'h-11 w-full min-w-0 rounded-full border border-transparent bg-[#202327] px-4 text-[15px] text-[#e7e9ea] outline-none transition-colors placeholder:text-[#71767b] focus:border-[#1d9bf0] focus:bg-black',
         className,
       )}
       {...props}
@@ -111,22 +99,18 @@ const formatDate = (value: string | null) => {
 }
 
 const statusIcon = (status: SynthesisItem['engagementStatus']) => {
-  if (status === 'queued') return <Clock3 className="size-4" />
-  if (status === 'sent') return <CheckCircle2 className="size-4" />
-  if (status === 'failed') return <X className="size-4" />
-  return <Filter className="size-4" />
+  if (status === 'queued') return <Clock3 className="size-3.5" />
+  if (status === 'sent') return <CheckCircle2 className="size-3.5" />
+  if (status === 'failed') return <X className="size-3.5" />
+  return <Filter className="size-3.5" />
 }
 
-const statusVariant = (status: SynthesisItem['engagementStatus']) => {
-  if (status === 'queued') return 'amber' as const
-  if (status === 'failed') return 'rose' as const
-  if (status === 'sent') return 'teal' as const
-  return 'neutral' as const
-}
+const formatScore = (value: number) => Math.round(value * 100)
 
-async function fetchFeed(tag: string, minScore: number): Promise<FeedResponse> {
-  const params = new URLSearchParams({ limit: '60', minScore: String(minScore) })
+async function fetchFeed(tag: string, minScore: number, cursor?: string): Promise<FeedResponse> {
+  const params = new URLSearchParams({ limit: '24', minScore: String(minScore) })
   if (tag !== 'all') params.set('tag', tag)
+  if (cursor) params.set('cursor', cursor)
   const response = await fetch(`/api/feed?${params.toString()}`)
   if (!response.ok) throw new Error(`feed request failed: ${response.status}`)
   return (await response.json()) as FeedResponse
@@ -139,168 +123,131 @@ function App() {
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [mobileDetailOpen, setMobileDetailOpen] = useState(false)
 
-  const feed = useQuery({
+  const feed = useInfiniteQuery({
     queryKey: ['synthesis-feed', tag, minScore],
-    queryFn: () => fetchFeed(tag, minScore),
+    queryFn: ({ pageParam }) => fetchFeed(tag, minScore, pageParam),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     refetchInterval: 45_000,
   })
 
+  const loadedItems = useMemo(() => feed.data?.pages.flatMap((page) => page.items) ?? [], [feed.data?.pages])
+
   const items = useMemo(() => {
     const lowered = query.trim().toLowerCase()
-    const base = feed.data?.items ?? []
-    if (!lowered) return base
-    return base.filter((item) =>
+    if (!lowered) return loadedItems
+    return loadedItems.filter((item) =>
       [item.summary, item.whyValuable, item.observedText, item.authorHandle, item.topicTags.join(' ')]
         .filter(Boolean)
         .some((value) => value?.toLowerCase().includes(lowered)),
     )
-  }, [feed.data?.items, query])
+  }, [loadedItems, query])
 
   const selectedItem = items.find((item) => item.id === selectedId) ?? items[0] ?? null
-  const highSignalCount = items.filter((item) => item.score >= 0.85).length
-  const queuedCount = items.filter((item) => item.engagementStatus === 'queued').length
+  const highSignalCount = loadedItems.filter((item) => item.score >= 0.85).length
+  const queuedCount = loadedItems.filter((item) => item.engagementStatus === 'queued').length
+
+  const fetchNextPage = () => {
+    if (feed.hasNextPage && !feed.isFetchingNextPage) {
+      void feed.fetchNextPage()
+    }
+  }
+
+  const loadMoreIfNeeded = (event: UIEvent<HTMLDivElement>) => {
+    const target = event.currentTarget
+    const distanceToBottom = target.scrollHeight - target.scrollTop - target.clientHeight
+    if (distanceToBottom < 720) fetchNextPage()
+  }
 
   return (
-    <main className="grid h-dvh w-full grid-cols-1 overflow-hidden bg-[#f4f1ea] text-[#201c18] lg:grid-cols-[280px_minmax(0,1fr)_440px]">
-      <aside className="hidden min-h-0 border-r border-[#ddd6ca] bg-[#eee8dd] lg:flex lg:flex-col">
-        <div className="px-5 py-5">
-          <div className="flex items-center gap-2 text-sm font-medium text-[#5d554b]">
-            <span className="size-2 rounded-full bg-[#1f7a6f]" />
-            synthesis
+    <main className="grid h-dvh w-full grid-cols-1 overflow-hidden bg-black text-[#e7e9ea] xl:grid-cols-[244px_minmax(0,640px)_minmax(340px,1fr)]">
+      <aside className="hidden min-h-0 justify-end border-r border-[#2f3336] bg-black xl:flex">
+        <div className="flex w-[244px] flex-col px-2 py-3">
+          <div className="mb-2 flex size-12 items-center justify-center rounded-full">
+            <Sparkles className="size-7" />
           </div>
-          <h1 className="mt-3 text-2xl font-semibold tracking-normal text-[#181512]">Feed synthesis</h1>
-          <p className="mt-2 text-sm leading-6 text-[#6f675d]">Signal-dense X posts, condensed for review.</p>
-        </div>
-
-        <div className="grid grid-cols-2 gap-2 px-5">
-          <RailMetric label="items" value={String(items.length)} />
-          <RailMetric label="high signal" value={String(highSignalCount)} />
-          <RailMetric label="queued" value={String(queuedCount)} />
-          <RailMetric label="score" value={minScore.toFixed(2)} />
-        </div>
-
-        <div className="mt-5 border-y border-[#ddd6ca] px-5 py-4">
-          <div className="mb-3 flex items-center justify-between gap-3">
-            <span className="text-xs font-semibold uppercase tracking-[0.14em] text-[#7b7368]">minimum score</span>
-            <span className="text-sm font-semibold text-[#201c18]">{minScore.toFixed(2)}</span>
+          <nav className="grid gap-1">
+            <RailButton active icon={<Home className="size-6" />}>
+              Home
+            </RailButton>
+            <RailButton icon={<Search className="size-6" />}>Explore</RailButton>
+            <RailButton icon={<Filter className="size-6" />}>Filters</RailButton>
+          </nav>
+          <Button className="mt-5 h-12 w-full">Curate</Button>
+          <div className="mt-auto px-3 py-4 text-sm leading-6 text-[#71767b]">
+            <p>synthesis feed</p>
+            <p>{loadedItems.length} loaded</p>
           </div>
-          <input
-            aria-label="Minimum score"
-            type="range"
-            min="0"
-            max="1"
-            step="0.05"
-            value={minScore}
-            onChange={(event) => setMinScore(Number(event.target.value))}
-            className="h-2 w-full accent-[#1f7a6f]"
-          />
         </div>
-
-        <ScrollArea className="flex-1 px-5 py-4">
-          <div className="grid gap-2">
-            {['all', ...defaultTags].map((value) => (
-              <Button
-                key={value}
-                size="sm"
-                variant={tag === value ? 'soft' : 'ghost'}
-                className="w-full justify-start"
-                onClick={() => setTag(value)}
-              >
-                {value}
-              </Button>
-            ))}
-          </div>
-        </ScrollArea>
       </aside>
 
-      <section className="flex min-w-0 flex-col">
-        <header className="border-b border-[#ddd6ca] bg-[#fbfaf7]/90 px-4 py-4 backdrop-blur md:px-6">
-          <div className="flex flex-wrap items-center justify-between gap-3">
+      <section className="flex min-w-0 flex-col border-x border-[#2f3336] bg-black">
+        <header className="sticky top-0 z-10 border-b border-[#2f3336] bg-black/85 px-4 py-3 backdrop-blur">
+          <div className="flex items-center justify-between gap-3">
             <div className="min-w-0">
-              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[#7b7368]">x.com / for you</p>
-              <h2 className="mt-1 text-2xl font-semibold tracking-normal text-[#181512] md:text-3xl">
-                Intelligence queue
-              </h2>
+              <h1 className="text-xl font-bold tracking-normal">For You</h1>
+              <p className="mt-0.5 text-xs text-[#71767b]">{loadedItems.length} loaded</p>
             </div>
             <Button
               size="icon"
-              variant="outline"
+              variant="ghost"
               onClick={() => feed.refetch()}
               aria-label="Refresh feed"
               title="Refresh feed"
             >
-              <RefreshCw className={cx('size-4', feed.isFetching && 'animate-spin')} />
+              <RefreshCw className={cx('size-5 text-[#1d9bf0]', feed.isFetching && 'animate-spin')} />
             </Button>
           </div>
 
-          <div className="mt-4 flex flex-wrap items-center gap-3">
-            <div className="relative min-w-[240px] flex-1">
-              <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[#8b8378]" />
+          <div className="mt-3">
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-[#71767b]" />
               <Input
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
-                placeholder="filter summaries, authors, tags"
-                className="pl-9"
+                placeholder="Search Synthesis"
+                className="pl-11"
               />
-            </div>
-            <div className="flex items-center gap-2 lg:hidden">
-              <span className="text-xs font-semibold uppercase tracking-[0.12em] text-[#7b7368]">score</span>
-              <input
-                aria-label="Minimum score"
-                type="range"
-                min="0"
-                max="1"
-                step="0.05"
-                value={minScore}
-                onChange={(event) => setMinScore(Number(event.target.value))}
-                className="h-2 w-24 accent-[#1f7a6f]"
-              />
-              <span className="w-9 text-right text-sm font-semibold text-[#201c18]">{minScore.toFixed(2)}</span>
             </div>
           </div>
 
-          <div className="mt-3 flex gap-2 overflow-x-auto pb-1 lg:hidden">
+          <div className="-mx-4 mt-3 flex gap-1 overflow-x-auto border-t border-[#2f3336] px-4 pt-2">
             {['all', ...defaultTags].map((value) => (
-              <Button
+              <button
                 key={value}
-                size="sm"
-                variant={tag === value ? 'soft' : 'outline'}
-                className="shrink-0"
+                type="button"
+                className={cx(
+                  'shrink-0 rounded-full px-3 py-2 text-sm font-semibold tracking-normal transition-colors hover:bg-[#080808]',
+                  tag === value ? 'text-[#1d9bf0]' : 'text-[#e7e9ea]',
+                )}
                 onClick={() => setTag(value)}
               >
                 {value}
-              </Button>
+              </button>
             ))}
           </div>
         </header>
 
-        <ScrollArea className="flex-1 px-4 py-4 md:px-6">
+        <ScrollArea className="flex-1" onScroll={loadMoreIfNeeded}>
           {feed.isLoading ? (
-            <div className="grid gap-3">
-              {Array.from({ length: 6 }, (_, index) => (
-                <div key={index} className="h-[154px] rounded-lg border border-[#ddd6ca] bg-white p-4">
-                  <div className="mb-4 h-4 w-1/3 rounded bg-[#eee8dd] animate-pulse" />
-                  <div className="mb-2 h-4 w-full rounded bg-[#eee8dd] animate-pulse" />
-                  <div className="mb-4 h-4 w-5/6 rounded bg-[#eee8dd] animate-pulse" />
-                  <div className="flex gap-2">
-                    <div className="h-6 w-20 rounded bg-[#eee8dd] animate-pulse" />
-                    <div className="h-6 w-24 rounded bg-[#eee8dd] animate-pulse" />
-                  </div>
-                </div>
+            <div>
+              {Array.from({ length: 7 }, (_, index) => (
+                <TimelineSkeleton key={index} />
               ))}
             </div>
           ) : feed.error ? (
-            <div role="alert" className="rounded-lg border border-[#e7b8b8] bg-[#fff3f2] p-4 text-sm text-[#9a3412]">
+            <div role="alert" className="border-b border-[#2f3336] px-4 py-5 text-sm text-[#ff7a85]">
               {feed.error instanceof Error ? feed.error.message : 'feed unavailable'}
             </div>
           ) : items.length === 0 ? (
-            <div className="rounded-lg border border-[#ddd6ca] bg-white p-8 text-sm text-[#6f675d]">
-              No synthesis items match the current filters.
+            <div className="px-8 py-16 text-center">
+              <h2 className="text-2xl font-bold">No signal here yet</h2>
+              <p className="mt-2 text-[15px] leading-6 text-[#71767b]">Try a different tag or lower the score floor.</p>
             </div>
           ) : (
-            <div className="grid gap-3">
+            <>
               {items.map((item) => (
-                <FeedCard
+                <FeedPost
                   key={item.id}
                   item={item}
                   selected={selectedItem?.id === item.id}
@@ -310,17 +257,31 @@ function App() {
                   }}
                 />
               ))}
-            </div>
+              <InfiniteFooter
+                hasNextPage={Boolean(feed.hasNextPage)}
+                isFetchingNextPage={feed.isFetchingNextPage}
+                onLoadMore={fetchNextPage}
+              />
+            </>
           )}
         </ScrollArea>
       </section>
 
-      <aside className="hidden min-h-0 border-l border-[#ddd6ca] bg-[#fbfaf7] lg:flex">
-        {selectedItem ? <DetailPane item={selectedItem} /> : null}
+      <aside className="hidden min-h-0 bg-black xl:flex">
+        <div className="w-full max-w-[400px] px-5 py-3">
+          <FeedControls
+            minScore={minScore}
+            setMinScore={setMinScore}
+            loadedItems={loadedItems}
+            highSignalCount={highSignalCount}
+            queuedCount={queuedCount}
+          />
+          {selectedItem ? <DetailPane item={selectedItem} /> : null}
+        </div>
       </aside>
 
       {mobileDetailOpen && selectedItem ? (
-        <div className="fixed inset-0 z-50 flex flex-col bg-[#fbfaf7] lg:hidden">
+        <div className="fixed inset-0 z-50 flex flex-col bg-black xl:hidden">
           <DetailPane item={selectedItem} onClose={() => setMobileDetailOpen(false)} />
         </div>
       ) : null}
@@ -328,61 +289,167 @@ function App() {
   )
 }
 
-function FeedCard({ item, selected, onSelect }: { item: SynthesisItem; selected: boolean; onSelect: () => void }) {
+function RailButton({ active, icon, children }: { active?: boolean; icon: ReactNode; children: ReactNode }) {
   return (
     <button
       type="button"
-      onClick={onSelect}
       className={cx(
-        'group rounded-lg border bg-white p-4 text-left shadow-[0_1px_0_rgba(32,28,24,0.04)] transition-colors',
-        selected ? 'border-[#1f7a6f] ring-2 ring-[#1f7a6f]/10' : 'border-[#ddd6ca] hover:border-[#bfb6a8]',
+        'flex w-fit items-center gap-4 rounded-full px-4 py-3 text-xl tracking-normal transition-colors hover:bg-[#181818]',
+        active ? 'font-bold text-[#e7e9ea]' : 'font-normal text-[#e7e9ea]',
       )}
     >
-      <div className="flex items-start justify-between gap-4">
+      {icon}
+      <span>{children}</span>
+    </button>
+  )
+}
+
+function FeedControls({
+  minScore,
+  setMinScore,
+  loadedItems,
+  highSignalCount,
+  queuedCount,
+}: {
+  minScore: number
+  setMinScore: (value: number) => void
+  loadedItems: SynthesisItem[]
+  highSignalCount: number
+  queuedCount: number
+}) {
+  return (
+    <section className="border-b border-[#2f3336] pb-5">
+      <h2 className="text-xl font-bold tracking-normal">Synthesis</h2>
+      <p className="mt-2 text-sm leading-6 text-[#71767b]">
+        {loadedItems.length} loaded · {highSignalCount} high signal · {queuedCount} queued
+      </p>
+      <label className="mt-5 block">
+        <span className="flex items-center justify-between text-sm">
+          <span className="font-semibold">Minimum score</span>
+          <span className="text-[#71767b]">{minScore.toFixed(2)}</span>
+        </span>
+        <input
+          aria-label="Minimum score"
+          type="range"
+          min="0"
+          max="1"
+          step="0.05"
+          value={minScore}
+          onChange={(event) => setMinScore(Number(event.target.value))}
+          className="mt-3 h-2 w-full accent-[#1d9bf0]"
+        />
+      </label>
+    </section>
+  )
+}
+
+function FeedPost({ item, selected, onSelect }: { item: SynthesisItem; selected: boolean; onSelect: () => void }) {
+  return (
+    <article
+      className={cx(
+        'cursor-pointer border-b border-[#2f3336] px-4 py-4 hover:bg-[#080808]',
+        selected && 'bg-white/[0.03]',
+      )}
+      onClick={onSelect}
+    >
+      <div className="flex gap-3">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[#202327] text-sm font-bold text-[#e7e9ea]">
+          {(item.authorHandle?.[0] ?? 'x').toUpperCase()}
+        </div>
         <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2 text-xs text-[#7b7368]">
-            <span className="font-semibold text-[#5d554b]">
-              {item.authorHandle ? `@${item.authorHandle}` : 'x.com'}
+          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[15px]">
+            <span className="font-bold">{item.authorName ?? item.authorHandle ?? 'x.com'}</span>
+            <span className="truncate text-[#71767b]">
+              {item.authorHandle ? `@${item.authorHandle}` : '@synthesis'}
             </span>
-            <span>{formatDate(item.observedAt)}</span>
-            <Badge variant={statusVariant(item.engagementStatus)} className="h-5">
+            <span className="text-[#71767b]">·</span>
+            <span className="text-[#71767b]">{formatDate(item.observedAt)}</span>
+          </div>
+
+          <p className="mt-2 text-[15px] leading-6">{item.summary}</p>
+          {item.whyValuable ? <p className="mt-2 text-[15px] leading-6 text-[#71767b]">{item.whyValuable}</p> : null}
+
+          <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-[#71767b]">
+            <span>score {formatScore(item.score)}</span>
+            <span>confidence {formatScore(item.confidence)}</span>
+            <span className="inline-flex items-center gap-1">
               {statusIcon(item.engagementStatus)}
               {item.engagementStatus}
-            </Badge>
+            </span>
           </div>
-          <p className="mt-3 line-clamp-2 text-base font-semibold leading-6 tracking-normal text-[#181512]">
-            {item.summary}
-          </p>
-          {item.whyValuable ? (
-            <p className="mt-2 line-clamp-2 text-sm leading-6 text-[#6f675d]">{item.whyValuable}</p>
-          ) : null}
-        </div>
-        <div className="flex size-14 shrink-0 flex-col items-center justify-center rounded-lg border border-[#cfe8e1] bg-[#edf8f4] text-[#17665e]">
-          <span className="text-lg font-semibold">{Math.round(item.score * 100)}</span>
-          <span className="text-[10px] font-semibold uppercase tracking-[0.1em]">score</span>
-        </div>
-      </div>
 
-      <div className="mt-4 flex flex-wrap items-center gap-2">
-        {item.topicTags.slice(0, 5).map((topic) => (
-          <Badge key={topic}>{topic}</Badge>
-        ))}
-        <span className="ml-auto hidden text-xs text-[#8b8378] md:inline">run {item.runId.slice(0, 8)}</span>
+          <div className="mt-3 flex flex-wrap gap-x-3 gap-y-1 text-sm text-[#71767b]">
+            {item.topicTags.slice(0, 5).map((topic) => (
+              <span key={topic}>#{topic}</span>
+            ))}
+          </div>
+
+          <div className="mt-3 flex max-w-md justify-between text-[#71767b]">
+            <span className="inline-flex items-center gap-2 text-sm">
+              <MessageCircle className="size-4" />
+              {item.engagementRecommendation === 'reply' ? 'reply queued' : 'reply'}
+            </span>
+            <span className="inline-flex items-center gap-2 text-sm">
+              <ThumbsUp className="size-4" />
+              {item.engagementRecommendation === 'like' ? 'like queued' : 'like'}
+            </span>
+            <span className="inline-flex items-center gap-2 text-sm">
+              <ArrowUpRight className="size-4" />
+              original
+            </span>
+          </div>
+        </div>
       </div>
-    </button>
+    </article>
+  )
+}
+
+const InfiniteFooter = ({
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+}: {
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  onLoadMore: () => void
+}) => (
+  <div className="border-b border-[#2f3336] px-4 py-6 text-center">
+    {hasNextPage ? (
+      <Button variant="ghost" onClick={onLoadMore} disabled={isFetchingNextPage}>
+        {isFetchingNextPage ? 'Loading more' : 'Show more'}
+      </Button>
+    ) : (
+      <span className="text-sm text-[#71767b]">End of loaded synthesis</span>
+    )}
+  </div>
+)
+
+function TimelineSkeleton() {
+  return (
+    <div className="border-b border-[#2f3336] px-4 py-4">
+      <div className="flex gap-3">
+        <div className="size-10 rounded-full bg-[#202327] animate-pulse" />
+        <div className="flex-1">
+          <div className="mb-3 h-4 w-1/3 rounded bg-[#202327] animate-pulse" />
+          <div className="mb-2 h-4 w-full rounded bg-[#202327] animate-pulse" />
+          <div className="mb-2 h-4 w-5/6 rounded bg-[#202327] animate-pulse" />
+          <div className="h-4 w-2/3 rounded bg-[#202327] animate-pulse" />
+        </div>
+      </div>
+    </div>
   )
 }
 
 function DetailPane({ item, onClose }: { item: SynthesisItem; onClose?: () => void }) {
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <header className="border-b border-[#ddd6ca] px-5 py-5">
-        <div className="mb-4 flex items-start justify-between gap-3">
+    <div className="flex min-h-0 flex-1 flex-col bg-black xl:border-b xl:border-[#2f3336]">
+      <header className="border-b border-[#2f3336] px-4 py-4 xl:px-0">
+        <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
-            <p className="truncate text-sm font-semibold text-[#5d554b]">
-              {item.authorHandle ? `@${item.authorHandle}` : 'x.com'}
+            <p className="truncate text-sm font-semibold text-[#71767b]">
+              {item.authorHandle ? `@${item.authorHandle}` : '@synthesis'}
             </p>
-            <h2 className="mt-1 text-2xl font-semibold tracking-normal text-[#181512]">Post detail</h2>
+            <h2 className="mt-1 text-xl font-bold tracking-normal">Post detail</h2>
           </div>
           <div className="flex shrink-0 items-center gap-2">
             <AnchorButton
@@ -390,45 +457,39 @@ function DetailPane({ item, onClose }: { item: SynthesisItem; onClose?: () => vo
               target="_blank"
               rel="noreferrer"
               size="icon"
-              variant="outline"
               aria-label="Open original post"
             >
-              <ExternalLink className="size-4" />
+              <ExternalLink className="size-5" />
             </AnchorButton>
             {onClose ? (
-              <Button size="icon" variant="outline" onClick={onClose} aria-label="Close detail">
-                <X className="size-4" />
+              <Button size="icon" variant="ghost" onClick={onClose} aria-label="Close detail">
+                <X className="size-5" />
               </Button>
             ) : null}
           </div>
         </div>
-        <div className="grid grid-cols-3 gap-2">
-          <Metric label="score" value={item.score.toFixed(2)} />
-          <Metric label="confidence" value={item.confidence.toFixed(2)} />
-          <Metric label="state" value={item.engagementStatus} />
-        </div>
+        <p className="mt-3 text-sm leading-6 text-[#71767b]">
+          score {formatScore(item.score)} · confidence {formatScore(item.confidence)} · {item.engagementStatus}
+        </p>
       </header>
 
-      <ScrollArea className="flex-1 px-5 py-5">
+      <ScrollArea className="flex-1 px-4 py-4 xl:px-0">
         <div className="grid gap-5">
-          <DetailSection title="summary">
-            <p className="text-base font-semibold leading-7 text-[#181512]">{item.summary}</p>
+          <DetailSection title="Summary">
+            <p className="text-[15px] leading-6">{item.summary}</p>
           </DetailSection>
 
           {item.whyValuable ? (
-            <DetailSection title="why it matters">
-              <p className="text-sm leading-6 text-[#514a42]">{item.whyValuable}</p>
+            <DetailSection title="Why it matters">
+              <p className="text-[15px] leading-6 text-[#d6d9db]">{item.whyValuable}</p>
             </DetailSection>
           ) : null}
 
           {item.evidence.length ? (
-            <DetailSection title="evidence">
-              <ul className="grid gap-2">
+            <DetailSection title="Evidence">
+              <ul className="grid gap-2 text-sm leading-6 text-[#d6d9db]">
                 {item.evidence.map((line) => (
-                  <li
-                    key={line}
-                    className="rounded-lg border border-[#ddd6ca] bg-white p-3 text-sm leading-6 text-[#514a42]"
-                  >
+                  <li key={line} className="border-l border-[#2f3336] pl-3">
                     {line}
                   </li>
                 ))}
@@ -436,28 +497,17 @@ function DetailPane({ item, onClose }: { item: SynthesisItem; onClose?: () => vo
             </DetailSection>
           ) : null}
 
-          <DetailSection title="observed post">
-            <p className="whitespace-pre-wrap rounded-lg border border-[#ddd6ca] bg-white p-3 font-mono text-xs leading-6 text-[#514a42]">
+          <DetailSection title="Observed post">
+            <p className="whitespace-pre-wrap border-l border-[#2f3336] pl-3 text-sm leading-6 text-[#d6d9db]">
               {item.observedText}
             </p>
           </DetailSection>
 
-          <DetailSection title="actions">
-            <div className="flex flex-wrap gap-2">
-              <Badge variant="teal">
-                <ThumbsUp className="size-3.5" />
-                {item.engagementRecommendation}
-              </Badge>
-              {item.replyText ? (
-                <Badge variant="amber">
-                  <MessageCircle className="size-3.5" />
-                  {item.replyText}
-                </Badge>
-              ) : null}
-              <AnchorButton href={item.originalUrl} target="_blank" rel="noreferrer" size="sm" variant="outline">
-                <ArrowUpRight className="size-3.5" />
-                original
-              </AnchorButton>
+          <DetailSection title="Actions">
+            <div className="flex flex-wrap gap-x-4 gap-y-2 text-sm text-[#71767b]">
+              <span>{item.engagementRecommendation}</span>
+              {item.replyText ? <span>reply: {item.replyText}</span> : null}
+              <span>run {item.runId.slice(0, 8)}</span>
             </div>
           </DetailSection>
         </div>
@@ -466,28 +516,10 @@ function DetailPane({ item, onClose }: { item: SynthesisItem; onClose?: () => vo
   )
 }
 
-function RailMetric({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-lg border border-[#ddd6ca] bg-[#fbfaf7] px-3 py-3">
-      <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[#8b8378]">{label}</div>
-      <div className="mt-1 text-xl font-semibold tracking-normal text-[#181512]">{value}</div>
-    </div>
-  )
-}
-
-function Metric({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-lg border border-[#ddd6ca] bg-white px-3 py-3">
-      <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[#8b8378]">{label}</div>
-      <div className="mt-1 truncate text-sm font-semibold tracking-normal text-[#181512]">{value}</div>
-    </div>
-  )
-}
-
 function DetailSection({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section>
-      <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[#8b8378]">{title}</h3>
+      <h3 className="mb-2 text-sm font-bold text-[#71767b]">{title}</h3>
       {children}
     </section>
   )

--- a/apps/synthesis/src/server/__tests__/api.test.ts
+++ b/apps/synthesis/src/server/__tests__/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
-import { handleCreateRun } from '../api'
+import { handleCreateRun, handleListFeed, handleSubmitItem } from '../api'
 import { createInMemorySynthesisStore, setSynthesisStoreForTests } from '../store'
 
 const token = 'test-synthesis-token'
@@ -13,6 +13,24 @@ const createRunRequest = (authorization?: string) =>
       ...(authorization ? { authorization } : {}),
     },
     body: JSON.stringify({ source: 'x.com/home', interests: ['semis'] }),
+  })
+
+const submitItemRequest = (runId: string, index: number) =>
+  new Request('http://synthesis.test/api/items', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      runId,
+      originalUrl: `https://x.com/example/status/${1000 + index}`,
+      observedText: `observed post ${index} about semis and devtools`,
+      summary: `semis/devtools summary ${index}`,
+      topicTags: ['semis', 'devtools'],
+      score: 0.8 + index * 0.01,
+      confidence: 0.75,
+    }),
   })
 
 describe('synthesis REST auth', () => {
@@ -38,5 +56,29 @@ describe('synthesis REST auth', () => {
 
     expect(response.status).toBe(201)
     expect(payload.run.source).toBe('x.com/home')
+  })
+
+  test('paginates the feed with a cursor', async () => {
+    const runResponse = await handleCreateRun(createRunRequest(`Bearer ${token}`))
+    const runPayload = await runResponse.json()
+
+    for (let index = 0; index < 5; index += 1) {
+      const submitResponse = await handleSubmitItem(submitItemRequest(runPayload.run.id, index))
+      expect(submitResponse.status).toBe(201)
+    }
+
+    const firstResponse = await handleListFeed(new Request('http://synthesis.test/api/feed?limit=2&minScore=0'))
+    const firstPage = await firstResponse.json()
+    expect(firstPage.items).toHaveLength(2)
+    expect(firstPage.nextCursor).toEqual(expect.any(String))
+
+    const secondResponse = await handleListFeed(
+      new Request(`http://synthesis.test/api/feed?limit=2&minScore=0&cursor=${firstPage.nextCursor}`),
+    )
+    const secondPage = await secondResponse.json()
+    expect(secondPage.items).toHaveLength(2)
+
+    const firstIds = new Set(firstPage.items.map((item: { id: string }) => item.id))
+    expect(secondPage.items.some((item: { id: string }) => firstIds.has(item.id))).toBe(false)
   })
 })

--- a/apps/synthesis/src/server/api.ts
+++ b/apps/synthesis/src/server/api.ts
@@ -18,6 +18,7 @@ const parseFeedQuery = (request: Request) => {
   const url = new URL(request.url)
   const parsed = ListFeedInputSchema.safeParse({
     limit: url.searchParams.get('limit') ?? undefined,
+    cursor: url.searchParams.get('cursor') ?? undefined,
     tag: url.searchParams.get('tag') ?? undefined,
     minScore: url.searchParams.get('minScore') ?? undefined,
     engagementStatus: url.searchParams.get('engagementStatus') ?? undefined,

--- a/apps/synthesis/src/server/schema.ts
+++ b/apps/synthesis/src/server/schema.ts
@@ -52,6 +52,7 @@ export const SubmitBatchInputSchema = z
 export const ListFeedInputSchema = z
   .object({
     limit: z.coerce.number().int().min(1).max(100).default(40),
+    cursor: z.string().trim().min(1).max(240).optional(),
     tag: z.string().trim().min(1).max(60).optional(),
     minScore: z.coerce.number().min(0).max(1).optional(),
     engagementStatus: EngagementStatusSchema.optional(),
@@ -168,5 +169,6 @@ export type NextEngagementResult = {
 
 export type FeedResponse = {
   items: SynthesisItem[]
+  nextCursor: string | null
   fetchedAt: string
 }

--- a/apps/synthesis/src/server/store.ts
+++ b/apps/synthesis/src/server/store.ts
@@ -95,6 +95,33 @@ const toIso = (value: Date | string | null | undefined) => {
 
 const nowIso = () => new Date().toISOString()
 
+type FeedCursor = {
+  createdAt: string
+  id: string
+}
+
+const encodeFeedCursor = (item: SynthesisItem) =>
+  Buffer.from(JSON.stringify({ createdAt: item.createdAt, id: item.id } satisfies FeedCursor)).toString('base64url')
+
+const decodeFeedCursor = (cursor: string | undefined): FeedCursor | null => {
+  if (!cursor) return null
+  try {
+    const parsed: unknown = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'))
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed) &&
+      typeof (parsed as FeedCursor).createdAt === 'string' &&
+      typeof (parsed as FeedCursor).id === 'string'
+    ) {
+      return parsed as FeedCursor
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
 const parseJsonArray = (value: unknown): string[] => {
   if (Array.isArray(value)) return value.map(String)
   if (typeof value === 'string') {
@@ -228,14 +255,25 @@ class InMemorySynthesisStore implements SynthesisStore {
   }
 
   async listFeed(input: ListFeedInput): Promise<FeedResponse> {
-    const items = [...this.items.values()]
+    const cursor = decodeFeedCursor(input.cursor)
+    const matching = [...this.items.values()]
       .filter((item) => (input.tag ? item.topicTags.includes(input.tag.toLowerCase()) : true))
       .filter((item) => (input.minScore == null ? true : item.score >= input.minScore))
       .filter((item) => (input.engagementStatus ? item.engagementStatus === input.engagementStatus : true))
-      .sort((left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt))
-      .slice(0, input.limit)
+      .sort((left, right) => {
+        const createdAtDiff = Date.parse(right.createdAt) - Date.parse(left.createdAt)
+        return createdAtDiff || right.id.localeCompare(left.id)
+      })
+      .filter((item) => {
+        if (!cursor) return true
+        const itemTime = Date.parse(item.createdAt)
+        const cursorTime = Date.parse(cursor.createdAt)
+        return itemTime < cursorTime || (itemTime === cursorTime && item.id < cursor.id)
+      })
+    const items = matching.slice(0, input.limit)
+    const nextCursor = matching.length > input.limit && items.length ? encodeFeedCursor(items[items.length - 1]) : null
 
-    return { items, fetchedAt: nowIso() }
+    return { items, nextCursor, fetchedAt: nowIso() }
   }
 
   async getItem(id: string): Promise<SynthesisItem | null> {
@@ -557,6 +595,7 @@ class PostgresSynthesisStore implements SynthesisStore {
     await this.ensureSchema()
     const where: string[] = []
     const values: unknown[] = []
+    const cursor = decodeFeedCursor(input.cursor)
     if (input.tag) {
       values.push(input.tag.toLowerCase())
       where.push(`i.topic_tags ? $${values.length}`)
@@ -569,18 +608,25 @@ class PostgresSynthesisStore implements SynthesisStore {
       values.push(input.engagementStatus)
       where.push(`i.engagement_status = $${values.length}`)
     }
-    values.push(input.limit)
+    if (cursor) {
+      values.push(cursor.createdAt, cursor.id)
+      where.push(`(i.created_at, i.id) < ($${values.length - 1}::timestamptz, $${values.length})`)
+    }
+    values.push(input.limit + 1)
     const result = await this.pool.query<ItemRow>(
       `SELECT ${this.itemSelectSql('i')}
        FROM synthesis_items i
        JOIN x_posts p ON p.id = i.x_post_key
        ${where.length ? `WHERE ${where.join(' AND ')}` : ''}
-       ORDER BY i.created_at DESC
+       ORDER BY i.created_at DESC, i.id DESC
        LIMIT $${values.length}`,
       values,
     )
+    const rows = result.rows.map(mapItemRow)
+    const items = rows.slice(0, input.limit)
     return {
-      items: result.rows.map(mapItemRow),
+      items,
+      nextCursor: rows.length > input.limit && items.length ? encodeFeedCursor(items[items.length - 1]) : null,
       fetchedAt: nowIso(),
     }
   }


### PR DESCRIPTION
## Summary

- Reworks the Synthesis feed into a minimal X-style dark timeline with restrained neutral surfaces and a single active accent.
- Replaces the eager feed query with cursor-backed infinite paging and a manual fallback loader.
- Adds REST feed cursor parsing plus in-memory/Postgres cursor pagination support.
- Adds a regression test that verifies cursor pages do not repeat feed items.

## Related Issues

None

## Testing

- `bun run --cwd apps/synthesis format`
- `bun run --cwd apps/synthesis lint`
- `bun run --cwd apps/synthesis test`
- `bun run --cwd apps/synthesis build`
- `bunx playwright screenshot --channel chrome --viewport-size=1440,1000 --wait-for-timeout=2000 http://localhost:3025 /tmp/synthesis-app-minimal-x.png`
- `bunx playwright screenshot --channel chrome --viewport-size=390,844 --wait-for-timeout=2000 http://localhost:3025 /tmp/synthesis-app-minimal-x-mobile.png`
- Playwright scroll smoke against the local preview confirmed the feed advances from `24 loaded` to `48 loaded` after scrolling the timeline near the bottom.

## Screenshots (if applicable)

Local desktop and mobile screenshots were captured for the minimal dark timeline:

- `/tmp/synthesis-app-minimal-x.png`
- `/tmp/synthesis-app-minimal-x-mobile.png`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
