### PR TITLE
fix(synthesis): configure deep alpha agent system prompt

### DIFF
--- a/argocd/applications/synthesis/agents-domain/synthesis-deep-alpha-agent.yaml
+++ b/argocd/applications/synthesis/agents-domain/synthesis-deep-alpha-agent.yaml
@@ -5,6 +5,11 @@ metadata:
 spec:
   providerRef:
     name: synthesis-deep-alpha
+  defaults:
+    systemPromptRef:
+      kind: ConfigMap
+      name: codex-agent-system-prompt
+      key: system-prompt.md
   security:
     allowedSecrets:
       - codex-auth

--- a/docs/superpowers/plans/2026-05-26-synthesis-deep-alpha-scheduled-agentrun.md
+++ b/docs/superpowers/plans/2026-05-26-synthesis-deep-alpha-scheduled-agentrun.md
@@ -315,6 +315,11 @@ metadata:
 spec:
   providerRef:
     name: synthesis-deep-alpha
+  defaults:
+    systemPromptRef:
+      kind: ConfigMap
+      name: codex-agent-system-prompt
+      key: system-prompt.md
   security:
     allowedSecrets:
       - codex-auth


### PR DESCRIPTION
## Summary

- Adds `defaults.systemPromptRef` to `synthesis-deep-alpha-agent`.
- Reuses the existing `codex-agent-system-prompt` ConfigMap in `agents`, matching existing Agent patterns.
- Updates the saved implementation plan so future replays include the required system prompt configuration.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/synthesis >/tmp/synthesis-render.yaml`
- `kustomize build argocd/applications/synthesis/agents-domain >/tmp/synthesis-agents-domain-render.yaml`
- `bun run lint:argocd`
- `kubectl apply --server-side --dry-run=server -f /tmp/synthesis-agents-domain-render.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
