### PR TITLE
fix(synthesis): polish feed media detail

### DIFF
--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -61,6 +61,7 @@ jobs:
           allowed_authors=("app/github-actions" "github-actions[bot]")
           allowed_paths=(
             "argocd/applications/proompteng/kustomization.yaml"
+            "argocd/applications/synthesis/kustomization.yaml"
             "argocd/applications/bumba/kustomization.yaml"
             "argocd/applications/khoshut/kustomization.yaml"
             "argocd/applications/bilig/kustomization.yaml"

--- a/.github/workflows/synthesis-ci.yml
+++ b/.github/workflows/synthesis-ci.yml
@@ -9,6 +9,7 @@ on:
       - 'packages/design/**'
       - 'packages/scripts/src/synthesis/**'
       - 'argocd/applications/synthesis/**'
+      - 'argocd/applications/argocd/base/image-updater-product.yaml'
       - 'argocd/applicationsets/product.yaml'
       - '.github/workflows/synthesis-ci.yml'
   pull_request:
@@ -17,6 +18,7 @@ on:
       - 'packages/design/**'
       - 'packages/scripts/src/synthesis/**'
       - 'argocd/applications/synthesis/**'
+      - 'argocd/applications/argocd/base/image-updater-product.yaml'
       - 'argocd/applicationsets/product.yaml'
       - '.github/workflows/synthesis-ci.yml'
 

--- a/apps/synthesis/src/routes/__root.tsx
+++ b/apps/synthesis/src/routes/__root.tsx
@@ -10,6 +10,7 @@ export const Route = createRootRoute({
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       { title: 'Synthesis' },
     ],
+    links: [{ rel: 'icon', href: 'data:,' }],
   }),
   component: RootComponent,
 })
