### PR TITLE
fix(torghut): prefer live paper route target plan

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4677,12 +4677,48 @@ def _merge_external_paper_route_target_plan(
 ) -> dict[str, object]:
     gate = dict(live_submission_gate)
     local_plan = _to_str_map(gate.get("runtime_ledger_paper_probation_import_plan"))
-    if _paper_route_target_plan_targets(local_plan):
+    if (
+        _paper_route_target_plan_targets(local_plan)
+        and not settings.trading_paper_route_target_plan_url
+    ):
         return gate
 
     external_plan = _load_external_paper_route_target_plan()
     if not external_plan:
+        if _paper_route_target_plan_targets(local_plan):
+            return gate
         return gate
+
+    load_error = str(external_plan.get("load_error") or "").strip()
+    if load_error:
+        gate["paper_route_target_plan_error"] = load_error
+        if settings.trading_paper_route_target_plan_url:
+            gate["runtime_ledger_paper_probation_import_plan"] = {
+                "schema_version": local_plan.get("schema_version")
+                or "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 0,
+                "skipped_target_count": len(
+                    _paper_route_target_plan_targets(local_plan)
+                ),
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "final_promotion_authorized": False,
+                "targets": [],
+                "skipped_targets": [
+                    {
+                        "reason": "external_paper_route_target_plan_unavailable",
+                        "missing_or_blocking_fields": [load_error],
+                    }
+                ],
+            }
+            gate["paper_route_target_plan_source"] = "external_target_plan_url"
+        return gate
+
+    if _paper_route_target_plan_targets(
+        local_plan
+    ) and not _paper_route_target_plan_targets(external_plan):
+        return gate
+
     if _paper_route_target_plan_targets(external_plan):
         merged_plan = dict(external_plan)
         merged_targets: list[dict[str, Any]] = []
