### PR TITLE
fix(synthesis): backfill item embeddings

### DIFF
--- a/apps/synthesis/src/server/store.ts
+++ b/apps/synthesis/src/server/store.ts
@@ -199,6 +199,11 @@ const mergeAttachments = (left: SynthesisAttachment[], right: SynthesisAttachmen
 
 const digestKey = (value: string) => createHash('sha256').update(value).digest('base64url').slice(0, 24)
 
+const embeddingBackfillLimit = () => {
+  const parsed = Number(process.env.SYNTHESIS_EMBEDDING_BACKFILL_LIMIT ?? 1000)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1000
+}
+
 const normalizeSubmitItem = async (input: SubmitItemInput): Promise<NormalizedSubmitItem> => {
   const sourcePosts = input.sourcePosts.map(normalizeSourcePost)
   const primarySource = sourcePosts[0]
@@ -882,6 +887,39 @@ class PostgresSynthesisStore implements SynthesisStore {
     )
   }
 
+  private async backfillMissingEmbeddings() {
+    const result = await this.pool.query<ItemRow>(
+      `SELECT ${this.itemSelectSql('i')}
+       FROM ${this.itemRelationSql('i')}
+       WHERE e.item_id IS NULL
+       ORDER BY i.created_at ASC, i.id ASC
+       LIMIT $1`,
+      [embeddingBackfillLimit()],
+    )
+    if (!result.rows.length) return
+
+    const client = await this.pool.connect()
+    try {
+      for (const row of result.rows) {
+        const item = mapItemRow(row)
+        const embeddingRecord = await createSynthesisEmbedding(
+          buildEmbeddingText({
+            title: item.title,
+            synthesis: item.synthesis,
+            takeaways: item.takeaways,
+            whyValuable: item.whyValuable,
+            topicTags: item.topicTags,
+            factChecks: item.factChecks,
+            sourcePosts: item.sourcePosts,
+          }),
+        )
+        await this.upsertEmbedding(client, item.id, embeddingRecord)
+      }
+    } finally {
+      client.release()
+    }
+  }
+
   private ensureSchema() {
     this.schemaPromise ??= this.createSchema()
     return this.schemaPromise
@@ -1020,6 +1058,7 @@ class PostgresSynthesisStore implements SynthesisStore {
       CREATE INDEX IF NOT EXISTS synthesis_attachments_item_idx ON synthesis_attachments (item_id);
       CREATE INDEX IF NOT EXISTS synthesis_item_embeddings_model_idx ON synthesis_item_embeddings (model, dimension);
     `)
+    await this.backfillMissingEmbeddings()
   }
 }
 

--- a/argocd/applications/synthesis/deployment.yaml
+++ b/argocd/applications/synthesis/deployment.yaml
@@ -50,6 +50,8 @@ spec:
               value: "qwen3-embedding-saigak:8b"
             - name: SYNTHESIS_EMBEDDING_DIMENSION
               value: "4096"
+            - name: SYNTHESIS_EMBEDDING_BACKFILL_LIMIT
+              value: "1000"
             - name: SYNTHESIS_ASSET_STORAGE_REQUIRED
               value: "true"
             - name: SYNTHESIS_ASSET_ENDPOINT

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -10,5 +10,5 @@ resources:
   - networkpolicy.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: 0.576.0
+    newTag: xcurate-backfill-202605260253-9eaea9508
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Backfills missing Postgres `synthesis_item_embeddings` rows at startup using the same local-model embedding path used for new submissions.
- Adds an explicit `SYNTHESIS_EMBEDDING_BACKFILL_LIMIT` deployment setting so stored curation items do not stay invisible to semantic search.
- Pins a verified arm64 image with the backfill code: `registry.ide-newton.ts.net/lab/synthesis:xcurate-backfill-202605260253-9eaea9508` (`sha256:d0c0b84ee7d4d7e114592addf5e9b76d8cc95c312d35c6c1ff5f76fa98717d78`).

## Related Issues

None

## Testing

- `bun run --filter synthesis test`
- `bun run --filter synthesis lint`
- `bun run build:synthesis`
- `kustomize build argocd/applications/synthesis`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/synthesis:xcurate-backfill-202605260253-9eaea9508`

## Screenshots (if applicable)

N/A. This is a server/storage backfill and GitOps rollout fix.

## Breaking Changes

None. The deployment now backfills missing embeddings on startup; production already has the required local embedding endpoint configured.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
