### PR TITLE
fix(agents): require repository for mcp vcs runs

### DIFF
--- a/services/agents/src/server/mcp.test.ts
+++ b/services/agents/src/server/mcp.test.ts
@@ -182,6 +182,7 @@ describe('Agents MCP handler', () => {
     )
     const createTool = tools.find((tool) => tool.name === 'create_agent_run')
     expect(createTool?.description).toContain('secretBindingRef')
+    expect(createTool?.description).toContain('payload.parameters.repository')
     expect(createTool?.inputSchema?.properties?.secretBindingRef).toBeDefined()
   })
 
@@ -517,6 +518,42 @@ describe('Agents MCP handler', () => {
     expect(create.response.status).toBe(200)
     expect(create.json?.error?.code).toBe(-32602)
     expect(create.json?.error?.message).toContain('payload.policy.secretBindingRef is required')
+    expect(calls.create).toEqual([])
+  })
+
+  it('rejects create_agent_run VCS submissions without a repository parameter', async () => {
+    const { service } = makeService()
+    const { service: agentRunsService, calls } = makeAgentRunsService()
+
+    const create = await post(
+      service,
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'create_agent_run',
+          arguments: {
+            deliveryId: 'delivery-missing-vcs-repository',
+            payload: {
+              agentRef: { name: 'codex-agent' },
+              implementation: { text: 'Implement the requested change.' },
+              runtime: { type: 'job' },
+              policy: { secretBindingRef: 'codex-github-token' },
+              vcsRef: { name: 'github' },
+              vcsPolicy: { required: true, mode: 'read-write' },
+              parameters: { head: 'codex/demo' },
+            },
+          },
+        },
+      },
+      {},
+      agentRunsService,
+    )
+
+    expect(create.response.status).toBe(200)
+    expect(create.json?.error?.code).toBe(-32602)
+    expect(create.json?.error?.message).toContain('payload.parameters.repository is required')
     expect(calls.create).toEqual([])
   })
 

--- a/services/agents/src/server/mcp.ts
+++ b/services/agents/src/server/mcp.ts
@@ -143,7 +143,7 @@ const toolsListResult = {
     {
       name: 'create_agent_run',
       description:
-        'Create a real AgentRun through the Agents v1 API. Requires an idempotent deliveryId. When payload.secrets are requested or VCS credentials are required, pass secretBindingRef or payload.policy.secretBindingRef.',
+        'Create a real AgentRun through the Agents v1 API. Requires an idempotent deliveryId. For VCS runs, set payload.parameters.repository plus secretBindingRef or payload.policy.secretBindingRef.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -182,7 +182,7 @@ const toolsListResult = {
               parameters: {
                 type: 'object',
                 description:
-                  'Run parameters such as repository/base/head/stage. parameters.prompt is rejected; use implementation text or ImplementationSpec text.',
+                  'Run parameters such as repository/base/head/stage. VCS runs require repository. parameters.prompt is rejected; use implementation text or ImplementationSpec text.',
                 additionalProperties: true,
               },
               secrets: {
@@ -487,6 +487,11 @@ const payloadSecretBindingRef = (payload: Record<string, unknown>) => {
   return recordString(policy, 'secretBindingRef')
 }
 
+const payloadRepository = (payload: Record<string, unknown>) => {
+  const parameters = isRecord(payload.parameters) ? payload.parameters : null
+  return recordString(parameters, 'repository')
+}
+
 const withSecretBindingRef = (payload: Record<string, unknown>, secretBindingRef: string | null) => {
   const current = payloadSecretBindingRef(payload)
   if (secretBindingRef && current && current !== secretBindingRef) {
@@ -519,6 +524,10 @@ const validateCreateAgentRunPayloadForMcp = (payload: Record<string, unknown>) =
     throw new Error(
       'payload.policy.secretBindingRef is required when payload.secrets are requested or vcsRef/vcsPolicy needs credentials; pass secretBindingRef or payload.policy.secretBindingRef',
     )
+  }
+
+  if (payloadRequestsVcsCredentials(payload) && !payloadRepository(payload)) {
+    throw new Error('payload.parameters.repository is required when vcsRef/vcsPolicy requests version control')
   }
 }
 


### PR DESCRIPTION
## Summary

- Require `payload.parameters.repository` for MCP-created VCS AgentRuns before forwarding to `/v1/agent-runs`.
- Update the `create_agent_run` MCP tool description and parameter docs to call out the repository requirement.
- Add regression coverage for VCS submissions that include credentials but omit the repository.

## Related Issues

None

## Testing

- `bun run --cwd services/agents test -- src/server/mcp.test.ts`
- `bun run --cwd services/agents tsc`
- `bun run --cwd services/agents lint`
- `bun run --cwd services/agents test`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
