### PR TITLE
fix(torghut): scope paper route import audit to next window

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1356,17 +1356,14 @@ def _runtime_window_import_audit(
     *,
     next_targets: Mapping[str, object],
     target_audits: Sequence[Mapping[str, object]],
+    next_target_audits: Sequence[Mapping[str, object]],
 ) -> dict[str, object]:
     session_readiness = _as_mapping(next_targets.get("session_readiness"))
     import_blockers = _unique_text_items(session_readiness.get("import_blockers"))
-    selected_target_audits = _selected_runtime_window_target_audits(
-        next_targets=next_targets,
-        target_audits=target_audits,
-    )
     source_missing_reasons = sorted(
         {
             str(reason).strip()
-            for audit in selected_target_audits
+            for audit in next_target_audits
             for reason in _as_sequence(
                 _as_mapping(audit.get("source_activity")).get("missing_reasons")
             )
@@ -1376,7 +1373,7 @@ def _runtime_window_import_audit(
     runtime_ledger_blockers = sorted(
         {
             str(blocker).strip()
-            for audit in selected_target_audits
+            for audit in next_target_audits
             for blocker in _as_sequence(
                 _as_mapping(audit.get("runtime_ledger")).get("blockers")
             )
@@ -1384,9 +1381,9 @@ def _runtime_window_import_audit(
         }
     )
     source_plan_target_count = len(target_audits)
-    current_target_count = len(selected_target_audits)
+    current_target_count = len(next_target_audits)
     raw_source_counts = _runtime_window_target_counts(target_audits)
-    selected_target_counts = _runtime_window_target_counts(selected_target_audits)
+    selected_target_counts = _runtime_window_target_counts(next_target_audits)
     targets_with_source_activity = selected_target_counts["source_activity"]
     targets_with_runtime_ledger = selected_target_counts["runtime_ledger"]
     targets_with_evidence_grade_runtime_ledger = selected_target_counts[
@@ -1478,38 +1475,6 @@ def _runtime_window_import_audit(
             ],
         },
     }
-
-
-def _runtime_window_target_key(target: Mapping[str, object]) -> tuple[str | None, ...]:
-    return (
-        _safe_text(target.get("hypothesis_id")),
-        _safe_text(target.get("candidate_id")),
-        _safe_text(target.get("strategy_family")),
-        _safe_text(target.get("strategy_name")),
-        _safe_text(target.get("source_manifest_ref")),
-        _safe_text(target.get("dataset_snapshot_ref")),
-    )
-
-
-def _selected_runtime_window_target_audits(
-    *,
-    next_targets: Mapping[str, object],
-    target_audits: Sequence[Mapping[str, object]],
-) -> list[Mapping[str, object]]:
-    selected_keys = {
-        _runtime_window_target_key(_as_mapping(target))
-        for target in _as_mapping_items(next_targets.get("targets"))
-    }
-    if not selected_keys:
-        return []
-    selected: list[Mapping[str, object]] = []
-    seen: set[tuple[str | None, ...]] = set()
-    for audit in target_audits:
-        key = _runtime_window_target_key(_as_mapping(audit.get("target")))
-        if key in selected_keys and key not in seen:
-            selected.append(audit)
-            seen.add(key)
-    return selected
 
 
 def _runtime_window_target_counts(
@@ -1724,9 +1689,20 @@ def build_paper_route_evidence_audit(
         live_submission_gate=live_submission_gate,
         generated_at=resolved_generated_at,
     )
+    next_target_audits = [
+        _target_audit(
+            session,
+            raw_target=target,
+            probe=probe,
+            generated_at=resolved_generated_at,
+            lookback_hours=lookback_hours,
+        )
+        for target in _as_mapping_items(next_targets.get("targets"))
+    ]
     runtime_window_import_audit = _runtime_window_import_audit(
         next_targets=next_targets,
         target_audits=target_audits,
+        next_target_audits=next_target_audits,
     )
     proof_packet_handoff = _runtime_ledger_proof_packet_handoff(
         next_targets=next_targets,
@@ -1776,6 +1752,7 @@ def build_paper_route_evidence_audit(
         },
         "paper_route_probe": probe,
         "next_paper_route_runtime_window_targets": next_targets,
+        "next_runtime_window_target_audits": next_target_audits,
         "runtime_window_import_audit": runtime_window_import_audit,
         "runtime_ledger_proof_packet_handoff": proof_packet_handoff,
         "summary": {

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -797,7 +797,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                                 "observed_stage": "paper",
                                 "strategy_family": "microbar_pairs",
                                 "strategy_name": strategy_name,
-                                "account_label": "paper",
+                                "account_label": "TORGHUT_SIM",
                                 "source_manifest_ref": "config/trading/hypotheses/h-ledger-audit.json",
                                 "window_start": window_start.isoformat(),
                                 "window_end": window_end.isoformat(),
@@ -842,7 +842,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             session.flush()
             decision = TradeDecision(
                 strategy_id=strategy.id,
-                alpaca_account_label="paper",
+                alpaca_account_label="TORGHUT_SIM",
                 symbol="AAPL",
                 timeframe="1Min",
                 decision_json={"action": "buy", "qty": "2"},
@@ -855,7 +855,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             session.flush()
             execution = Execution(
                 trade_decision_id=decision.id,
-                alpaca_account_label="paper",
+                alpaca_account_label="TORGHUT_SIM",
                 alpaca_order_id="ledger-audit-order-1",
                 client_order_id="ledger-audit-client-1",
                 symbol="AAPL",
@@ -878,7 +878,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     execution_id=execution.id,
                     trade_decision_id=decision.id,
                     strategy_id=strategy.id,
-                    alpaca_account_label="paper",
+                    alpaca_account_label="TORGHUT_SIM",
                     symbol="AAPL",
                     side="buy",
                     arrival_price=Decimal("99"),
@@ -924,7 +924,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     observed_stage="paper",
                     bucket_started_at=window_start,
                     bucket_ended_at=window_end,
-                    account_label="paper",
+                    account_label="TORGHUT_SIM",
                     runtime_strategy_name=strategy_name,
                     strategy_family="microbar_pairs",
                     fill_count=2,
@@ -991,7 +991,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             session.flush()
             decision = TradeDecision(
                 strategy_id=strategy.id,
-                alpaca_account_label="paper",
+                alpaca_account_label="TORGHUT_SIM",
                 symbol="AAPL",
                 timeframe="1Min",
                 decision_json={"action": "buy", "qty": "1"},
@@ -1004,7 +1004,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             session.flush()
             execution = Execution(
                 trade_decision_id=decision.id,
-                alpaca_account_label="paper",
+                alpaca_account_label="TORGHUT_SIM",
                 alpaca_order_id="post-window-order-1",
                 client_order_id="post-window-client-1",
                 symbol="AAPL",
@@ -1027,7 +1027,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     execution_id=execution.id,
                     trade_decision_id=decision.id,
                     strategy_id=strategy.id,
-                    alpaca_account_label="paper",
+                    alpaca_account_label="TORGHUT_SIM",
                     symbol="AAPL",
                     side="buy",
                     arrival_price=Decimal("99"),
@@ -1063,7 +1063,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                                 "observed_stage": "paper",
                                 "strategy_family": "microbar_pairs",
                                 "strategy_name": strategy_name,
-                                "account_label": "paper",
+                                "account_label": "TORGHUT_SIM",
                                 "source_manifest_ref": "config/trading/hypotheses/h-post-window.json",
                                 "window_start": window_start.isoformat(),
                                 "window_end": window_end.isoformat(),
@@ -1134,7 +1134,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             session.flush()
             decision = TradeDecision(
                 strategy_id=strategy.id,
-                alpaca_account_label="paper",
+                alpaca_account_label="TORGHUT_SIM",
                 symbol="INTC",
                 timeframe="1Min",
                 decision_json={"action": "buy", "qty": "1"},
@@ -1147,7 +1147,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             session.flush()
             execution = Execution(
                 trade_decision_id=decision.id,
-                alpaca_account_label="paper",
+                alpaca_account_label="TORGHUT_SIM",
                 alpaca_order_id="refreshed-probe-order-1",
                 client_order_id="refreshed-probe-client-1",
                 symbol="INTC",
@@ -1170,7 +1170,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     execution_id=execution.id,
                     trade_decision_id=decision.id,
                     strategy_id=strategy.id,
-                    alpaca_account_label="paper",
+                    alpaca_account_label="TORGHUT_SIM",
                     symbol="INTC",
                     side="buy",
                     arrival_price=Decimal("99"),
@@ -1206,7 +1206,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                                 "observed_stage": "paper",
                                 "strategy_family": "microbar_pairs",
                                 "strategy_name": strategy_name,
-                                "account_label": "paper",
+                                "account_label": "TORGHUT_SIM",
                                 "source_kind": "paper_route_probe_runtime_observed",
                                 "window_start": window_start.isoformat(),
                                 "window_end": window_end.isoformat(),
@@ -1404,7 +1404,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             session.flush()
             decision = TradeDecision(
                 strategy_id=strategy.id,
-                alpaca_account_label="paper",
+                alpaca_account_label="TORGHUT_SIM",
                 symbol="AAPL",
                 timeframe="1Min",
                 decision_json={"action": "buy", "qty": "2"},
@@ -1417,7 +1417,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             session.flush()
             execution = Execution(
                 trade_decision_id=decision.id,
-                alpaca_account_label="paper",
+                alpaca_account_label="TORGHUT_SIM",
                 alpaca_order_id="paper-route-order-1",
                 client_order_id="paper-route-client-1",
                 symbol="AAPL",
@@ -1441,7 +1441,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         execution_id=execution.id,
                         trade_decision_id=decision.id,
                         strategy_id=strategy.id,
-                        alpaca_account_label="paper",
+                        alpaca_account_label="TORGHUT_SIM",
                         symbol="AAPL",
                         side="buy",
                         arrival_price=Decimal("99"),
@@ -1464,7 +1464,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         observed_stage="paper",
                         bucket_started_at=window_start,
                         bucket_ended_at=window_end,
-                        account_label="paper",
+                        account_label="TORGHUT_SIM",
                         runtime_strategy_name=strategy_name,
                         strategy_family="microbar_pairs",
                         fill_count=2,
@@ -1530,7 +1530,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                                 "observed_stage": "paper",
                                 "strategy_family": "microbar_pairs",
                                 "strategy_name": strategy_name,
-                                "account_label": "paper",
+                                "account_label": "TORGHUT_SIM",
                                 "source_manifest_ref": "config/trading/hypotheses/h-active-route.json",
                                 "window_start": window_start.isoformat(),
                                 "window_end": window_end.isoformat(),
@@ -1659,7 +1659,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             session.flush()
             decision = TradeDecision(
                 strategy_id=strategy.id,
-                alpaca_account_label="paper",
+                alpaca_account_label="TORGHUT_SIM",
                 symbol="AAPL",
                 timeframe="1Min",
                 decision_json={"action": "buy", "qty": "2"},
@@ -1672,7 +1672,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             session.flush()
             execution = Execution(
                 trade_decision_id=decision.id,
-                alpaca_account_label="paper",
+                alpaca_account_label="TORGHUT_SIM",
                 alpaca_order_id="selected-paper-route-order-1",
                 client_order_id="selected-paper-route-client-1",
                 symbol="AAPL",
@@ -1696,7 +1696,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         execution_id=execution.id,
                         trade_decision_id=decision.id,
                         strategy_id=strategy.id,
-                        alpaca_account_label="paper",
+                        alpaca_account_label="TORGHUT_SIM",
                         symbol="AAPL",
                         side="buy",
                         arrival_price=Decimal("99"),
@@ -1719,7 +1719,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         observed_stage="paper",
                         bucket_started_at=window_start,
                         bucket_ended_at=window_end,
-                        account_label="paper",
+                        account_label="TORGHUT_SIM",
                         runtime_strategy_name=strategy_name,
                         strategy_family="microbar_pairs",
                         fill_count=2,
@@ -1760,7 +1760,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                                 "observed_stage": "paper",
                                 "strategy_family": "microbar_pairs",
                                 "strategy_name": strategy_name,
-                                "account_label": "paper",
+                                "account_label": "TORGHUT_SIM",
                                 "source_manifest_ref": "config/trading/hypotheses/h-selected-route.json",
                                 "window_start": window_start.isoformat(),
                                 "window_end": window_end.isoformat(),
@@ -1831,6 +1831,121 @@ class TestPaperRouteEvidenceAudit(TestCase):
             import_audit["counts"]["raw_source_plan_targets_with_runtime_ledger"],
             1,
         )
+        next_window_audits = payload["next_runtime_window_target_audits"]
+        self.assertEqual(len(next_window_audits), 1)
+        self.assertEqual(
+            next_window_audits[0]["target"]["account_label"], "TORGHUT_SIM"
+        )
+
+    def test_runtime_import_audit_does_not_count_historical_ledger_as_next_window(
+        self,
+    ) -> None:
+        historical_start = datetime(2026, 5, 21, 17, tzinfo=timezone.utc)
+        historical_end = datetime(2026, 5, 21, 17, 30, tzinfo=timezone.utc)
+        now = datetime(2026, 5, 26, 21, tzinfo=timezone.utc)
+        strategy_name = "historical-paper-route"
+        with Session(self.engine) as session:
+            session.add(
+                StrategyRuntimeLedgerBucket(
+                    run_id="historical-paper-route-run",
+                    candidate_id="candidate-historical-route",
+                    hypothesis_id="H-HISTORICAL-ROUTE",
+                    observed_stage="paper",
+                    bucket_started_at=historical_start,
+                    bucket_ended_at=historical_end,
+                    account_label="TORGHUT_REPLAY",
+                    runtime_strategy_name=strategy_name,
+                    strategy_family="microbar_pairs",
+                    fill_count=2,
+                    decision_count=1,
+                    submitted_order_count=1,
+                    closed_trade_count=1,
+                    open_position_count=0,
+                    filled_notional=Decimal("200"),
+                    gross_strategy_pnl=Decimal("12"),
+                    cost_amount=Decimal("2"),
+                    net_strategy_pnl_after_costs=Decimal("10"),
+                    post_cost_expectancy_bps=Decimal("500"),
+                    ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                    pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                    execution_policy_hash_counts={"policy-a": 1},
+                    cost_model_hash_counts={"cost-a": 1},
+                    lineage_hash_counts={"lineage-a": 1},
+                    blockers_json=[],
+                )
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 1,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-HISTORICAL-ROUTE",
+                                "candidate_id": "candidate-historical-route",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": strategy_name,
+                                "account_label": "TORGHUT_REPLAY",
+                                "source_manifest_ref": "config/trading/hypotheses/h-historical-route.json",
+                                "window_start": historical_start.isoformat(),
+                                "window_end": historical_end.isoformat(),
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": ["AAPL"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                    },
+                },
+                generated_at=now,
+            )
+
+        import_audit = payload["runtime_window_import_audit"]
+        self.assertEqual(import_audit["state"], "import_due_source_activity_missing")
+        self.assertEqual(import_audit["counts"]["selected_target_count"], 1)
+        self.assertEqual(import_audit["counts"]["targets_with_source_activity"], 0)
+        self.assertEqual(import_audit["counts"]["targets_with_runtime_ledger"], 0)
+        self.assertEqual(
+            import_audit["counts"]["targets_with_evidence_grade_runtime_ledger"],
+            0,
+        )
+        self.assertEqual(
+            import_audit["counts"]["raw_source_plan_targets_with_runtime_ledger"],
+            1,
+        )
+        self.assertEqual(
+            import_audit["blockers"],
+            [
+                "paper_route_source_activity_missing",
+                "source_decisions_missing",
+                "source_executions_missing",
+                "source_tca_missing",
+            ],
+        )
+        next_window_audit = payload["next_runtime_window_target_audits"][0]
+        self.assertEqual(next_window_audit["target"]["account_label"], "TORGHUT_SIM")
+        self.assertEqual(next_window_audit["runtime_ledger"]["bucket_count"], 0)
 
     def test_runtime_ledger_summary_is_scoped_to_target_stage_account_and_strategy(
         self,


### PR DESCRIPTION
## Summary

- Scope paper-route runtime-window import audit counts to explicit next-window target audits instead of reusing historical source-plan audits.
- Expose `next_runtime_window_target_audits` so operators can inspect the actual `TORGHUT_SIM` target window evidence separately from raw replay/source-plan evidence.
- Add regression coverage proving historical replay ledger buckets do not satisfy the next live-paper import window.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py -k paper_route_evidence -q`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py tests/test_run_empirical_promotion_jobs.py -k 'paper_route or runtime_window_target_plan' -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