@@ -4693,6 +4729,10 @@ def _merge_external_paper_route_target_plan(
                 target["paper_route_probe_scope_authority"] = "external_target_plan"
             merged_targets.append(target)
         merged_plan["targets"] = merged_targets
+        merged_plan["target_count"] = len(merged_targets)
+        merged_plan["skipped_target_count"] = int(
+            merged_plan.get("skipped_target_count") or 0
+        )
         merged_plan["promotion_allowed"] = False
         merged_plan["final_promotion_allowed"] = False
         merged_plan["final_promotion_authorized"] = False
@@ -4700,9 +4740,6 @@ def _merge_external_paper_route_target_plan(
         gate["paper_route_target_plan_source"] = "external_target_plan_url"
         return gate
 
-    load_error = str(external_plan.get("load_error") or "").strip()
-    if load_error:
-        gate["paper_route_target_plan_error"] = load_error
     return gate
 
 

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1749,6 +1749,12 @@ def build_paper_route_evidence_audit(
                 "promotion_allowed": False,
                 "final_promotion_allowed": False,
             },
+            "paper_route_target_plan_source": _safe_text(
+                live_submission_gate.get("paper_route_target_plan_source")
+            ),
+            "paper_route_target_plan_error": _safe_text(
+                live_submission_gate.get("paper_route_target_plan_error")
+            ),
         },
         "paper_route_probe": probe,
         "next_paper_route_runtime_window_targets": next_targets,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7055,7 +7055,7 @@ class TestTradingApi(TestCase):
             else:
                 app.state.trading_scheduler = original_scheduler
 
-    def test_trading_paper_route_evidence_uses_external_plan_when_local_plan_empty(
+    def test_trading_paper_route_evidence_uses_external_plan_when_url_configured(
         self,
     ) -> None:
         original_scheduler = getattr(app.state, "trading_scheduler", None)
@@ -7087,11 +7087,16 @@ class TestTradingApi(TestCase):
             "promotion_eligible_total": 0,
             "runtime_ledger_paper_probation_import_plan": {
                 "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
-                "target_count": 0,
+                "target_count": 1,
                 "skipped_target_count": 0,
                 "promotion_allowed": False,
                 "final_promotion_allowed": False,
-                "targets": [],
+                "targets": [
+                    {
+                        **target,
+                        "paper_route_probe_symbols": ["AAPL", "AMZN", "INTC"],
+                    }
+                ],
             },
         }
         proof_floor = {
@@ -7102,7 +7107,7 @@ class TestTradingApi(TestCase):
                     "configured_enabled": True,
                     "active": False,
                     "effective_max_notional": "0",
-                    "next_session_max_notional": "25",
+                    "next_session_max_notional": "63180",
                     "eligible_symbol_count": 2,
                     "eligible_symbols": ["AAPL", "AMZN"],
                     "active_symbols": [],
@@ -7145,6 +7150,10 @@ class TestTradingApi(TestCase):
                     "runtime_ledger_paper_probation_import_plan"
                 ]["target_count"],
                 1,
+            )
+            self.assertEqual(
+                payload["live_submission_gate"]["paper_route_target_plan_source"],
+                "external_target_plan_url",
             )
             self.assertEqual(
                 payload["targets"][0]["target"]["candidate_id"],
@@ -7379,6 +7388,38 @@ class TestTradingApi(TestCase):
         with patch("app.main._load_external_paper_route_target_plan", return_value={}):
             self.assertEqual(_merge_external_paper_route_target_plan({}), {})
 
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        try:
+            settings.trading_paper_route_target_plan_url = (
+                "http://torghut.example/paper-route-plan"
+            )
+            with patch(
+                "app.main._load_external_paper_route_target_plan",
+                return_value={},
+            ):
+                self.assertEqual(
+                    _merge_external_paper_route_target_plan(local_gate),
+                    local_gate,
+                )
+        finally:
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        try:
+            settings.trading_paper_route_target_plan_url = (
+                "http://torghut.example/paper-route-plan"
+            )
+            with patch(
+                "app.main._load_external_paper_route_target_plan",
+                return_value={"targets": []},
+            ):
+                self.assertEqual(
+                    _merge_external_paper_route_target_plan(local_gate),
+                    local_gate,
+                )
+        finally:
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+
         with patch(
             "app.main._load_external_paper_route_target_plan",
             return_value={"load_error": "paper_route_target_plan_missing"},
@@ -7388,6 +7429,59 @@ class TestTradingApi(TestCase):
             gate["paper_route_target_plan_error"],
             "paper_route_target_plan_missing",
         )
+
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        try:
+            settings.trading_paper_route_target_plan_url = (
+                "http://torghut.example/paper-route-plan"
+            )
+            with patch(
+                "app.main._load_external_paper_route_target_plan",
+                return_value={"load_error": "paper_route_target_plan_missing"},
+            ):
+                gate = _merge_external_paper_route_target_plan(local_gate)
+            plan = gate["runtime_ledger_paper_probation_import_plan"]
+            self.assertEqual(
+                gate["paper_route_target_plan_source"], "external_target_plan_url"
+            )
+            self.assertEqual(
+                gate["paper_route_target_plan_error"],
+                "paper_route_target_plan_missing",
+            )
+            self.assertEqual(plan["target_count"], 0)
+            self.assertEqual(plan["skipped_target_count"], 1)
+            self.assertEqual(plan["targets"], [])
+        finally:
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        try:
+            settings.trading_paper_route_target_plan_url = (
+                "http://torghut.example/paper-route-plan"
+            )
+            with patch(
+                "app.main._load_external_paper_route_target_plan",
+                return_value={
+                    "promotion_allowed": True,
+                    "final_promotion_allowed": True,
+                    "final_promotion_authorized": True,
+                    "targets": [
+                        {
+                            "candidate_id": "external",
+                            "paper_route_probe_symbols": ["AAPL"],
+                        }
+                    ],
+                },
+            ):
+                gate = _merge_external_paper_route_target_plan(local_gate)
+            plan = gate["runtime_ledger_paper_probation_import_plan"]
+            self.assertEqual(
+                gate["paper_route_target_plan_source"], "external_target_plan_url"
+            )
+            self.assertEqual(plan["target_count"], 1)
+            self.assertEqual(plan["targets"][0]["candidate_id"], "external")
+        finally:
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
 
         with patch(
             "app.main._load_external_paper_route_target_plan",
@@ -7468,7 +7562,7 @@ class TestTradingApi(TestCase):
                     "configured_enabled": True,
                     "active": False,
                     "effective_max_notional": "0",
-                    "next_session_max_notional": "25",
+                    "next_session_max_notional": "63180",
                     "eligible_symbol_count": 3,
                     "eligible_symbols": ["AAPL", "AMZN", "INTC"],
                     "active_symbols": [],


### PR DESCRIPTION
## Summary

- Prefer a configured external paper-route target plan over local paper-service paper-probation targets, preserving the live H-PAIRS symbol envelope for sim probes.
- Fail closed when that configured external target plan is unavailable by clearing divergent local targets and surfacing the load error.
- Expose paper-route target plan source/error in the evidence audit and strengthen API tests for external-plan preservation and load-error behavior.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan or external_paper_route_target'`
- `uv run --frozen ruff check app/main.py app/trading/paper_route_evidence.py tests/test_trading_api.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
