### PR TITLE
feat(agents): add AgentRun status filter

### DIFF
--- a/services/agents/src/app-routes/primitives.$kind.tsx
+++ b/services/agents/src/app-routes/primitives.$kind.tsx
@@ -3,6 +3,10 @@ import { useEffect, useState } from 'react'
 
 import { fetchPrimitiveResources, type PrimitiveResourceSummary } from '../control-plane/api-client'
 import { findPrimitiveDefinition } from '../control-plane/registry'
+import {
+  filterAgentRunsByStatuses,
+  parseAgentRunStatusSearch,
+} from '../components/control-plane/agent-run-status-filter'
 import { ControlPlanePage } from '../components/control-plane/control-plane-page'
 import { Alert, AlertDescription } from '../components/ui/alert'
 import { Badge } from '../components/ui/badge'
@@ -28,11 +32,15 @@ function PrimitiveKindRoute() {
 }
 
 function PrimitiveListPage() {
+  const location = useLocation()
   const { kind } = Route.useParams()
   const primitive = findPrimitiveDefinition(kind)
   const [items, setItems] = useState<PrimitiveResourceSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const selectedStatuses =
+    primitive?.kind === 'AgentRun' ? parseAgentRunStatusSearch((location.search as Record<string, unknown>).status) : []
+  const visibleItems = primitive?.kind === 'AgentRun' ? filterAgentRunsByStatuses(items, selectedStatuses) : items
 
   const load = async () => {
     if (!primitive) return
@@ -80,7 +88,7 @@ function PrimitiveListPage() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {items.map((item) => {
+            {visibleItems.map((item) => {
               const name = metadataValue(item, 'name')
               const namespace = metadataValue(item, 'namespace') || 'agents'
               const creationTimestamp = metadataValue(item, 'creationTimestamp')
@@ -108,10 +116,19 @@ function PrimitiveListPage() {
                 </TableRow>
               )
             })}
-            {!loading && items.length === 0 ? (
+            {!loading && visibleItems.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={4} className="h-24 text-center text-muted-foreground">
-                  No resources found.
+                  {primitive.kind === 'AgentRun' && selectedStatuses.length > 0 ? (
+                    <span>
+                      No AgentRuns match the selected statuses: {selectedStatuses.join(', ')}. Clear the status filter
+                      to see all AgentRuns.
+                    </span>
+                  ) : primitive.kind === 'AgentRun' ? (
+                    'No AgentRuns found.'
+                  ) : (
+                    'No resources found.'
+                  )}
                 </TableCell>
               </TableRow>
             ) : null}

--- a/services/agents/src/components/control-plane/agent-run-status-filter.test.ts
+++ b/services/agents/src/components/control-plane/agent-run-status-filter.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  filterAgentRunsByStatuses,
+  parseAgentRunStatusSearch,
+  serializeAgentRunStatusSearch,
+  type AgentRunStatus,
+} from './agent-run-status-filter'
+import type { PrimitiveResourceSummary } from '../../control-plane/api-client'
+
+const run = (name: string, phase: string | null): PrimitiveResourceSummary => ({
+  apiVersion: 'agents.proompteng.ai/v1alpha1',
+  kind: 'AgentRun',
+  metadata: { name, namespace: 'agents' },
+  spec: {},
+  status: phase ? { phase } : {},
+})
+
+describe('AgentRun status filter helpers', () => {
+  it('parses URL status params into known statuses in display order', () => {
+    expect(parseAgentRunStatusSearch('Failed,Running,unknown,Succeeded,Failed')).toEqual([
+      'Running',
+      'Succeeded',
+      'Failed',
+    ])
+    expect(parseAgentRunStatusSearch(['Cancelled', 'Pending,Running'])).toEqual(['Pending', 'Running', 'Cancelled'])
+  })
+
+  it('serializes statuses for a shareable URL search param', () => {
+    const statuses: AgentRunStatus[] = ['Failed', 'Running', 'Running']
+
+    expect(serializeAgentRunStatusSearch(statuses)).toBe('Running,Failed')
+    expect(serializeAgentRunStatusSearch([])).toBeUndefined()
+  })
+
+  it('filters AgentRun rows by multiple selected phases', () => {
+    const rows = [run('waiting', 'Pending'), run('active', 'Running'), run('done', 'Succeeded'), run('missing', null)]
+
+    expect(filterAgentRunsByStatuses(rows, ['Pending', 'Succeeded']).map((item) => item.metadata.name)).toEqual([
+      'waiting',
+      'done',
+    ])
+    expect(filterAgentRunsByStatuses(rows, [])).toHaveLength(rows.length)
+  })
+})

--- a/services/agents/src/components/control-plane/agent-run-status-filter.tsx
+++ b/services/agents/src/components/control-plane/agent-run-status-filter.tsx
@@ -1,0 +1,210 @@
+import { CheckIcon, ChevronsUpDownIcon, FilterIcon, SearchIcon, XIcon } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+import { cn } from '@/lib/utils'
+import type { PrimitiveResourceSummary } from '../../control-plane/api-client'
+import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
+
+export const agentRunStatusOptions = [
+  { value: 'Pending', label: 'Pending', description: 'Accepted and waiting for runtime work.' },
+  { value: 'Running', label: 'Running', description: 'Runtime work is active.' },
+  { value: 'Succeeded', label: 'Succeeded', description: 'Completed successfully.' },
+  { value: 'Failed', label: 'Failed', description: 'Finished with an error.' },
+  { value: 'Cancelled', label: 'Cancelled', description: 'Stopped before completion.' },
+] as const
+
+export type AgentRunStatus = (typeof agentRunStatusOptions)[number]['value']
+
+const agentRunStatusSet = new Set<string>(agentRunStatusOptions.map((option) => option.value))
+const agentRunStatusRank = new Map(agentRunStatusOptions.map((option, index) => [option.value, index]))
+
+export const parseAgentRunStatusSearch = (value: unknown): AgentRunStatus[] => {
+  const rawValues = Array.isArray(value) ? value : typeof value === 'string' ? [value] : []
+  const selected = new Set<AgentRunStatus>()
+  for (const rawValue of rawValues) {
+    if (typeof rawValue !== 'string') continue
+    for (const entry of rawValue.split(',')) {
+      const status = entry.trim()
+      if (agentRunStatusSet.has(status)) selected.add(status as AgentRunStatus)
+    }
+  }
+
+  return [...selected].sort((left, right) => (agentRunStatusRank.get(left) ?? 0) - (agentRunStatusRank.get(right) ?? 0))
+}
+
+export const serializeAgentRunStatusSearch = (statuses: readonly AgentRunStatus[]) => {
+  const selected = parseAgentRunStatusSearch(statuses)
+  return selected.length > 0 ? selected.join(',') : undefined
+}
+
+export const agentRunPhase = (resource: PrimitiveResourceSummary) =>
+  typeof resource.status.phase === 'string' && resource.status.phase.trim().length > 0 ? resource.status.phase : null
+
+export const filterAgentRunsByStatuses = (
+  resources: readonly PrimitiveResourceSummary[],
+  statuses: readonly AgentRunStatus[],
+) => {
+  if (statuses.length === 0) return [...resources]
+  const selected = new Set(statuses)
+  return resources.filter((resource) => {
+    const phase = agentRunPhase(resource)
+    return phase ? selected.has(phase as AgentRunStatus) : false
+  })
+}
+
+type AgentRunStatusFilterProps = {
+  selectedStatuses: AgentRunStatus[]
+  onSelectedStatusesChange: (statuses: AgentRunStatus[]) => void
+}
+
+export function AgentRunStatusFilter({ selectedStatuses, onSelectedStatusesChange }: AgentRunStatusFilterProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const selectedSet = useMemo(() => new Set(selectedStatuses), [selectedStatuses])
+  const filteredOptions = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase()
+    if (!normalizedQuery) return agentRunStatusOptions
+    return agentRunStatusOptions.filter(
+      (option) =>
+        option.label.toLowerCase().includes(normalizedQuery) ||
+        option.description.toLowerCase().includes(normalizedQuery),
+    )
+  }, [query])
+
+  const toggleStatus = (status: AgentRunStatus) => {
+    const next = selectedSet.has(status)
+      ? selectedStatuses.filter((selected) => selected !== status)
+      : [...selectedStatuses, status]
+    onSelectedStatusesChange(parseAgentRunStatusSearch(next))
+  }
+
+  const selectedLabel = selectedStatuses.length === 0 ? 'Status' : `${selectedStatuses.length} selected`
+
+  return (
+    <div className="flex min-w-0 items-center gap-1.5">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            role="combobox"
+            aria-expanded={open}
+            aria-label="Filter AgentRuns by status"
+            className="max-w-[calc(100vw-8rem)] justify-between gap-2 sm:w-[18rem]"
+          >
+            <span className="flex min-w-0 items-center gap-1.5">
+              <FilterIcon data-icon="inline-start" className="text-muted-foreground" />
+              <span className="shrink-0 text-muted-foreground sm:hidden">{selectedLabel}</span>
+              <span className="hidden min-w-0 items-center gap-1 sm:flex">
+                {selectedStatuses.length === 0 ? (
+                  <span className="text-muted-foreground">Filter status</span>
+                ) : (
+                  <SelectedStatusBadges statuses={selectedStatuses} />
+                )}
+              </span>
+            </span>
+            <ChevronsUpDownIcon data-icon="inline-end" className="text-muted-foreground" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-[min(20rem,calc(100vw-2rem))] p-0">
+          <div className="border-b p-2">
+            <div className="relative">
+              <SearchIcon className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search statuses..."
+                className="h-8 pl-8"
+                aria-label="Search AgentRun statuses"
+              />
+            </div>
+          </div>
+          <div className="max-h-72 overflow-y-auto p-1" role="listbox" aria-multiselectable="true">
+            {filteredOptions.map((option) => {
+              const selected = selectedSet.has(option.value)
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="option"
+                  aria-selected={selected}
+                  className="flex w-full items-start gap-2 rounded-md px-2 py-2 text-left text-sm outline-hidden transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground"
+                  onClick={() => toggleStatus(option.value)}
+                >
+                  <span
+                    className={cn(
+                      'mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-sm border border-border',
+                      selected ? 'bg-primary text-primary-foreground' : 'text-transparent',
+                    )}
+                    aria-hidden="true"
+                  >
+                    <CheckIcon className="size-3" />
+                  </span>
+                  <span className="grid min-w-0 gap-0.5">
+                    <span className="font-medium">{option.label}</span>
+                    <span className="text-xs text-muted-foreground">{option.description}</span>
+                  </span>
+                </button>
+              )
+            })}
+            {filteredOptions.length === 0 ? (
+              <div className="px-2 py-6 text-center text-sm text-muted-foreground">No statuses found.</div>
+            ) : null}
+          </div>
+          <div className="flex items-center justify-between border-t p-2">
+            <span className="text-xs text-muted-foreground">
+              {selectedStatuses.length === 0 ? 'Showing all statuses' : `${selectedStatuses.length} selected`}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={() => {
+                onSelectedStatusesChange([])
+                setQuery('')
+              }}
+              disabled={selectedStatuses.length === 0 && query.length === 0}
+            >
+              Clear
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+      {selectedStatuses.length > 0 ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Clear AgentRun status filter"
+          onClick={() => onSelectedStatusesChange([])}
+        >
+          <XIcon />
+        </Button>
+      ) : null}
+    </div>
+  )
+}
+
+function SelectedStatusBadges({ statuses }: { statuses: readonly AgentRunStatus[] }) {
+  const visibleStatuses = statuses.slice(0, 2)
+  const overflowCount = statuses.length - visibleStatuses.length
+
+  return (
+    <>
+      {visibleStatuses.map((status) => (
+        <Badge key={status} variant="secondary" className="max-w-24 truncate px-1.5 py-0 text-xs">
+          {status}
+        </Badge>
+      ))}
+      {overflowCount > 0 ? (
+        <Badge variant="secondary" className="px-1.5 py-0 text-xs">
+          +{overflowCount}
+        </Badge>
+      ) : null}
+    </>
+  )
+}

--- a/services/agents/src/components/control-plane/app-shell.tsx
+++ b/services/agents/src/components/control-plane/app-shell.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from '@tanstack/react-router'
+import { Link, useLocation, useNavigate } from '@tanstack/react-router'
 import {
   BotIcon,
   BoxesIcon,
@@ -29,6 +29,12 @@ import { Fragment, type ReactNode } from 'react'
 
 import { getPrimitiveGroups } from '../../control-plane/primitive-groups'
 import { findPrimitiveDefinition } from '../../control-plane/registry'
+import {
+  AgentRunStatusFilter,
+  parseAgentRunStatusSearch,
+  serializeAgentRunStatusSearch,
+  type AgentRunStatus,
+} from './agent-run-status-filter'
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -115,6 +121,11 @@ const breadcrumbEntries = (pathname: string): BreadcrumbEntry[] => {
   return entries
 }
 
+const isAgentRunListPath = (pathname: string) => {
+  const segments = pathname.split('/').filter(Boolean)
+  return segments.length === 2 && segments[0] === 'primitives' && segments[1] === 'agent-run'
+}
+
 const headerPrimaryAction = (pathname: string): HeaderPrimaryAction | null => {
   const segments = pathname.split('/').filter(Boolean)
   if (segments.length === 0) {
@@ -127,10 +138,32 @@ const headerPrimaryAction = (pathname: string): HeaderPrimaryAction | null => {
 
 export function ControlPlaneShell({ children }: { children: ReactNode }) {
   const location = useLocation()
+  const navigate = useNavigate()
   const [sectionSegment, primitiveSegment] = location.pathname.split('/').filter(Boolean)
   const entries = breadcrumbEntries(location.pathname)
   const primaryAction = headerPrimaryAction(location.pathname)
+  const showAgentRunStatusFilter = isAgentRunListPath(location.pathname)
+  const selectedAgentRunStatuses = showAgentRunStatusFilter
+    ? parseAgentRunStatusSearch((location.search as Record<string, unknown>).status)
+    : []
   const sidebarGroups = getPrimitiveGroups()
+
+  const updateAgentRunStatuses = (statuses: AgentRunStatus[]) => {
+    const nextSearch: Record<string, unknown> = { ...(location.search as Record<string, unknown>) }
+    const serialized = serializeAgentRunStatusSearch(statuses)
+    if (serialized) {
+      nextSearch.status = serialized
+    } else {
+      delete nextSearch.status
+    }
+
+    void navigate({
+      to: '/primitives/$kind',
+      params: { kind: 'agent-run' },
+      search: nextSearch,
+      replace: true,
+    })
+  }
 
   return (
     <TooltipProvider delayDuration={150}>
@@ -203,14 +236,22 @@ export function ControlPlaneShell({ children }: { children: ReactNode }) {
                 </BreadcrumbList>
               </Breadcrumb>
             </div>
-            {primaryAction ? (
-              <Button asChild size="sm">
-                <Link to="/primitives/$kind/new" params={{ kind: primaryAction.kind }}>
-                  <PlusIcon data-icon="inline-start" />
-                  {primaryAction.label}
-                </Link>
-              </Button>
-            ) : null}
+            <div className="flex shrink-0 items-center gap-2">
+              {showAgentRunStatusFilter ? (
+                <AgentRunStatusFilter
+                  selectedStatuses={selectedAgentRunStatuses}
+                  onSelectedStatusesChange={updateAgentRunStatuses}
+                />
+              ) : null}
+              {primaryAction ? (
+                <Button asChild size="sm">
+                  <Link to="/primitives/$kind/new" params={{ kind: primaryAction.kind }}>
+                    <PlusIcon data-icon="inline-start" />
+                    {primaryAction.label}
+                  </Link>
+                </Button>
+              ) : null}
+            </div>
           </header>
           <main className="min-w-0 flex-1 bg-background">{children}</main>
         </SidebarInset>

--- a/services/agents/src/components/ui/popover.tsx
+++ b/services/agents/src/components/ui/popover.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import * as React from 'react'
+import { Popover as PopoverPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }


### PR DESCRIPTION
## Summary

- Added an AgentRun-only status combobox multiselect to the persistent control-plane header action area.
- Stored selected statuses in the `status` URL search param and used it to filter AgentRun table rows by `status.phase` without affecting other primitive pages.
- Added selected-status badges, clear affordances, and an AgentRun-specific empty state for filters with no matches.
- Added a shadcn-style Radix Popover wrapper and focused helper tests for status parsing, serialization, and multi-phase filtering.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test -- src/components/control-plane/agent-run-status-filter.test.ts`
- `bun run --cwd services/agents tsc`
- `bun run --cwd services/agents lint`
- `bun run --cwd services/agents lint:oxlint` (passes with existing warnings only)
- Browser QA with local `bun run --cwd services/agents dev -- --host 127.0.0.1 --port 5173` and a temporary Playwright script covering multiple selected statuses, clearing the filter, no-match empty state, and desktop/mobile header visibility.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
