### PR TITLE
fix(torghut): fail closed runtime proof receipts

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -33,6 +33,7 @@ from .models import (
     ExecutionTCAMetric,
     RejectedSignalOutcomeEvent,
     Strategy,
+    StrategyRuntimeLedgerBucket,
     TradeDecision,
     VNextDatasetSnapshot,
     VNextExperimentRun,
@@ -3859,6 +3860,93 @@ def trading_autonomy() -> dict[str, object]:
     }
 
 
+def _runtime_ledger_bucket_evidence_grade(row: StrategyRuntimeLedgerBucket) -> bool:
+    raw_blockers = cast(Sequence[object], row.blockers_json or [])
+    blockers = [str(item).strip() for item in raw_blockers if str(item).strip()]
+    return (
+        row.pnl_basis == "realized_strategy_pnl_after_explicit_costs"
+        and int(row.fill_count or 0) > 0
+        and int(row.submitted_order_count or 0) > 0
+        and int(row.closed_trade_count or 0) > 0
+        and int(row.open_position_count or 0) == 0
+        and row.filled_notional > 0
+        and bool(row.execution_policy_hash_counts)
+        and bool(row.cost_model_hash_counts)
+        and bool(row.lineage_hash_counts)
+        and not blockers
+    )
+
+
+def _daily_runtime_ledger_portfolio_summary(
+    *,
+    session: Session,
+    account_label: str,
+    stage_scope: str,
+    observed_at: datetime,
+) -> dict[str, object]:
+    observed = (
+        observed_at.astimezone(timezone.utc)
+        if observed_at.tzinfo
+        else observed_at.replace(tzinfo=timezone.utc)
+    )
+    day_start = observed.replace(hour=0, minute=0, second=0, microsecond=0)
+    stage = stage_scope.strip()
+    account = account_label.strip()
+    stmt = (
+        select(StrategyRuntimeLedgerBucket)
+        .where(StrategyRuntimeLedgerBucket.bucket_started_at >= day_start)
+        .where(StrategyRuntimeLedgerBucket.bucket_ended_at <= observed)
+        .where(StrategyRuntimeLedgerBucket.account_label == account)
+        .order_by(
+            StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
+            StrategyRuntimeLedgerBucket.created_at.desc(),
+        )
+    )
+    if stage in {"paper", "live"}:
+        stmt = stmt.where(StrategyRuntimeLedgerBucket.observed_stage == stage)
+    else:
+        stmt = stmt.where(StrategyRuntimeLedgerBucket.observed_stage == "__missing__")
+    rows = list(session.execute(stmt.limit(200)).scalars())
+    evidence_rows = [row for row in rows if _runtime_ledger_bucket_evidence_grade(row)]
+    net_pnl = sum(
+        (row.net_strategy_pnl_after_costs for row in evidence_rows),
+        Decimal("0"),
+    )
+    filled_notional = sum(
+        (row.filled_notional for row in evidence_rows),
+        Decimal("0"),
+    )
+    candidate_ids = sorted(
+        {
+            str(row.candidate_id).strip()
+            for row in evidence_rows
+            if str(row.candidate_id or "").strip()
+        }
+    )
+    blockers: list[str] = []
+    if not rows:
+        blockers.append("portfolio_runtime_ledger_summary_missing")
+    elif not evidence_rows:
+        blockers.append("portfolio_runtime_ledger_summary_not_evidence_grade")
+    return {
+        "summary_basis": "runtime_ledger_daily_stage_account_scope",
+        "day_start": day_start.isoformat(),
+        "observed_at": observed.isoformat(),
+        "filters": {
+            "account_label": account,
+            "stage_scope": stage,
+            "observed_stage": stage if stage in {"paper", "live"} else "__missing__",
+        },
+        "bucket_count": len(rows),
+        "evidence_grade_bucket_count": len(evidence_rows),
+        "post_cost_net_pnl_per_day": str(net_pnl),
+        "filled_notional": str(filled_notional),
+        "candidate_ids": candidate_ids,
+        "db_row_refs": [str(row.id) for row in evidence_rows],
+        "blockers": blockers,
+    }
+
+
 def _build_current_evidence_epoch(
     *,
     session: Session,
@@ -3981,13 +4069,44 @@ def _build_current_evidence_epoch(
             observed_at=observed_at,
         )
     )
+    portfolio_runtime_ledger_summary = _daily_runtime_ledger_portfolio_summary(
+        session=session,
+        account_label=account_label,
+        stage_scope=stage_scope,
+        observed_at=observed_at,
+    )
+    candidate_ids_raw = portfolio_runtime_ledger_summary.get("candidate_ids")
+    candidate_id_items: Sequence[object]
+    if isinstance(candidate_ids_raw, Sequence) and not isinstance(
+        candidate_ids_raw, (str, bytes, bytearray)
+    ):
+        candidate_id_items = cast(Sequence[object], candidate_ids_raw)
+    else:
+        candidate_id_items = ()
+    portfolio_candidate_ids = [
+        str(item).strip() for item in candidate_id_items if str(item).strip()
+    ]
+    portfolio_runtime_ledger_bucket_count = int(
+        Decimal(str(portfolio_runtime_ledger_summary.get("bucket_count") or "0"))
+    )
     receipts.append(
         build_portfolio_proof_receipt(
-            portfolio_candidate_id="",
+            portfolio_candidate_id=(
+                ",".join(portfolio_candidate_ids) if portfolio_candidate_ids else ""
+            ),
             target_net_pnl_per_day=Decimal("500"),
-            post_cost_net_pnl_per_day=Decimal("0"),
+            post_cost_net_pnl_per_day=Decimal(
+                str(
+                    portfolio_runtime_ledger_summary.get("post_cost_net_pnl_per_day")
+                    or "0"
+                )
+            ),
             holdout_result=None,
             runtime_closure_artifact_refs=(),
+            runtime_ledger_summary=portfolio_runtime_ledger_summary
+            if portfolio_runtime_ledger_bucket_count > 0
+            else None,
+            require_runtime_ledger_summary=True,
             observed_at=observed_at,
         )
     )

--- a/services/torghut/app/trading/completion.py
+++ b/services/torghut/app/trading/completion.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
+from zoneinfo import ZoneInfo
 
 import yaml
 from sqlalchemy import select
@@ -61,6 +62,7 @@ DOC29_EMPIRICAL_JOBS_GATE = 'empirical_jobs_persisted'
 DOC29_PAPER_GATE = 'paper_gate_satisfied'
 DOC29_LIVE_CANARY_GATE = 'live_canary_observed'
 DOC29_LIVE_SCALE_GATE = 'live_scale_observed'
+US_EQUITIES_REGULAR_TIMEZONE = 'America/New_York'
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
@@ -114,6 +116,30 @@ def _safe_float(value: Any, *, default: float = 0.0) -> float:
             except ValueError:
                 return default
     return default
