### PR TITLE
fix(synthesis): always pull main image

### DIFF
--- a/argocd/applications/synthesis/deployment.yaml
+++ b/argocd/applications/synthesis/deployment.yaml
@@ -22,6 +22,7 @@ spec:
       containers:
         - name: synthesis
           image: registry.ide-newton.ts.net/lab/synthesis
+          imagePullPolicy: Always
           resources:
             limits:
               cpu: "1"


### PR DESCRIPTION
## Summary\n- set imagePullPolicy: Always for the synthesis deployment because it uses the mutable main tag\n\n## Validation\n- kubectl kustomize argocd/applications/synthesis\n- scripts/kubeconform.sh argocd/applications/synthesis