### PR TITLE
fix(torghut): expose paper route drift reasons

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -500,6 +500,23 @@ def _runtime_window_import_health_gate(
                 return text, source
         return "false", "missing"
 
+    def reason_value(
+        default: str,
+        selected_source: str,
+        *items: tuple[str, object],
+    ) -> str:
+        for source, value in items:
+            if source != selected_source:
+                continue
+            text = _safe_text(value)
+            if text is not None:
+                return text
+        for _, value in items:
+            text = _safe_text(value)
+            if text is not None:
+                return text
+        return default
+
     dependency_quorum_decision, dependency_quorum_source = text_value(
         ("target_plan", target.get("dependency_quorum_decision")),
         (
@@ -524,6 +541,26 @@ def _runtime_window_import_health_gate(
         ("target_plan.runtime_window_import_health_gate", nested_gate.get("drift_ok")),
         ("live_submission_gate", live_submission_gate.get("drift_ok")),
     )
+    continuity_reason = reason_value(
+        "continuity_ok" if continuity_ok == "true" else "continuity_not_ok",
+        continuity_source,
+        ("target_plan", target.get("continuity_reason")),
+        (
+            "target_plan.runtime_window_import_health_gate",
+            nested_gate.get("continuity_reason"),
+        ),
+        ("live_submission_gate", live_submission_gate.get("continuity_reason")),
+    )
+    drift_reason = reason_value(
+        "drift_ok" if drift_ok == "true" else "drift_not_ok",
+        drift_source,
+        ("target_plan", target.get("drift_reason")),
+        (
+            "target_plan.runtime_window_import_health_gate",
+            nested_gate.get("drift_reason"),
+        ),
+        ("live_submission_gate", live_submission_gate.get("drift_reason")),
+    )
 
     blockers: list[str] = []
     promotion_blockers: list[str] = []
@@ -547,8 +584,10 @@ def _runtime_window_import_health_gate(
         "dependency_quorum_source": dependency_quorum_source,
         "continuity_ok": continuity_ok,
         "continuity_source": continuity_source,
+        "continuity_reason": continuity_reason,
         "drift_ok": drift_ok,
         "drift_source": drift_source,
+        "drift_reason": drift_reason,
         "ready": not blockers,
         "blockers": blockers,
         "promotion_blockers": promotion_blockers,
@@ -560,6 +599,8 @@ def _runtime_window_import_health_gate_summary(
 ) -> dict[str, object]:
     blockers: list[str] = []
     promotion_blockers: list[str] = []
+    continuity_reasons: list[str] = []
+    drift_reasons: list[str] = []
     ready_count = 0
     for target in targets:
         gate = _as_mapping(target.get("runtime_window_import_health_gate"))
@@ -567,6 +608,12 @@ def _runtime_window_import_health_gate_summary(
             ready_count += 1
         blockers.extend(_unique_text_items(gate.get("blockers")))
         promotion_blockers.extend(_unique_text_items(gate.get("promotion_blockers")))
+        continuity_reason = _safe_text(gate.get("continuity_reason"))
+        if continuity_reason is not None:
+            continuity_reasons.append(continuity_reason)
+        drift_reason = _safe_text(gate.get("drift_reason"))
+        if drift_reason is not None:
+            drift_reasons.append(drift_reason)
     return {
         "schema_version": "torghut.runtime-window-import-health-gate-summary.v1",
         "source": "paper_route_runtime_window_targets",
@@ -576,6 +623,8 @@ def _runtime_window_import_health_gate_summary(
         "blocked_target_count": max(0, len(targets) - ready_count),
         "blockers": _unique_text_items(blockers),
         "promotion_blockers": _unique_text_items(promotion_blockers),
+        "continuity_reasons": _unique_text_items(continuity_reasons),
+        "drift_reasons": _unique_text_items(drift_reasons),
     }
 
 
@@ -696,7 +745,9 @@ def _next_paper_route_runtime_window_targets(
             "source_kind": "paper_route_probe_runtime_observed",
             "dependency_quorum_decision": health_gate["dependency_quorum_decision"],
             "continuity_ok": health_gate["continuity_ok"],
+            "continuity_reason": health_gate["continuity_reason"],
             "drift_ok": health_gate["drift_ok"],
+            "drift_reason": health_gate["drift_reason"],
             "runtime_window_import_health_gate": health_gate,
             "runtime_window_import_health_gate_blockers": health_gate_blockers,
             "runtime_window_import_promotion_blockers": (

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -483,6 +483,8 @@ def _runtime_window_import_health_gate_summary(
     plan_gate = _mapping(plan.get("runtime_window_import_health_gate"))
     blockers = _text_list(plan_gate.get("blockers"))
     promotion_blockers = _text_list(plan_gate.get("promotion_blockers"))
+    continuity_reasons = _text_list(plan_gate.get("continuity_reasons"))
+    drift_reasons = _text_list(plan_gate.get("drift_reasons"))
     target_summaries: list[dict[str, Any]] = []
     ready_count = 0
     for index, target in enumerate(targets):
@@ -504,6 +506,10 @@ def _runtime_window_import_health_gate_summary(
         )
         continuity_ok = target.get("continuity_ok", gate.get("continuity_ok"))
         drift_ok = target.get("drift_ok", gate.get("drift_ok"))
+        continuity_reason = _text(
+            target.get("continuity_reason") or gate.get("continuity_reason")
+        )
+        drift_reason = _text(target.get("drift_reason") or gate.get("drift_reason"))
         if not gate:
             _extend_unique(
                 target_blockers, ["runtime_window_import_health_gate_missing"]
@@ -519,6 +525,8 @@ def _runtime_window_import_health_gate_summary(
             ready_count += 1
         _extend_unique(blockers, target_blockers)
         _extend_unique(promotion_blockers, target_promotion_blockers)
+        _extend_unique(continuity_reasons, [continuity_reason])
+        _extend_unique(drift_reasons, [drift_reason])
         target_summaries.append(
             {
                 "index": index,
@@ -526,7 +534,9 @@ def _runtime_window_import_health_gate_summary(
                 "candidate_id": _text(target.get("candidate_id")),
                 "dependency_quorum_decision": dependency_quorum_decision,
                 "continuity_ok": _text(continuity_ok),
+                "continuity_reason": continuity_reason,
                 "drift_ok": _text(drift_ok),
+                "drift_reason": drift_reason,
                 "ready": ready,
                 "blockers": target_blockers,
                 "promotion_blockers": target_promotion_blockers,
@@ -542,6 +552,8 @@ def _runtime_window_import_health_gate_summary(
         "ready": target_count > 0 and ready_count == target_count and not blockers,
         "blockers": blockers,
         "promotion_blockers": promotion_blockers,
+        "continuity_reasons": continuity_reasons,
+        "drift_reasons": drift_reasons,
         "targets": target_summaries,
     }
 

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -273,6 +273,8 @@ def _paper_route_target_plan_summary(
     health_gate_ready_count = 0
     health_gate_blockers: list[str] = []
     health_gate_promotion_blockers: list[str] = []
+    health_gate_continuity_reasons: list[str] = []
+    health_gate_drift_reasons: list[str] = []
     for target in targets:
         missing_identity = [
             field
@@ -338,6 +340,12 @@ def _paper_route_target_plan_summary(
         )
         continuity_ok = target.get("continuity_ok", health_gate.get("continuity_ok"))
         drift_ok = target.get("drift_ok", health_gate.get("drift_ok"))
+        continuity_reason = _text(
+            target.get("continuity_reason") or health_gate.get("continuity_reason")
+        )
+        drift_reason = _text(
+            target.get("drift_reason") or health_gate.get("drift_reason")
+        )
         if not health_gate:
             target_health_blockers.append("runtime_window_import_health_gate_missing")
         if dependency_quorum_decision != "allow":
@@ -356,6 +364,13 @@ def _paper_route_target_plan_summary(
         for blocker in target_health_promotion_blockers:
             if blocker not in health_gate_promotion_blockers:
                 health_gate_promotion_blockers.append(blocker)
+        if (
+            continuity_reason
+            and continuity_reason not in health_gate_continuity_reasons
+        ):
+            health_gate_continuity_reasons.append(continuity_reason)
+        if drift_reason and drift_reason not in health_gate_drift_reasons:
+            health_gate_drift_reasons.append(drift_reason)
         target_summaries.append(
             {
                 "hypothesis_id": _text(target.get("hypothesis_id")),
@@ -373,7 +388,9 @@ def _paper_route_target_plan_summary(
                 "promotion_blocked": promotion_blocked,
                 "dependency_quorum_decision": dependency_quorum_decision,
                 "continuity_ok": _text(continuity_ok),
+                "continuity_reason": continuity_reason,
                 "drift_ok": _text(drift_ok),
+                "drift_reason": drift_reason,
                 "runtime_window_import_health_gate_blockers": target_health_blockers,
                 "runtime_window_import_promotion_blockers": (
                     target_health_promotion_blockers
@@ -410,6 +427,8 @@ def _paper_route_target_plan_summary(
             "blocked_target_count": max(0, len(targets) - health_gate_ready_count),
             "blockers": health_gate_blockers,
             "promotion_blockers": health_gate_promotion_blockers,
+            "continuity_reasons": health_gate_continuity_reasons,
+            "drift_reasons": health_gate_drift_reasons,
         },
     }
 

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -621,12 +621,16 @@ class TestRuntimeLedgerProofPacket(TestCase):
         assert isinstance(plan, dict)
         target = plan["targets"][0]
         assert isinstance(target, dict)
+        target["continuity_reason"] = "signal_continuity_nominal"
         target["drift_ok"] = "false"
+        target["drift_reason"] = "drift_live_promotion_ineligible"
         target["runtime_window_import_health_gate"] = {
             "schema_version": "torghut.runtime-window-import-health-gate.v1",
             "dependency_quorum_decision": "allow",
             "continuity_ok": "true",
+            "continuity_reason": "signal_continuity_nominal",
             "drift_ok": "false",
+            "drift_reason": "drift_live_promotion_ineligible",
             "blockers": [],
             "promotion_blockers": [],
         }
@@ -649,6 +653,16 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertEqual(health_gate["blocked_target_count"], 0)
         self.assertEqual(health_gate["blockers"], [])
         self.assertEqual(health_gate["promotion_blockers"], ["drift_not_ok"])
+        self.assertEqual(
+            health_gate["continuity_reasons"], ["signal_continuity_nominal"]
+        )
+        self.assertEqual(
+            health_gate["drift_reasons"], ["drift_live_promotion_ineligible"]
+        )
+        self.assertEqual(
+            health_gate["targets"][0]["drift_reason"],
+            "drift_live_promotion_ineligible",
+        )
 
     def test_packet_blocks_non_authoritative_import_and_weak_daily_profit(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -188,7 +188,9 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     "promotion_eligible_total": 0,
                     "dependency_quorum_decision": "allow",
                     "continuity_ok": True,
+                    "continuity_reason": "signal_continuity_nominal",
                     "drift_ok": True,
+                    "drift_reason": "drift_live_promotion_eligible",
                     "runtime_ledger_paper_probation_import_plan": {
                         "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
                         "target_count": 2,
@@ -310,9 +312,19 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(target["source_kind"], "paper_route_probe_runtime_observed")
         self.assertEqual(target["dependency_quorum_decision"], "allow")
         self.assertEqual(target["continuity_ok"], "true")
+        self.assertEqual(target["continuity_reason"], "signal_continuity_nominal")
         self.assertEqual(target["drift_ok"], "true")
+        self.assertEqual(target["drift_reason"], "drift_live_promotion_eligible")
         self.assertEqual(target["runtime_window_import_health_gate"]["ready"], True)
         self.assertEqual(target["runtime_window_import_health_gate"]["blockers"], [])
+        self.assertEqual(
+            plan["runtime_window_import_health_gate"]["continuity_reasons"],
+            ["signal_continuity_nominal"],
+        )
+        self.assertEqual(
+            plan["runtime_window_import_health_gate"]["drift_reasons"],
+            ["drift_live_promotion_eligible"],
+        )
         self.assertEqual(target["max_notional"], "0")
         self.assertEqual(target["paper_route_probe_symbols"], ["AAPL"])
         self.assertEqual(target["paper_route_probe_next_session_max_notional"], "25")
@@ -544,7 +556,9 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     "promotion_eligible_total": 0,
                     "dependency_quorum_decision": "block",
                     "continuity_ok": "false",
+                    "continuity_reason": "signal_continuity_alert_active",
                     "drift_ok": "false",
+                    "drift_reason": "drift_live_promotion_ineligible",
                     "runtime_ledger_paper_probation_import_plan": {
                         "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
                         "target_count": 1,
@@ -589,7 +603,9 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(gate["dependency_quorum_source"], "live_submission_gate")
         self.assertEqual(gate["continuity_ok"], "false")
         self.assertEqual(gate["continuity_source"], "live_submission_gate")
+        self.assertEqual(gate["continuity_reason"], "signal_continuity_alert_active")
         self.assertEqual(gate["drift_ok"], "false")
+        self.assertEqual(gate["drift_reason"], "drift_live_promotion_ineligible")
         self.assertEqual(
             gate["blockers"],
             [
@@ -602,6 +618,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             target["runtime_window_import_promotion_blockers"],
             ["drift_checks_not_ok"],
         )
+        self.assertEqual(target["drift_reason"], "drift_live_promotion_ineligible")
 
     def test_next_paper_route_session_readiness_tracks_collection_and_import(
         self,

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -751,12 +751,16 @@ class TestVerifyTradingReadiness(TestCase):
             paper_route_evidence=_paper_route_evidence(
                 import_ready=True,
                 target_overrides={
+                    "continuity_reason": "signal_continuity_nominal",
                     "drift_ok": "false",
+                    "drift_reason": "drift_live_promotion_ineligible",
                     "runtime_window_import_health_gate": {
                         "schema_version": "torghut.runtime-window-import-health-gate.v1",
                         "dependency_quorum_decision": "allow",
                         "continuity_ok": "true",
+                        "continuity_reason": "signal_continuity_nominal",
                         "drift_ok": "false",
+                        "drift_reason": "drift_live_promotion_ineligible",
                         "blockers": [],
                         "promotion_blockers": ["drift_checks_not_ok"],
                     },
@@ -775,6 +779,15 @@ class TestVerifyTradingReadiness(TestCase):
         self.assertEqual(health_gate["blocked_target_count"], 0)
         self.assertEqual(health_gate["blockers"], [])
         self.assertEqual(health_gate["promotion_blockers"], ["drift_checks_not_ok"])
+        self.assertEqual(
+            health_gate["continuity_reasons"], ["signal_continuity_nominal"]
+        )
+        self.assertEqual(
+            health_gate["drift_reasons"], ["drift_live_promotion_ineligible"]
+        )
+        target = result["paper_route_target_plan"]["targets"][0]
+        self.assertEqual(target["continuity_reason"], "signal_continuity_nominal")
+        self.assertEqual(target["drift_reason"], "drift_live_promotion_ineligible")
 
     def test_paper_route_target_plan_synthesizes_drift_promotion_blocker(
         self,


### PR DESCRIPTION
## Summary

- Carries runtime-window import `continuity_reason` and `drift_reason` through paper-route target planning.
- Adds reason lists to paper-route health summaries, trading-readiness output, and runtime-ledger proof packets.
- Keeps drift-only evidence collection import-ready while leaving promotion blockers intact and explicit.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/paper_route_evidence.py scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py tests/test_paper_route_evidence.py tests/test_verify_trading_readiness.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py scripts/assemble_runtime_ledger_proof_packet.py scripts/verify_trading_readiness.py tests/test_paper_route_evidence.py tests/test_verify_trading_readiness.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen python -m pytest tests/test_paper_route_evidence.py tests/test_verify_trading_readiness.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv run --frozen coverage run -m pytest tests/test_paper_route_evidence.py tests/test_verify_trading_readiness.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv run --frozen coverage xml -o coverage.xml`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
