### PR TITLE
fix(synthesis): serve asset image mime types

### DIFF
--- a/apps/synthesis/src/server/__tests__/assets.test.ts
+++ b/apps/synthesis/src/server/__tests__/assets.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 
-import { materializeAttachments } from '../assets'
+import { assetResponseForAttachment, materializeAttachments } from '../assets'
 
 describe('synthesis assets', () => {
   afterEach(() => {
@@ -20,7 +20,8 @@ describe('synthesis assets', () => {
     process.env.SYNTHESIS_ASSET_REGION = 'us-east-1'
     process.env.SYNTHESIS_ASSET_STORAGE_REQUIRED = 'true'
 
-    const uploaded: Array<{ url: string; method: string | undefined; bodyLength: number }> = []
+    const uploaded: Array<{ url: string; method: string | undefined; bodyLength: number; contentType: string | null }> =
+      []
     const fetchImpl: typeof fetch = async (url, init) => {
       const resolvedUrl = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
       if (resolvedUrl.startsWith('https://pbs.twimg.com/media/')) {
@@ -30,10 +31,12 @@ describe('synthesis assets', () => {
         })
       }
       if (resolvedUrl.startsWith('http://object.local/synthesis-assets/')) {
+        const headers = new Headers(init?.headers)
         uploaded.push({
           url: resolvedUrl,
           method: init?.method,
           bodyLength: init?.body instanceof Uint8Array ? init.body.length : 0,
+          contentType: headers.get('content-type'),
         })
         return new Response(null, { status: 200 })
       }
@@ -60,6 +63,7 @@ describe('synthesis assets', () => {
         url: expect.stringContaining('/synthesis-assets/synthesis/2026-05-26/'),
         method: 'PUT',
         bodyLength: 3,
+        contentType: 'image/png',
       },
     ])
     expect(attachments[0]).toMatchObject({
@@ -69,5 +73,43 @@ describe('synthesis assets', () => {
       sizeBytes: 3,
       sourceUrl: 'https://pbs.twimg.com/media/source-chart.jpg',
     })
+  })
+
+  test('serves app-owned assets with the recorded image MIME type', async () => {
+    process.env.SYNTHESIS_ASSET_ENDPOINT = 'http://object.local'
+    process.env.SYNTHESIS_ASSET_BUCKET = 'synthesis-assets'
+    process.env.SYNTHESIS_ASSET_ACCESS_KEY_ID = 'test-access'
+    process.env.SYNTHESIS_ASSET_SECRET_ACCESS_KEY = 'test-secret'
+    process.env.SYNTHESIS_ASSET_REGION = 'us-east-1'
+
+    const originalFetch = globalThis.fetch
+    const fetchMock = vi.fn(async () => {
+      return new Response(new Uint8Array([137, 80, 78, 71]), {
+        status: 200,
+        headers: { 'content-type': 'binary/octet-stream' },
+      })
+    })
+    globalThis.fetch = fetchMock as typeof fetch
+
+    try {
+      const response = await assetResponseForAttachment({
+        id: 'asset-1',
+        kind: 'source_screenshot',
+        sourceUrl: 'https://x.com/example/status/1',
+        assetUrl: '/api/assets/asset-1',
+        objectKey: 'synthesis/2026-05-26/asset-1.png',
+        mimeType: 'image/png',
+        sizeBytes: 4,
+        alt: 'source chart',
+        label: 'source chart',
+        generated: false,
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toBe('image/png')
+      expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([137, 80, 78, 71]))
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 })

--- a/apps/synthesis/src/server/assets.ts
+++ b/apps/synthesis/src/server/assets.ts
@@ -103,15 +103,24 @@ const signedS3Request = (input: {
   key: string
   method: 'GET' | 'PUT'
   body?: Buffer
+  contentType?: string
   now: Date
 }) => {
   const { amzDate, datestamp } = toAmzDates(input.now)
   const payloadHash = input.body ? sha256Hex(input.body) : sha256Hex('')
   const { url, canonicalUri, host } = buildObjectUrl(input.config, input.key)
-  const signedHeaders = 'host;x-amz-content-sha256;x-amz-date'
-  const canonicalHeaders = [`host:${host}`, `x-amz-content-sha256:${payloadHash}`, `x-amz-date:${amzDate}`, ''].join(
-    '\n',
-  )
+  const headers = {
+    ...(input.contentType ? { 'content-type': input.contentType } : {}),
+    host,
+    'x-amz-content-sha256': payloadHash,
+    'x-amz-date': amzDate,
+  }
+  const signedHeaders = Object.keys(headers).sort().join(';')
+  const canonicalHeaders = Object.entries(headers)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}:${value}`)
+    .join('\n')
+    .concat('\n')
   const canonicalRequest = [input.method, canonicalUri, '', canonicalHeaders, signedHeaders, payloadHash].join('\n')
   const scope = `${datestamp}/${input.config.region}/s3/aws4_request`
   const stringToSign = ['AWS4-HMAC-SHA256', amzDate, scope, sha256Hex(canonicalRequest)].join('\n')
@@ -124,6 +133,7 @@ const signedS3Request = (input: {
         `SignedHeaders=${signedHeaders}`,
         `Signature=${signature}`,
       ].join(', '),
+      ...(input.contentType ? { 'content-type': input.contentType } : {}),
       'x-amz-content-sha256': payloadHash,
       'x-amz-date': amzDate,
     },
@@ -262,7 +272,14 @@ export const materializeAttachments = async (
         mimeType = body.mimeType
         sizeBytes = body.body.length
         objectKey = `synthesis/${now().toISOString().slice(0, 10)}/${id}.${extensionForMime(body.mimeType)}`
-        const request = signedS3Request({ config, key: objectKey, method: 'PUT', body: body.body, now: now() })
+        const request = signedS3Request({
+          config,
+          key: objectKey,
+          method: 'PUT',
+          body: body.body,
+          contentType: body.mimeType,
+          now: now(),
+        })
         const response = await fetchImpl(request.url, {
           method: 'PUT',
           headers: request.headers,
@@ -302,11 +319,12 @@ export const assetResponseForAttachment = async (attachment: SynthesisAttachment
     const request = signedS3Request({ config, key: attachment.objectKey, method: 'GET', now: new Date() })
     const response = await fetch(request.url, { headers: request.headers })
     if (!response.ok) return new Response('asset not found', { status: response.status })
+    const contentType = attachment.mimeType ?? response.headers.get('content-type')
     return new Response(response.body, {
       status: 200,
       headers: {
         'cache-control': 'private, max-age=3600',
-        ...(response.headers.get('content-type') ? { 'content-type': response.headers.get('content-type') ?? '' } : {}),
+        ...(contentType ? { 'content-type': contentType } : {}),
       },
     })
   }


### PR DESCRIPTION
## Summary

- Serve app-owned Synthesis assets with the attachment MIME type when object storage reports a generic content type.
- Sign and send `content-type` on S3-compatible PUTs so new image uploads retain their MIME metadata.
- Add regression coverage for source media upload headers and `/api/assets/:id` image responses.

## Related Issues

None

## Testing

- `bun run --filter synthesis test -- src/server/__tests__/assets.test.ts`
- `bun run --filter synthesis test`
- `bun run --filter synthesis lint`
- `bun run build:synthesis`
- Live verification before the fix: submitted xcurate item assets returned PNG bytes but `content-type: binary/octet-stream` from `http://synthesis.ide-newton.ts.net/api/assets/...`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
