### PR TITLE
feat(agents): redesign AgentRun detail page

### DIFF
--- a/services/agents/src/app-routes/primitives.$kind.$namespace.$name.tsx
+++ b/services/agents/src/app-routes/primitives.$kind.$namespace.$name.tsx
@@ -2,7 +2,9 @@ import { createFileRoute } from '@tanstack/react-router'
 import { useEffect, useState } from 'react'
 
 import { fetchPrimitiveResource } from '../control-plane/api-client'
+import { isAgentRunDetailKind } from '../control-plane/agentrun-detail'
 import { findPrimitiveDefinition } from '../control-plane/registry'
+import { AgentRunDetailPage } from '../components/control-plane/agentrun-detail'
 import { ControlPlanePage } from '../components/control-plane/control-plane-page'
 import { Alert, AlertDescription } from '../components/ui/alert'
 import { Skeleton } from '../components/ui/skeleton'
@@ -20,6 +22,8 @@ function PrimitiveDetailPage() {
 
   useEffect(() => {
     if (!primitive) return
+    setResource(null)
+    setError(null)
     fetchPrimitiveResource(primitive.display.pathSegment, namespace, name)
       .then((response) => setResource(response.resource))
       .catch((cause) => setError(cause instanceof Error ? cause.message : String(cause)))
@@ -37,35 +41,39 @@ function PrimitiveDetailPage() {
 
   return (
     <ControlPlanePage>
-      {error ? (
+      {!isAgentRunDetailKind(primitive.display.pathSegment) && error ? (
         <Alert variant="destructive">
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       ) : null}
-      <Tabs defaultValue="manifest" className="w-full">
-        <TabsList>
-          <TabsTrigger value="manifest">Manifest</TabsTrigger>
-          <TabsTrigger value="status">Status</TabsTrigger>
-        </TabsList>
-        <TabsContent value="manifest" className="rounded-md border bg-background">
-          {resource ? (
-            <pre className="max-h-[70vh] overflow-auto p-4 text-xs leading-relaxed">
-              {JSON.stringify(resource, null, 2)}
-            </pre>
-          ) : (
-            <ManifestSkeleton />
-          )}
-        </TabsContent>
-        <TabsContent value="status" className="rounded-md border bg-background">
-          {resource ? (
-            <pre className="max-h-[70vh] overflow-auto p-4 text-xs leading-relaxed">
-              {JSON.stringify((resource.status as unknown) ?? {}, null, 2)}
-            </pre>
-          ) : (
-            <ManifestSkeleton />
-          )}
-        </TabsContent>
-      </Tabs>
+      {isAgentRunDetailKind(primitive.display.pathSegment) ? (
+        <AgentRunDetailPage resource={resource} error={error} />
+      ) : (
+        <Tabs defaultValue="manifest" className="w-full">
+          <TabsList>
+            <TabsTrigger value="manifest">Manifest</TabsTrigger>
+            <TabsTrigger value="status">Status</TabsTrigger>
+          </TabsList>
+          <TabsContent value="manifest" className="rounded-md border bg-background">
+            {resource ? (
+              <pre className="max-h-[70vh] overflow-auto p-4 text-xs leading-relaxed">
+                {JSON.stringify(resource, null, 2)}
+              </pre>
+            ) : (
+              <ManifestSkeleton />
+            )}
+          </TabsContent>
+          <TabsContent value="status" className="rounded-md border bg-background">
+            {resource ? (
+              <pre className="max-h-[70vh] overflow-auto p-4 text-xs leading-relaxed">
+                {JSON.stringify((resource.status as unknown) ?? {}, null, 2)}
+              </pre>
+            ) : (
+              <ManifestSkeleton />
+            )}
+          </TabsContent>
+        </Tabs>
+      )}
     </ControlPlanePage>
   )
 }

--- a/services/agents/src/components/control-plane/agentrun-detail.tsx
+++ b/services/agents/src/components/control-plane/agentrun-detail.tsx
@@ -1,0 +1,794 @@
+import { Link } from '@tanstack/react-router'
+import {
+  AlertCircleIcon,
+  BoxesIcon,
+  CalendarClockIcon,
+  CheckCircle2Icon,
+  CircleDotIcon,
+  ClockIcon,
+  ExternalLinkIcon,
+  FileArchiveIcon,
+  FileJsonIcon,
+  FileTextIcon,
+  GitBranchIcon,
+  HistoryIcon,
+  ListChecksIcon,
+  LoaderCircleIcon,
+  PackageIcon,
+  RefreshCwIcon,
+  TerminalIcon,
+} from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+
+import {
+  fetchAgentRunLogs,
+  fetchPrimitiveEvents,
+  type AgentRunLogsResponse,
+  type PrimitiveEventSummary,
+} from '../../control-plane/api-client'
+import {
+  badgeVariantForPhase,
+  extractAgentRunDetail,
+  formatDateTime,
+  formatRelativeAge,
+  type AgentRunConditionSummary,
+  type AgentRunDetailModel,
+  type AgentRunRuntimeLink,
+} from '../../control-plane/agentrun-detail'
+import { cn } from '../../lib/utils'
+import { Alert, AlertDescription } from '../ui/alert'
+import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card'
+import { Input } from '../ui/input'
+import { Skeleton } from '../ui/skeleton'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, TableScrollArea } from '../ui/table'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs'
+
+const terminalEventHint = 'Terminal event acknowledgements are exposed through the AgentRun terminal-events API.'
+
+export function AgentRunDetailPage({
+  resource,
+  error,
+}: {
+  resource: Record<string, unknown> | null
+  error: string | null
+}) {
+  const detail = useMemo(() => (resource ? extractAgentRunDetail(resource) : null), [resource])
+
+  return (
+    <div className="flex flex-col gap-5">
+      {error ? (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+      {detail ? <AgentRunHeader detail={detail} /> : <AgentRunHeaderSkeleton />}
+      <Tabs defaultValue="overview" className="w-full">
+        <TabsList className="w-full justify-start overflow-x-auto">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="logs">Logs</TabsTrigger>
+          <TabsTrigger value="events">Events</TabsTrigger>
+          <TabsTrigger value="artifacts">Artifacts</TabsTrigger>
+          <TabsTrigger value="manifest">Manifest / Status</TabsTrigger>
+        </TabsList>
+        <TabsContent value="overview" className="pt-2">
+          {detail ? <OverviewTab detail={detail} /> : <OverviewSkeleton />}
+        </TabsContent>
+        <TabsContent value="logs" className="pt-2">
+          {detail ? <LogsTab detail={detail} /> : <PanelSkeleton lines={10} />}
+        </TabsContent>
+        <TabsContent value="events" className="pt-2">
+          {detail ? <EventsTab detail={detail} /> : <PanelSkeleton lines={8} />}
+        </TabsContent>
+        <TabsContent value="artifacts" className="pt-2">
+          {detail ? <ArtifactsTab detail={detail} /> : <PanelSkeleton lines={6} />}
+        </TabsContent>
+        <TabsContent value="manifest" className="pt-2">
+          {resource ? <ManifestStatusTab resource={resource} /> : <ManifestSkeleton />}
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+function AgentRunHeader({ detail }: { detail: AgentRunDetailModel }) {
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={badgeVariantForPhase(detail.phase)}>{detail.phase}</Badge>
+            <span className="min-w-0 truncate text-sm text-muted-foreground">
+              {detail.namespace}/{detail.name}
+            </span>
+          </div>
+          <h1 className="break-words text-2xl font-semibold tracking-normal">{detail.name}</h1>
+          <p className="max-w-4xl text-sm text-muted-foreground">{detail.statusSummary}</p>
+        </div>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:min-w-[560px]">
+          <Metric label="Age" value={detail.age} icon={ClockIcon} />
+          <Metric label="Started" value={formatDateTime(detail.startedAt)} icon={CalendarClockIcon} />
+          <Metric label="Completed" value={formatDateTime(detail.completedAt)} icon={CheckCircle2Icon} />
+          <Metric label="Duration" value={detail.duration ?? '-'} icon={HistoryIcon} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Metric({ label, value, icon: Icon }: { label: string; value: string; icon: typeof ClockIcon }) {
+  return (
+    <div className="min-w-0 rounded-md border px-3 py-2">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Icon className="size-3.5" />
+        <span>{label}</span>
+      </div>
+      <div className="mt-1 break-words text-xs leading-snug font-medium sm:text-sm" title={value}>
+        {value}
+      </div>
+    </div>
+  )
+}
+
+function OverviewTab({ detail }: { detail: AgentRunDetailModel }) {
+  return (
+    <div className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.75fr)]">
+      <div className="space-y-4">
+        <Card className="rounded-md">
+          <CardHeader>
+            <CardTitle>Run Summary</CardTitle>
+            <CardDescription>Execution identity, inputs, runtime, and result at a glance.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              <KeyValue label="Agent" value={detail.agentName} linkKind="agent" namespace={detail.namespace} />
+              <KeyValue label="Provider" value={detail.providerName} />
+              <KeyValue
+                label="Implementation Spec"
+                value={detail.implementationSpecName}
+                linkKind="implementation-spec"
+                namespace={detail.namespace}
+              />
+              <KeyValue label="Implementation Source" value={detail.implementationSource} />
+              <KeyValue label="Runtime" value={detail.runtimeType} />
+              <KeyValue label="Attempts" value={detail.attemptSummary} />
+              <KeyValue label="Namespace" value={detail.namespace} />
+              <KeyValue label="UID" value={detail.uid} />
+              <KeyValue label="Generation" value={detail.generation === null ? null : String(detail.generation)} />
+            </div>
+            {detail.inlineImplementationSummary ? (
+              <div className="mt-4 rounded-md border bg-muted/20 px-3 py-2 text-sm text-muted-foreground">
+                <span className="font-medium text-foreground">Inline implementation:</span>{' '}
+                {detail.inlineImplementationSummary}
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        <Card className="rounded-md">
+          <CardHeader>
+            <CardTitle>Conditions</CardTitle>
+            <CardDescription>Controller condition history reported on the AgentRun status.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ConditionsTable conditions={detail.conditions} />
+          </CardContent>
+        </Card>
+
+        <Card className="rounded-md">
+          <CardHeader>
+            <CardTitle>Workflow / Runtime</CardTitle>
+            <CardDescription>
+              Backing runtime references and retry state when the controller reports them.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <ResourceLinks links={detail.resourceLinks} />
+            <WorkflowSteps steps={detail.workflowSteps} />
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="space-y-4">
+        <Card className="rounded-md">
+          <CardHeader>
+            <CardTitle>Artifacts</CardTitle>
+            <CardDescription>{detail.artifactSummary}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ArtifactPreview detail={detail} />
+          </CardContent>
+        </Card>
+
+        <Card className="rounded-md">
+          <CardHeader>
+            <CardTitle>Version Control</CardTitle>
+            <CardDescription>VCS context captured by the run.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2 text-sm">
+              <KeyValueCompact label="Provider" value={detail.vcs.provider} />
+              <KeyValueCompact label="Repository" value={detail.vcs.repository} />
+              <KeyValueCompact label="Base" value={detail.vcs.baseBranch} />
+              <KeyValueCompact label="Head" value={detail.vcs.headBranch} />
+              <KeyValueCompact label="Mode" value={detail.vcs.mode} />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="rounded-md">
+          <CardHeader>
+            <CardTitle>Status Summary</CardTitle>
+            <CardDescription>Reason, message, and status timestamps.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2 text-sm">
+              <KeyValueCompact label="Reason" value={detail.reason} />
+              <KeyValueCompact label="Message" value={detail.message} />
+              <KeyValueCompact label="Updated" value={formatDateTime(detail.updatedAt)} />
+              <KeyValueCompact label="Created" value={formatDateTime(detail.createdAt)} />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+function KeyValue({
+  label,
+  value,
+  linkKind,
+  namespace,
+}: {
+  label: string
+  value: string | null
+  linkKind?: 'agent' | 'implementation-spec'
+  namespace?: string
+}) {
+  const content = value ? (
+    linkKind && namespace ? (
+      <Link
+        to="/primitives/$kind/$namespace/$name"
+        params={{ kind: linkKind, namespace, name: value }}
+        className="truncate underline-offset-4 hover:underline"
+      >
+        {value}
+      </Link>
+    ) : (
+      <span className="truncate" title={value}>
+        {value}
+      </span>
+    )
+  ) : (
+    <span className="text-muted-foreground">-</span>
+  )
+
+  return (
+    <div className="min-w-0 rounded-md border px-3 py-2">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="mt-1 flex min-w-0 text-sm font-medium">{content}</div>
+    </div>
+  )
+}
+
+function KeyValueCompact({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div className="grid min-w-0 grid-cols-[96px_minmax(0,1fr)] gap-3">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="min-w-0 truncate" title={value ?? undefined}>
+        {value || '-'}
+      </span>
+    </div>
+  )
+}
+
+function ConditionsTable({ conditions }: { conditions: AgentRunConditionSummary[] }) {
+  if (conditions.length === 0)
+    return <EmptyState icon={CircleDotIcon} title="No conditions" body="No status conditions have been reported yet." />
+
+  return (
+    <TableScrollArea>
+      <Table className="min-w-[820px]">
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[180px]">Type</TableHead>
+            <TableHead className="w-[90px]">Status</TableHead>
+            <TableHead className="w-[180px]">Reason</TableHead>
+            <TableHead>Message</TableHead>
+            <TableHead className="w-[190px]">Transition</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {conditions.map((condition) => (
+            <TableRow key={`${condition.type}-${condition.lastTransitionTime ?? condition.reason}`}>
+              <TableCell className="font-medium">{condition.type}</TableCell>
+              <TableCell>
+                <Badge variant={condition.status === 'True' ? 'secondary' : 'outline'}>{condition.status}</Badge>
+              </TableCell>
+              <TableCell className="max-w-[180px] truncate text-muted-foreground" title={condition.reason}>
+                {condition.reason}
+              </TableCell>
+              <TableCell className="max-w-[360px] truncate text-muted-foreground" title={condition.message}>
+                {condition.message || '-'}
+              </TableCell>
+              <TableCell className="text-muted-foreground">{formatDateTime(condition.lastTransitionTime)}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableScrollArea>
+  )
+}
+
+function ResourceLinks({ links }: { links: AgentRunRuntimeLink[] }) {
+  if (links.length === 0) {
+    return (
+      <EmptyState
+        icon={BoxesIcon}
+        title="No backing resources"
+        body="No Job, workflow, or runtime references are present on status yet."
+      />
+    )
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {links.map((link) => (
+        <div key={`${link.kind}/${link.namespace}/${link.name}`} className="rounded-md border px-3 py-2 text-sm">
+          <div className="flex items-center gap-2">
+            <Badge variant="outline">{link.kind}</Badge>
+            <span className="font-medium">{link.name}</span>
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">{link.namespace}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function WorkflowSteps({ steps }: { steps: AgentRunDetailModel['workflowSteps'] }) {
+  if (steps.length === 0) {
+    return (
+      <EmptyState
+        icon={ListChecksIcon}
+        title="No workflow steps"
+        body="This AgentRun has not reported workflow step status."
+      />
+    )
+  }
+
+  return (
+    <TableScrollArea>
+      <Table className="min-w-[760px]">
+        <TableHeader>
+          <TableRow>
+            <TableHead>Step</TableHead>
+            <TableHead>Phase</TableHead>
+            <TableHead>Attempt</TableHead>
+            <TableHead>Job</TableHead>
+            <TableHead>Started</TableHead>
+            <TableHead>Finished</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {steps.map((step) => (
+            <TableRow key={step.name}>
+              <TableCell className="max-w-[220px] truncate font-medium" title={step.name}>
+                {step.name}
+              </TableCell>
+              <TableCell>
+                <Badge variant={badgeVariantForPhase(step.phase)}>{step.phase}</Badge>
+              </TableCell>
+              <TableCell className="text-muted-foreground">{step.attempt ?? '-'}</TableCell>
+              <TableCell className="max-w-[180px] truncate text-muted-foreground" title={step.jobRef?.name}>
+                {step.jobRef?.name ?? '-'}
+              </TableCell>
+              <TableCell className="text-muted-foreground">{formatDateTime(step.startedAt)}</TableCell>
+              <TableCell className="text-muted-foreground">{formatDateTime(step.finishedAt)}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableScrollArea>
+  )
+}
+
+function ArtifactPreview({ detail }: { detail: AgentRunDetailModel }) {
+  if (detail.artifacts.length === 0) {
+    return <EmptyState icon={PackageIcon} title="No artifacts" body="The runner has not reported output artifacts." />
+  }
+
+  return (
+    <div className="space-y-2">
+      {detail.artifacts.slice(0, 5).map((artifact) => (
+        <div
+          key={`${artifact.name}-${artifact.key ?? artifact.path ?? artifact.url ?? ''}`}
+          className="min-w-0 rounded-md border px-3 py-2"
+        >
+          <div className="flex min-w-0 items-center justify-between gap-3">
+            <span className="min-w-0 truncate text-sm font-medium" title={artifact.name}>
+              {artifact.name}
+            </span>
+            {artifact.url ? (
+              <a
+                href={artifact.url}
+                target="_blank"
+                rel="noreferrer"
+                className="shrink-0 text-muted-foreground hover:text-foreground"
+              >
+                <ExternalLinkIcon className="size-4" />
+              </a>
+            ) : null}
+          </div>
+          <div
+            className="mt-1 truncate text-xs text-muted-foreground"
+            title={artifact.key ?? artifact.path ?? artifact.url ?? undefined}
+          >
+            {artifact.key ?? artifact.path ?? artifact.url ?? 'No location reported'}
+          </div>
+        </div>
+      ))}
+      {detail.artifacts.length > 5 ? (
+        <div className="text-xs text-muted-foreground">+{detail.artifacts.length - 5} more artifacts</div>
+      ) : null}
+    </div>
+  )
+}
+
+function LogsTab({ detail }: { detail: AgentRunDetailModel }) {
+  const [tailLines, setTailLines] = useState(200)
+  const [logs, setLogs] = useState<AgentRunLogsResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadLogs = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetchAgentRunLogs({ namespace: detail.namespace, name: detail.name, tailLines })
+      setLogs(response)
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadLogs()
+  }, [detail.namespace, detail.name])
+
+  return (
+    <Card className="rounded-md">
+      <CardHeader>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <CardTitle>Runner Logs</CardTitle>
+            <CardDescription>
+              Tail logs from the backing AgentRun pod using the control-plane logs endpoint.
+            </CardDescription>
+          </div>
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+            <label className="text-xs text-muted-foreground" htmlFor="tail-lines">
+              Tail lines
+            </label>
+            <Input
+              id="tail-lines"
+              type="number"
+              min={1}
+              max={5000}
+              value={tailLines}
+              onChange={(event) => setTailLines(Number(event.target.value) || 200)}
+              className="sm:w-28"
+            />
+            <Button type="button" variant="outline" size="sm" onClick={() => void loadLogs()} disabled={loading}>
+              {loading ? (
+                <LoaderCircleIcon data-icon="inline-start" className="animate-spin" />
+              ) : (
+                <RefreshCwIcon data-icon="inline-start" />
+              )}
+              Refresh
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {error ? (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        ) : null}
+        {logs ? <PodSummary logs={logs} /> : null}
+        {loading ? (
+          <LogSkeleton />
+        ) : logs && logs.logs.length > 0 ? (
+          <pre className="max-h-[62vh] overflow-auto rounded-md border bg-muted/20 p-3 font-mono text-xs leading-relaxed whitespace-pre">
+            {logs.logs}
+          </pre>
+        ) : (
+          <EmptyState icon={TerminalIcon} title="No logs yet" body="No pod logs are available for this AgentRun." />
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function PodSummary({ logs }: { logs: AgentRunLogsResponse }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Badge variant="outline">
+        {logs.pods.length} pod{logs.pods.length === 1 ? '' : 's'}
+      </Badge>
+      {logs.pod ? <Badge variant="secondary">pod {logs.pod}</Badge> : null}
+      {logs.container ? <Badge variant="secondary">container {logs.container}</Badge> : null}
+      {logs.tailLines ? <Badge variant="outline">tail {logs.tailLines}</Badge> : null}
+    </div>
+  )
+}
+
+function EventsTab({ detail }: { detail: AgentRunDetailModel }) {
+  const [events, setEvents] = useState<PrimitiveEventSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    fetchPrimitiveEvents({
+      kind: 'AgentRun',
+      namespace: detail.namespace,
+      name: detail.name,
+      uid: detail.uid,
+      limit: 75,
+    })
+      .then((response) => {
+        if (!cancelled) setEvents(response.items)
+      })
+      .catch((cause) => {
+        if (!cancelled) setError(cause instanceof Error ? cause.message : String(cause))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [detail.namespace, detail.name, detail.uid])
+
+  return (
+    <Card className="rounded-md">
+      <CardHeader>
+        <CardTitle>Events</CardTitle>
+        <CardDescription>Kubernetes events for this AgentRun. {terminalEventHint}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {error ? (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        ) : null}
+        {loading ? <PanelSkeleton lines={8} /> : <EventsTable events={events} />}
+      </CardContent>
+    </Card>
+  )
+}
+
+function EventsTable({ events }: { events: PrimitiveEventSummary[] }) {
+  if (events.length === 0) {
+    return (
+      <EmptyState
+        icon={FileArchiveIcon}
+        title="No events"
+        body="The control plane did not return events for this AgentRun."
+      />
+    )
+  }
+
+  return (
+    <TableScrollArea>
+      <Table className="min-w-[900px]">
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[180px]">Time</TableHead>
+            <TableHead className="w-[100px]">Type</TableHead>
+            <TableHead className="w-[180px]">Reason</TableHead>
+            <TableHead>Message</TableHead>
+            <TableHead className="w-[80px] text-right">Count</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {events.map((event, index) => {
+            const time = event.eventTime ?? event.lastTimestamp ?? event.firstTimestamp
+            return (
+              <TableRow key={`${event.name ?? 'event'}-${index}`}>
+                <TableCell className="text-muted-foreground">{formatDateTime(time)}</TableCell>
+                <TableCell>
+                  <Badge variant={event.type === 'Warning' ? 'destructive' : 'outline'}>{event.type ?? '-'}</Badge>
+                </TableCell>
+                <TableCell className="max-w-[180px] truncate" title={event.reason ?? undefined}>
+                  {event.reason ?? '-'}
+                </TableCell>
+                <TableCell className="max-w-[480px] truncate text-muted-foreground" title={event.message ?? undefined}>
+                  {event.message ?? '-'}
+                </TableCell>
+                <TableCell className="text-right text-muted-foreground">{event.count ?? '-'}</TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </TableScrollArea>
+  )
+}
+
+function ArtifactsTab({ detail }: { detail: AgentRunDetailModel }) {
+  return (
+    <Card className="rounded-md">
+      <CardHeader>
+        <CardTitle>Artifacts</CardTitle>
+        <CardDescription>{detail.artifactSummary}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {detail.artifacts.length === 0 ? (
+          <EmptyState
+            icon={PackageIcon}
+            title="No artifacts"
+            body="Artifacts will appear here after the runner reports them in AgentRun status."
+          />
+        ) : (
+          <TableScrollArea>
+            <Table className="min-w-[760px]">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Key</TableHead>
+                  <TableHead>Path</TableHead>
+                  <TableHead>URL</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {detail.artifacts.map((artifact) => (
+                  <TableRow key={`${artifact.name}-${artifact.key ?? artifact.path ?? artifact.url ?? ''}`}>
+                    <TableCell className="font-medium">{artifact.name}</TableCell>
+                    <TableCell
+                      className="max-w-[220px] truncate text-muted-foreground"
+                      title={artifact.key ?? undefined}
+                    >
+                      {artifact.key ?? '-'}
+                    </TableCell>
+                    <TableCell
+                      className="max-w-[220px] truncate text-muted-foreground"
+                      title={artifact.path ?? undefined}
+                    >
+                      {artifact.path ?? '-'}
+                    </TableCell>
+                    <TableCell className="max-w-[260px] truncate">
+                      {artifact.url ? (
+                        <a
+                          href={artifact.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="underline-offset-4 hover:underline"
+                        >
+                          {artifact.url}
+                        </a>
+                      ) : (
+                        <span className="text-muted-foreground">-</span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableScrollArea>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function ManifestStatusTab({ resource }: { resource: Record<string, unknown> }) {
+  return (
+    <div className="grid gap-4 xl:grid-cols-2">
+      <JsonPanel title="Manifest" icon={FileJsonIcon} value={resource} />
+      <JsonPanel title="Status" icon={FileTextIcon} value={(resource.status as unknown) ?? {}} />
+    </div>
+  )
+}
+
+function JsonPanel({ title, icon: Icon, value }: { title: string; icon: typeof FileJsonIcon; value: unknown }) {
+  return (
+    <Card className="rounded-md">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Icon className="size-4 text-muted-foreground" />
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <pre className="max-h-[68vh] overflow-auto rounded-md border bg-muted/20 p-3 font-mono text-xs leading-relaxed whitespace-pre">
+          {JSON.stringify(value, null, 2)}
+        </pre>
+      </CardContent>
+    </Card>
+  )
+}
+
+function EmptyState({ icon: Icon, title, body }: { icon: typeof PackageIcon; title: string; body: string }) {
+  return (
+    <div className="flex min-h-32 flex-col items-center justify-center rounded-md border border-dashed px-4 py-8 text-center">
+      <Icon className="size-5 text-muted-foreground" />
+      <div className="mt-2 text-sm font-medium">{title}</div>
+      <div className="mt-1 max-w-md text-xs text-muted-foreground">{body}</div>
+    </div>
+  )
+}
+
+function AgentRunHeaderSkeleton() {
+  return (
+    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+      <div className="min-w-0 flex-1 space-y-3">
+        <Skeleton className="h-5 w-44" />
+        <Skeleton className="h-8 w-[420px] max-w-full" />
+        <Skeleton className="h-4 w-[640px] max-w-full" />
+      </div>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:min-w-[560px]">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="rounded-md border px-3 py-2">
+            <Skeleton className="h-3 w-16" />
+            <Skeleton className="mt-2 h-4 w-20" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function OverviewSkeleton() {
+  return (
+    <div className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.75fr)]">
+      <PanelSkeleton lines={10} />
+      <PanelSkeleton lines={8} />
+    </div>
+  )
+}
+
+function PanelSkeleton({ lines }: { lines: number }) {
+  return (
+    <Card className="rounded-md">
+      <CardContent className="space-y-3">
+        {Array.from({ length: lines }).map((_, index) => (
+          <Skeleton
+            key={index}
+            className={cn('h-4', index % 3 === 0 ? 'w-3/4' : index % 3 === 1 ? 'w-full' : 'w-1/2')}
+          />
+        ))}
+      </CardContent>
+    </Card>
+  )
+}
+
+function LogSkeleton() {
+  return (
+    <div className="rounded-md border bg-muted/20 p-3 font-mono text-xs leading-relaxed">
+      {Array.from({ length: 14 }).map((_, index) => (
+        <Skeleton
+          key={index}
+          className={cn('mb-2 h-3', index % 4 === 0 ? 'w-5/6' : index % 4 === 1 ? 'w-full' : 'w-2/3')}
+        />
+      ))}
+    </div>
+  )
+}
+
+function ManifestSkeleton() {
+  return (
+    <div className="grid gap-4 xl:grid-cols-2">
+      <PanelSkeleton lines={14} />
+      <PanelSkeleton lines={10} />
+    </div>
+  )
+}

--- a/services/agents/src/control-plane/agentrun-detail.test.ts
+++ b/services/agents/src/control-plane/agentrun-detail.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractAgentRunDetail, formatRelativeAge, isAgentRunDetailKind } from './agentrun-detail'
+
+describe('AgentRun detail model', () => {
+  it('recognizes AgentRun detail route aliases', () => {
+    expect(isAgentRunDetailKind('agent-run')).toBe(true)
+    expect(isAgentRunDetailKind('AgentRun')).toBe(true)
+    expect(isAgentRunDetailKind('agentruns')).toBe(true)
+    expect(isAgentRunDetailKind('agent')).toBe(false)
+  })
+
+  it('extracts high-signal status, refs, attempts, resources, and artifacts', () => {
+    const detail = extractAgentRunDetail(
+      {
+        kind: 'AgentRun',
+        metadata: {
+          name: 'run-1',
+          namespace: 'agents',
+          uid: 'uid-1',
+          generation: 3,
+          creationTimestamp: '2026-05-25T10:00:00.000Z',
+        },
+        spec: {
+          agentRef: { name: 'codex-agent' },
+          implementationSpecRef: { name: 'impl-1' },
+          runtime: { type: 'workflow' },
+          vcsPolicy: { mode: 'read-write' },
+        },
+        status: {
+          phase: 'Failed',
+          reason: 'StepFailed',
+          message: 'tests failed',
+          startedAt: '2026-05-25T10:01:00.000Z',
+          finishedAt: '2026-05-25T10:03:05.000Z',
+          runtimeRef: { type: 'workflow', name: 'run-1-step-1', namespace: 'agents' },
+          vcs: {
+            provider: 'github',
+            repository: 'proompteng/lab',
+            baseBranch: 'main',
+            headBranch: 'codex/example',
+            mode: 'read-write',
+          },
+          conditions: [
+            {
+              type: 'Failed',
+              status: 'True',
+              reason: 'StepFailed',
+              message: 'step build failed',
+              lastTransitionTime: '2026-05-25T10:03:05.000Z',
+            },
+          ],
+          workflow: {
+            steps: [
+              {
+                name: 'build',
+                phase: 'Failed',
+                attempt: 2,
+                startedAt: '2026-05-25T10:02:00.000Z',
+                finishedAt: '2026-05-25T10:03:05.000Z',
+                jobRef: { name: 'run-1-build-attempt-2', namespace: 'agents' },
+              },
+            ],
+          },
+          artifacts: [{ name: 'summary', key: 'runs/run-1/summary.md', url: 'https://example.test/summary.md' }],
+        },
+      },
+      Date.parse('2026-05-25T11:00:00.000Z'),
+    )
+
+    expect(detail).toMatchObject({
+      name: 'run-1',
+      namespace: 'agents',
+      phase: 'Failed',
+      phaseTone: 'danger',
+      statusSummary: 'tests failed',
+      agentName: 'codex-agent',
+      implementationSpecName: 'impl-1',
+      runtimeType: 'workflow',
+      age: '1h ago',
+      duration: '2m 5s',
+      attemptSummary: 'Max attempt 2',
+      artifactSummary: '1 artifact, 1 with location',
+    })
+    expect(detail.resourceLinks.map((link) => `${link.kind}/${link.name}`)).toEqual([
+      'Workflow/run-1-step-1',
+      'Job/run-1-build-attempt-2',
+    ])
+    expect(detail.conditions[0]?.message).toBe('step build failed')
+    expect(detail.vcs.repository).toBe('proompteng/lab')
+  })
+
+  it('handles sparse pending AgentRuns without inventing events or resources', () => {
+    const detail = extractAgentRunDetail({
+      metadata: { name: 'run-2' },
+      spec: { runtime: { type: 'job' } },
+      status: {},
+    })
+
+    expect(detail.namespace).toBe('agents')
+    expect(detail.phase).toBe('Unknown')
+    expect(detail.statusSummary).toBe('The controller has not reported a phase yet.')
+    expect(detail.resourceLinks).toEqual([])
+    expect(detail.artifacts).toEqual([])
+    expect(detail.artifactSummary).toBe('No artifacts reported')
+  })
+
+  it('formats relative age defensively', () => {
+    const now = Date.parse('2026-05-25T11:00:00.000Z')
+    expect(formatRelativeAge('2026-05-25T10:59:45.000Z', now)).toBe('just now')
+    expect(formatRelativeAge('2026-05-25T10:30:00.000Z', now)).toBe('30m ago')
+    expect(formatRelativeAge('2026-05-24T09:00:00.000Z', now)).toBe('26h ago')
+    expect(formatRelativeAge('not-a-date', now)).toBe('-')
+  })
+})

--- a/services/agents/src/control-plane/agentrun-detail.ts
+++ b/services/agents/src/control-plane/agentrun-detail.ts
@@ -1,0 +1,337 @@
+export type AgentRunPhaseTone = 'success' | 'danger' | 'warning' | 'neutral'
+
+export type AgentRunConditionSummary = {
+  type: string
+  status: string
+  reason: string
+  message: string
+  lastTransitionTime: string | null
+}
+
+export type AgentRunArtifactSummary = {
+  name: string
+  key: string | null
+  path: string | null
+  url: string | null
+}
+
+export type AgentRunRuntimeLink = {
+  kind: 'Job' | 'Pod' | 'Workflow' | 'Temporal' | 'Runtime'
+  name: string
+  namespace: string
+}
+
+export type AgentRunWorkflowStepSummary = {
+  name: string
+  phase: string
+  attempt: number | null
+  startedAt: string | null
+  finishedAt: string | null
+  nextRetryAt: string | null
+  jobRef: AgentRunRuntimeLink | null
+  message: string | null
+}
+
+export type AgentRunDetailModel = {
+  name: string
+  namespace: string
+  uid: string | null
+  generation: number | null
+  phase: string
+  phaseTone: AgentRunPhaseTone
+  reason: string | null
+  message: string | null
+  agentName: string | null
+  providerName: string | null
+  implementationSpecName: string | null
+  implementationSource: string | null
+  inlineImplementationSummary: string | null
+  runtimeType: string | null
+  runtimeRef: AgentRunRuntimeLink | null
+  resourceLinks: AgentRunRuntimeLink[]
+  vcs: {
+    provider: string | null
+    repository: string | null
+    baseBranch: string | null
+    headBranch: string | null
+    mode: string | null
+  }
+  createdAt: string | null
+  startedAt: string | null
+  completedAt: string | null
+  updatedAt: string | null
+  age: string
+  duration: string | null
+  attemptSummary: string | null
+  artifacts: AgentRunArtifactSummary[]
+  artifactSummary: string
+  conditions: AgentRunConditionSummary[]
+  workflowSteps: AgentRunWorkflowStepSummary[]
+  statusSummary: string
+}
+
+const terminalPhases = new Set(['Succeeded', 'Failed', 'Cancelled'])
+const failurePhases = new Set(['Failed', 'Error'])
+const pendingPhases = new Set(['Pending', 'Queued', 'Accepted', 'Blocked'])
+const runningPhases = new Set(['Running', 'Reconciling', 'Progressing'])
+
+export const isAgentRunDetailKind = (kind: string | null | undefined) => {
+  const normalized = kind?.trim().toLowerCase()
+  return normalized === 'agent-run' || normalized === 'agentrun' || normalized === 'agentruns'
+}
+
+export const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+
+const asArray = (value: unknown): unknown[] => (Array.isArray(value) ? value : [])
+
+export const asString = (value: unknown): string | null =>
+  typeof value === 'string' && value.length > 0 ? value : null
+
+const asNumber = (value: unknown): number | null => (typeof value === 'number' && Number.isFinite(value) ? value : null)
+
+const refName = (value: unknown) => asString(asRecord(value)?.name)
+
+const readSource = (source: Record<string, unknown> | null) => {
+  if (!source) return null
+  const provider = asString(source.provider)
+  const externalId = asString(source.externalId)
+  const url = asString(source.url)
+  return [provider, externalId || url].filter(Boolean).join(' · ') || null
+}
+
+const readImplementationSource = (spec: Record<string, unknown>) => {
+  const inline = asRecord(asRecord(spec.implementation)?.inline)
+  const source = readSource(asRecord(inline?.source))
+  const summary = asString(inline?.summary) ?? asString(inline?.description)
+  return { source, summary }
+}
+
+const readPhase = (status: Record<string, unknown>) => {
+  const explicit = asString(status.phase)
+  if (explicit) return explicit
+  const conditions = asArray(status.conditions)
+    .map((entry) => asRecord(entry))
+    .filter(Boolean)
+  if (conditions.some((condition) => condition?.type === 'Succeeded' && condition.status === 'True')) return 'Succeeded'
+  if (conditions.some((condition) => condition?.type === 'Failed' && condition.status === 'True')) return 'Failed'
+  if (conditions.some((condition) => condition?.type === 'Progressing' && condition.status === 'True')) return 'Running'
+  return 'Unknown'
+}
+
+export const phaseTone = (phase: string): AgentRunPhaseTone => {
+  if (phase === 'Succeeded') return 'success'
+  if (failurePhases.has(phase)) return 'danger'
+  if (pendingPhases.has(phase)) return 'warning'
+  return runningPhases.has(phase) ? 'neutral' : 'neutral'
+}
+
+export const badgeVariantForPhase = (phase: string): 'secondary' | 'destructive' | 'outline' => {
+  if (phase === 'Succeeded') return 'secondary'
+  if (failurePhases.has(phase)) return 'destructive'
+  return 'outline'
+}
+
+const formatDuration = (milliseconds: number) => {
+  const seconds = Math.max(0, Math.floor(milliseconds / 1000))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 48) return `${hours}h ${minutes % 60}m`
+  const days = Math.floor(hours / 24)
+  return `${days}d ${hours % 24}h`
+}
+
+export const formatRelativeAge = (value: string | null | undefined, now = Date.now()) => {
+  if (!value) return '-'
+  const timestamp = Date.parse(value)
+  if (Number.isNaN(timestamp)) return '-'
+  const elapsed = Math.max(0, now - timestamp)
+  if (elapsed < 60_000) return 'just now'
+  const minutes = Math.floor(elapsed / 60_000)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 48) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+export const formatDateTime = (value: string | null | undefined) => {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+}
+
+const durationBetween = (startedAt: string | null, completedAt: string | null) => {
+  if (!startedAt || !completedAt) return null
+  const start = Date.parse(startedAt)
+  const end = Date.parse(completedAt)
+  if (Number.isNaN(start) || Number.isNaN(end) || end < start) return null
+  return formatDuration(end - start)
+}
+
+const readConditions = (status: Record<string, unknown>): AgentRunConditionSummary[] =>
+  asArray(status.conditions)
+    .map((entry) => asRecord(entry))
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry))
+    .map((condition) => ({
+      type: asString(condition.type) ?? 'Unknown',
+      status: asString(condition.status) ?? 'Unknown',
+      reason: asString(condition.reason) ?? '-',
+      message: asString(condition.message) ?? '',
+      lastTransitionTime: asString(condition.lastTransitionTime),
+    }))
+
+const readArtifacts = (status: Record<string, unknown>): AgentRunArtifactSummary[] =>
+  asArray(status.artifacts)
+    .map((entry) => asRecord(entry))
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry))
+    .map((artifact) => ({
+      name: asString(artifact.name) ?? 'artifact',
+      key: asString(artifact.key),
+      path: asString(artifact.path),
+      url: asString(artifact.url),
+    }))
+
+const runtimeKind = (type: string | null | undefined): AgentRunRuntimeLink['kind'] => {
+  if (type === 'job') return 'Job'
+  if (type === 'workflow') return 'Workflow'
+  if (type === 'temporal') return 'Temporal'
+  return 'Runtime'
+}
+
+const readRuntimeRef = (status: Record<string, unknown>, namespace: string): AgentRunRuntimeLink | null => {
+  const runtimeRef = asRecord(status.runtimeRef)
+  const name = asString(runtimeRef?.name) ?? asString(runtimeRef?.workflowId)
+  if (!name) return null
+  const type = asString(runtimeRef?.type)
+  return {
+    kind: runtimeKind(type),
+    name,
+    namespace: asString(runtimeRef?.namespace) ?? namespace,
+  }
+}
+
+const readJobRef = (value: unknown, namespace: string): AgentRunRuntimeLink | null => {
+  const ref = asRecord(value)
+  const name = asString(ref?.name)
+  if (!name) return null
+  return { kind: 'Job', name, namespace: asString(ref?.namespace) ?? namespace }
+}
+
+const readWorkflowSteps = (status: Record<string, unknown>, namespace: string): AgentRunWorkflowStepSummary[] => {
+  const workflow = asRecord(status.workflow)
+  return asArray(workflow?.steps)
+    .map((entry) => asRecord(entry))
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry))
+    .map((step) => ({
+      name: asString(step.name) ?? 'step',
+      phase: asString(step.phase) ?? 'Unknown',
+      attempt: asNumber(step.attempt),
+      startedAt: asString(step.startedAt),
+      finishedAt: asString(step.finishedAt),
+      nextRetryAt: asString(step.nextRetryAt),
+      jobRef: readJobRef(step.jobRef, namespace),
+      message: asString(step.message),
+    }))
+}
+
+const resourceLinksFrom = (runtimeRef: AgentRunRuntimeLink | null, workflowSteps: AgentRunWorkflowStepSummary[]) => {
+  const links = new Map<string, AgentRunRuntimeLink>()
+  const add = (link: AgentRunRuntimeLink | null) => {
+    if (!link) return
+    links.set(`${link.kind}/${link.namespace}/${link.name}`, link)
+  }
+  add(runtimeRef)
+  workflowSteps.forEach((step) => add(step.jobRef))
+  return [...links.values()]
+}
+
+const readAttemptSummary = (status: Record<string, unknown>, workflowSteps: AgentRunWorkflowStepSummary[]) => {
+  const directAttempt = asNumber(status.attempt) ?? asNumber(asRecord(status.runner)?.attempt)
+  if (directAttempt !== null) return `Attempt ${directAttempt}`
+  const attempts = workflowSteps.map((step) => step.attempt).filter((attempt): attempt is number => attempt !== null)
+  if (attempts.length === 0) return null
+  const maxAttempt = Math.max(...attempts)
+  const retrying = workflowSteps.filter((step) => step.nextRetryAt).length
+  return retrying > 0 ? `Max attempt ${maxAttempt}; ${retrying} retry scheduled` : `Max attempt ${maxAttempt}`
+}
+
+const artifactSummary = (artifacts: AgentRunArtifactSummary[]) => {
+  if (artifacts.length === 0) return 'No artifacts reported'
+  const linked = artifacts.filter((artifact) => artifact.url || artifact.key || artifact.path).length
+  return `${artifacts.length} artifact${artifacts.length === 1 ? '' : 's'}${linked > 0 ? `, ${linked} with location` : ''}`
+}
+
+const statusSummary = (phase: string, reason: string | null, message: string | null) => {
+  if (message) return message
+  if (reason) return reason
+  if (phase === 'Unknown') return 'The controller has not reported a phase yet.'
+  if (terminalPhases.has(phase)) return `AgentRun ${phase.toLowerCase()}.`
+  return `AgentRun is ${phase.toLowerCase()}.`
+}
+
+export const extractAgentRunDetail = (resource: Record<string, unknown>, now = Date.now()): AgentRunDetailModel => {
+  const metadata = asRecord(resource.metadata) ?? {}
+  const spec = asRecord(resource.spec) ?? {}
+  const status = asRecord(resource.status) ?? {}
+  const namespace = asString(metadata.namespace) ?? 'agents'
+  const name = asString(metadata.name) ?? 'unknown'
+  const phase = readPhase(status)
+  const startedAt = asString(status.startedAt)
+  const completedAt = asString(status.finishedAt)
+  const workflowSteps = readWorkflowSteps(status, namespace)
+  const runtimeRef = readRuntimeRef(status, namespace)
+  const artifacts = readArtifacts(status)
+  const implementation = readImplementationSource(spec)
+  const vcs = asRecord(status.vcs) ?? asRecord(spec.vcsPolicy) ?? {}
+  const conditions = readConditions(status)
+  const runner = asRecord(status.runner)
+
+  return {
+    name,
+    namespace,
+    uid: asString(metadata.uid),
+    generation: asNumber(metadata.generation),
+    phase,
+    phaseTone: phaseTone(phase),
+    reason: asString(status.reason),
+    message: asString(status.message),
+    agentName: refName(spec.agentRef),
+    providerName: asString(runner?.provider) ?? asString(vcs.provider),
+    implementationSpecName: refName(spec.implementationSpecRef),
+    implementationSource: implementation.source,
+    inlineImplementationSummary: implementation.summary,
+    runtimeType: asString(asRecord(spec.runtime)?.type) ?? asString(asRecord(status.runtimeRef)?.type),
+    runtimeRef,
+    resourceLinks: resourceLinksFrom(runtimeRef, workflowSteps),
+    vcs: {
+      provider: asString(vcs.provider),
+      repository: asString(vcs.repository),
+      baseBranch: asString(vcs.baseBranch),
+      headBranch: asString(vcs.headBranch),
+      mode: asString(vcs.mode),
+    },
+    createdAt: asString(metadata.creationTimestamp),
+    startedAt,
+    completedAt,
+    updatedAt: asString(status.updatedAt),
+    age: formatRelativeAge(asString(metadata.creationTimestamp), now),
+    duration: durationBetween(startedAt, completedAt),
+    attemptSummary: readAttemptSummary(status, workflowSteps),
+    artifacts,
+    artifactSummary: artifactSummary(artifacts),
+    conditions,
+    workflowSteps,
+    statusSummary: statusSummary(phase, asString(status.reason), asString(status.message)),
+  }
+}

--- a/services/agents/src/control-plane/api-client.test.ts
+++ b/services/agents/src/control-plane/api-client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { createIdempotencyKey, createPrimitiveResource } from './api-client'
+import { createIdempotencyKey, createPrimitiveResource, fetchAgentRunLogs, fetchPrimitiveEvents } from './api-client'
 
 describe('control-plane API client', () => {
   afterEach(() => {
@@ -25,6 +25,55 @@ describe('control-plane API client', () => {
     })
 
     expect(createIdempotencyKey()).toBe('00010203-0405-4607-8809-0a0b0c0d0e0f')
+  })
+
+  it('fetches AgentRun logs with namespace, name, and tail line controls', async () => {
+    vi.stubGlobal('window', { location: { origin: 'https://agents.test' } })
+    const fetchCalls: URL[] = []
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      fetchCalls.push(input as URL)
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          name: 'run-1',
+          namespace: 'agents',
+          pods: [],
+          logs: '',
+          pod: null,
+          container: null,
+          tailLines: 200,
+        }),
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchAgentRunLogs({ namespace: 'agents', name: 'run-1', tailLines: 200 })
+
+    const url = fetchCalls[0]
+    expect(url.pathname).toBe('/v1/control-plane/logs')
+    expect(url.searchParams.get('namespace')).toBe('agents')
+    expect(url.searchParams.get('name')).toBe('run-1')
+    expect(url.searchParams.get('tailLines')).toBe('200')
+  })
+
+  it('fetches AgentRun events with uid and limit filters', async () => {
+    vi.stubGlobal('window', { location: { origin: 'https://agents.test' } })
+    const fetchCalls: URL[] = []
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      fetchCalls.push(input as URL)
+      return new Response(JSON.stringify({ ok: true, kind: 'AgentRun', namespace: 'agents', name: 'run-1', items: [] }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchPrimitiveEvents({ kind: 'AgentRun', namespace: 'agents', name: 'run-1', uid: 'uid-1', limit: 75 })
+
+    const url = fetchCalls[0]
+    expect(url.pathname).toBe('/v1/control-plane/events')
+    expect(url.searchParams.get('kind')).toBe('AgentRun')
+    expect(url.searchParams.get('namespace')).toBe('agents')
+    expect(url.searchParams.get('name')).toBe('run-1')
+    expect(url.searchParams.get('uid')).toBe('uid-1')
+    expect(url.searchParams.get('limit')).toBe('75')
   })
 
   it('sends the fallback idempotency key when creating a primitive resource', async () => {

--- a/services/agents/src/control-plane/api-client.ts
+++ b/services/agents/src/control-plane/api-client.ts
@@ -29,6 +29,43 @@ export type PrimitiveResourceGetResponse = {
   resource: Record<string, unknown>
 }
 
+export type AgentRunLogsResponse = {
+  ok: true
+  name: string
+  namespace: string
+  pods: Array<{
+    name: string
+    phase: string | null
+    containers: Array<{ name: string; type: 'main' | 'init' }>
+  }>
+  logs: string
+  pod: string | null
+  container: string | null
+  tailLines: number | null
+}
+
+export type PrimitiveEventSummary = {
+  name: string | null
+  namespace: string | null
+  type: string | null
+  reason: string | null
+  action: string | null
+  count: number | null
+  message: string | null
+  firstTimestamp: string | null
+  lastTimestamp: string | null
+  eventTime: string | null
+  involvedObject: unknown
+}
+
+export type PrimitiveEventsResponse = {
+  ok: true
+  kind: string
+  namespace: string
+  name: string
+  items: PrimitiveEventSummary[]
+}
+
 const assertOk = async (response: Response) => {
   if (response.ok) return response
   const body = (await response.text()).trim()
@@ -92,4 +129,50 @@ export const createPrimitiveResource = async (kind: string, manifest: Record<str
     }),
   )
   return (await response.json()) as PrimitiveResourceGetResponse
+}
+
+export const fetchAgentRunLogs = async ({
+  namespace,
+  name,
+  pod,
+  container,
+  tailLines,
+}: {
+  namespace: string
+  name: string
+  pod?: string | null
+  container?: string | null
+  tailLines?: number | null
+}) => {
+  const url = new URL('/v1/control-plane/logs', window.location.origin)
+  url.searchParams.set('namespace', namespace)
+  url.searchParams.set('name', name)
+  if (pod) url.searchParams.set('pod', pod)
+  if (container) url.searchParams.set('container', container)
+  if (tailLines) url.searchParams.set('tailLines', String(tailLines))
+  const response = await assertOk(await fetch(url))
+  return (await response.json()) as AgentRunLogsResponse
+}
+
+export const fetchPrimitiveEvents = async ({
+  kind,
+  namespace,
+  name,
+  uid,
+  limit = 50,
+}: {
+  kind: string
+  namespace: string
+  name: string
+  uid?: string | null
+  limit?: number
+}) => {
+  const url = new URL('/v1/control-plane/events', window.location.origin)
+  url.searchParams.set('kind', kind)
+  url.searchParams.set('namespace', namespace)
+  url.searchParams.set('name', name)
+  url.searchParams.set('limit', String(limit))
+  if (uid) url.searchParams.set('uid', uid)
+  const response = await assertOk(await fetch(url))
+  return (await response.json()) as PrimitiveEventsResponse
 }

--- a/services/agents/src/runner/codex-app-server.test.ts
+++ b/services/agents/src/runner/codex-app-server.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 
 import type { CodexAppServerOptions, CodexAppServerTurnOptions, StreamDelta, Turn } from '@proompteng/codex'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   CodexRunnerArtifactError,
@@ -48,8 +48,26 @@ const deferred = <T = void>() => {
 }
 
 const NORMALIZED_PROMPT = 'run the normalized Codex adapter contract'
+const systemPromptEnvKeys = [
+  'CODEX_SYSTEM_PROMPT_PATH',
+  'CODEX_SYSTEM_PROMPT_EXPECTED_HASH',
+  'CODEX_SYSTEM_PROMPT_REQUIRED',
+]
+const originalSystemPromptEnv = Object.fromEntries(systemPromptEnvKeys.map((key) => [key, process.env[key]]))
 
 describe('codex app-server runner adapter', () => {
+  beforeEach(() => {
+    for (const key of systemPromptEnvKeys) delete process.env[key]
+  })
+
+  afterEach(() => {
+    for (const key of systemPromptEnvKeys) {
+      const value = originalSystemPromptEnv[key]
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  })
+
   it('uses an absolute Codex binary path by default for Bun child-process spawning', () => {
     expect(resolveCodexBinaryPath({}, {})).toBe(DEFAULT_CODEX_BINARY_PATH)
     expect(resolveCodexBinaryPath({}, { AGENTS_CODEX_BINARY: '/custom/agents-codex' })).toBe('/custom/agents-codex')


### PR DESCRIPTION
## Summary

- Redesigns the AgentRun detail route into a tabbed operator UI with Overview, Logs, Events, Artifacts, and Manifest / Status surfaces.
- Adds AgentRun presentation helpers for phases, timestamps, conditions, runtime references, attempts, workflow steps, and artifact summaries.
- Wires the detail page to existing control-plane logs and events endpoints, including a tail-lines control and loading/empty states.
- Keeps non-AgentRun primitive detail pages on the existing manifest/status behavior and isolates runner tests from ambient Codex system-prompt environment variables.

## Related Issues

None

## Testing

- Passed: `bun run --cwd services/agents tsc` (followed by `bunx oxfmt services/agents/src/control-plane/primitive-registry.generated.ts` to preserve the repository's root formatting after registry generation).
- Passed: `bun run --cwd services/agents lint`.
- Passed: `bun run --cwd services/agents test`.
- Passed: `bunx playwright test services/agents/.qa/agentrun-qa.spec.ts --browser=chromium --reporter=line` against local `bun run --cwd services/agents dev --host 127.0.0.1 --port 4321`, covering desktop and mobile AgentRun detail tabs. Temporary QA spec was removed after validation.

## Screenshots (if applicable)

Validated locally with Playwright screenshots for the redesigned Overview and Manifest / Status states at `/tmp/agentrun-detail-overview-loaded.png` and `/tmp/agentrun-detail-qa.png`, plus mobile logs at `/tmp/agentrun-detail-mobile-qa.png`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
