### PR TITLE
fix(torghut): materialize source runtime ledger

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -569,6 +569,29 @@ def _runtime_window_source_kind_is_informational(
     return scope == "evidence_collection_only"
 
 
+_AUTHORITATIVE_RUNTIME_LEDGER_MATERIALIZATION_SOURCE_KINDS = frozenset(
+    {
+        "paper_route_probe_runtime_observed",
+        "paper_runtime_observed",
+        "live_runtime_observed",
+    }
+)
+
+
+def _source_kind_allows_runtime_ledger_materialization(
+    *,
+    source_kind: str,
+    target_metadata: Mapping[str, Any],
+) -> bool:
+    if _runtime_window_source_kind_is_informational(
+        source_kind=source_kind,
+        target_metadata=target_metadata,
+    ):
+        return False
+    normalized = source_kind.strip().lower().replace("-", "_")
+    return normalized in _AUTHORITATIVE_RUNTIME_LEDGER_MATERIALIZATION_SOURCE_KINDS
+
+
 def _runtime_window_import_proof_hygiene_blockers(
     *,
     source_kind: str,
@@ -667,6 +690,8 @@ def _execution_signed_qty(*, side: Any, qty: Any) -> Decimal:
 
 def _build_realized_strategy_pnl_rows(
     execution_rows: list[dict[str, object]],
+    *,
+    allow_authoritative_runtime_ledger_materialization: bool = False,
 ) -> list[dict[str, object]]:
     ledger_rows: list[RuntimeLedgerFill | dict[str, object]] = []
     event_times: list[datetime] = []
@@ -800,26 +825,50 @@ def _build_realized_strategy_pnl_rows(
             bucket=bucket,
             computed_at=unique_times[-1],
         )
-        row["post_cost_expectancy_basis"] = POST_COST_BASIS_EXECUTION_RECONSTRUCTION
-        row["post_cost_promotion_eligible"] = False
-        row["authoritative"] = False
-        row["authority_reason"] = "execution_reconstruction_not_runtime_ledger_proof"
-        row["pnl_derivation"] = "execution_reconstructed_from_execution_rows"
-        row["promotion_blocker"] = "execution_reconstruction_not_runtime_ledger_proof"
-        blockers = list(row.get("runtime_ledger_blockers") or [])
-        if "execution_reconstruction_not_runtime_ledger_proof" not in blockers:
-            blockers.append("execution_reconstruction_not_runtime_ledger_proof")
-        row["runtime_ledger_blockers"] = blockers
         bucket_payload = row.get("runtime_ledger_bucket")
-        if isinstance(bucket_payload, Mapping):
-            bucket_payload = dict(bucket_payload)
-            bucket_payload["blockers"] = blockers
-            bucket_payload["pnl_basis"] = POST_COST_BASIS_EXECUTION_RECONSTRUCTION
-            bucket_payload["authoritative"] = False
-            bucket_payload["authority_reason"] = (
-                "execution_reconstruction_not_runtime_ledger_proof"
+        source_execution_materialized = (
+            allow_authoritative_runtime_ledger_materialization
+            and isinstance(bucket_payload, Mapping)
+            and _runtime_ledger_bucket_profit_proof_present(bucket_payload)
+        )
+        if source_execution_materialized:
+            row["authoritative"] = True
+            row["authority_reason"] = "source_execution_runtime_ledger_materialized"
+            row["pnl_derivation"] = (
+                "source_execution_lifecycle_materialized_runtime_ledger"
             )
-            row["runtime_ledger_bucket"] = bucket_payload
+            if isinstance(bucket_payload, Mapping):
+                row["runtime_ledger_bucket"] = {
+                    **dict(bucket_payload),
+                    "authoritative": True,
+                    "authority_reason": (
+                        "source_execution_runtime_ledger_materialized"
+                    ),
+                    "pnl_derivation": (
+                        "source_execution_lifecycle_materialized_runtime_ledger"
+                    ),
+                    "source_materialization": "source_execution_lifecycle",
+                }
+        else:
+            row["post_cost_expectancy_basis"] = POST_COST_BASIS_EXECUTION_RECONSTRUCTION
+            row["post_cost_promotion_eligible"] = False
+            row["authoritative"] = False
+            row["authority_reason"] = "execution_reconstruction_not_runtime_ledger_proof"
+            row["pnl_derivation"] = "execution_reconstructed_from_execution_rows"
+            row["promotion_blocker"] = "execution_reconstruction_not_runtime_ledger_proof"
+            blockers = list(row.get("runtime_ledger_blockers") or [])
+            if "execution_reconstruction_not_runtime_ledger_proof" not in blockers:
+                blockers.append("execution_reconstruction_not_runtime_ledger_proof")
+            row["runtime_ledger_blockers"] = blockers
+            if isinstance(bucket_payload, Mapping):
+                bucket_payload = dict(bucket_payload)
+                bucket_payload["blockers"] = blockers
+                bucket_payload["pnl_basis"] = POST_COST_BASIS_EXECUTION_RECONSTRUCTION
+                bucket_payload["authoritative"] = False
+                bucket_payload["authority_reason"] = (
+                    "execution_reconstruction_not_runtime_ledger_proof"
+                )
+                row["runtime_ledger_bucket"] = bucket_payload
         realized_rows.append(row)
     return realized_rows
 
@@ -1444,6 +1493,7 @@ def _query_timestamps(
     window_start: datetime,
     window_end: datetime,
     symbols: Sequence[str] | None = None,
+    allow_authoritative_runtime_ledger_materialization: bool = False,
 ) -> tuple[list[datetime], list[datetime], list[dict[str, object]]]:
     if not strategy_names:
         raise RuntimeError("strategy_name_not_configured")
@@ -1591,7 +1641,14 @@ def _query_timestamps(
                 for row in cur.fetchall()
                 if row[0] is not None
             ]
-    tca_rows.extend(_build_realized_strategy_pnl_rows(execution_rows))
+    tca_rows.extend(
+        _build_realized_strategy_pnl_rows(
+            execution_rows,
+            allow_authoritative_runtime_ledger_materialization=(
+                allow_authoritative_runtime_ledger_materialization
+            ),
+        )
+    )
     return decisions, executions, tca_rows
 
 
@@ -1717,6 +1774,12 @@ def main() -> int:
     source_kind = args.source_kind.strip() or (
         "simulation_paper_runtime" if args.observed_stage == "paper" else "live_runtime"
     )
+    allow_authoritative_runtime_ledger_materialization = (
+        _source_kind_allows_runtime_ledger_materialization(
+            source_kind=source_kind,
+            target_metadata=target_metadata,
+        )
+    )
     decisions: list[datetime] = []
     executions: list[datetime] = []
     tca_rows: list[dict[str, object]] = []
@@ -1728,6 +1791,9 @@ def main() -> int:
             window_start=window_start,
             window_end=window_end,
             symbols=source_activity_symbols,
+            allow_authoritative_runtime_ledger_materialization=(
+                allow_authoritative_runtime_ledger_materialization
+            ),
         )
     bucket_ranges: list[tuple[datetime, datetime, int]] = []
     runtime_ledger_artifact_metadata: dict[str, Any] = {

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -42,6 +42,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _runtime_ledger_tca_rows_from_artifacts,
     _runtime_window_import_proof_hygiene_blockers,
     _runtime_window_source_kind_is_informational,
+    _source_kind_allows_runtime_ledger_materialization,
     _source_activity_missing_summary,
     _stable_payload_digest,
     _strategy_name_candidates,
@@ -738,6 +739,28 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             )
         )
 
+    def test_source_kind_allows_authoritative_materialization_only_for_observed_runtime(
+        self,
+    ) -> None:
+        self.assertTrue(
+            _source_kind_allows_runtime_ledger_materialization(
+                source_kind="paper_route_probe_runtime_observed",
+                target_metadata={"paper_route_probe_symbols": ["AAPL"]},
+            )
+        )
+        self.assertFalse(
+            _source_kind_allows_runtime_ledger_materialization(
+                source_kind="simulation_paper_runtime",
+                target_metadata={"paper_route_probe_symbols": ["AAPL"]},
+            )
+        )
+        self.assertFalse(
+            _source_kind_allows_runtime_ledger_materialization(
+                source_kind="paper_runtime_observed",
+                target_metadata={"evidence_scope": "evidence_collection_only"},
+            )
+        )
+
     def test_source_activity_missing_summary_includes_proof_hygiene_blockers(
         self,
     ) -> None:
@@ -1012,6 +1035,61 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             rows[0]["authority_reason"],
             "execution_reconstruction_not_runtime_ledger_proof",
         )
