### PR TITLE
chore(torghut): promote image 73a9c95b

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.574.4-10-gbf9f8867e
+              value: v0.574.5-6-g73a9c95b1
             - name: TORGHUT_OPTIONS_COMMIT
-              value: bf9f8867efd9746dfd5f59ee55343bbc30da4ddc
+              value: 73a9c95b1b7ec5060eb5c81343b55fe1eaf1019a
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.574.4-10-gbf9f8867e
+              value: v0.574.5-6-g73a9c95b1
             - name: TORGHUT_OPTIONS_COMMIT
-              value: bf9f8867efd9746dfd5f59ee55343bbc30da4ddc
+              value: 73a9c95b1b7ec5060eb5c81343b55fe1eaf1019a
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -100,7 +100,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+                  value: sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-25T22:51:20Z"
+        client.knative.dev/updateTimestamp: "2026-05-25T23:25:36Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
           ports:
             - name: http1
               containerPort: 8181
@@ -503,11 +503,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.574.4-10-gbf9f8867e
+              value: v0.574.5-6-g73a9c95b1
             - name: TORGHUT_COMMIT
-              value: bf9f8867efd9746dfd5f59ee55343bbc30da4ddc
+              value: 73a9c95b1b7ec5060eb5c81343b55fe1eaf1019a
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+              value: sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-25T22:51:20Z"
+        client.knative.dev/updateTimestamp: "2026-05-25T23:25:36Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
           ports:
             - name: http1
               containerPort: 8181
@@ -322,11 +322,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.574.4-10-gbf9f8867e
+              value: v0.574.5-6-g73a9c95b1
             - name: TORGHUT_COMMIT
-              value: bf9f8867efd9746dfd5f59ee55343bbc30da4ddc
+              value: 73a9c95b1b7ec5060eb5c81343b55fe1eaf1019a
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+              value: sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:87b045ea4624e033801815af4d11067bb3e87c9718648b6b6404dc13695ed201
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `73a9c95b1b7ec5060eb5c81343b55fe1eaf1019a`
- Image tag: `73a9c95b`
- Image digest: `sha256:925be6ff80ee4526ed9e5d1412f34a6515fd51aecd17703fdb33480c3a3338bc`