### PR TITLE
feat(agents): sort AgentRun list via query state

### DIFF
--- a/services/agents/src/app-routes/primitives.$kind.tsx
+++ b/services/agents/src/app-routes/primitives.$kind.tsx
@@ -1,7 +1,24 @@
 import { Link, Outlet, createFileRoute, useLocation } from '@tanstack/react-router'
-import { useEffect, useState } from 'react'
+import { ArrowDownIcon, ArrowUpDownIcon, ArrowUpIcon } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { fetchPrimitiveResources, type PrimitiveResourceSummary } from '../control-plane/api-client'
+import {
+  agentRunAgentName,
+  agentRunSortKeys,
+  defaultAgentRunSort,
+  formatAgentRunImplementationSource,
+  nextAgentRunSortSearch,
+  parseAgentRunListSearch,
+  resourceCreationTimestamp,
+  resourceName,
+  resourceNamespace,
+  resourcePhase,
+  sortAgentRunResources,
+  type AgentRunListSearchState,
+  type AgentRunSortDirection,
+  type AgentRunSortKey,
+} from '../control-plane/agentrun-list-sort'
 import { findPrimitiveDefinition } from '../control-plane/registry'
 import {
   filterAgentRunsByStatuses,
@@ -10,16 +27,43 @@ import {
 import { ControlPlanePage } from '../components/control-plane/control-plane-page'
 import { Alert, AlertDescription } from '../components/ui/alert'
 import { Badge } from '../components/ui/badge'
+import { Button } from '../components/ui/button'
 import { Skeleton } from '../components/ui/skeleton'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table'
 
 export const Route = createFileRoute('/primitives/$kind')({
+  validateSearch: parseAgentRunListSearch,
   component: PrimitiveKindRoute,
 })
 
 const metadataValue = (resource: PrimitiveResourceSummary, key: string) => {
   const value = resource.metadata[key]
   return typeof value === 'string' ? value : ''
+}
+
+const sortableAgentRunColumnLabels: Record<AgentRunSortKey, string> = {
+  name: 'Name',
+  phase: 'Status',
+  agent: 'Agent',
+  source: 'Implementation',
+  namespace: 'Namespace',
+  createdAt: 'Age',
+}
+
+const ariaSortValue = (search: AgentRunListSearchState, sort: AgentRunSortKey): 'ascending' | 'descending' | 'none' =>
+  (search.sort ?? defaultAgentRunSort.sort) === sort
+    ? (search.direction ?? defaultAgentRunSort.direction) === 'asc'
+      ? 'ascending'
+      : 'descending'
+    : 'none'
+
+const SortIcon = ({ active, direction }: { active: boolean; direction: AgentRunSortDirection }) => {
+  if (!active) return <ArrowUpDownIcon className="size-3.5 opacity-40" aria-hidden="true" />
+  return direction === 'asc' ? (
+    <ArrowUpIcon className="size-3.5" aria-hidden="true" />
+  ) : (
+    <ArrowDownIcon className="size-3.5" aria-hidden="true" />
+  )
 }
 
 function PrimitiveKindRoute() {
@@ -32,22 +76,37 @@ function PrimitiveKindRoute() {
 }
 
 function PrimitiveListPage() {
-  const location = useLocation()
   const { kind } = Route.useParams()
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
   const primitive = findPrimitiveDefinition(kind)
   const [items, setItems] = useState<PrimitiveResourceSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const selectedStatuses =
-    primitive?.kind === 'AgentRun' ? parseAgentRunStatusSearch((location.search as Record<string, unknown>).status) : []
-  const visibleItems = primitive?.kind === 'AgentRun' ? filterAgentRunsByStatuses(items, selectedStatuses) : items
+  const isAgentRunList = primitive?.kind === 'AgentRun'
+  const selectedStatuses = useMemo(
+    () => (isAgentRunList ? parseAgentRunStatusSearch(search.status) : []),
+    [isAgentRunList, search.status],
+  )
+  const visibleItems = useMemo(
+    () => (isAgentRunList ? filterAgentRunsByStatuses(items, selectedStatuses) : items),
+    [isAgentRunList, items, selectedStatuses],
+  )
 
   const load = async () => {
     if (!primitive) return
     setLoading(true)
     setError(null)
     try {
-      const response = await fetchPrimitiveResources(primitive.display.pathSegment)
+      const response = await fetchPrimitiveResources(primitive.display.pathSegment, {
+        namespace: search.namespace,
+        phase: search.phase,
+        status: search.status,
+        runtime: search.runtime,
+        labelSelector: search.labelSelector,
+        label_selector: search.label_selector,
+        limit: search.limit,
+      })
       setItems(response.items)
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : String(cause))
@@ -58,7 +117,36 @@ function PrimitiveListPage() {
 
   useEffect(() => {
     void load()
-  }, [primitive?.kind])
+  }, [
+    primitive?.kind,
+    search.labelSelector,
+    search.label_selector,
+    search.limit,
+    search.namespace,
+    search.phase,
+    search.runtime,
+    search.status,
+  ])
+
+  const sortedItems = useMemo(
+    () =>
+      isAgentRunList
+        ? sortAgentRunResources(
+            visibleItems,
+            search.sort ?? defaultAgentRunSort.sort,
+            search.direction ?? defaultAgentRunSort.direction,
+          )
+        : visibleItems,
+    [isAgentRunList, search.direction, search.sort, visibleItems],
+  )
+
+  const updateSort = async (sort: AgentRunSortKey) => {
+    await navigate({
+      to: '/primitives/$kind',
+      params: { kind: primitive?.display.pathSegment ?? kind },
+      search: nextAgentRunSortSearch(search, sort),
+    })
+  }
 
   if (!primitive) {
     return (
@@ -81,18 +169,49 @@ function PrimitiveListPage() {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Name</TableHead>
-              <TableHead>Namespace</TableHead>
-              <TableHead>Phase</TableHead>
-              <TableHead className="text-right">Age</TableHead>
+              {isAgentRunList ? (
+                <>
+                  {agentRunSortKeys.map((sort) => (
+                    <TableHead
+                      key={sort}
+                      aria-sort={ariaSortValue(search, sort)}
+                      className={sort === 'createdAt' ? 'text-right' : undefined}
+                    >
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className={sort === 'createdAt' ? 'ml-auto -mr-2 px-2' : '-ml-2 px-2'}
+                        aria-label={`Sort AgentRuns by ${sortableAgentRunColumnLabels[sort]}`}
+                        onClick={() => void updateSort(sort)}
+                      >
+                        {sortableAgentRunColumnLabels[sort]}
+                        <SortIcon
+                          active={(search.sort ?? defaultAgentRunSort.sort) === sort}
+                          direction={search.direction ?? defaultAgentRunSort.direction}
+                        />
+                      </Button>
+                    </TableHead>
+                  ))}
+                </>
+              ) : (
+                <>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Namespace</TableHead>
+                  <TableHead>Phase</TableHead>
+                  <TableHead className="text-right">Age</TableHead>
+                </>
+              )}
             </TableRow>
           </TableHeader>
           <TableBody>
-            {visibleItems.map((item) => {
-              const name = metadataValue(item, 'name')
-              const namespace = metadataValue(item, 'namespace') || 'agents'
-              const creationTimestamp = metadataValue(item, 'creationTimestamp')
-              const phase = typeof item.status.phase === 'string' ? item.status.phase : ''
+            {sortedItems.map((item) => {
+              const name = resourceName(item) || metadataValue(item, 'name')
+              const namespace = resourceNamespace(item)
+              const creationTimestamp = resourceCreationTimestamp(item) || metadataValue(item, 'creationTimestamp')
+              const phase = resourcePhase(item)
+              const agent = agentRunAgentName(item)
+              const source = formatAgentRunImplementationSource(item)
               return (
                 <TableRow key={`${namespace}/${name}`}>
                   <TableCell className="font-medium">
@@ -104,27 +223,44 @@ function PrimitiveListPage() {
                       {name}
                     </Link>
                   </TableCell>
-                  <TableCell>{namespace}</TableCell>
-                  <TableCell>
-                    {phase ? (
-                      <Badge variant="secondary">{phase}</Badge>
-                    ) : (
-                      <span className="text-muted-foreground">-</span>
-                    )}
-                  </TableCell>
+                  {isAgentRunList ? (
+                    <>
+                      <TableCell>
+                        {phase ? (
+                          <Badge variant="secondary">{phase}</Badge>
+                        ) : (
+                          <span className="text-muted-foreground">-</span>
+                        )}
+                      </TableCell>
+                      <TableCell>{agent || <span className="text-muted-foreground">-</span>}</TableCell>
+                      <TableCell>{source || <span className="text-muted-foreground">-</span>}</TableCell>
+                      <TableCell>{namespace}</TableCell>
+                    </>
+                  ) : (
+                    <>
+                      <TableCell>{namespace}</TableCell>
+                      <TableCell>
+                        {phase ? (
+                          <Badge variant="secondary">{phase}</Badge>
+                        ) : (
+                          <span className="text-muted-foreground">-</span>
+                        )}
+                      </TableCell>
+                    </>
+                  )}
                   <TableCell className="text-right text-muted-foreground">{creationTimestamp || '-'}</TableCell>
                 </TableRow>
               )
             })}
-            {!loading && visibleItems.length === 0 ? (
+            {!loading && sortedItems.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={4} className="h-24 text-center text-muted-foreground">
-                  {primitive.kind === 'AgentRun' && selectedStatuses.length > 0 ? (
+                <TableCell colSpan={isAgentRunList ? 6 : 4} className="h-24 text-center text-muted-foreground">
+                  {isAgentRunList && selectedStatuses.length > 0 ? (
                     <span>
                       No AgentRuns match the selected statuses: {selectedStatuses.join(', ')}. Clear the status filter
                       to see all AgentRuns.
                     </span>
-                  ) : primitive.kind === 'AgentRun' ? (
+                  ) : isAgentRunList ? (
                     'No AgentRuns found.'
                   ) : (
                     'No resources found.'
@@ -139,12 +275,31 @@ function PrimitiveListPage() {
                     <TableCell>
                       <Skeleton className="h-4 w-[240px] max-w-full" />
                     </TableCell>
-                    <TableCell>
-                      <Skeleton className="h-4 w-24" />
-                    </TableCell>
-                    <TableCell>
-                      <Skeleton className="h-5 w-20 rounded-full" />
-                    </TableCell>
+                    {isAgentRunList ? (
+                      <>
+                        <TableCell>
+                          <Skeleton className="h-5 w-20 rounded-full" />
+                        </TableCell>
+                        <TableCell>
+                          <Skeleton className="h-4 w-24" />
+                        </TableCell>
+                        <TableCell>
+                          <Skeleton className="h-4 w-32" />
+                        </TableCell>
+                        <TableCell>
+                          <Skeleton className="h-4 w-24" />
+                        </TableCell>
+                      </>
+                    ) : (
+                      <>
+                        <TableCell>
+                          <Skeleton className="h-4 w-24" />
+                        </TableCell>
+                        <TableCell>
+                          <Skeleton className="h-5 w-20 rounded-full" />
+                        </TableCell>
+                      </>
+                    )}
                     <TableCell>
                       <div className="flex justify-end">
                         <Skeleton className="h-4 w-36" />

--- a/services/agents/src/control-plane/agentrun-list-sort.test.ts
+++ b/services/agents/src/control-plane/agentrun-list-sort.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest'
+
+import type { PrimitiveResourceSummary } from './api-client'
+import {
+  nextAgentRunSortSearch,
+  parseAgentRunListSearch,
+  sortAgentRunResources,
+  type AgentRunListSearchState,
+} from './agentrun-list-sort'
+
+const run = ({
+  name,
+  namespace = 'agents',
+  createdAt,
+  phase,
+  agent,
+  implementationSpec,
+  inlineProvider,
+}: {
+  name: string
+  namespace?: string
+  createdAt?: string
+  phase?: string
+  agent?: string
+  implementationSpec?: string
+  inlineProvider?: string
+}): PrimitiveResourceSummary => ({
+  apiVersion: 'agents.proompteng.ai/v1alpha1',
+  kind: 'AgentRun',
+  metadata: {
+    name,
+    namespace,
+    ...(createdAt ? { creationTimestamp: createdAt } : {}),
+  },
+  spec: {
+    ...(agent ? { agentRef: { name: agent } } : {}),
+    ...(implementationSpec
+      ? { implementationSpecRef: { name: implementationSpec } }
+      : inlineProvider
+        ? { implementation: { inline: { source: { provider: inlineProvider } } } }
+        : {}),
+  },
+  status: {
+    ...(phase ? { phase } : {}),
+  },
+})
+
+describe('AgentRun list query sort state', () => {
+  it('parses valid query sort state and query-backed filters', () => {
+    expect(
+      parseAgentRunListSearch({
+        sort: 'agent',
+        direction: 'asc',
+        phase: 'Running',
+        runtime: 'job',
+        namespace: 'agents',
+        limit: '25',
+        search: 'worker',
+      }),
+    ).toEqual({
+      sort: 'agent',
+      direction: 'asc',
+      namespace: 'agents',
+      phase: 'Running',
+      status: undefined,
+      runtime: 'job',
+      labelSelector: undefined,
+      label_selector: undefined,
+      limit: 25,
+      page: undefined,
+      search: 'worker',
+      q: undefined,
+    })
+  })
+
+  it('falls back to newest-first sort state for invalid query params', () => {
+    expect(parseAgentRunListSearch({ sort: 'prompt', direction: 'sideways', limit: '-4' })).toMatchObject({
+      sort: 'createdAt',
+      direction: 'desc',
+      limit: undefined,
+    })
+  })
+
+  it('normalizes user-facing sort key aliases at the route boundary', () => {
+    expect(parseAgentRunListSearch({ sort: 'status', direction: 'asc' })).toMatchObject({
+      sort: 'phase',
+      direction: 'asc',
+    })
+    expect(parseAgentRunListSearch({ sort: 'age', direction: 'desc' })).toMatchObject({
+      sort: 'createdAt',
+      direction: 'desc',
+    })
+    expect(parseAgentRunListSearch({ sort: 'implementationSpec', direction: 'asc' })).toMatchObject({
+      sort: 'source',
+      direction: 'asc',
+    })
+  })
+
+  it('serializes the next sort state without dropping existing filters', () => {
+    const current: AgentRunListSearchState = {
+      sort: 'createdAt',
+      direction: 'desc',
+      status: 'Running,Failed',
+      phase: 'Failed',
+      runtime: 'job',
+      page: 3,
+      search: 'controller',
+    }
+
+    expect(nextAgentRunSortSearch(current, 'name')).toEqual({
+      sort: 'name',
+      direction: 'asc',
+      status: 'Running,Failed',
+      phase: 'Failed',
+      runtime: 'job',
+      page: 3,
+      search: 'controller',
+    })
+  })
+
+  it('toggles direction when sorting the active column again', () => {
+    expect(nextAgentRunSortSearch({ sort: 'name', direction: 'asc' }, 'name')).toMatchObject({
+      sort: 'name',
+      direction: 'desc',
+    })
+  })
+})
+
+describe('AgentRun resource sorting', () => {
+  const runs = [
+    run({
+      name: 'beta',
+      namespace: 'agents',
+      createdAt: '2026-05-26T10:00:00Z',
+      phase: 'Failed',
+      agent: 'writer',
+      implementationSpec: 'docs-spec',
+    }),
+    run({
+      name: 'alpha',
+      namespace: 'agents',
+      createdAt: '2026-05-26T12:00:00Z',
+      phase: 'Running',
+      agent: 'builder',
+      inlineProvider: 'github',
+    }),
+    run({
+      name: 'gamma',
+      namespace: 'ops',
+      phase: 'Pending',
+    }),
+  ]
+
+  it('defaults to newest AgentRuns first with missing timestamps last', () => {
+    expect(sortAgentRunResources(runs).map((item) => item.metadata.name)).toEqual(['alpha', 'beta', 'gamma'])
+  })
+
+  it('sorts by name in ascending and descending order', () => {
+    expect(sortAgentRunResources(runs, 'name', 'asc').map((item) => item.metadata.name)).toEqual([
+      'alpha',
+      'beta',
+      'gamma',
+    ])
+    expect(sortAgentRunResources(runs, 'name', 'desc').map((item) => item.metadata.name)).toEqual([
+      'gamma',
+      'beta',
+      'alpha',
+    ])
+  })
+
+  it('sorts by phase, agent, source, namespace, and creation timestamp deterministically', () => {
+    expect(sortAgentRunResources(runs, 'phase', 'asc').map((item) => item.metadata.name)).toEqual([
+      'beta',
+      'gamma',
+      'alpha',
+    ])
+    expect(sortAgentRunResources(runs, 'agent', 'asc').map((item) => item.metadata.name)).toEqual([
+      'alpha',
+      'beta',
+      'gamma',
+    ])
+    expect(sortAgentRunResources(runs, 'source', 'asc').map((item) => item.metadata.name)).toEqual([
+      'beta',
+      'alpha',
+      'gamma',
+    ])
+    expect(sortAgentRunResources(runs, 'namespace', 'desc').map((item) => item.metadata.name)).toEqual([
+      'gamma',
+      'alpha',
+      'beta',
+    ])
+    expect(sortAgentRunResources(runs, 'createdAt', 'asc').map((item) => item.metadata.name)).toEqual([
+      'beta',
+      'alpha',
+      'gamma',
+    ])
+  })
+
+  it('uses newest timestamp, namespace, and name as stable tie-breaks', () => {
+    const tied = [
+      run({ name: 'zeta', namespace: 'agents', createdAt: '2026-05-26T09:00:00Z', phase: 'Running' }),
+      run({ name: 'alpha', namespace: 'agents', createdAt: '2026-05-26T09:00:00Z', phase: 'Running' }),
+      run({ name: 'middle', namespace: 'ops', createdAt: '2026-05-26T11:00:00Z', phase: 'Running' }),
+    ]
+
+    expect(
+      sortAgentRunResources(tied, 'phase', 'asc').map((item) => `${item.metadata.namespace}/${item.metadata.name}`),
+    ).toEqual(['ops/middle', 'agents/alpha', 'agents/zeta'])
+  })
+})

--- a/services/agents/src/control-plane/agentrun-list-sort.ts
+++ b/services/agents/src/control-plane/agentrun-list-sort.ts
@@ -1,0 +1,202 @@
+import type { PrimitiveResourceSummary } from './api-client'
+
+type JsonObject = Record<string, unknown>
+
+export const agentRunSortKeys = ['name', 'phase', 'agent', 'source', 'namespace', 'createdAt'] as const
+export type AgentRunSortKey = (typeof agentRunSortKeys)[number]
+export type AgentRunSortDirection = 'asc' | 'desc'
+
+export type AgentRunListSearchState = {
+  sort?: AgentRunSortKey
+  direction?: AgentRunSortDirection
+  namespace?: string
+  phase?: string
+  status?: string
+  runtime?: string
+  labelSelector?: string
+  label_selector?: string
+  limit?: number
+  page?: number
+  search?: string
+  q?: string
+}
+
+export const defaultAgentRunSort = {
+  sort: 'createdAt' as AgentRunSortKey,
+  direction: 'desc' as AgentRunSortDirection,
+}
+
+const asRecord = (value: unknown): JsonObject =>
+  value && typeof value === 'object' && !Array.isArray(value) ? (value as JsonObject) : {}
+
+const stringValue = (value: unknown) => (typeof value === 'string' ? value.trim() : '')
+
+const optionalString = (value: unknown) => {
+  const string = stringValue(value)
+  return string.length > 0 ? string : undefined
+}
+
+const parseNumber = (value: unknown) => {
+  const raw = typeof value === 'number' ? value : typeof value === 'string' ? Number.parseInt(value, 10) : Number.NaN
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : undefined
+}
+
+const parseSortKey = (value: unknown): AgentRunSortKey => {
+  const sort = stringValue(value)
+  if (sort === 'status') return 'phase'
+  if (sort === 'age' || sort === 'creationTimestamp') return 'createdAt'
+  if (sort === 'implementation' || sort === 'implementationSpec') return 'source'
+  return agentRunSortKeys.includes(sort as AgentRunSortKey) ? (sort as AgentRunSortKey) : defaultAgentRunSort.sort
+}
+
+const parseDirection = (value: unknown): AgentRunSortDirection => {
+  const direction = stringValue(value).toLowerCase()
+  return direction === 'asc' || direction === 'desc' ? direction : defaultAgentRunSort.direction
+}
+
+export const parseAgentRunListSearch = (search: Record<string, unknown>): AgentRunListSearchState => ({
+  sort: parseSortKey(search.sort),
+  direction: parseDirection(search.direction),
+  namespace: optionalString(search.namespace),
+  phase: optionalString(search.phase),
+  status: optionalString(search.status),
+  runtime: optionalString(search.runtime),
+  labelSelector: optionalString(search.labelSelector),
+  label_selector: optionalString(search.label_selector),
+  limit: parseNumber(search.limit),
+  page: parseNumber(search.page),
+  search: optionalString(search.search),
+  q: optionalString(search.q),
+})
+
+export const nextAgentRunSortSearch = (
+  current: AgentRunListSearchState,
+  sort: AgentRunSortKey,
+): AgentRunListSearchState => ({
+  ...current,
+  sort,
+  direction: current.sort === sort && (current.direction ?? defaultAgentRunSort.direction) === 'asc' ? 'desc' : 'asc',
+})
+
+export const resourceName = (resource: PrimitiveResourceSummary) => stringValue(resource.metadata.name)
+
+export const resourceNamespace = (resource: PrimitiveResourceSummary) =>
+  stringValue(resource.metadata.namespace) || 'agents'
+
+export const resourceCreationTimestamp = (resource: PrimitiveResourceSummary) =>
+  stringValue(resource.metadata.creationTimestamp)
+
+export const resourcePhase = (resource: PrimitiveResourceSummary) =>
+  stringValue(resource.status.phase) || stringValue(resource.status.status)
+
+export const agentRunAgentName = (resource: PrimitiveResourceSummary) => {
+  const spec = asRecord(resource.spec)
+  const agentRef = asRecord(spec.agentRef)
+  return stringValue(agentRef.name)
+}
+
+export const agentRunImplementationSource = (resource: PrimitiveResourceSummary) => {
+  const spec = asRecord(resource.spec)
+  const implementationSpecRef = asRecord(spec.implementationSpecRef)
+  const implementationSpecName = stringValue(implementationSpecRef.name)
+  if (implementationSpecName) return implementationSpecName
+
+  const implementation = asRecord(spec.implementation)
+  const inline = asRecord(implementation.inline)
+  const source = asRecord(inline.source)
+  const provider = stringValue(source.provider)
+  const externalId = stringValue(source.externalId)
+  const url = stringValue(source.url)
+  const summary = stringValue(inline.summary)
+
+  if (provider && externalId) return `${provider}:${externalId}`
+  if (provider && url) return `${provider}:${url}`
+  if (provider) return provider
+  if (summary) return `inline:${summary}`
+  return inline && Object.keys(inline).length > 0 ? 'inline' : ''
+}
+
+export const formatAgentRunImplementationSource = (resource: PrimitiveResourceSummary) => {
+  const spec = asRecord(resource.spec)
+  const implementationSpecRef = asRecord(spec.implementationSpecRef)
+  const implementationSpecName = stringValue(implementationSpecRef.name)
+  if (implementationSpecName) return implementationSpecName
+
+  const implementation = asRecord(spec.implementation)
+  const inline = asRecord(implementation.inline)
+  const source = asRecord(inline.source)
+  const provider = stringValue(source.provider)
+  const externalId = stringValue(source.externalId)
+  const url = stringValue(source.url)
+
+  if (provider && externalId) return `${provider} / ${externalId}`
+  if (provider && url) return `${provider} / ${url}`
+  if (provider) return provider
+  return inline && Object.keys(inline).length > 0 ? 'inline' : ''
+}
+
+const sortValue = (resource: PrimitiveResourceSummary, sort: AgentRunSortKey) => {
+  switch (sort) {
+    case 'name':
+      return resourceName(resource)
+    case 'phase':
+      return resourcePhase(resource)
+    case 'agent':
+      return agentRunAgentName(resource)
+    case 'source':
+      return agentRunImplementationSource(resource)
+    case 'namespace':
+      return resourceNamespace(resource)
+    case 'createdAt':
+      return resourceCreationTimestamp(resource)
+  }
+}
+
+const timestampValue = (value: string) => {
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const compareStrings = (left: string, right: string, direction: AgentRunSortDirection) => {
+  const leftMissing = left.length === 0
+  const rightMissing = right.length === 0
+  if (leftMissing && rightMissing) return 0
+  if (leftMissing) return 1
+  if (rightMissing) return -1
+  const compared = left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' })
+  return direction === 'asc' ? compared : -compared
+}
+
+const compareTimestamps = (left: string, right: string, direction: AgentRunSortDirection) => {
+  const leftTimestamp = timestampValue(left)
+  const rightTimestamp = timestampValue(right)
+  if (leftTimestamp === null && rightTimestamp === null) return 0
+  if (leftTimestamp === null) return 1
+  if (rightTimestamp === null) return -1
+  const compared = leftTimestamp - rightTimestamp
+  return direction === 'asc' ? compared : -compared
+}
+
+const compareBy = (
+  left: PrimitiveResourceSummary,
+  right: PrimitiveResourceSummary,
+  sort: AgentRunSortKey,
+  direction: AgentRunSortDirection,
+) => {
+  const leftValue = sortValue(left, sort)
+  const rightValue = sortValue(right, sort)
+  return sort === 'createdAt'
+    ? compareTimestamps(leftValue, rightValue, direction)
+    : compareStrings(leftValue, rightValue, direction)
+}
+
+const deterministicTieBreak = (left: PrimitiveResourceSummary, right: PrimitiveResourceSummary) =>
+  compareTimestamps(resourceCreationTimestamp(left), resourceCreationTimestamp(right), 'desc') ||
+  compareStrings(resourceNamespace(left), resourceNamespace(right), 'asc') ||
+  compareStrings(resourceName(left), resourceName(right), 'asc')
+
+export const sortAgentRunResources = (
+  resources: PrimitiveResourceSummary[],
+  sort: AgentRunSortKey = defaultAgentRunSort.sort,
+  direction: AgentRunSortDirection = defaultAgentRunSort.direction,
+) => [...resources].sort((left, right) => compareBy(left, right, sort, direction) || deterministicTieBreak(left, right))

--- a/services/agents/src/control-plane/api-client.ts
+++ b/services/agents/src/control-plane/api-client.ts
@@ -102,9 +102,26 @@ export const fetchPrimitiveDefinitions = async () => {
   return (await response.json()) as PrimitiveListResponse
 }
 
-export const fetchPrimitiveResources = async (kind: string, namespace = 'agents') => {
+export type PrimitiveResourceQuery = {
+  namespace?: string
+  phase?: string
+  status?: string
+  runtime?: string
+  labelSelector?: string
+  label_selector?: string
+  limit?: number
+}
+
+export const fetchPrimitiveResources = async (kind: string, query: PrimitiveResourceQuery | string = {}) => {
   const url = new URL(`/api/primitives/${encodeURIComponent(kind)}/resources`, window.location.origin)
-  url.searchParams.set('namespace', namespace)
+  const params = typeof query === 'string' ? { namespace: query } : query
+  url.searchParams.set('namespace', params.namespace ?? 'agents')
+  if (params.phase) url.searchParams.set('phase', params.phase)
+  if (!params.phase && params.status) url.searchParams.set('phase', params.status)
+  if (params.runtime) url.searchParams.set('runtime', params.runtime)
+  if (params.labelSelector) url.searchParams.set('labelSelector', params.labelSelector)
+  if (params.label_selector) url.searchParams.set('label_selector', params.label_selector)
+  if (typeof params.limit === 'number') url.searchParams.set('limit', params.limit.toString())
   const response = await assertOk(await fetch(url))
   return (await response.json()) as PrimitiveResourceListResponse
 }


### PR DESCRIPTION
## Summary

- Added AgentRun-specific sortable table headers for name, status, agent, implementation, namespace, and age.
- Made `/primitives/agent-run` sort state derive from validated URL query params, with safe aliases/defaults and URL-updating header interactions.
- Preserved query-backed filters such as namespace, phase/status, runtime, label selector, limit, page, and search state while changing sort.
- Added focused unit coverage for query parsing, sort serialization, deterministic sorting, and filter preservation.

## Related Issues

None

## Testing

- PASS: `bun run --cwd services/agents tsc`
- PASS: `bun run --cwd services/agents lint`
- PASS: `bun run --cwd services/agents test`
- PASS: Browser QA with Playwright screenshot at `/tmp/agentrun-sort-rebased.png` for `http://127.0.0.1:3000/primitives/agent-run?sort=createdAt&direction=desc&status=Running`; verified dark shell, breadcrumbs/sidebar, status filter, sortable headers, active age descending indicator, and loading table layout.
- PASS: Browser QA with Playwright click automation; clicked `Sort AgentRuns by Name` and verified URL changed to `/primitives/agent-run?sort=name&direction=asc&status=Running`, preserving the status filter.

## Screenshots (if applicable)

Local visual QA screenshot captured at `/tmp/agentrun-sort-rebased.png`; not attached to this PR.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; no documentation changes were required for this UI-only enhancement.