+
+    def test_build_realized_strategy_pnl_rows_can_materialize_source_runtime_ledger(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(
+            rows[0]["post_cost_expectancy_basis"], POST_COST_BASIS_RUNTIME_LEDGER
+        )
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], True)
+        self.assertEqual(rows[0]["authoritative"], True)
+        self.assertEqual(
+            rows[0]["authority_reason"],
+            "source_execution_runtime_ledger_materialized",
+        )
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["blockers"], [])
+        self.assertEqual(bucket["pnl_basis"], POST_COST_BASIS_RUNTIME_LEDGER)
+        self.assertEqual(bucket["source_materialization"], "source_execution_lifecycle")
+        self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
 
     def test_build_realized_strategy_pnl_rows_normalizes_nested_runtime_payloads(
         self,
@@ -2317,6 +2395,12 @@ class TestImportHypothesisRuntimeWindows(TestCase):
 
         self.assertEqual(exit_code, 0)
         query_timestamps.assert_called_once()
+        self.assertEqual(
+            query_timestamps.call_args.kwargs[
+                "allow_authoritative_runtime_ledger_materialization"
+            ],
+            True,
+        )
         source_buckets.assert_called_once()
         tca_rows = build_buckets.call_args.kwargs["tca_rows"]
         self.assertEqual(tca_rows, [source_tca_row])


### PR DESCRIPTION
## Summary

- Allows the runtime-window importer to materialize promotion-grade runtime-ledger rows from real source execution lifecycle rows for explicitly runtime-observed source kinds.
- Keeps execution reconstruction non-authoritative by default and blocks simulation or evidence-collection-only sources from becoming runtime-ledger authority.
- Adds regression coverage for the source-kind guard, authoritative materialization path, and import wiring.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'build_realized_strategy_pnl_rows or source_kind_allows or query_timestamps_filters_to_execution_eligible_decisions or main_imports_source_runtime_ledger_bucket_with_source_dsn'`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen pytest tests/test_runtime_window_import.py -k 'runtime_ledger or persist_observed_runtime_windows'`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -k 'runtime_window_import_proof or post_cost_profit_target or risk_quality or runtime_ledger'`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
