### PR TITLE
fix(agents): finalize orphaned terminal job runs

### DIFF
--- a/services/agents/src/server/agents-controller/agent-run-reconciler.test.ts
+++ b/services/agents/src/server/agents-controller/agent-run-reconciler.test.ts
@@ -5,6 +5,40 @@ import { PROVIDER_CAPACITY_EXHAUSTED_REASON } from './provider-capacity'
 import { RESOURCE_MAP } from '../kube-types'
 
 describe('agents controller agent-run reconciler', () => {
+  const createBaseDependencies = (overrides: Partial<Parameters<typeof createAgentRunReconciler>[0]> = {}) => ({
+    setStatus: vi.fn(async () => undefined),
+    nowIso: () => '2026-05-18T14:00:00.000Z',
+    isKubeNotFoundError: () => false,
+    resolveJobImage: () => 'registry.example/runner:latest',
+    resolveAgentRunRetentionSeconds: () => 0,
+    getPrimitivesStore: async () => null,
+    getTemporalClient: async () => ({}),
+    reconcileWorkflowRun: vi.fn(),
+    submitJobRun: vi.fn(),
+    submitCustomRun: vi.fn(),
+    submitTemporalRun: vi.fn(),
+    reconcileTemporalRun: vi.fn(),
+    buildConditions: () => [],
+    isAgentRunImmutabilityEnforced: () => true,
+    isAgentRunIdempotencyEnabled: () => false,
+    parseQueueLimits: () => ({ perNamespace: 0, perRepo: 0, cluster: 0 }),
+    parseRateLimits: () => ({ perNamespace: 0, perRepo: 0, cluster: 0, windowSeconds: 60 }),
+    getControllerSnapshot: () => null,
+    getControllerRateState: () => ({
+      cluster: { count: 0, resetAt: 0 },
+      perNamespace: new Map(),
+      perRepo: new Map(),
+    }),
+    validateImplementationContract: () => ({ ok: true as const, requiredKeys: [] }),
+    buildContractStatus: () => undefined,
+    resolveRunnerServiceAccount: () => null,
+    applyJobTtlAfterStatus: vi.fn(),
+    verifyJobConfigMaps: vi.fn(async () => ({ ok: true as const, names: [] })),
+    isJobComplete: () => false,
+    isJobFailed: () => false,
+    ...overrides,
+  })
+
   it('recognizes provider capacity readiness blocks', () => {
     expect(
       resolveProviderReadinessBlock({
@@ -63,38 +97,12 @@ describe('agents controller agent-run reconciler', () => {
         return null
       }),
     }
-    const reconciler = createAgentRunReconciler({
-      setStatus,
-      nowIso: () => '2026-05-18T14:00:00.000Z',
-      isKubeNotFoundError: () => false,
-      resolveJobImage: () => 'registry.example/runner:latest',
-      resolveAgentRunRetentionSeconds: () => 0,
-      getPrimitivesStore: async () => null,
-      getTemporalClient: async () => ({}),
-      reconcileWorkflowRun: vi.fn(),
-      submitJobRun,
-      submitCustomRun: vi.fn(),
-      submitTemporalRun: vi.fn(),
-      reconcileTemporalRun: vi.fn(),
-      buildConditions: () => [],
-      isAgentRunImmutabilityEnforced: () => true,
-      isAgentRunIdempotencyEnabled: () => false,
-      parseQueueLimits: () => ({ perNamespace: 0, perRepo: 0, cluster: 0 }),
-      parseRateLimits: () => ({ perNamespace: 0, perRepo: 0, cluster: 0, windowSeconds: 60 }),
-      getControllerSnapshot: () => null,
-      getControllerRateState: () => ({
-        cluster: { count: 0, resetAt: 0 },
-        perNamespace: new Map(),
-        perRepo: new Map(),
+    const reconciler = createAgentRunReconciler(
+      createBaseDependencies({
+        setStatus,
+        submitJobRun,
       }),
-      validateImplementationContract: () => ({ ok: true, requiredKeys: [] }),
-      buildContractStatus: () => undefined,
-      resolveRunnerServiceAccount: () => null,
-      applyJobTtlAfterStatus: vi.fn(),
-      verifyJobConfigMaps: vi.fn(async () => ({ ok: true as const, names: [] })),
-      isJobComplete: () => false,
-      isJobFailed: () => false,
-    })
+    )
 
     await reconciler.reconcileAgentRun(
       kube as never,
@@ -128,6 +136,82 @@ describe('agents controller agent-run reconciler', () => {
         phase: 'Pending',
         reason: PROVIDER_CAPACITY_EXHAUSTED_REASON,
         message: expect.stringContaining('provider capacity exhausted'),
+      }),
+    )
+  })
+
+  it('finalizes a running job AgentRun from stored terminal runner status when the Job was already pruned', async () => {
+    const setStatus = vi.fn(async () => undefined)
+    const kube = {
+      patch: vi.fn(async () => ({})),
+      get: vi.fn(async () => null),
+    }
+    const reconciler = createAgentRunReconciler(createBaseDependencies({ setStatus }))
+
+    await reconciler.reconcileAgentRun(
+      kube as never,
+      {
+        metadata: {
+          name: 'run-1',
+          namespace: 'agents',
+          generation: 1,
+          finalizers: ['agents.proompteng.ai/runtime-cleanup'],
+        },
+        spec: {
+          agentRef: { name: 'codex-agent' },
+          runtime: { type: 'job' },
+          parameters: {},
+          workload: {},
+        },
+        status: {
+          phase: 'Running',
+          startedAt: '2026-05-18T13:00:00.000Z',
+          runtimeRef: {
+            type: 'job',
+            name: 'run-1-job',
+            namespace: 'agents',
+            jobObservedAt: '2026-05-18T13:00:01.000Z',
+          },
+          runner: {
+            status: 'succeeded',
+            provider: 'codex-app-server',
+            exitCode: 0,
+            startedAt: '2026-05-18T13:00:02.000Z',
+            finishedAt: '2026-05-18T13:08:00.000Z',
+            artifacts: {
+              outputArtifacts: [{ name: 'runner-log', path: '/workspace/.agent/runner.log' }],
+            },
+          },
+        },
+      },
+      'agents',
+      [],
+      [],
+      {
+        perNamespace: 10,
+        perAgent: 10,
+        cluster: 10,
+        repoConcurrency: { enabled: false, defaultLimit: 0, overrides: new Map() },
+      },
+      { total: 0, perAgent: new Map(), perRepository: new Map() },
+      0,
+    )
+
+    expect(kube.get).toHaveBeenCalledWith('job', 'run-1-job', 'agents')
+    expect(setStatus).toHaveBeenCalledWith(
+      kube,
+      expect.any(Object),
+      expect.objectContaining({
+        phase: 'Succeeded',
+        reason: undefined,
+        message: undefined,
+        finishedAt: '2026-05-18T13:08:00.000Z',
+        runner: expect.objectContaining({ status: 'succeeded', exitCode: 0 }),
+        artifacts: [{ name: 'runner-log', path: '/workspace/.agent/runner.log' }],
+        conditions: expect.arrayContaining([
+          expect.objectContaining({ type: 'Warning', status: 'True', reason: 'JobMissing' }),
+          expect.objectContaining({ type: 'Succeeded', status: 'True', reason: 'Completed' }),
+        ]),
       }),
     )
   })

--- a/services/agents/src/server/agents-controller/agent-run-reconciler.ts
+++ b/services/agents/src/server/agents-controller/agent-run-reconciler.ts
@@ -32,6 +32,7 @@ import {
 import {
   extractRunnerStatusFromJobPods,
   mergeAgentRunArtifacts,
+  parseRunnerTerminalStatus,
   runnerStatusForAgentRunStatus,
   runnerStatusOutputArtifacts,
   runnerStatusToTerminalOutcome,
@@ -1171,12 +1172,41 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
       if (!job) {
         if (jobObservedAt) {
           const message = `job ${jobName || 'unknown'} not found`
-          const updated = upsertCondition(conditions, {
+          const warningConditions = upsertCondition(conditions, {
             type: 'Warning',
             status: 'True',
             reason: 'JobMissing',
             message,
           })
+          const storedRunnerStatus = parseRunnerTerminalStatus(status.runner)
+          if (storedRunnerStatus) {
+            const runnerOutcome = runnerStatusToTerminalOutcome(storedRunnerStatus)
+            const terminalMessage = runnerOutcome.message ?? message
+            const terminalConditions = upsertCondition(warningConditions, {
+              type: runnerOutcome.conditionType,
+              status: 'True',
+              reason: runnerOutcome.reason,
+              message: runnerOutcome.message,
+            })
+            const runnerArtifacts = runnerStatusOutputArtifacts(storedRunnerStatus)
+            logTerminalOutcome(runnerOutcome.phase, runnerOutcome.reason, terminalMessage)
+            await setStatus(kube, agentRun, {
+              observedGeneration,
+              phase: runnerOutcome.phase,
+              reason: runnerOutcome.phase === 'Succeeded' ? undefined : runnerOutcome.reason,
+              message: runnerOutcome.phase === 'Succeeded' ? undefined : terminalMessage,
+              startedAt: storedRunnerStatus.startedAt ?? asString(status.startedAt) ?? undefined,
+              finishedAt: storedRunnerStatus.finishedAt ?? asString(status.finishedAt) ?? nowIso(),
+              runtimeRef,
+              conditions: terminalConditions,
+              vcs: asRecord(status.vcs) ?? undefined,
+              runner: runnerStatusForAgentRunStatus(storedRunnerStatus),
+              ...(runnerArtifacts.length > 0
+                ? { artifacts: mergeAgentRunArtifacts(status.artifacts, runnerArtifacts) }
+                : {}),
+            })
+            return
+          }
           logAgentsControllerWarn('reconcile_runtime_orphaned', {
             ...logContext,
             decision: 'runtime_orphaned',
@@ -1189,7 +1219,7 @@ export const createAgentRunReconciler = (deps: AgentRunReconcilerDependencies) =
             phase: 'Running',
             startedAt: asString(status.startedAt) ?? nowIso(),
             runtimeRef,
-            conditions: updated,
+            conditions: warningConditions,
             vcs: asRecord(status.vcs) ?? undefined,
           })
         }


### PR DESCRIPTION
## Summary

- Finalizes job-backed AgentRuns from stored terminal runner status when the Kubernetes Job has already been pruned.
- Preserves the `JobMissing` warning while moving the AgentRun to `Succeeded`, `Failed`, or `Cancelled` according to the runner result.
- Adds a regression test for the stale `Running`/runner-succeeded orphan case seen in the `agents` namespace.

## Related Issues

None

## Testing

- `bun test services/agents/src/server/agents-controller/agent-run-reconciler.test.ts`
- `bun run --filter @proompteng/agents test -- src/server/agents-controller/agent-run-reconciler.test.ts`
- `bun run --filter @proompteng/agents tsc`
- `bunx tsc --noEmit -p services/agents/tsconfig.json`
- `bunx oxfmt --check services/agents/src/server/agents-controller/agent-run-reconciler.ts services/agents/src/server/agents-controller/agent-run-reconciler.test.ts`
- `bunx oxlint --config .oxlintrc.json services/agents/src/server/agents-controller/agent-run-reconciler.ts services/agents/src/server/agents-controller/agent-run-reconciler.test.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
