### PR TITLE
feat(synthesis): polish reading UI and company analysis

### DIFF
--- a/apps/synthesis/src/index.css
+++ b/apps/synthesis/src/index.css
@@ -82,7 +82,9 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply font-sans bg-background text-foreground;
+    @apply font-sans bg-background text-foreground antialiased;
+    font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
+    text-rendering: optimizeLegibility;
   }
   html {
     @apply font-sans;

--- a/apps/synthesis/src/lib/company-symbols.test.ts
+++ b/apps/synthesis/src/lib/company-symbols.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest'
+
+import { extractCompanySymbols, segmentCompanySymbols } from './company-symbols'
+
+describe('company symbol detection', () => {
+  test('links known stock symbols and cashtags without linking ordinary all-caps words', () => {
+    expect(extractCompanySymbols('AI capex: $NVDA, MSFT, and AAPL matter; CPU and USA should not.')).toEqual([
+      'NVDA',
+      'MSFT',
+      'AAPL',
+    ])
+  })
+
+  test('segments linked symbols with internal company hrefs', () => {
+    expect(segmentCompanySymbols('TSLA and AMD supply-chain notes')).toEqual([
+      { kind: 'symbol', text: 'TSLA', symbol: 'TSLA', href: '/companies/TSLA' },
+      { kind: 'text', text: ' and ' },
+      { kind: 'symbol', text: 'AMD', symbol: 'AMD', href: '/companies/AMD' },
+      { kind: 'text', text: ' supply-chain notes' },
+    ])
+  })
+})

--- a/apps/synthesis/src/lib/company-symbols.ts
+++ b/apps/synthesis/src/lib/company-symbols.ts
@@ -1,0 +1,93 @@
+import type { SynthesisItem } from '~/server/schema'
+
+export type CompanySymbol = (typeof knownCompanySymbols)[number]
+
+export const knownCompanySymbols = [
+  'AAPL',
+  'AMD',
+  'AMZN',
+  'ARM',
+  'ASML',
+  'AVGO',
+  'COIN',
+  'CRM',
+  'GOOG',
+  'GOOGL',
+  'IBM',
+  'INTC',
+  'JPM',
+  'META',
+  'MSFT',
+  'MU',
+  'NFLX',
+  'NOW',
+  'NVDA',
+  'ORCL',
+  'PLTR',
+  'QCOM',
+  'SMCI',
+  'TSLA',
+  'TSM',
+] as const
+
+const knownCompanySymbolSet = new Set<string>(knownCompanySymbols)
+const symbolPattern = /(^|[^A-Za-z0-9])\$?([A-Z]{2,5})(?=$|[^A-Za-z0-9])/g
+
+export type TextSegment =
+  | { kind: 'text'; text: string }
+  | { kind: 'symbol'; text: string; symbol: string; href: string }
+
+export const normalizeCompanySymbol = (value: string) => {
+  const symbol = value.trim().replace(/^\$+/, '').toUpperCase()
+  return knownCompanySymbolSet.has(symbol) ? symbol : null
+}
+
+export const companyPath = (symbol: string) => `/companies/${symbol.toUpperCase()}`
+
+export const extractCompanySymbols = (text: string) => {
+  const symbols: string[] = []
+  const seen = new Set<string>()
+  for (const match of text.matchAll(symbolPattern)) {
+    const symbol = normalizeCompanySymbol(match[2] ?? '')
+    if (!symbol || seen.has(symbol)) continue
+    seen.add(symbol)
+    symbols.push(symbol)
+  }
+  return symbols
+}
+
+export const segmentCompanySymbols = (text: string): TextSegment[] => {
+  const segments: TextSegment[] = []
+  let lastIndex = 0
+  for (const match of text.matchAll(symbolPattern)) {
+    const prefix = match[1] ?? ''
+    const token = match[2] ?? ''
+    const symbol = normalizeCompanySymbol(token)
+    const tokenStart = (match.index ?? 0) + prefix.length
+    const tokenEnd = tokenStart + (match[0]?.slice(prefix.length).length ?? token.length)
+    if (!symbol) continue
+    if (tokenStart > lastIndex) segments.push({ kind: 'text', text: text.slice(lastIndex, tokenStart) })
+    segments.push({ kind: 'symbol', text: text.slice(tokenStart, tokenEnd), symbol, href: companyPath(symbol) })
+    lastIndex = tokenEnd
+  }
+  if (lastIndex < text.length) segments.push({ kind: 'text', text: text.slice(lastIndex) })
+  return segments.length ? segments : [{ kind: 'text', text }]
+}
+
+export const symbolsFromSynthesisItem = (item: SynthesisItem) => {
+  const text = [
+    item.title,
+    item.synthesis,
+    item.summary,
+    item.whyValuable,
+    item.observedText,
+    ...item.takeaways,
+    ...item.evidence,
+    ...item.topicTags,
+    ...item.sourcePosts.flatMap((source) => [source.observedText, source.authorHandle, source.authorName]),
+    ...item.factChecks.flatMap((factCheck) => [factCheck.claim, factCheck.explanation]),
+  ]
+    .filter(Boolean)
+    .join(' ')
+  return extractCompanySymbols(text)
+}

--- a/apps/synthesis/src/lib/image-modal.test.ts
+++ b/apps/synthesis/src/lib/image-modal.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest'
+
+import { imageModalCaptionId, imageModalTitleId, initialImageModalState, reduceImageModalState } from './image-modal'
+
+describe('attachment image modal behavior', () => {
+  test('opens images and closes via button/backdrop action', () => {
+    const open = reduceImageModalState(initialImageModalState, { type: 'open', imageId: 'asset-1' })
+
+    expect(open).toEqual({ isOpen: true, imageId: 'asset-1' })
+    expect(reduceImageModalState(open, { type: 'close' })).toEqual(initialImageModalState)
+  })
+
+  test('closes on Escape and ignores unrelated keys', () => {
+    const open = { isOpen: true, imageId: 'asset-1' }
+
+    expect(reduceImageModalState(open, { type: 'escape', key: 'Tab' })).toBe(open)
+    expect(reduceImageModalState(open, { type: 'escape', key: 'Escape' })).toEqual(initialImageModalState)
+  })
+
+  test('uses stable accessible ids for title and caption context', () => {
+    expect(imageModalTitleId('asset-1')).toBe('attachment-image-modal-title-asset-1')
+    expect(imageModalCaptionId('asset-1')).toBe('attachment-image-modal-caption-asset-1')
+  })
+})

--- a/apps/synthesis/src/lib/image-modal.ts
+++ b/apps/synthesis/src/lib/image-modal.ts
@@ -1,0 +1,18 @@
+export type ImageModalState = {
+  isOpen: boolean
+  imageId: string | null
+}
+
+export type ImageModalAction = { type: 'open'; imageId: string } | { type: 'close' } | { type: 'escape'; key: string }
+
+export const initialImageModalState: ImageModalState = { isOpen: false, imageId: null }
+
+export const reduceImageModalState = (state: ImageModalState, action: ImageModalAction): ImageModalState => {
+  if (action.type === 'open') return { isOpen: true, imageId: action.imageId }
+  if (action.type === 'close') return initialImageModalState
+  if (action.type === 'escape' && action.key === 'Escape') return initialImageModalState
+  return state
+}
+
+export const imageModalCaptionId = (imageId: string) => `attachment-image-modal-caption-${imageId}`
+export const imageModalTitleId = (imageId: string) => `attachment-image-modal-title-${imageId}`

--- a/apps/synthesis/src/lib/synthesis-ui-contract.test.ts
+++ b/apps/synthesis/src/lib/synthesis-ui-contract.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  synthesisHasBottomLeftCounter,
+  synthesisHasCurateAction,
+  synthesisSearchInputClassName,
+  synthesisSidebarItems,
+} from './synthesis-ui-contract'
+
+describe('synthesis shell polish contract', () => {
+  test('removes legacy navigation/actions and makes search full width', () => {
+    expect(synthesisSidebarItems).toEqual(['Feed'])
+    expect(synthesisSidebarItems).not.toContain('Search')
+    expect(synthesisHasCurateAction).toBe(false)
+    expect(synthesisHasBottomLeftCounter).toBe(false)
+    expect(synthesisSearchInputClassName.split(/\s+/)).toContain('w-full')
+  })
+})

