### PR TITLE
fix(synthesis): use larger model for deep alpha agent

### DIFF
--- a/argocd/applications/synthesis/agents-domain/synthesis-deep-alpha-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/synthesis-deep-alpha-agentprovider.yaml
@@ -7,8 +7,8 @@ spec:
   adapter:
     type: codex-app-server
     codex:
-      model: gpt-5.3-codex-spark
-      effort: xhigh
+      model: gpt-5.5
+      effort: high
       sandbox: danger-full-access
       approval: never
       cwd: /workspace/lab
@@ -30,16 +30,16 @@ spec:
     CODEX_CONFIG: /root/.codex/config.toml
     CODEX_LOG_LEVEL: info
     CODEX_MAX_SESSION_ATTEMPTS: "3"
-    CODEX_MODEL: gpt-5.3-codex-spark
-    CODEX_MODEL_FALLBACKS: gpt-5.5,gpt-5.4,gpt-5.4-mini,gpt-5.2-codex,gpt-5-codex
+    CODEX_MODEL: gpt-5.5
+    CODEX_MODEL_FALLBACKS: gpt-5.4,gpt-5.4-mini,gpt-5.2-codex,gpt-5-codex
     HOME: /root
     SYNTHESIS_MCP_URL: http://synthesis.synthesis.svc.cluster.local:3000/mcp
   inputFiles:
     - path: /root/.codex/config.toml
       content: |-
-        model = "gpt-5.3-codex-spark"
-        model_reasoning_summary = "none"
-        model_reasoning_effort = "xhigh"
+        model = "gpt-5.5"
+        model_reasoning_summary = "detailed"
+        model_reasoning_effort = "high"
         model_verbosity = "medium"
         approval_policy = "never"
         sandbox_mode = "danger-full-access"

--- a/argocd/applications/synthesis/agents-domain/synthesis-deep-alpha-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/synthesis-deep-alpha-implspec.yaml
@@ -39,7 +39,8 @@ spec:
        - interests: `["deep-alpha","options","technical-analysis","equities","2-3-week-hold"]`
        - notes: current UTC timestamp, market session context, and that this is a scheduled run.
     2. Gather current market evidence with live web search and any available market-data tools.
-    3. Select 3 to 6 candidates. Prefer liquid large-cap equities or ETFs. Avoid obscure tickers.
+       Keep the research pass bounded: use no more than 12 source URLs total and keep only evidence needed for submission.
+    3. Select 3 to 4 candidates. Prefer liquid large-cap equities or ETFs. Avoid obscure tickers.
     4. For each candidate, require:
        - ticker or theme
        - directional thesis
@@ -67,6 +68,6 @@ spec:
 
     Submission quality bar:
     - Do not submit generic market commentary.
-    - Do not submit an item without at least two independent sources unless the confidence is no higher than 0.45 and the missing evidence is stated.
+    - Prefer two independent sources per item. If only one source is available, confidence must be no higher than 0.45 and the missing evidence must be stated.
     - Do not submit naked high-risk options as the preferred structure; prefer defined-risk strategies.
     - Do not finish until `synthesis_submit_batch` returns success.

--- a/docs/superpowers/plans/2026-05-26-synthesis-deep-alpha-scheduled-agentrun.md
+++ b/docs/superpowers/plans/2026-05-26-synthesis-deep-alpha-scheduled-agentrun.md
@@ -126,8 +126,8 @@ spec:
   adapter:
     type: codex-app-server
     codex:
-      model: gpt-5.3-codex-spark
-      effort: xhigh
+      model: gpt-5.5
+      effort: high
       sandbox: danger-full-access
       approval: never
       cwd: /workspace/lab
@@ -149,16 +149,16 @@ spec:
     AGENT_RUN_NAMESPACE: "{{agentRun.namespace}}"
     CODEX_CONFIG: /root/.codex/config.toml
     CODEX_MAX_SESSION_ATTEMPTS: "3"
-    CODEX_MODEL: gpt-5.3-codex-spark
-    CODEX_MODEL_FALLBACKS: gpt-5.5,gpt-5.4,gpt-5.4-mini,gpt-5.2-codex,gpt-5-codex
+    CODEX_MODEL: gpt-5.5
+    CODEX_MODEL_FALLBACKS: gpt-5.4,gpt-5.4-mini,gpt-5.2-codex,gpt-5-codex
     HOME: /root
     SYNTHESIS_MCP_URL: http://synthesis.synthesis.svc.cluster.local:3000/mcp
   inputFiles:
     - path: /root/.codex/config.toml
       content: |-
-        model = "gpt-5.3-codex-spark"
-        model_reasoning_summary = "none"
-        model_reasoning_effort = "xhigh"
+        model = "gpt-5.5"
+        model_reasoning_summary = "detailed"
+        model_reasoning_effort = "high"
         model_verbosity = "medium"
         approval_policy = "never"
         sandbox_mode = "danger-full-access"
@@ -374,7 +374,8 @@ spec:
        - interests: `["deep-alpha","options","technical-analysis","equities","2-3-week-hold"]`
        - notes: current UTC timestamp, market session context, and that this is a scheduled run.
     2. Gather current market evidence with live web search and any available market-data tools.
-    3. Select 3 to 6 candidates. Prefer liquid large-cap equities or ETFs. Avoid obscure tickers.
+       Keep the research pass bounded: use no more than 12 source URLs total and keep only evidence needed for submission.
+    3. Select 3 to 4 candidates. Prefer liquid large-cap equities or ETFs. Avoid obscure tickers.
     4. For each candidate, require:
        - ticker or theme
        - directional thesis
@@ -402,7 +403,7 @@ spec:
 
     Submission quality bar:
     - Do not submit generic market commentary.
-    - Do not submit an item without at least two independent sources unless the confidence is no higher than 0.45 and the missing evidence is stated.
+    - Prefer two independent sources per item. If only one source is available, confidence must be no higher than 0.45 and the missing evidence must be stated.
     - Do not submit naked high-risk options as the preferred structure; prefer defined-risk strategies.
     - Do not finish until `synthesis_submit_batch` returns success.
 ```


### PR DESCRIPTION
## Summary

- Moves the scheduled Synthesis deep-alpha provider from Spark to `gpt-5.5`.
- Bounds the research pass to 12 source URLs and 3-4 candidates to avoid context exhaustion during scheduled runs.
- Updates the saved implementation plan with the same provider and prompt constraints.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/synthesis >/tmp/synthesis-render.yaml`
- `kustomize build argocd/applications/synthesis/agents-domain >/tmp/synthesis-agents-domain-render.yaml`
- `bun run lint:argocd`
- `kubectl apply --server-side --force-conflicts --dry-run=server -f /tmp/synthesis-agents-domain-render.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
