### PR TITLE
fix(torghut): unblock drift-only paper import health

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -526,6 +526,7 @@ def _runtime_window_import_health_gate(
     )
 
     blockers: list[str] = []
+    promotion_blockers: list[str] = []
     if dependency_quorum_source == "missing":
         blockers.append("runtime_window_import_dependency_quorum_missing")
     elif dependency_quorum_decision != "allow":
@@ -535,9 +536,9 @@ def _runtime_window_import_health_gate(
     elif continuity_ok != "true":
         blockers.append("evidence_continuity_not_ok")
     if drift_source == "missing":
-        blockers.append("runtime_window_import_drift_missing")
+        promotion_blockers.append("runtime_window_import_drift_missing")
     elif drift_ok != "true":
-        blockers.append("drift_checks_not_ok")
+        promotion_blockers.append("drift_checks_not_ok")
 
     return {
         "schema_version": "torghut.runtime-window-import-health-gate.v1",
@@ -550,6 +551,7 @@ def _runtime_window_import_health_gate(
         "drift_source": drift_source,
         "ready": not blockers,
         "blockers": blockers,
+        "promotion_blockers": promotion_blockers,
     }
 
 
@@ -557,12 +559,14 @@ def _runtime_window_import_health_gate_summary(
     targets: Sequence[Mapping[str, object]],
 ) -> dict[str, object]:
     blockers: list[str] = []
+    promotion_blockers: list[str] = []
     ready_count = 0
     for target in targets:
         gate = _as_mapping(target.get("runtime_window_import_health_gate"))
         if bool(gate.get("ready")):
             ready_count += 1
         blockers.extend(_unique_text_items(gate.get("blockers")))
+        promotion_blockers.extend(_unique_text_items(gate.get("promotion_blockers")))
     return {
         "schema_version": "torghut.runtime-window-import-health-gate-summary.v1",
         "source": "paper_route_runtime_window_targets",
@@ -571,6 +575,7 @@ def _runtime_window_import_health_gate_summary(
         "ready_target_count": ready_count,
         "blocked_target_count": max(0, len(targets) - ready_count),
         "blockers": _unique_text_items(blockers),
+        "promotion_blockers": _unique_text_items(promotion_blockers),
     }
 
 
@@ -673,6 +678,9 @@ def _next_paper_route_runtime_window_targets(
             live_submission_gate=live_submission_gate,
         )
         health_gate_blockers = _unique_text_items(health_gate.get("blockers"))
+        health_gate_promotion_blockers = _unique_text_items(
+            health_gate.get("promotion_blockers")
+        )
         planned_target: dict[str, object] = {
             "hypothesis_id": hypothesis_id,
             "candidate_id": candidate_id,
@@ -691,6 +699,9 @@ def _next_paper_route_runtime_window_targets(
             "drift_ok": health_gate["drift_ok"],
             "runtime_window_import_health_gate": health_gate,
             "runtime_window_import_health_gate_blockers": health_gate_blockers,
+            "runtime_window_import_promotion_blockers": (
+                health_gate_promotion_blockers
+            ),
             "window_start": _isoformat(window_start),
             "window_end": _isoformat(window_end),
             "paper_route_probe_symbols": target_probe_symbols,
@@ -729,6 +740,7 @@ def _next_paper_route_runtime_window_targets(
                     "paper_route_runtime_ledger_import_pending",
                     *_unique_text_items(target.get("candidate_blockers")),
                     *health_gate_blockers,
+                    *health_gate_promotion_blockers,
                 ]
             ),
             "runtime_ledger_target_metadata_blockers": _unique_text_items(
@@ -736,6 +748,7 @@ def _next_paper_route_runtime_window_targets(
                     "paper_route_runtime_ledger_import_pending",
                     "live_runtime_ledger_required",
                     *health_gate_blockers,
+                    *health_gate_promotion_blockers,
                 ]
             ),
             "handoff": "next_paper_route_runtime_window_import",

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -136,6 +136,7 @@ def _runtime_window_import_health_gate_inputs(
     )
     drift_ok, drift_source, drift_reason = _runtime_window_import_drift_signal(state)
     blockers: list[str] = []
+    promotion_blockers: list[str] = []
     if dependency_quorum_decision != "allow":
         blockers.append("dependency_quorum_not_allow")
     if continuity_source == "missing":
@@ -143,9 +144,9 @@ def _runtime_window_import_health_gate_inputs(
     elif continuity_ok != "true":
         blockers.append("evidence_continuity_not_ok")
     if drift_source == "missing":
-        blockers.append("runtime_window_import_drift_missing")
+        promotion_blockers.append("runtime_window_import_drift_missing")
     elif drift_ok != "true":
-        blockers.append("drift_checks_not_ok")
+        promotion_blockers.append("drift_checks_not_ok")
     return {
         "continuity_ok": continuity_ok,
         "continuity_source": continuity_source,
@@ -166,8 +167,10 @@ def _runtime_window_import_health_gate_inputs(
             "drift_reason": drift_reason,
             "ready": not blockers,
             "blockers": blockers,
+            "promotion_blockers": promotion_blockers,
         },
         "runtime_window_import_health_gate_blockers": blockers,
+        "runtime_window_import_promotion_blockers": promotion_blockers,
     }
 
 

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -482,6 +482,7 @@ def _runtime_window_import_health_gate_summary(
 ) -> dict[str, Any]:
     plan_gate = _mapping(plan.get("runtime_window_import_health_gate"))
     blockers = _text_list(plan_gate.get("blockers"))
+    promotion_blockers = _text_list(plan_gate.get("promotion_blockers"))
     target_summaries: list[dict[str, Any]] = []
     ready_count = 0
     for index, target in enumerate(targets):
@@ -490,6 +491,13 @@ def _runtime_window_import_health_gate_summary(
             target.get("runtime_window_import_health_gate_blockers")
         )
         _extend_unique(target_blockers, _text_list(gate.get("blockers")))
+        target_promotion_blockers = _text_list(
+            target.get("runtime_window_import_promotion_blockers")
+        )
+        _extend_unique(
+            target_promotion_blockers,
+            _text_list(gate.get("promotion_blockers")),
+        )
         dependency_quorum_decision = _text(
             target.get("dependency_quorum_decision")
             or gate.get("dependency_quorum_decision")
@@ -504,12 +512,13 @@ def _runtime_window_import_health_gate_summary(
             _extend_unique(target_blockers, ["dependency_quorum_not_allow"])
         if not _health_gate_bool(continuity_ok):
             _extend_unique(target_blockers, ["continuity_not_ok"])
-        if not _health_gate_bool(drift_ok):
-            _extend_unique(target_blockers, ["drift_not_ok"])
+        if not _health_gate_bool(drift_ok) and not target_promotion_blockers:
+            _extend_unique(target_promotion_blockers, ["drift_not_ok"])
         ready = not target_blockers
         if ready:
             ready_count += 1
         _extend_unique(blockers, target_blockers)
+        _extend_unique(promotion_blockers, target_promotion_blockers)
         target_summaries.append(
             {
                 "index": index,
@@ -520,6 +529,7 @@ def _runtime_window_import_health_gate_summary(
                 "drift_ok": _text(drift_ok),
                 "ready": ready,
                 "blockers": target_blockers,
+                "promotion_blockers": target_promotion_blockers,
             }
         )
     target_count = len(targets)
@@ -531,6 +541,7 @@ def _runtime_window_import_health_gate_summary(
         "blocked_target_count": max(0, target_count - ready_count),
         "ready": target_count > 0 and ready_count == target_count and not blockers,
         "blockers": blockers,
+        "promotion_blockers": promotion_blockers,
         "targets": target_summaries,
     }
 

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -60,6 +60,7 @@ RUNTIME_WINDOW_TARGET_METADATA_KEYS = (
     "drift_ok",
     "runtime_window_import_health_gate",
     "runtime_window_import_health_gate_blockers",
+    "runtime_window_import_promotion_blockers",
     "window_start",
     "window_end",
     "max_notional",

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -272,6 +272,7 @@ def _paper_route_target_plan_summary(
     promotion_blocked_count = 0
     health_gate_ready_count = 0
     health_gate_blockers: list[str] = []
+    health_gate_promotion_blockers: list[str] = []
     for target in targets:
         missing_identity = [
             field
@@ -320,6 +321,17 @@ def _paper_route_target_plan_summary(
             blocker = _text(reason)
             if blocker and blocker not in target_health_blockers:
                 target_health_blockers.append(blocker)
+        target_health_promotion_blockers = [
+            _text(reason)
+            for reason in _sequence(
+                target.get("runtime_window_import_promotion_blockers")
+            )
+            if _text(reason)
+        ]
+        for reason in _sequence(health_gate.get("promotion_blockers")):
+            blocker = _text(reason)
+            if blocker and blocker not in target_health_promotion_blockers:
+                target_health_promotion_blockers.append(blocker)
         dependency_quorum_decision = _text(
             target.get("dependency_quorum_decision")
             or health_gate.get("dependency_quorum_decision")
@@ -332,14 +344,18 @@ def _paper_route_target_plan_summary(
             target_health_blockers.append("dependency_quorum_not_allow")
         if not _health_gate_bool(continuity_ok):
             target_health_blockers.append("continuity_not_ok")
-        if not _health_gate_bool(drift_ok):
-            target_health_blockers.append("drift_not_ok")
+        if not _health_gate_bool(drift_ok) and not target_health_promotion_blockers:
+            target_health_promotion_blockers.append("drift_not_ok")
         target_health_blockers = sorted(set(target_health_blockers))
+        target_health_promotion_blockers = sorted(set(target_health_promotion_blockers))
         if not target_health_blockers:
             health_gate_ready_count += 1
         for blocker in target_health_blockers:
             if blocker not in health_gate_blockers:
                 health_gate_blockers.append(blocker)
+        for blocker in target_health_promotion_blockers:
+            if blocker not in health_gate_promotion_blockers:
+                health_gate_promotion_blockers.append(blocker)
         target_summaries.append(
             {
                 "hypothesis_id": _text(target.get("hypothesis_id")),
@@ -359,6 +375,9 @@ def _paper_route_target_plan_summary(
                 "continuity_ok": _text(continuity_ok),
                 "drift_ok": _text(drift_ok),
                 "runtime_window_import_health_gate_blockers": target_health_blockers,
+                "runtime_window_import_promotion_blockers": (
+                    target_health_promotion_blockers
+                ),
                 "missing_identity_fields": missing_identity,
             }
         )
@@ -390,6 +409,7 @@ def _paper_route_target_plan_summary(
             "ready_target_count": health_gate_ready_count,
             "blocked_target_count": max(0, len(targets) - health_gate_ready_count),
             "blockers": health_gate_blockers,
+            "promotion_blockers": health_gate_promotion_blockers,
         },
     }
 

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -615,6 +615,41 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertEqual(health_gate["ready_target_count"], 0)
         self.assertEqual(health_gate["blocked_target_count"], 1)
 
+    def test_packet_treats_drift_only_as_promotion_not_import_blocker(self) -> None:
+        evidence = _paper_route_evidence(import_ready=True)
+        plan = evidence["next_paper_route_runtime_window_targets"]
+        assert isinstance(plan, dict)
+        target = plan["targets"][0]
+        assert isinstance(target, dict)
+        target["drift_ok"] = "false"
+        target["runtime_window_import_health_gate"] = {
+            "schema_version": "torghut.runtime-window-import-health-gate.v1",
+            "dependency_quorum_decision": "allow",
+            "continuity_ok": "true",
+            "drift_ok": "false",
+            "blockers": [],
+            "promotion_blockers": [],
+        }
+        target["runtime_window_import_health_gate_blockers"] = []
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=evidence,
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertTrue(result["ok"], result)
+        health_gate = result["evidence"]["paper_route_target_plan"][
+            "runtime_window_import_health_gate"
+        ]
+        self.assertTrue(health_gate["ready"])
+        self.assertEqual(health_gate["ready_target_count"], 1)
+        self.assertEqual(health_gate["blocked_target_count"], 0)
+        self.assertEqual(health_gate["blockers"], [])
+        self.assertEqual(health_gate["promotion_blockers"], ["drift_not_ok"])
+
     def test_packet_blocks_non_authoritative_import_and_weak_daily_profit(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(
             _status(),

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -506,8 +506,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
             [
                 "runtime_window_import_dependency_quorum_missing",
                 "runtime_window_import_continuity_missing",
-                "runtime_window_import_drift_missing",
             ],
+        )
+        self.assertEqual(
+            target["runtime_window_import_health_gate"]["promotion_blockers"],
+            ["runtime_window_import_drift_missing"],
         )
         self.assertIn(
             "runtime_window_import_dependency_quorum_missing",
@@ -522,6 +525,10 @@ class TestPaperRouteEvidenceAudit(TestCase):
         ]
         self.assertEqual(health_gate["ready_target_count"], 0)
         self.assertEqual(health_gate["blocked_target_count"], 1)
+        self.assertEqual(
+            health_gate["promotion_blockers"],
+            ["runtime_window_import_drift_missing"],
+        )
 
     def test_builder_exports_non_allow_runtime_window_health_gate_blockers(
         self,
@@ -588,8 +595,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
             [
                 "dependency_quorum_not_allow",
                 "evidence_continuity_not_ok",
-                "drift_checks_not_ok",
             ],
+        )
+        self.assertEqual(gate["promotion_blockers"], ["drift_checks_not_ok"])
+        self.assertEqual(
+            target["runtime_window_import_promotion_blockers"],
+            ["drift_checks_not_ok"],
         )
 
     def test_next_paper_route_session_readiness_tracks_collection_and_import(

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -855,6 +855,9 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                             "runtime_window_import_health_gate_blockers": [
                                 "runtime_window_import_dependency_quorum_missing"
                             ],
+                            "runtime_window_import_promotion_blockers": [
+                                "runtime_window_import_drift_missing"
+                            ],
                             "window_start": "2026-05-26T13:30:00+00:00",
                             "window_end": "2026-05-26T20:00:00+00:00",
                             "paper_route_probe_symbols": ["AAPL"],
@@ -957,6 +960,10 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual(
             targets[0].target_metadata["runtime_window_import_health_gate_blockers"],
             ["runtime_window_import_dependency_quorum_missing"],
+        )
+        self.assertEqual(
+            targets[0].target_metadata["runtime_window_import_promotion_blockers"],
+            ["runtime_window_import_drift_missing"],
         )
         self.assertEqual(targets[0].target_metadata["max_notional"], "0")
         self.assertEqual(

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -3446,9 +3446,12 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(gate["dependency_quorum_decision"], "allow")
         self.assertEqual(gate["continuity_ok"], "true")
         self.assertEqual(gate["drift_ok"], "false")
-        self.assertEqual(gate["blockers"], ["drift_checks_not_ok"])
+        self.assertEqual(gate["blockers"], [])
+        self.assertTrue(gate["ready"])
+        self.assertEqual(gate["promotion_blockers"], ["drift_checks_not_ok"])
+        self.assertEqual(result["runtime_window_import_health_gate_blockers"], [])
         self.assertEqual(
-            result["runtime_window_import_health_gate_blockers"],
+            result["runtime_window_import_promotion_blockers"],
             ["drift_checks_not_ok"],
         )
 

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -743,6 +743,72 @@ class TestVerifyTradingReadiness(TestCase):
         )
         self.assertTrue(ready["ok"], ready)
 
+    def test_paper_route_target_plan_allows_drift_only_evidence_collection(
+        self,
+    ) -> None:
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            paper_route_evidence=_paper_route_evidence(
+                import_ready=True,
+                target_overrides={
+                    "drift_ok": "false",
+                    "runtime_window_import_health_gate": {
+                        "schema_version": "torghut.runtime-window-import-health-gate.v1",
+                        "dependency_quorum_decision": "allow",
+                        "continuity_ok": "true",
+                        "drift_ok": "false",
+                        "blockers": [],
+                        "promotion_blockers": ["drift_checks_not_ok"],
+                    },
+                    "runtime_window_import_health_gate_blockers": [],
+                },
+            ),
+            require_paper_route_target_plan=True,
+            require_paper_route_import_ready=True,
+        )
+
+        self.assertTrue(result["ok"], result)
+        health_gate = result["paper_route_target_plan"][
+            "runtime_window_import_health_gate"
+        ]
+        self.assertEqual(health_gate["ready_target_count"], 1)
+        self.assertEqual(health_gate["blocked_target_count"], 0)
+        self.assertEqual(health_gate["blockers"], [])
+        self.assertEqual(health_gate["promotion_blockers"], ["drift_checks_not_ok"])
+
+    def test_paper_route_target_plan_synthesizes_drift_promotion_blocker(
+        self,
+    ) -> None:
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            paper_route_evidence=_paper_route_evidence(
+                import_ready=True,
+                target_overrides={
+                    "drift_ok": "false",
+                    "runtime_window_import_health_gate": {
+                        "schema_version": "torghut.runtime-window-import-health-gate.v1",
+                        "dependency_quorum_decision": "allow",
+                        "continuity_ok": "true",
+                        "drift_ok": "false",
+                        "blockers": [],
+                        "promotion_blockers": [],
+                    },
+                    "runtime_window_import_health_gate_blockers": [],
+                },
+            ),
+            require_paper_route_target_plan=True,
+            require_paper_route_import_ready=True,
+        )
+
+        self.assertTrue(result["ok"], result)
+        health_gate = result["paper_route_target_plan"][
+            "runtime_window_import_health_gate"
+        ]
+        self.assertEqual(health_gate["ready_target_count"], 1)
+        self.assertEqual(health_gate["blocked_target_count"], 0)
+        self.assertEqual(health_gate["blockers"], [])
+        self.assertEqual(health_gate["promotion_blockers"], ["drift_not_ok"])
+
     def test_paper_route_target_plan_requires_runtime_import_health_gate(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Keeps drift failures visible as runtime-window import promotion blockers instead of import-health blockers.
- Allows bounded paper-route evidence collection/import when dependency quorum and continuity are healthy but drift is not promotion-ready.
- Preserves the new promotion-blocker metadata through the paper-route plan, empirical renewal target metadata, readiness verifier, and runtime-ledger proof packet.

## Related Issues

None

## Testing

- `uv run --frozen python -m pytest tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_verify_trading_readiness.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_run_empirical_promotion_jobs.py -k 'runtime_window_import_health_gate or next_paper_route_runtime_window_targets or session_readiness or paper_route_target_plan or paper_route_import_health_gate or drift_only or runtime_window_target_plan_payload_accepts_paper_route_evidence_plan' -q`
- `uv run --frozen python -m pytest tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_verify_trading_readiness.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_run_empirical_promotion_jobs.py -q`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py app/trading/submission_council.py scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_verify_trading_readiness.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py app/trading/submission_council.py scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_submission_council.py tests/test_verify_trading_readiness.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_run_empirical_promotion_jobs.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