--- a/apps/synthesis/src/lib/synthesis-ui-contract.ts
+++ b/apps/synthesis/src/lib/synthesis-ui-contract.ts
@@ -1,0 +1,5 @@
+export const synthesisSidebarItems = ['Feed'] as const
+export const synthesisHasCurateAction = false
+export const synthesisHasBottomLeftCounter = false
+export const synthesisSearchInputClassName =
+  'h-9 w-full rounded-md border border-[#2f3336] bg-[#080808] pl-9 pr-3 text-[15px] text-[#e7e9ea] outline-none placeholder:text-[#71767b] focus:border-[#1d9bf0]/70 focus:ring-2 focus:ring-[#1d9bf0]/25'

--- a/apps/synthesis/src/lib/tags.test.ts
+++ b/apps/synthesis/src/lib/tags.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest'
+
+import { deriveTopicTagsFromItemContent, normalizeTopicTags } from './tags'
+
+describe('synthesis tags', () => {
+  test('normalizes explicit tags and removes empty chrome', () => {
+    expect(normalizeTopicTags([' Semis ', '', '#AI Agents', 'semis'])).toEqual(['semis', 'ai-agents'])
+  })
+
+  test('derives useful display tags from item content when explicit tags are missing', () => {
+    expect(
+      deriveTopicTagsFromItemContent({
+        title: 'NVDA HBM packaging constraints move into inference systems',
+        synthesis:
+          'Semiconductor packaging and inference deployment notes make this a useful chip supply-chain signal.',
+        takeaways: ['watch HBM allocation for model deployment'],
+        topicTags: [],
+      }),
+    ).toEqual(expect.arrayContaining(['semis', 'machine-learning']))
+  })
+})

--- a/apps/synthesis/src/lib/tags.ts
+++ b/apps/synthesis/src/lib/tags.ts
@@ -1,0 +1,74 @@
+import type { SynthesisFactCheck, SynthesisSourcePost } from '~/server/schema'
+
+const tagRules: Array<{ tag: string; patterns: RegExp[] }> = [
+  { tag: 'semis', patterns: [/\bsemi(conductor)?s?\b/i, /\bchip(s|let)?\b/i, /\bhbm\b/i, /\bpackaging\b/i] },
+  { tag: 'ai-agents', patterns: [/\bagents?\b/i, /\bautonomous\b/i, /\bbrowser agents?\b/i] },
+  { tag: 'devtools', patterns: [/\bdev ?tools?\b/i, /\bdeveloper\b/i, /\bide\b/i, /\bcli\b/i] },
+  { tag: 'software-engineering', patterns: [/\bsoftware\b/i, /\bengineering\b/i, /\bdeploy(ment)?\b/i] },
+  { tag: 'machine-learning', patterns: [/\bmachine learning\b/i, /\bml\b/i, /\bmodel(s)?\b/i, /\binference\b/i] },
+  { tag: 'quant-trading', patterns: [/\bquant\b/i, /\btrading\b/i, /\bmarket(s)?\b/i] },
+  { tag: 'options', patterns: [/\boptions?\b/i, /\bvol(atility)?\b/i, /\bput(s)?\b/i, /\bcall(s)?\b/i] },
+  { tag: 'trading-systems', patterns: [/\bexecution\b/i, /\border book\b/i, /\blatency\b/i, /\bsystems?\b/i] },
+  { tag: 'security', patterns: [/\bsecurity\b/i, /\bcve\b/i, /\bauth\b/i, /\bexploit\b/i] },
+]
+
+const normalizeTag = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/^#+/, '')
+    .replace(/[^a-z0-9$+._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60)
+
+export const normalizeTopicTags = (tags: readonly string[]) => {
+  const seen = new Set<string>()
+  const normalized: string[] = []
+  for (const tag of tags) {
+    const value = normalizeTag(tag)
+    if (!value || seen.has(value)) continue
+    seen.add(value)
+    normalized.push(value)
+  }
+  return normalized
+}
+
+export const deriveTopicTagsFromText = (text: string, limit = 6) => {
+  const tags: string[] = []
+  for (const rule of tagRules) {
+    if (rule.patterns.some((pattern) => pattern.test(text))) tags.push(rule.tag)
+  }
+  return normalizeTopicTags(tags).slice(0, limit)
+}
+
+export const deriveTopicTagsFromItemContent = (input: {
+  title?: string | null
+  synthesis?: string | null
+  summary?: string | null
+  whyValuable?: string | null
+  observedText?: string | null
+  takeaways?: readonly string[] | null
+  evidence?: readonly string[] | null
+  topicTags?: readonly string[] | null
+  sourcePosts?: readonly Pick<SynthesisSourcePost, 'observedText' | 'authorHandle' | 'authorName'>[] | null
+  factChecks?: readonly Pick<SynthesisFactCheck, 'claim' | 'explanation'>[] | null
+}) => {
+  const provided = normalizeTopicTags(input.topicTags ?? [])
+  if (provided.length) return provided
+
+  const text = [
+    input.title,
+    input.synthesis,
+    input.summary,
+    input.whyValuable,
+    input.observedText,
+    ...(input.takeaways ?? []),
+    ...(input.evidence ?? []),
+    ...(input.sourcePosts ?? []).flatMap((source) => [source.observedText, source.authorHandle, source.authorName]),
+    ...(input.factChecks ?? []).flatMap((factCheck) => [factCheck.claim, factCheck.explanation]),
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return deriveTopicTagsFromText(text)
+}

--- a/apps/synthesis/src/routeTree.gen.ts
+++ b/apps/synthesis/src/routeTree.gen.ts
@@ -11,11 +11,13 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as McpRouteImport } from './routes/mcp'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as CompaniesSymbolRouteImport } from './routes/companies/$symbol'
 import { Route as ApiRunsRouteImport } from './routes/api/runs'
 import { Route as ApiItemsRouteImport } from './routes/api/items'
 import { Route as ApiFeedRouteImport } from './routes/api/feed'
 import { Route as ApiItemsBatchRouteImport } from './routes/api/items/batch'
 import { Route as ApiItemsIdRouteImport } from './routes/api/items/$id'
+import { Route as ApiCompaniesSymbolRouteImport } from './routes/api/companies/$symbol'
 import { Route as ApiAssetsIdRouteImport } from './routes/api/assets/$id'
 import { Route as ApiItemsIdFeedbackRouteImport } from './routes/api/items/$id/feedback'
 
