### PR TITLE
chore(synthesis): promote image 0.576.2

### DIFF
--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -10,5 +10,5 @@ resources:
   - networkpolicy.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: 0.576.1
+    newTag: 0.576.2
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote Synthesis to image `registry.ide-newton.ts.net/lab/synthesis:0.576.2`.
- Deploys the merged `/api/assets/:id` MIME fix from PR #8011 through Argo CD GitOps.
- Keeps object-storage-backed source screenshots and generated infographics rendered as image assets instead of generic binary downloads.

## Related Issues

None

## Testing

- `bun run --filter synthesis test -- src/server/__tests__/assets.test.ts`
- `bun run --filter synthesis test`
- `bun run --filter synthesis lint`
- `bun run build:synthesis`
- `kustomize build argocd/applications/synthesis`
- `skopeo inspect --override-os linux --override-arch arm64 docker://registry.ide-newton.ts.net/lab/synthesis:0.576.2`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
