### PR TITLE
chore(torghut): promote image 2371552e

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.574.5-10-gd15088a38
+              value: v0.574.5-15-g2371552e2
             - name: TORGHUT_OPTIONS_COMMIT
-              value: d15088a3854c61da96b53c0b20089c830e2bc60c
+              value: 2371552e27fe8f6157b29785c1968a84f55b3662
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.574.5-10-gd15088a38
+              value: v0.574.5-15-g2371552e2
             - name: TORGHUT_OPTIONS_COMMIT
-              value: d15088a3854c61da96b53c0b20089c830e2bc60c
+              value: 2371552e27fe8f6157b29785c1968a84f55b3662
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -100,7 +100,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+                  value: sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-26T00:02:44Z"
+        client.knative.dev/updateTimestamp: "2026-05-26T00:35:22Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
           ports:
             - name: http1
               containerPort: 8181
@@ -503,11 +503,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.574.5-10-gd15088a38
+              value: v0.574.5-15-g2371552e2
             - name: TORGHUT_COMMIT
-              value: d15088a3854c61da96b53c0b20089c830e2bc60c
+              value: 2371552e27fe8f6157b29785c1968a84f55b3662
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+              value: sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-26T00:02:44Z"
+        client.knative.dev/updateTimestamp: "2026-05-26T00:35:22Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
           ports:
             - name: http1
               containerPort: 8181
@@ -322,11 +322,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.574.5-10-gd15088a38
+              value: v0.574.5-15-g2371552e2
             - name: TORGHUT_COMMIT
-              value: d15088a3854c61da96b53c0b20089c830e2bc60c
+              value: 2371552e27fe8f6157b29785c1968a84f55b3662
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+              value: sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9c8aa1c1a2b63d8624c9441e567e144360e97202fc1c9aada686368e818543d3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `2371552e27fe8f6157b29785c1968a84f55b3662`
- Image tag: `2371552e`
- Image digest: `sha256:05740ed1e1e55290fcf428ab07a2c6bfdb0d54492cd861ca8e7860fb0ab46d49`