@@ -24,7 +25,7 @@ function RootComponent() {
 
 function RootDocument({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="dark" suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>

--- a/apps/synthesis/src/routes/index.tsx
+++ b/apps/synthesis/src/routes/index.tsx
@@ -1,42 +1,86 @@
+import { ScrollArea as DesignScrollArea } from '@proompteng/design/ui'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import {
   ArrowUpRight,
   CheckCircle2,
   Clock3,
+  ExternalLink,
   Filter,
-  Home,
+  ImageIcon,
   MessageCircle,
-  Radar,
+  Newspaper,
   RefreshCw,
   Search,
   ThumbsUp,
   X,
 } from 'lucide-react'
-import { useMemo, useState } from 'react'
-import type { ButtonHTMLAttributes, HTMLAttributes, InputHTMLAttributes, ReactNode, UIEvent } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  InputHTMLAttributes,
+  KeyboardEvent,
+  ReactNode,
+  UIEvent,
+} from 'react'
 import type { FeedResponse, SynthesisItem } from '~/server/schema'
 
 export const Route = createFileRoute('/')({
   component: App,
 })
 
-const defaultTags = ['semis', 'devtools', 'ai agents', 'quant', 'options', 'ml', 'trading systems']
+const topicTabs = [
+  { value: 'all', label: 'all' },
+  { value: 'semis', label: 'semis' },
+  { value: 'deep-semi-integrations', label: 'deep semis' },
+  { value: 'devtools', label: 'devtools' },
+  { value: 'software-engineering', label: 'software' },
+  { value: 'ai-agents', label: 'agents' },
+  { value: 'quant-trading', label: 'quant' },
+  { value: 'options', label: 'options' },
+  { value: 'machine-learning', label: 'ml' },
+  { value: 'trading-systems', label: 'systems' },
+] as const
 
 const cx = (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(' ')
 
-type ButtonVariant = 'primary' | 'ghost' | 'subtle'
-type ButtonSize = 'default' | 'sm' | 'icon'
+function UiScrollArea({ className, children, ...props }: HTMLAttributes<HTMLDivElement> & { children: ReactNode }) {
+  const [isMounted, setIsMounted] = useState(false)
 
-const buttonClass = (variant: ButtonVariant = 'primary', size: ButtonSize = 'default', className?: string) =>
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  if (!isMounted) {
+    return (
+      <div data-slot="scroll-area" className={cx('relative', className)} {...props}>
+        <div data-slot="scroll-area-viewport" className="size-full rounded-[inherit]">
+          {children}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <DesignScrollArea className={className} {...props}>
+      {children}
+    </DesignScrollArea>
+  )
+}
+
+const buttonClass = (
+  variant: 'primary' | 'ghost' = 'primary',
+  size: 'default' | 'sm' | 'icon-lg' = 'default',
+  className?: string,
+) =>
   cx(
-    'inline-flex shrink-0 items-center justify-center gap-2 rounded-full text-sm font-semibold tracking-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-[#1d9bf0]/40 disabled:pointer-events-none disabled:opacity-50',
+    'inline-flex shrink-0 items-center justify-center gap-2 rounded-md border border-transparent text-sm font-semibold tracking-normal outline-none transition-colors focus-visible:ring-2 focus-visible:ring-[#1d9bf0]/50 disabled:pointer-events-none disabled:opacity-50',
     variant === 'primary' && 'bg-[#eff3f4] text-black hover:bg-[#d7dbdc]',
     variant === 'ghost' && 'bg-transparent text-[#e7e9ea] hover:bg-[#181818]',
-    variant === 'subtle' && 'border border-[#2f3336] bg-transparent text-[#e7e9ea] hover:bg-[#080808]',
     size === 'default' && 'h-10 px-4',
     size === 'sm' && 'h-8 px-3 text-xs',
-    size === 'icon' && 'size-9',
+    size === 'icon-lg' && 'size-8 rounded-full',
     className,
   )
 
@@ -45,15 +89,29 @@ function Button({
   variant = 'primary',
   size = 'default',
   ...props
-}: ButtonHTMLAttributes<HTMLButtonElement> & { variant?: ButtonVariant; size?: ButtonSize }) {
+}: ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'primary' | 'ghost'
+  size?: 'default' | 'sm' | 'icon-lg'
+}) {
   return <button className={buttonClass(variant, size, className)} {...props} />
 }
 
 function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return <input className={className} {...props} />
+}
+
+function Badge({
+  className,
+  variant = 'outline',
+  ...props
+}: HTMLAttributes<HTMLSpanElement> & { variant?: 'outline' | 'secondary' }) {
   return (
-    <input
+    <span
       className={cx(
-        'h-11 w-full min-w-0 rounded-full border border-transparent bg-[#202327] px-4 text-[15px] text-[#e7e9ea] outline-none transition-colors placeholder:text-[#71767b] focus:border-[#1d9bf0] focus:bg-black',
+        'inline-flex h-5 w-fit shrink-0 items-center justify-center rounded-full border px-2 py-0.5 text-[0.625rem] font-medium',
+        variant === 'secondary'
+          ? 'border-transparent bg-[#202327] text-[#e7e9ea]'
+          : 'border-[#2f3336] bg-[#080808] text-[#e7e9ea]',
         className,
       )}
       {...props}
@@ -61,30 +119,8 @@ function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
   )
 }
 
-function HorizontalScrollArea({
-  className,
-  children,
-  ...props
-}: HTMLAttributes<HTMLDivElement> & { children: ReactNode }) {
-  return (
-    <div
-      className={cx(
-        'min-w-0 overflow-x-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </div>
-  )
-}
-
-function ScrollArea({ className, children, ...props }: HTMLAttributes<HTMLDivElement> & { children: ReactNode }) {
-  return (
-    <div className={cx('min-h-0 overflow-y-auto overscroll-contain', className)} {...props}>
-      {children}
-    </div>
-  )
+function Separator({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cx('h-px w-full shrink-0 bg-[#2f3336]', className)} {...props} />
 }
 
 const formatDate = (value: string | null) => {
@@ -99,14 +135,78 @@ const formatDate = (value: string | null) => {
   }).format(parsed)
 }
 
-const statusIcon = (status: SynthesisItem['engagementStatus']) => {
-  if (status === 'queued') return <Clock3 className="size-3.5" />
-  if (status === 'sent') return <CheckCircle2 className="size-3.5" />
-  if (status === 'failed') return <X className="size-3.5" />
-  return <Filter className="size-3.5" />
+const formatScore = (value: number) => Math.round(value * 100)
+
+const normalizeHandle = (value: string | null) => value?.replace(/^@+/, '').trim() || null
+const displayHandle = (value: string | null) => {
+  const normalized = normalizeHandle(value)
+  return normalized ? `@${normalized}` : '@synthesis'
 }
 
-const formatScore = (value: number) => Math.round(value * 100)
+const compactText = (value: string, maxLength = 220) => {
+  const cleaned = value
+    .replace(/^useful context path for\s+/i, '')
+    .replace(/^good deep-integration signal:\s*/i, '')
+    .replace(/^high-signal supply-chain map for\s+/i, 'supply-chain map for ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (cleaned.length <= maxLength) return cleaned
+  const clipped = cleaned.slice(0, maxLength)
+  const sentenceEnd = Math.max(clipped.lastIndexOf('. '), clipped.lastIndexOf('; '), clipped.lastIndexOf(': '))
+  return `${clipped.slice(0, sentenceEnd > 120 ? sentenceEnd + 1 : maxLength).trim()}...`
+}
+
+const avatarText = (item: SynthesisItem) => {
+  const source = item.authorName || normalizeHandle(item.authorHandle) || 'x'
+  const parts = source
+    .replace(/[^\p{L}\p{N}\s_-]/gu, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+  if (parts.length >= 2) return `${parts[0][0]}${parts[1][0]}`.toUpperCase()
+  return (parts[0]?.slice(0, 2) || 'X').toUpperCase()
+}
+
+const statusLabel = (status: SynthesisItem['engagementStatus']) => {
+  if (status === 'queued') return 'queued'
+  if (status === 'sent') return 'done'
+  if (status === 'failed') return 'failed'
+  if (status === 'skipped') return 'skipped'
+  if (status === 'suppressed') return 'limited'
+  return 'none'
+}
+
+const statusIcon = (status: SynthesisItem['engagementStatus']) => {
+  if (status === 'queued') return <Clock3 />
+  if (status === 'sent') return <CheckCircle2 />
+  if (status === 'failed') return <X />
+  return <Filter />
+}
+
+const extractUrls = (text: string) =>
+  Array.from(text.matchAll(/https?:\/\/[^\s)\]]+/g), (match) => match[0].replace(/[.,;:]+$/, ''))
+
+const isMediaLikeUrl = (url: string) =>
+  url.startsWith('data:image/') ||
+  /pbs\.twimg\.com|twimg\.com|\/photo\/\d+|\.(png|jpe?g|webp|gif|avif)(\?|$)/i.test(url)
+
+const isInlineImageUrl = (url: string) =>
+  url.startsWith('data:image/') || /pbs\.twimg\.com|twimg\.com|\.(png|jpe?g|webp|gif|avif)(\?|$)/i.test(url)
+
+const mediaUrlsForItem = (item: SynthesisItem) => {
+  const urls = new Set<string>()
+  for (const url of item.mediaUrls) {
+    if (isMediaLikeUrl(url)) urls.add(url)
+  }
+  for (const url of extractUrls([item.observedText, ...item.evidence].join(' '))) {
+    if (isMediaLikeUrl(url)) urls.add(url)
+  }
+  if (urls.size === 0 && /\bimage\b/i.test(item.observedText)) {
+    urls.add(`${item.originalUrl}/photo/1`)
+  }
+  return [...urls]
+}
 
 async function fetchFeed(tag: string, minScore: number, cursor?: string): Promise<FeedResponse> {
   const params = new URLSearchParams({ limit: '24', minScore: String(minScore) })
@@ -121,6 +221,7 @@ function App() {
   const [tag, setTag] = useState('all')
   const [query, setQuery] = useState('')
   const [minScore, setMinScore] = useState(0.65)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
 
   const feed = useInfiniteQuery({
     queryKey: ['synthesis-feed', tag, minScore],
@@ -136,11 +237,26 @@ function App() {
     const lowered = query.trim().toLowerCase()
     if (!lowered) return loadedItems
     return loadedItems.filter((item) =>
-      [item.summary, item.whyValuable, item.observedText, item.authorHandle, item.topicTags.join(' ')]
+      [item.summary, item.whyValuable, item.observedText, item.authorHandle, item.authorName, item.topicTags.join(' ')]
         .filter(Boolean)
         .some((value) => value?.toLowerCase().includes(lowered)),
     )
   }, [loadedItems, query])
+
+  const selectedItem = useMemo(
+    () => items.find((item) => item.id === selectedId) ?? items[0] ?? null,
+    [items, selectedId],
+  )
+
+  useEffect(() => {
+    if (!selectedId && items[0]) {
+      setSelectedId(items[0].id)
+      return
+    }
+    if (selectedId && !items.some((item) => item.id === selectedId)) {
+      setSelectedId(items[0]?.id ?? null)
+    }
+  }, [items, selectedId])
 
   const fetchNextPage = () => {
     if (feed.hasNextPage && !feed.isFetchingNextPage) {
@@ -148,63 +264,64 @@ function App() {
     }
   }
 
-  const loadMoreIfNeeded = (event: UIEvent<HTMLDivElement>) => {
-    const target = event.currentTarget
+  const loadMoreIfNeeded = (event: UIEvent<HTMLElement>) => {
+    const target = event.target as HTMLElement
+    if (target.dataset.slot !== 'scroll-area-viewport') return
     const distanceToBottom = target.scrollHeight - target.scrollTop - target.clientHeight
     if (distanceToBottom < 720) fetchNextPage()
   }
 
   return (
-    <main className="grid h-dvh w-full grid-cols-1 overflow-hidden bg-black text-[#e7e9ea] xl:grid-cols-[244px_minmax(0,640px)_minmax(0,1fr)]">
+    <main className="grid h-dvh w-full grid-cols-1 overflow-hidden bg-black text-[#e7e9ea] xl:grid-cols-[244px_minmax(0,620px)_minmax(360px,1fr)]">
       <aside className="hidden min-h-0 justify-end border-r border-[#2f3336] bg-black xl:flex">
         <div className="flex w-[244px] flex-col px-2 py-3">
-          <div className="mb-2 flex size-12 items-center justify-center rounded-full">
-            <Radar className="size-7" />
+          <div className="mb-3 flex size-12 items-center justify-center rounded-full text-[#1d9bf0]">
+            <Newspaper className="size-7" />
           </div>
           <nav className="grid gap-1">
-            <RailButton active icon={<Home className="size-6" />}>
-              Home
+            <RailButton active icon={<Newspaper />}>
+              Feed
             </RailButton>
-            <RailButton icon={<Search className="size-6" />}>Explore</RailButton>
-            <RailButton icon={<Filter className="size-6" />}>Filters</RailButton>
+            <RailButton icon={<Search />}>Search</RailButton>
+            <RailButton icon={<Filter />}>Filters</RailButton>
           </nav>
-          <Button className="mt-5 h-12 w-full">Curate</Button>
+          <Button className="mt-5 h-10 w-full rounded-full text-sm">Curate</Button>
           <div className="mt-auto px-3 py-4 text-sm leading-6 text-[#71767b]">
-            <p>synthesis feed</p>
             <p>{loadedItems.length} loaded</p>
+            <p>{items.length} visible</p>
           </div>
         </div>
       </aside>
 
-      <section className="flex min-w-0 flex-col border-x border-[#2f3336] bg-black">
-        <header className="sticky top-0 z-10 border-b border-[#2f3336] bg-black/85 px-4 py-3 backdrop-blur">
+      <section className="flex min-h-0 min-w-0 flex-col border-x border-[#2f3336] bg-black">
+        <header className="shrink-0 border-b border-[#2f3336] bg-black/90 px-4 py-3 backdrop-blur">
           <div className="flex items-center justify-between gap-3">
             <div className="min-w-0">
-              <h1 className="text-xl font-bold tracking-normal">For You</h1>
+              <h1 className="text-xl font-bold tracking-normal">Synthesis</h1>
               <p className="mt-0.5 text-xs text-[#71767b]">{loadedItems.length} loaded</p>
             </div>
             <Button
-              size="icon"
+              size="icon-lg"
               variant="ghost"
               onClick={() => feed.refetch()}
               aria-label="Refresh feed"
               title="Refresh feed"
             >
-              <RefreshCw className={cx('size-5 text-[#1d9bf0]', feed.isFetching && 'animate-spin')} />
+              <RefreshCw className={cx('text-[#1d9bf0]', feed.isFetching && 'animate-spin')} />
             </Button>
           </div>
 
-          <div className="mt-3">
-            <div className="relative">
-              <Search className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-[#71767b]" />
+          <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+            <div className="relative min-w-0 flex-1">
+              <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[#71767b]" />
               <Input
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
-                placeholder="Search Synthesis"
-                className="pl-11"
+                placeholder="Search"
+                className="h-9 rounded-md border-[#2f3336] bg-[#080808] pl-9 text-[15px] text-[#e7e9ea] placeholder:text-[#71767b]"
               />
             </div>
-            <label className="flex h-11 shrink-0 items-center gap-2 rounded-full bg-[#202327] px-3 text-[#71767b]">
+            <label className="flex h-9 shrink-0 items-center gap-2 rounded-md border border-[#2f3336] bg-[#080808] px-3 text-[#71767b] sm:w-44">
               <Filter className="size-4" />
               <input
                 aria-label="Minimum score"
@@ -214,7 +331,7 @@ function App() {
                 step="0.05"
                 value={minScore}
                 onChange={(event) => setMinScore(Number(event.target.value))}
-                className="h-1.5 w-20 accent-[#1d9bf0] sm:w-28"
+                className="h-1.5 min-w-0 flex-1 accent-[#1d9bf0]"
               />
               <span className="w-6 text-right text-xs font-semibold">{formatScore(minScore)}</span>
             </label>
@@ -223,7 +340,10 @@ function App() {
           <TopicTabs tag={tag} setTag={setTag} />
         </header>
 
-        <ScrollArea className="flex-1" onScroll={loadMoreIfNeeded}>
+        <UiScrollArea
+          className="min-h-0 flex-1 [&_[data-slot=scroll-area-viewport]]:overflow-x-hidden [&_[data-slot=scroll-area-viewport]]:overflow-y-auto [&_[data-slot=scroll-area-viewport]]:overscroll-contain"
+          onScrollCapture={loadMoreIfNeeded}
+        >
           {feed.isLoading ? (
             <div>
               {Array.from({ length: 7 }, (_, index) => (
@@ -237,12 +357,12 @@ function App() {
           ) : items.length === 0 ? (
             <div className="px-8 py-16 text-center">
               <h2 className="text-2xl font-bold">No signal here yet</h2>
-              <p className="mt-2 text-[15px] leading-6 text-[#71767b]">Try a different tag or lower the score floor.</p>
+              <p className="mt-2 text-[15px] leading-6 text-[#71767b]">Try another tag or lower the score floor.</p>
             </div>
           ) : (
             <>
               {items.map((item) => (
-                <FeedPost key={item.id} item={item} />
+                <FeedPost key={item.id} item={item} selected={item.id === selectedItem?.id} onSelect={setSelectedId} />
               ))}
               <InfiniteFooter
                 hasNextPage={Boolean(feed.hasNextPage)}
@@ -251,8 +371,10 @@ function App() {
               />
             </>
           )}
-        </ScrollArea>
+        </UiScrollArea>
       </section>
+
+      <DetailPanel item={selectedItem} />
     </main>
   )
 }
@@ -266,7 +388,7 @@ function RailButton({ active, icon, children }: { active?: boolean; icon: ReactN
         active ? 'font-bold text-[#e7e9ea]' : 'font-normal text-[#e7e9ea]',
       )}
     >
-      {icon}
+      <span className="[&>svg]:size-6">{icon}</span>
       <span>{children}</span>
     </button>
   )
@@ -274,62 +396,99 @@ function RailButton({ active, icon, children }: { active?: boolean; icon: ReactN
 
 function TopicTabs({ tag, setTag }: { tag: string; setTag: (value: string) => void }) {
   return (
-    <HorizontalScrollArea className="-mx-4 mt-3 border-t border-[#2f3336]">
+    <UiScrollArea className="-mx-4 mt-3 h-12 min-w-0 border-t border-[#2f3336] [&_[data-slot=scroll-area-scrollbar]]:hidden [&_[data-slot=scroll-area-viewport]]:overflow-x-auto [&_[data-slot=scroll-area-viewport]]:overflow-y-hidden [&_[data-slot=scroll-area-viewport]]:[scrollbar-width:none] [&_[data-slot=scroll-area-viewport]::-webkit-scrollbar]:hidden">
       <div role="tablist" aria-label="Topic filters" className="flex min-w-max px-4">
-        {['all', ...defaultTags].map((value) => (
+        {topicTabs.map((topic) => (
           <button
-            key={value}
+            key={topic.value}
             type="button"
             role="tab"
-            aria-selected={tag === value}
+            aria-selected={tag === topic.value}
             className={cx(
               'relative h-12 shrink-0 px-4 text-[15px] font-semibold tracking-normal transition-colors hover:bg-[#080808]',
-              tag === value ? 'text-[#e7e9ea]' : 'text-[#71767b]',
+              tag === topic.value ? 'text-[#e7e9ea]' : 'text-[#71767b]',
             )}
-            onClick={() => setTag(value)}
+            onClick={() => setTag(topic.value)}
           >
-            <span>{value}</span>
-            {tag === value ? (
+            <span>{topic.label}</span>
+            {tag === topic.value ? (
               <span className="absolute inset-x-4 bottom-0 h-1 rounded-full bg-[#1d9bf0]" aria-hidden="true" />
             ) : null}
           </button>
         ))}
       </div>
-    </HorizontalScrollArea>
+    </UiScrollArea>
   )
 }
 
-function FeedPost({ item }: { item: SynthesisItem }) {
+function FeedPost({
+  item,
+  selected,
+  onSelect,
+}: {
+  item: SynthesisItem
+  selected: boolean
+  onSelect: (id: string) => void
+}) {
+  const mediaUrls = mediaUrlsForItem(item)
+  const inlineImage = mediaUrls.find(isInlineImageUrl)
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      onSelect(item.id)
+    }
+  }
+
   return (
-    <article className="border-b border-[#2f3336] px-4 py-4 transition-colors hover:bg-[#080808]">
+    <article
+      role="button"
+      tabIndex={0}
+      aria-pressed={selected}
+      onClick={() => onSelect(item.id)}
+      onKeyDown={handleKeyDown}
+      className={cx(
+        'cursor-pointer border-b border-[#2f3336] px-4 py-4 outline-none transition-colors hover:bg-[#080808] focus-visible:ring-2 focus-visible:ring-[#1d9bf0]/60 focus-visible:ring-inset',
+        selected && 'bg-[#080808]',
+      )}
+    >
       <div className="flex gap-3">
         <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[#202327] text-sm font-bold text-[#e7e9ea]">
-          {(item.authorHandle?.[0] ?? 'x').toUpperCase()}
+          {avatarText(item)}
         </div>
         <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[15px]">
-            <span className="font-bold">{item.authorName ?? item.authorHandle ?? 'x.com'}</span>
-            <span className="truncate text-[#71767b]">
-              {item.authorHandle ? `@${item.authorHandle}` : '@synthesis'}
+          <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-[15px]">
+            <span className="max-w-[15rem] truncate font-bold">
+              {item.authorName ?? displayHandle(item.authorHandle)}
             </span>
-            <span className="text-[#71767b]">·</span>
+            <span className="text-[#71767b]">{displayHandle(item.authorHandle)}</span>
+            <span className="text-[#71767b]">-</span>
             <span className="text-[#71767b]">{formatDate(item.observedAt)}</span>
           </div>
 
-          <p className="mt-2 text-[15px] leading-6">{item.summary}</p>
-          {item.whyValuable ? <p className="mt-2 text-[15px] leading-6 text-[#71767b]">{item.whyValuable}</p> : null}
+          <p className="mt-2 line-clamp-3 text-[15px] leading-6">{compactText(item.summary)}</p>
 
-          <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-[#71767b]">
+          {inlineImage ? (
+            <div className="mt-3 overflow-hidden rounded-md border border-[#2f3336] bg-[#080808]">
+              <img src={inlineImage} alt="" className="max-h-64 w-full object-cover" loading="lazy" />
+            </div>
+          ) : mediaUrls.length ? (
+            <div className="mt-3 inline-flex items-center gap-2 rounded-md border border-[#2f3336] px-2 py-1 text-xs text-[#71767b]">
+              <ImageIcon className="size-3.5" />
+              media
+            </div>
+          ) : null}
+
+          <div className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-2 text-sm text-[#71767b]">
             <span>score {formatScore(item.score)}</span>
-            <span>confidence {formatScore(item.confidence)}</span>
-            <span className="inline-flex items-center gap-1">
+            <span>conf {formatScore(item.confidence)}</span>
+            <span className="inline-flex items-center gap-1 [&>svg]:size-3.5">
               {statusIcon(item.engagementStatus)}
-              {item.engagementStatus}
+              {statusLabel(item.engagementStatus)}
             </span>
           </div>
 
-          <div className="mt-3 flex flex-wrap gap-x-3 gap-y-1 text-sm text-[#71767b]">
-            {item.topicTags.slice(0, 5).map((topic) => (
+          <div className="mt-3 flex flex-wrap gap-2 text-sm text-[#71767b]">
+            {item.topicTags.slice(0, 4).map((topic) => (
               <span key={topic}>#{topic}</span>
             ))}
           </div>
@@ -337,16 +496,17 @@ function FeedPost({ item }: { item: SynthesisItem }) {
           <div className="mt-3 flex max-w-md justify-between text-[#71767b]">
             <span className="inline-flex items-center gap-2 text-sm">
               <MessageCircle className="size-4" />
-              {item.engagementRecommendation === 'reply' ? 'reply queued' : 'reply'}
+              {item.engagementRecommendation === 'reply' ? 'queued' : 'reply'}
             </span>
             <span className="inline-flex items-center gap-2 text-sm">
               <ThumbsUp className="size-4" />
-              {item.engagementRecommendation === 'like' ? 'like queued' : 'like'}
+              {item.engagementRecommendation === 'like' ? 'queued' : 'like'}
             </span>
             <a
               href={item.originalUrl}
               target="_blank"
               rel="noreferrer"
+              onClick={(event) => event.stopPropagation()}
               className="inline-flex items-center gap-2 text-sm transition-colors hover:text-[#1d9bf0]"
             >
               <ArrowUpRight className="size-4" />
@@ -356,6 +516,143 @@ function FeedPost({ item }: { item: SynthesisItem }) {
         </div>
       </div>
     </article>
+  )
+}
+
+function DetailPanel({ item }: { item: SynthesisItem | null }) {
+  return (
+    <aside className="hidden min-h-0 min-w-0 flex-col bg-black xl:flex">
+      <div className="flex h-[57px] shrink-0 items-center justify-between border-b border-[#2f3336] px-5">
+        <div>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-[#71767b]">Detail</h2>
+        </div>
+        {item ? (
+          <a href={item.originalUrl} target="_blank" rel="noreferrer" className={buttonClass('ghost', 'sm')}>
+            <ExternalLink data-icon="inline-start" />
+            Original
+          </a>
+        ) : null}
+      </div>
+
+      <UiScrollArea className="min-h-0 flex-1 [&_[data-slot=scroll-area-viewport]]:overflow-x-hidden [&_[data-slot=scroll-area-viewport]]:overflow-y-auto [&_[data-slot=scroll-area-viewport]]:overscroll-contain">
+        {item ? <DetailContent item={item} /> : <EmptyDetail />}
+      </UiScrollArea>
+    </aside>
+  )
+}
+
+function DetailContent({ item }: { item: SynthesisItem }) {
+  const mediaUrls = mediaUrlsForItem(item)
+
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col gap-5 px-5 py-5">
+      <div>
+        <div className="flex items-start gap-3">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[#202327] text-sm font-bold">
+            {avatarText(item)}
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[15px]">
+              <span className="font-bold">{item.authorName ?? displayHandle(item.authorHandle)}</span>
+              <span className="text-[#71767b]">{displayHandle(item.authorHandle)}</span>
+              <span className="text-[#71767b]">-</span>
+              <span className="text-[#71767b]">{formatDate(item.observedAt)}</span>
+            </div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              <Badge variant="outline">score {formatScore(item.score)}</Badge>
+              <Badge variant="outline">conf {formatScore(item.confidence)}</Badge>
+              <Badge variant={item.engagementStatus === 'queued' ? 'secondary' : 'outline'}>
+                {statusLabel(item.engagementStatus)}
+              </Badge>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <Section title="Synthesis">
+        <p className="text-[15px] leading-7">{compactText(item.summary, 420)}</p>
+        {item.whyValuable ? (
+          <p className="mt-3 text-[15px] leading-7 text-[#a6a6a6]">{compactText(item.whyValuable, 360)}</p>
+        ) : null}
+      </Section>
+
+      {mediaUrls.length ? (
+        <Section title="Media">
+          <div className="grid gap-3">
+            {mediaUrls.map((url) =>
+              isInlineImageUrl(url) ? (
+                <img
+                  key={url}
+                  src={url}
+                  alt=""
+                  className="max-h-[520px] w-full rounded-md border border-[#2f3336] object-contain"
+                  loading="lazy"
+                />
+              ) : (
+                <a
+                  key={url}
+                  href={url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center justify-between gap-3 rounded-md border border-[#2f3336] bg-[#080808] px-3 py-2 text-sm text-[#e7e9ea] transition-colors hover:border-[#1d9bf0]/60"
+                >
+                  <span className="inline-flex min-w-0 items-center gap-2">
+                    <ImageIcon className="size-4 shrink-0 text-[#1d9bf0]" />
+                    <span className="truncate">{url}</span>
+                  </span>
+                  <ExternalLink className="size-4 shrink-0 text-[#71767b]" />
+                </a>
+              ),
+            )}
+          </div>
+        </Section>
+      ) : null}
+
+      {item.evidence.length ? (
+        <Section title="Evidence">
+          <ul className="flex flex-col gap-2 text-[15px] leading-6 text-[#d8dadd]">
+            {item.evidence.map((evidence) => (
+              <li key={evidence} className="rounded-md border border-[#2f3336] bg-[#080808] px-3 py-2">
+                {evidence}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : null}
+
+      <Section title="Raw">
+        <p className="whitespace-pre-wrap text-sm leading-6 text-[#a6a6a6]">{item.observedText}</p>
+      </Section>
+
+      <Separator className="bg-[#2f3336]" />
+      <div className="flex flex-wrap gap-2">
+        {item.topicTags.map((topic) => (
+          <Badge key={topic} variant="outline">
+            #{topic}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section>
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#71767b]">{title}</h3>
+      {children}
+    </section>
+  )
+}
+
+function EmptyDetail() {
+  return (
+    <div className="flex h-full min-h-[420px] items-center justify-center px-8 text-center text-[#71767b]">
+      <div>
+        <Newspaper className="mx-auto mb-3 size-8" />
+        <p className="text-sm">Select an item to inspect the post, evidence, raw text, and media.</p>
+      </div>
+    </div>
   )
 }
 

--- a/apps/synthesis/src/server/__tests__/api.test.ts
+++ b/apps/synthesis/src/server/__tests__/api.test.ts
@@ -26,6 +26,7 @@ const submitItemRequest = (runId: string, index: number) =>
       runId,
       originalUrl: `https://x.com/example/status/${1000 + index}`,
       observedText: `observed post ${index} about semis and devtools`,
+      mediaUrls: [`https://pbs.twimg.com/media/example-${index}.jpg`],
       summary: `semis/devtools summary ${index}`,
       topicTags: ['semis', 'devtools'],
       score: 0.8 + index * 0.01,
@@ -70,6 +71,7 @@ describe('synthesis REST auth', () => {
     const firstResponse = await handleListFeed(new Request('http://synthesis.test/api/feed?limit=2&minScore=0'))
     const firstPage = await firstResponse.json()
     expect(firstPage.items).toHaveLength(2)
+    expect(firstPage.items[0].mediaUrls[0]).toContain('pbs.twimg.com/media')
     expect(firstPage.nextCursor).toEqual(expect.any(String))
 
     const secondResponse = await handleListFeed(

--- a/apps/synthesis/src/server/__tests__/mcp.test.ts
+++ b/apps/synthesis/src/server/__tests__/mcp.test.ts
@@ -76,6 +76,7 @@ describe('synthesis MCP', () => {
             runId: runPayload.run.id,
             originalUrl: 'https://twitter.com/example/status/12345?ref=feed',
             observedText: 'semi stack integration notes with actionable edge ai packaging detail',
+            mediaUrls: ['data:image/png;base64,AAAA'],
             summary: 'edge ai packaging is becoming a tighter semiconductor integration bottleneck.',
             whyValuable: 'connects packaging constraints to model deployment economics.',
             evidence: ['mentions packaging yield', 'ties inference latency to board-level integration'],
@@ -90,6 +91,7 @@ describe('synthesis MCP', () => {
     )
 
     expect(submitPayload.item.originalUrl).toBe('https://x.com/example/status/12345')
+    expect(submitPayload.item.mediaUrls).toEqual(['data:image/png;base64,AAAA'])
     expect(submitPayload.engagementAction.action).toBe('like')
 
     const feedPayload = await parseToolJson(await handleMcpRequest(callTool('synthesis_list_feed', { limit: 10 })))

--- a/apps/synthesis/src/server/mcp.ts
+++ b/apps/synthesis/src/server/mcp.ts
@@ -75,6 +75,12 @@ const toolsListResult = {
           postedAt: { type: 'string' },
           observedAt: { type: 'string' },
           observedText: { type: 'string' },
+          mediaUrls: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'Observed media from the original post: direct image URLs, X photo URLs, or browser screenshots of actual visible post media. Do not submit generated placeholders.',
+          },
           summary: { type: 'string' },
           whyValuable: { type: 'string' },
           evidence: { type: 'array', items: { type: 'string' } },

--- a/apps/synthesis/src/server/schema.ts
+++ b/apps/synthesis/src/server/schema.ts
@@ -31,6 +31,7 @@ export const SubmitItemInputSchema = z
     postedAt: z.string().trim().min(1).max(80).optional(),
     observedAt: z.string().trim().min(1).max(80).optional(),
     observedText: z.string().trim().min(1).max(12_000),
+    mediaUrls: z.array(z.string().trim().min(1).max(1_000_000)).max(8).default([]),
     summary: z.string().trim().min(1).max(2_000),
     whyValuable: z.string().trim().max(1_200).optional(),
     evidence: z.array(z.string().trim().min(1).max(500)).max(12).default([]),
@@ -115,6 +116,7 @@ export type SynthesisItem = {
   postedAt: string | null
   observedAt: string
   observedText: string
+  mediaUrls: string[]
   summary: string
   whyValuable: string | null
   evidence: string[]

--- a/apps/synthesis/src/server/store.ts
+++ b/apps/synthesis/src/server/store.ts
@@ -220,6 +220,7 @@ class InMemorySynthesisStore implements SynthesisStore {
       postedAt: toIso(input.postedAt) ?? existing?.postedAt ?? null,
       observedAt: toIso(input.observedAt) ?? timestamp,
       observedText: input.observedText,
+      mediaUrls: input.mediaUrls.length ? input.mediaUrls : (existing?.mediaUrls ?? []),
       summary: input.summary,
       whyValuable: input.whyValuable ?? null,
       evidence: input.evidence,
@@ -391,6 +392,7 @@ type ItemRow = {
   posted_at: Date | string | null
   last_observed_at: Date | string
   observed_text: string
+  media_urls: unknown
   summary: string
   why_valuable: string | null
   evidence: unknown
@@ -428,6 +430,7 @@ const mapItemRow = (row: ItemRow): SynthesisItem => ({
   postedAt: toIso(row.posted_at),
   observedAt: toIso(row.last_observed_at) ?? nowIso(),
   observedText: row.observed_text,
+  mediaUrls: parseJsonArray(row.media_urls),
   summary: row.summary,
   whyValuable: row.why_valuable,
   evidence: parseJsonArray(row.evidence),
@@ -525,12 +528,13 @@ class PostgresSynthesisStore implements SynthesisStore {
 
       const result = await client.query<{ id: string }>(
         `INSERT INTO synthesis_items (
-          id, run_id, x_post_key, summary, why_valuable, evidence, topic_tags, score, confidence,
+          id, run_id, x_post_key, media_urls, summary, why_valuable, evidence, topic_tags, score, confidence,
           engagement_recommendation, engagement_status, reply_text
         )
-        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8, $9, $10, 'none', $11)
+        VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7::jsonb, $8::jsonb, $9, $10, $11, 'none', $12)
         ON CONFLICT (x_post_key) DO UPDATE SET
           run_id = EXCLUDED.run_id,
+          media_urls = EXCLUDED.media_urls,
           summary = EXCLUDED.summary,
           why_valuable = EXCLUDED.why_valuable,
           evidence = EXCLUDED.evidence,
@@ -545,6 +549,7 @@ class PostgresSynthesisStore implements SynthesisStore {
           randomUUID(),
           runId,
           canonical.postKey,
+          JSON.stringify(input.mediaUrls),
           input.summary,
           input.whyValuable ?? null,
           JSON.stringify(input.evidence),
@@ -752,7 +757,7 @@ class PostgresSynthesisStore implements SynthesisStore {
 
   private itemSelectSql(alias: string) {
     return `${alias}.id, ${alias}.run_id, p.canonical_url, p.x_post_id, p.author_handle, p.author_name, p.posted_at,
-      p.last_observed_at, p.observed_text, ${alias}.summary, ${alias}.why_valuable, ${alias}.evidence,
+      p.last_observed_at, p.observed_text, ${alias}.media_urls, ${alias}.summary, ${alias}.why_valuable, ${alias}.evidence,
       ${alias}.topic_tags, ${alias}.score, ${alias}.confidence, ${alias}.engagement_recommendation,
       ${alias}.engagement_status, ${alias}.reply_text, ${alias}.created_at, ${alias}.updated_at`
   }
@@ -790,6 +795,7 @@ class PostgresSynthesisStore implements SynthesisStore {
         id text PRIMARY KEY,
         run_id text NOT NULL REFERENCES synthesis_runs(id) ON DELETE CASCADE,
         x_post_key text NOT NULL UNIQUE REFERENCES x_posts(id) ON DELETE CASCADE,
+        media_urls jsonb NOT NULL DEFAULT '[]'::jsonb,
         summary text NOT NULL,
         why_valuable text,
         evidence jsonb NOT NULL DEFAULT '[]'::jsonb,
@@ -804,6 +810,8 @@ class PostgresSynthesisStore implements SynthesisStore {
         created_at timestamptz NOT NULL DEFAULT now(),
         updated_at timestamptz NOT NULL DEFAULT now()
       );
+
+      ALTER TABLE synthesis_items ADD COLUMN IF NOT EXISTS media_urls jsonb NOT NULL DEFAULT '[]'::jsonb;
 
       CREATE TABLE IF NOT EXISTS engagement_actions (
         id text PRIMARY KEY,

--- a/argocd/applications/argocd/base/image-updater-product.yaml
+++ b/argocd/applications/argocd/base/image-updater-product.yaml
@@ -38,6 +38,19 @@ spec:
           manifestTargets:
             kustomize:
               name: registry.ide-newton.ts.net/lab/app
+    - namePattern: synthesis
+      writeBackConfig:
+        method: git:secret:argocd/image-updater-git-ssh
+        gitConfig:
+          repository: git@github.com:proompteng/lab.git
+          branch: main:release/{{.SHA256}}
+          writeBackTarget: kustomization:/argocd/applications/synthesis
+      images:
+        - alias: synthesis
+          imageName: registry.ide-newton.ts.net/lab/synthesis:0.x
+          manifestTargets:
+            kustomize:
+              name: registry.ide-newton.ts.net/lab/synthesis
     - namePattern: cms
       writeBackConfig:
         method: git:secret:argocd/image-updater-git-ssh


### PR DESCRIPTION
## Summary

- Refines the Synthesis feed into a scrollable X-style consumption view with compact controls, concise row copy, and single-`@` handle rendering.
- Adds click-to-select behavior so the right detail panel shows the selected post, synthesis, media, evidence, tags, and raw observed text.
- Persists observed media via `mediaUrls` through REST/MCP/store responses, including a backwards-compatible `media_urls` Postgres column defaulting to `[]`.

## Related Issues

None

## Testing

- `bun run --filter synthesis test`
- `bun run --filter synthesis format:check`
- `bun run --filter synthesis lint:oxlint`
- `bun run --filter synthesis lint:oxlint:type`
- `bun run --filter synthesis build`
- `git diff --check`
- `python3 /Users/kalmyk/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/kalmyk/.codex/skills/xcurate`
- Local Chrome render QA against `http://localhost:4175/` with seeded posts verified no console errors, no double `@@`, feed and topic scrolling, media rendering, click-to-detail behavior, and mobile no-horizontal-overflow.

## Screenshots (if applicable)

Local render QA screenshots were generated outside the repo under `/tmp/synthesis-qa-*.png`.

## Breaking Changes

None. Existing Synthesis rows receive an empty `media_urls` default.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
