### PR TITLE
chore(synthesis): promote strict xcurate image

### DIFF
--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -9,5 +9,5 @@ resources:
   - networkpolicy.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: 0.575.0
+    newTag: xcurate-strict-20260526001830
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promotes the Synthesis deployment back to the published `xcurate-strict-20260526001830` image.
- Restores the live MCP/API strict synthesized-theme submission contract after the latest release image regressed it.
- Keeps the change limited to GitOps image selection; no application code changes are included.

## Related Issues

None

## Testing

- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/synthesis:xcurate-strict-20260526001830`
- `kubectl kustomize argocd/applications/synthesis | rg -n "image:|kind: Deployment|name: synthesis"`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
