### PR TITLE
fix(torghut): gate runtime proof risk quality

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -27,6 +27,9 @@ DOC29_LIVE_SCALE_GATE = "live_scale_observed"
 DEFAULT_MIN_RUNTIME_LEDGER_NET_PNL = Decimal("500")
 DEFAULT_MIN_RUNTIME_LEDGER_DAILY_NET_PNL = Decimal("500")
 DEFAULT_MIN_RUNTIME_LEDGER_TRADING_DAYS = 1
+DEFAULT_MAX_RUNTIME_LEDGER_DRAWDOWN_PCT_EQUITY = Decimal("0.08")
+DEFAULT_MAX_RUNTIME_LEDGER_BEST_DAY_SHARE = Decimal("0.25")
+DEFAULT_MAX_RUNTIME_LEDGER_SYMBOL_CONCENTRATION_SHARE = Decimal("0.50")
 STATUS_ENDPOINT = "/trading/status"
 PAPER_ROUTE_EVIDENCE_ENDPOINT = "/trading/paper-route-evidence"
 COMPLETION_DOC29_ENDPOINT = "/trading/completion/doc29"
@@ -108,6 +111,18 @@ def _decimal_text(value: Decimal | None) -> str | None:
         return None
     text = format(value, "f")
     return text.rstrip("0").rstrip(".") if "." in text else text
+
+
+def _first_decimal(
+    payload: Mapping[str, Any],
+    keys: Sequence[str],
+) -> tuple[Decimal | None, str]:
+    for key in keys:
+        if key in payload:
+            value = _decimal(payload.get(key))
+            if value is not None:
+                return value, key
+    return None, ""
 
 
 def _mapping(value: object) -> Mapping[str, Any]:
@@ -746,6 +761,18 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
             _extend_unique(
                 actions, ["collect_or_improve_post_cost_runtime_profit_evidence"]
             )
