### PR TITLE
fix(torghut): add offline replay triage sidecar

### DIFF
--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -98,6 +98,13 @@ RUNTIME_WINDOW_TARGET_METADATA_KEYS = (
     "handoff",
     "promotion_gate",
 )
+RUNTIME_WINDOW_TARGET_PLAN_DEFERRED_REASONS = frozenset(
+    (
+        "runtime_window_target_plan_window_not_closed",
+        "runtime_window_target_plan_window_settlement_pending",
+    )
+)
+OFFLINE_REPLAY_TRIAGE_CANDIDATE_LIMIT = 5
 
 
 def _parse_args() -> argparse.Namespace:
@@ -1231,8 +1238,9 @@ def _run_runtime_window_import(
     default_window_start, default_window_end = (
         explicit_window or _runtime_window_bounds(args, now)
     )
+    targets = _runtime_window_targets(args)
     imports: list[dict[str, Any]] = []
-    for target in _runtime_window_targets(args):
+    for target in targets:
         imports.append(
             _run_runtime_window_import_target(
                 args=args,
@@ -1246,20 +1254,357 @@ def _run_runtime_window_import(
                 allow_source_activity_window=explicit_window is None,
             )
         )
+    offline_replay_triage = _offline_replay_triage_for_deferred_imports(
+        args=args,
+        imports=imports,
+        now=now,
+    )
     if len(imports) == 1:
-        return imports[0]
+        payload = dict(imports[0])
+        if offline_replay_triage is not None:
+            payload["offline_replay_triage"] = offline_replay_triage
+        return payload
     proof_blockers = [
         blocker
         for item in imports
         for blocker in item.get("proof_blockers", [])
         if isinstance(blocker, Mapping)
     ]
-    return {
+    payload = {
         "status": "ok",
         "proof_status": "blocked" if proof_blockers else "ok",
         "proof_blockers": proof_blockers,
         "target_count": len(imports),
         "imports": imports,
+    }
+    if offline_replay_triage is not None:
+        payload["offline_replay_triage"] = offline_replay_triage
+    return payload
+
+
+def _runtime_window_import_is_paper_route(item: Mapping[str, Any]) -> bool:
+    source_kind = _as_text(item.get("source_kind")) or ""
+    if "paper_route" in source_kind:
+        return True
+    metadata = _as_dict(item.get("target_metadata"))
+    return any(str(key).startswith("paper_route_") for key in metadata)
+
+
+def _offline_replay_artifact_refs(item: Mapping[str, Any]) -> list[str]:
+    refs: list[str] = []
+
+    def append_ref(value: Any) -> None:
+        ref = _as_text(value)
+        if ref is not None and ref not in refs:
+            refs.append(ref)
+
+    metadata = _as_dict(item.get("target_metadata"))
+    for key in (
+        "runtime_ledger_artifact_ref",
+        "exact_replay_ledger_artifact_ref",
+        "runtime_ledger_bucket_ref",
+    ):
+        append_ref(metadata.get(key))
+    for key in ("runtime_ledger_artifact_refs", "exact_replay_ledger_artifact_refs"):
+        for ref in _as_text_list(metadata.get(key)):
+            append_ref(ref)
+    for ref in _as_text_list(item.get("artifact_refs")):
+        append_ref(ref)
+    return refs
+
+
+def _offline_replay_exact_artifact_refs(item: Mapping[str, Any]) -> list[str]:
+    refs: list[str] = []
+    metadata = _as_dict(item.get("target_metadata"))
+    for key in ("exact_replay_ledger_artifact_ref", "runtime_ledger_artifact_ref"):
+        ref = _as_text(metadata.get(key))
+        if ref is not None and ref not in refs:
+            refs.append(ref)
+    for key in ("exact_replay_ledger_artifact_refs", "runtime_ledger_artifact_refs"):
+        for ref in _as_text_list(metadata.get(key)):
+            if ref not in refs:
+                refs.append(ref)
+    return refs
+
+
+def _offline_replay_triage_source_kind(item: Mapping[str, Any]) -> str:
+    source_kind = _as_text(item.get("source_kind")) or ""
+    exact_refs = _offline_replay_exact_artifact_refs(item)
+    if source_kind == "simulation_exact_replay_runtime_ledger" or exact_refs:
+        return "simulation_exact_replay_runtime_ledger"
+    return source_kind or "research_handoff"
+
+
+def _offline_replay_triage_candidate_from_import(
+    item: Mapping[str, Any],
+) -> dict[str, Any]:
+    metadata = _as_dict(item.get("target_metadata"))
+    candidate: dict[str, Any] = {
+        "authority": "non_authoritative_research_triage",
+        "promotion_allowed": False,
+        "excluded_from_runtime_window_import_proof": True,
+        "source_kind": _offline_replay_triage_source_kind(item),
+        "hypothesis_id": _as_text(item.get("hypothesis_id")) or "",
+        "candidate_id": _as_text(item.get("candidate_id")) or "",
+        "strategy_name": _as_text(item.get("strategy_name")) or "",
+        "account_label": _as_text(item.get("account_label")) or "",
+        "window_start": _as_text(item.get("window_start")) or "",
+        "window_end": _as_text(item.get("window_end")) or "",
+        "deferred_reason": _as_text(item.get("reason")) or "",
+        "source_artifact_refs": _offline_replay_artifact_refs(item),
+        "exact_replay_ledger_artifact_refs": _offline_replay_exact_artifact_refs(item),
+    }
+    selection = {
+        key: metadata[key]
+        for key in (
+            "candidate_selection",
+            "selected_by",
+            "selection_reason",
+            "replay_selection_reason",
+            "probation_reason",
+            "promotion_gate",
+        )
+        if key in metadata
+    }
+    if selection:
+        candidate["selection"] = selection
+    blockers: list[str] = []
+    for key in (
+        "runtime_ledger_target_metadata_blockers",
+        "runtime_window_import_health_gate_blockers",
+        "runtime_window_import_promotion_blockers",
+        "final_promotion_blockers",
+        "candidate_blockers",
+    ):
+        for blocker in _as_text_list(metadata.get(key)):
+            if blocker not in blockers:
+                blockers.append(blocker)
+    if blockers:
+        candidate["research_blockers"] = blockers
+    handoff = metadata.get("paper_route_runtime_import_handoff") or metadata.get(
+        "handoff"
+    )
+    if handoff:
+        candidate["handoff"] = handoff
+    return candidate
+
+
+def _offline_replay_triage_candidate_from_ranking(
+    candidate: Mapping[str, Any],
+    *,
+    source_ref: str,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "authority": "non_authoritative_research_triage",
+        "promotion_allowed": False,
+        "excluded_from_runtime_window_import_proof": True,
+        "source_kind": "simulation_exact_replay_runtime_ledger",
+        "source_artifact_ref": source_ref,
+    }
+    for key in (
+        "candidate_id",
+        "artifact_ref",
+        "promotion_status",
+        "window_start",
+        "window_end",
+        "window_net_pnl_per_day",
+        "active_net_pnl_per_day",
+        "total_net_pnl_after_costs",
+        "window_weekday_count",
+        "avg_filled_notional_per_window_weekday",
+        "best_day_share",
+        "max_single_fill_notional_pct_equity",
+    ):
+        value = candidate.get(key)
+        if value not in (None, ""):
+            payload[key] = value
+    for key in ("promotion_blockers", "runtime_ledger_blockers"):
+        values = _as_text_list(candidate.get(key))
+        if values:
+            payload[key] = values
+    return payload
+
+
+def _offline_replay_triage_from_artifact_payload(
+    *,
+    payload: Mapping[str, Any],
+    source_ref: str,
+) -> dict[str, Any] | None:
+    schema_version = _as_text(payload.get("schema_version")) or ""
+    if schema_version == "torghut.replay-runtime-window-handoff.v1":
+        ranking = _as_dict(payload.get("ranking"))
+        candidates = _offline_replay_triage_candidates_from_ranking(
+            ranking=ranking,
+            source_ref=source_ref,
+        )
+        best_candidate = _as_dict(payload.get("best_exact_replay_ledger_candidate"))
+        if best_candidate and not candidates:
+            candidates = [
+                _offline_replay_triage_candidate_from_ranking(
+                    best_candidate,
+                    source_ref=source_ref,
+                )
+            ]
+        return {
+            "source_ref": source_ref,
+            "schema_version": schema_version,
+            "source": _as_text(payload.get("source"))
+            or "exact_replay_ledger_runtime_window_handoff",
+            "candidate_count": len(candidates),
+            "candidates": candidates,
+        }
+    if schema_version == "torghut.exact-replay-ledger-ranking.v1":
+        candidates = _offline_replay_triage_candidates_from_ranking(
+            ranking=payload,
+            source_ref=source_ref,
+        )
+        return {
+            "source_ref": source_ref,
+            "schema_version": schema_version,
+            "source": "exact_replay_ledger_ranking",
+            "candidate_count": len(candidates),
+            "candidates": candidates,
+        }
+    candidate_board = _as_dict(payload.get("candidate_board"))
+    if candidate_board:
+        best_candidate = _as_dict(
+            candidate_board.get("best_exact_replay_ledger_candidate")
+        )
+        candidates = (
+            [
+                _offline_replay_triage_candidate_from_ranking(
+                    best_candidate,
+                    source_ref=source_ref,
+                )
+            ]
+            if best_candidate
+            else []
+        )
+        return {
+            "source_ref": source_ref,
+            "schema_version": _as_text(candidate_board.get("schema_version"))
+            or "candidate_board",
+            "source": "autoresearch_candidate_board",
+            "candidate_count": len(candidates),
+            "candidates": candidates,
+        }
+    return None
+
+
+def _offline_replay_triage_candidates_from_ranking(
+    *,
+    ranking: Mapping[str, Any],
+    source_ref: str,
+) -> list[dict[str, Any]]:
+    raw_candidates = ranking.get("candidates")
+    if not isinstance(raw_candidates, Sequence) or isinstance(
+        raw_candidates,
+        (str, bytes, bytearray),
+    ):
+        return []
+    candidates: list[dict[str, Any]] = []
+    for raw_candidate in raw_candidates[:OFFLINE_REPLAY_TRIAGE_CANDIDATE_LIMIT]:
+        candidate = _as_dict(raw_candidate)
+        if not candidate:
+            continue
+        candidates.append(
+            _offline_replay_triage_candidate_from_ranking(
+                candidate,
+                source_ref=source_ref,
+            )
+        )
+    return candidates
+
+
+def _offline_replay_triage_source_reports(
+    imports: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    reports: list[dict[str, Any]] = []
+    seen_refs: set[str] = set()
+    for item in imports:
+        for ref in _offline_replay_artifact_refs(item):
+            if ref in seen_refs:
+                continue
+            seen_refs.add(ref)
+            path = Path(ref)
+            if not path.exists() or not path.is_file():
+                continue
+            report = _offline_replay_triage_from_artifact_payload(
+                payload=_read_json_mapping(path),
+                source_ref=ref,
+            )
+            if report is not None:
+                reports.append(report)
+    return reports
+
+
+def _offline_replay_triage_for_deferred_imports(
+    *,
+    args: argparse.Namespace,
+    imports: Sequence[Mapping[str, Any]],
+    now: datetime,
+) -> dict[str, Any] | None:
+    if not bool(getattr(args, "runtime_window_target_plan_exclusive", False)):
+        return None
+    if not imports:
+        return None
+    deferred_reasons = [
+        _as_text(item.get("reason")) or ""
+        for item in imports
+        if _as_text(item.get("status")) == "deferred"
+    ]
+    if len(deferred_reasons) != len(imports):
+        return None
+    if any(
+        reason not in RUNTIME_WINDOW_TARGET_PLAN_DEFERRED_REASONS
+        for reason in deferred_reasons
+    ):
+        return None
+    if not any(_runtime_window_import_is_paper_route(item) for item in imports):
+        return None
+    import_candidates = [
+        _offline_replay_triage_candidate_from_import(item)
+        for item in imports[:OFFLINE_REPLAY_TRIAGE_CANDIDATE_LIMIT]
+    ]
+    source_reports = _offline_replay_triage_source_reports(imports)
+    report_candidates: list[dict[str, Any]] = []
+    for report in source_reports:
+        for candidate in report.get("candidates", []):
+            if isinstance(candidate, Mapping):
+                report_candidates.append(dict(candidate))
+            if len(report_candidates) >= OFFLINE_REPLAY_TRIAGE_CANDIDATE_LIMIT:
+                break
+        if len(report_candidates) >= OFFLINE_REPLAY_TRIAGE_CANDIDATE_LIMIT:
+            break
+    source_kind = (
+        "simulation_exact_replay_runtime_ledger"
+        if any(
+            candidate.get("source_kind") == "simulation_exact_replay_runtime_ledger"
+            for candidate in (*import_candidates, *report_candidates)
+        )
+        else "research_handoff"
+    )
+    return {
+        "schema_version": "torghut.offline-replay-triage.v1",
+        "status": "informational",
+        "authority": "non_authoritative_research_triage",
+        "promotion_allowed": False,
+        "promotion_authority": "blocked",
+        "excluded_from_runtime_window_import_proof": True,
+        "source_kind": source_kind,
+        "reason": "authoritative_runtime_window_imports_deferred",
+        "generated_at": _utc_iso(now),
+        "deferred_reasons": sorted(set(deferred_reasons)),
+        "authoritative_import_target_count": len(imports),
+        "proof_status_effect": "none",
+        "promotion_authority_effect": "none",
+        "runtime_window_import_proof_effect": "none",
+        "lifecycle_count_effect": "none",
+        "doc29_live_scale_gate_effect": "none",
+        "post_cost_pnl_target_gate_effect": "none",
+        "candidates": import_candidates,
+        "source_reports": source_reports,
+        "source_report_candidates": report_candidates,
     }
 
 

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -2399,6 +2399,535 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             "25",
         )
 
+    def test_deferred_paper_route_targets_emit_offline_replay_triage(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-pairs-01.json"
+        hypothesis_path.write_text(
+            json.dumps({"candidate_id": "cand-paper-route"}),
+            encoding="utf-8",
+        )
+        ranking_path = self.tmp_dir / "exact-replay-ledger-ranking.json"
+        ranking_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "torghut.exact-replay-ledger-ranking.v1",
+                    "candidate_count": 1,
+                    "candidates": [
+                        {
+                            "candidate_id": "cand-replay-triage",
+                            "artifact_ref": "proof/exact-replay-ledger.json",
+                            "promotion_status": "blocked_pending_runtime_promotion_proof",
+                            "promotion_blockers": ["replay_artifact_only_not_live"],
+                            "runtime_ledger_blockers": [],
+                            "window_start": "2026-05-25T13:30:00Z",
+                            "window_end": "2026-05-25T20:00:00Z",
+                            "window_net_pnl_per_day": "625",
+                            "total_net_pnl_after_costs": "625",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        plan_path = self.tmp_dir / "paper-route-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "next_paper_route_runtime_window_targets": {
+                        "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                        "targets": [
+                            {
+                                "candidate_id": "cand-paper-route",
+                                "hypothesis_id": "H-PAIRS-01",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "paper-route-candidate-v1",
+                                "source_manifest_ref": str(hypothesis_path),
+                                "source_dsn_env": "SIM_DB_DSN",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "artifact_refs": [str(ranking_path)],
+                                "exact_replay_ledger_artifact_ref": "proof/exact-replay-ledger.json",
+                                "window_start": "2026-05-26T13:30:00Z",
+                                "window_end": "2026-05-26T20:00:00Z",
+                                "paper_route_probe_next_session_max_notional": "25",
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "final_promotion_allowed": False,
+                                "runtime_ledger_target_metadata_blockers": [
+                                    "replay_artifact_only_not_live"
+                                ],
+                            }
+                        ],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        args = SimpleNamespace(
+            runtime_window_import=True,
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_target_plan_url=[],
+            runtime_window_target_plan_url_timeout_seconds=2.0,
+            runtime_window_target_plan_exclusive=True,
+            runtime_window_target_plan_required=True,
+            runtime_window_target_plan_settlement_seconds=0,
+            runtime_window_targets_from_latest_autoresearch=True,
+            runtime_window_targets_from_registry=True,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_start="",
+            runtime_window_end="",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with (
+            patch.object(
+                renewal.subprocess,
+                "run",
+                side_effect=AssertionError("future target window should not import"),
+            ),
+            patch.object(
+                renewal,
+                "_latest_autoresearch_runtime_window_targets",
+                side_effect=AssertionError("autoresearch fallback should not run"),
+            ),
+            patch.object(
+                renewal,
+                "_registry_runtime_window_targets",
+                side_effect=AssertionError("registry fallback should not run"),
+            ),
+        ):
+            payload = renewal._run_runtime_window_import(
+                args=args,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                now=datetime(2026, 5, 25, 20, 23, tzinfo=timezone.utc),
+            )
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertEqual(payload["status"], "deferred")
+        self.assertEqual(payload["proof_status"], "deferred")
+        self.assertEqual(
+            payload["reason"], "runtime_window_target_plan_window_not_closed"
+        )
+        self.assertEqual(
+            payload["proof_blockers"][0]["type"],
+            "runtime_window_target_plan_window_not_closed",
+        )
+        triage = payload["offline_replay_triage"]
+        self.assertEqual(triage["authority"], "non_authoritative_research_triage")
+        self.assertFalse(triage["promotion_allowed"])
+        self.assertEqual(triage["promotion_authority"], "blocked")
+        self.assertTrue(triage["excluded_from_runtime_window_import_proof"])
+        self.assertEqual(
+            triage["source_kind"], "simulation_exact_replay_runtime_ledger"
+        )
+        self.assertEqual(triage["proof_status_effect"], "none")
+        self.assertEqual(triage["runtime_window_import_proof_effect"], "none")
+        self.assertEqual(triage["lifecycle_count_effect"], "none")
+        self.assertEqual(triage["doc29_live_scale_gate_effect"], "none")
+        self.assertEqual(triage["post_cost_pnl_target_gate_effect"], "none")
+        self.assertEqual(
+            triage["deferred_reasons"],
+            ["runtime_window_target_plan_window_not_closed"],
+        )
+        self.assertEqual(triage["candidates"][0]["candidate_id"], "cand-paper-route")
+        self.assertFalse(triage["candidates"][0]["promotion_allowed"])
+        self.assertTrue(
+            triage["candidates"][0]["excluded_from_runtime_window_import_proof"]
+        )
+        self.assertEqual(
+            triage["candidates"][0]["source_kind"],
+            "simulation_exact_replay_runtime_ledger",
+        )
+        self.assertEqual(
+            triage["source_reports"][0]["schema_version"],
+            "torghut.exact-replay-ledger-ranking.v1",
+        )
+        self.assertEqual(
+            triage["source_report_candidates"][0]["candidate_id"],
+            "cand-replay-triage",
+        )
+        self.assertFalse(triage["source_report_candidates"][0]["promotion_allowed"])
+
+    def test_offline_replay_triage_does_not_displace_import_ready_paper_route(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-pairs-01.json"
+        hypothesis_path.write_text(
+            json.dumps({"candidate_id": "cand-paper-route"}),
+            encoding="utf-8",
+        )
+        plan_path = self.tmp_dir / "paper-route-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "next_paper_route_runtime_window_targets": {
+                        "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                        "targets": [
+                            {
+                                "candidate_id": "cand-paper-route",
+                                "hypothesis_id": "H-PAIRS-01",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "paper-route-candidate-v1",
+                                "source_manifest_ref": str(hypothesis_path),
+                                "source_dsn_env": "SIM_DB_DSN",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "runtime_ledger_artifact_ref": "proof/exact-replay-ledger.json",
+                                "window_start": "2026-05-25T13:30:00Z",
+                                "window_end": "2026-05-25T20:00:00Z",
+                                "paper_route_probe_next_session_max_notional": "25",
+                            }
+                        ],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        completed = SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "status": "ok",
+                    "promotion_allowed": False,
+                    "promotion_blocking_reasons": [
+                        "paper_stage_evidence_collection_only"
+                    ],
+                    "runtime_observation": {
+                        "authoritative": False,
+                        "authority_reason": "runtime_without_runtime_ledger_profit_proof",
+                    },
+                }
+            )
+        )
+        args = SimpleNamespace(
+            runtime_window_import=True,
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_target_plan_url=[],
+            runtime_window_target_plan_url_timeout_seconds=2.0,
+            runtime_window_target_plan_exclusive=True,
+            runtime_window_target_plan_required=True,
+            runtime_window_target_plan_settlement_seconds=0,
+            runtime_window_targets_from_latest_autoresearch=False,
+            runtime_window_targets_from_registry=False,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_start="",
+            runtime_window_end="",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with patch.object(
+            renewal.subprocess,
+            "run",
+            return_value=completed,
+        ) as run_mock:
+            payload = renewal._run_runtime_window_import(
+                args=args,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                now=datetime(2026, 5, 25, 21, 23, tzinfo=timezone.utc),
+            )
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["proof_status"], "blocked")
+        self.assertNotIn("offline_replay_triage", payload)
+        command = run_mock.call_args.args[0]
+        self.assertIn("scripts/import_hypothesis_runtime_windows.py", command)
+        self.assertIn("cand-paper-route", command)
+        self.assertIn("proof/exact-replay-ledger.json", command)
+
+    def test_offline_replay_triage_handles_multi_deferred_bounded_sources(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-pairs-01.json"
+        hypothesis_path.write_text(
+            json.dumps({"candidate_id": "cand-paper-route"}),
+            encoding="utf-8",
+        )
+        ranking_path = self.tmp_dir / "exact-replay-ledger-ranking.json"
+        ranking_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "torghut.exact-replay-ledger-ranking.v1",
+                    "candidates": [
+                        {
+                            "candidate_id": f"cand-replay-triage-{index}",
+                            "artifact_ref": f"proof/exact-replay-ledger-{index}.json",
+                            "promotion_status": "blocked_pending_runtime_promotion_proof",
+                        }
+                        for index in range(7)
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        plan_path = self.tmp_dir / "paper-route-plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "next_paper_route_runtime_window_targets": {
+                        "targets": [
+                            {
+                                "candidate_id": "cand-paper-route-a",
+                                "hypothesis_id": "H-PAIRS-01",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "paper-route-candidate-v1",
+                                "source_manifest_ref": str(hypothesis_path),
+                                "source_dsn_env": "SIM_DB_DSN",
+                                "source_kind": "research_handoff",
+                                "artifact_refs": [str(ranking_path)],
+                                "exact_replay_ledger_artifact_refs": [
+                                    "proof/exact-replay-ledger-a.json"
+                                ],
+                                "runtime_ledger_artifact_refs": [
+                                    "proof/runtime-ledger-a.json"
+                                ],
+                                "candidate_selection": "exact_replay_ledger_best_candidate",
+                                "selected_by": "replay_runtime_window_handoff_ranking",
+                                "selection_reason": "blocked_pending_runtime_proof",
+                                "handoff": "runtime_window_import_from_exact_replay_ledger",
+                                "window_start": "2026-05-26T13:30:00Z",
+                                "window_end": "2026-05-26T20:00:00Z",
+                                "paper_route_probe_next_session_max_notional": "25",
+                            },
+                            {
+                                "candidate_id": "cand-paper-route-b",
+                                "hypothesis_id": "H-PAIRS-02",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "paper-route-candidate-v2",
+                                "source_manifest_ref": str(hypothesis_path),
+                                "source_dsn_env": "SIM_DB_DSN",
+                                "source_kind": "research_handoff",
+                                "artifact_refs": [str(ranking_path)],
+                                "exact_replay_ledger_artifact_refs": [
+                                    "proof/exact-replay-ledger-b.json"
+                                ],
+                                "runtime_ledger_artifact_refs": [
+                                    "proof/runtime-ledger-b.json"
+                                ],
+                                "handoff": "runtime_window_import_from_exact_replay_ledger",
+                                "window_start": "2026-05-26T13:30:00Z",
+                                "window_end": "2026-05-26T20:00:00Z",
+                                "paper_route_probe_next_session_max_notional": "25",
+                            },
+                        ],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        args = SimpleNamespace(
+            runtime_window_import=True,
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[str(plan_path)],
+            runtime_window_target_plan_url=[],
+            runtime_window_target_plan_url_timeout_seconds=2.0,
+            runtime_window_target_plan_exclusive=True,
+            runtime_window_target_plan_required=True,
+            runtime_window_target_plan_settlement_seconds=0,
+            runtime_window_targets_from_latest_autoresearch=False,
+            runtime_window_targets_from_registry=False,
+            runtime_window_hypothesis_id="",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_start="",
+            runtime_window_end="",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_source_manifest_ref="",
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with patch.object(
+            renewal.subprocess,
+            "run",
+            side_effect=AssertionError("future target window should not import"),
+        ):
+            payload = renewal._run_runtime_window_import(
+                args=args,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                now=datetime(2026, 5, 25, 20, 23, tzinfo=timezone.utc),
+            )
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertEqual(payload["target_count"], 2)
+        self.assertEqual(
+            [item["status"] for item in payload["imports"]],
+            ["deferred", "deferred"],
+        )
+        triage = payload["offline_replay_triage"]
+        self.assertEqual(
+            triage["source_kind"], "simulation_exact_replay_runtime_ledger"
+        )
+        self.assertEqual(len(triage["source_reports"]), 1)
+        self.assertEqual(len(triage["source_report_candidates"]), 5)
+        self.assertEqual(
+            triage["candidates"][0]["selection"]["selected_by"],
+            "replay_runtime_window_handoff_ranking",
+        )
+        self.assertEqual(
+            triage["candidates"][0]["handoff"],
+            "runtime_window_import_from_exact_replay_ledger",
+        )
+        self.assertEqual(
+            triage["candidates"][0]["exact_replay_ledger_artifact_refs"],
+            ["proof/exact-replay-ledger-a.json", "proof/runtime-ledger-a.json"],
+        )
+
+    def test_offline_replay_triage_artifact_payload_variants(
+        self,
+    ) -> None:
+        handoff_report = renewal._offline_replay_triage_from_artifact_payload(
+            payload={
+                "schema_version": "torghut.replay-runtime-window-handoff.v1",
+                "source": "",
+                "ranking": {"candidates": []},
+                "best_exact_replay_ledger_candidate": {
+                    "candidate_id": "cand-handoff",
+                    "artifact_ref": "proof/handoff-ledger.json",
+                },
+            },
+            source_ref="handoff.json",
+        )
+        self.assertIsNotNone(handoff_report)
+        assert handoff_report is not None
+        self.assertEqual(
+            handoff_report["source"], "exact_replay_ledger_runtime_window_handoff"
+        )
+        self.assertEqual(
+            handoff_report["candidates"][0]["candidate_id"], "cand-handoff"
+        )
+
+        candidate_board_report = renewal._offline_replay_triage_from_artifact_payload(
+            payload={
+                "candidate_board": {
+                    "schema_version": "torghut.strategy-autoresearch-candidate-board.v1",
+                    "best_exact_replay_ledger_candidate": {
+                        "candidate_id": "cand-board",
+                        "artifact_ref": "proof/board-ledger.json",
+                    },
+                }
+            },
+            source_ref="candidate-board.json",
+        )
+        self.assertIsNotNone(candidate_board_report)
+        assert candidate_board_report is not None
+        self.assertEqual(
+            candidate_board_report["source"], "autoresearch_candidate_board"
+        )
+        self.assertEqual(
+            candidate_board_report["candidates"][0]["candidate_id"], "cand-board"
+        )
+
+        self.assertEqual(
+            renewal._offline_replay_triage_candidates_from_ranking(
+                ranking={"candidates": "not-a-list"},
+                source_ref="ranking.json",
+            ),
+            [],
+        )
+        self.assertEqual(
+            renewal._offline_replay_triage_candidates_from_ranking(
+                ranking={"candidates": ["not-a-mapping", {"candidate_id": "cand-ok"}]},
+                source_ref="ranking.json",
+            )[0]["candidate_id"],
+            "cand-ok",
+        )
+
+    def test_offline_replay_triage_early_exit_guards(self) -> None:
+        now = datetime(2026, 5, 25, 20, 23, tzinfo=timezone.utc)
+        args = SimpleNamespace(runtime_window_target_plan_exclusive=False)
+        deferred = {
+            "status": "deferred",
+            "reason": "runtime_window_target_plan_window_not_closed",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "target_metadata": {},
+        }
+
+        self.assertIsNone(
+            renewal._offline_replay_triage_for_deferred_imports(
+                args=args,
+                imports=[deferred],
+                now=now,
+            )
+        )
+        args.runtime_window_target_plan_exclusive = True
+        self.assertIsNone(
+            renewal._offline_replay_triage_for_deferred_imports(
+                args=args,
+                imports=[],
+                now=now,
+            )
+        )
+        self.assertIsNone(
+            renewal._offline_replay_triage_for_deferred_imports(
+                args=args,
+                imports=[
+                    {
+                        **deferred,
+                        "reason": "runtime_window_import_blocked_for_other_reason",
+                    }
+                ],
+                now=now,
+            )
+        )
+        self.assertIsNone(
+            renewal._offline_replay_triage_for_deferred_imports(
+                args=args,
+                imports=[
+                    {
+                        **deferred,
+                        "source_kind": "research_handoff",
+                    }
+                ],
+                now=now,
+            )
+        )
+
     def test_runtime_window_import_future_target_plan_requires_candidate_id(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds a bounded `offline_replay_triage` sidecar for target-plan-exclusive paper-route runtime-window imports that are deferred because the target window is not closed or settlement grace is still pending.
- Marks the sidecar and all triage candidates as non-authoritative research only, with `promotion_allowed: false`, `authority: non_authoritative_research_triage`, and `excluded_from_runtime_window_import_proof: true`.
- Parses only explicit local artifact refs from selected targets for exact-replay ranking or handoff context, without adding sidecar candidates to authoritative imports or proof gates.
- Adds regression coverage for fallback skipping, deferred triage emission, unchanged proof authority, and import-ready paper-route behavior.

## Related Issues

None

## Testing

- `cd services/torghut && PATH="$HOME/.local/bin:$PATH" uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k 'runtime_window_target_plan_exclusive or offline_replay_triage'` — passed, 7 passed / 49 deselected.
- `cd services/torghut && PATH="$HOME/.local/bin:$PATH" uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py` — passed, 56 passed.
- `cd services/torghut && PATH="$HOME/.local/bin:$PATH" uv run --with ruff ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py` — passed.
- `cd services/torghut && PATH="$HOME/.local/bin:$PATH" uv run --with ruff ruff format --check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py` — passed.
- `cd services/torghut && PATH="$HOME/.local/bin:$PATH" uv run --with coverage python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90` — passed after local coverage generation, 149/149 changed renewal-script lines covered.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
