### PR TITLE
fix(torghut): harden queue survival candidate gates

### DIFF
--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -3242,6 +3242,9 @@ def _candidate_sleeve_goal_rows(
                         spec, scorecard
                     )
                 )
+                row["queue_position_survival_fill_quality"] = (
+                    _candidate_board_queue_position_survival_summary(spec, scorecard)
+                )
             row["evidence_status"] = "replayed" if evidence is not None else "missing"
             row["evidence_lineage"] = _candidate_board_evidence_lineage_summary(
                 evidence
@@ -3284,6 +3287,11 @@ def _candidate_sleeve_goal_rows(
             if spec is not None
             else {"required": False, "passed": True, "blockers": []}
         )
+        queue_position_survival_summary = (
+            _candidate_board_queue_position_survival_summary(spec, scorecard)
+            if spec is not None
+            else {"required": False, "passed": True, "blockers": []}
+        )
         evidence_lineage = _candidate_board_evidence_lineage_summary(evidence)
         replay_window_coverage = _candidate_board_replay_window_coverage_summary(
             scorecard
@@ -3318,6 +3326,9 @@ def _candidate_sleeve_goal_rows(
                 "evidence_lineage": evidence_lineage,
                 "replay_window_coverage": replay_window_coverage,
                 "order_type_execution_quality": order_type_summary,
+                "queue_position_survival_fill_quality": (
+                    queue_position_survival_summary
+                ),
                 **proof_handoff,
                 "failure_reasons": [
                     _string(item)
@@ -8739,6 +8750,147 @@ def _candidate_board_scorecard_with_order_type_blockers(
     return updated_scorecard, summary
 
 
+def _candidate_spec_requires_queue_position_survival(spec: CandidateSpec) -> bool:
+    overlay_ids = set(
+        _string_list_from_value(spec.parameter_space.get("mechanism_overlay_ids"))
+    )
+    return (
+        "queue_position_survival_fill_curve" in overlay_ids
+        or _boolish(
+            spec.promotion_contract.get("requires_queue_position_survival_fill_curve")
+        )
+        or _boolish(spec.promotion_contract.get("requires_nonfill_opportunity_cost"))
+        or _boolish(spec.promotion_contract.get("requires_time_to_fill_quantiles"))
+        or "required_queue_position_survival_fill_curve" in spec.hard_vetoes
+        or "required_min_queue_position_survival_sample_count" in spec.hard_vetoes
+        or "required_max_queue_position_nonfill_opportunity_cost_bps"
+        in spec.hard_vetoes
+    )
+
+
+def _candidate_board_queue_position_survival_summary(
+    spec: CandidateSpec, scorecard: Mapping[str, Any]
+) -> dict[str, Any]:
+    required = _candidate_spec_requires_queue_position_survival(spec)
+    min_sample_count = _candidate_board_int_field(
+        spec.hard_vetoes, "required_min_queue_position_survival_sample_count"
+    )
+    if min_sample_count <= 0:
+        min_sample_count = 60
+    max_nonfill_opportunity_cost_bps = _decimal(
+        spec.hard_vetoes.get(
+            "required_max_queue_position_nonfill_opportunity_cost_bps"
+        ),
+        default="8",
+    )
+    evidence_present = _boolish(
+        scorecard.get("queue_position_survival_fill_curve_evidence_present")
+        or scorecard.get("queue_position_survival_evidence_present")
+    )
+    sample_count = _candidate_board_first_int_field(
+        scorecard,
+        (
+            "queue_position_survival_sample_count",
+            "queue_position_survival_fill_sample_count",
+        ),
+    )
+    fill_rate = _decimal(scorecard.get("queue_position_survival_fill_rate"))
+    queue_ratio_p95 = _decimal(scorecard.get("queue_position_survival_queue_ratio_p95"))
+    queue_ahead_evidence_present = _boolish(
+        scorecard.get("queue_position_survival_queue_ahead_depletion_evidence_present")
+        or scorecard.get("delay_adjusted_depth_queue_ahead_depletion_evidence_present")
+        or scorecard.get("queue_ahead_depletion_evidence_present")
+    )
+    queue_ahead_sample_count = _candidate_board_first_int_field(
+        scorecard,
+        (
+            "queue_position_survival_queue_ahead_depletion_sample_count",
+            "delay_adjusted_depth_queue_ahead_depletion_sample_count",
+            "queue_ahead_depletion_sample_count",
+        ),
+    )
+    nonfill_opportunity_cost_raw = scorecard.get(
+        "queue_position_survival_nonfill_opportunity_cost_bps"
+    ) or scorecard.get("queue_position_nonfill_opportunity_cost_bps")
+    nonfill_opportunity_cost_present = nonfill_opportunity_cost_raw not in (None, "")
+    nonfill_opportunity_cost_bps = _decimal(
+        nonfill_opportunity_cost_raw,
+        default="999999",
+    )
+    require_time_to_fill_quantiles = _boolish(
+        spec.hard_vetoes.get("required_time_to_fill_quantiles")
+    ) or _boolish(spec.promotion_contract.get("requires_time_to_fill_quantiles"))
+    time_to_fill_quantiles_present = scorecard.get("fill_time_ms_p50") not in (
+        None,
+        "",
+    ) and scorecard.get("fill_time_ms_p95") not in (None, "")
+    blockers: list[str] = []
+    if required:
+        if not evidence_present:
+            blockers.append(
+                "queue_position_survival_fill_curve_evidence_present_failed"
+            )
+        if sample_count < min_sample_count:
+            blockers.append("queue_position_survival_sample_count_failed")
+        if fill_rate <= 0:
+            blockers.append("queue_position_survival_fill_rate_failed")
+        if not queue_ahead_evidence_present:
+            blockers.append("queue_ahead_depletion_evidence_present_failed")
+        if queue_ahead_sample_count <= 0:
+            blockers.append("queue_ahead_depletion_sample_count_failed")
+        if not nonfill_opportunity_cost_present:
+            blockers.append(
+                "queue_position_survival_nonfill_opportunity_cost_present_failed"
+            )
+        elif nonfill_opportunity_cost_bps > max_nonfill_opportunity_cost_bps:
+            blockers.append(
+                "queue_position_survival_nonfill_opportunity_cost_bps_failed"
+            )
+        if require_time_to_fill_quantiles and not time_to_fill_quantiles_present:
+            blockers.append("time_to_fill_quantiles_present_failed")
+    return {
+        "required": required,
+        "passed": not blockers,
+        "blockers": blockers,
+        "evidence_present": evidence_present,
+        "sample_count": sample_count,
+        "min_sample_count": min_sample_count,
+        "fill_rate": str(fill_rate),
+        "queue_ratio_p95": str(queue_ratio_p95),
+        "queue_ahead_depletion_evidence_present": queue_ahead_evidence_present,
+        "queue_ahead_depletion_sample_count": queue_ahead_sample_count,
+        "nonfill_opportunity_cost_present": nonfill_opportunity_cost_present,
+        "nonfill_opportunity_cost_bps": str(nonfill_opportunity_cost_bps),
+        "max_nonfill_opportunity_cost_bps": str(max_nonfill_opportunity_cost_bps),
+        "time_to_fill_quantiles_required": require_time_to_fill_quantiles,
+        "time_to_fill_quantiles_present": time_to_fill_quantiles_present,
+        "source_marker": "queue_position_survival_fill_probability_arxiv_2512_05734_2025",
+    }
+
+
+def _candidate_board_scorecard_with_queue_position_survival_blockers(
+    spec: CandidateSpec, scorecard: Mapping[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    summary = _candidate_board_queue_position_survival_summary(spec, scorecard)
+    updated_scorecard = dict(scorecard)
+    blockers = [
+        _string(blocker)
+        for blocker in cast(Sequence[Any], summary.get("blockers") or ())
+        if _string(blocker)
+    ]
+    if blockers:
+        updated_scorecard["oracle_passed"] = False
+        oracle_payload = dict(_mapping(updated_scorecard.get("profit_target_oracle")))
+        oracle_blockers = [
+            _string(blocker)
+            for blocker in cast(Sequence[Any], oracle_payload.get("blockers") or ())
+            if _string(blocker)
+        ]
+        oracle_payload["blockers"] = list(dict.fromkeys([*oracle_blockers, *blockers]))
+        updated_scorecard["profit_target_oracle"] = oracle_payload
+    return updated_scorecard, summary
+
+
 def _candidate_board_scorecard_with_rejected_signal_blockers(
     spec: CandidateSpec, scorecard: Mapping[str, Any]
 ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -9898,6 +10050,11 @@ def _candidate_board_payload(
                 else (),
             )
         )
+        scorecard, queue_position_survival_summary = (
+            _candidate_board_scorecard_with_queue_position_survival_blockers(
+                spec, scorecard
+            )
+        )
         scorecard, predictability_decay_summary = (
             _candidate_board_scorecard_with_predictability_decay_blockers(
                 spec, scorecard, target=target
@@ -10041,6 +10198,21 @@ def _candidate_board_payload(
                         "queue_position_survival_queue_ahead_depletion_sample_count",
                     )
                 ),
+                "queue_position_survival_nonfill_opportunity_cost_bps": (
+                    _candidate_board_decimal_field(
+                        scorecard,
+                        "queue_position_survival_nonfill_opportunity_cost_bps",
+                    )
+                    or _candidate_board_decimal_field(
+                        scorecard, "queue_position_nonfill_opportunity_cost_bps"
+                    )
+                ),
+                "fill_time_ms_p50": _candidate_board_decimal_field(
+                    scorecard, "fill_time_ms_p50"
+                ),
+                "fill_time_ms_p95": _candidate_board_decimal_field(
+                    scorecard, "fill_time_ms_p95"
+                ),
                 "delay_adjusted_depth_queue_ahead_depletion_evidence_present": _boolish(
                     scorecard.get(
                         "delay_adjusted_depth_queue_ahead_depletion_evidence_present"
@@ -10166,6 +10338,9 @@ def _candidate_board_payload(
                 "regime_specialist_validation": regime_specialist_validation,
                 "rejected_signal_outcome_learning": rejected_signal_summary,
                 "order_type_execution_quality": order_type_summary,
+                "queue_position_survival_fill_quality": (
+                    queue_position_survival_summary
+                ),
                 "predictability_decay_stress": predictability_decay_summary,
                 "evidence_lineage": evidence_lineage,
                 "replay_window_coverage": replay_window_coverage,

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -6699,6 +6699,137 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertTrue(row["order_type_execution_quality"]["passed"])
         self.assertTrue(row["oracle_passed"])
 
+    def test_candidate_board_rejects_queue_survival_overlay_without_lifecycle_depth(
+        self,
+    ) -> None:
+        spec = replace(
+            self._candidate_spec("spec-queue-survival-proof"),
+            parameter_space={
+                "mechanism_overlay_ids": ["queue_position_survival_fill_curve"]
+            },
+            hard_vetoes={
+                "required_queue_position_survival_fill_curve": True,
+                "required_min_queue_position_survival_sample_count": "60",
+                "required_max_queue_position_nonfill_opportunity_cost_bps": "8",
+                "required_time_to_fill_quantiles": True,
+                "required_order_lifecycle_fill_evidence": True,
+            },
+            promotion_contract={
+                "requires_queue_position_survival_fill_curve": True,
+                "requires_time_to_fill_quantiles": True,
+                "requires_nonfill_opportunity_cost": True,
+                "requires_order_lifecycle_fill_evidence": True,
+            },
+        )
+        evidence = runner.CandidateEvidenceBundle(
+            schema_version="torghut.candidate-evidence-bundle.v1",
+            evidence_bundle_id="ev-queue-survival-proof",
+            candidate_id="cand-queue-survival-proof",
+            candidate_spec_id=spec.candidate_spec_id,
+            dataset_snapshot_id="snapshot-queue-survival-proof",
+            feature_spec_hash="hash-queue-survival-proof",
+            code_commit="commit-test",
+            replay_artifact_refs=("replay.json",),
+            objective_scorecard={
+                "net_pnl_per_day": "640",
+                "target_met": True,
+                "oracle_passed": True,
+                "profit_target_oracle": {"blockers": []},
+                "queue_position_survival_fill_curve_evidence_present": True,
+                "queue_position_survival_sample_count": 12,
+                "queue_position_survival_fill_rate": "0.85",
+                "queue_position_survival_queue_ratio_p95": "0.25",
+                "queue_position_survival_queue_ahead_depletion_evidence_present": True,
+                "queue_position_survival_queue_ahead_depletion_sample_count": 12,
+                "queue_position_survival_nonfill_opportunity_cost_bps": "12",
+            },
+            fold_metrics=(),
+            stress_metrics=(),
+            cost_calibration={"status": "calibrated", "source": "route_tca"},
+            null_comparator={},
+            promotion_readiness={},
+        )
+
+        board = runner._candidate_board_payload(
+            epoch_id="epoch-queue-survival-board",
+            output_dir=Path("/tmp/epoch-queue-survival-board"),
+            target=Decimal("500"),
+            candidate_specs=(spec,),
+            candidate_selection={
+                "rows": [
+                    {
+                        "candidate_spec_id": spec.candidate_spec_id,
+                        "selected_for_replay": True,
+                    }
+                ]
+            },
+            pre_replay_proposal_rows=(
+                {
+                    "candidate_spec_id": spec.candidate_spec_id,
+                    "rank": 1,
+                    "proposal_score": "9.0",
+                },
+            ),
+            proposal_rows=(),
+            evidence_bundles=(evidence,),
+            portfolio=None,
+            promotion_readiness={"promotable": True},
+            runtime_closure={},
+        )
+
+        row = board["rows"][0]
+        queue_summary = row["queue_position_survival_fill_quality"]
+        self.assertFalse(row["oracle_passed"])
+        self.assertFalse(queue_summary["passed"])
+        self.assertIn("queue_position_survival_sample_count_failed", row["blockers"])
+        self.assertIn(
+            "queue_position_survival_nonfill_opportunity_cost_bps_failed",
+            row["blockers"],
+        )
+        self.assertIn("time_to_fill_quantiles_present_failed", row["blockers"])
+        self.assertEqual(queue_summary["min_sample_count"], 60)
+
+    def test_candidate_board_accepts_queue_survival_overlay_with_lifecycle_depth(
+        self,
+    ) -> None:
+        spec = replace(
+            self._candidate_spec("spec-queue-survival-pass"),
+            parameter_space={
+                "mechanism_overlay_ids": ["queue_position_survival_fill_curve"]
+            },
+            hard_vetoes={
+                "required_queue_position_survival_fill_curve": True,
+                "required_min_queue_position_survival_sample_count": "60",
+                "required_max_queue_position_nonfill_opportunity_cost_bps": "8",
+                "required_time_to_fill_quantiles": True,
+            },
+            promotion_contract={
+                "requires_queue_position_survival_fill_curve": True,
+                "requires_time_to_fill_quantiles": True,
+                "requires_nonfill_opportunity_cost": True,
+            },
+        )
+
+        summary = runner._candidate_board_queue_position_survival_summary(
+            spec,
+            {
+                "queue_position_survival_fill_curve_evidence_present": True,
+                "queue_position_survival_sample_count": 60,
+                "queue_position_survival_fill_rate": "0.85",
+                "queue_position_survival_queue_ratio_p95": "0.25",
+                "queue_position_survival_queue_ahead_depletion_evidence_present": True,
+                "queue_position_survival_queue_ahead_depletion_sample_count": 60,
+                "queue_position_survival_nonfill_opportunity_cost_bps": "8",
+                "fill_time_ms_p50": "110",
+                "fill_time_ms_p95": "450",
+            },
+        )
+
+        self.assertTrue(summary["required"])
+        self.assertTrue(summary["passed"])
+        self.assertEqual(summary["blockers"], [])
+        self.assertTrue(summary["time_to_fill_quantiles_present"])
+
     def test_candidate_board_rejects_market_limit_candidate_with_unreachable_artifacts(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds candidate-board enforcement for queue-position survival overlays.
- Blocks queue-survival candidates that lack minimum lifecycle sample depth, queue-ahead depletion evidence, non-fill opportunity-cost evidence, or required time-to-fill quantiles.
- Surfaces the queue-survival proof summary in candidate-board and sleeve-goal rows.

## Related Issues

None

## Testing

- `uv run --frozen ruff format scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'queue_survival_overlay or market_limit_candidate' -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
