### PR TITLE
fix(agents): support primitive create on http origins

### DIFF
--- a/services/agents/src/control-plane/api-client.test.ts
+++ b/services/agents/src/control-plane/api-client.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createIdempotencyKey, createPrimitiveResource } from './api-client'
+
+describe('control-plane API client', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('uses crypto.randomUUID for idempotency keys when available', () => {
+    vi.stubGlobal('crypto', {
+      randomUUID: () => '11111111-2222-4333-8444-555555555555',
+    })
+
+    expect(createIdempotencyKey()).toBe('11111111-2222-4333-8444-555555555555')
+  })
+
+  it('creates an idempotency key when randomUUID is unavailable on non-secure origins', () => {
+    vi.stubGlobal('crypto', {
+      getRandomValues: (bytes: Uint8Array) => {
+        bytes.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+        return bytes
+      },
+    })
+
+    expect(createIdempotencyKey()).toBe('00010203-0405-4607-8809-0a0b0c0d0e0f')
+  })
+
+  it('sends the fallback idempotency key when creating a primitive resource', async () => {
+    vi.stubGlobal('crypto', {
+      getRandomValues: (bytes: Uint8Array) => {
+        bytes.fill(7)
+        return bytes
+      },
+    })
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true, resource: {} })))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await createPrimitiveResource('artifact', {
+      apiVersion: 'artifacts.proompteng.ai/v1alpha1',
+      kind: 'Artifact',
+      metadata: { name: 'ui-proof', namespace: 'agents' },
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/primitives/artifact/resources',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'content-type': 'application/json',
+          'idempotency-key': '07070707-0707-4707-8707-070707070707',
+        }),
+      }),
+    )
+  })
+})

--- a/services/agents/src/control-plane/api-client.ts
+++ b/services/agents/src/control-plane/api-client.ts
@@ -35,6 +35,31 @@ const assertOk = async (response: Response) => {
   throw new Error(body || `${response.status} ${response.statusText}`)
 }
 
+const formatUuidV4 = (bytes: Uint8Array) => {
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
+export const createIdempotencyKey = () => {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID()
+  }
+
+  const bytes = new Uint8Array(16)
+  if (typeof globalThis.crypto?.getRandomValues === 'function') {
+    globalThis.crypto.getRandomValues(bytes)
+  } else {
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = Math.floor(Math.random() * 256)
+    }
+  }
+
+  return formatUuidV4(bytes)
+}
+
 export const fetchPrimitiveDefinitions = async () => {
   const response = await assertOk(await fetch('/api/primitives'))
   return (await response.json()) as PrimitiveListResponse
@@ -61,7 +86,7 @@ export const createPrimitiveResource = async (kind: string, manifest: Record<str
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'idempotency-key': crypto.randomUUID(),
+        'idempotency-key': createIdempotencyKey(),
       },
       body: JSON.stringify(manifest),
     }),


### PR DESCRIPTION
## Summary

- Adds a browser-safe primitive create idempotency-key generator.
- Falls back to `crypto.getRandomValues()` when `crypto.randomUUID()` is unavailable on non-secure HTTP origins.
- Covers the fallback path and create-request header with unit tests.

## Related Issues

None.

## Testing

- `bun run --cwd services/agents test -- src/control-plane/api-client.test.ts`
- `bun run --cwd services/agents tsc`
- `bun run --cwd services/agents lint`
- `bun run --cwd services/agents test`
- `bun run --cwd services/agents build`
- `git diff --check`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
