### PR TITLE
fix(torghut): mark deferred proof packet checks

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -367,9 +367,11 @@ def _check(
     expected: object,
     blockers: Sequence[str] = (),
     detail: object | None = None,
+    status: str | None = None,
 ) -> None:
     payload: dict[str, Any] = {
         "passed": bool(passed),
+        "status": status or ("passed" if passed else "failed"),
         "observed": observed,
         "expected": expected,
     }
@@ -896,6 +898,9 @@ def build_runtime_ledger_proof_packet(
     runtime_import_due = (
         import_ready and not paper_import_blockers and not health_gate_blockers
     )
+    deferred_until_runtime_import_due = (
+        "deferred_until_paper_route_runtime_window_import_is_due"
+    )
     _check(
         checks,
         "paper_route_runtime_window_import_audit",
@@ -911,6 +916,7 @@ def build_runtime_ledger_proof_packet(
         blockers=[]
         if (not runtime_import_due or bool(import_audit))
         else ["runtime_window_import_audit_missing"],
+        status=None if runtime_import_due else deferred_until_runtime_import_due,
     )
     if runtime_import_due and not import_audit:
         _extend_unique(blockers, ["runtime_window_import_audit_missing"])
@@ -941,6 +947,7 @@ def build_runtime_ledger_proof_packet(
         expected="paper-route source decisions, executions, and TCA exist for every import target when runtime import is due",
         blockers=source_activity_blockers
         or ([] if source_activity_ok else ["paper_route_source_activity_missing"]),
+        status=None if runtime_import_due else deferred_until_runtime_import_due,
     )
     if not source_activity_ok:
         _extend_unique(
@@ -998,6 +1005,9 @@ def build_runtime_ledger_proof_packet(
             if runtime_import_ok or not runtime_import_due
             else ["runtime_window_import_missing"]
         ),
+        status=None
+        if runtime_import_due
+        else "waiting_for_paper_route_runtime_window_import",
     )
     if runtime_import_blockers:
         _extend_unique(blockers, runtime_import_blockers)
@@ -1035,6 +1045,7 @@ def build_runtime_ledger_proof_packet(
             if gate_satisfied or not runtime_import_due
             else ["doc29_live_scale_gate_not_satisfied"]
         ),
+        status=None if runtime_import_due else deferred_until_runtime_import_due,
     )
     if completion_gate_blockers:
         _extend_unique(blockers, completion_gate_blockers)
@@ -1062,6 +1073,7 @@ def build_runtime_ledger_proof_packet(
         "runtime_ledger_db_refs",
         passed=(not runtime_import_due) or (bool(ledger_refs) and not unbacked_refs),
         observed={
+            "runtime_import_due": runtime_import_due,
             "strategy_runtime_ledger_buckets": ledger_refs,
             "unbacked_metric_windows": unbacked_refs,
         },
@@ -1069,6 +1081,7 @@ def build_runtime_ledger_proof_packet(
         blockers=[]
         if (bool(ledger_refs) and not unbacked_refs) or not runtime_import_due
         else ["runtime_ledger_db_refs_missing_or_unbacked"],
+        status=None if runtime_import_due else deferred_until_runtime_import_due,
     )
     if runtime_import_due and (not ledger_refs or unbacked_refs):
         _extend_unique(blockers, ["runtime_ledger_db_refs_missing_or_unbacked"])
@@ -1088,6 +1101,7 @@ def build_runtime_ledger_proof_packet(
         "runtime_ledger_lifecycle_counts",
         passed=not lifecycle_blockers,
         observed={
+            "runtime_import_due": runtime_import_due,
             "bucket_count": bucket_count,
             "fill_count": fill_count,
             "closed_trade_count": closed_trade_count,
@@ -1096,6 +1110,7 @@ def build_runtime_ledger_proof_packet(
         },
         expected="positive buckets, fills, closed trips, filled notional, and post-cost expectancy",
         blockers=lifecycle_blockers,
+        status=None if runtime_import_due else deferred_until_runtime_import_due,
     )
     _extend_unique(blockers, lifecycle_blockers)
     pnl_blockers: list[str] = []
@@ -1112,6 +1127,7 @@ def build_runtime_ledger_proof_packet(
         "runtime_ledger_post_cost_profit_target",
         passed=not pnl_blockers,
         observed={
+            "runtime_import_due": runtime_import_due,
             "net_pnl_after_costs": _decimal_text(net_pnl),
             "trading_days": trading_days,
             "daily_net_pnl_after_costs": _decimal_text(daily_net_pnl),
@@ -1124,6 +1140,7 @@ def build_runtime_ledger_proof_packet(
             ),
         },
         blockers=pnl_blockers,
+        status=None if runtime_import_due else deferred_until_runtime_import_due,
     )
     _extend_unique(blockers, pnl_blockers)
 

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -1017,6 +1017,24 @@ class TestRuntimeLedgerProofPacket(TestCase):
             self.assertEqual(exit_code, 1)
             payload = json.loads(output_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["verdict"], "waiting_for_runtime_window")
+            self.assertEqual(
+                payload["checks"]["runtime_window_import_proof"]["status"],
+                "waiting_for_paper_route_runtime_window_import",
+            )
+            self.assertEqual(
+                payload["checks"]["runtime_ledger_post_cost_profit_target"]["status"],
+                "deferred_until_paper_route_runtime_window_import_is_due",
+            )
+            self.assertTrue(
+                payload["checks"]["runtime_ledger_post_cost_profit_target"]["observed"][
+                    "runtime_import_due"
+                ]
+                is False
+            )
+            self.assertEqual(
+                payload["checks"]["runtime_ledger_lifecycle_counts"]["status"],
+                "deferred_until_paper_route_runtime_window_import_is_due",
+            )
 
     def test_cli_can_assemble_from_service_base_url(self) -> None:
         class _Response:


### PR DESCRIPTION
## Summary

- Adds explicit `status` metadata to runtime-ledger proof packet checks.
- Marks pre-import ledger, source-activity, and doc29 checks as deferred until the paper-route runtime-window import is due.
- Keeps `runtime_window_import_proof` blocked while exposing a waiting status so deferred checks cannot be mistaken for promotion proof.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv run --frozen ruff format scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- Assembled a live pre-window proof packet from current `/trading/status` and `/trading/paper-route-evidence` payloads; deferred checks now report `deferred_until_paper_route_runtime_window_import_is_due`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
