### PR TITLE
feat(synthesis): require curated theme submissions

### DIFF
--- a/apps/synthesis/src/routeTree.gen.ts
+++ b/apps/synthesis/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as ApiFeedRouteImport } from './routes/api/feed'
 import { Route as ApiItemsBatchRouteImport } from './routes/api/items/batch'
 import { Route as ApiItemsIdRouteImport } from './routes/api/items/$id'
 import { Route as ApiEngagementNextRouteImport } from './routes/api/engagement/next'
+import { Route as ApiAssetsIdRouteImport } from './routes/api/assets/$id'
 import { Route as ApiItemsIdFeedbackRouteImport } from './routes/api/items/$id/feedback'
 import { Route as ApiEngagementIdResultRouteImport } from './routes/api/engagement/$id/result'
 
@@ -60,6 +61,11 @@ const ApiEngagementNextRoute = ApiEngagementNextRouteImport.update({
   path: '/api/engagement/next',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiAssetsIdRoute = ApiAssetsIdRouteImport.update({
+  id: '/api/assets/$id',
+  path: '/api/assets/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiItemsIdFeedbackRoute = ApiItemsIdFeedbackRouteImport.update({
   id: '/feedback',
   path: '/feedback',
@@ -77,6 +83,7 @@ export interface FileRoutesByFullPath {
   '/api/feed': typeof ApiFeedRoute
   '/api/items': typeof ApiItemsRouteWithChildren
   '/api/runs': typeof ApiRunsRoute
+  '/api/assets/$id': typeof ApiAssetsIdRoute
   '/api/engagement/next': typeof ApiEngagementNextRoute
   '/api/items/$id': typeof ApiItemsIdRouteWithChildren
   '/api/items/batch': typeof ApiItemsBatchRoute
@@ -89,6 +96,7 @@ export interface FileRoutesByTo {
   '/api/feed': typeof ApiFeedRoute
   '/api/items': typeof ApiItemsRouteWithChildren
   '/api/runs': typeof ApiRunsRoute
+  '/api/assets/$id': typeof ApiAssetsIdRoute
   '/api/engagement/next': typeof ApiEngagementNextRoute
   '/api/items/$id': typeof ApiItemsIdRouteWithChildren
   '/api/items/batch': typeof ApiItemsBatchRoute
@@ -102,6 +110,7 @@ export interface FileRoutesById {
   '/api/feed': typeof ApiFeedRoute
   '/api/items': typeof ApiItemsRouteWithChildren
   '/api/runs': typeof ApiRunsRoute
+  '/api/assets/$id': typeof ApiAssetsIdRoute
   '/api/engagement/next': typeof ApiEngagementNextRoute
   '/api/items/$id': typeof ApiItemsIdRouteWithChildren
   '/api/items/batch': typeof ApiItemsBatchRoute
@@ -116,6 +125,7 @@ export interface FileRouteTypes {
     | '/api/feed'
     | '/api/items'
     | '/api/runs'
+    | '/api/assets/$id'
     | '/api/engagement/next'
     | '/api/items/$id'
     | '/api/items/batch'
@@ -128,6 +138,7 @@ export interface FileRouteTypes {
     | '/api/feed'
     | '/api/items'
     | '/api/runs'
+    | '/api/assets/$id'
     | '/api/engagement/next'
     | '/api/items/$id'
     | '/api/items/batch'
@@ -140,6 +151,7 @@ export interface FileRouteTypes {
     | '/api/feed'
     | '/api/items'
     | '/api/runs'
+    | '/api/assets/$id'
     | '/api/engagement/next'
     | '/api/items/$id'
     | '/api/items/batch'
@@ -153,6 +165,7 @@ export interface RootRouteChildren {
   ApiFeedRoute: typeof ApiFeedRoute
   ApiItemsRoute: typeof ApiItemsRouteWithChildren
   ApiRunsRoute: typeof ApiRunsRoute
+  ApiAssetsIdRoute: typeof ApiAssetsIdRoute
   ApiEngagementNextRoute: typeof ApiEngagementNextRoute
   ApiEngagementIdResultRoute: typeof ApiEngagementIdResultRoute
 }
@@ -215,6 +228,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiEngagementNextRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/assets/$id': {
+      id: '/api/assets/$id'
+      path: '/api/assets/$id'
+      fullPath: '/api/assets/$id'
+      preLoaderRoute: typeof ApiAssetsIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/items/$id/feedback': {
       id: '/api/items/$id/feedback'
       path: '/feedback'
@@ -264,6 +284,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiFeedRoute: ApiFeedRoute,
   ApiItemsRoute: ApiItemsRouteWithChildren,
   ApiRunsRoute: ApiRunsRoute,
+  ApiAssetsIdRoute: ApiAssetsIdRoute,
   ApiEngagementNextRoute: ApiEngagementNextRoute,
   ApiEngagementIdResultRoute: ApiEngagementIdResultRoute,
 }

--- a/apps/synthesis/src/routes/api/assets/$id.ts
+++ b/apps/synthesis/src/routes/api/assets/$id.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/assets/$id')({
+  server: {
+    handlers: {
+      GET: async ({ request, params }: { request: Request; params: { id: string } }) => {
+        const { handleGetAsset } = await import('~/server/api')
+        return handleGetAsset(request, params.id)
+      },
+    },
+  },
+})

--- a/apps/synthesis/src/routes/index.tsx
+++ b/apps/synthesis/src/routes/index.tsx
@@ -184,26 +184,24 @@ const statusIcon = (status: SynthesisItem['engagementStatus']) => {
   return <Filter />
 }
 
-const extractUrls = (text: string) =>
-  Array.from(text.matchAll(/https?:\/\/[^\s)\]]+/g), (match) => match[0].replace(/[.,;:]+$/, ''))
-
 const isMediaLikeUrl = (url: string) =>
   url.startsWith('data:image/') ||
+  url.startsWith('/api/assets/') ||
   /pbs\.twimg\.com|twimg\.com|\/photo\/\d+|\.(png|jpe?g|webp|gif|avif)(\?|$)/i.test(url)
 
 const isInlineImageUrl = (url: string) =>
-  url.startsWith('data:image/') || /pbs\.twimg\.com|twimg\.com|\.(png|jpe?g|webp|gif|avif)(\?|$)/i.test(url)
+  url.startsWith('data:image/') ||
+  url.startsWith('/api/assets/') ||
+  /pbs\.twimg\.com|twimg\.com|\.(png|jpe?g|webp|gif|avif)(\?|$)/i.test(url)
 
 const mediaUrlsForItem = (item: SynthesisItem) => {
   const urls = new Set<string>()
+  for (const attachment of item.attachments) {
+    if (isMediaLikeUrl(attachment.assetUrl)) urls.add(attachment.assetUrl)
+  }
+  if (urls.size > 0) return [...urls]
   for (const url of item.mediaUrls) {
     if (isMediaLikeUrl(url)) urls.add(url)
-  }
-  for (const url of extractUrls([item.observedText, ...item.evidence].join(' '))) {
-    if (isMediaLikeUrl(url)) urls.add(url)
-  }
-  if (urls.size === 0 && /\bimage\b/i.test(item.observedText)) {
-    urls.add(`${item.originalUrl}/photo/1`)
   }
   return [...urls]
 }
@@ -237,7 +235,15 @@ function App() {
     const lowered = query.trim().toLowerCase()
     if (!lowered) return loadedItems
     return loadedItems.filter((item) =>
-      [item.summary, item.whyValuable, item.observedText, item.authorHandle, item.authorName, item.topicTags.join(' ')]
+      [
+        item.title,
+        item.synthesis,
+        item.whyValuable,
+        item.takeaways.join(' '),
+        item.factChecks.map((factCheck) => factCheck.claim).join(' '),
+        item.sourcePosts.map((source) => [source.authorHandle, source.authorName].filter(Boolean).join(' ')).join(' '),
+        item.topicTags.join(' '),
+      ]
         .filter(Boolean)
         .some((value) => value?.toLowerCase().includes(lowered)),
     )
@@ -465,7 +471,8 @@ function FeedPost({
             <span className="text-[#71767b]">{formatDate(item.observedAt)}</span>
           </div>
 
-          <p className="mt-2 line-clamp-3 text-[15px] leading-6">{compactText(item.summary)}</p>
+          <h2 className="mt-2 line-clamp-2 text-[16px] font-semibold leading-6">{compactText(item.title, 180)}</h2>
+          <p className="mt-1 line-clamp-3 text-[15px] leading-6 text-[#d8dadd]">{compactText(item.synthesis, 280)}</p>
 
           {inlineImage ? (
             <div className="mt-3 overflow-hidden rounded-md border border-[#2f3336] bg-[#080808]">
@@ -481,6 +488,9 @@ function FeedPost({
           <div className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-2 text-sm text-[#71767b]">
             <span>score {formatScore(item.score)}</span>
             <span>conf {formatScore(item.confidence)}</span>
+            <span>
+              {item.sourceCount} source{item.sourceCount === 1 ? '' : 's'}
+            </span>
             <span className="inline-flex items-center gap-1 [&>svg]:size-3.5">
               {statusIcon(item.engagementStatus)}
               {statusLabel(item.engagementStatus)}
@@ -510,7 +520,7 @@ function FeedPost({
               className="inline-flex items-center gap-2 text-sm transition-colors hover:text-[#1d9bf0]"
             >
               <ArrowUpRight className="size-4" />
-              original
+              source
             </a>
           </div>
         </div>
@@ -529,7 +539,7 @@ function DetailPanel({ item }: { item: SynthesisItem | null }) {
         {item ? (
           <a href={item.originalUrl} target="_blank" rel="noreferrer" className={buttonClass('ghost', 'sm')}>
             <ExternalLink data-icon="inline-start" />
-            Original
+            Source
           </a>
         ) : null}
       </div>
@@ -570,14 +580,82 @@ function DetailContent({ item }: { item: SynthesisItem }) {
       </div>
 
       <Section title="Synthesis">
-        <p className="text-[15px] leading-7">{compactText(item.summary, 420)}</p>
+        <h1 className="mb-3 text-2xl font-bold leading-8 tracking-normal">{item.title}</h1>
+        <p className="text-[15px] leading-7">{compactText(item.synthesis, 900)}</p>
         {item.whyValuable ? (
-          <p className="mt-3 text-[15px] leading-7 text-[#a6a6a6]">{compactText(item.whyValuable, 360)}</p>
+          <div className="mt-4 rounded-md border border-[#2f3336] bg-[#080808] px-3 py-3">
+            <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#71767b]">Why it matters</h4>
+            <p className="text-[15px] leading-7 text-[#d8dadd]">{compactText(item.whyValuable, 520)}</p>
+          </div>
         ) : null}
       </Section>
 
+      {item.takeaways.length ? (
+        <Section title="Takeaways">
+          <ul className="grid gap-2 text-[15px] leading-6 text-[#d8dadd]">
+            {item.takeaways.map((takeaway) => (
+              <li key={takeaway} className="rounded-md border border-[#2f3336] bg-[#080808] px-3 py-2">
+                {takeaway}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : null}
+
+      {item.factChecks.length ? (
+        <Section title="Fact Checks">
+          <div className="grid gap-3">
+            {item.factChecks.map((factCheck) => (
+              <div key={factCheck.claim} className="rounded-md border border-[#2f3336] bg-[#080808] px-3 py-3">
+                <div className="mb-1 flex flex-wrap items-center gap-2">
+                  <Badge variant={factCheck.status === 'verified' ? 'secondary' : 'outline'}>{factCheck.status}</Badge>
+                  <span className="text-sm font-semibold text-[#e7e9ea]">{factCheck.claim}</span>
+                </div>
+                <p className="text-sm leading-6 text-[#a6a6a6]">{factCheck.explanation}</p>
+                {factCheck.sources.length ? (
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {factCheck.sources.map((source) => (
+                      <a
+                        key={source.url}
+                        href={source.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex max-w-full items-center gap-1 rounded-md border border-[#2f3336] px-2 py-1 text-xs text-[#71767b] transition-colors hover:border-[#1d9bf0]/60 hover:text-[#e7e9ea]"
+                      >
+                        <span className="truncate">{source.title ?? source.publisher ?? source.url}</span>
+                        <ExternalLink className="size-3 shrink-0" />
+                      </a>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </Section>
+      ) : null}
+
+      <Section title="Sources">
+        <div className="flex flex-wrap gap-2">
+          {item.sourcePosts.map((source, index) => (
+            <a
+              key={source.postKey}
+              href={source.canonicalUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex max-w-full items-center gap-2 rounded-md border border-[#2f3336] bg-[#080808] px-3 py-2 text-sm text-[#e7e9ea] transition-colors hover:border-[#1d9bf0]/60"
+            >
+              <span className="text-[#71767b]">{index + 1}</span>
+              <span className="truncate">
+                {source.authorHandle ? displayHandle(source.authorHandle) : 'x.com post'}
+              </span>
+              <ExternalLink className="size-4 shrink-0 text-[#71767b]" />
+            </a>
+          ))}
+        </div>
+      </Section>
+
       {mediaUrls.length ? (
-        <Section title="Media">
+        <Section title="Attachments">
           <div className="grid gap-3">
             {mediaUrls.map((url) =>
               isInlineImageUrl(url) ? (
@@ -608,22 +686,6 @@ function DetailContent({ item }: { item: SynthesisItem }) {
         </Section>
       ) : null}
 
-      {item.evidence.length ? (
-        <Section title="Evidence">
-          <ul className="flex flex-col gap-2 text-[15px] leading-6 text-[#d8dadd]">
-            {item.evidence.map((evidence) => (
-              <li key={evidence} className="rounded-md border border-[#2f3336] bg-[#080808] px-3 py-2">
-                {evidence}
-              </li>
-            ))}
-          </ul>
-        </Section>
-      ) : null}
-
-      <Section title="Raw">
-        <p className="whitespace-pre-wrap text-sm leading-6 text-[#a6a6a6]">{item.observedText}</p>
-      </Section>
-
       <Separator className="bg-[#2f3336]" />
       <div className="flex flex-wrap gap-2">
         {item.topicTags.map((topic) => (
@@ -650,7 +712,7 @@ function EmptyDetail() {
     <div className="flex h-full min-h-[420px] items-center justify-center px-8 text-center text-[#71767b]">
       <div>
         <Newspaper className="mx-auto mb-3 size-8" />
-        <p className="text-sm">Select an item to inspect the post, evidence, raw text, and media.</p>
+        <p className="text-sm">Select an item to inspect synthesis, sources, fact checks, and attachments.</p>
       </div>
     </div>
   )

--- a/apps/synthesis/src/server/__tests__/api.test.ts
+++ b/apps/synthesis/src/server/__tests__/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
-import { handleCreateRun, handleListFeed, handleSubmitItem } from '../api'
+import { handleCreateRun, handleGetAsset, handleListFeed, handleSubmitItem } from '../api'
 import { createInMemorySynthesisStore, setSynthesisStoreForTests } from '../store'
 
 const token = 'test-synthesis-token'
@@ -24,10 +24,18 @@ const submitItemRequest = (runId: string, index: number) =>
     },
     body: JSON.stringify({
       runId,
-      originalUrl: `https://x.com/example/status/${1000 + index}`,
-      observedText: `observed post ${index} about semis and devtools`,
-      mediaUrls: [`https://pbs.twimg.com/media/example-${index}.jpg`],
-      summary: `semis/devtools summary ${index}`,
+      title: `Semis and devtools signal ${index}`,
+      synthesis: `Semis/devtools synthesis ${index} turns the observed post into a concise curated item.`,
+      takeaways: [`watch the tooling signal ${index}`],
+      whyValuable: 'It is concrete enough to preserve without making the reader inspect the raw timeline.',
+      sourcePosts: [
+        {
+          originalUrl: `https://x.com/example/status/${1000 + index}`,
+          observedText: `observed post ${index} about semis and devtools`,
+          mediaUrls: [`https://pbs.twimg.com/media/example-${index}.jpg`],
+        },
+      ],
+      dedupeKey: `theme:semis-devtools-${index}`,
       topicTags: ['semis', 'devtools'],
       score: 0.8 + index * 0.01,
       confidence: 0.75,
@@ -59,6 +67,31 @@ describe('synthesis REST auth', () => {
     expect(payload.run.source).toBe('x.com/home')
   })
 
+  test('rejects old single-post submit payloads', async () => {
+    const runResponse = await handleCreateRun(createRunRequest(`Bearer ${token}`))
+    const runPayload = await runResponse.json()
+    const response = await handleSubmitItem(
+      new Request('http://synthesis.test/api/items', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          runId: runPayload.run.id,
+          originalUrl: 'https://x.com/example/status/999',
+          observedText: 'raw timeline post',
+          summary: 'old summary field',
+          score: 0.91,
+        }),
+      }),
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(JSON.stringify(payload.details)).toContain('Unrecognized')
+  })
+
   test('paginates the feed with a cursor', async () => {
     const runResponse = await handleCreateRun(createRunRequest(`Bearer ${token}`))
     const runPayload = await runResponse.json()
@@ -82,5 +115,125 @@ describe('synthesis REST auth', () => {
 
     const firstIds = new Set(firstPage.items.map((item: { id: string }) => item.id))
     expect(secondPage.items.some((item: { id: string }) => firstIds.has(item.id))).toBe(false)
+  })
+
+  test('stores one synthesized theme with multiple sources and app-owned attachments', async () => {
+    const runResponse = await handleCreateRun(createRunRequest(`Bearer ${token}`))
+    const runPayload = await runResponse.json()
+    const submitResponse = await handleSubmitItem(
+      new Request('http://synthesis.test/api/items', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          runId: runPayload.run.id,
+          title: 'HBM capacity is tightening around inference demand',
+          synthesis:
+            'Multiple posts point to the same useful signal: HBM supply is moving from a headline constraint into a packaging and allocation constraint for inference clusters.',
+          takeaways: ['capacity is allocation-limited', 'packaging is the bottleneck to watch'],
+          sourcePosts: [
+            {
+              originalUrl: 'https://x.com/example/status/2001',
+              authorHandle: 'example',
+              observedText: 'hbm allocation notes with packaging detail',
+              mediaUrls: ['https://pbs.twimg.com/media/hbm-1.jpg'],
+            },
+            {
+              originalUrl: 'https://x.com/another/status/2002',
+              authorHandle: 'another',
+              observedText: 'second post describing the same hbm packaging constraint',
+            },
+          ],
+          factChecks: [
+            {
+              claim: 'HBM demand is pressuring advanced packaging capacity.',
+              status: 'verified',
+              explanation: 'Company capacity commentary and reputable reporting both support this direction.',
+              sources: [{ title: 'Company earnings transcript', url: 'https://example.com/hbm-transcript' }],
+            },
+          ],
+          attachments: [
+            {
+              kind: 'source_image',
+              url: 'https://pbs.twimg.com/media/hbm-1.jpg',
+              sourceUrl: 'https://x.com/example/status/2001',
+              mimeType: 'image/jpeg',
+            },
+          ],
+          generatedAttachments: [
+            {
+              kind: 'generated_infographic',
+              data: 'data:image/png;base64,AAAA',
+              label: 'HBM bottleneck map',
+            },
+          ],
+          whyValuable: 'It turns scattered timeline chatter into a concrete semiconductor supply-chain watch item.',
+          topicTags: ['semis', 'ai agents'],
+          dedupeKey: 'theme:hbm-capacity',
+          score: 0.93,
+          confidence: 0.86,
+        }),
+      }),
+    )
+    const payload = await submitResponse.json()
+
+    expect(submitResponse.status).toBe(201)
+    expect(payload.item.title).toContain('HBM capacity')
+    expect(payload.item.sourceCount).toBe(2)
+    expect(payload.item.sourcePosts).toHaveLength(2)
+    expect(payload.item.factChecks[0].status).toBe('verified')
+    expect(payload.item.attachments).toHaveLength(2)
+    expect(payload.item.attachments[0].assetUrl).toMatch(/^\/api\/assets\//)
+
+    const assetResponse = await handleGetAsset(
+      new Request(`http://synthesis.test${payload.item.attachments[0].assetUrl}`),
+      payload.item.attachments[0].id,
+    )
+    expect(assetResponse.status).toBe(302)
+    expect(assetResponse.headers.get('location')).toBe('https://pbs.twimg.com/media/hbm-1.jpg')
+  })
+
+  test('merges duplicate theme submissions instead of creating raw-post duplicates', async () => {
+    const runResponse = await handleCreateRun(createRunRequest(`Bearer ${token}`))
+    const runPayload = await runResponse.json()
+    const submit = (statusId: number) =>
+      handleSubmitItem(
+        new Request('http://synthesis.test/api/items', {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${token}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            runId: runPayload.run.id,
+            title: 'Agent browser tooling is consolidating',
+            synthesis: 'Two posts describe the same shift toward browser-native agent tooling.',
+            takeaways: ['browser-native agent tooling is clustering into one workflow pattern'],
+            whyValuable: 'It combines overlapping timeline items into one clear product signal.',
+            sourcePosts: [
+              {
+                originalUrl: `https://x.com/example/status/${statusId}`,
+                observedText: `agent browser tooling source ${statusId}`,
+              },
+            ],
+            topicTags: ['devtools'],
+            dedupeKey: 'theme:agent-browser-tooling',
+            score: 0.88,
+            confidence: 0.8,
+          }),
+        }),
+      )
+
+    await submit(3001)
+    const secondResponse = await submit(3002)
+    const secondPayload = await secondResponse.json()
+    const feedResponse = await handleListFeed(new Request('http://synthesis.test/api/feed?limit=10&minScore=0'))
+    const feedPayload = await feedResponse.json()
+
+    expect(secondPayload.item.sourceCount).toBe(2)
+    expect(feedPayload.items).toHaveLength(1)
+    expect(feedPayload.items[0].dedupeKey).toBe('theme:agent-browser-tooling')
   })
 })

--- a/apps/synthesis/src/server/__tests__/mcp.test.ts
+++ b/apps/synthesis/src/server/__tests__/mcp.test.ts
@@ -48,9 +48,22 @@ describe('synthesis MCP', () => {
     const toolsResponse = await handleMcpRequest(rpc('tools/list'))
     const toolsPayload = await toolsResponse.json()
     const toolNames = toolsPayload.result.tools.map((tool: { name: string }) => tool.name)
+    const submitTool = toolsPayload.result.tools.find((tool: { name: string }) => tool.name === 'synthesis_submit_item')
 
     expect(toolNames).toContain('synthesis_submit_item')
     expect(toolNames).toContain('synthesis_next_engagement')
+    expect(submitTool.inputSchema.required).toEqual([
+      'title',
+      'synthesis',
+      'takeaways',
+      'whyValuable',
+      'sourcePosts',
+      'dedupeKey',
+      'score',
+      'confidence',
+    ])
+    expect(submitTool.inputSchema.properties.summary).toBeUndefined()
+    expect(submitTool.inputSchema.properties.originalUrl).toBeUndefined()
 
     const resourceResponse = await handleMcpRequest(rpc('resources/read', { uri: 'synthesis://config' }))
     const resourcePayload = await resourceResponse.json()
@@ -74,12 +87,19 @@ describe('synthesis MCP', () => {
           'synthesis_submit_item',
           {
             runId: runPayload.run.id,
-            originalUrl: 'https://twitter.com/example/status/12345?ref=feed',
-            observedText: 'semi stack integration notes with actionable edge ai packaging detail',
-            mediaUrls: ['data:image/png;base64,AAAA'],
-            summary: 'edge ai packaging is becoming a tighter semiconductor integration bottleneck.',
+            title: 'Edge AI packaging is becoming a deployment bottleneck',
+            synthesis:
+              'The useful signal is that edge AI hardware economics are getting constrained by packaging and board integration, not just model size.',
+            takeaways: ['packaging constraints are now part of edge AI deployment math'],
             whyValuable: 'connects packaging constraints to model deployment economics.',
-            evidence: ['mentions packaging yield', 'ties inference latency to board-level integration'],
+            sourcePosts: [
+              {
+                originalUrl: 'https://twitter.com/example/status/12345?ref=feed',
+                observedText: 'semi stack integration notes with actionable edge ai packaging detail',
+                mediaUrls: ['data:image/png;base64,AAAA'],
+              },
+            ],
+            dedupeKey: 'theme:edge-ai-packaging',
             topicTags: ['semis', 'ai agents'],
             score: 0.91,
             confidence: 0.82,
@@ -97,5 +117,82 @@ describe('synthesis MCP', () => {
     const feedPayload = await parseToolJson(await handleMcpRequest(callTool('synthesis_list_feed', { limit: 10 })))
     expect(feedPayload.items).toHaveLength(1)
     expect(feedPayload.items[0].id).toBe(submitPayload.item.id)
+  })
+
+  test('rejects old submit arguments at the MCP boundary', async () => {
+    const headers = { authorization: `Bearer ${token}` }
+    const response = await handleMcpRequest(
+      callTool(
+        'synthesis_submit_item',
+        {
+          originalUrl: 'https://x.com/example/status/777',
+          observedText: 'raw timeline post',
+          summary: 'old summary field',
+          score: 0.91,
+        },
+        headers,
+      ),
+    )
+    const payload = await response.json()
+
+    expect(payload.error.code).toBe(-32602)
+    expect(payload.error.message).toBe('Invalid synthesis_submit_item input')
+  })
+
+  test('submits a multi-source synthesized theme through the expanded contract', async () => {
+    const headers = { authorization: `Bearer ${token}` }
+    const runPayload = await parseToolJson(await handleMcpRequest(callTool('synthesis_start_run', {}, headers)))
+    const submitPayload = await parseToolJson(
+      await handleMcpRequest(
+        callTool(
+          'synthesis_submit_item',
+          {
+            runId: runPayload.run.id,
+            title: 'Browser agents are moving into real workflows',
+            synthesis:
+              'The useful signal is not another browser-agent demo. Multiple posts point to browser sessions becoming the control surface for authenticated SaaS work.',
+            takeaways: [
+              'logged-in browser context is becoming the product surface',
+              'approval queues matter for risky actions',
+            ],
+            sourcePosts: [
+              {
+                originalUrl: 'https://x.com/example/status/4101',
+                authorHandle: 'example',
+                observedText: 'browser agent post with logged in workflow details',
+              },
+              {
+                originalUrl: 'https://x.com/example/status/4102',
+                authorHandle: 'example',
+                observedText: 'second browser agent post about approval queues',
+              },
+            ],
+            factChecks: [
+              {
+                claim: 'Automated engagement should stay behind approval.',
+                status: 'verified',
+                explanation: 'Platform automation rules restrict unsolicited automated engagement.',
+                sources: [{ title: 'X automation rules', url: 'https://help.x.com/articles/76915' }],
+              },
+            ],
+            attachments: [{ kind: 'source_image', url: 'https://pbs.twimg.com/media/browser-agent.jpg' }],
+            generatedAttachments: [{ kind: 'generated_infographic', data: 'data:image/png;base64,AAAA' }],
+            dedupeKey: 'theme:browser-agent-workflows',
+            whyValuable: 'It converts two overlapping posts into one concrete product-design direction.',
+            topicTags: ['ai agents', 'devtools'],
+            score: 0.94,
+            confidence: 0.87,
+          },
+          headers,
+        ),
+      ),
+    )
+
+    expect(submitPayload.item.title).toContain('Browser agents')
+    expect(submitPayload.item.sourceCount).toBe(2)
+    expect(submitPayload.item.takeaways).toHaveLength(2)
+    expect(submitPayload.item.factChecks[0].status).toBe('verified')
+    expect(submitPayload.item.attachments).toHaveLength(2)
+    expect(submitPayload.item.generatedAttachments).toHaveLength(1)
   })
 })

--- a/apps/synthesis/src/server/api.ts
+++ b/apps/synthesis/src/server/api.ts
@@ -7,6 +7,7 @@ import {
   SubmitBatchInputSchema,
   SubmitItemInputSchema,
 } from './schema'
+import { assetResponseForAttachment } from './assets'
 import { getSynthesisStore } from './store'
 import { requireAuthorized } from './auth'
 import { badRequest, jsonResponse, notFound, readJson } from './http'
@@ -87,6 +88,16 @@ export const handleGetItem = async (_request: Request, id: string) => {
     const item = await getSynthesisStore().getItem(id)
     if (!item) return notFound('synthesis item not found')
     return jsonResponse({ item })
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+export const handleGetAsset = async (_request: Request, id: string) => {
+  try {
+    const attachment = await getSynthesisStore().getAttachment(id)
+    if (!attachment) return notFound('asset not found')
+    return assetResponseForAttachment(attachment)
   } catch (error) {
     return internalError(error)
   }

--- a/apps/synthesis/src/server/assets.ts
+++ b/apps/synthesis/src/server/assets.ts
@@ -1,0 +1,309 @@
+import { createHash, createHmac, randomUUID } from 'node:crypto'
+
+import type { AttachmentInput, SynthesisAttachment } from './schema'
+
+type AssetStorageConfig = {
+  endpoint: string
+  bucket: string
+  accessKeyId: string
+  secretAccessKey: string
+  region: string
+  maxBytes: number
+}
+
+type MaterializeAttachmentOptions = {
+  now?: () => Date
+  fetch?: typeof fetch
+}
+
+const defaultMaxBytes = 8 * 1024 * 1024
+
+const normalizeNonEmpty = (value: string | undefined | null) => {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+const resolveAssetStorageConfig = (
+  env: Record<string, string | undefined> = process.env,
+): AssetStorageConfig | null => {
+  const endpoint = normalizeNonEmpty(env.SYNTHESIS_ASSET_ENDPOINT)
+  const bucket = normalizeNonEmpty(env.SYNTHESIS_ASSET_BUCKET)
+  const accessKeyId = normalizeNonEmpty(env.SYNTHESIS_ASSET_ACCESS_KEY_ID)
+  const secretAccessKey = normalizeNonEmpty(env.SYNTHESIS_ASSET_SECRET_ACCESS_KEY)
+  if (!endpoint && !bucket && !accessKeyId && !secretAccessKey) return null
+  if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) {
+    throw new Error(
+      'asset storage requires SYNTHESIS_ASSET_ENDPOINT, SYNTHESIS_ASSET_BUCKET, SYNTHESIS_ASSET_ACCESS_KEY_ID, and SYNTHESIS_ASSET_SECRET_ACCESS_KEY',
+    )
+  }
+
+  return {
+    endpoint: endpoint.startsWith('http://') || endpoint.startsWith('https://') ? endpoint : `https://${endpoint}`,
+    bucket,
+    accessKeyId,
+    secretAccessKey,
+    region: normalizeNonEmpty(env.SYNTHESIS_ASSET_REGION) ?? 'us-east-1',
+    maxBytes: Number(normalizeNonEmpty(env.SYNTHESIS_ASSET_MAX_BYTES) ?? defaultMaxBytes),
+  }
+}
+
+const awsEncode = (value: string) =>
+  encodeURIComponent(value).replace(/[!'()*]/g, (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`)
+
+const encodePath = (path: string) =>
+  path
+    .split('/')
+    .map((segment) => awsEncode(segment))
+    .join('/')
+    .replace(/\/+/g, '/')
+
+const sha256Hex = (value: Buffer | string) => createHash('sha256').update(value).digest('hex')
+const hmac = (key: Buffer | string, value: string) => createHmac('sha256', key).update(value).digest()
+const hmacHex = (key: Buffer | string, value: string) => createHmac('sha256', key).update(value).digest('hex')
+
+const signingKey = (secretKey: string, datestamp: string, region: string) => {
+  const dateKey = hmac(`AWS4${secretKey}`, datestamp)
+  const regionKey = hmac(dateKey, region)
+  const serviceKey = hmac(regionKey, 's3')
+  return hmac(serviceKey, 'aws4_request')
+}
+
+const toAmzDates = (date: Date) => {
+  const iso = date.toISOString().replace(/[:-]|\.\d{3}/g, '')
+  return {
+    amzDate: iso,
+    datestamp: iso.slice(0, 8),
+  }
+}
+
+const normalizeKey = (key: string) =>
+  key
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .join('/')
+
+const buildObjectUrl = (config: AssetStorageConfig, key: string) => {
+  const endpoint = new URL(config.endpoint)
+  const basePath = endpoint.pathname === '/' ? '' : endpoint.pathname.replace(/\/$/, '')
+  const canonicalUri = encodePath(`${basePath}/${config.bucket}/${normalizeKey(key)}`)
+  endpoint.pathname = canonicalUri
+  endpoint.search = ''
+  return { url: endpoint.toString(), canonicalUri, host: endpoint.host }
+}
+
+const signedS3Request = (input: {
+  config: AssetStorageConfig
+  key: string
+  method: 'GET' | 'PUT'
+  body?: Buffer
+  now: Date
+}) => {
+  const { amzDate, datestamp } = toAmzDates(input.now)
+  const payloadHash = input.body ? sha256Hex(input.body) : sha256Hex('')
+  const { url, canonicalUri, host } = buildObjectUrl(input.config, input.key)
+  const signedHeaders = 'host;x-amz-content-sha256;x-amz-date'
+  const canonicalHeaders = [`host:${host}`, `x-amz-content-sha256:${payloadHash}`, `x-amz-date:${amzDate}`, ''].join(
+    '\n',
+  )
+  const canonicalRequest = [input.method, canonicalUri, '', canonicalHeaders, signedHeaders, payloadHash].join('\n')
+  const scope = `${datestamp}/${input.config.region}/s3/aws4_request`
+  const stringToSign = ['AWS4-HMAC-SHA256', amzDate, scope, sha256Hex(canonicalRequest)].join('\n')
+  const signature = hmacHex(signingKey(input.config.secretAccessKey, datestamp, input.config.region), stringToSign)
+  return {
+    url,
+    headers: {
+      Authorization: [
+        `AWS4-HMAC-SHA256 Credential=${input.config.accessKeyId}/${scope}`,
+        `SignedHeaders=${signedHeaders}`,
+        `Signature=${signature}`,
+      ].join(', '),
+      'x-amz-content-sha256': payloadHash,
+      'x-amz-date': amzDate,
+    },
+  }
+}
+
+const extensionForMime = (mimeType: string) => {
+  if (mimeType === 'image/png') return 'png'
+  if (mimeType === 'image/jpeg') return 'jpg'
+  if (mimeType === 'image/webp') return 'webp'
+  if (mimeType === 'image/gif') return 'gif'
+  if (mimeType === 'image/avif') return 'avif'
+  return 'bin'
+}
+
+const assertSupportedMime = (mimeType: string) => {
+  if (!mimeType.toLowerCase().startsWith('image/')) {
+    throw new Error(`unsupported synthesis asset MIME type: ${mimeType}`)
+  }
+}
+
+const parseDataUrl = (url: string): { body: Buffer; mimeType: string } | null => {
+  const match = url.match(/^data:([^;,]+);base64,(.+)$/)
+  if (!match) return null
+  return {
+    mimeType: match[1],
+    body: Buffer.from(match[2], 'base64'),
+  }
+}
+
+const readRemoteAsset = async (url: string, maxBytes: number, fetchImpl: typeof fetch) => {
+  const response = await fetchImpl(url, { headers: { accept: 'image/*,*/*;q=0.5' } })
+  if (!response.ok) throw new Error(`asset download failed for ${url}: ${response.status}`)
+  const mimeType = response.headers.get('content-type')?.split(';')[0]?.trim() || 'application/octet-stream'
+  assertSupportedMime(mimeType)
+  const body = Buffer.from(await response.arrayBuffer())
+  if (body.length > maxBytes) throw new Error(`asset exceeds max size: ${body.length} > ${maxBytes}`)
+  return { body, mimeType }
+}
+
+const materializeBody = async (
+  input: AttachmentInput,
+  config: AssetStorageConfig,
+  fetchImpl: typeof fetch,
+): Promise<{ body: Buffer; mimeType: string } | null> => {
+  if (input.data) {
+    const data = parseDataUrl(input.data)
+    if (!data) throw new Error('attachment data must be a base64 data URL')
+    assertSupportedMime(data.mimeType)
+    if (data.body.length > config.maxBytes)
+      throw new Error(`asset exceeds max size: ${data.body.length} > ${config.maxBytes}`)
+    return data
+  }
+  if (input.url?.startsWith('data:')) {
+    const data = parseDataUrl(input.url)
+    if (!data) throw new Error('attachment URL data must be a base64 data URL')
+    assertSupportedMime(data.mimeType)
+    if (data.body.length > config.maxBytes)
+      throw new Error(`asset exceeds max size: ${data.body.length} > ${config.maxBytes}`)
+    return data
+  }
+  if (input.url) return readRemoteAsset(input.url, config.maxBytes, fetchImpl)
+  return null
+}
+
+export const normalizeAttachmentInputs = (input: {
+  attachments: AttachmentInput[]
+  generatedAttachments: AttachmentInput[]
+  mediaUrls: string[]
+}) => {
+  const normalized: Array<AttachmentInput & { generated: boolean }> = []
+  for (const attachment of input.attachments) normalized.push({ ...attachment, generated: false })
+  for (const attachment of input.generatedAttachments) normalized.push({ ...attachment, generated: true })
+  for (const url of input.mediaUrls) {
+    normalized.push({ kind: 'source_image', url, sourceUrl: url, generated: false })
+  }
+  return normalized
+}
+
+export const materializeAttachments = async (
+  inputs: Array<AttachmentInput & { generated: boolean }>,
+  options: MaterializeAttachmentOptions = {},
+): Promise<SynthesisAttachment[]> => {
+  if (inputs.length === 0) return []
+
+  const config = resolveAssetStorageConfig()
+  const fetchImpl = options.fetch ?? fetch
+  const now = options.now ?? (() => new Date())
+  const seen = new Set<string>()
+  const attachments: SynthesisAttachment[] = []
+
+  for (const input of inputs) {
+    const identity = `${input.kind}:${input.url ?? input.data ?? input.sourceUrl ?? ''}`
+    if (seen.has(identity)) continue
+    seen.add(identity)
+
+    const id = randomUUID()
+    const sourceUrl = input.url?.startsWith('data:') ? null : (input.url ?? input.sourceUrl ?? null)
+    let objectKey: string | null = null
+    let assetUrl = input.url ?? input.data ?? ''
+    let mimeType = input.mimeType ?? null
+    let sizeBytes: number | null = null
+
+    if (input.data || input.url?.startsWith('data:')) {
+      const data = parseDataUrl(input.data ?? input.url ?? '')
+      if (!data) throw new Error('attachment data must be a base64 data URL')
+      assertSupportedMime(data.mimeType)
+      mimeType = data.mimeType
+      sizeBytes = data.body.length
+      if (sizeBytes > (config?.maxBytes ?? defaultMaxBytes)) {
+        throw new Error(`asset exceeds max size: ${sizeBytes} > ${config?.maxBytes ?? defaultMaxBytes}`)
+      }
+    } else if (mimeType) {
+      assertSupportedMime(mimeType)
+    }
+
+    if (config) {
+      const body = await materializeBody(input, config, fetchImpl)
+      if (body) {
+        mimeType = body.mimeType
+        sizeBytes = body.body.length
+        objectKey = `synthesis/${now().toISOString().slice(0, 10)}/${id}.${extensionForMime(body.mimeType)}`
+        const request = signedS3Request({ config, key: objectKey, method: 'PUT', body: body.body, now: now() })
+        const response = await fetchImpl(request.url, {
+          method: 'PUT',
+          headers: request.headers,
+          body: new Uint8Array(body.body),
+        })
+        if (!response.ok) {
+          const text = await response.text().catch(() => '')
+          throw new Error(`asset upload failed for s3://${config.bucket}/${objectKey}: ${response.status} ${text}`)
+        }
+        assetUrl = `/api/assets/${id}`
+      }
+    } else if (sourceUrl) {
+      assetUrl = `/api/assets/${id}`
+    }
+
+    attachments.push({
+      id,
+      kind: input.kind,
+      sourceUrl,
+      assetUrl,
+      objectKey,
+      mimeType,
+      sizeBytes,
+      alt: input.alt ?? null,
+      label: input.label ?? null,
+      generated: input.generated,
+    })
+  }
+
+  return attachments
+}
+
+export const assetResponseForAttachment = async (attachment: SynthesisAttachment): Promise<Response> => {
+  if (attachment.objectKey) {
+    const config = resolveAssetStorageConfig()
+    if (!config) return new Response('asset storage unavailable', { status: 503 })
+    const request = signedS3Request({ config, key: attachment.objectKey, method: 'GET', now: new Date() })
+    const response = await fetch(request.url, { headers: request.headers })
+    if (!response.ok) return new Response('asset not found', { status: response.status })
+    return new Response(response.body, {
+      status: 200,
+      headers: {
+        'cache-control': 'private, max-age=3600',
+        ...(response.headers.get('content-type') ? { 'content-type': response.headers.get('content-type') ?? '' } : {}),
+      },
+    })
+  }
+
+  if (attachment.assetUrl.startsWith('data:')) {
+    const data = parseDataUrl(attachment.assetUrl)
+    if (!data) return new Response('invalid inline asset', { status: 404 })
+    return new Response(new Uint8Array(data.body), {
+      headers: {
+        'cache-control': 'private, max-age=3600',
+        'content-type': data.mimeType,
+      },
+    })
+  }
+
+  const redirectUrl = attachment.sourceUrl ?? attachment.assetUrl
+  if (redirectUrl.startsWith('http://') || redirectUrl.startsWith('https://')) {
+    return Response.redirect(redirectUrl, 302)
+  }
+
+  return new Response('asset not found', { status: 404 })
+}

--- a/apps/synthesis/src/server/mcp.ts
+++ b/apps/synthesis/src/server/mcp.ts
@@ -64,39 +64,111 @@ const toolsListResult = {
     },
     {
       name: 'synthesis_submit_item',
-      description: 'Submit one condensed high-signal X.com post synthesis item.',
+      description:
+        'Submit one polished synthesis item. One item can represent multiple X posts; raw post text is stored only as source/audit material.',
       inputSchema: {
         type: 'object',
         properties: {
           runId: { type: 'string' },
-          originalUrl: { type: 'string' },
-          authorHandle: { type: 'string' },
-          authorName: { type: 'string' },
-          postedAt: { type: 'string' },
-          observedAt: { type: 'string' },
-          observedText: { type: 'string' },
-          mediaUrls: {
+          title: { type: 'string', description: 'Human title for the synthesized theme.' },
+          synthesis: { type: 'string', description: 'Concise human synthesis, not a raw post summary.' },
+          takeaways: { type: 'array', items: { type: 'string' }, minItems: 1, maxItems: 8 },
+          whyValuable: { type: 'string', description: 'Why this item belongs in the curated feed.' },
+          sourcePosts: {
             type: 'array',
-            items: { type: 'string' },
-            description:
-              'Observed media from the original post: direct image URLs, X photo URLs, or browser screenshots of actual visible post media. Do not submit generated placeholders.',
+            minItems: 1,
+            maxItems: 12,
+            items: {
+              type: 'object',
+              properties: {
+                originalUrl: { type: 'string' },
+                authorHandle: { type: 'string' },
+                authorName: { type: 'string' },
+                postedAt: { type: 'string' },
+                observedAt: { type: 'string' },
+                observedText: { type: 'string' },
+                mediaUrls: { type: 'array', items: { type: 'string' } },
+              },
+              required: ['originalUrl', 'observedText'],
+              additionalProperties: false,
+            },
+            description: 'Original X posts that support the synthesis. Can contain multiple posts for one theme.',
           },
-          summary: { type: 'string' },
-          whyValuable: { type: 'string' },
-          evidence: { type: 'array', items: { type: 'string' } },
+          factChecks: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                claim: { type: 'string' },
+                status: { type: 'string', enum: ['verified', 'unclear', 'refuted'] },
+                explanation: { type: 'string' },
+                sources: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      title: { type: 'string' },
+                      url: { type: 'string' },
+                      publisher: { type: 'string' },
+                      checkedAt: { type: 'string' },
+                    },
+                    required: ['url'],
+                    additionalProperties: false,
+                  },
+                },
+              },
+              required: ['claim', 'status', 'explanation'],
+              additionalProperties: false,
+            },
+          },
+          attachments: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                kind: { type: 'string', enum: ['source_image', 'source_screenshot', 'generated_infographic'] },
+                url: { type: 'string' },
+                data: { type: 'string' },
+                sourceUrl: { type: 'string' },
+                mimeType: { type: 'string' },
+                alt: { type: 'string' },
+                label: { type: 'string' },
+              },
+              required: ['kind'],
+              additionalProperties: false,
+            },
+          },
+          generatedAttachments: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                kind: { type: 'string', enum: ['generated_infographic'] },
+                url: { type: 'string' },
+                data: { type: 'string' },
+                sourceUrl: { type: 'string' },
+                mimeType: { type: 'string' },
+                alt: { type: 'string' },
+                label: { type: 'string' },
+              },
+              required: ['kind'],
+              additionalProperties: false,
+            },
+          },
+          dedupeKey: { type: 'string' },
           topicTags: { type: 'array', items: { type: 'string' } },
           score: { type: 'number', minimum: 0, maximum: 1 },
           confidence: { type: 'number', minimum: 0, maximum: 1 },
           engagementRecommendation: { type: 'string', enum: ['none', 'like', 'reply'] },
           replyText: { type: 'string' },
         },
-        required: ['originalUrl', 'observedText', 'summary', 'score'],
+        required: ['title', 'synthesis', 'takeaways', 'whyValuable', 'sourcePosts', 'dedupeKey', 'score', 'confidence'],
         additionalProperties: false,
       },
     },
     {
       name: 'synthesis_submit_batch',
-      description: 'Submit multiple condensed X.com synthesis items.',
+      description: 'Submit multiple polished synthesis theme items.',
       inputSchema: {
         type: 'object',
         properties: {

--- a/apps/synthesis/src/server/schema.ts
+++ b/apps/synthesis/src/server/schema.ts
@@ -22,22 +22,76 @@ export const StartRunInputSchema = z
   })
   .strict()
 
-export const SubmitItemInputSchema = z
+export const SourcePostInputSchema = z
   .object({
-    runId: z.string().trim().min(1).optional(),
     originalUrl: z.string().trim().min(1).max(1_000),
     authorHandle: z.string().trim().min(1).max(80).optional(),
     authorName: z.string().trim().min(1).max(120).optional(),
     postedAt: z.string().trim().min(1).max(80).optional(),
     observedAt: z.string().trim().min(1).max(80).optional(),
     observedText: z.string().trim().min(1).max(12_000),
-    mediaUrls: z.array(z.string().trim().min(1).max(1_000_000)).max(8).default([]),
-    summary: z.string().trim().min(1).max(2_000),
-    whyValuable: z.string().trim().max(1_200).optional(),
-    evidence: z.array(z.string().trim().min(1).max(500)).max(12).default([]),
+    mediaUrls: z.array(z.string().trim().min(1).max(1_000_000)).max(12).default([]),
+  })
+  .strict()
+
+export const FactCheckStatusSchema = z.enum(['verified', 'unclear', 'refuted'])
+
+export const FactCheckSourceSchema = z
+  .object({
+    title: z.string().trim().min(1).max(240).optional(),
+    url: z.string().trim().min(1).max(1_000),
+    publisher: z.string().trim().min(1).max(160).optional(),
+    checkedAt: z.string().trim().min(1).max(80).optional(),
+  })
+  .strict()
+
+export const FactCheckInputSchema = z
+  .object({
+    claim: z.string().trim().min(1).max(500),
+    status: FactCheckStatusSchema,
+    explanation: z.string().trim().min(1).max(800),
+    sources: z.array(FactCheckSourceSchema).max(8).default([]),
+  })
+  .strict()
+
+export const AttachmentKindSchema = z.enum(['source_image', 'source_screenshot', 'generated_infographic'])
+
+export const AttachmentInputSchema = z
+  .object({
+    kind: AttachmentKindSchema,
+    url: z.string().trim().min(1).max(1_000_000).optional(),
+    data: z.string().trim().min(1).max(12_000_000).optional(),
+    sourceUrl: z.string().trim().min(1).max(1_000).optional(),
+    mimeType: z.string().trim().min(1).max(120).optional(),
+    alt: z.string().trim().max(300).optional(),
+    label: z.string().trim().max(120).optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (!value.url && !value.data) {
+      context.addIssue({
+        code: 'custom',
+        message: 'attachment requires url or data',
+        path: ['url'],
+      })
+    }
+  })
+
+export const SubmitItemInputSchema = z
+  .object({
+    runId: z.string().trim().min(1).optional(),
+    title: z.string().trim().min(1).max(180),
+    synthesis: z.string().trim().min(1).max(3_000),
+    takeaways: z.array(z.string().trim().min(1).max(220)).min(1).max(8),
+    whyValuable: z.string().trim().min(1).max(1_200),
+    sourcePosts: z.array(SourcePostInputSchema).min(1).max(12),
+    factChecks: z.array(FactCheckInputSchema).max(12).default([]),
+    attachments: z.array(AttachmentInputSchema).max(16).default([]),
+    generatedAttachments: z.array(AttachmentInputSchema).max(8).default([]),
+    dedupeKey: z.string().trim().min(1).max(240),
     topicTags: z.array(TopicTagSchema).max(16).default([]),
     score: z.coerce.number().min(0).max(1),
-    confidence: z.coerce.number().min(0).max(1).default(0.7),
+    confidence: z.coerce.number().min(0).max(1),
     engagementRecommendation: EngagementRecommendationSchema.default('none'),
     replyText: z.string().trim().max(180).optional(),
   })
@@ -84,6 +138,12 @@ export const RecordEngagementResultInputSchema = z
   .strict()
 
 export type StartRunInput = z.infer<typeof StartRunInputSchema>
+export type SourcePostInput = z.infer<typeof SourcePostInputSchema>
+export type FactCheckInput = z.infer<typeof FactCheckInputSchema>
+export type FactCheckSource = z.infer<typeof FactCheckSourceSchema>
+export type FactCheckStatus = z.infer<typeof FactCheckStatusSchema>
+export type AttachmentInput = z.infer<typeof AttachmentInputSchema>
+export type AttachmentKind = z.infer<typeof AttachmentKindSchema>
 export type SubmitItemInput = z.infer<typeof SubmitItemInputSchema>
 export type SubmitBatchInput = z.infer<typeof SubmitBatchInputSchema>
 export type ListFeedInput = z.infer<typeof ListFeedInputSchema>
@@ -109,6 +169,10 @@ export type SynthesisRun = {
 export type SynthesisItem = {
   id: string
   runId: string
+  title: string
+  synthesis: string
+  takeaways: string[]
+  dedupeKey: string
   originalUrl: string
   xPostId: string | null
   authorHandle: string | null
@@ -120,6 +184,11 @@ export type SynthesisItem = {
   summary: string
   whyValuable: string | null
   evidence: string[]
+  sourcePosts: SynthesisSourcePost[]
+  sourceCount: number
+  factChecks: SynthesisFactCheck[]
+  attachments: SynthesisAttachment[]
+  generatedAttachments: SynthesisAttachment[]
   topicTags: string[]
   score: number
   confidence: number
@@ -128,6 +197,39 @@ export type SynthesisItem = {
   replyText: string | null
   createdAt: string
   updatedAt: string
+}
+
+export type SynthesisSourcePost = {
+  originalUrl: string
+  canonicalUrl: string
+  xPostId: string | null
+  postKey: string
+  authorHandle: string | null
+  authorName: string | null
+  postedAt: string | null
+  observedAt: string
+  observedText: string
+  mediaUrls: string[]
+}
+
+export type SynthesisFactCheck = {
+  claim: string
+  status: FactCheckStatus
+  explanation: string
+  sources: FactCheckSource[]
+}
+
+export type SynthesisAttachment = {
+  id: string
+  kind: AttachmentKind
+  sourceUrl: string | null
+  assetUrl: string
+  objectKey: string | null
+  mimeType: string | null
+  sizeBytes: number | null
+  alt: string | null
+  label: string | null
+  generated: boolean
 }
 
 export type EngagementAction = {

--- a/apps/synthesis/src/server/store.ts
+++ b/apps/synthesis/src/server/store.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { Pool, type PoolClient } from 'pg'
 
+import { materializeAttachments, normalizeAttachmentInputs } from './assets'
 import type {
   EngagementAction,
   EngagementActionKind,
@@ -13,12 +14,16 @@ import type {
   NextEngagementResult,
   RecordEngagementResultInput,
   RecordFeedbackInput,
+  SourcePostInput,
   StartRunInput,
   SubmitBatchInput,
   SubmitBatchResult,
   SubmitItemInput,
   SubmitItemResult,
+  SynthesisAttachment,
+  SynthesisFactCheck,
   SynthesisItem,
+  SynthesisSourcePost,
   SynthesisRun,
 } from './schema'
 
@@ -32,6 +37,7 @@ export type SynthesisStore = {
   submitBatch(input: SubmitBatchInput): Promise<SubmitBatchResult>
   listFeed(input: ListFeedInput): Promise<FeedResponse>
   getItem(id: string): Promise<SynthesisItem | null>
+  getAttachment(id: string): Promise<SynthesisAttachment | null>
   recordFeedback(input: RecordFeedbackInput): Promise<FeedbackEvent>
   nextEngagement(input: NextEngagementInput): Promise<NextEngagementResult>
   recordEngagementResult(input: RecordEngagementResultInput): Promise<EngagementAction>
@@ -135,6 +141,16 @@ const parseJsonArray = (value: unknown): string[] => {
   return []
 }
 
+const parseJsonValue = <T>(value: unknown, fallback: T): T => {
+  if (value == null) return fallback
+  if (typeof value !== 'string') return value as T
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return fallback
+  }
+}
+
 const getEngagementMode = (): EngagementMode => {
   const raw = process.env.SYNTHESIS_ENGAGEMENT_MODE?.trim().toLowerCase()
   return raw === 'off' ? 'off' : 'queue'
@@ -179,10 +195,105 @@ const planEngagement = async (
   return { status: 'queued', action: 'like', replyText: null, reason: 'like recommended by synthesis' }
 }
 
+type NormalizedSubmitItem = {
+  runId: string | undefined
+  title: string
+  synthesis: string
+  takeaways: string[]
+  dedupeKey: string
+  sourcePosts: SynthesisSourcePost[]
+  factChecks: SynthesisFactCheck[]
+  attachments: SynthesisAttachment[]
+  generatedAttachments: SynthesisAttachment[]
+  mediaUrls: string[]
+  summary: string
+  whyValuable: string | null
+  evidence: string[]
+  topicTags: string[]
+  score: number
+  confidence: number
+  engagementRecommendation: SubmitItemInput['engagementRecommendation']
+  replyText: string | undefined
+}
+
+const normalizeSourcePost = (source: SourcePostInput): SynthesisSourcePost => {
+  const canonical = canonicalizeXPostUrl(source.originalUrl)
+  return {
+    originalUrl: source.originalUrl,
+    canonicalUrl: canonical.canonicalUrl,
+    xPostId: canonical.xPostId,
+    postKey: canonical.postKey,
+    authorHandle: source.authorHandle ?? null,
+    authorName: source.authorName ?? null,
+    postedAt: toIso(source.postedAt),
+    observedAt: toIso(source.observedAt) ?? nowIso(),
+    observedText: source.observedText,
+    mediaUrls: source.mediaUrls,
+  }
+}
+
+const mergeSourcePosts = (left: SynthesisSourcePost[], right: SynthesisSourcePost[]) => {
+  const posts = new Map<string, SynthesisSourcePost>()
+  for (const source of [...left, ...right]) posts.set(source.postKey, source)
+  return [...posts.values()]
+}
+
+const attachmentMergeKey = (attachment: SynthesisAttachment) =>
+  `${attachment.kind}:${attachment.objectKey ?? attachment.sourceUrl ?? attachment.assetUrl}`
+
+const mergeAttachments = (left: SynthesisAttachment[], right: SynthesisAttachment[]) => {
+  const attachments = new Map<string, SynthesisAttachment>()
+  for (const attachment of [...left, ...right]) attachments.set(attachmentMergeKey(attachment), attachment)
+  return [...attachments.values()]
+}
+
+const digestKey = (value: string) => createHash('sha256').update(value).digest('base64url').slice(0, 24)
+
+const normalizeSubmitItem = async (input: SubmitItemInput): Promise<NormalizedSubmitItem> => {
+  const sourcePosts = input.sourcePosts.map(normalizeSourcePost)
+  const primarySource = sourcePosts[0]
+  if (!primarySource) throw new Error('submit item requires at least one source post')
+  const sourceKey = sourcePosts
+    .map((source) => source.postKey)
+    .sort()
+    .join('|')
+  const dedupeKey = input.dedupeKey || `theme:${digestKey(sourceKey)}`
+  const mediaUrls = [...new Set(sourcePosts.flatMap((source) => source.mediaUrls))]
+  const attachments = await materializeAttachments(
+    normalizeAttachmentInputs({
+      attachments: input.attachments,
+      generatedAttachments: input.generatedAttachments,
+      mediaUrls,
+    }),
+  )
+  const generatedAttachments = attachments.filter((attachment) => attachment.generated)
+
+  return {
+    runId: input.runId,
+    title: input.title,
+    synthesis: input.synthesis,
+    takeaways: input.takeaways,
+    dedupeKey,
+    sourcePosts,
+    factChecks: input.factChecks,
+    attachments,
+    generatedAttachments,
+    mediaUrls,
+    summary: input.synthesis,
+    whyValuable: input.whyValuable,
+    evidence: input.factChecks.map((factCheck) => `${factCheck.status}: ${factCheck.claim}`),
+    topicTags: input.topicTags,
+    score: input.score,
+    confidence: input.confidence,
+    engagementRecommendation: input.engagementRecommendation,
+    replyText: input.replyText,
+  }
+}
+
 class InMemorySynthesisStore implements SynthesisStore {
   private runs = new Map<string, SynthesisRun>()
   private posts = new Map<string, CanonicalXPost & { observedText: string }>()
-  private itemByPostKey = new Map<string, string>()
+  private itemByDedupeKey = new Map<string, string>()
   private items = new Map<string, SynthesisItem>()
   private engagements = new Map<string, EngagementAction>()
   private feedbackEvents = new Map<string, FeedbackEvent>()
@@ -203,38 +314,59 @@ class InMemorySynthesisStore implements SynthesisStore {
   }
 
   async submitItem(input: SubmitItemInput): Promise<SubmitItemResult> {
-    const canonical = canonicalizeXPostUrl(input.originalUrl)
-    this.posts.set(canonical.postKey, { ...canonical, observedText: input.observedText })
+    const normalized = await normalizeSubmitItem(input)
+    for (const source of normalized.sourcePosts) {
+      this.posts.set(source.postKey, {
+        canonicalUrl: source.canonicalUrl,
+        xPostId: source.xPostId,
+        postKey: source.postKey,
+        observedText: source.observedText,
+      })
+    }
 
-    const runId = input.runId ?? (await this.startRun({ source: 'x.com/home', interests: [] })).id
-    const existingId = this.itemByPostKey.get(canonical.postKey)
+    const primarySource = normalized.sourcePosts[0]
+    if (!primarySource) throw new Error('submit item requires at least one source post')
+    const runId = normalized.runId ?? (await this.startRun({ source: 'x.com/home', interests: [] })).id
+    const existingId = this.itemByDedupeKey.get(normalized.dedupeKey)
     const existing = existingId ? this.items.get(existingId) : null
     const timestamp = nowIso()
+    const sourcePosts = mergeSourcePosts(existing?.sourcePosts ?? [], normalized.sourcePosts)
+    const attachments = mergeAttachments(existing?.attachments ?? [], normalized.attachments)
+    const generatedAttachments = attachments.filter((attachment) => attachment.generated)
     const item: SynthesisItem = {
       id: existing?.id ?? randomUUID(),
       runId,
-      originalUrl: canonical.canonicalUrl,
-      xPostId: canonical.xPostId,
-      authorHandle: input.authorHandle ?? existing?.authorHandle ?? null,
-      authorName: input.authorName ?? existing?.authorName ?? null,
-      postedAt: toIso(input.postedAt) ?? existing?.postedAt ?? null,
-      observedAt: toIso(input.observedAt) ?? timestamp,
-      observedText: input.observedText,
-      mediaUrls: input.mediaUrls.length ? input.mediaUrls : (existing?.mediaUrls ?? []),
-      summary: input.summary,
-      whyValuable: input.whyValuable ?? null,
-      evidence: input.evidence,
-      topicTags: input.topicTags,
-      score: input.score,
-      confidence: input.confidence,
-      engagementRecommendation: input.engagementRecommendation,
+      title: normalized.title,
+      synthesis: normalized.synthesis,
+      takeaways: normalized.takeaways,
+      dedupeKey: normalized.dedupeKey,
+      originalUrl: primarySource.canonicalUrl,
+      xPostId: primarySource.xPostId,
+      authorHandle: primarySource.authorHandle ?? existing?.authorHandle ?? null,
+      authorName: primarySource.authorName ?? existing?.authorName ?? null,
+      postedAt: primarySource.postedAt ?? existing?.postedAt ?? null,
+      observedAt: primarySource.observedAt,
+      observedText: primarySource.observedText,
+      mediaUrls: normalized.mediaUrls.length ? normalized.mediaUrls : (existing?.mediaUrls ?? []),
+      summary: normalized.summary,
+      whyValuable: normalized.whyValuable,
+      evidence: normalized.evidence,
+      sourcePosts,
+      sourceCount: sourcePosts.length,
+      factChecks: normalized.factChecks,
+      attachments,
+      generatedAttachments,
+      topicTags: normalized.topicTags,
+      score: normalized.score,
+      confidence: normalized.confidence,
+      engagementRecommendation: normalized.engagementRecommendation,
       engagementStatus: existing?.engagementStatus ?? 'none',
-      replyText: input.replyText ? normalizeReplyText(input.replyText) : null,
+      replyText: normalized.replyText ? normalizeReplyText(normalized.replyText) : null,
       createdAt: existing?.createdAt ?? timestamp,
       updatedAt: timestamp,
     }
 
-    this.itemByPostKey.set(canonical.postKey, item.id)
+    this.itemByDedupeKey.set(normalized.dedupeKey, item.id)
     this.items.set(item.id, item)
 
     const engagementAction = await this.maybeQueueEngagement(item, input)
@@ -279,6 +411,14 @@ class InMemorySynthesisStore implements SynthesisStore {
 
   async getItem(id: string): Promise<SynthesisItem | null> {
     return this.items.get(id) ?? null
+  }
+
+  async getAttachment(id: string): Promise<SynthesisAttachment | null> {
+    for (const item of this.items.values()) {
+      const attachment = item.attachments.find((candidate) => candidate.id === id)
+      if (attachment) return attachment
+    }
+    return null
   }
 
   async recordFeedback(input: RecordFeedbackInput): Promise<FeedbackEvent> {
@@ -385,6 +525,11 @@ class InMemorySynthesisStore implements SynthesisStore {
 type ItemRow = {
   id: string
   run_id: string
+  x_post_key: string
+  title: string | null
+  synthesis: string | null
+  takeaways: unknown
+  dedupe_key: string | null
   canonical_url: string
   x_post_id: string | null
   author_handle: string | null
@@ -396,6 +541,10 @@ type ItemRow = {
   summary: string
   why_valuable: string | null
   evidence: unknown
+  source_posts: unknown
+  fact_checks: unknown
+  attachments: unknown
+  generated_attachments: unknown
   topic_tags: unknown
   score: number | string
   confidence: number | string
@@ -404,6 +553,19 @@ type ItemRow = {
   reply_text: string | null
   created_at: Date | string
   updated_at: Date | string
+}
+
+type AttachmentRow = {
+  id: string
+  kind: SynthesisAttachment['kind']
+  source_url: string | null
+  asset_url: string
+  object_key: string | null
+  mime_type: string | null
+  size_bytes: number | string | null
+  alt: string | null
+  label: string | null
+  generated: boolean
 }
 
 type EngagementRow = {
@@ -420,28 +582,72 @@ type EngagementRow = {
   performed_at: Date | string | null
 }
 
-const mapItemRow = (row: ItemRow): SynthesisItem => ({
-  id: row.id,
-  runId: row.run_id,
+const sourcePostFromRow = (row: ItemRow): SynthesisSourcePost => ({
   originalUrl: row.canonical_url,
+  canonicalUrl: row.canonical_url,
   xPostId: row.x_post_id,
+  postKey: row.x_post_key,
   authorHandle: row.author_handle,
   authorName: row.author_name,
   postedAt: toIso(row.posted_at),
   observedAt: toIso(row.last_observed_at) ?? nowIso(),
   observedText: row.observed_text,
   mediaUrls: parseJsonArray(row.media_urls),
-  summary: row.summary,
-  whyValuable: row.why_valuable,
-  evidence: parseJsonArray(row.evidence),
-  topicTags: parseJsonArray(row.topic_tags),
-  score: Number(row.score),
-  confidence: Number(row.confidence),
-  engagementRecommendation: row.engagement_recommendation,
-  engagementStatus: row.engagement_status,
-  replyText: row.reply_text,
-  createdAt: toIso(row.created_at) ?? nowIso(),
-  updatedAt: toIso(row.updated_at) ?? nowIso(),
+})
+
+const mapItemRow = (row: ItemRow): SynthesisItem => {
+  const sourcePosts = parseJsonValue<SynthesisSourcePost[]>(row.source_posts, [])
+  const resolvedSourcePosts = sourcePosts.length ? sourcePosts : [sourcePostFromRow(row)]
+  const attachments = parseJsonValue<SynthesisAttachment[]>(row.attachments, [])
+
+  return {
+    id: row.id,
+    runId: row.run_id,
+    title: row.title ?? row.summary,
+    synthesis: row.synthesis ?? row.summary,
+    takeaways: parseJsonValue<string[]>(row.takeaways, []),
+    dedupeKey: row.dedupe_key ?? row.x_post_key,
+    originalUrl: row.canonical_url,
+    xPostId: row.x_post_id,
+    authorHandle: row.author_handle,
+    authorName: row.author_name,
+    postedAt: toIso(row.posted_at),
+    observedAt: toIso(row.last_observed_at) ?? nowIso(),
+    observedText: row.observed_text,
+    mediaUrls: parseJsonArray(row.media_urls),
+    summary: row.summary,
+    whyValuable: row.why_valuable,
+    evidence: parseJsonArray(row.evidence),
+    sourcePosts: resolvedSourcePosts,
+    sourceCount: resolvedSourcePosts.length,
+    factChecks: parseJsonValue<SynthesisFactCheck[]>(row.fact_checks, []),
+    attachments,
+    generatedAttachments: parseJsonValue<SynthesisAttachment[]>(
+      row.generated_attachments,
+      attachments.filter((attachment) => attachment.generated),
+    ),
+    topicTags: parseJsonArray(row.topic_tags),
+    score: Number(row.score),
+    confidence: Number(row.confidence),
+    engagementRecommendation: row.engagement_recommendation,
+    engagementStatus: row.engagement_status,
+    replyText: row.reply_text,
+    createdAt: toIso(row.created_at) ?? nowIso(),
+    updatedAt: toIso(row.updated_at) ?? nowIso(),
+  }
+}
+
+const mapAttachmentRow = (row: AttachmentRow): SynthesisAttachment => ({
+  id: row.id,
+  kind: row.kind,
+  sourceUrl: row.source_url,
+  assetUrl: row.asset_url,
+  objectKey: row.object_key,
+  mimeType: row.mime_type,
+  sizeBytes: row.size_bytes == null ? null : Number(row.size_bytes),
+  alt: row.alt,
+  label: row.label,
+  generated: row.generated,
 })
 
 const mapEngagementRow = (row: EngagementRow): EngagementAction => ({
@@ -497,43 +703,69 @@ class PostgresSynthesisStore implements SynthesisStore {
 
   async submitItem(input: SubmitItemInput): Promise<SubmitItemResult> {
     await this.ensureSchema()
-    const runId = input.runId ?? (await this.startRun({ source: 'x.com/home', interests: [] })).id
+    const normalized = await normalizeSubmitItem(input)
+    const primarySource = normalized.sourcePosts[0]
+    if (!primarySource) throw new Error('submit item requires at least one source post')
+
+    const runId = normalized.runId ?? (await this.startRun({ source: 'x.com/home', interests: [] })).id
     const client = await this.pool.connect()
     try {
       await client.query('BEGIN')
-      const canonical = canonicalizeXPostUrl(input.originalUrl)
-      await client.query(
-        `INSERT INTO x_posts (
-          id, canonical_url, x_post_id, author_handle, author_name, posted_at, first_observed_at, last_observed_at,
-          observed_text
+      for (const source of normalized.sourcePosts) {
+        await client.query(
+          `INSERT INTO x_posts (
+            id, canonical_url, x_post_id, author_handle, author_name, posted_at, first_observed_at, last_observed_at,
+            observed_text
+          )
+          VALUES ($1, $2, $3, $4, $5, $6, COALESCE($7::timestamptz, now()), COALESCE($7::timestamptz, now()), $8)
+          ON CONFLICT (canonical_url) DO UPDATE SET
+            author_handle = COALESCE(EXCLUDED.author_handle, x_posts.author_handle),
+            author_name = COALESCE(EXCLUDED.author_name, x_posts.author_name),
+            posted_at = COALESCE(EXCLUDED.posted_at, x_posts.posted_at),
+            last_observed_at = EXCLUDED.last_observed_at,
+            observed_text = EXCLUDED.observed_text`,
+          [
+            source.postKey,
+            source.canonicalUrl,
+            source.xPostId,
+            source.authorHandle,
+            source.authorName,
+            toIso(source.postedAt),
+            toIso(source.observedAt),
+            source.observedText,
+          ],
         )
-        VALUES ($1, $2, $3, $4, $5, $6, COALESCE($7::timestamptz, now()), COALESCE($7::timestamptz, now()), $8)
-        ON CONFLICT (canonical_url) DO UPDATE SET
-          author_handle = COALESCE(EXCLUDED.author_handle, x_posts.author_handle),
-          author_name = COALESCE(EXCLUDED.author_name, x_posts.author_name),
-          posted_at = COALESCE(EXCLUDED.posted_at, x_posts.posted_at),
-          last_observed_at = EXCLUDED.last_observed_at,
-          observed_text = EXCLUDED.observed_text`,
-        [
-          canonical.postKey,
-          canonical.canonicalUrl,
-          canonical.xPostId,
-          input.authorHandle ?? null,
-          input.authorName ?? null,
-          toIso(input.postedAt),
-          toIso(input.observedAt),
-          input.observedText,
-        ],
+      }
+
+      const existingResult = await client.query<ItemRow>(
+        `SELECT ${this.itemSelectSql('i')} FROM synthesis_items i JOIN x_posts p ON p.id = i.x_post_key
+         WHERE i.dedupe_key = $1 LIMIT 1`,
+        [normalized.dedupeKey],
       )
+      const existing = existingResult.rows[0] ? mapItemRow(existingResult.rows[0]) : null
+      const sourcePosts = mergeSourcePosts(existing?.sourcePosts ?? [], normalized.sourcePosts)
+      const attachments = mergeAttachments(existing?.attachments ?? [], normalized.attachments)
+      const generatedAttachments = attachments.filter((attachment) => attachment.generated)
 
       const result = await client.query<{ id: string }>(
         `INSERT INTO synthesis_items (
-          id, run_id, x_post_key, media_urls, summary, why_valuable, evidence, topic_tags, score, confidence,
+          id, run_id, x_post_key, dedupe_key, title, synthesis, takeaways, source_posts, fact_checks, attachments,
+          generated_attachments, media_urls, summary, why_valuable, evidence, topic_tags, score, confidence,
           engagement_recommendation, engagement_status, reply_text
         )
-        VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7::jsonb, $8::jsonb, $9, $10, $11, 'none', $12)
-        ON CONFLICT (x_post_key) DO UPDATE SET
+        VALUES (
+          $1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9::jsonb, $10::jsonb, $11::jsonb, $12::jsonb,
+          $13, $14, $15::jsonb, $16::jsonb, $17, $18, $19, 'none', $20
+        )
+        ON CONFLICT (dedupe_key) DO UPDATE SET
           run_id = EXCLUDED.run_id,
+          title = EXCLUDED.title,
+          synthesis = EXCLUDED.synthesis,
+          takeaways = EXCLUDED.takeaways,
+          source_posts = EXCLUDED.source_posts,
+          fact_checks = EXCLUDED.fact_checks,
+          attachments = EXCLUDED.attachments,
+          generated_attachments = EXCLUDED.generated_attachments,
           media_urls = EXCLUDED.media_urls,
           summary = EXCLUDED.summary,
           why_valuable = EXCLUDED.why_valuable,
@@ -548,18 +780,60 @@ class PostgresSynthesisStore implements SynthesisStore {
         [
           randomUUID(),
           runId,
-          canonical.postKey,
-          JSON.stringify(input.mediaUrls),
-          input.summary,
-          input.whyValuable ?? null,
-          JSON.stringify(input.evidence),
-          JSON.stringify(input.topicTags),
-          input.score,
-          input.confidence,
-          input.engagementRecommendation,
-          input.replyText ? normalizeReplyText(input.replyText) : null,
+          primarySource.postKey,
+          normalized.dedupeKey,
+          normalized.title,
+          normalized.synthesis,
+          JSON.stringify(normalized.takeaways),
+          JSON.stringify(sourcePosts),
+          JSON.stringify(normalized.factChecks),
+          JSON.stringify(attachments),
+          JSON.stringify(generatedAttachments),
+          JSON.stringify(normalized.mediaUrls),
+          normalized.summary,
+          normalized.whyValuable,
+          JSON.stringify(normalized.evidence),
+          JSON.stringify(normalized.topicTags),
+          normalized.score,
+          normalized.confidence,
+          normalized.engagementRecommendation,
+          normalized.replyText ? normalizeReplyText(normalized.replyText) : null,
         ],
       )
+
+      await client.query(`DELETE FROM synthesis_item_sources WHERE item_id = $1`, [result.rows[0].id])
+      for (const [index, source] of sourcePosts.entries()) {
+        await client.query(
+          `INSERT INTO synthesis_item_sources (item_id, x_post_key, source_order)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (item_id, x_post_key) DO UPDATE SET source_order = EXCLUDED.source_order`,
+          [result.rows[0].id, source.postKey, index],
+        )
+      }
+
+      await client.query(`DELETE FROM synthesis_attachments WHERE item_id = $1`, [result.rows[0].id])
+      for (const attachment of attachments) {
+        await client.query(
+          `INSERT INTO synthesis_attachments (
+            id, item_id, kind, source_url, asset_url, object_key, mime_type, size_bytes, alt, label, generated
+          )
+          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+          [
+            attachment.id,
+            result.rows[0].id,
+            attachment.kind,
+            attachment.sourceUrl,
+            attachment.assetUrl,
+            attachment.objectKey,
+            attachment.mimeType,
+            attachment.sizeBytes,
+            attachment.alt,
+            attachment.label,
+            attachment.generated,
+          ],
+        )
+      }
+
       const itemResult = await client.query<ItemRow>(
         `SELECT ${this.itemSelectSql('i')} FROM synthesis_items i JOIN x_posts p ON p.id = i.x_post_key WHERE i.id = $1`,
         [result.rows[0].id],
@@ -643,6 +917,12 @@ class PostgresSynthesisStore implements SynthesisStore {
       [id],
     )
     return result.rows[0] ? mapItemRow(result.rows[0]) : null
+  }
+
+  async getAttachment(id: string): Promise<SynthesisAttachment | null> {
+    await this.ensureSchema()
+    const result = await this.pool.query<AttachmentRow>(`SELECT * FROM synthesis_attachments WHERE id = $1`, [id])
+    return result.rows[0] ? mapAttachmentRow(result.rows[0]) : null
   }
 
   async recordFeedback(input: RecordFeedbackInput): Promise<FeedbackEvent> {
@@ -756,9 +1036,11 @@ class PostgresSynthesisStore implements SynthesisStore {
   }
 
   private itemSelectSql(alias: string) {
-    return `${alias}.id, ${alias}.run_id, p.canonical_url, p.x_post_id, p.author_handle, p.author_name, p.posted_at,
-      p.last_observed_at, p.observed_text, ${alias}.media_urls, ${alias}.summary, ${alias}.why_valuable, ${alias}.evidence,
-      ${alias}.topic_tags, ${alias}.score, ${alias}.confidence, ${alias}.engagement_recommendation,
+    return `${alias}.id, ${alias}.run_id, ${alias}.x_post_key, ${alias}.dedupe_key, ${alias}.title, ${alias}.synthesis,
+      ${alias}.takeaways, ${alias}.source_posts, ${alias}.fact_checks, ${alias}.attachments,
+      ${alias}.generated_attachments, p.canonical_url, p.x_post_id, p.author_handle, p.author_name, p.posted_at,
+      p.last_observed_at, p.observed_text, ${alias}.media_urls, ${alias}.summary, ${alias}.why_valuable,
+      ${alias}.evidence, ${alias}.topic_tags, ${alias}.score, ${alias}.confidence, ${alias}.engagement_recommendation,
       ${alias}.engagement_status, ${alias}.reply_text, ${alias}.created_at, ${alias}.updated_at`
   }
 
@@ -795,6 +1077,14 @@ class PostgresSynthesisStore implements SynthesisStore {
         id text PRIMARY KEY,
         run_id text NOT NULL REFERENCES synthesis_runs(id) ON DELETE CASCADE,
         x_post_key text NOT NULL UNIQUE REFERENCES x_posts(id) ON DELETE CASCADE,
+        dedupe_key text NOT NULL UNIQUE,
+        title text NOT NULL,
+        synthesis text NOT NULL,
+        takeaways jsonb NOT NULL DEFAULT '[]'::jsonb,
+        source_posts jsonb NOT NULL DEFAULT '[]'::jsonb,
+        fact_checks jsonb NOT NULL DEFAULT '[]'::jsonb,
+        attachments jsonb NOT NULL DEFAULT '[]'::jsonb,
+        generated_attachments jsonb NOT NULL DEFAULT '[]'::jsonb,
         media_urls jsonb NOT NULL DEFAULT '[]'::jsonb,
         summary text NOT NULL,
         why_valuable text,
@@ -812,6 +1102,46 @@ class PostgresSynthesisStore implements SynthesisStore {
       );
 
       ALTER TABLE synthesis_items ADD COLUMN IF NOT EXISTS media_urls jsonb NOT NULL DEFAULT '[]'::jsonb;
+      ALTER TABLE synthesis_items ADD COLUMN IF NOT EXISTS dedupe_key text;
+      ALTER TABLE synthesis_items ADD COLUMN IF NOT EXISTS title text;
+      ALTER TABLE synthesis_items ADD COLUMN IF NOT EXISTS synthesis text;
+      ALTER TABLE synthesis_items ADD COLUMN IF NOT EXISTS takeaways jsonb NOT NULL DEFAULT '[]'::jsonb;
+      ALTER TABLE synthesis_items ADD COLUMN IF NOT EXISTS source_posts jsonb NOT NULL DEFAULT '[]'::jsonb;
+      ALTER TABLE synthesis_items ADD COLUMN IF NOT EXISTS fact_checks jsonb NOT NULL DEFAULT '[]'::jsonb;
+      ALTER TABLE synthesis_items ADD COLUMN IF NOT EXISTS attachments jsonb NOT NULL DEFAULT '[]'::jsonb;
+      ALTER TABLE synthesis_items ADD COLUMN IF NOT EXISTS generated_attachments jsonb NOT NULL DEFAULT '[]'::jsonb;
+      UPDATE synthesis_items
+      SET
+        dedupe_key = COALESCE(dedupe_key, x_post_key),
+        title = COALESCE(title, summary),
+        synthesis = COALESCE(synthesis, summary)
+      WHERE dedupe_key IS NULL OR title IS NULL OR synthesis IS NULL;
+      ALTER TABLE synthesis_items ALTER COLUMN dedupe_key SET NOT NULL;
+      ALTER TABLE synthesis_items ALTER COLUMN title SET NOT NULL;
+      ALTER TABLE synthesis_items ALTER COLUMN synthesis SET NOT NULL;
+
+      CREATE TABLE IF NOT EXISTS synthesis_item_sources (
+        item_id text NOT NULL REFERENCES synthesis_items(id) ON DELETE CASCADE,
+        x_post_key text NOT NULL REFERENCES x_posts(id) ON DELETE CASCADE,
+        source_order integer NOT NULL DEFAULT 0,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        PRIMARY KEY (item_id, x_post_key)
+      );
+
+      CREATE TABLE IF NOT EXISTS synthesis_attachments (
+        id text PRIMARY KEY,
+        item_id text NOT NULL REFERENCES synthesis_items(id) ON DELETE CASCADE,
+        kind text NOT NULL CHECK (kind IN ('source_image', 'source_screenshot', 'generated_infographic')),
+        source_url text,
+        asset_url text NOT NULL,
+        object_key text,
+        mime_type text,
+        size_bytes bigint,
+        alt text,
+        label text,
+        generated boolean NOT NULL DEFAULT false,
+        created_at timestamptz NOT NULL DEFAULT now()
+      );
 
       CREATE TABLE IF NOT EXISTS engagement_actions (
         id text PRIMARY KEY,
@@ -851,7 +1181,10 @@ class PostgresSynthesisStore implements SynthesisStore {
       );
 
       CREATE INDEX IF NOT EXISTS synthesis_items_created_at_idx ON synthesis_items (created_at DESC);
+      CREATE UNIQUE INDEX IF NOT EXISTS synthesis_items_dedupe_key_idx ON synthesis_items (dedupe_key);
       CREATE INDEX IF NOT EXISTS synthesis_items_score_idx ON synthesis_items (score DESC);
+      CREATE INDEX IF NOT EXISTS synthesis_item_sources_x_post_idx ON synthesis_item_sources (x_post_key);
+      CREATE INDEX IF NOT EXISTS synthesis_attachments_item_idx ON synthesis_attachments (item_id);
       CREATE INDEX IF NOT EXISTS engagement_actions_status_created_idx ON engagement_actions (status, created_at);
     `)
   }

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -9,5 +9,5 @@ resources:
   - networkpolicy.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: 0.574.5
+    newTag: xcurate-strict-20260526001830
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Requires strict synthesized-theme submissions for Synthesis MCP/API items.
- Stores one curated item per theme with source mappings, fact checks, app-owned attachments, and generated infographic attachments.
- Removes raw-detail UI duplication and renders synthesized detail, source chips, fact checks, score/confidence, and attachments.
- Pins the Synthesis GitOps image tag to the built strict-contract image `xcurate-strict-20260526001830`.

## Related Issues

None

## Testing

- `bun run --filter synthesis test`
- `bun run --filter synthesis lint`
- `bun run build:synthesis`
- `python /Users/gregkonush/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/gregkonush/.codex/skills/xcurate`
- Local MCP smoke against `http://localhost:4637/mcp`: strict synthesized-theme submit succeeded, old top-level `originalUrl`/`observedText`/`summary` submit failed with `Invalid synthesis_submit_item input`.
- Built and pushed `registry.ide-newton.ts.net/lab/synthesis:xcurate-strict-20260526001830`; verified registry digest `sha256:1ff6b0d075e62c7d7f91df820e63bf0a59f0468a25d6441ab37546cc64c0f862`.

## Screenshots (if applicable)

N/A - no visual screenshot required; UI behavior is covered by local feed/detail smoke and tests.

## Breaking Changes

Synthesis submit callers must now send the strict synthesized-theme contract: `title`, `synthesis`, `takeaways`, `whyValuable`, `sourcePosts`, `dedupeKey`, `score`, and `confidence`. Top-level `originalUrl`, `observedText`, `summary`, `evidence`, and `mediaUrls` are rejected.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
