### PR TITLE
fix(torghut): audit paper-route proof through sim service

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -64,7 +64,7 @@ spec:
                     | tee "${RENEWAL_OUTPUT}"
                   /opt/venv/bin/python scripts/assemble_runtime_ledger_proof_packet.py \
                     --status-service-base-url http://torghut.torghut.svc.cluster.local \
-                    --paper-route-service-base-url http://torghut.torghut.svc.cluster.local \
+                    --paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local \
                     --completion-service-base-url http://torghut.torghut.svc.cluster.local \
                     --runtime-window-import-file "${RENEWAL_OUTPUT}" \
                     --output-file "${PROOF_PACKET_OUTPUT}" \

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -44,7 +44,7 @@ PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL = "TORGHUT_SIM"
 PAPER_ROUTE_RUNTIME_IMPORT_SETTLEMENT_SECONDS = 3600
 DEFAULT_TORGHUT_LIVE_SERVICE_BASE_URL = "http://torghut.torghut.svc.cluster.local"
 DEFAULT_TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL = (
-    "http://torghut.torghut.svc.cluster.local"
+    "http://torghut-sim.torghut.svc.cluster.local"
 )
 RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE = "artifacts/runtime-ledger-proof-packet.json"
 RUNTIME_WINDOW_IMPORT_OUTPUT_FILE = "artifacts/runtime-window-import.json"
@@ -1597,7 +1597,7 @@ def _runtime_ledger_proof_packet_handoff(
         ),
         "source_service_authority": {
             "status": "live_torghut_service",
-            "paper_route_evidence": "live_torghut_service",
+            "paper_route_evidence": "torghut_sim_service",
             "completion_doc29": "live_torghut_service",
         },
         "source_endpoints": {

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -878,11 +878,11 @@ class TestLiveConfigManifestContract(TestCase):
             args,
         )
         self.assertIn(
-            "--paper-route-service-base-url http://torghut.torghut.svc.cluster.local",
+            "--paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local",
             args,
         )
         self.assertNotIn(
-            "--paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local",
+            "--paper-route-service-base-url http://torghut.torghut.svc.cluster.local",
             args,
         )
         self.assertIn(

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -405,13 +405,13 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertEqual(
             proof_handoff["default_paper_route_service_base_url"],
-            "http://torghut.torghut.svc.cluster.local",
+            "http://torghut-sim.torghut.svc.cluster.local",
         )
         self.assertEqual(
             proof_handoff["source_service_authority"],
             {
                 "status": "live_torghut_service",
-                "paper_route_evidence": "live_torghut_service",
+                "paper_route_evidence": "torghut_sim_service",
                 "completion_doc29": "live_torghut_service",
             },
         )


### PR DESCRIPTION
## Summary

- Point the empirical renewal proof-packet paper-route evidence source at `torghut-sim` while keeping status and completion checks on live `torghut`.
- Update the runtime-ledger proof handoff defaults so operator commands audit paper-route evidence through the sim service.
- Update manifest and handoff contract tests for the split live/sim authority path.

## Related Issues

None

## Testing

- `uv run --project services/torghut --frozen pytest services/torghut/tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_empirical_promotion_renewal_imports_authoritative_live_paper_plan_and_sim_db services/torghut/tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_builder_exports_next_paper_route_runtime_window_targets`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json` from `services/torghut`
- `uv run --frozen pyright --project pyrightconfig.alpha.json` from `services/torghut`
- `uv run --frozen pyright --project pyrightconfig.scripts.json` from `services/torghut`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_live_config_manifest_contract.py tests/test_paper_route_evidence.py` from `services/torghut`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
