### PR TITLE
chore(torghut): promote image 586ba755

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.575.0-14-g74336a0a0
+              value: v0.576.2-4-g586ba755f
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 74336a0a014322e78e4ba19fef20e6d4392e552e
+              value: 586ba755f43408fc08ee99f8b43cc47bad4644b8
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.575.0-14-g74336a0a0
+              value: v0.576.2-4-g586ba755f
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 74336a0a014322e78e4ba19fef20e6d4392e552e
+              value: 586ba755f43408fc08ee99f8b43cc47bad4644b8
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -100,7 +100,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+                  value: sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-26T02:05:57Z"
+        client.knative.dev/updateTimestamp: "2026-05-26T03:43:21Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
           ports:
             - name: http1
               containerPort: 8181
@@ -503,11 +503,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.575.0-14-g74336a0a0
+              value: v0.576.2-4-g586ba755f
             - name: TORGHUT_COMMIT
-              value: 74336a0a014322e78e4ba19fef20e6d4392e552e
+              value: 586ba755f43408fc08ee99f8b43cc47bad4644b8
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+              value: sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-26T02:05:57Z"
+        client.knative.dev/updateTimestamp: "2026-05-26T03:43:21Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
           ports:
             - name: http1
               containerPort: 8181
@@ -322,11 +322,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.575.0-14-g74336a0a0
+              value: v0.576.2-4-g586ba755f
             - name: TORGHUT_COMMIT
-              value: 74336a0a014322e78e4ba19fef20e6d4392e552e
+              value: 586ba755f43408fc08ee99f8b43cc47bad4644b8
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+              value: sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bf8b6e5adf641ed38ac9750f17ad20151054ed32008f8fcee222dc41c6c70b55
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `586ba755f43408fc08ee99f8b43cc47bad4644b8`
- Image tag: `586ba755`
- Image digest: `sha256:8138ffd9e59b94fc2c1c9cae0fa504589001f32465ef4bd4f28a064d627f5ef0`