@@ -27,6 +29,11 @@ const McpRoute = McpRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CompaniesSymbolRoute = CompaniesSymbolRouteImport.update({
+  id: '/companies/$symbol',
+  path: '/companies/$symbol',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiRunsRoute = ApiRunsRouteImport.update({
@@ -54,6 +61,11 @@ const ApiItemsIdRoute = ApiItemsIdRouteImport.update({
   path: '/$id',
   getParentRoute: () => ApiItemsRoute,
 } as any)
+const ApiCompaniesSymbolRoute = ApiCompaniesSymbolRouteImport.update({
+  id: '/api/companies/$symbol',
+  path: '/api/companies/$symbol',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiAssetsIdRoute = ApiAssetsIdRouteImport.update({
   id: '/api/assets/$id',
   path: '/api/assets/$id',
@@ -71,7 +83,9 @@ export interface FileRoutesByFullPath {
   '/api/feed': typeof ApiFeedRoute
   '/api/items': typeof ApiItemsRouteWithChildren
   '/api/runs': typeof ApiRunsRoute
+  '/companies/$symbol': typeof CompaniesSymbolRoute
   '/api/assets/$id': typeof ApiAssetsIdRoute
+  '/api/companies/$symbol': typeof ApiCompaniesSymbolRoute
   '/api/items/$id': typeof ApiItemsIdRouteWithChildren
   '/api/items/batch': typeof ApiItemsBatchRoute
   '/api/items/$id/feedback': typeof ApiItemsIdFeedbackRoute
@@ -82,7 +96,9 @@ export interface FileRoutesByTo {
   '/api/feed': typeof ApiFeedRoute
   '/api/items': typeof ApiItemsRouteWithChildren
   '/api/runs': typeof ApiRunsRoute
+  '/companies/$symbol': typeof CompaniesSymbolRoute
   '/api/assets/$id': typeof ApiAssetsIdRoute
+  '/api/companies/$symbol': typeof ApiCompaniesSymbolRoute
   '/api/items/$id': typeof ApiItemsIdRouteWithChildren
   '/api/items/batch': typeof ApiItemsBatchRoute
   '/api/items/$id/feedback': typeof ApiItemsIdFeedbackRoute
@@ -94,7 +110,9 @@ export interface FileRoutesById {
   '/api/feed': typeof ApiFeedRoute
   '/api/items': typeof ApiItemsRouteWithChildren
   '/api/runs': typeof ApiRunsRoute
+  '/companies/$symbol': typeof CompaniesSymbolRoute
   '/api/assets/$id': typeof ApiAssetsIdRoute
+  '/api/companies/$symbol': typeof ApiCompaniesSymbolRoute
   '/api/items/$id': typeof ApiItemsIdRouteWithChildren
   '/api/items/batch': typeof ApiItemsBatchRoute
   '/api/items/$id/feedback': typeof ApiItemsIdFeedbackRoute
@@ -107,7 +125,9 @@ export interface FileRouteTypes {
     | '/api/feed'
     | '/api/items'
     | '/api/runs'
+    | '/companies/$symbol'
     | '/api/assets/$id'
+    | '/api/companies/$symbol'
     | '/api/items/$id'
     | '/api/items/batch'
     | '/api/items/$id/feedback'
@@ -118,7 +138,9 @@ export interface FileRouteTypes {
     | '/api/feed'
     | '/api/items'
     | '/api/runs'
+    | '/companies/$symbol'
     | '/api/assets/$id'
+    | '/api/companies/$symbol'
     | '/api/items/$id'
     | '/api/items/batch'
     | '/api/items/$id/feedback'
@@ -129,7 +151,9 @@ export interface FileRouteTypes {
     | '/api/feed'
     | '/api/items'
     | '/api/runs'
+    | '/companies/$symbol'
     | '/api/assets/$id'
+    | '/api/companies/$symbol'
     | '/api/items/$id'
     | '/api/items/batch'
     | '/api/items/$id/feedback'
@@ -141,7 +165,9 @@ export interface RootRouteChildren {
   ApiFeedRoute: typeof ApiFeedRoute
   ApiItemsRoute: typeof ApiItemsRouteWithChildren
   ApiRunsRoute: typeof ApiRunsRoute
+  CompaniesSymbolRoute: typeof CompaniesSymbolRoute
   ApiAssetsIdRoute: typeof ApiAssetsIdRoute
+  ApiCompaniesSymbolRoute: typeof ApiCompaniesSymbolRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -158,6 +184,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/companies/$symbol': {
+      id: '/companies/$symbol'
+      path: '/companies/$symbol'
+      fullPath: '/companies/$symbol'
+      preLoaderRoute: typeof CompaniesSymbolRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/runs': {
@@ -194,6 +227,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/items/$id'
       preLoaderRoute: typeof ApiItemsIdRouteImport
       parentRoute: typeof ApiItemsRoute
+    }
+    '/api/companies/$symbol': {
+      id: '/api/companies/$symbol'
+      path: '/api/companies/$symbol'
+      fullPath: '/api/companies/$symbol'
+      preLoaderRoute: typeof ApiCompaniesSymbolRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/api/assets/$id': {
       id: '/api/assets/$id'
@@ -244,7 +284,9 @@ const rootRouteChildren: RootRouteChildren = {
   ApiFeedRoute: ApiFeedRoute,
   ApiItemsRoute: ApiItemsRouteWithChildren,
   ApiRunsRoute: ApiRunsRoute,
+  CompaniesSymbolRoute: CompaniesSymbolRoute,
   ApiAssetsIdRoute: ApiAssetsIdRoute,
+  ApiCompaniesSymbolRoute: ApiCompaniesSymbolRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/synthesis/src/routes/api/companies/$symbol.ts
+++ b/apps/synthesis/src/routes/api/companies/$symbol.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/companies/$symbol')({
+  server: {
+    handlers: {
+      GET: async ({ params, request }: { params: { symbol: string }; request: Request }) => {
+        const { handleGetCompany } = await import('~/server/api')
+        return handleGetCompany(request, params.symbol)
+      },
+    },
+  },
+})

--- a/apps/synthesis/src/routes/companies/$symbol.tsx
+++ b/apps/synthesis/src/routes/companies/$symbol.tsx
@@ -1,0 +1,154 @@
+import { useQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import { ArrowLeft, BarChart3, ExternalLink } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+import { normalizeCompanySymbol } from '~/lib/company-symbols'
+import type { CompanyAnalysis, CompanyMetric } from '~/server/company'
+
+export const Route = createFileRoute('/companies/$symbol')({
+  component: CompanyPage,
+})
+
+type CompanyResponse = {
+  company: CompanyAnalysis
+}
+
+async function fetchCompany(symbol: string): Promise<CompanyAnalysis> {
+  const response = await fetch(`/api/companies/${encodeURIComponent(symbol)}`)
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as { error?: string } | null
+    throw new Error(payload?.error ?? `company analysis unavailable: ${response.status}`)
+  }
+  const payload = (await response.json()) as CompanyResponse
+  return payload.company
+}
+
+function CompanyPage() {
+  const { symbol: symbolParam } = Route.useParams()
+  const symbol = normalizeCompanySymbol(symbolParam) ?? symbolParam.toUpperCase()
+  const company = useQuery({
+    queryKey: ['synthesis-company', symbol],
+    queryFn: () => fetchCompany(symbol),
+    retry: false,
+  })
+
+  return (
+    <main className="min-h-dvh bg-black text-[#e7e9ea]">
+      <div className="mx-auto flex min-h-dvh w-full max-w-5xl flex-col border-x border-[#2f3336]">
+        <header className="border-b border-[#2f3336] px-4 py-3 sm:px-6">
+          <a
+            href="/"
+            className="inline-flex items-center gap-2 rounded-md px-2 py-1 text-sm text-[#a6a6a6] transition-colors hover:bg-[#181818] hover:text-[#e7e9ea] focus-visible:ring-2 focus-visible:ring-[#1d9bf0]/50"
+          >
+            <ArrowLeft className="size-4" />
+            Synthesis
+          </a>
+          <div className="mt-4 flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#71767b]">Company</p>
+              <h1 className="mt-1 text-3xl font-semibold tracking-[-0.02em] sm:text-4xl">{symbol}</h1>
+            </div>
+            <a
+              href={`https://www.alphavantage.co/query?function=OVERVIEW&symbol=${encodeURIComponent(symbol)}`}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 rounded-md border border-[#2f3336] px-3 py-2 text-sm text-[#a6a6a6] transition-colors hover:border-[#1d9bf0]/60 hover:text-[#e7e9ea]"
+            >
+              Market source
+              <ExternalLink className="size-4" />
+            </a>
+          </div>
+        </header>
+
+        <section className="flex-1 px-4 py-5 sm:px-6">
+          {company.isLoading ? <CompanyLoading /> : company.error ? <CompanyError error={company.error} /> : null}
+          {company.data ? <CompanyAnalysisView company={company.data} /> : null}
+        </section>
+      </div>
+    </main>
+  )
+}
+
+function CompanyAnalysisView({ company }: { company: CompanyAnalysis }) {
+  return (
+    <div className="grid gap-5">
+      <section className="rounded-lg border border-[#2f3336] bg-[#080808] p-4 sm:p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-2xl font-semibold tracking-[-0.01em]">{company.identity.name}</h2>
+            <p className="mt-1 text-sm text-[#71767b]">
+              {[company.identity.exchange, company.identity.sector, company.identity.industry]
+                .filter(Boolean)
+                .join(' · ')}
+            </p>
+          </div>
+          <span className="rounded-full border border-[#2f3336] px-3 py-1 font-mono text-xs text-[#a6a6a6]">
+            {company.source}
+          </span>
+        </div>
+        {company.identity.description ? (
+          <p className="mt-4 max-w-4xl text-[15px] leading-7 text-[#d8dadd]">{company.identity.description}</p>
+        ) : null}
+        <p className="mt-4 font-mono text-xs text-[#71767b]">Updated {new Date(company.updatedAt).toLocaleString()}</p>
+      </section>
+
+      <div className="grid gap-5 lg:grid-cols-3">
+        <MetricSection
+          icon={<BarChart3 className="size-4" />}
+          title="Fundamental analysis"
+          metrics={company.fundamentals}
+        />
+        <MetricSection title="Technical analysis" metrics={company.technicals} />
+        <MetricSection title="Financial analysis" metrics={company.financials} />
+      </div>
+    </div>
+  )
+}
+
+function MetricSection({ icon, title, metrics }: { icon?: ReactNode; title: string; metrics: CompanyMetric[] }) {
+  return (
+    <section className="rounded-lg border border-[#2f3336] bg-[#080808] p-4">
+      <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-[#a6a6a6]">
+        {icon}
+        {title}
+      </h3>
+      {metrics.length ? (
+        <dl className="grid gap-2">
+          {metrics.map((metric) => (
+            <div
+              key={metric.label}
+              className="flex items-baseline justify-between gap-3 border-t border-[#202327] pt-2"
+            >
+              <dt className="text-sm text-[#71767b]">{metric.label}</dt>
+              <dd className="text-right font-mono text-sm text-[#e7e9ea]">{metric.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : (
+        <p className="text-sm leading-6 text-[#71767b]">Current market-data fields are unavailable.</p>
+      )}
+    </section>
+  )
+}
+
+function CompanyLoading() {
+  return (
+    <div className="grid gap-4" aria-label="Loading company analysis">
+      <div className="h-36 rounded-lg border border-[#2f3336] bg-[#080808] animate-pulse" />
+      <div className="grid gap-4 lg:grid-cols-3">
+        {Array.from({ length: 3 }, (_, index) => (
+          <div key={index} className="h-64 rounded-lg border border-[#2f3336] bg-[#080808] animate-pulse" />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function CompanyError({ error }: { error: Error }) {
+  return (
+    <div role="alert" className="rounded-lg border border-[#5f1f2b] bg-[#16070a] px-4 py-4 text-sm text-[#ff9aa5]">
+      {error.message}
+    </div>
+  )
+}

--- a/apps/synthesis/src/routes/index.tsx
+++ b/apps/synthesis/src/routes/index.tsx
@@ -1,17 +1,25 @@
-import { ScrollArea as DesignScrollArea } from '@proompteng/design/ui'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { ArrowUpRight, ExternalLink, ImageIcon, Newspaper, Search } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { ArrowUpRight, ExternalLink, ImageIcon, Newspaper, Search, X } from 'lucide-react'
+import { useEffect, useMemo, useReducer, useState } from 'react'
 import type {
   ButtonHTMLAttributes,
   HTMLAttributes,
   InputHTMLAttributes,
   KeyboardEvent,
+  MouseEvent,
   ReactNode,
   UIEvent,
 } from 'react'
-import type { FeedResponse, SynthesisItem } from '~/server/schema'
+import {
+  imageModalCaptionId,
+  imageModalTitleId,
+  initialImageModalState,
+  reduceImageModalState,
+} from '~/lib/image-modal'
+import { normalizeCompanySymbol, segmentCompanySymbols, symbolsFromSynthesisItem } from '~/lib/company-symbols'
+import { synthesisSearchInputClassName, synthesisSidebarItems } from '~/lib/synthesis-ui-contract'
+import type { FeedResponse, SynthesisAttachment, SynthesisItem } from '~/server/schema'
 
 export const Route = createFileRoute('/')({
   component: App,
@@ -33,26 +41,12 @@ const topicTabs = [
 const cx = (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(' ')
 
 function UiScrollArea({ className, children, ...props }: HTMLAttributes<HTMLDivElement> & { children: ReactNode }) {
-  const [isMounted, setIsMounted] = useState(false)
-
-  useEffect(() => {
-    setIsMounted(true)
-  }, [])
-
-  if (!isMounted) {
-    return (
-      <div data-slot="scroll-area" className={cx('relative', className)} {...props}>
-        <div data-slot="scroll-area-viewport" className="size-full rounded-[inherit]">
-          {children}
-        </div>
-      </div>
-    )
-  }
-
   return (
-    <DesignScrollArea className={className} {...props}>
-      {children}
-    </DesignScrollArea>
+    <div data-slot="scroll-area" className={cx('relative overflow-hidden', className)} {...props}>
+      <div data-slot="scroll-area-viewport" className="size-full rounded-[inherit]">
+        {children}
+      </div>
+    </div>
   )
 }
 
@@ -186,6 +180,7 @@ function App() {
   const [tag, setTag] = useState('all')
   const [query, setQuery] = useState('')
   const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [imageModal, dispatchImageModal] = useReducer(reduceImageModalState, initialImageModalState)
 
   const feed = useInfiniteQuery({
     queryKey: ['synthesis-feed', tag, query.trim()],
@@ -202,6 +197,19 @@ function App() {
     () => items.find((item) => item.id === selectedId) ?? items[0] ?? null,
     [items, selectedId],
   )
+  const selectedModalAttachment = useMemo(() => {
+    if (!imageModal.imageId) return null
+    return items.flatMap((item) => item.attachments).find((attachment) => attachment.id === imageModal.imageId) ?? null
+  }, [imageModal.imageId, items])
+
+  useEffect(() => {
+    if (!imageModal.isOpen) return undefined
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      dispatchImageModal({ type: 'escape', key: event.key })
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [imageModal.isOpen])
 
   useEffect(() => {
     if (!selectedId && items[0]) {
@@ -227,40 +235,37 @@ function App() {
   }
 
   return (
-    <main className="grid h-dvh w-full grid-cols-1 overflow-hidden bg-black text-[#e7e9ea] xl:grid-cols-[244px_minmax(0,620px)_minmax(360px,1fr)]">
+    <main className="grid h-dvh w-full grid-cols-1 overflow-hidden bg-black text-[#e7e9ea] xl:grid-cols-[220px_minmax(0,760px)_minmax(360px,1fr)]">
       <aside className="hidden min-h-0 justify-end border-r border-[#2f3336] bg-black xl:flex">
-        <div className="flex w-[244px] flex-col px-2 py-3">
-          <nav className="grid gap-1">
-            <RailButton active icon={<Newspaper />}>
-              Feed
-            </RailButton>
-            <RailButton icon={<Search />}>Search</RailButton>
+        <div className="flex w-[220px] flex-col px-2 py-3">
+          <nav className="grid gap-1" aria-label="Synthesis navigation">
+            {synthesisSidebarItems.map((item) => (
+              <RailButton key={item} active={item === 'Feed'} icon={<Newspaper />}>
+                {item}
+              </RailButton>
+            ))}
           </nav>
-          <Button className="mt-5 h-10 w-full rounded-full text-sm">Curate</Button>
-          <div className="mt-auto px-3 py-4 text-sm leading-6 text-[#71767b]">
-            <p>{loadedItems.length} loaded</p>
-            <p>{items.length} visible</p>
-          </div>
+          <div className="mt-auto px-3 py-4 font-mono text-xs leading-6 text-[#71767b]">private reading output</div>
         </div>
       </aside>
 
       <section className="flex min-h-0 min-w-0 flex-col border-x border-[#2f3336] bg-black">
-        <header className="shrink-0 border-b border-[#2f3336] bg-black/90 px-4 py-3 backdrop-blur">
+        <header className="shrink-0 border-b border-[#2f3336] bg-black/90 px-4 py-3 backdrop-blur sm:px-5">
           <div className="flex items-center gap-3">
             <div className="min-w-0">
-              <h1 className="text-xl font-bold tracking-normal">Synthesis</h1>
-              <p className="mt-0.5 text-xs text-[#71767b]">{loadedItems.length} loaded</p>
+              <h1 className="text-xl font-semibold tracking-[-0.01em]">Synthesis</h1>
+              <p className="mt-0.5 text-xs text-[#71767b]">curated research feed</p>
             </div>
           </div>
 
-          <div className="mt-3">
-            <div className="relative min-w-0 flex-1">
+          <div className="mt-3 w-full">
+            <div className="relative w-full min-w-0">
               <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[#71767b]" />
               <Input
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
                 placeholder="Search"
-                className="h-9 rounded-md border-[#2f3336] bg-[#080808] pl-9 text-[15px] text-[#e7e9ea] placeholder:text-[#71767b]"
+                className={synthesisSearchInputClassName}
               />
             </div>
           </div>
@@ -290,7 +295,13 @@ function App() {
           ) : (
             <>
               {items.map((item) => (
-                <FeedPost key={item.id} item={item} selected={item.id === selectedItem?.id} onSelect={setSelectedId} />
+                <FeedPost
+                  key={item.id}
+                  item={item}
+                  selected={item.id === selectedItem?.id}
+                  onOpenImage={(imageId) => dispatchImageModal({ type: 'open', imageId })}
+                  onSelect={setSelectedId}
+                />
               ))}
               <InfiniteFooter
                 hasNextPage={Boolean(feed.hasNextPage)}
@@ -302,7 +313,14 @@ function App() {
         </UiScrollArea>
       </section>
 
-      <DetailPanel item={selectedItem} />
+      <DetailPanel item={selectedItem} onOpenImage={(imageId) => dispatchImageModal({ type: 'open', imageId })} />
+
+      {imageModal.isOpen && selectedModalAttachment ? (
+        <AttachmentImageModal
+          attachment={selectedModalAttachment}
+          onClose={() => dispatchImageModal({ type: 'close' })}
+        />
+      ) : null}
     </main>
   )
 }
@@ -352,10 +370,12 @@ function TopicTabs({ tag, setTag }: { tag: string; setTag: (value: string) => vo
 function FeedPost({
   item,
   selected,
+  onOpenImage,
   onSelect,
 }: {
   item: SynthesisItem
   selected: boolean
+  onOpenImage: (imageId: string) => void
   onSelect: (id: string) => void
 }) {
   const mediaAttachments = mediaAttachmentsForItem(item)
@@ -393,18 +413,30 @@ function FeedPost({
             <span className="text-[#71767b]">{formatDate(item.observedAt)}</span>
           </div>
 
-          <h2 className="mt-2 line-clamp-2 text-[16px] font-semibold leading-6">{compactText(item.title, 180)}</h2>
-          <p className="mt-1 line-clamp-3 text-[15px] leading-6 text-[#d8dadd]">{compactText(item.synthesis, 280)}</p>
+          <h2 className="mt-2 line-clamp-2 text-[16px] font-semibold leading-6">
+            <SymbolLinkedText text={compactText(item.title, 180)} onClick={(event) => event.stopPropagation()} />
+          </h2>
+          <p className="mt-1 line-clamp-3 text-[15px] leading-6 text-[#d8dadd]">
+            <SymbolLinkedText text={compactText(item.synthesis, 280)} onClick={(event) => event.stopPropagation()} />
+          </p>
 
           {inlineImage ? (
-            <div className="mt-3 overflow-hidden rounded-md border border-[#2f3336] bg-[#080808]">
+            <button
+              type="button"
+              className="mt-3 block w-full overflow-hidden rounded-md border border-[#2f3336] bg-[#080808] text-left transition-colors hover:border-[#1d9bf0]/60 focus-visible:ring-2 focus-visible:ring-[#1d9bf0]/50"
+              aria-label="Open attachment image"
+              onClick={(event) => {
+                event.stopPropagation()
+                onOpenImage(inlineImage.id)
+              }}
+            >
               <img
                 src={inlineImage.assetUrl}
                 alt={inlineImage.alt ?? inlineImage.label ?? ''}
                 className="max-h-64 w-full object-cover"
                 loading="lazy"
               />
-            </div>
+            </button>
           ) : mediaAttachments.length ? (
             <div className="mt-3 inline-flex items-center gap-2 rounded-md border border-[#2f3336] px-2 py-1 text-xs text-[#71767b]">
               <ImageIcon className="size-3.5" />
@@ -420,11 +452,13 @@ function FeedPost({
             </span>
           </div>
 
-          <div className="mt-3 flex flex-wrap gap-2 text-sm text-[#71767b]">
-            {item.topicTags.slice(0, 4).map((topic) => (
-              <span key={topic}>#{topic}</span>
-            ))}
-          </div>
+          {item.topicTags.length ? (
+            <div className="mt-3 flex flex-wrap gap-2 text-sm text-[#71767b]">
+              {item.topicTags.slice(0, 4).map((topic) => (
+                <TopicTagLink key={topic} topic={topic} onClick={(event) => event.stopPropagation()} />
+              ))}
+            </div>
+          ) : null}
 
           <div className="mt-3 flex max-w-md justify-between text-[#71767b]">
             <a
@@ -448,7 +482,7 @@ function FeedPost({
   )
 }
 
-function DetailPanel({ item }: { item: SynthesisItem | null }) {
+function DetailPanel({ item, onOpenImage }: { item: SynthesisItem | null; onOpenImage: (imageId: string) => void }) {
   return (
     <aside className="hidden min-h-0 min-w-0 flex-col bg-black xl:flex">
       <div className="flex h-[57px] shrink-0 items-center justify-between border-b border-[#2f3336] px-5">
@@ -464,13 +498,13 @@ function DetailPanel({ item }: { item: SynthesisItem | null }) {
       </div>
 
       <UiScrollArea className="min-h-0 flex-1 [&_[data-slot=scroll-area-viewport]]:overflow-x-hidden [&_[data-slot=scroll-area-viewport]]:overflow-y-auto [&_[data-slot=scroll-area-viewport]]:overscroll-contain">
-        {item ? <DetailContent item={item} /> : <EmptyDetail />}
+        {item ? <DetailContent item={item} onOpenImage={onOpenImage} /> : <EmptyDetail />}
       </UiScrollArea>
     </aside>
   )
 }
 
-function DetailContent({ item }: { item: SynthesisItem }) {
+function DetailContent({ item, onOpenImage }: { item: SynthesisItem; onOpenImage: (imageId: string) => void }) {
   const mediaAttachments = mediaAttachmentsForItem(item)
 
   return (
@@ -499,12 +533,18 @@ function DetailContent({ item }: { item: SynthesisItem }) {
       </div>
 
       <Section title="Synthesis">
-        <h1 className="mb-3 text-2xl font-bold leading-8 tracking-normal">{item.title}</h1>
-        <p className="text-[15px] leading-7">{compactText(item.synthesis, 900)}</p>
+        <h1 className="mb-3 text-2xl font-bold leading-8 tracking-[-0.01em]">
+          <SymbolLinkedText text={item.title} />
+        </h1>
+        <p className="text-[15px] leading-7">
+          <SymbolLinkedText text={compactText(item.synthesis, 900)} />
+        </p>
         {item.whyValuable ? (
           <div className="mt-4 rounded-md border border-[#2f3336] bg-[#080808] px-3 py-3">
             <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#71767b]">Why it matters</h4>
-            <p className="text-[15px] leading-7 text-[#d8dadd]">{compactText(item.whyValuable, 520)}</p>
+            <p className="text-[15px] leading-7 text-[#d8dadd]">
+              <SymbolLinkedText text={compactText(item.whyValuable, 520)} />
+            </p>
           </div>
         ) : null}
       </Section>
@@ -514,7 +554,7 @@ function DetailContent({ item }: { item: SynthesisItem }) {
           <ul className="grid gap-2 text-[15px] leading-6 text-[#d8dadd]">
             {item.takeaways.map((takeaway) => (
               <li key={takeaway} className="rounded-md border border-[#2f3336] bg-[#080808] px-3 py-2">
-                {takeaway}
+                <SymbolLinkedText text={takeaway} />
               </li>
             ))}
           </ul>
@@ -579,12 +619,19 @@ function DetailContent({ item }: { item: SynthesisItem }) {
             {mediaAttachments.map((attachment) =>
               isInlineImageUrl(attachment.assetUrl) ? (
                 <figure key={attachment.id} className="overflow-hidden rounded-md border border-[#2f3336] bg-[#080808]">
-                  <img
-                    src={attachment.assetUrl}
-                    alt={attachment.alt ?? attachment.label ?? ''}
-                    className="max-h-[520px] w-full object-contain"
-                    loading="lazy"
-                  />
+                  <button
+                    type="button"
+                    className="block w-full bg-black focus-visible:ring-2 focus-visible:ring-[#1d9bf0]/50"
+                    aria-label="Open attachment image"
+                    onClick={() => onOpenImage(attachment.id)}
+                  >
+                    <img
+                      src={attachment.assetUrl}
+                      alt={attachment.alt ?? attachment.label ?? ''}
+                      className="max-h-[520px] w-full object-contain"
+                      loading="lazy"
+                    />
+                  </button>
                   {attachment.label || attachment.alt ? (
                     <figcaption className="border-t border-[#2f3336] px-3 py-2 text-sm leading-6 text-[#a6a6a6]">
                       {attachment.label ? <p className="font-semibold text-[#e7e9ea]">{attachment.label}</p> : null}
@@ -613,12 +660,118 @@ function DetailContent({ item }: { item: SynthesisItem }) {
       ) : null}
 
       <Separator className="bg-[#2f3336]" />
-      <div className="flex flex-wrap gap-2">
-        {item.topicTags.map((topic) => (
-          <Badge key={topic} variant="outline">
-            #{topic}
-          </Badge>
-        ))}
+      {item.topicTags.length || symbolsFromSynthesisItem(item).length ? (
+        <div className="flex flex-wrap gap-2">
+          {item.topicTags.map((topic) => (
+            <TopicTagLink key={topic} topic={topic} />
+          ))}
+          {symbolsFromSynthesisItem(item).map((symbol) => (
+            <a
+              key={symbol}
+              href={`/companies/${symbol}`}
+              className="inline-flex h-5 w-fit shrink-0 items-center justify-center rounded-full border border-[#2f3336] bg-[#080808] px-2 py-0.5 font-mono text-[0.625rem] font-medium text-[#e7e9ea] transition-colors hover:border-[#1d9bf0]/60"
+            >
+              ${symbol}
+            </a>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function SymbolLinkedText({
+  text,
+  onClick,
+}: {
+  text: string
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void
+}) {
+  return (
+    <>
+      {segmentCompanySymbols(text).map((segment, index) =>
+        segment.kind === 'symbol' ? (
+          <a
+            key={`${segment.symbol}-${index}`}
+            href={segment.href}
+            onClick={onClick}
+            className="font-mono text-[#e7e9ea] underline decoration-[#1d9bf0]/60 underline-offset-2 transition-colors hover:text-[#1d9bf0]"
+          >
+            {segment.text}
+          </a>
+        ) : (
+          <span key={`text-${index}`}>{segment.text}</span>
+        ),
+      )}
+    </>
+  )
+}
+
+function TopicTagLink({ topic, onClick }: { topic: string; onClick?: (event: MouseEvent<HTMLAnchorElement>) => void }) {
+  const symbol = normalizeCompanySymbol(topic)
+  if (symbol) {
+    return (
+      <a
+        href={`/companies/${symbol}`}
+        onClick={onClick}
+        className="inline-flex h-5 w-fit shrink-0 items-center justify-center rounded-full border border-[#2f3336] bg-[#080808] px-2 py-0.5 font-mono text-[0.625rem] font-medium text-[#e7e9ea] transition-colors hover:border-[#1d9bf0]/60"
+      >
+        ${symbol}
+      </a>
+    )
+  }
+
+  return (
+    <span className="inline-flex h-5 w-fit shrink-0 items-center justify-center rounded-full border border-[#2f3336] bg-[#080808] px-2 py-0.5 text-[0.625rem] font-medium text-[#e7e9ea]">
+      #{topic}
+    </span>
+  )
+}
+
+function AttachmentImageModal({ attachment, onClose }: { attachment: SynthesisAttachment; onClose: () => void }) {
+  const caption = [attachment.label, attachment.alt].filter(Boolean).join(' — ')
+  const titleId = imageModalTitleId(attachment.id)
+  const captionId = imageModalCaptionId(attachment.id)
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={caption ? captionId : undefined}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 px-3 py-4 backdrop-blur-sm sm:px-6"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-full w-full max-w-5xl flex-col overflow-hidden rounded-lg border border-[#2f3336] bg-[#080808] shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex min-h-12 items-center justify-between gap-3 border-b border-[#2f3336] px-3 py-2 sm:px-4">
+          <h2 id={titleId} className="truncate text-sm font-semibold text-[#e7e9ea]">
+            {attachment.label ?? 'Attachment image'}
+          </h2>
+          <button
+            type="button"
+            aria-label="Close image preview"
+            autoFocus
+            className="inline-flex size-8 shrink-0 items-center justify-center rounded-full text-[#a6a6a6] transition-colors hover:bg-[#181818] hover:text-[#e7e9ea] focus-visible:ring-2 focus-visible:ring-[#1d9bf0]/50"
+            onClick={onClose}
+          >
+            <X className="size-5" />
+          </button>
+        </div>
+        <div className="flex min-h-0 flex-1 items-center justify-center bg-black p-2 sm:p-4">
+          <img
+            src={attachment.assetUrl}
+            alt={attachment.alt ?? attachment.label ?? ''}
+            className="max-h-[78dvh] max-w-full object-contain"
+          />
+        </div>
+        {caption ? (
+          <p id={captionId} className="border-t border-[#2f3336] px-3 py-2 text-sm leading-6 text-[#a6a6a6] sm:px-4">
+            {caption}
+          </p>
+        ) : null}
       </div>
     </div>
   )

--- a/apps/synthesis/src/server/__tests__/api.test.ts
+++ b/apps/synthesis/src/server/__tests__/api.test.ts
@@ -141,6 +141,41 @@ describe('synthesis REST auth', () => {
     expect(secondPage.items.some((item: { id: string }) => firstIds.has(item.id))).toBe(false)
   })
 
+  test('derives non-empty topic tags for submitted items when content has enough signal', async () => {
+    const runResponse = await handleCreateRun(createRunRequest(`Bearer ${token}`))
+    const runPayload = await runResponse.json()
+    const submitResponse = await handleSubmitItem(
+      new Request('http://synthesis.test/api/items', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          runId: runPayload.run.id,
+          title: 'NVDA HBM packaging is tightening around inference demand',
+          synthesis:
+            'Semiconductor supply-chain posts point to HBM packaging becoming a concrete inference deployment bottleneck.',
+          takeaways: ['watch HBM allocation for model deployment'],
+          whyValuable: 'It turns scattered chip supply commentary into a useful supply-chain watch item.',
+          sourcePosts: [
+            {
+              originalUrl: 'https://x.com/example/status/2101',
+              observedText: 'hbm packaging notes for semis and inference systems',
+            },
+          ],
+          dedupeKey: 'theme:hbm-tag-derivation',
+          score: 0.91,
+          confidence: 0.82,
+        }),
+      }),
+    )
+    const payload = await submitResponse.json()
+
+    expect(submitResponse.status).toBe(201)
+    expect(payload.item.topicTags).toEqual(expect.arrayContaining(['semis', 'machine-learning']))
+  })
+
   test('stores one synthesized theme with multiple sources and app-owned attachments', async () => {
     const runResponse = await handleCreateRun(createRunRequest(`Bearer ${token}`))
     const runPayload = await runResponse.json()

--- a/apps/synthesis/src/server/__tests__/company.test.ts
+++ b/apps/synthesis/src/server/__tests__/company.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { handleGetCompany } from '../api'
+import { setCompanyDataProviderForTests } from '../company'
+
+describe('company analysis API', () => {
+  afterEach(() => {
+    setCompanyDataProviderForTests(null)
+  })
+
+  test('fails closed when live market data provider is not configured', async () => {
+    const response = await handleGetCompany(new Request('http://synthesis.test/api/companies/NVDA'), 'NVDA')
+    const payload = await response.json()
+
+    expect(response.status).toBe(503)
+    expect(payload.error).toContain('not configured')
+  })
+
+  test('returns provider-backed company identity, fundamental, technical, and financial analysis', async () => {
+    setCompanyDataProviderForTests({
+      async getCompanyAnalysis(symbol) {
+        return {
+          symbol,
+          identity: {
+            name: 'NVIDIA Corporation',
+            exchange: 'NASDAQ',
+            sector: 'Technology',
+            industry: 'Semiconductors',
+            description: 'Provider-backed fixture for tests only.',
+          },
+          fundamentals: [{ label: 'Market cap', value: '$3.1T' }],
+          technicals: [{ label: 'RSI 14D', value: '55.4' }],
+          financials: [{ label: 'Revenue TTM', value: '$96B' }],
+          source: 'test-provider',
+          updatedAt: '2026-05-26T00:00:00.000Z',
+        }
+      },
+    })
+
+    const response = await handleGetCompany(new Request('http://synthesis.test/api/companies/NVDA'), 'NVDA')
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.company.identity.name).toBe('NVIDIA Corporation')
+    expect(payload.company.fundamentals).toHaveLength(1)
+    expect(payload.company.technicals).toHaveLength(1)
+    expect(payload.company.financials).toHaveLength(1)
+  })
+})

--- a/apps/synthesis/src/server/api.ts
+++ b/apps/synthesis/src/server/api.ts
@@ -6,6 +6,7 @@ import {
   SubmitItemInputSchema,
 } from './schema'
 import { assetResponseForAttachment } from './assets'
+import { createCompanyDataProvider } from './company'
 import { getSynthesisStore } from './store'
 import { requireAuthorized } from './auth'
 import { badRequest, jsonResponse, notFound, readJson } from './http'
@@ -78,6 +79,21 @@ export const handleListFeed = async (request: Request) => {
     return jsonResponse(await getSynthesisStore().listFeed(query))
   } catch (error) {
     return internalError(error)
+  }
+}
+
+export const handleGetCompany = async (_request: Request, symbol: string) => {
+  const provider = createCompanyDataProvider()
+  if (!provider) {
+    return jsonResponse({ error: 'company market data provider is not configured' }, { status: 503 })
+  }
+
+  try {
+    return jsonResponse({ company: await provider.getCompanyAnalysis(symbol) })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'company analysis unavailable'
+    if (message.startsWith('unsupported company symbol')) return badRequest(message)
+    return jsonResponse({ error: message }, { status: 502 })
   }
 }
 

--- a/apps/synthesis/src/server/company.ts
+++ b/apps/synthesis/src/server/company.ts
@@ -1,0 +1,245 @@
+import { z } from 'zod'
+
+import { normalizeCompanySymbol } from '~/lib/company-symbols'
+
+export type CompanyMetric = {
+  label: string
+  value: string
+}
+
+export type CompanyAnalysis = {
+  symbol: string
+  identity: {
+    name: string
+    exchange: string | null
+    sector: string | null
+    industry: string | null
+    description: string | null
+  }
+  fundamentals: CompanyMetric[]
+  technicals: CompanyMetric[]
+  financials: CompanyMetric[]
+  source: string
+  updatedAt: string
+}
+
+export type CompanyDataProvider = {
+  getCompanyAnalysis(symbol: string): Promise<CompanyAnalysis>
+}
+
+const alphaVantageErrorSchema = z
+  .object({
+    Note: z.string().optional(),
+    Information: z.string().optional(),
+    'Error Message': z.string().optional(),
+  })
+  .passthrough()
+
+const overviewSchema = z
+  .object({
+    Symbol: z.string().optional(),
+    Name: z.string().optional(),
+    Exchange: z.string().optional(),
+    Sector: z.string().optional(),
+    Industry: z.string().optional(),
+    Description: z.string().optional(),
+    MarketCapitalization: z.string().optional(),
+    PERatio: z.string().optional(),
+    EPS: z.string().optional(),
+    DividendYield: z.string().optional(),
+    Beta: z.string().optional(),
+    AnalystTargetPrice: z.string().optional(),
+    ProfitMargin: z.string().optional(),
+    RevenueTTM: z.string().optional(),
+    EBITDA: z.string().optional(),
+    QuarterlyRevenueGrowthYOY: z.string().optional(),
+    QuarterlyEarningsGrowthYOY: z.string().optional(),
+    GrossProfitTTM: z.string().optional(),
+    FiscalYearEnd: z.string().optional(),
+    '52WeekHigh': z.string().optional(),
+    '52WeekLow': z.string().optional(),
+    '50DayMovingAverage': z.string().optional(),
+    '200DayMovingAverage': z.string().optional(),
+  })
+  .passthrough()
+
+const quoteSchema = z
+  .object({
+    'Global Quote': z
+      .object({
+        '05. price': z.string().optional(),
+        '09. change': z.string().optional(),
+        '10. change percent': z.string().optional(),
+      })
+      .optional(),
+  })
+  .passthrough()
+
+const rsiSchema = z
+  .object({
+    'Technical Analysis: RSI': z.record(z.string(), z.object({ RSI: z.string().optional() })).optional(),
+  })
+  .passthrough()
+
+const cleanValue = (value: string | null | undefined) => {
+  if (!value || value === 'None' || value === '-' || value === '0') return null
+  return value
+}
+
+const formatNumber = (value: string | null | undefined) => {
+  const cleaned = cleanValue(value)
+  if (!cleaned) return null
+  const parsed = Number(cleaned)
+  if (!Number.isFinite(parsed)) return cleaned
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(parsed)
+}
+
+const formatCurrency = (value: string | null | undefined) => {
+  const cleaned = cleanValue(value)
+  if (!cleaned) return null
+  const parsed = Number(cleaned)
+  if (!Number.isFinite(parsed)) return cleaned
+  return new Intl.NumberFormat('en-US', {
+    currency: 'USD',
+    maximumFractionDigits: parsed >= 100 ? 0 : 2,
+    style: 'currency',
+  }).format(parsed)
+}
+
+const formatLargeCurrency = (value: string | null | undefined) => {
+  const cleaned = cleanValue(value)
+  if (!cleaned) return null
+  const parsed = Number(cleaned)
+  if (!Number.isFinite(parsed)) return cleaned
+  return new Intl.NumberFormat('en-US', {
+    currency: 'USD',
+    maximumFractionDigits: 2,
+    notation: 'compact',
+    style: 'currency',
+  }).format(parsed)
+}
+
+const formatPercent = (value: string | null | undefined) => {
+  const cleaned = cleanValue(value)
+  if (!cleaned) return null
+  const withoutPercent = cleaned.replace(/%$/, '')
+  const parsed = Number(withoutPercent)
+  if (!Number.isFinite(parsed)) return cleaned
+  const percent = cleaned.endsWith('%') || Math.abs(parsed) > 1 ? parsed : parsed * 100
+  return `${new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(percent)}%`
+}
+
+const metric = (label: string, value: string | null | undefined): CompanyMetric | null => {
+  const cleaned = cleanValue(value)
+  return cleaned ? { label, value: cleaned } : null
+}
+
+const compactMetrics = (metrics: Array<CompanyMetric | null>) =>
+  metrics.filter((item): item is CompanyMetric => Boolean(item))
+
+const assertAlphaVantagePayload = (payload: unknown, symbol: string) => {
+  const error = alphaVantageErrorSchema.parse(payload)
+  if (error.Note || error.Information || error['Error Message']) {
+    throw new Error(
+      error.Note ?? error.Information ?? error['Error Message'] ?? `market data unavailable for ${symbol}`,
+    )
+  }
+}
+
+class AlphaVantageCompanyDataProvider implements CompanyDataProvider {
+  private readonly apiKey: string
+  private readonly fetchImpl: typeof fetch
+
+  constructor(apiKey: string, fetchImpl: typeof fetch = fetch) {
+    this.apiKey = apiKey
+    this.fetchImpl = fetchImpl
+  }
+
+  async getCompanyAnalysis(symbol: string): Promise<CompanyAnalysis> {
+    const normalized = normalizeCompanySymbol(symbol)
+    if (!normalized) throw new Error(`unsupported company symbol: ${symbol}`)
+
+    const [overviewPayload, quotePayload, rsiPayload] = await Promise.all([
+      this.request({ function: 'OVERVIEW', symbol: normalized }),
+      this.request({ function: 'GLOBAL_QUOTE', symbol: normalized }),
+      this.request({ function: 'RSI', symbol: normalized, interval: 'daily', time_period: '14', series_type: 'close' }),
+    ])
+
+    const overview = overviewSchema.parse(overviewPayload)
+    const quote = quoteSchema.parse(quotePayload)['Global Quote']
+    const rsiEntries = rsiSchema.parse(rsiPayload)['Technical Analysis: RSI'] ?? {}
+    const latestRsi = Object.keys(rsiEntries)
+      .sort()
+      .reverse()
+      .map((key) => rsiEntries[key]?.RSI)
+      .find(Boolean)
+
+    if (!overview.Name) throw new Error(`market data unavailable for ${normalized}`)
+
+    return {
+      symbol: normalized,
+      identity: {
+        name: overview.Name,
+        exchange: cleanValue(overview.Exchange),
+        sector: cleanValue(overview.Sector),
+        industry: cleanValue(overview.Industry),
+        description: cleanValue(overview.Description),
+      },
+      fundamentals: compactMetrics([
+        metric('Market cap', formatLargeCurrency(overview.MarketCapitalization)),
+        metric('P/E ratio', formatNumber(overview.PERatio)),
+        metric('EPS', formatCurrency(overview.EPS)),
+        metric('Dividend yield', formatPercent(overview.DividendYield)),
+        metric('Profit margin', formatPercent(overview.ProfitMargin)),
+        metric('Beta', formatNumber(overview.Beta)),
+        metric('Analyst target', formatCurrency(overview.AnalystTargetPrice)),
+      ]),
+      technicals: compactMetrics([
+        metric('Last price', formatCurrency(quote?.['05. price'])),
+        metric('Change', formatCurrency(quote?.['09. change'])),
+        metric('Change %', formatPercent(quote?.['10. change percent'])),
+        metric('RSI 14D', formatNumber(latestRsi)),
+        metric('52W high', formatCurrency(overview['52WeekHigh'])),
+        metric('52W low', formatCurrency(overview['52WeekLow'])),
+        metric('50D average', formatCurrency(overview['50DayMovingAverage'])),
+        metric('200D average', formatCurrency(overview['200DayMovingAverage'])),
+      ]),
+      financials: compactMetrics([
+        metric('Revenue TTM', formatLargeCurrency(overview.RevenueTTM)),
+        metric('EBITDA', formatLargeCurrency(overview.EBITDA)),
+        metric('Gross profit TTM', formatLargeCurrency(overview.GrossProfitTTM)),
+        metric('Revenue growth YoY', formatPercent(overview.QuarterlyRevenueGrowthYOY)),
+        metric('Earnings growth YoY', formatPercent(overview.QuarterlyEarningsGrowthYOY)),
+        metric('Fiscal year end', cleanValue(overview.FiscalYearEnd)),
+      ]),
+      source: 'Alpha Vantage',
+      updatedAt: new Date().toISOString(),
+    }
+  }
+
+  private async request(params: Record<string, string>) {
+    const url = new URL('https://www.alphavantage.co/query')
+    for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value)
+    url.searchParams.set('apikey', this.apiKey)
+
+    const response = await this.fetchImpl(url)
+    if (!response.ok) throw new Error(`Alpha Vantage request failed: ${response.status}`)
+    const payload: unknown = await response.json()
+    assertAlphaVantagePayload(payload, params.symbol ?? 'unknown')
+    return payload
+  }
+}
+
+let providerForTests: CompanyDataProvider | null = null
+
+export const createCompanyDataProvider = (): CompanyDataProvider | null => {
+  if (providerForTests) return providerForTests
+
+  const apiKey = process.env.SYNTHESIS_ALPHA_VANTAGE_API_KEY?.trim()
+  if (!apiKey) return null
+  return new AlphaVantageCompanyDataProvider(apiKey)
+}
+
+export const setCompanyDataProviderForTests = (provider: CompanyDataProvider | null) => {
+  providerForTests = provider
+}

--- a/apps/synthesis/src/server/store.ts
+++ b/apps/synthesis/src/server/store.ts
@@ -1,6 +1,8 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { Pool, type PoolClient } from 'pg'
 
+import { deriveTopicTagsFromItemContent } from '~/lib/tags'
+
 import { materializeAttachments, normalizeAttachmentInputs } from './assets'
 import {
   buildEmbeddingText,
@@ -237,7 +239,15 @@ const normalizeSubmitItem = async (input: SubmitItemInput): Promise<NormalizedSu
     summary: input.synthesis,
     whyValuable: input.whyValuable,
     evidence: input.factChecks.map((factCheck) => `${factCheck.status}: ${factCheck.claim}`),
-    topicTags: input.topicTags,
+    topicTags: deriveTopicTagsFromItemContent({
+      title: input.title,
+      synthesis: input.synthesis,
+      takeaways: input.takeaways,
+      whyValuable: input.whyValuable,
+      sourcePosts,
+      factChecks: input.factChecks,
+      topicTags: input.topicTags,
+    }),
     score: input.score,
     confidence: input.confidence,
   }
@@ -485,13 +495,30 @@ const mapItemRow = (row: ItemRow): SynthesisItem => {
   const sourcePosts = parseJsonValue<SynthesisSourcePost[]>(row.source_posts, [])
   const resolvedSourcePosts = sourcePosts.length ? sourcePosts : [sourcePostFromRow(row)]
   const attachments = parseJsonValue<SynthesisAttachment[]>(row.attachments, [])
+  const takeaways = parseJsonValue<string[]>(row.takeaways, [])
+  const evidence = parseJsonArray(row.evidence)
+  const factChecks = parseJsonValue<SynthesisFactCheck[]>(row.fact_checks, [])
+  const title = row.title ?? row.summary
+  const synthesis = row.synthesis ?? row.summary
+  const topicTags = deriveTopicTagsFromItemContent({
+    title,
+    synthesis,
+    summary: row.summary,
+    whyValuable: row.why_valuable,
+    observedText: row.observed_text,
+    takeaways,
+    evidence,
+    sourcePosts: resolvedSourcePosts,
+    factChecks,
+    topicTags: parseJsonArray(row.topic_tags),
+  })
 
   return {
     id: row.id,
     runId: row.run_id,
-    title: row.title ?? row.summary,
-    synthesis: row.synthesis ?? row.summary,
-    takeaways: parseJsonValue<string[]>(row.takeaways, []),
+    title,
+    synthesis,
+    takeaways,
     dedupeKey: row.dedupe_key ?? row.x_post_key,
     originalUrl: row.canonical_url,
     xPostId: row.x_post_id,
@@ -503,10 +530,10 @@ const mapItemRow = (row: ItemRow): SynthesisItem => {
     mediaUrls: parseJsonArray(row.media_urls),
     summary: row.summary,
     whyValuable: row.why_valuable,
-    evidence: parseJsonArray(row.evidence),
+    evidence,
     sourcePosts: resolvedSourcePosts,
     sourceCount: resolvedSourcePosts.length,
-    factChecks: parseJsonValue<SynthesisFactCheck[]>(row.fact_checks, []),
+    factChecks,
     attachments,
     generatedAttachments: parseJsonValue<SynthesisAttachment[]>(
       row.generated_attachments,
@@ -521,7 +548,7 @@ const mapItemRow = (row: ItemRow): SynthesisItem => {
             createdAt: toIso(row.embedding_created_at) ?? nowIso(),
           }
         : null,
-    topicTags: parseJsonArray(row.topic_tags),
+    topicTags,
     score: Number(row.score),
     confidence: Number(row.confidence),
     createdAt: toIso(row.created_at) ?? nowIso(),
@@ -887,6 +914,32 @@ class PostgresSynthesisStore implements SynthesisStore {
     )
   }
 
+  private async backfillMissingTopicTags() {
+    const result = await this.pool.query<ItemRow>(
+      `SELECT ${this.itemSelectSql('i')}
+       FROM ${this.itemRelationSql('i')}
+       WHERE jsonb_array_length(i.topic_tags) = 0
+       ORDER BY i.created_at ASC, i.id ASC
+       LIMIT $1`,
+      [embeddingBackfillLimit()],
+    )
+    if (!result.rows.length) return
+
+    const client = await this.pool.connect()
+    try {
+      for (const row of result.rows) {
+        const item = mapItemRow(row)
+        if (!item.topicTags.length) continue
+        await client.query(`UPDATE synthesis_items SET topic_tags = $2::jsonb, updated_at = updated_at WHERE id = $1`, [
+          item.id,
+          JSON.stringify(item.topicTags),
+        ])
+      }
+    } finally {
+      client.release()
+    }
+  }
+
   private async backfillMissingEmbeddings() {
     const result = await this.pool.query<ItemRow>(
       `SELECT ${this.itemSelectSql('i')}
@@ -1058,6 +1111,7 @@ class PostgresSynthesisStore implements SynthesisStore {
       CREATE INDEX IF NOT EXISTS synthesis_attachments_item_idx ON synthesis_attachments (item_id);
       CREATE INDEX IF NOT EXISTS synthesis_item_embeddings_model_idx ON synthesis_item_embeddings (model, dimension);
     `)
+    await this.backfillMissingTopicTags()
     await this.backfillMissingEmbeddings()
   }
 }

--- a/apps/synthesis/vitest.config.ts
+++ b/apps/synthesis/vitest.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    include: ['src/server/**/*.test.ts'],
+    include: ['src/{lib,server}/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
## Summary

- Polishes the Synthesis reading shell, spacing, typography, full-width search, and removes the Curate action, sidebar Search item, and bottom-left counters.
- Adds visible non-empty tag derivation/backfill behavior plus focused tag rendering contracts so old and new synthesis items do not show empty tag chrome.
- Adds clickable attachment image previews with an accessible in-app modal/lightbox and internal stock-symbol linking to company pages.
- Adds `/companies/$symbol` and `/api/companies/$symbol` with an Alpha Vantage-backed provider abstraction that fails closed when live market data is not configured.

## Related Issues

None

## Testing

- `bun install --frozen-lockfile` (required installing `make`/`g++` in the workspace first so native deps could build)
- `bun run --filter synthesis test` — passed (8 files, 27 tests)
- `bun run --filter synthesis lint` — passed (Oxlint, type-aware Oxlint, oxfmt check)
- `bun run build:synthesis` — passed
- Local preview/manual HTTP verification: `PORT=4319 HOST=127.0.0.1 SYNTHESIS_STORAGE=memory bun run start:synthesis`, then verified `/` returned HTTP 200, `/companies/NVDA` returned HTTP 200, and `/api/companies/NVDA` returned HTTP 503 with `company market data provider is not configured` when no live provider key is present.

## Screenshots (if applicable)

N/A — no browser screenshot was captured in this workspace; manual preview was verified by local HTTP responses.

## Breaking Changes

None. Production company analysis requires `SYNTHESIS_ALPHA_VANTAGE_API_KEY`; without it, the company API/page fails closed instead of showing fake market data.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