+        elif blocker in {
+            "runtime_ledger_drawdown_pct_equity_missing",
+            "runtime_ledger_drawdown_pct_equity_above_limit",
+            "runtime_ledger_best_day_share_missing",
+            "runtime_ledger_best_day_share_above_limit",
+            "runtime_ledger_symbol_concentration_share_missing",
+            "runtime_ledger_symbol_concentration_share_above_limit",
+        }:
+            _extend_unique(
+                actions,
+                ["improve_runtime_ledger_drawdown_concentration_or_position_sizing"],
+            )
         elif blocker.startswith("runtime_ledger_") or blocker in {
             "filled_notional_missing",
             "closed_round_trip_missing",
@@ -796,6 +823,15 @@ def build_runtime_ledger_proof_packet(
     min_runtime_ledger_net_pnl: Decimal = DEFAULT_MIN_RUNTIME_LEDGER_NET_PNL,
     min_runtime_ledger_daily_net_pnl: Decimal = DEFAULT_MIN_RUNTIME_LEDGER_DAILY_NET_PNL,
     min_runtime_ledger_trading_days: int = DEFAULT_MIN_RUNTIME_LEDGER_TRADING_DAYS,
+    max_runtime_ledger_drawdown_pct_equity: Decimal = (
+        DEFAULT_MAX_RUNTIME_LEDGER_DRAWDOWN_PCT_EQUITY
+    ),
+    max_runtime_ledger_best_day_share: Decimal = (
+        DEFAULT_MAX_RUNTIME_LEDGER_BEST_DAY_SHARE
+    ),
+    max_runtime_ledger_symbol_concentration_share: Decimal = (
+        DEFAULT_MAX_RUNTIME_LEDGER_SYMBOL_CONCENTRATION_SHARE
+    ),
     generated_at: str | None = None,
 ) -> dict[str, Any]:
     checks: dict[str, dict[str, Any]] = {}
@@ -1068,6 +1104,31 @@ def build_runtime_ledger_proof_packet(
         if net_pnl is not None and trading_days > 0
         else None
     )
+    drawdown_pct, drawdown_source = _first_decimal(
+        runtime_summary,
+        (
+            "runtime_ledger_max_drawdown_pct_equity",
+            "runtime_ledger_drawdown_pct_equity",
+            "max_drawdown_pct_equity",
+            "drawdown_pct_equity",
+        ),
+    )
+    best_day_share, best_day_share_source = _first_decimal(
+        runtime_summary,
+        (
+            "runtime_ledger_best_day_share",
+            "runtime_ledger_max_single_day_contribution_share",
+            "best_day_share",
+            "max_single_day_contribution_share",
+        ),
+    )
+    symbol_concentration_share, symbol_concentration_source = _first_decimal(
+        runtime_summary,
+        (
+            "runtime_ledger_symbol_concentration_share",
+            "symbol_concentration_share",
+        ),
+    )
     _check(
         checks,
         "runtime_ledger_db_refs",
@@ -1143,6 +1204,57 @@ def build_runtime_ledger_proof_packet(
         status=None if runtime_import_due else deferred_until_runtime_import_due,
     )
     _extend_unique(blockers, pnl_blockers)
+    risk_blockers: list[str] = []
+    if runtime_import_due and drawdown_pct is None:
+        risk_blockers.append("runtime_ledger_drawdown_pct_equity_missing")
+    elif (
+        runtime_import_due
+        and drawdown_pct is not None
+        and drawdown_pct > max_runtime_ledger_drawdown_pct_equity
+    ):
+        risk_blockers.append("runtime_ledger_drawdown_pct_equity_above_limit")
+    if runtime_import_due and best_day_share is None:
+        risk_blockers.append("runtime_ledger_best_day_share_missing")
+    elif (
+        runtime_import_due
+        and best_day_share is not None
+        and best_day_share > max_runtime_ledger_best_day_share
+    ):
+        risk_blockers.append("runtime_ledger_best_day_share_above_limit")
+    if runtime_import_due and symbol_concentration_share is None:
+        risk_blockers.append("runtime_ledger_symbol_concentration_share_missing")
+    elif (
+        runtime_import_due
+        and symbol_concentration_share is not None
+        and symbol_concentration_share > max_runtime_ledger_symbol_concentration_share
+    ):
+        risk_blockers.append("runtime_ledger_symbol_concentration_share_above_limit")
+    _check(
+        checks,
+        "runtime_ledger_risk_quality",
+        passed=not risk_blockers,
+        observed={
+            "runtime_import_due": runtime_import_due,
+            "drawdown_pct_equity": _decimal_text(drawdown_pct),
+            "drawdown_pct_equity_source": drawdown_source,
+            "best_day_share": _decimal_text(best_day_share),
+            "best_day_share_source": best_day_share_source,
+            "symbol_concentration_share": _decimal_text(symbol_concentration_share),
+            "symbol_concentration_share_source": symbol_concentration_source,
+        },
+        expected={
+            "max_drawdown_pct_equity": _decimal_text(
+                max_runtime_ledger_drawdown_pct_equity
+            ),
+            "max_best_day_share": _decimal_text(max_runtime_ledger_best_day_share),
+            "max_symbol_concentration_share": _decimal_text(
+                max_runtime_ledger_symbol_concentration_share
+            ),
+        },
+        blockers=risk_blockers,
+        status=None if runtime_import_due else deferred_until_runtime_import_due,
+    )
+    _extend_unique(blockers, risk_blockers)
 
     failed_checks = [key for key, value in checks.items() if not value["passed"]]
     waiting_blockers = {
@@ -1180,6 +1292,15 @@ def build_runtime_ledger_proof_packet(
                 min_runtime_ledger_daily_net_pnl
             ),
             "min_runtime_ledger_trading_days": min_runtime_ledger_trading_days,
+            "max_runtime_ledger_drawdown_pct_equity": _decimal_text(
+                max_runtime_ledger_drawdown_pct_equity
+            ),
+            "max_runtime_ledger_best_day_share": _decimal_text(
+                max_runtime_ledger_best_day_share
+            ),
+            "max_runtime_ledger_symbol_concentration_share": _decimal_text(
+                max_runtime_ledger_symbol_concentration_share
+            ),
         },
         "candidate": _first_identity(
             paper_targets=paper_targets,
@@ -1294,6 +1415,21 @@ def _parser() -> argparse.ArgumentParser:
         default=DEFAULT_MIN_RUNTIME_LEDGER_TRADING_DAYS,
         help="Minimum observed runtime-ledger trading days.",
     )
+    parser.add_argument(
+        "--max-runtime-ledger-drawdown-pct-equity",
+        default=str(DEFAULT_MAX_RUNTIME_LEDGER_DRAWDOWN_PCT_EQUITY),
+        help="Maximum observed runtime-ledger drawdown as a fraction of equity.",
+    )
+    parser.add_argument(
+        "--max-runtime-ledger-best-day-share",
+        default=str(DEFAULT_MAX_RUNTIME_LEDGER_BEST_DAY_SHARE),
+        help="Maximum share of post-cost runtime-ledger PnL attributable to one trading day.",
+    )
+    parser.add_argument(
+        "--max-runtime-ledger-symbol-concentration-share",
+        default=str(DEFAULT_MAX_RUNTIME_LEDGER_SYMBOL_CONCENTRATION_SHARE),
+        help="Maximum share of post-cost runtime-ledger PnL attributable to one symbol.",
+    )
     parser.add_argument("--generated-at", default=None)
     parser.add_argument("--timeout-seconds", type=float, default=10.0)
     parser.add_argument("--output-file", type=Path, default=None)
@@ -1360,6 +1496,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise SystemExit(
             f"--min-runtime-ledger-daily-net-pnl must be decimal: {args.min_runtime_ledger_daily_net_pnl!r}"
         )
+    max_drawdown_pct_equity = _decimal(args.max_runtime_ledger_drawdown_pct_equity)
+    if max_drawdown_pct_equity is None:
+        raise SystemExit(
+            "--max-runtime-ledger-drawdown-pct-equity must be decimal: "
+            f"{args.max_runtime_ledger_drawdown_pct_equity!r}"
+        )
+    max_best_day_share = _decimal(args.max_runtime_ledger_best_day_share)
+    if max_best_day_share is None:
+        raise SystemExit(
+            "--max-runtime-ledger-best-day-share must be decimal: "
+            f"{args.max_runtime_ledger_best_day_share!r}"
+        )
+    max_symbol_concentration_share = _decimal(
+        args.max_runtime_ledger_symbol_concentration_share
+    )
+    if max_symbol_concentration_share is None:
+        raise SystemExit(
+            "--max-runtime-ledger-symbol-concentration-share must be decimal: "
+            f"{args.max_runtime_ledger_symbol_concentration_share!r}"
+        )
     status = _load_optional_json_object(
         path=args.status_file,
         url=args.status_url,
@@ -1391,6 +1547,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         min_runtime_ledger_trading_days=max(
             0, int(args.min_runtime_ledger_trading_days)
         ),
+        max_runtime_ledger_drawdown_pct_equity=max_drawdown_pct_equity,
+        max_runtime_ledger_best_day_share=max_best_day_share,
+        max_runtime_ledger_symbol_concentration_share=max_symbol_concentration_share,
         generated_at=args.generated_at,
     )
     if service_default_urls:

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -184,9 +184,29 @@ def _completion(
     net_pnl: str = "650",
     trading_days: int = 1,
     expectancy_bps: str = "13",
+    drawdown_pct: str | None = "0.04",
+    best_day_share: str | None = "0.20",
+    symbol_concentration_share: str | None = "0.35",
     ledger_refs: list[str] | None = None,
     unbacked_refs: list[str] | None = None,
 ) -> dict[str, object]:
+    runtime_ledger_summary: dict[str, object] = {
+        "runtime_ledger_bucket_count": 1,
+        "runtime_ledger_fill_count": 4,
+        "runtime_ledger_closed_trade_count": 2,
+        "runtime_ledger_filled_notional": "50000",
+        "runtime_ledger_net_strategy_pnl_after_costs": net_pnl,
+        "runtime_ledger_post_cost_expectancy_bps": expectancy_bps,
+        "runtime_ledger_observed_trading_day_count": trading_days,
+    }
+    if drawdown_pct is not None:
+        runtime_ledger_summary["runtime_ledger_max_drawdown_pct_equity"] = drawdown_pct
+    if best_day_share is not None:
+        runtime_ledger_summary["runtime_ledger_best_day_share"] = best_day_share
+    if symbol_concentration_share is not None:
+        runtime_ledger_summary["runtime_ledger_symbol_concentration_share"] = (
+            symbol_concentration_share
+        )
     return {
         "doc_id": "doc29",
         "summary": {"all_satisfied": status == "satisfied"},
@@ -195,15 +215,7 @@ def _completion(
                 "gate_id": packet.DOC29_LIVE_SCALE_GATE,
                 "status": status,
                 "candidate_id": "c88421d619759b2cfaa6f4d0",
-                "runtime_ledger_summary": {
-                    "runtime_ledger_bucket_count": 1,
-                    "runtime_ledger_fill_count": 4,
-                    "runtime_ledger_closed_trade_count": 2,
-                    "runtime_ledger_filled_notional": "50000",
-                    "runtime_ledger_net_strategy_pnl_after_costs": net_pnl,
-                    "runtime_ledger_post_cost_expectancy_bps": expectancy_bps,
-                    "runtime_ledger_observed_trading_day_count": trading_days,
-                },
+                "runtime_ledger_summary": runtime_ledger_summary,
                 "db_row_refs": {
                     "strategy_runtime_ledger_buckets": ledger_refs
                     if ledger_refs is not None
@@ -330,6 +342,16 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 "daily_net_pnl_after_costs"
             ],
             "650",
+        )
+        self.assertEqual(
+            result["checks"]["runtime_ledger_risk_quality"]["observed"][
+                "drawdown_pct_equity"
+            ],
+            "0.04",
+        )
+        self.assertEqual(
+            result["target"]["max_runtime_ledger_drawdown_pct_equity"],
+            "0.08",
         )
 
     def test_cli_uploads_durable_proof_packet_artifact_with_runtime_run_id(
@@ -729,6 +751,86 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertIn(
             "runtime_ledger_daily_net_pnl_below_target",
             result["promotion_authority"]["blocking_reasons"],
+        )
+
+    def test_packet_blocks_missing_runtime_ledger_risk_quality_when_import_due(
+        self,
+    ) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(
+                drawdown_pct=None,
+                best_day_share=None,
+                symbol_concentration_share=None,
+            ),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn(
+            "runtime_ledger_risk_quality",
+            result["promotion_authority"]["failed_checks"],
+        )
+        self.assertIn(
+            "runtime_ledger_drawdown_pct_equity_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "runtime_ledger_best_day_share_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "runtime_ledger_symbol_concentration_share_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "improve_runtime_ledger_drawdown_concentration_or_position_sizing",
+            result["required_actions"],
+        )
+        self.assertEqual(
+            result["checks"]["runtime_ledger_risk_quality"]["observed"][
+                "drawdown_pct_equity"
+            ],
+            None,
+        )
+
+    def test_packet_blocks_excessive_runtime_ledger_risk_quality(self) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(
+                drawdown_pct="0.13",
+                best_day_share="0.40",
+                symbol_concentration_share="0.75",
+            ),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["verdict"], "blocked")
+        self.assertIn(
+            "runtime_ledger_drawdown_pct_equity_above_limit",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "runtime_ledger_best_day_share_above_limit",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "runtime_ledger_symbol_concentration_share_above_limit",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertEqual(
+            result["checks"]["runtime_ledger_risk_quality"]["expected"],
+            {
+                "max_drawdown_pct_equity": "0.08",
+                "max_best_day_share": "0.25",
+                "max_symbol_concentration_share": "0.5",
+            },
         )
 
     def test_packet_blocks_incomplete_identity_unbacked_refs_and_lifecycle_gaps(


### PR DESCRIPTION
## Summary

- Added runtime-ledger risk-quality authority gates to the live-paper proof packet.
- The packet now fails closed when import-due runtime ledger evidence is missing drawdown, best-day share, or symbol concentration metrics.
- The packet blocks excessive drawdown, best-day concentration, and symbol concentration using explicit default thresholds with CLI overrides.
- Added focused regression tests for complete, missing, and excessive risk-quality proof cases.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv run --frozen ruff format scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Proof packets can remain blocked until runtime-ledger completion evidence includes the new risk-quality metrics or callers explicitly provide stricter/looser CLI thresholds.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
