### PR TITLE
fix(agents): guard mcp agentrun secret bindings

### DIFF
--- a/services/agents/src/server/mcp.test.ts
+++ b/services/agents/src/server/mcp.test.ts
@@ -161,7 +161,12 @@ describe('Agents MCP handler', () => {
 
     const list = await post(service, { jsonrpc: '2.0', id: 2, method: 'tools/list' })
     expect(list.response.status).toBe(200)
-    expect(list.json?.result?.tools?.map((tool: { name: string }) => tool.name)).toEqual(
+    const tools = list.json?.result?.tools as Array<{
+      name: string
+      description?: string
+      inputSchema?: { properties?: Record<string, unknown> }
+    }>
+    expect(tools.map((tool) => tool.name)).toEqual(
       expect.arrayContaining([
         'persist_memory',
         'retrieve_memory',
@@ -175,6 +180,9 @@ describe('Agents MCP handler', () => {
         'rerun_agent_run',
       ]),
     )
+    const createTool = tools.find((tool) => tool.name === 'create_agent_run')
+    expect(createTool?.description).toContain('secretBindingRef')
+    expect(createTool?.inputSchema?.properties?.secretBindingRef).toBeDefined()
   })
 
   it('supports resources/list + resources/templates/list', async () => {
@@ -387,6 +395,162 @@ describe('Agents MCP handler', () => {
       },
     ])
     expect(calls.rerun).toEqual([{ agentRunId: 'run-1', deliveryId: 'rerun-1', payload: { reason: 'mcp smoke' } }])
+  })
+
+  it('injects create_agent_run secretBindingRef into payload policy', async () => {
+    const { service } = makeService()
+    const { service: agentRunsService, calls } = makeAgentRunsService()
+
+    const create = await post(
+      service,
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'create_agent_run',
+          arguments: {
+            deliveryId: 'delivery-with-secrets',
+            secretBindingRef: 'codex-github-token',
+            payload: {
+              agentRef: { name: 'codex-agent' },
+              implementation: { text: 'Implement the requested change.' },
+              runtime: { type: 'job' },
+              secrets: ['github-token', 'codex-auth'],
+              parameters: {
+                repository: 'proompteng/lab',
+                base: 'main',
+                head: 'codex/demo',
+                stage: 'implementation',
+              },
+            },
+          },
+        },
+      },
+      {},
+      agentRunsService,
+    )
+
+    expect(create.response.status).toBe(200)
+    expect(calls.create).toEqual([
+      {
+        deliveryId: 'delivery-with-secrets',
+        payload: {
+          agentRef: { name: 'codex-agent' },
+          implementation: { text: 'Implement the requested change.' },
+          runtime: { type: 'job' },
+          secrets: ['github-token', 'codex-auth'],
+          parameters: {
+            repository: 'proompteng/lab',
+            base: 'main',
+            head: 'codex/demo',
+            stage: 'implementation',
+          },
+          policy: { secretBindingRef: 'codex-github-token' },
+        },
+        dryRun: null,
+      },
+    ])
+  })
+
+  it('rejects create_agent_run submissions that request secrets without a SecretBinding', async () => {
+    const { service } = makeService()
+    const { service: agentRunsService, calls } = makeAgentRunsService()
+
+    const create = await post(
+      service,
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'create_agent_run',
+          arguments: {
+            deliveryId: 'delivery-missing-binding',
+            payload: {
+              agentRef: { name: 'codex-agent' },
+              implementation: { text: 'Implement the requested change.' },
+              runtime: { type: 'job' },
+              secrets: ['github-token'],
+            },
+          },
+        },
+      },
+      {},
+      agentRunsService,
+    )
+
+    expect(create.response.status).toBe(200)
+    expect(create.json?.error?.code).toBe(-32602)
+    expect(create.json?.error?.message).toContain('payload.policy.secretBindingRef is required')
+    expect(calls.create).toEqual([])
+  })
+
+  it('rejects create_agent_run VCS credential requests without a SecretBinding', async () => {
+    const { service } = makeService()
+    const { service: agentRunsService, calls } = makeAgentRunsService()
+
+    const create = await post(
+      service,
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'create_agent_run',
+          arguments: {
+            deliveryId: 'delivery-missing-vcs-binding',
+            payload: {
+              agentRef: { name: 'codex-agent' },
+              implementation: { text: 'Implement the requested change.' },
+              runtime: { type: 'job' },
+              vcsRef: { name: 'github' },
+              vcsPolicy: { required: true, mode: 'read-write' },
+            },
+          },
+        },
+      },
+      {},
+      agentRunsService,
+    )
+
+    expect(create.response.status).toBe(200)
+    expect(create.json?.error?.code).toBe(-32602)
+    expect(create.json?.error?.message).toContain('payload.policy.secretBindingRef is required')
+    expect(calls.create).toEqual([])
+  })
+
+  it('rejects create_agent_run prompt parameters before calling the AgentRun API', async () => {
+    const { service } = makeService()
+    const { service: agentRunsService, calls } = makeAgentRunsService()
+
+    const create = await post(
+      service,
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'create_agent_run',
+          arguments: {
+            deliveryId: 'delivery-prompt',
+            payload: {
+              agentRef: { name: 'codex-agent' },
+              implementationSpecRef: { name: 'demo-spec' },
+              runtime: { type: 'job' },
+              parameters: { prompt: 'do the thing' },
+            },
+          },
+        },
+      },
+      {},
+      agentRunsService,
+    )
+
+    expect(create.response.status).toBe(200)
+    expect(create.json?.error?.code).toBe(-32602)
+    expect(create.json?.error?.message).toContain('payload.parameters.prompt is not allowed')
+    expect(calls.create).toEqual([])
   })
 
   it('returns JSON-RPC tool errors when the underlying service fails', async () => {

--- a/services/agents/src/server/mcp.ts
+++ b/services/agents/src/server/mcp.ts
@@ -142,12 +142,81 @@ const toolsListResult = {
     },
     {
       name: 'create_agent_run',
-      description: 'Create a real AgentRun through the Agents v1 API. Requires an idempotent deliveryId.',
+      description:
+        'Create a real AgentRun through the Agents v1 API. Requires an idempotent deliveryId. When payload.secrets are requested or VCS credentials are required, pass secretBindingRef or payload.policy.secretBindingRef.',
       inputSchema: {
         type: 'object',
         properties: {
           deliveryId: { type: 'string', description: 'Required idempotency key for the AgentRun submission' },
-          payload: { type: 'object', description: 'AgentRun submission payload accepted by POST /v1/agent-runs' },
+          secretBindingRef: {
+            type: 'string',
+            description:
+              'Optional convenience value injected into payload.policy.secretBindingRef; required when payload.secrets are non-empty or vcsRef/vcsPolicy needs credentials.',
+          },
+          payload: {
+            type: 'object',
+            description:
+              'AgentRun submission payload accepted by POST /v1/agent-runs. Use top-level goal for Codex goals, omit goal.tokenBudget for no-budget runs, and never set parameters.prompt.',
+            properties: {
+              agentRef: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+                required: ['name'],
+                additionalProperties: true,
+              },
+              implementationSpecRef: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+                additionalProperties: true,
+              },
+              implementation: {
+                type: 'object',
+                description: 'Inline implementation source; the API wraps this as spec.implementation.inline.',
+                additionalProperties: true,
+              },
+              goal: {
+                type: 'object',
+                description: 'Optional Codex goal. Omit tokenBudget entirely for a goal with no token budget.',
+                additionalProperties: true,
+              },
+              parameters: {
+                type: 'object',
+                description:
+                  'Run parameters such as repository/base/head/stage. parameters.prompt is rejected; use implementation text or ImplementationSpec text.',
+                additionalProperties: true,
+              },
+              secrets: {
+                type: 'array',
+                items: { type: 'string' },
+                description:
+                  'Secret names to mount. If non-empty, secretBindingRef or payload.policy.secretBindingRef is required.',
+              },
+              policy: {
+                type: 'object',
+                properties: {
+                  secretBindingRef: {
+                    type: 'string',
+                    description: 'SecretBinding authorizing requested secrets and VCS credentials.',
+                  },
+                },
+                additionalProperties: true,
+              },
+              vcsRef: {
+                type: 'object',
+                properties: { name: { type: 'string' } },
+                additionalProperties: true,
+              },
+              vcsPolicy: {
+                type: 'object',
+                properties: {
+                  required: { type: 'boolean' },
+                  mode: { type: 'string', enum: ['read-write', 'read-only', 'none'] },
+                },
+                additionalProperties: true,
+              },
+            },
+            additionalProperties: true,
+          },
           dryRun: { type: ['string', 'boolean'], description: 'Optional dryRun query value' },
         },
         required: ['deliveryId', 'payload'],
@@ -394,6 +463,65 @@ const parseWithErrors = <T>(parse: () => T): ParsedToolInput<T> => {
   }
 }
 
+const recordString = (record: Record<string, unknown> | null | undefined, key: string) => {
+  const value = record?.[key]
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const payloadRequestsSecrets = (payload: Record<string, unknown>) =>
+  Array.isArray(payload.secrets) &&
+  payload.secrets.some((entry) => typeof entry === 'string' && entry.trim().length > 0)
+
+const payloadRequestsVcsCredentials = (payload: Record<string, unknown>) => {
+  const vcsRef = isRecord(payload.vcsRef) ? payload.vcsRef : null
+  const vcsPolicy = isRecord(payload.vcsPolicy) ? payload.vcsPolicy : null
+  if (!recordString(vcsRef, 'name')) return false
+  if (recordString(vcsPolicy, 'mode') === 'none') return false
+  return true
+}
+
+const payloadSecretBindingRef = (payload: Record<string, unknown>) => {
+  const policy = isRecord(payload.policy) ? payload.policy : null
+  return recordString(policy, 'secretBindingRef')
+}
+
+const withSecretBindingRef = (payload: Record<string, unknown>, secretBindingRef: string | null) => {
+  const current = payloadSecretBindingRef(payload)
+  if (secretBindingRef && current && current !== secretBindingRef) {
+    throw new Error('secretBindingRef must match payload.policy.secretBindingRef when both are provided')
+  }
+  if (!secretBindingRef) return payload
+  const policy = isRecord(payload.policy) ? payload.policy : {}
+  return {
+    ...payload,
+    policy: {
+      ...policy,
+      secretBindingRef,
+    },
+  }
+}
+
+const validateCreateAgentRunPayloadForMcp = (payload: Record<string, unknown>) => {
+  const parameters = isRecord(payload.parameters) ? payload.parameters : {}
+  const forbiddenPromptKey = Object.keys(parameters).find((key) => key.trim().toLowerCase() === 'prompt')
+  if (forbiddenPromptKey) {
+    throw new Error(
+      `payload.parameters.${forbiddenPromptKey} is not allowed; use implementation text or ImplementationSpec text`,
+    )
+  }
+
+  if (
+    (payloadRequestsSecrets(payload) || payloadRequestsVcsCredentials(payload)) &&
+    !payloadSecretBindingRef(payload)
+  ) {
+    throw new Error(
+      'payload.policy.secretBindingRef is required when payload.secrets are requested or vcsRef/vcsPolicy needs credentials; pass secretBindingRef or payload.policy.secretBindingRef',
+    )
+  }
+}
+
 const parseCreateAgentRunInput = (args: Record<string, unknown>) =>
   parseWithErrors<AgentsAgentRunSubmitInput>(() => {
     const rawDryRun = args.dryRun
@@ -405,9 +533,11 @@ const parseCreateAgentRunInput = (args: Record<string, unknown>) =>
     } else {
       dryRun = requiredString(args, 'dryRun')
     }
+    const payload = withSecretBindingRef(requiredRecord(args, 'payload'), optionalString(args, 'secretBindingRef'))
+    validateCreateAgentRunPayloadForMcp(payload)
     return {
       deliveryId: requiredString(args, 'deliveryId'),
-      payload: requiredRecord(args, 'payload'),
+      payload,
       dryRun,
     }
   })


### PR DESCRIPTION
## Summary

- Add `secretBindingRef` guidance to the `create_agent_run` MCP tool schema.
- Allow callers to pass top-level `secretBindingRef`, which is injected into `payload.policy.secretBindingRef`.
- Reject secret/VCS AgentRun submissions without a SecretBinding before forwarding to `/v1/agent-runs`, and reject `parameters.prompt`.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test -- src/server/mcp.test.ts`
- `bun run --cwd services/agents lint`
- `bun run --cwd services/agents tsc`
- `bun run --cwd services/agents test`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
