### PR TITLE
fix(torghut): scope paper-route probes to target plan

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -125,6 +125,10 @@ from .trading.profit_carry_passports import build_profit_carry_passport_ledger
 from .trading.profit_freshness_frontier import build_profit_freshness_frontier
 from .trading.profit_repair_settlement import build_profit_repair_settlement_ledger
 from .trading.profit_signal_quorum import build_profit_signal_quorum
+from .trading.paper_route_target_plan import (
+    mapping_items as _shared_mapping_items,
+    paper_route_target_plan_from_payload as _shared_paper_route_target_plan_from_payload,
+)
 from .trading.paper_route_evidence import build_paper_route_evidence_audit
 from .trading.proof_floor import build_profitability_proof_floor_receipt
 from .trading.quality_adjusted_profit_frontier import (
@@ -4573,13 +4577,7 @@ def trading_paper_route_evidence(
 
 
 def _mapping_items(value: object) -> list[dict[str, Any]]:
-    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
-        return []
-    return [
-        _to_str_map(cast(object, item))
-        for item in cast(Sequence[object], value)
-        if isinstance(item, Mapping)
-    ]
+    return _shared_mapping_items(value)
 
 
 def _paper_route_target_plan_targets(plan: Mapping[str, Any]) -> list[dict[str, Any]]:
@@ -4587,27 +4585,7 @@ def _paper_route_target_plan_targets(plan: Mapping[str, Any]) -> list[dict[str, 
 
 
 def _paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
-    live_gate = _to_str_map(payload.get("live_submission_gate"))
-    runtime_window_plan = _to_str_map(payload.get("runtime_window_import_plan"))
-    next_paper_route_plan = _to_str_map(
-        payload.get("next_paper_route_runtime_window_targets")
-    )
-    paper_route_payload = (
-        payload.get("schema_version") == "torghut.paper-route-evidence.v1"
-    )
-    paper_route_plans = [next_paper_route_plan] if paper_route_payload else []
-    candidate_plans = [
-        runtime_window_plan,
-        *paper_route_plans,
-        _to_str_map(live_gate.get("runtime_ledger_paper_probation_import_plan")),
-        _to_str_map(payload.get("runtime_ledger_paper_probation_import_plan")),
-        *([] if paper_route_payload else [next_paper_route_plan]),
-        dict(payload) if _paper_route_target_plan_targets(payload) else {},
-    ]
-    for plan in candidate_plans:
-        if _paper_route_target_plan_targets(plan):
-            return plan
-    return {}
+    return _shared_paper_route_target_plan_from_payload(payload)
 
 
 def _fetch_paper_route_target_plan_url(

--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -1,0 +1,133 @@
+"""Helpers for external paper-route runtime-window target plans."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from http.client import HTTPConnection, HTTPSConnection
+from typing import Any, cast
+from urllib.parse import urlsplit
+
+
+def _to_str_map(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[object, Any], value).items()}
+
+
+def mapping_items(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [
+        _to_str_map(cast(object, item))
+        for item in cast(Sequence[object], value)
+        if isinstance(item, Mapping)
+    ]
+
+
+def paper_route_target_plan_targets(plan: Mapping[str, Any]) -> list[dict[str, Any]]:
+    return mapping_items(plan.get("targets"))
+
+
+def paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    live_gate = _to_str_map(payload.get("live_submission_gate"))
+    runtime_window_plan = _to_str_map(payload.get("runtime_window_import_plan"))
+    next_paper_route_plan = _to_str_map(
+        payload.get("next_paper_route_runtime_window_targets")
+    )
+    paper_route_payload = (
+        payload.get("schema_version") == "torghut.paper-route-evidence.v1"
+    )
+    paper_route_plans = [next_paper_route_plan] if paper_route_payload else []
+    candidate_plans = [
+        runtime_window_plan,
+        *paper_route_plans,
+        _to_str_map(live_gate.get("runtime_ledger_paper_probation_import_plan")),
+        _to_str_map(payload.get("runtime_ledger_paper_probation_import_plan")),
+        *([] if paper_route_payload else [next_paper_route_plan]),
+        dict(payload) if paper_route_target_plan_targets(payload) else {},
+    ]
+    for plan in candidate_plans:
+        if paper_route_target_plan_targets(plan):
+            return plan
+    return {}
+
+
+def fetch_paper_route_target_plan_url(
+    url: str,
+    *,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"}:
+        return {
+            "load_error": f"paper_route_target_plan_invalid_scheme:{scheme or 'missing'}"
+        }
+    if not parsed.hostname:
+        return {"load_error": "paper_route_target_plan_invalid_host"}
+
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    connection_class = HTTPSConnection if scheme == "https" else HTTPConnection
+    connection = connection_class(
+        parsed.hostname,
+        parsed.port,
+        timeout=max(float(timeout_seconds), 0.1),
+    )
+    try:
+        connection.request("GET", path, headers={"Accept": "application/json"})
+        response = connection.getresponse()
+        if response.status < 200 or response.status >= 300:
+            return {
+                "load_error": f"paper_route_target_plan_http_status:{response.status}"
+            }
+        raw = response.read(5_000_001)
+    except Exception as exc:  # pragma: no cover - depends on network
+        return {"load_error": f"paper_route_target_plan_fetch_failed:{exc}"}
+    finally:
+        connection.close()
+
+    if len(raw) > 5_000_000:
+        return {"load_error": "paper_route_target_plan_response_too_large"}
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except Exception as exc:
+        return {"load_error": f"paper_route_target_plan_invalid_json:{exc}"}
+    if not isinstance(payload, Mapping):
+        return {"load_error": "paper_route_target_plan_invalid_payload"}
+    plan = paper_route_target_plan_from_payload(cast(Mapping[str, Any], payload))
+    if not plan:
+        return {"load_error": "paper_route_target_plan_missing"}
+    plan = dict(plan)
+    plan.setdefault("source", "external_paper_route_target_plan")
+    return plan
+
+
+def paper_route_target_plan_probe_symbols(plan: Mapping[str, Any]) -> set[str]:
+    symbols: set[str] = set()
+    for target in paper_route_target_plan_targets(plan):
+        raw_symbols = target.get("paper_route_probe_symbols")
+        if isinstance(raw_symbols, str):
+            values: Sequence[object] = raw_symbols.split(",")
+        elif isinstance(raw_symbols, Sequence) and not isinstance(
+            raw_symbols, (bytes, bytearray)
+        ):
+            values = cast(Sequence[object], raw_symbols)
+        else:
+            values = ()
+        for raw_symbol in values:
+            symbol = str(raw_symbol).strip().upper()
+            if symbol:
+                symbols.add(symbol)
+    return symbols
+
+
+__all__ = [
+    "fetch_paper_route_target_plan_url",
+    "mapping_items",
+    "paper_route_target_plan_from_payload",
+    "paper_route_target_plan_probe_symbols",
+    "paper_route_target_plan_targets",
+]

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -19,6 +19,10 @@ from ..feature_quality import FeatureQualityThresholds, evaluate_feature_batch_q
 from ..firewall import OrderFirewallBlocked
 from ..ingest import SignalBatch
 from ..models import SignalEnvelope, StrategyDecision
+from ..paper_route_target_plan import (
+    fetch_paper_route_target_plan_url,
+    paper_route_target_plan_probe_symbols,
+)
 from ..prices import MarketSnapshot
 from ..proof_floor import build_profitability_proof_floor_receipt
 from ..simple_risk import (
@@ -697,6 +701,23 @@ class SimpleTradingPipeline(TradingPipeline):
                 return True
         return True
 
+    @staticmethod
+    def _external_paper_route_target_probe_symbols() -> tuple[set[str], str | None]:
+        url = str(settings.trading_paper_route_target_plan_url or "").strip()
+        if not url:
+            return set(), None
+        plan = fetch_paper_route_target_plan_url(
+            url,
+            timeout_seconds=settings.trading_paper_route_target_plan_timeout_seconds,
+        )
+        load_error = str(plan.get("load_error") or "").strip()
+        if load_error:
+            return set(), load_error
+        symbols = paper_route_target_plan_probe_symbols(plan)
+        if not symbols:
+            return set(), "paper_route_target_plan_probe_symbols_missing"
+        return symbols, None
+
     def _paper_route_probe_context(
         self,
         *,
@@ -729,6 +750,13 @@ class SimpleTradingPipeline(TradingPipeline):
             if str(item).strip()
         }
         symbol = decision.symbol.strip().upper()
+        target_plan_symbols, target_plan_error = (
+            self._external_paper_route_target_probe_symbols()
+        )
+        if target_plan_error:
+            return None
+        if target_plan_symbols and symbol not in target_plan_symbols:
+            return None
         symbol_route_probe_reasons = self._proof_floor_symbol_route_probe_reasons(
             proof_floor,
             symbol,
@@ -761,6 +789,10 @@ class SimpleTradingPipeline(TradingPipeline):
             "blocking_reasons": sorted(blocking_reasons | symbol_route_probe_reasons),
             "route_repair_symbols": sorted(repair_symbols),
             "paper_route_probe_symbols": sorted(paper_route_probe_symbols),
+            "paper_route_target_plan_symbols": sorted(target_plan_symbols),
+            "paper_route_target_plan_source": "external_target_plan_url"
+            if target_plan_symbols
+            else None,
         }
 
     def _apply_paper_route_probe_cap(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -41,6 +41,10 @@ from app.main import (
     _route_claim_symbols,
     app,
 )
+from app.trading.paper_route_target_plan import (
+    fetch_paper_route_target_plan_url as shared_fetch_paper_route_target_plan_url,
+    paper_route_target_plan_probe_symbols,
+)
 from app.trading.forecast_runtime import forecast_registry
 from app.trading.scheduler import TradingScheduler
 from app.trading.feature_quality import FeatureQualityReport
@@ -7347,6 +7351,145 @@ class TestTradingApi(TestCase):
             )
         self.assertEqual(plan["source"], "external_paper_route_target_plan")
         self.assertEqual(plan["targets"][0]["candidate_id"], "c88421d619759b2cfaa6f4d0")
+
+    def test_shared_paper_route_target_plan_helpers_validate_response(self) -> None:
+        class FakeResponse:
+            def __init__(self, status: int, raw: bytes) -> None:
+                self.status = status
+                self._raw = raw
+
+            def read(self, size: int) -> bytes:
+                self.read_size = size
+                return self._raw
+
+        def connection_class(status: int, raw: bytes) -> type[Any]:
+            class FakeConnection:
+                instances: list["FakeConnection"] = []
+
+                def __init__(
+                    self,
+                    hostname: str,
+                    port: int | None,
+                    *,
+                    timeout: float,
+                ) -> None:
+                    self.hostname = hostname
+                    self.port = port
+                    self.timeout = timeout
+                    self.request_path: str | None = None
+                    self.closed = False
+                    self.instances.append(self)
+
+                def request(
+                    self,
+                    method: str,
+                    path: str,
+                    *,
+                    headers: dict[str, str],
+                ) -> None:
+                    self.request_method = method
+                    self.request_path = path
+                    self.request_headers = headers
+
+                def getresponse(self) -> FakeResponse:
+                    return FakeResponse(status, raw)
+
+                def close(self) -> None:
+                    self.closed = True
+
+            return FakeConnection
+
+        self.assertEqual(
+            shared_fetch_paper_route_target_plan_url(
+                "file:///tmp/plan.json",
+                timeout_seconds=1,
+            ),
+            {"load_error": "paper_route_target_plan_invalid_scheme:file"},
+        )
+        self.assertEqual(
+            shared_fetch_paper_route_target_plan_url(
+                "http:///missing-host",
+                timeout_seconds=1,
+            ),
+            {"load_error": "paper_route_target_plan_invalid_host"},
+        )
+
+        http_error_connection = connection_class(503, b"{}")
+        with patch(
+            "app.trading.paper_route_target_plan.HTTPConnection",
+            http_error_connection,
+        ):
+            self.assertEqual(
+                shared_fetch_paper_route_target_plan_url(
+                    "http://torghut.example/plan?mode=paper",
+                    timeout_seconds=0,
+                ),
+                {"load_error": "paper_route_target_plan_http_status:503"},
+            )
+        self.assertEqual(http_error_connection.instances[0].hostname, "torghut.example")
+        self.assertEqual(
+            http_error_connection.instances[0].request_path, "/plan?mode=paper"
+        )
+        self.assertEqual(http_error_connection.instances[0].timeout, 0.1)
+        self.assertTrue(http_error_connection.instances[0].closed)
+
+        for raw, expected in (
+            (b"{", "paper_route_target_plan_invalid_json:"),
+            (b"[]", "paper_route_target_plan_invalid_payload"),
+            (
+                json.dumps({"runtime_window_import_plan": {"targets": []}}).encode(
+                    "utf-8"
+                ),
+                "paper_route_target_plan_missing",
+            ),
+            (b"x" * 5_000_001, "paper_route_target_plan_response_too_large"),
+        ):
+            fake_connection = connection_class(200, raw)
+            with patch(
+                "app.trading.paper_route_target_plan.HTTPConnection",
+                fake_connection,
+            ):
+                result = shared_fetch_paper_route_target_plan_url(
+                    "http://torghut.example",
+                    timeout_seconds=1,
+                )
+            self.assertTrue(str(result["load_error"]).startswith(expected))
+
+        success_connection = connection_class(
+            200,
+            json.dumps(
+                {
+                    "runtime_window_import_plan": {
+                        "targets": [
+                            {
+                                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                                "paper_route_probe_symbols": " aapl, AMZN ",
+                            },
+                            {
+                                "candidate_id": "other",
+                                "paper_route_probe_symbols": [],
+                            },
+                            {
+                                "candidate_id": "missing-symbols",
+                            },
+                        ]
+                    }
+                }
+            ).encode("utf-8"),
+        )
+        with patch(
+            "app.trading.paper_route_target_plan.HTTPConnection",
+            success_connection,
+        ):
+            plan = shared_fetch_paper_route_target_plan_url(
+                "http://torghut.example",
+                timeout_seconds=3,
+            )
+        self.assertEqual(plan["source"], "external_paper_route_target_plan")
+        self.assertEqual(
+            paper_route_target_plan_probe_symbols(plan),
+            {"AAPL", "AMZN"},
+        )
 
     def test_load_external_paper_route_target_plan_uses_configured_url(self) -> None:
         original_target_plan_url = settings.trading_paper_route_target_plan_url

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -777,6 +777,8 @@ class TestTradingPipeline(TestCase):
                 "trading_simple_order_feed_telemetry_enabled",
                 "trading_simple_paper_route_probe_enabled",
                 "trading_simple_paper_route_probe_max_notional",
+                "trading_paper_route_target_plan_url",
+                "trading_paper_route_target_plan_timeout_seconds",
                 "trading_universe_static_fallback_enabled",
                 "trading_universe_static_fallback_symbols_raw",
                 "trading_market_context_url",
@@ -3397,6 +3399,98 @@ class TestTradingPipeline(TestCase):
                 decision=decision,
             )
         )
+
+    def test_paper_route_probe_context_honors_external_target_plan_scope(self) -> None:
+        from app import config
+
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        decision = StrategyDecision(
+            strategy_id="strategy-1",
+            symbol="NVDA",
+            event_ts=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="route-probe-target-plan-scope",
+            params={"price": "100"},
+        )
+        proof_floor = {
+            "market_window": {"session_open": True},
+            "blocking_reasons": ["alpha_readiness_not_promotion_eligible"],
+            "route_reacquisition_book": {
+                "summary": {
+                    "repair_candidate_symbols": ["AAPL", "NVDA"],
+                    "paper_route_probe_eligible_symbols": ["AAPL", "NVDA"],
+                }
+            },
+        }
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_max_notional = 25.0
+        config.settings.trading_paper_route_target_plan_url = (
+            "http://torghut.local/trading/paper-route-evidence"
+        )
+        config.settings.trading_paper_route_target_plan_timeout_seconds = 1.0
+
+        with patch(
+            "app.trading.scheduler.simple_pipeline.fetch_paper_route_target_plan_url",
+            return_value={"targets": [{"paper_route_probe_symbols": ["AAPL"]}]},
+        ):
+            self.assertIsNone(
+                pipeline._paper_route_probe_context(
+                    proof_floor=proof_floor,
+                    decision=decision,
+                )
+            )
+            scoped_context = pipeline._paper_route_probe_context(
+                proof_floor=proof_floor,
+                decision=decision.model_copy(update={"symbol": "AAPL"}),
+            )
+
+        self.assertIsNotNone(scoped_context)
+        assert scoped_context is not None
+        self.assertEqual(
+            scoped_context.get("paper_route_target_plan_symbols"), ["AAPL"]
+        )
+        self.assertEqual(
+            scoped_context.get("paper_route_target_plan_source"),
+            "external_target_plan_url",
+        )
+
+        with patch(
+            "app.trading.scheduler.simple_pipeline.fetch_paper_route_target_plan_url",
+            return_value={"load_error": "paper_route_target_plan_fetch_failed:test"},
+        ):
+            self.assertIsNone(
+                pipeline._paper_route_probe_context(
+                    proof_floor=proof_floor,
+                    decision=decision.model_copy(update={"symbol": "AAPL"}),
+                )
+            )
+        with patch(
+            "app.trading.scheduler.simple_pipeline.fetch_paper_route_target_plan_url",
+            return_value={"targets": [{"paper_route_probe_symbols": []}]},
+        ):
+            self.assertIsNone(
+                pipeline._paper_route_probe_context(
+                    proof_floor=proof_floor,
+                    decision=decision.model_copy(update={"symbol": "AAPL"}),
+                )
+            )
 
     def test_paper_route_probe_short_increasing_sell_classification(self) -> None:
         decision = StrategyDecision(


### PR DESCRIPTION
## Summary

- Added shared paper-route target-plan parsing helpers for Torghut runtime-window plans.
- Scoped simple-lane paper-route probe submits to `paper_route_probe_symbols` from `TRADING_PAPER_ROUTE_TARGET_PLAN_URL`.
- Fail closed on external target-plan fetch errors or missing probe symbols so paper probes cannot drift outside the selected proof target.
- Added regression coverage for target-plan-scoped paper-route probes and setting restoration.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_target_plan.py app/main.py app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py tests/test_trading_api.py --check`
- `uv run --frozen ruff check app/trading/paper_route_target_plan.py app/main.py app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py tests/test_trading_api.py`
- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan or paper_route_evidence' -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_route_probe_context or paper_route_probe_helpers' -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
