### PR TITLE
fix(torghut): keep pre-window proof actions focused

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -788,6 +788,18 @@ def _completion_blockers(gate: Mapping[str, Any]) -> list[str]:
 
 def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
     actions: list[str] = []
+    if verdict == "waiting_for_runtime_window":
+        for blocker in blockers:
+            if blocker in {
+                "paper_route_session_window_not_open",
+                "paper_route_session_window_not_closed",
+                "paper_route_import_not_ready",
+            }:
+                _extend_unique(actions, ["wait_for_regular_session_runtime_window"])
+            elif blocker == "paper_route_session_settlement_pending":
+                _extend_unique(actions, ["wait_for_paper_route_settlement_grace"])
+        if actions:
+            return actions
     for blocker in blockers:
         if blocker in {
             "paper_route_session_window_not_open",

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -597,6 +597,50 @@ class TestRuntimeLedgerProofPacket(TestCase):
             ]
         )
 
+    def test_waiting_packet_prioritizes_wait_action_over_drift_repair(
+        self,
+    ) -> None:
+        evidence = _paper_route_evidence(
+            import_ready=False,
+            import_blockers=["paper_route_session_window_not_open"],
+        )
+        plan = evidence["next_paper_route_runtime_window_targets"]
+        assert isinstance(plan, dict)
+        target = plan["targets"][0]
+        assert isinstance(target, dict)
+        target["drift_ok"] = "false"
+        target["drift_reason"] = "drift_live_promotion_ineligible"
+        target["runtime_window_import_health_gate"] = {
+            "schema_version": "torghut.runtime-window-import-health-gate.v1",
+            "dependency_quorum_decision": "allow",
+            "continuity_ok": "true",
+            "drift_ok": "false",
+            "drift_reason": "drift_live_promotion_ineligible",
+            "blockers": [],
+            "promotion_blockers": ["drift_checks_not_ok"],
+        }
+        target["runtime_window_import_health_gate_blockers"] = []
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=evidence,
+            generated_at="2026-05-25T21:05:00+00:00",
+        )
+
+        self.assertEqual(result["verdict"], "waiting_for_runtime_window")
+        self.assertIn(
+            "drift_checks_not_ok",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertEqual(
+            result["required_actions"],
+            ["wait_for_regular_session_runtime_window"],
+        )
+        self.assertNotIn(
+            "repair_runtime_window_import_health_gate",
+            result["required_actions"],
+        )
+
     def test_packet_blocks_with_source_activity_audit_before_generic_import_missing(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adjusts runtime-ledger proof-packet action selection so `waiting_for_runtime_window` packets return wait/settlement actions instead of mixing in capital-promotion repairs.
- Keeps drift and capital gate blockers visible in promotion authority; this does not relax post-cost proof or promotion gates.
- Adds regression coverage for a pre-window paper-route packet where drift remains a promotion blocker but the correct next action is to wait for the session window.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -k 'waiting_packet_prioritizes or waits_before_paper_route_window or drift_only' -q`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv run --frozen ruff format --check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Live pre-open packet assembled from current `/trading/status` and `/trading/paper-route-evidence` returned `verdict=waiting_for_runtime_window`, `required_actions=["wait_for_regular_session_runtime_window"]`, while promotion blockers still included `drift_checks_not_ok`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
