### PR TITLE
fix(torghut): preserve external paper route audit scope

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -441,6 +441,12 @@ def _target_identity(
         "dataset_snapshot_ref": _safe_text(target.get("dataset_snapshot_ref")),
         "window_start": _safe_text(target.get("window_start")),
         "window_end": _safe_text(target.get("window_end")),
+        "paper_route_target_plan_source": _safe_text(
+            target.get("paper_route_target_plan_source")
+        ),
+        "paper_route_probe_scope_authority": _safe_text(
+            target.get("paper_route_probe_scope_authority")
+        ),
         "paper_route_probe_symbols": _target_probe_symbols(target, probe),
         "runtime_ledger_bucket_ref": _safe_text(
             target.get("runtime_ledger_bucket_ref")
@@ -730,6 +736,12 @@ def _next_paper_route_runtime_window_targets(
         health_gate_promotion_blockers = _unique_text_items(
             health_gate.get("promotion_blockers")
         )
+        paper_route_target_plan_source = _safe_text(
+            target.get("paper_route_target_plan_source")
+        )
+        paper_route_probe_scope_authority = _safe_text(
+            target.get("paper_route_probe_scope_authority")
+        )
         planned_target: dict[str, object] = {
             "hypothesis_id": hypothesis_id,
             "candidate_id": candidate_id,
@@ -760,6 +772,9 @@ def _next_paper_route_runtime_window_targets(
             "paper_route_probe_next_session_max_notional": next_notional,
             "paper_route_probe_window_start": _isoformat(window_start),
             "paper_route_probe_window_end": _isoformat(window_end),
+            "paper_route_target_plan_source": paper_route_target_plan_source or "",
+            "paper_route_probe_scope_authority": paper_route_probe_scope_authority
+            or "",
             "paper_route_session_readiness_state": _safe_text(
                 session_readiness.get("state")
             )

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1245,6 +1245,79 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(source_activity["filled_execution_count"], 1)
         self.assertEqual(source_activity["tca_sample_count"], 1)
 
+    def test_external_target_plan_scope_is_preserved_in_next_window_audit(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": True,
+                    "reason": "non_live_mode",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": (
+                            "torghut.next-paper-route-runtime-window-targets.v1"
+                        ),
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-external-scope",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": "external-scope-strategy",
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                                "paper_route_target_plan_source": (
+                                    "external_target_plan_url"
+                                ),
+                                "paper_route_probe_scope_authority": (
+                                    "external_target_plan"
+                                ),
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": False,
+                        "next_session_max_notional": "63180",
+                        "eligible_symbol_count": 3,
+                        "eligible_symbols": ["AMZN", "AAPL", "INTC"],
+                        "active_symbols": [],
+                        "blocking_reasons": ["market_session_closed"],
+                    },
+                },
+                generated_at=window_start - timedelta(days=2),
+            )
+
+        next_target = payload["next_paper_route_runtime_window_targets"]["targets"][0]
+        self.assertEqual(next_target["paper_route_probe_symbols"], ["AAPL", "AMZN"])
+        self.assertEqual(
+            next_target["paper_route_probe_scope_authority"],
+            "external_target_plan",
+        )
+        next_audit_target = payload["next_runtime_window_target_audits"][0]["target"]
+        self.assertEqual(
+            next_audit_target["paper_route_probe_symbols"], ["AAPL", "AMZN"]
+        )
+        self.assertNotIn("INTC", next_audit_target["paper_route_probe_symbols"])
+
     def test_source_activity_is_scoped_to_target_account_and_probe_symbols(
         self,
     ) -> None:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7602,7 +7602,18 @@ class TestTradingApi(TestCase):
                 0
             ]
             self.assertEqual(next_target["paper_route_probe_symbols"], ["AAPL", "AMZN"])
+            self.assertEqual(
+                next_target["paper_route_probe_scope_authority"],
+                "external_target_plan",
+            )
+            next_audit_target = payload["next_runtime_window_target_audits"][0][
+                "target"
+            ]
+            self.assertEqual(
+                next_audit_target["paper_route_probe_symbols"], ["AAPL", "AMZN"]
+            )
             self.assertNotIn("INTC", next_target["paper_route_probe_symbols"])
+            self.assertNotIn("INTC", next_audit_target["paper_route_probe_symbols"])
         finally:
             settings.trading_paper_route_target_plan_url = original_target_plan_url
             if original_scheduler is None:


### PR DESCRIPTION
## Summary

- Preserve `paper_route_probe_scope_authority` and `paper_route_target_plan_source` when generating next-session paper-route runtime targets.
- Keep external live target-plan symbol envelopes authoritative through `next_runtime_window_target_audits`, so sim cannot re-expand AAPL/AMZN targets with local-only INTC.
- Add regression coverage for the live/sim mismatch found after the `9d7273f9` image promotion.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'external_target_plan_scope or current_paper_route_probe_symbols_extend_next_window_target_scope' -q`
- `uv run --frozen pytest tests/test_trading_api.py -k 'external_paper_route_target_preserves_live_symbol_envelope or trading_paper_route_evidence_uses_external_plan_when_url_configured' -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py -k 'paper_route_target_plan or external_target_plan_scope or current_paper_route_probe_symbols_extend_next_window_target_scope or external_paper_route_target_preserves_live_symbol_envelope or trading_paper_route_evidence_uses_external_plan_when_url_configured' -q`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