+
+
+def _runtime_ledger_trading_day_key(dt: datetime) -> str:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(ZoneInfo(US_EQUITIES_REGULAR_TIMEZONE)).date().isoformat()
+
+
+def _median_decimal(values: Sequence[Decimal]) -> Decimal:
+    if not values:
+        return Decimal('0')
+    sorted_values = sorted(values)
+    middle = len(sorted_values) // 2
+    if len(sorted_values) % 2:
+        return sorted_values[middle]
+    return (sorted_values[middle - 1] + sorted_values[middle]) / Decimal('2')
+
+
+def _p10_decimal(values: Sequence[Decimal]) -> Decimal:
+    if not values:
+        return Decimal('0')
+    sorted_values = sorted(values)
+    index = max(0, ((len(sorted_values) + 9) // 10) - 1)
+    return sorted_values[index]
 
 
 def _gate_policy_parameters(
@@ -609,7 +635,9 @@ def _runtime_ledger_bucket_matches_window(
     return bucket_started <= window_ended and bucket_ended >= window_started
 
 
-def _runtime_ledger_bucket_is_promotion_grade(bucket: StrategyRuntimeLedgerBucket) -> bool:
+def _runtime_ledger_bucket_is_promotion_grade(
+    bucket: StrategyRuntimeLedgerBucket,
+) -> bool:
     blockers = [item for item in _as_list(bucket.blockers_json) if str(item).strip()]
     return (
         _as_text(bucket.ledger_schema_version) in _RUNTIME_LEDGER_BUCKET_SCHEMAS
@@ -639,22 +667,86 @@ def _runtime_ledger_bucket_summary(
         Decimal('0'),
     )
     expectancy_bps = (
-        float((total_net_pnl / total_filled_notional) * Decimal('10000'))
-        if total_filled_notional > 0
-        else 0.0
+        float((total_net_pnl / total_filled_notional) * Decimal('10000')) if total_filled_notional > 0 else 0.0
     )
+    daily_summary = _runtime_ledger_daily_summary(rows)
     return {
         'runtime_ledger_bucket_count': len(rows),
         'runtime_ledger_fill_count': sum(max(0, _safe_int(row.fill_count)) for row in rows),
-        'runtime_ledger_submitted_order_count': sum(
-            max(0, _safe_int(row.submitted_order_count)) for row in rows
-        ),
+        'runtime_ledger_submitted_order_count': sum(max(0, _safe_int(row.submitted_order_count)) for row in rows),
         'runtime_ledger_closed_trade_count': sum(max(0, _safe_int(row.closed_trade_count)) for row in rows),
         'runtime_ledger_filled_notional': float(total_filled_notional),
         'runtime_ledger_net_strategy_pnl_after_costs': float(total_net_pnl),
         'runtime_ledger_post_cost_expectancy_bps': expectancy_bps,
+        **daily_summary,
         'db_row_refs': [str(row.id) for row in rows],
     }
+
+
+def _runtime_ledger_daily_summary(
+    rows: Sequence[StrategyRuntimeLedgerBucket],
+) -> dict[str, Any]:
+    persisted = _runtime_ledger_persisted_daily_summary(rows)
+    if persisted:
+        return persisted
+    trading_days = sorted({_runtime_ledger_trading_day_key(row.bucket_started_at) for row in rows})
+    net_pnl_by_day = {day: Decimal('0') for day in trading_days}
+    filled_notional_by_day = {day: Decimal('0') for day in trading_days}
+    closed_trade_count_by_day = {day: 0 for day in trading_days}
+    cumulative_by_day = {day: Decimal('0') for day in trading_days}
+    peak_by_day = {day: Decimal('0') for day in trading_days}
+    max_intraday_drawdown = Decimal('0')
+    for row in sorted(rows, key=lambda item: item.bucket_started_at or item.created_at):
+        day = _runtime_ledger_trading_day_key(row.bucket_started_at)
+        net_pnl = row.net_strategy_pnl_after_costs or Decimal('0')
+        net_pnl_by_day[day] += net_pnl
+        filled_notional_by_day[day] += row.filled_notional or Decimal('0')
+        closed_trade_count_by_day[day] += max(0, _safe_int(row.closed_trade_count))
+        cumulative_by_day[day] += net_pnl
+        if cumulative_by_day[day] > peak_by_day[day]:
+            peak_by_day[day] = cumulative_by_day[day]
+        drawdown = peak_by_day[day] - cumulative_by_day[day]
+        if drawdown > max_intraday_drawdown:
+            max_intraday_drawdown = drawdown
+    day_count = len(trading_days)
+    daily_net_values = [net_pnl_by_day[day] for day in trading_days]
+    total_daily_net_pnl = sum(daily_net_values, Decimal('0'))
+    total_filled_notional = sum(
+        (filled_notional_by_day[day] for day in trading_days),
+        Decimal('0'),
+    )
+    mean_daily_net_pnl = total_daily_net_pnl / Decimal(day_count) if day_count > 0 else Decimal('0')
+    avg_daily_filled_notional = total_filled_notional / Decimal(day_count) if day_count > 0 else Decimal('0')
+    return {
+        'runtime_ledger_observed_trading_day_count': day_count,
+        'runtime_ledger_net_pnl_by_trading_day': {day: str(net_pnl_by_day[day]) for day in trading_days},
+        'runtime_ledger_mean_daily_net_pnl_after_costs': str(mean_daily_net_pnl),
+        'runtime_ledger_median_daily_net_pnl_after_costs': str(_median_decimal(daily_net_values)),
+        'runtime_ledger_p10_daily_net_pnl_after_costs': str(_p10_decimal(daily_net_values)),
+        'runtime_ledger_worst_day_net_pnl_after_costs': str(
+            min(daily_net_values) if daily_net_values else Decimal('0')
+        ),
+        'runtime_ledger_max_intraday_drawdown': str(max_intraday_drawdown),
+        'runtime_ledger_avg_daily_filled_notional': str(avg_daily_filled_notional),
+        'runtime_ledger_closed_trade_count_by_day': {day: closed_trade_count_by_day[day] for day in trading_days},
+    }
+
+
+def _runtime_ledger_persisted_daily_summary(
+    rows: Sequence[StrategyRuntimeLedgerBucket],
+) -> dict[str, Any]:
+    selected: dict[str, Any] = {}
+    selected_day_count = -1
+    for row in rows:
+        payload = _as_dict(row.payload_json)
+        summary = _as_dict(payload.get('runtime_ledger_daily_summary'))
+        if not summary:
+            continue
+        day_count = _safe_int(summary.get('runtime_ledger_observed_trading_day_count'))
+        if day_count > selected_day_count:
+            selected = summary
+            selected_day_count = day_count
+    return dict(selected)
 
 
 def _runtime_ledger_bucket_refs_for_windows(

--- a/services/torghut/app/trading/evidence_receipts.py
+++ b/services/torghut/app/trading/evidence_receipts.py
@@ -465,6 +465,8 @@ def build_portfolio_proof_receipt(
     holdout_result: Mapping[str, object] | None,
     runtime_closure_artifact_refs: Sequence[str],
     contribution: Mapping[str, object] | None = None,
+    runtime_ledger_summary: Mapping[str, object] | None = None,
+    require_runtime_ledger_summary: bool = False,
     observed_at: datetime | None = None,
     ttl_seconds: int = _DEFAULT_TTL_SECONDS,
 ) -> EvidenceReceipt:
@@ -472,8 +474,19 @@ def build_portfolio_proof_receipt(
     holdout = dict(holdout_result or {})
     holdout_status = _string(holdout.get("status"))
     refs = tuple(item for item in runtime_closure_artifact_refs if item.strip())
+    ledger_summary = dict(runtime_ledger_summary or {})
     reasons: list[str] = []
-    if not _string(portfolio_candidate_id):
+    if require_runtime_ledger_summary and not ledger_summary:
+        state: ReceiptState = "missing"
+        reasons.append("portfolio_runtime_ledger_summary_missing")
+    elif (
+        require_runtime_ledger_summary
+        and int(Decimal(str(ledger_summary.get("evidence_grade_bucket_count") or "0")))
+        <= 0
+    ):
+        state = "fail"
+        reasons.append("portfolio_runtime_ledger_summary_not_evidence_grade")
+    elif not _string(portfolio_candidate_id):
         state: ReceiptState = "missing"
         reasons.append("portfolio_proof_missing")
     elif post_cost_net_pnl_per_day < target_net_pnl_per_day:
@@ -506,6 +519,8 @@ def build_portfolio_proof_receipt(
             "holdout_result": holdout,
             "runtime_closure_artifact_refs": list(refs),
             "contribution": dict(contribution or {}),
+            "runtime_ledger_summary": ledger_summary,
+            "require_runtime_ledger_summary": require_runtime_ledger_summary,
         },
         ttl_seconds=ttl_seconds,
         consumer_refs=("paper", "canary", "live", "scale"),

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -970,6 +970,108 @@ def _runtime_ledger_post_cost_from_observed_buckets(
     )
 
 
+def _runtime_ledger_trading_day_key(dt: datetime) -> str:
+    return (
+        _utc(dt).astimezone(ZoneInfo(US_EQUITIES_REGULAR_TIMEZONE)).date().isoformat()
+    )
+
+
+def _median_decimal(values: Sequence[Decimal]) -> Decimal:
+    if not values:
+        return Decimal("0")
+    sorted_values = sorted(values)
+    middle = len(sorted_values) // 2
+    if len(sorted_values) % 2:
+        return sorted_values[middle]
+    return (sorted_values[middle - 1] + sorted_values[middle]) / Decimal("2")
+
+
+def _p10_decimal(values: Sequence[Decimal]) -> Decimal:
+    if not values:
+        return Decimal("0")
+    sorted_values = sorted(values)
+    index = max(0, ((len(sorted_values) + 9) // 10) - 1)
+    return sorted_values[index]
+
+
+def _runtime_ledger_daily_summary_from_observed_buckets(
+    buckets: Sequence[ObservedRuntimeBucket],
+) -> dict[str, Any]:
+    ordered_buckets = sorted(buckets, key=lambda item: item.window_started_at)
+    trading_days = sorted(
+        {
+            _runtime_ledger_trading_day_key(bucket.window_started_at)
+            for bucket in ordered_buckets
+        }
+    )
+    net_pnl_by_day = {day: Decimal("0") for day in trading_days}
+    filled_notional_by_day = {day: Decimal("0") for day in trading_days}
+    closed_trade_count_by_day = {day: 0 for day in trading_days}
+    cumulative_by_day = {day: Decimal("0") for day in trading_days}
+    peak_by_day = {day: Decimal("0") for day in trading_days}
+    max_intraday_drawdown = Decimal("0")
+
+    for bucket in ordered_buckets:
+        day = _runtime_ledger_trading_day_key(bucket.window_started_at)
+        bucket_net_pnl = Decimal("0")
+        for ledger_payload in _runtime_ledger_bucket_payloads(bucket.payload_json):
+            if _runtime_ledger_bucket_blockers(ledger_payload):
+                continue
+            net_pnl = _optional_decimal(
+                ledger_payload.get("net_strategy_pnl_after_costs")
+            )
+            filled_notional = _optional_decimal(ledger_payload.get("filled_notional"))
+            if net_pnl is not None:
+                bucket_net_pnl += net_pnl
+                net_pnl_by_day[day] += net_pnl
+            if filled_notional is not None and filled_notional > 0:
+                filled_notional_by_day[day] += filled_notional
+            closed_trade_count_by_day[day] += _observation_int(
+                ledger_payload.get("closed_trade_count")
+            )
+        cumulative_by_day[day] += bucket_net_pnl
+        if cumulative_by_day[day] > peak_by_day[day]:
+            peak_by_day[day] = cumulative_by_day[day]
+        drawdown = peak_by_day[day] - cumulative_by_day[day]
+        if drawdown > max_intraday_drawdown:
+            max_intraday_drawdown = drawdown
+
+    day_count = len(trading_days)
+    daily_net_values = [net_pnl_by_day[day] for day in trading_days]
+    total_daily_net_pnl = sum(daily_net_values, Decimal("0"))
+    total_filled_notional = sum(
+        (filled_notional_by_day[day] for day in trading_days),
+        Decimal("0"),
+    )
+    mean_daily_net_pnl = (
+        total_daily_net_pnl / Decimal(day_count) if day_count > 0 else Decimal("0")
+    )
+    avg_daily_filled_notional = (
+        total_filled_notional / Decimal(day_count) if day_count > 0 else Decimal("0")
+    )
+    return {
+        "runtime_ledger_observed_trading_day_count": day_count,
+        "runtime_ledger_net_pnl_by_trading_day": {
+            day: str(net_pnl_by_day[day]) for day in trading_days
+        },
+        "runtime_ledger_mean_daily_net_pnl_after_costs": str(mean_daily_net_pnl),
+        "runtime_ledger_median_daily_net_pnl_after_costs": str(
+            _median_decimal(daily_net_values)
+        ),
+        "runtime_ledger_p10_daily_net_pnl_after_costs": str(
+            _p10_decimal(daily_net_values)
+        ),
+        "runtime_ledger_worst_day_net_pnl_after_costs": str(
+            min(daily_net_values) if daily_net_values else Decimal("0")
+        ),
+        "runtime_ledger_max_intraday_drawdown": str(max_intraday_drawdown),
+        "runtime_ledger_avg_daily_filled_notional": str(avg_daily_filled_notional),
+        "runtime_ledger_closed_trade_count_by_day": {
+            day: closed_trade_count_by_day[day] for day in trading_days
+        },
+    }
+
+
 def persist_observed_runtime_windows(
     *,
     session: Session,
@@ -1108,6 +1210,9 @@ def persist_observed_runtime_windows(
     ]
     raw_window_count = len(raw_buckets)
     skipped_zero_activity_window_count = raw_window_count - len(sorted_buckets)
+    runtime_ledger_daily_summary = _runtime_ledger_daily_summary_from_observed_buckets(
+        raw_buckets
+    )
     inserted = len(sorted_buckets)
     total_session_samples = sum(
         bucket.market_session_count for bucket in sorted_buckets
@@ -1342,7 +1447,10 @@ def persist_observed_runtime_windows(
                     )
                     or None,
                     blockers_json=_string_list(ledger_payload.get("blockers")),
-                    payload_json=ledger_payload,
+                    payload_json={
+                        **ledger_payload,
+                        "runtime_ledger_daily_summary": runtime_ledger_daily_summary,
+                    },
                 )
             )
 
@@ -1384,6 +1492,7 @@ def persist_observed_runtime_windows(
                 "runtime_ledger_net_strategy_pnl_after_costs": str(
                     runtime_ledger_net_strategy_pnl_after_costs
                 ),
+                **runtime_ledger_daily_summary,
                 "promotion_allowed": promotion_allowed,
                 "promotion_blocking_reasons": promotion_blocking_reasons,
                 "delay_adjusted_depth_stress": delay_depth_stress_summary,
@@ -1420,6 +1529,7 @@ def persist_observed_runtime_windows(
                 "runtime_ledger_net_strategy_pnl_after_costs": str(
                     runtime_ledger_net_strategy_pnl_after_costs
                 ),
+                **runtime_ledger_daily_summary,
                 "latest_three_within_budget": latest_three_budget_ok,
                 "promotion_allowed": promotion_allowed,
                 "promotion_blocking_reasons": promotion_blocking_reasons,
@@ -1451,6 +1561,7 @@ def persist_observed_runtime_windows(
         "runtime_ledger_net_strategy_pnl_after_costs": str(
             runtime_ledger_net_strategy_pnl_after_costs
         ),
+        **runtime_ledger_daily_summary,
         "latest_three_within_budget": latest_three_budget_ok,
         "slippage_budget_bps": str(budget),
         "promotion_allowed": promotion_allowed,

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -353,7 +353,8 @@ def _runtime_ledger_tca_row_from_bucket(
             bucket.bucket_started_at,
             bucket.bucket_ended_at - timedelta(microseconds=1),
         ),
-        "abs_slippage_bps": (
+        "abs_slippage_bps": None,
+        "explicit_cost_bps": (
             (bucket.cost_amount / bucket.filled_notional) * Decimal("10000")
             if bucket.filled_notional > 0
             else None
@@ -535,6 +536,60 @@ def _runtime_ledger_target_metadata_blockers(
             blockers.append("runtime_ledger_artifact_window_weekday_count_below_min")
 
     return list(dict.fromkeys(blockers))
+
+
+def _runtime_window_source_kind_is_informational(
+    *,
+    source_kind: str,
+    target_metadata: Mapping[str, Any],
+) -> bool:
+    normalized = source_kind.strip().lower().replace("-", "_")
+    if normalized.startswith("simulation_"):
+        return True
+    if any(
+        marker in normalized
+        for marker in (
+            "informational",
+            "non_authoritative",
+            "offline_replay_triage",
+            "selection_only",
+        )
+    ):
+        return True
+    scope = (
+        str(
+            target_metadata.get("paper_probation_authorization_scope")
+            or target_metadata.get("evidence_scope")
+            or ""
+        )
+        .strip()
+        .lower()
+        .replace("-", "_")
+    )
+    return scope == "evidence_collection_only"
+
+
+def _runtime_window_import_proof_hygiene_blockers(
+    *,
+    source_kind: str,
+    target_metadata: Mapping[str, Any],
+    dependency_quorum_decision: str,
+    continuity_ok: str,
+    drift_ok: str,
+) -> list[str]:
+    blockers: list[str] = []
+    if not target_metadata and not _runtime_window_source_kind_is_informational(
+        source_kind=source_kind,
+        target_metadata=target_metadata,
+    ):
+        blockers.append("runtime_window_target_metadata_missing")
+    if not dependency_quorum_decision.strip():
+        blockers.append("dependency_quorum_decision_missing")
+    if not continuity_ok.strip():
+        blockers.append("continuity_gate_missing")
+    if not drift_ok.strip():
+        blockers.append("drift_gate_missing")
+    return blockers
 
 
 def _runtime_ledger_profit_proof_present(
@@ -747,6 +802,9 @@ def _build_realized_strategy_pnl_rows(
         )
         row["post_cost_expectancy_basis"] = POST_COST_BASIS_EXECUTION_RECONSTRUCTION
         row["post_cost_promotion_eligible"] = False
+        row["authoritative"] = False
+        row["authority_reason"] = "execution_reconstruction_not_runtime_ledger_proof"
+        row["pnl_derivation"] = "execution_reconstructed_from_execution_rows"
         row["promotion_blocker"] = "execution_reconstruction_not_runtime_ledger_proof"
         blockers = list(row.get("runtime_ledger_blockers") or [])
         if "execution_reconstruction_not_runtime_ledger_proof" not in blockers:
@@ -757,6 +815,10 @@ def _build_realized_strategy_pnl_rows(
             bucket_payload = dict(bucket_payload)
             bucket_payload["blockers"] = blockers
             bucket_payload["pnl_basis"] = POST_COST_BASIS_EXECUTION_RECONSTRUCTION
+            bucket_payload["authoritative"] = False
+            bucket_payload["authority_reason"] = (
+                "execution_reconstruction_not_runtime_ledger_proof"
+            )
             row["runtime_ledger_bucket"] = bucket_payload
         realized_rows.append(row)
     return realized_rows
@@ -1549,6 +1611,7 @@ def _source_activity_missing_summary(
     dataset_snapshot_ref: str | None,
     source_activity_symbols: Sequence[str] | None = None,
     target_metadata: Mapping[str, Any] | None = None,
+    proof_hygiene_blockers: Sequence[str] = (),
 ) -> dict[str, Any]:
     metadata = _as_mapping(target_metadata)
     symbol_filter = _metadata_symbol_list(source_activity_symbols or ())
@@ -1568,10 +1631,26 @@ def _source_activity_missing_summary(
             "before importing promotion evidence."
         ),
     }
+    proof_blockers = [blocker]
+    for reason in proof_hygiene_blockers:
+        proof_blockers.append(
+            {
+                "blocker": reason,
+                "hypothesis_id": hypothesis_id,
+                "candidate_id": candidate_id or None,
+                "observed_stage": observed_stage,
+                "window_start": window_start.isoformat(),
+                "window_end": window_end.isoformat(),
+                "remediation": (
+                    "Provide explicit runtime-window target metadata and health-gate "
+                    "inputs before treating this import as proof-grade evidence."
+                ),
+            }
+        )
     return {
         "status": "skipped",
         "proof_status": "blocked",
-        "proof_blockers": [blocker],
+        "proof_blockers": proof_blockers,
         "run_id": run_id,
         "candidate_id": candidate_id or None,
         "hypothesis_id": hypothesis_id,
@@ -1635,6 +1714,9 @@ def main() -> int:
         str(getattr(args, "target_metadata_json", "") or "")
     )
     source_activity_symbols = _target_metadata_source_symbols(target_metadata)
+    source_kind = args.source_kind.strip() or (
+        "simulation_paper_runtime" if args.observed_stage == "paper" else "live_runtime"
+    )
     decisions: list[datetime] = []
     executions: list[datetime] = []
     tca_rows: list[dict[str, object]] = []
@@ -1729,11 +1811,24 @@ def main() -> int:
     dataset_snapshot_ref = (
         str(getattr(args, "dataset_snapshot_ref", "") or "").strip() or None
     )
-    runtime_ledger_target_metadata_blockers = _runtime_ledger_target_metadata_blockers(
-        target_metadata=target_metadata,
-        runtime_ledger_artifact_metadata=runtime_ledger_artifact_metadata,
-        window_start=window_start,
-        window_end=window_end,
+    runtime_ledger_target_metadata_blockers = list(
+        dict.fromkeys(
+            [
+                *_runtime_ledger_target_metadata_blockers(
+                    target_metadata=target_metadata,
+                    runtime_ledger_artifact_metadata=runtime_ledger_artifact_metadata,
+                    window_start=window_start,
+                    window_end=window_end,
+                ),
+                *_runtime_window_import_proof_hygiene_blockers(
+                    source_kind=source_kind,
+                    target_metadata=target_metadata,
+                    dependency_quorum_decision=args.dependency_quorum_decision,
+                    continuity_ok=args.continuity_ok,
+                    drift_ok=args.drift_ok,
+                ),
+            ]
+        )
     )
     if not decisions and not executions and not tca_rows:
         summary = _source_activity_missing_summary(
@@ -1751,6 +1846,7 @@ def main() -> int:
             dataset_snapshot_ref=dataset_snapshot_ref,
             source_activity_symbols=source_activity_symbols,
             target_metadata=target_metadata,
+            proof_hygiene_blockers=runtime_ledger_target_metadata_blockers,
         )
         if args.json:
             print(json.dumps(summary, indent=2))
@@ -1799,9 +1895,6 @@ def main() -> int:
         "paper_runtime_observed"
         if args.observed_stage == "paper"
         else "live_runtime_observed"
-    )
-    source_kind = args.source_kind.strip() or (
-        "simulation_paper_runtime" if args.observed_stage == "paper" else "live_runtime"
     )
     runtime_observation_payload = {
         **_runtime_observation_authority_payload(

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -1677,17 +1677,15 @@ def _runtime_window_import_health_gate_args(
     dependency_quorum_decision = (
         _as_text(target.dependency_quorum_decision)
         or _as_text(runtime_manifest.get("dependency_quorum_decision"))
-        or "missing"
+        or ""
     )
     continuity_ok = (
         _as_text(target.continuity_ok)
         or _as_text(runtime_manifest.get("continuity_ok"))
-        or "false"
+        or ""
     )
     drift_ok = (
-        _as_text(target.drift_ok)
-        or _as_text(runtime_manifest.get("drift_ok"))
-        or "false"
+        _as_text(target.drift_ok) or _as_text(runtime_manifest.get("drift_ok")) or ""
     )
     return dependency_quorum_decision, continuity_ok, drift_ok
 

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -461,6 +461,27 @@ def _runtime_ledger_trading_day_count(
     return 0, None
 
 
+def _runtime_ledger_daily_net_pnl(
+    summary: Mapping[str, Any],
+    *,
+    net_pnl: Decimal | None,
+    trading_day_count: int,
+) -> tuple[Decimal | None, str]:
+    for key in (
+        "runtime_ledger_mean_daily_net_pnl_after_costs",
+        "runtime_ledger_daily_net_pnl_after_costs",
+        "mean_daily_net_pnl_after_costs",
+        "daily_net_pnl_after_costs",
+    ):
+        if key in summary:
+            parsed = _decimal(summary.get(key))
+            if parsed is not None:
+                return parsed, key
+    if net_pnl is not None and trading_day_count > 0:
+        return net_pnl / Decimal(trading_day_count), "computed_from_total_net_pnl"
+    return None, "missing"
+
+
 def _add_runtime_ledger_proof_packet_check(
     checks: dict[str, dict[str, Any]],
     runtime_ledger_proof_packet: Mapping[str, Any] | None,
@@ -599,10 +620,10 @@ def _add_runtime_ledger_profit_proof_checks(
         observed=str(net_pnl) if net_pnl is not None else None,
         expected=f">={min_runtime_ledger_net_pnl}",
     )
-    daily_net_pnl = (
-        net_pnl / Decimal(trading_day_count)
-        if net_pnl is not None and trading_day_count > 0
-        else None
+    daily_net_pnl, daily_net_pnl_key = _runtime_ledger_daily_net_pnl(
+        summary,
+        net_pnl=net_pnl,
+        trading_day_count=trading_day_count,
     )
     daily_net_pnl_required = min_runtime_ledger_daily_net_pnl > 0
     _add_check(
@@ -615,7 +636,10 @@ def _add_runtime_ledger_profit_proof_checks(
         ),
         observed=str(daily_net_pnl) if daily_net_pnl is not None else None,
         expected=f">={min_runtime_ledger_daily_net_pnl}",
-        detail={"trading_day_count": trading_day_count},
+        detail={
+            "trading_day_count": trading_day_count,
+            "source_key": daily_net_pnl_key,
+        },
     )
     _add_check(
         checks,

--- a/services/torghut/tests/test_completion_trace.py
+++ b/services/torghut/tests/test_completion_trace.py
@@ -23,6 +23,10 @@ from app.trading.completion import (
     DOC29_PAPER_GATE,
     DOC29_SIMULATION_FULL_DAY_GATE,
     TRACE_STATUS_SATISFIED,
+    _median_decimal,
+    _p10_decimal,
+    _runtime_ledger_daily_summary,
+    _runtime_ledger_trading_day_key,
     build_completion_trace,
     build_doc29_completion_status,
     persist_completion_trace,
@@ -165,6 +169,68 @@ class TestCompletionTrace(TestCase):
 
     def test_runtime_and_doc_completion_matrices_match(self) -> None:
         self.assertTrue(runtime_and_doc_completion_matrices_match())
+
+    def test_runtime_ledger_daily_summary_counts_day_distribution_and_drawdown(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _runtime_ledger_trading_day_key(datetime(2026, 3, 6, 14, 30)),
+            '2026-03-06',
+        )
+        self.assertEqual(
+            _median_decimal([Decimal('3'), Decimal('1'), Decimal('2')]),
+            Decimal('2'),
+        )
+        self.assertEqual(_p10_decimal([Decimal('5'), Decimal('-1')]), Decimal('-1'))
+
+        rows = [
+            _runtime_ledger_bucket(
+                run_id='daily-positive',
+                bucket_started_at=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                bucket_ended_at=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                payload_json={'source': 'raw-runtime-ledger'},
+            ),
+            _runtime_ledger_bucket(
+                run_id='daily-drawdown',
+                bucket_started_at=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                bucket_ended_at=datetime(2026, 3, 6, 15, 30, tzinfo=timezone.utc),
+                payload_json={'source': 'raw-runtime-ledger'},
+            ),
+            _runtime_ledger_bucket(
+                run_id='persisted-summary',
+                bucket_started_at=datetime(2026, 3, 9, 13, 30, tzinfo=timezone.utc),
+                bucket_ended_at=datetime(2026, 3, 9, 14, 0, tzinfo=timezone.utc),
+                payload_json={
+                    'runtime_ledger_daily_summary': {
+                        'runtime_ledger_observed_trading_day_count': 25,
+                        'runtime_ledger_mean_daily_net_pnl_after_costs': '24',
+                    }
+                },
+            ),
+        ]
+        rows[0].net_strategy_pnl_after_costs = Decimal('100')
+        rows[1].net_strategy_pnl_after_costs = Decimal('-40')
+
+        summary = _runtime_ledger_daily_summary(rows[:2])
+        self.assertEqual(
+            summary['runtime_ledger_net_pnl_by_trading_day'],
+            {'2026-03-06': '60'},
+        )
+        self.assertEqual(summary['runtime_ledger_max_intraday_drawdown'], '40')
+        self.assertEqual(
+            summary['runtime_ledger_closed_trade_count_by_day'],
+            {'2026-03-06': 12},
+        )
+
+        persisted_summary = _runtime_ledger_daily_summary(rows)
+        self.assertEqual(
+            persisted_summary['runtime_ledger_observed_trading_day_count'],
+            25,
+        )
+        self.assertEqual(
+            persisted_summary['runtime_ledger_mean_daily_net_pnl_after_costs'],
+            '24',
+        )
 
     def test_persist_completion_trace_round_trips_gate_rows(self) -> None:
         trace = build_completion_trace(
@@ -604,6 +670,50 @@ class TestCompletionTrace(TestCase):
         self.assertEqual(
             scale_gate['runtime_ledger_summary']['runtime_ledger_mean_daily_net_pnl_after_costs'],
             '24',
+        )
+
+    def test_runtime_ledger_daily_summary_falls_back_to_bucket_rows(self) -> None:
+        first = _runtime_ledger_bucket(
+            run_id='fallback-day-1a',
+            bucket_started_at=datetime(2026, 3, 6, 14, 30),
+            bucket_ended_at=datetime(2026, 3, 6, 15, 0),
+        )
+        first.net_strategy_pnl_after_costs = Decimal('100')
+        first.filled_notional = Decimal('1000')
+        first.closed_trade_count = 2
+        second = _runtime_ledger_bucket(
+            run_id='fallback-day-1b',
+            bucket_started_at=datetime(2026, 3, 6, 15, 0),
+            bucket_ended_at=datetime(2026, 3, 6, 15, 30),
+        )
+        second.net_strategy_pnl_after_costs = Decimal('-130')
+        second.filled_notional = Decimal('500')
+        second.closed_trade_count = -2
+        third = _runtime_ledger_bucket(
+            run_id='fallback-day-2',
+            bucket_started_at=datetime(2026, 3, 9, 14, 30),
+            bucket_ended_at=datetime(2026, 3, 9, 15, 0),
+        )
+        third.net_strategy_pnl_after_costs = Decimal('10')
+        third.filled_notional = Decimal('100')
+        third.closed_trade_count = 0
+
+        summary = _runtime_ledger_daily_summary([first, second, third])
+
+        self.assertEqual(summary['runtime_ledger_observed_trading_day_count'], 2)
+        self.assertEqual(
+            summary['runtime_ledger_net_pnl_by_trading_day'],
+            {'2026-03-06': '-30', '2026-03-09': '10'},
+        )
+        self.assertEqual(summary['runtime_ledger_mean_daily_net_pnl_after_costs'], '-10')
+        self.assertEqual(summary['runtime_ledger_median_daily_net_pnl_after_costs'], '-10')
+        self.assertEqual(summary['runtime_ledger_p10_daily_net_pnl_after_costs'], '-30')
+        self.assertEqual(summary['runtime_ledger_worst_day_net_pnl_after_costs'], '-30')
+        self.assertEqual(summary['runtime_ledger_max_intraday_drawdown'], '130')
+        self.assertEqual(summary['runtime_ledger_avg_daily_filled_notional'], '800')
+        self.assertEqual(
+            summary['runtime_ledger_closed_trade_count_by_day'],
+            {'2026-03-06': 2, '2026-03-09': 0},
         )
 
     def test_doc29_live_scale_blocks_non_runtime_ledger_window_pnl(self) -> None:

--- a/services/torghut/tests/test_completion_trace.py
+++ b/services/torghut/tests/test_completion_trace.py
@@ -81,6 +81,7 @@ def _runtime_ledger_bucket(
     bucket_started_at: datetime,
     bucket_ended_at: datetime,
     ledger_schema_version: str = 'torghut.runtime-ledger-bucket.v1',
+    payload_json: dict[str, object] | None = None,
 ) -> StrategyRuntimeLedgerBucket:
     return StrategyRuntimeLedgerBucket(
         run_id=run_id,
@@ -110,7 +111,7 @@ def _runtime_ledger_bucket(
         cost_model_hash_counts={'cost-hash': 12},
         lineage_hash_counts={'lineage-hash': 12},
         blockers_json=[],
-        payload_json={'source': 'test-runtime-ledger'},
+        payload_json=payload_json or {'source': 'test-runtime-ledger'},
     )
 
 
@@ -510,6 +511,23 @@ class TestCompletionTrace(TestCase):
                 )
 
             live_window_start = now - timedelta(days=1)
+            runtime_daily_summary = {
+                'runtime_ledger_observed_trading_day_count': 25,
+                'runtime_ledger_net_pnl_by_trading_day': {
+                    '2026-03-06': '600',
+                    '2026-03-09': '0',
+                },
+                'runtime_ledger_mean_daily_net_pnl_after_costs': '24',
+                'runtime_ledger_median_daily_net_pnl_after_costs': '0',
+                'runtime_ledger_p10_daily_net_pnl_after_costs': '0',
+                'runtime_ledger_worst_day_net_pnl_after_costs': '0',
+                'runtime_ledger_max_intraday_drawdown': '0',
+                'runtime_ledger_avg_daily_filled_notional': '4800',
+                'runtime_ledger_closed_trade_count_by_day': {
+                    '2026-03-06': 6,
+                    '2026-03-09': 0,
+                },
+            }
             for index in range(10):
                 run_id = f'live-run-{index}'
                 live_window_end = live_window_start + timedelta(minutes=index + 1)
@@ -552,6 +570,10 @@ class TestCompletionTrace(TestCase):
                         run_id=run_id,
                         bucket_started_at=live_window_start,
                         bucket_ended_at=live_window_end,
+                        payload_json={
+                            'source': 'test-runtime-ledger',
+                            'runtime_ledger_daily_summary': runtime_daily_summary,
+                        },
                     )
                 )
             session.commit()
@@ -574,6 +596,14 @@ class TestCompletionTrace(TestCase):
         self.assertEqual(
             scale_gate['runtime_ledger_summary']['runtime_ledger_post_cost_expectancy_bps'],
             1.4,
+        )
+        self.assertEqual(
+            scale_gate['runtime_ledger_summary']['runtime_ledger_observed_trading_day_count'],
+            25,
+        )
+        self.assertEqual(
+            scale_gate['runtime_ledger_summary']['runtime_ledger_mean_daily_net_pnl_after_costs'],
+            '24',
         )
 
     def test_doc29_live_scale_blocks_non_runtime_ledger_window_pnl(self) -> None:

--- a/services/torghut/tests/test_evidence_epochs.py
+++ b/services/torghut/tests/test_evidence_epochs.py
@@ -13,7 +13,12 @@ from sqlalchemy.pool import StaticPool
 
 from app.config import settings
 from app.db import get_session
-from app.main import _build_current_evidence_epoch, _env_json_string_list, app
+from app.main import (
+    _build_current_evidence_epoch,
+    _daily_runtime_ledger_portfolio_summary,
+    _env_json_string_list,
+    app,
+)
 from app.models import Base, EvidenceEpochRecord, StrategyRuntimeLedgerBucket
 from app.trading.evidence_epochs import (
     compile_evidence_epoch,
@@ -190,10 +195,25 @@ class TestEvidenceEpochs(TestCase):
             runtime_closure_artifact_refs=("runtime-closure/summary.json",),
             observed_at=observed_at,
         )
+        non_evidence_grade_receipt = build_portfolio_proof_receipt(
+            portfolio_candidate_id="portfolio-1",
+            target_net_pnl_per_day=Decimal("500"),
+            post_cost_net_pnl_per_day=Decimal("525"),
+            holdout_result={"status": "pass"},
+            runtime_closure_artifact_refs=("runtime-closure/summary.json",),
+            runtime_ledger_summary={"evidence_grade_bucket_count": 0},
+            require_runtime_ledger_summary=True,
+            observed_at=observed_at,
+        )
         self.assertIn("portfolio_holdout_missing", holdout_missing_receipt.reason_codes)
         self.assertIn(
             "portfolio_runtime_closure_refs_missing",
             refs_missing_receipt.reason_codes,
+        )
+        self.assertEqual(non_evidence_grade_receipt.state, "fail")
+        self.assertIn(
+            "portfolio_runtime_ledger_summary_not_evidence_grade",
+            non_evidence_grade_receipt.reason_codes,
         )
         self.assertEqual(serializable_receipt.state, "pass")
 
@@ -348,6 +368,92 @@ class TestEvidenceEpochs(TestCase):
         )
         self.assertIn("portfolio_holdout_missing", receipt.reason_codes)
 
+    def test_daily_runtime_ledger_portfolio_summary_fails_non_evidence_rows(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        observed_at = datetime.now(timezone.utc)
+        with session_local() as session:
+            session.add(
+                StrategyRuntimeLedgerBucket(
+                    run_id="portfolio-proof-blocked",
+                    candidate_id="candidate-blocked",
+                    hypothesis_id="H-PORTFOLIO-PROOF",
+                    observed_stage="paper",
+                    bucket_started_at=observed_at - timedelta(hours=1),
+                    bucket_ended_at=observed_at - timedelta(minutes=30),
+                    account_label="paper",
+                    runtime_strategy_name="portfolio-proof-strategy",
+                    strategy_family="portfolio_proof",
+                    fill_count=2,
+                    decision_count=2,
+                    submitted_order_count=2,
+                    closed_trade_count=1,
+                    open_position_count=0,
+                    filled_notional=Decimal("1000"),
+                    gross_strategy_pnl=Decimal("526"),
+                    cost_amount=Decimal("1"),
+                    net_strategy_pnl_after_costs=Decimal("525"),
+                    post_cost_expectancy_bps=Decimal("1250"),
+                    ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                    pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                    execution_policy_hash_counts={"policy": 2},
+                    cost_model_hash_counts={"cost": 2},
+                    lineage_hash_counts={"lineage": 2},
+                    blockers_json=["runtime_ledger_stage_not_live"],
+                )
+            )
+            session.commit()
+
+            summary = _daily_runtime_ledger_portfolio_summary(
+                session=session,
+                account_label="paper",
+                stage_scope="paper",
+                observed_at=observed_at,
+            )
+
+        self.assertEqual(summary["bucket_count"], 1)
+        self.assertEqual(summary["evidence_grade_bucket_count"], 0)
+        self.assertEqual(
+            summary["blockers"],
+            ["portfolio_runtime_ledger_summary_not_evidence_grade"],
+        )
+
+    def test_daily_runtime_ledger_portfolio_summary_uses_missing_stage_filter(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        observed_at = datetime(2026, 5, 26, 12, 0, tzinfo=timezone.utc)
+        with session_local() as session:
+            summary = _daily_runtime_ledger_portfolio_summary(
+                session=session,
+                account_label="paper",
+                stage_scope="research",
+                observed_at=observed_at,
+            )
+
+        self.assertEqual(
+            summary["filters"]["observed_stage"],
+            "__missing__",
+        )
+        self.assertEqual(
+            summary["blockers"], ["portfolio_runtime_ledger_summary_missing"]
+        )
+
     def test_current_epoch_portfolio_proof_fails_closed_without_daily_ledger(
         self,
     ) -> None:
@@ -390,6 +496,52 @@ class TestEvidenceEpochs(TestCase):
             receipt.reason_codes,
         )
         self.assertEqual(receipt.payload["post_cost_net_pnl_per_day"], "0")
+
+    def test_current_epoch_ignores_scalar_portfolio_candidate_ids(self) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            with (
+                patch(
+                    "app.main._evaluate_database_contract",
+                    return_value={
+                        "ok": True,
+                        "schema_current": True,
+                        "schema_graph_lineage_ready": True,
+                        "schema_graph_lineage_errors": [],
+                        "schema_head_signature": "abc123",
+                    },
+                ),
+                patch(
+                    "app.main.build_empirical_jobs_status", return_value={"ready": True}
+                ),
+                patch(
+                    "app.main._daily_runtime_ledger_portfolio_summary",
+                    return_value={
+                        "bucket_count": 1,
+                        "evidence_grade_bucket_count": 1,
+                        "post_cost_net_pnl_per_day": "525",
+                        "candidate_ids": "candidate-scalar",
+                    },
+                ),
+            ):
+                epoch = _build_current_evidence_epoch(
+                    session=session,
+                    account_label="paper",
+                    stage_scope="paper",
+                )
+
+        receipt = next(
+            item for item in epoch.receipts if item.receipt_type == "portfolio_proof"
+        )
+        self.assertEqual(receipt.payload["portfolio_candidate_id"], "")
+        self.assertIn("portfolio_proof_missing", receipt.reason_codes)
 
     def test_compile_epoch_flags_missing_and_reasonless_required_receipts(self) -> None:
         observed_at = datetime(2026, 5, 5, 12, 0)

--- a/services/torghut/tests/test_evidence_epochs.py
+++ b/services/torghut/tests/test_evidence_epochs.py
@@ -14,7 +14,7 @@ from sqlalchemy.pool import StaticPool
 from app.config import settings
 from app.db import get_session
 from app.main import _build_current_evidence_epoch, _env_json_string_list, app
-from app.models import Base, EvidenceEpochRecord
+from app.models import Base, EvidenceEpochRecord, StrategyRuntimeLedgerBucket
 from app.trading.evidence_epochs import (
     compile_evidence_epoch,
     load_evidence_epoch_payload,
@@ -260,6 +260,136 @@ class TestEvidenceEpochs(TestCase):
             "service_health:trading_status_failed",
             epoch.reason_codes,
         )
+
+    def test_current_epoch_portfolio_proof_uses_stage_account_runtime_ledger(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        now = datetime.now(timezone.utc)
+        with session_local() as session:
+            for suffix, observed_stage, account_label, net_pnl in (
+                ("wrong-stage", "live", "paper", Decimal("999")),
+                ("wrong-account", "paper", "other-paper", Decimal("999")),
+                ("right", "paper", "paper", Decimal("525")),
+            ):
+                session.add(
+                    StrategyRuntimeLedgerBucket(
+                        run_id=f"portfolio-proof-{suffix}",
+                        candidate_id=f"candidate-{suffix}",
+                        hypothesis_id="H-PORTFOLIO-PROOF",
+                        observed_stage=observed_stage,
+                        bucket_started_at=now - timedelta(hours=1),
+                        bucket_ended_at=now - timedelta(minutes=30),
+                        account_label=account_label,
+                        runtime_strategy_name="portfolio-proof-strategy",
+                        strategy_family="portfolio_proof",
+                        fill_count=2,
+                        decision_count=2,
+                        submitted_order_count=2,
+                        closed_trade_count=1,
+                        open_position_count=0,
+                        filled_notional=Decimal("1000"),
+                        gross_strategy_pnl=net_pnl + Decimal("1"),
+                        cost_amount=Decimal("1"),
+                        net_strategy_pnl_after_costs=net_pnl,
+                        post_cost_expectancy_bps=Decimal("1250"),
+                        ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={"policy": 2},
+                        cost_model_hash_counts={"cost": 2},
+                        lineage_hash_counts={"lineage": 2},
+                        blockers_json=[],
+                    )
+                )
+            session.commit()
+            with (
+                patch(
+                    "app.main._evaluate_database_contract",
+                    return_value={
+                        "ok": True,
+                        "schema_current": True,
+                        "schema_graph_lineage_ready": True,
+                        "schema_graph_lineage_errors": [],
+                        "schema_head_signature": "abc123",
+                    },
+                ),
+                patch(
+                    "app.main.build_empirical_jobs_status", return_value={"ready": True}
+                ),
+            ):
+                epoch = _build_current_evidence_epoch(
+                    session=session,
+                    account_label="paper",
+                    stage_scope="paper",
+                )
+
+        receipt = next(
+            item for item in epoch.receipts if item.receipt_type == "portfolio_proof"
+        )
+        self.assertEqual(receipt.payload["post_cost_net_pnl_per_day"], "525")
+        self.assertEqual(receipt.payload["portfolio_candidate_id"], "candidate-right")
+        summary = receipt.payload["runtime_ledger_summary"]
+        self.assertEqual(summary["bucket_count"], 1)
+        self.assertEqual(summary["evidence_grade_bucket_count"], 1)
+        self.assertEqual(
+            summary["filters"],
+            {
+                "account_label": "paper",
+                "stage_scope": "paper",
+                "observed_stage": "paper",
+            },
+        )
+        self.assertIn("portfolio_holdout_missing", receipt.reason_codes)
+
+    def test_current_epoch_portfolio_proof_fails_closed_without_daily_ledger(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        with session_local() as session:
+            with (
+                patch(
+                    "app.main._evaluate_database_contract",
+                    return_value={
+                        "ok": True,
+                        "schema_current": True,
+                        "schema_graph_lineage_ready": True,
+                        "schema_graph_lineage_errors": [],
+                        "schema_head_signature": "abc123",
+                    },
+                ),
+                patch(
+                    "app.main.build_empirical_jobs_status", return_value={"ready": True}
+                ),
+            ):
+                epoch = _build_current_evidence_epoch(
+                    session=session,
+                    account_label="paper",
+                    stage_scope="paper",
+                )
+
+        receipt = next(
+            item for item in epoch.receipts if item.receipt_type == "portfolio_proof"
+        )
+        self.assertEqual(receipt.state, "missing")
+        self.assertIn(
+            "portfolio_runtime_ledger_summary_missing",
+            receipt.reason_codes,
+        )
+        self.assertEqual(receipt.payload["post_cost_net_pnl_per_day"], "0")
 
     def test_compile_epoch_flags_missing_and_reasonless_required_receipts(self) -> None:
         observed_at = datetime(2026, 5, 5, 12, 0)

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -41,6 +41,8 @@ from scripts.import_hypothesis_runtime_windows import (
     _runtime_ledger_tca_rows_from_source_dsn,
     _runtime_ledger_tca_rows_from_artifacts,
     _runtime_window_import_proof_hygiene_blockers,
+    _runtime_window_source_kind_is_informational,
+    _source_activity_missing_summary,
     _stable_payload_digest,
     _strategy_name_candidates,
     main,
@@ -727,6 +729,41 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "dependency_quorum_decision_missing",
                 "continuity_gate_missing",
                 "drift_gate_missing",
+            ],
+        )
+        self.assertTrue(
+            _runtime_window_source_kind_is_informational(
+                source_kind="non-authoritative-selection",
+                target_metadata={},
+            )
+        )
+
+    def test_source_activity_missing_summary_includes_proof_hygiene_blockers(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        summary = _source_activity_missing_summary(
+            run_id="run-source-missing",
+            candidate_id="cand-1",
+            hypothesis_id="H-PAIRS-01",
+            observed_stage="paper",
+            strategy_name="microbar-cross-sectional-pairs-v1",
+            strategy_names=["microbar-cross-sectional-pairs-v1"],
+            account_label="TORGHUT_SIM",
+            window_start=window_start,
+            window_end=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+            source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+            source_kind="paper_runtime_observed",
+            dataset_snapshot_ref="snapshot-1",
+            proof_hygiene_blockers=("runtime_window_target_metadata_missing",),
+        )
+
+        self.assertEqual(summary["proof_status"], "blocked")
+        self.assertEqual(
+            [item["blocker"] for item in summary["proof_blockers"]],
+            [
+                "runtime_window_source_activity_missing",
+                "runtime_window_target_metadata_missing",
             ],
         )
 

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from app.models import Base, StrategyRuntimeLedgerBucket
+from app.trading.runtime_ledger import RuntimeLedgerBucket
 from scripts.import_hypothesis_runtime_windows import (
     EXECUTION_ELIGIBLE_DECISION_STATUSES,
     POST_COST_BASIS_EXECUTION_RECONSTRUCTION,
@@ -35,9 +36,11 @@ from scripts.import_hypothesis_runtime_windows import (
     _runtime_ledger_profit_proof_present,
     _runtime_observation_authority_payload,
     _runtime_ledger_target_metadata_blockers,
+    _runtime_ledger_tca_row_from_bucket,
     _runtime_ledger_tca_rows_from_durable_buckets,
     _runtime_ledger_tca_rows_from_source_dsn,
     _runtime_ledger_tca_rows_from_artifacts,
+    _runtime_window_import_proof_hygiene_blockers,
     _stable_payload_digest,
     _strategy_name_candidates,
     main,
@@ -694,6 +697,39 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ["runtime_ledger_artifact_candidate_id_mismatch"],
         )
 
+    def test_runtime_window_proof_hygiene_blocks_missing_authoritative_gates(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _runtime_window_import_proof_hygiene_blockers(
+                source_kind="paper_runtime_observed",
+                target_metadata={},
+                dependency_quorum_decision="",
+                continuity_ok="",
+                drift_ok="",
+            ),
+            [
+                "runtime_window_target_metadata_missing",
+                "dependency_quorum_decision_missing",
+                "continuity_gate_missing",
+                "drift_gate_missing",
+            ],
+        )
+        self.assertEqual(
+            _runtime_window_import_proof_hygiene_blockers(
+                source_kind="simulation_paper_runtime",
+                target_metadata={},
+                dependency_quorum_decision="",
+                continuity_ok="",
+                drift_ok="",
+            ),
+            [
+                "dependency_quorum_decision_missing",
+                "continuity_gate_missing",
+                "drift_gate_missing",
+            ],
+        )
+
     def test_main_requires_source_dsn_or_durable_runtime_ledger_bucket(self) -> None:
         args = SimpleNamespace(
             run_id="run-missing-source",
@@ -934,6 +970,11 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             rows[0]["post_cost_expectancy_bps"],
             Decimal("34.82587064676616915422885572"),
         )
+        self.assertEqual(rows[0]["authoritative"], False)
+        self.assertEqual(
+            rows[0]["authority_reason"],
+            "execution_reconstruction_not_runtime_ledger_proof",
+        )
 
     def test_build_realized_strategy_pnl_rows_normalizes_nested_runtime_payloads(
         self,
@@ -1006,9 +1047,45 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ["execution_reconstruction_not_runtime_ledger_proof"],
         )
         self.assertEqual(bucket["pnl_basis"], POST_COST_BASIS_EXECUTION_RECONSTRUCTION)
+        self.assertEqual(bucket["authoritative"], False)
         self.assertGreaterEqual(len(bucket["execution_policy_hash_counts"]), 1)
         self.assertGreaterEqual(len(bucket["cost_model_hash_counts"]), 1)
         self.assertGreaterEqual(len(bucket["lineage_hash_counts"]), 1)
+
+    def test_runtime_ledger_tca_row_separates_explicit_cost_from_slippage(
+        self,
+    ) -> None:
+        bucket = RuntimeLedgerBucket(
+            bucket_started_at=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+            bucket_ended_at=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+            account_label="TORGHUT_SIM",
+            strategy_id="intraday-tsmom-profit-v3",
+            symbol="AAPL",
+            fill_count=2,
+            decision_count=2,
+            submitted_order_count=2,
+            cancelled_order_count=0,
+            rejected_order_count=0,
+            unfilled_order_count=0,
+            closed_trade_count=1,
+            open_position_count=0,
+            filled_notional=Decimal("200"),
+            gross_strategy_pnl=Decimal("1"),
+            cost_amount=Decimal("0.25"),
+            net_strategy_pnl_after_costs=Decimal("0.75"),
+            post_cost_expectancy_bps=Decimal("37.5"),
+            cost_basis_counts={"broker_reported_commission_and_fees": 2},
+            execution_policy_hash_counts={"policy-sha": 2},
+            cost_model_hash_counts={"cost-sha": 2},
+            lineage_hash_counts={"lineage-sha": 2},
+            blockers=[],
+        )
+
+        row = _runtime_ledger_tca_row_from_bucket(bucket=bucket)
+
+        self.assertIsNone(row["abs_slippage_bps"])
+        self.assertEqual(row["explicit_cost_bps"], Decimal("12.50000"))
+        self.assertEqual(row["post_cost_promotion_eligible"], True)
 
     def test_build_realized_strategy_pnl_rows_rejects_shortfall_only_costs(
         self,

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -2049,9 +2049,12 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertIn("torghut-chip-full-day-20260505-4c330ce9-r1", joined)
         self.assertIn("--delay-adjusted-depth-stress-report-ref", joined)
         self.assertIn("/proof/h-micro-delay-depth.json", joined)
-        self.assertIn("--dependency-quorum-decision missing", joined)
-        self.assertIn("--continuity-ok false", joined)
-        self.assertIn("--drift-ok false", joined)
+        for command in commands:
+            self.assertEqual(
+                command[command.index("--dependency-quorum-decision") + 1], ""
+            )
+            self.assertEqual(command[command.index("--continuity-ok") + 1], "")
+            self.assertEqual(command[command.index("--drift-ok") + 1], "")
 
     def test_runtime_window_import_uses_latest_source_activity_window_when_unpinned(
         self,
@@ -3276,6 +3279,31 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                 "paper_stage_evidence_collection_only",
                 "runtime_observation_not_authoritative",
             ],
+        )
+
+    def test_runtime_window_import_health_gate_args_do_not_synthesize_passes(
+        self,
+    ) -> None:
+        target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="cand-paper-route",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            strategy_name="paper-route-candidate-v1",
+            account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="",
+            source_manifest_ref="manifest.json",
+            source_kind="paper_route_probe_runtime_observed",
+            delay_adjusted_depth_stress_report_ref="",
+        )
+
+        self.assertEqual(
+            renewal._runtime_window_import_health_gate_args(
+                target=target,
+                runtime_manifest={},
+            ),
+            ("", "", ""),
         )
 
     def test_runtime_window_import_rejects_non_mapping_import_payload(

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -682,6 +682,90 @@ class TestRuntimeWindowImport(TestCase):
             decision.payload_json["runtime_ledger_filled_notional"], "10100"
         )
 
+    def test_persist_observed_runtime_windows_daily_pnl_counts_idle_days(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    6,
+                ),
+                (
+                    datetime(2026, 3, 9, 13, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 9, 14, 0, tzinfo=timezone.utc),
+                    6,
+                ),
+            ],
+            decision_times=[datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+            execution_times=[datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("1"),
+                    "post_cost_expectancy_bps": Decimal("600"),
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        filled_notional="10000",
+                        net_strategy_pnl_after_costs="600",
+                        cost_amount="1",
+                        post_cost_expectancy_bps="600",
+                    ),
+                    **_runtime_pnl_basis(),
+                },
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        with self.session_local() as session:
+            summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-live-daily-dollar-proof",
+                candidate_id="cand-daily-proof",
+                hypothesis_id="H-CONT-01",
+                observed_stage="live",
+                strategy_family="intraday_continuation",
+                source_manifest_ref="config/trading/hypotheses/h-cont-01.json",
+                buckets=buckets,
+            )
+            session.commit()
+            decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
+            ledger_bucket = session.execute(
+                select(StrategyRuntimeLedgerBucket)
+            ).scalar_one()
+
+        self.assertEqual(summary["raw_window_count"], 2)
+        self.assertEqual(summary["window_count"], 1)
+        self.assertEqual(summary["skipped_zero_activity_window_count"], 1)
+        self.assertEqual(summary["runtime_ledger_observed_trading_day_count"], 2)
+        self.assertEqual(
+            summary["runtime_ledger_net_pnl_by_trading_day"],
+            {"2026-03-06": "600", "2026-03-09": "0"},
+        )
+        self.assertEqual(
+            summary["runtime_ledger_mean_daily_net_pnl_after_costs"], "300"
+        )
+        self.assertEqual(
+            summary["runtime_ledger_median_daily_net_pnl_after_costs"], "300"
+        )
+        self.assertEqual(summary["runtime_ledger_p10_daily_net_pnl_after_costs"], "0")
+        self.assertEqual(summary["runtime_ledger_worst_day_net_pnl_after_costs"], "0")
+        self.assertEqual(summary["runtime_ledger_avg_daily_filled_notional"], "5000")
+        assert decision.payload_json is not None
+        self.assertEqual(
+            decision.payload_json["runtime_ledger_mean_daily_net_pnl_after_costs"],
+            "300",
+        )
+        assert ledger_bucket.payload_json is not None
+        self.assertEqual(
+            ledger_bucket.payload_json["runtime_ledger_daily_summary"][
+                "runtime_ledger_observed_trading_day_count"
+            ],
+            2,
+        )
+
     def test_persist_observed_runtime_windows_blocks_missing_health_gate_evidence(
         self,
     ) -> None:

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -26,6 +26,7 @@ from app.trading.runtime_window_import import (
     _parse_observation_datetime,
     _runtime_ledger_bucket_blockers,
     _runtime_ledger_bucket_payloads,
+    _runtime_ledger_daily_summary_from_observed_buckets,
     _runtime_window_import_proof_blockers,
     build_observed_runtime_buckets,
     build_regular_session_buckets,
@@ -764,6 +765,87 @@ class TestRuntimeWindowImport(TestCase):
                 "runtime_ledger_observed_trading_day_count"
             ],
             2,
+        )
+
+    def test_runtime_ledger_daily_summary_from_observed_buckets_tracks_drawdown(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _runtime_ledger_daily_summary_from_observed_buckets([])[
+                "runtime_ledger_median_daily_net_pnl_after_costs"
+            ],
+            "0",
+        )
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    1,
+                ),
+                (
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 30, tzinfo=timezone.utc),
+                    1,
+                ),
+                (
+                    datetime(2026, 3, 9, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 9, 15, 0, tzinfo=timezone.utc),
+                    1,
+                ),
+            ],
+            decision_times=[],
+            execution_times=[],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 45, tzinfo=timezone.utc),
+                    "post_cost_expectancy_basis": "realized_strategy_pnl_after_explicit_costs",
+                    "post_cost_promotion_eligible": True,
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        net_strategy_pnl_after_costs="100",
+                        filled_notional="1000",
+                        closed_trade_count=2,
+                    ),
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 15, 15, tzinfo=timezone.utc),
+                    "post_cost_expectancy_basis": "realized_strategy_pnl_after_explicit_costs",
+                    "post_cost_promotion_eligible": True,
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        net_strategy_pnl_after_costs="-130",
+                        filled_notional="500",
+                        closed_trade_count=1,
+                    ),
+                },
+                {
+                    "computed_at": datetime(2026, 3, 9, 14, 45, tzinfo=timezone.utc),
+                    "post_cost_expectancy_basis": "realized_strategy_pnl_after_explicit_costs",
+                    "post_cost_promotion_eligible": True,
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        net_strategy_pnl_after_costs="10",
+                        filled_notional="100",
+                        closed_trade_count=1,
+                    ),
+                },
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        summary = _runtime_ledger_daily_summary_from_observed_buckets(buckets)
+
+        self.assertEqual(
+            summary["runtime_ledger_net_pnl_by_trading_day"]["2026-03-06"], "-30"
+        )
+        self.assertEqual(
+            summary["runtime_ledger_mean_daily_net_pnl_after_costs"], "-10"
+        )
+        self.assertEqual(summary["runtime_ledger_p10_daily_net_pnl_after_costs"], "-30")
+        self.assertEqual(summary["runtime_ledger_max_intraday_drawdown"], "130")
+        self.assertEqual(
+            summary["runtime_ledger_closed_trade_count_by_day"],
+            {"2026-03-06": 3, "2026-03-09": 1},
         )
 
     def test_persist_observed_runtime_windows_blocks_missing_health_gate_evidence(

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -482,6 +482,16 @@ class TestVerifyTradingReadiness(TestCase):
             "runtime_ledger_mean_daily_net_pnl_after_costs",
         )
 
+    def test_runtime_ledger_daily_net_pnl_reports_missing_without_inputs(self) -> None:
+        self.assertEqual(
+            verifier._runtime_ledger_daily_net_pnl(
+                {},
+                net_pnl=None,
+                trading_day_count=0,
+            ),
+            (None, "missing"),
+        )
+
     def test_live_and_either_profiles_use_live_floor_states_and_market_window(
         self,
     ) -> None:

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -128,6 +128,7 @@ def _completion_status(
     net_pnl: str = "600",
     expectancy_bps: str = "12.5",
     trading_day_count: int | None = 25,
+    mean_daily_net_pnl: str | None = None,
     ledger_refs: list[str] | None = None,
     unbacked_refs: list[str] | None = None,
 ) -> dict[str, object]:
@@ -142,6 +143,10 @@ def _completion_status(
     if trading_day_count is not None:
         runtime_ledger_summary["runtime_ledger_observed_trading_day_count"] = (
             trading_day_count
+        )
+    if mean_daily_net_pnl is not None:
+        runtime_ledger_summary["runtime_ledger_mean_daily_net_pnl_after_costs"] = (
+            mean_daily_net_pnl
         )
     return {
         "doc_id": "doc29",
@@ -452,6 +457,29 @@ class TestVerifyTradingReadiness(TestCase):
         self.assertIn(
             "runtime_ledger_daily_net_pnl_target",
             weak_daily["failed_checks"],
+        )
+
+    def test_runtime_ledger_profit_proof_prefers_persisted_daily_mean(self) -> None:
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            completion_status=_completion_status(
+                net_pnl="15000",
+                trading_day_count=25,
+                mean_daily_net_pnl="300",
+            ),
+            min_runtime_ledger_net_pnl=Decimal("12500"),
+            min_runtime_ledger_trading_days=25,
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
+            require_runtime_ledger_profit_proof=True,
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertIn("runtime_ledger_daily_net_pnl_target", result["failed_checks"])
+        self.assertEqual(
+            result["checks"]["runtime_ledger_daily_net_pnl_target"]["detail"][
+                "source_key"
+            ],
+            "runtime_ledger_mean_daily_net_pnl_after_costs",
         )
 
     def test_live_and_either_profiles_use_live_floor_states_and_market_window(


### PR DESCRIPTION
## Summary

- Fail closed runtime-window imports when target metadata or explicit health-gate inputs are missing, while keeping informational/offline triage sources non-authoritative.
- Mark execution-row PnL reconstruction as non-authoritative and separate explicit cost bps from slippage bps.
- Carry runtime-ledger daily dollar proof through import, completion, readiness, and evidence receipts, including idle scheduled trading days in the denominator.
- Add regression coverage for the runtime-ledger daily-dollar proof branches and the fail-closed receipt/readiness paths.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_runtime_window_import.py tests/test_completion_trace.py tests/test_verify_trading_readiness.py tests/test_import_hypothesis_runtime_windows.py tests/test_run_empirical_promotion_jobs.py tests/test_evidence_epochs.py -q`
- `uv run --frozen coverage erase && uv run --frozen pytest tests/test_completion_trace.py tests/test_runtime_window_import.py tests/test_evidence_epochs.py tests/test_import_hypothesis_runtime_windows.py tests/test_verify_trading_readiness.py --cov --cov-branch --cov-fail-under=0 --cov-report= && uv run --frozen coverage xml -o coverage.xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen ruff check app/main.py app/trading/runtime_window_import.py app/trading/completion.py app/trading/evidence_receipts.py scripts/import_hypothesis_runtime_windows.py scripts/renew_latest_empirical_promotion_jobs.py scripts/verify_trading_readiness.py tests/test_runtime_window_import.py tests/test_completion_trace.py tests/test_verify_trading_readiness.py tests/test_import_hypothesis_runtime_windows.py tests/test_run_empirical_promotion_jobs.py tests/test_evidence_epochs.py`
- `uv run --frozen ruff check tests/test_completion_trace.py tests/test_runtime_window_import.py tests/test_evidence_epochs.py tests/test_import_hypothesis_runtime_windows.py tests/test_verify_trading_readiness.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
