### PR TITLE
fix(synthesis): harden deep alpha agent runtime

### DIFF
--- a/argocd/applications/synthesis/agents-domain/synthesis-deep-alpha-agent.yaml
+++ b/argocd/applications/synthesis/agents-domain/synthesis-deep-alpha-agent.yaml
@@ -13,6 +13,7 @@ spec:
   security:
     allowedSecrets:
       - codex-auth
+      - agents-artifacts
       - synthesis-env
     allowedServiceAccounts:
       - agents-sa

--- a/argocd/applications/synthesis/agents-domain/synthesis-deep-alpha-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/synthesis-deep-alpha-agentprovider.yaml
@@ -18,21 +18,34 @@ spec:
             command: node
             args:
               - /root/.codex/synthesis-mcp-proxy.mjs
+            env:
+              SYNTHESIS_API_TOKEN_FILE: /var/run/synthesis/SYNTHESIS_API_TOKEN
+              SYNTHESIS_MCP_URL: http://synthesis.synthesis.svc.cluster.local:3000/mcp
         web_search: live
   argsTemplate: []
   secretEnv:
     - name: SYNTHESIS_API_TOKEN
       secretName: synthesis-env
       key: SYNTHESIS_API_TOKEN
+    - name: AGENTS_ARTIFACTS_ACCESS_KEY_ID
+      secretName: agents-artifacts
+      key: AWS_ACCESS_KEY_ID
+    - name: AGENTS_ARTIFACTS_SECRET_ACCESS_KEY
+      secretName: agents-artifacts
+      key: AWS_SECRET_ACCESS_KEY
   envTemplate:
     AGENT_RUN_NAME: "{{agentRun.name}}"
     AGENT_RUN_NAMESPACE: "{{agentRun.namespace}}"
+    AGENTS_ARTIFACTS_BUCKET: agents-artifacts
+    AGENTS_ARTIFACTS_ENDPOINT: http://rook-ceph-rgw-objectstore.rook-ceph.svc:80
+    AGENTS_ARTIFACTS_SECURE: "false"
     CODEX_CONFIG: /root/.codex/config.toml
     CODEX_LOG_LEVEL: info
     CODEX_MAX_SESSION_ATTEMPTS: "3"
     CODEX_MODEL: gpt-5.5
     CODEX_MODEL_FALLBACKS: gpt-5.4,gpt-5.4-mini,gpt-5.2-codex,gpt-5-codex
     HOME: /root
+    SYNTHESIS_API_TOKEN_FILE: /var/run/synthesis/SYNTHESIS_API_TOKEN
     SYNTHESIS_MCP_URL: http://synthesis.synthesis.svc.cluster.local:3000/mcp
   inputFiles:
     - path: /root/.codex/config.toml
@@ -71,14 +84,30 @@ spec:
         [mcp_servers.synthesis]
         command = "node"
         args = ["/root/.codex/synthesis-mcp-proxy.mjs"]
+        env = { SYNTHESIS_API_TOKEN_FILE = "/var/run/synthesis/SYNTHESIS_API_TOKEN", SYNTHESIS_MCP_URL = "http://synthesis.synthesis.svc.cluster.local:3000/mcp" }
     - path: /root/.codex/synthesis-mcp-proxy.mjs
       content: |-
         #!/usr/bin/env node
 
+        import { readFileSync } from 'node:fs'
         import readline from 'node:readline'
 
+        const readFirstTokenFile = (paths) => {
+          for (const path of paths) {
+            if (!path) continue
+            try {
+              const token = readFileSync(path, 'utf8').trim()
+              if (token) return token
+            } catch {}
+          }
+          return ''
+        }
+
         const endpoint = process.env.SYNTHESIS_MCP_URL || 'http://synthesis.synthesis.svc.cluster.local:3000/mcp'
-        const token = process.env.SYNTHESIS_API_TOKEN || process.env.SYNTHESIS_MCP_TOKEN || ''
+        const token =
+          process.env.SYNTHESIS_API_TOKEN ||
+          process.env.SYNTHESIS_MCP_TOKEN ||
+          readFirstTokenFile([process.env.SYNTHESIS_API_TOKEN_FILE, '/var/run/synthesis/SYNTHESIS_API_TOKEN'])
 
         const buildError = (id, code, message, data) => ({
           jsonrpc: '2.0',

--- a/argocd/applications/synthesis/agents-domain/synthesis-deep-alpha-agentrun-template.yaml
+++ b/argocd/applications/synthesis/agents-domain/synthesis-deep-alpha-agentrun-template.yaml
@@ -26,6 +26,12 @@ spec:
   secrets:
     - synthesis-env
   workload:
+    volumes:
+      - type: secret
+        name: synthesis-env
+        secretName: synthesis-env
+        mountPath: /var/run/synthesis
+        readOnly: true
     resources:
       requests:
         cpu: "1"

--- a/docs/superpowers/plans/2026-05-26-synthesis-deep-alpha-scheduled-agentrun.md
+++ b/docs/superpowers/plans/2026-05-26-synthesis-deep-alpha-scheduled-agentrun.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a GitOps-managed Synthesis AgentRun that runs every 3 hours, researches short-term 2-3 week options strategy candidates with technical-analysis entry timing, and posts strict synthesized items to Synthesis.
 
-**Architecture:** Keep the resources owned by the Synthesis Argo CD app under `argocd/applications/synthesis`, but run the AgentRun primitives in the existing `agents` namespace where the controller, `agents-sa`, and `codex-auth` already work. Reflect the existing `synthesis/synthesis-env` secret into `agents`, inject `SYNTHESIS_API_TOKEN` into the Codex runner, and connect Codex to the in-cluster Synthesis MCP endpoint through an input-file MCP proxy.
+**Architecture:** Keep the resources owned by the Synthesis Argo CD app under `argocd/applications/synthesis`, but run the AgentRun primitives in the existing `agents` namespace where the controller, `agents-sa`, and `codex-auth` already work. Reflect the existing `synthesis/synthesis-env` secret into `agents`, inject `SYNTHESIS_API_TOKEN` into the Codex runner, mount the same secret at `/var/run/synthesis` so Codex MCP subprocesses can read a token file even when secret env is scrubbed, and connect Codex to the in-cluster Synthesis MCP endpoint through an input-file MCP proxy. Keyed reports upload to the existing `agents-artifacts` bucket.
 
 **Tech Stack:** Argo CD/Kustomize, Agents CRDs (`AgentProvider`, `Agent`, `ImplementationSpec`, `AgentRun`, `Schedule`), Kubernetes reflector, Bitnami SealedSecret template annotations, Codex app-server runner, Synthesis MCP.
 


### PR DESCRIPTION
## Summary

- Mount the reflected `synthesis-env` secret into Synthesis deep-alpha AgentRun pods so the MCP proxy can read a token file when secret env is scrubbed from subprocesses.
- Pass explicit MCP proxy env for the Synthesis endpoint and token-file path.
- Configure existing `agents-artifacts` storage credentials so keyed deep-alpha reports can upload successfully.

## Related Issues

None

## Testing

- `kustomize build argocd/applications/synthesis`
- `kustomize build argocd/applications/synthesis/agents-domain`
- `bun run lint:argocd`
- `kubectl apply --server-side --force-conflicts --dry-run=server -f /tmp/synthesis-agents-domain-render.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
