### PR TITLE
ci(synthesis): enable release image automation

### DIFF
--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -61,6 +61,7 @@ jobs:
           allowed_authors=("app/github-actions" "github-actions[bot]")
           allowed_paths=(
             "argocd/applications/proompteng/kustomization.yaml"
+            "argocd/applications/synthesis/kustomization.yaml"
             "argocd/applications/bumba/kustomization.yaml"
             "argocd/applications/khoshut/kustomization.yaml"
             "argocd/applications/bilig/kustomization.yaml"

--- a/.github/workflows/synthesis-ci.yml
+++ b/.github/workflows/synthesis-ci.yml
@@ -9,6 +9,7 @@ on:
       - 'packages/design/**'
       - 'packages/scripts/src/synthesis/**'
       - 'argocd/applications/synthesis/**'
+      - 'argocd/applications/argocd/base/image-updater-product.yaml'
       - 'argocd/applicationsets/product.yaml'
       - '.github/workflows/synthesis-ci.yml'
   pull_request:
@@ -17,6 +18,7 @@ on:
       - 'packages/design/**'
       - 'packages/scripts/src/synthesis/**'
       - 'argocd/applications/synthesis/**'
+      - 'argocd/applications/argocd/base/image-updater-product.yaml'
       - 'argocd/applicationsets/product.yaml'
       - '.github/workflows/synthesis-ci.yml'
 

--- a/argocd/applications/argocd/base/image-updater-product.yaml
+++ b/argocd/applications/argocd/base/image-updater-product.yaml
@@ -38,6 +38,19 @@ spec:
           manifestTargets:
             kustomize:
               name: registry.ide-newton.ts.net/lab/app
+    - namePattern: synthesis
+      writeBackConfig:
+        method: git:secret:argocd/image-updater-git-ssh
+        gitConfig:
+          repository: git@github.com:proompteng/lab.git
+          branch: main:release/{{.SHA256}}
+          writeBackTarget: kustomization:/argocd/applications/synthesis
+      images:
+        - alias: synthesis
+          imageName: registry.ide-newton.ts.net/lab/synthesis:0.x
+          manifestTargets:
+            kustomize:
+              name: registry.ide-newton.ts.net/lab/synthesis
     - namePattern: cms
       writeBackConfig:
         method: git:secret:argocd/image-updater-git-ssh


### PR DESCRIPTION
## Summary

- Adds Synthesis to the central Argo CD ImageUpdater product configuration.
- Allows automated Synthesis release PRs that only update `argocd/applications/synthesis/kustomization.yaml` to use release auto-merge.
- Makes Synthesis CI run when the product image-updater config changes.

## Related Issues

None

## Testing

- `git diff --check`
- `bun run lint:argocd`
- `bun run lint:synthesis`
- `bun run --filter synthesis test`
- `bun run --filter synthesis build`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
