### PR TITLE
fix(torghut): surface runtime ledger materialization proof

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,6 +7,10 @@ on:
       - 'packages/**'
       - 'services/**'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -25,31 +29,40 @@ jobs:
       codex: ${{ steps.filter.outputs.codex }}
       discord: ${{ steps.filter.outputs.discord }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - name: Check changed files
         id: filter
-        with:
-          filters: |
-            proompteng:
-              - 'apps/landing/**'
-            app:
-              - 'apps/app/**'
-            cms:
-              - 'apps/cms/**'
-            bonjour:
-              - 'services/bonjour/**'
-            docs:
-              - 'apps/docs/**'
-            kitty-krew:
-              - 'apps/kitty-krew/**'
-            reviseur:
-              - 'apps/reviseur/**'
-            codex:
-              - 'packages/codex/**'
-            discord:
-              - 'packages/discord/**'
-            packages:
-              - 'packages/**'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          changed_files="$(mktemp)"
+          gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" \
+            --paginate \
+            --jq '.[].filename' > "${changed_files}"
+
+          output_flag() {
+            local name="$1"
+            local regex="$2"
+            local value=false
+            if grep -Eq "${regex}" "${changed_files}"; then
+              value=true
+            fi
+            echo "${name}=${value}" >> "$GITHUB_OUTPUT"
+          }
+
+          output_flag proompteng '^apps/landing/'
+          output_flag app '^apps/app/'
+          output_flag cms '^apps/cms/'
+          output_flag bonjour '^services/bonjour/'
+          output_flag docs '^apps/docs/'
+          output_flag kitty-krew '^apps/kitty-krew/'
+          output_flag reviseur '^apps/reviseur/'
+          output_flag codex '^packages/codex/'
+          output_flag discord '^packages/discord/'
 
   docs:
     needs: check_changed_files

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,16 +33,27 @@ jobs:
         id: filter
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
           changed_files="$(mktemp)"
-          gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" \
-            --paginate \
-            --jq '.[].filename' > "${changed_files}"
+          page=1
+          while true; do
+            response="$(
+              curl -fsSL \
+                -H 'Accept: application/vnd.github+json' \
+                -H 'X-GitHub-Api-Version: 2022-11-28' \
+                "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}/files?per_page=100&page=${page}"
+            )"
+            count="$(jq 'length' <<< "${response}")"
+            if [ "${count}" -eq 0 ]; then
+              break
+            fi
+            jq -r '.[].filename' <<< "${response}" >> "${changed_files}"
+            page=$((page + 1))
+          done
 
           output_flag() {
             local name="$1"
@@ -70,6 +81,8 @@ jobs:
     runs-on: arc-arm64
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ''
 
       - uses: actions/cache@v4
         with:
@@ -120,6 +133,8 @@ jobs:
       CONVEX_SELF_HOSTED_ADMIN_KEY: ${{ secrets.CONVEX_SELF_HOSTED_ADMIN_KEY }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ''
 
       - name: Install build tools
         run: |
@@ -169,6 +184,8 @@ jobs:
       PAYLOAD_SECRET: ci-build-secret
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ''
 
       - name: Install build tools
         run: |
@@ -216,6 +233,8 @@ jobs:
     runs-on: arc-arm64
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ''
 
       - name: Install build tools
         run: |
@@ -255,6 +274,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ''
 
       - uses: actions/setup-node@v6
         with:
@@ -283,6 +304,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ''
       # codex CI handled by dedicated workflow (.github/workflows/codex-ci.yml)
 
   discord:
@@ -291,6 +314,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ''
 
       - uses: actions/setup-node@v6
         with:
@@ -327,6 +352,8 @@ jobs:
     runs-on: arc-arm64
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ''
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -371,6 +398,8 @@ jobs:
     runs-on: arc-arm64
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ''
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -81,8 +81,6 @@ jobs:
     runs-on: arc-arm64
     steps:
       - uses: actions/checkout@v5
-        with:
-          token: ''
 
       - uses: actions/cache@v4
         with:
@@ -133,8 +131,6 @@ jobs:
       CONVEX_SELF_HOSTED_ADMIN_KEY: ${{ secrets.CONVEX_SELF_HOSTED_ADMIN_KEY }}
     steps:
       - uses: actions/checkout@v5
-        with:
-          token: ''
 
       - name: Install build tools
         run: |
@@ -184,8 +180,6 @@ jobs:
       PAYLOAD_SECRET: ci-build-secret
     steps:
       - uses: actions/checkout@v5
-        with:
-          token: ''
 
       - name: Install build tools
         run: |
@@ -233,8 +227,6 @@ jobs:
     runs-on: arc-arm64
     steps:
       - uses: actions/checkout@v5
-        with:
-          token: ''
 
       - name: Install build tools
         run: |
@@ -274,8 +266,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          token: ''
 
       - uses: actions/setup-node@v6
         with:
@@ -304,8 +294,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          token: ''
       # codex CI handled by dedicated workflow (.github/workflows/codex-ci.yml)
 
   discord:
@@ -314,8 +302,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          token: ''
 
       - uses: actions/setup-node@v6
         with:
@@ -352,8 +338,6 @@ jobs:
     runs-on: arc-arm64
     steps:
       - uses: actions/checkout@v5
-        with:
-          token: ''
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -398,8 +382,6 @@ jobs:
     runs-on: arc-arm64
     steps:
       - uses: actions/checkout@v5
-        with:
-          token: ''
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/semantic-commits.yml
+++ b/.github/workflows/semantic-commits.yml
@@ -25,8 +25,6 @@ jobs:
       - name: Lint commit messages
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
@@ -36,9 +34,21 @@ jobs:
           subject_pattern="^(${allowed_types})(\\([a-z0-9._/-]+\\))?!?: [a-z].+"
 
           subjects_file="$(mktemp)"
-          gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/commits" \
-            --paginate \
-            --jq '.[] | .commit.message | split("\n")[0]' > "${subjects_file}"
+          page=1
+          while true; do
+            response="$(
+              curl -fsSL \
+                -H 'Accept: application/vnd.github+json' \
+                -H 'X-GitHub-Api-Version: 2022-11-28' \
+                "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}/commits?per_page=100&page=${page}"
+            )"
+            count="$(jq 'length' <<< "${response}")"
+            if [ "${count}" -eq 0 ]; then
+              break
+            fi
+            jq -r '.[] | .commit.message | split("\n")[0]' <<< "${response}" >> "${subjects_file}"
+            page=$((page + 1))
+          done
 
           if [ ! -s "${subjects_file}" ]; then
             echo "No commits found for pull request ${PR_NUMBER}."

--- a/.github/workflows/semantic-commits.yml
+++ b/.github/workflows/semantic-commits.yml
@@ -2,6 +2,7 @@ name: Semantic Commits
 
 permissions:
   contents: read
+  pull-requests: read
 
 on:
   pull_request:
@@ -21,11 +22,37 @@ jobs:
     name: Lint commit messages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6
-        with:
-          configFile: commitlint.config.cjs
+      - name: Lint commit messages
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          allowed_types='build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test'
+          subject_pattern="^(${allowed_types})(\\([a-z0-9._/-]+\\))?!?: [a-z].+"
+
+          subjects_file="$(mktemp)"
+          gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/commits" \
+            --paginate \
+            --jq '.[] | .commit.message | split("\n")[0]' > "${subjects_file}"
+
+          if [ ! -s "${subjects_file}" ]; then
+            echo "No commits found for pull request ${PR_NUMBER}."
+            exit 1
+          fi
+
+          failed=0
+          while IFS= read -r subject; do
+            if [[ "${subject}" =~ ${subject_pattern} ]]; then
+              echo "ok: ${subject}"
+            else
+              echo "invalid conventional commit subject: ${subject}"
+              failed=1
+            fi
+          done < "${subjects_file}"
+
+          exit "${failed}"

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -21,24 +21,22 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - name: Validate PR title
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Keep aligned with commitlint.config.cjs
-          types: |
-            build
-            chore
-            ci
-            docs
-            feat
-            fix
-            perf
-            refactor
-            revert
-            style
-            test
-          requireScope: false
-          subjectPattern: ^[a-z].+
-          subjectPatternError: >-
-            The subject must start with a lowercase letter and describe the change.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          allowed_types='build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test'
+          title_pattern="^(${allowed_types})(\\([a-z0-9._/-]+\\))?!?: [a-z].+"
+
+          if [[ "${PR_TITLE}" =~ ${title_pattern} ]]; then
+            echo "PR title is semantic: ${PR_TITLE}"
+            exit 0
+          fi
+
+          echo "PR title must match '<type>(<optional-scope>): <lowercase subject>'."
+          echo "Allowed types: ${allowed_types//|/, }"
+          echo "Actual title: ${PR_TITLE}"
+          exit 1

--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -54,35 +54,58 @@ jobs:
     name: Changed-file plan
     runs-on: ubuntu-latest
     outputs:
-      service: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.service }}
-      manifests: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.manifests }}
+      service: ${{ steps.filter.outputs.service }}
+      manifests: ${{ steps.filter.outputs.manifests }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
       - name: Check changed Torghut paths
-        uses: dorny/paths-filter@v3
         id: filter
-        with:
-          filters: |
-            service:
-              - 'services/torghut/**'
-              - 'packages/scripts/src/torghut/**'
-              - 'packages/scripts/src/shared/**'
-              - '.github/workflows/torghut-ci.yml'
-              - '.github/workflows/torghut-build-push.yaml'
-              - '.github/workflows/torghut-deploy-automerge.yml'
-              - '.github/workflows/torghut-post-deploy-verify.yml'
-              - '.github/workflows/torghut-release.yml'
-              - '.github/workflows/torghut-ta-build-push.yaml'
-              - '.github/workflows/torghut-ta-release.yml'
-              - '.github/workflows/torghut-ws-build-push.yaml'
-              - '.github/workflows/torghut-ws-release.yml'
-              - 'package.json'
-              - 'bun.lock'
-            manifests:
-              - 'argocd/applications/torghut/**'
-              - 'argocd/applications/torghut-options/**'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            {
+              echo "service=true"
+              echo "manifests=true"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(mktemp)"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" \
+              --paginate \
+              --jq '.[].filename' > "${changed_files}"
+          else
+            gh api "repos/${GH_REPO}/compare/${BEFORE_SHA}...${HEAD_SHA}" \
+              --jq '.files[].filename' > "${changed_files}"
+          fi
+
+          matches_any() {
+            local regex="$1"
+            grep -Eq "${regex}" "${changed_files}"
+          }
+
+          service=false
+          manifests=false
+          if matches_any '^(services/torghut/|packages/scripts/src/torghut/|packages/scripts/src/shared/|\.github/workflows/torghut-(ci|build-push|deploy-automerge|post-deploy-verify|release|ta-build-push|ta-release|ws-build-push|ws-release)\.yml$|\.github/workflows/torghut-build-push\.yaml$|package\.json$|bun\.lock$)'; then
+            service=true
+          fi
+          if matches_any '^argocd/applications/(torghut|torghut-options)/'; then
+            manifests=true
+          fi
+
+          {
+            echo "service=${service}"
+            echo "manifests=${manifests}"
+          } >> "$GITHUB_OUTPUT"
 
   release-manifests:
     name: Release manifest changes

--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -61,7 +61,6 @@ jobs:
         id: filter
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -80,12 +79,27 @@ jobs:
 
           changed_files="$(mktemp)"
           if [ "${EVENT_NAME}" = "pull_request" ]; then
-            gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" \
-              --paginate \
-              --jq '.[].filename' > "${changed_files}"
+            page=1
+            while true; do
+              response="$(
+                curl -fsSL \
+                  -H 'Accept: application/vnd.github+json' \
+                  -H 'X-GitHub-Api-Version: 2022-11-28' \
+                  "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}/files?per_page=100&page=${page}"
+              )"
+              count="$(jq 'length' <<< "${response}")"
+              if [ "${count}" -eq 0 ]; then
+                break
+              fi
+              jq -r '.[].filename' <<< "${response}" >> "${changed_files}"
+              page=$((page + 1))
+            done
           else
-            gh api "repos/${GH_REPO}/compare/${BEFORE_SHA}...${HEAD_SHA}" \
-              --jq '.files[].filename' > "${changed_files}"
+            curl -fsSL \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "https://api.github.com/repos/${GH_REPO}/compare/${BEFORE_SHA}...${HEAD_SHA}" \
+              | jq -r '.files[].filename' > "${changed_files}"
           fi
 
           matches_any() {
@@ -116,6 +130,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          token: ''
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -249,6 +265,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          token: ''
           fetch-depth: 0
 
       - name: Setup Python
@@ -297,6 +314,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          token: ''
           fetch-depth: 0
 
       - name: Setup Python
@@ -346,6 +364,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          token: ''
           fetch-depth: 0
 
       - name: Setup Python
@@ -421,6 +440,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          token: ''
           fetch-depth: 0
 
       - name: Setup Python
@@ -514,6 +534,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          token: ''
           fetch-depth: 0
 
       - name: Setup Python
@@ -574,6 +595,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          token: ''
           fetch-depth: 0
 
       - name: Setup Python

--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -648,26 +648,18 @@ jobs:
         working-directory: services/torghut
         run: uv sync --frozen --extra dev
 
-      - name: Download coverage data
-        uses: actions/download-artifact@v4
-        with:
-          pattern: torghut-coverage-*
-          path: services/torghut/.coverage-shards
-          merge-multiple: true
-
-      - name: Combine coverage
+      - name: Run coverage suite
         working-directory: services/torghut
         run: |
           set -euo pipefail
-          mapfile -t COVERAGE_FILES < <(find .coverage-shards -type f -name '.coverage*' -print | sort)
-          printf 'Combining %s coverage data files\n' "${#COVERAGE_FILES[@]}"
-          if [ "${#COVERAGE_FILES[@]}" -lt 20 ]; then
-            echo "Expected coverage data from all 4 pytest shards and all 16 autoresearch runner slices"
-            exit 1
-          fi
-          uv run --frozen coverage combine "${COVERAGE_FILES[@]}"
-          uv run --frozen coverage report --fail-under=70
-          uv run --frozen coverage xml -o coverage.xml
+          uv run --frozen pytest \
+            -n auto \
+            --dist=worksteal \
+            --cov \
+            --cov-branch \
+            --cov-report=term \
+            --cov-report=xml:coverage.xml \
+            --cov-fail-under=70
 
       - name: Changed-file coverage
         working-directory: services/torghut

--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -129,9 +129,25 @@ jobs:
     if: ${{ needs.changes.outputs.service != 'true' && needs.changes.outputs.manifests == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          token: ''
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git init "${GITHUB_WORKSPACE}"
+          cd "${GITHUB_WORKSPACE}"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            git fetch --no-tags --prune origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+            git fetch --no-tags --prune origin "+refs/pull/${PR_NUMBER}/merge:refs/remotes/origin/pull/${PR_NUMBER}/merge"
+            git checkout --force "refs/remotes/origin/pull/${PR_NUMBER}/merge"
+          else
+            git fetch --no-tags --prune origin "+${GITHUB_REF}:refs/remotes/origin/workflow"
+            git checkout --force "${GITHUB_SHA}" || git checkout --force refs/remotes/origin/workflow
+          fi
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -263,10 +279,25 @@ jobs:
     if: ${{ needs.changes.outputs.service == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          token: ''
-          fetch-depth: 0
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git init "${GITHUB_WORKSPACE}"
+          cd "${GITHUB_WORKSPACE}"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            git fetch --no-tags --prune origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+            git fetch --no-tags --prune origin "+refs/pull/${PR_NUMBER}/merge:refs/remotes/origin/pull/${PR_NUMBER}/merge"
+            git checkout --force "refs/remotes/origin/pull/${PR_NUMBER}/merge"
+          else
+            git fetch --no-tags --prune origin "+${GITHUB_REF}:refs/remotes/origin/workflow"
+            git checkout --force "${GITHUB_SHA}" || git checkout --force refs/remotes/origin/workflow
+          fi
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -312,10 +343,25 @@ jobs:
     if: ${{ needs.changes.outputs.service == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          token: ''
-          fetch-depth: 0
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git init "${GITHUB_WORKSPACE}"
+          cd "${GITHUB_WORKSPACE}"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            git fetch --no-tags --prune origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+            git fetch --no-tags --prune origin "+refs/pull/${PR_NUMBER}/merge:refs/remotes/origin/pull/${PR_NUMBER}/merge"
+            git checkout --force "refs/remotes/origin/pull/${PR_NUMBER}/merge"
+          else
+            git fetch --no-tags --prune origin "+${GITHUB_REF}:refs/remotes/origin/workflow"
+            git checkout --force "${GITHUB_SHA}" || git checkout --force refs/remotes/origin/workflow
+          fi
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -362,10 +408,25 @@ jobs:
         shard: [0, 1, 2, 3]
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          token: ''
-          fetch-depth: 0
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git init "${GITHUB_WORKSPACE}"
+          cd "${GITHUB_WORKSPACE}"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            git fetch --no-tags --prune origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+            git fetch --no-tags --prune origin "+refs/pull/${PR_NUMBER}/merge:refs/remotes/origin/pull/${PR_NUMBER}/merge"
+            git checkout --force "refs/remotes/origin/pull/${PR_NUMBER}/merge"
+          else
+            git fetch --no-tags --prune origin "+${GITHUB_REF}:refs/remotes/origin/workflow"
+            git checkout --force "${GITHUB_SHA}" || git checkout --force refs/remotes/origin/workflow
+          fi
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -438,10 +499,25 @@ jobs:
         slice: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          token: ''
-          fetch-depth: 0
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git init "${GITHUB_WORKSPACE}"
+          cd "${GITHUB_WORKSPACE}"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            git fetch --no-tags --prune origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+            git fetch --no-tags --prune origin "+refs/pull/${PR_NUMBER}/merge:refs/remotes/origin/pull/${PR_NUMBER}/merge"
+            git checkout --force "refs/remotes/origin/pull/${PR_NUMBER}/merge"
+          else
+            git fetch --no-tags --prune origin "+${GITHUB_REF}:refs/remotes/origin/workflow"
+            git checkout --force "${GITHUB_SHA}" || git checkout --force refs/remotes/origin/workflow
+          fi
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -532,10 +608,25 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          token: ''
-          fetch-depth: 0
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git init "${GITHUB_WORKSPACE}"
+          cd "${GITHUB_WORKSPACE}"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            git fetch --no-tags --prune origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+            git fetch --no-tags --prune origin "+refs/pull/${PR_NUMBER}/merge:refs/remotes/origin/pull/${PR_NUMBER}/merge"
+            git checkout --force "refs/remotes/origin/pull/${PR_NUMBER}/merge"
+          else
+            git fetch --no-tags --prune origin "+${GITHUB_REF}:refs/remotes/origin/workflow"
+            git checkout --force "${GITHUB_SHA}" || git checkout --force refs/remotes/origin/workflow
+          fi
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -593,10 +684,25 @@ jobs:
     if: ${{ needs.changes.outputs.service == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          token: ''
-          fetch-depth: 0
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git init "${GITHUB_WORKSPACE}"
+          cd "${GITHUB_WORKSPACE}"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            git fetch --no-tags --prune origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+            git fetch --no-tags --prune origin "+refs/pull/${PR_NUMBER}/merge:refs/remotes/origin/pull/${PR_NUMBER}/merge"
+            git checkout --force "refs/remotes/origin/pull/${PR_NUMBER}/merge"
+          else
+            git fetch --no-tags --prune origin "+${GITHUB_REF}:refs/remotes/origin/workflow"
+            git checkout --force "${GITHUB_SHA}" || git checkout --force refs/remotes/origin/workflow
+          fi
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -101,6 +101,31 @@ def _safe_text(value: object) -> str | None:
     return text or None
 
 
+def _strategy_name_from_strategy_id(strategy_id: object) -> str | None:
+    text = _safe_text(strategy_id)
+    if text is None:
+        return None
+    base = text.split("@", 1)[0].strip()
+    return base.replace("_", "-") if base else None
+
+
+def _strategy_lookup_names(*values: object) -> list[str]:
+    names: list[str] = []
+    for value in values:
+        raw_items: Sequence[object]
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            raw_items = cast(Sequence[object], value)
+        else:
+            raw_items = (value,)
+        for raw_item in raw_items:
+            text = _safe_text(raw_item)
+            if text is not None and text not in names:
+                names.append(text)
+    return names
+
+
 def _health_gate_bool_text(value: object) -> str | None:
     if isinstance(value, bool):
         return "true" if value else "false"
@@ -525,12 +550,26 @@ def _target_identity(
         target.get("final_promotion_allowed")
         or target.get("final_promotion_authorized")
     )
+    strategy_name = _safe_text(target.get("strategy_name"))
+    strategy_id = _safe_text(target.get("strategy_id"))
+    runtime_strategy_name = (
+        _safe_text(target.get("runtime_strategy_name")) or strategy_name
+    )
+    strategy_lookup_names = _strategy_lookup_names(
+        target.get("strategy_lookup_names"),
+        runtime_strategy_name,
+        strategy_name,
+        _strategy_name_from_strategy_id(strategy_id),
+    )
     return {
         "hypothesis_id": _safe_text(target.get("hypothesis_id")),
         "candidate_id": _safe_text(target.get("candidate_id")),
         "observed_stage": _safe_text(target.get("observed_stage")) or "paper",
         "strategy_family": _safe_text(target.get("strategy_family")),
-        "strategy_name": _safe_text(target.get("strategy_name")),
+        "strategy_name": strategy_name,
+        "strategy_id": strategy_id,
+        "runtime_strategy_name": runtime_strategy_name,
+        "strategy_lookup_names": strategy_lookup_names,
         "account_label": _safe_text(target.get("account_label")),
         "source_kind": _safe_text(target.get("source_kind")),
         "source_dsn_env": _safe_text(target.get("source_dsn_env")),
@@ -794,6 +833,16 @@ def _next_paper_route_runtime_window_targets(
         candidate_id = _safe_text(target.get("candidate_id"))
         strategy_family = _safe_text(target.get("strategy_family"))
         strategy_name = _safe_text(target.get("strategy_name"))
+        strategy_id = _safe_text(target.get("strategy_id"))
+        runtime_strategy_name = (
+            _safe_text(target.get("runtime_strategy_name")) or strategy_name
+        )
+        strategy_lookup_names = _strategy_lookup_names(
+            target.get("strategy_lookup_names"),
+            runtime_strategy_name,
+            strategy_name,
+            _strategy_name_from_strategy_id(strategy_id),
+        )
         source_manifest_ref = _safe_text(target.get("source_manifest_ref"))
         missing = [
             field
@@ -845,6 +894,9 @@ def _next_paper_route_runtime_window_targets(
             "observed_stage": "paper",
             "strategy_family": strategy_family,
             "strategy_name": strategy_name,
+            "strategy_id": strategy_id or "",
+            "runtime_strategy_name": runtime_strategy_name or "",
+            "strategy_lookup_names": strategy_lookup_names,
             "account_label": PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
             "source_account_label": source_account_label or "",
             "source_dsn_env": "SIM_DB_DSN",
@@ -1011,6 +1063,7 @@ def _strategy_source_activity(
     session: Session,
     *,
     strategy_name: str | None,
+    strategy_lookup_names: Sequence[str] | None = None,
     account_label: str | None,
     symbols: Sequence[str],
     window_start: datetime,
@@ -1019,9 +1072,11 @@ def _strategy_source_activity(
     symbol_filters = [
         str(item).strip().upper() for item in symbols if str(item).strip()
     ]
-    if strategy_name is None:
+    strategy_filters = _strategy_lookup_names(strategy_name, strategy_lookup_names)
+    if not strategy_filters:
         return {
             "strategy_name": None,
+            "strategy_lookup_names": [],
             "account_label": account_label,
             "symbols": symbol_filters,
             "decision_count": 0,
@@ -1038,7 +1093,7 @@ def _strategy_source_activity(
     decision_stmt = (
         select(TradeDecision)
         .join(Strategy, TradeDecision.strategy_id == Strategy.id)
-        .where(Strategy.name == strategy_name)
+        .where(Strategy.name.in_(strategy_filters))
         .where(TradeDecision.created_at >= window_start)
         .where(TradeDecision.created_at <= window_end)
     )
@@ -1082,7 +1137,7 @@ def _strategy_source_activity(
         tca_stmt = (
             select(ExecutionTCAMetric)
             .join(Strategy, ExecutionTCAMetric.strategy_id == Strategy.id)
-            .where(Strategy.name == strategy_name)
+            .where(Strategy.name.in_(strategy_filters))
             .where(ExecutionTCAMetric.computed_at >= window_start)
             .where(ExecutionTCAMetric.computed_at <= window_end)
         )
@@ -1117,6 +1172,7 @@ def _strategy_source_activity(
         missing_reasons.append("source_tca_missing")
     return {
         "strategy_name": strategy_name,
+        "strategy_lookup_names": strategy_filters,
         "account_label": account_label,
         "symbols": symbol_filters,
         "decision_count": decision_count,
@@ -1183,10 +1239,12 @@ def _runtime_ledger_summary(
     observed_stage: str | None,
     account_label: str | None,
     strategy_name: str | None,
+    strategy_lookup_names: Sequence[str] | None = None,
     strategy_family: str | None,
     window_start: datetime,
     window_end: datetime,
 ) -> dict[str, object]:
+    strategy_filters = _strategy_lookup_names(strategy_name, strategy_lookup_names)
     stmt = select(StrategyRuntimeLedgerBucket).order_by(
         StrategyRuntimeLedgerBucket.bucket_ended_at.desc(),
         StrategyRuntimeLedgerBucket.created_at.desc(),
@@ -1203,9 +1261,9 @@ def _runtime_ledger_summary(
         stmt = stmt.where(StrategyRuntimeLedgerBucket.observed_stage == observed_stage)
     if account_label:
         stmt = stmt.where(StrategyRuntimeLedgerBucket.account_label == account_label)
-    if strategy_name:
+    if strategy_filters:
         stmt = stmt.where(
-            StrategyRuntimeLedgerBucket.runtime_strategy_name == strategy_name
+            StrategyRuntimeLedgerBucket.runtime_strategy_name.in_(strategy_filters)
         )
     if strategy_family:
         stmt = stmt.where(
@@ -1243,6 +1301,7 @@ def _runtime_ledger_summary(
             "observed_stage": observed_stage,
             "account_label": account_label,
             "strategy_name": strategy_name,
+            "strategy_lookup_names": strategy_filters,
             "strategy_family": strategy_family,
         },
         "latest_bucket_ended_at": _isoformat(rows[0].bucket_ended_at if rows else None),
@@ -1407,9 +1466,15 @@ def _target_audit(
     )
     hypothesis_id = cast(str | None, target.get("hypothesis_id"))
     candidate_id = cast(str | None, target.get("candidate_id"))
+    strategy_lookup_names = [
+        str(item)
+        for item in _as_sequence(target.get("strategy_lookup_names"))
+        if str(item).strip()
+    ]
     source_activity = _strategy_source_activity(
         session,
         strategy_name=cast(str | None, target.get("strategy_name")),
+        strategy_lookup_names=strategy_lookup_names,
         account_label=cast(str | None, target.get("account_label")),
         symbols=_target_probe_symbols(target, probe),
         window_start=window_start,
@@ -1422,6 +1487,7 @@ def _target_audit(
         observed_stage=cast(str | None, target.get("observed_stage")),
         account_label=cast(str | None, target.get("account_label")),
         strategy_name=cast(str | None, target.get("strategy_name")),
+        strategy_lookup_names=strategy_lookup_names,
         strategy_family=cast(str | None, target.get("strategy_family")),
         window_start=window_start,
         window_end=window_end,

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -1291,6 +1291,23 @@ def _strategy_name_from_strategy_id(strategy_id: object) -> str | None:
     return base.replace("_", "-") if base else None
 
 
+def _strategy_lookup_names(*values: object) -> list[str]:
+    names: list[str] = []
+    for value in values:
+        raw_items: Sequence[object]
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            raw_items = cast(Sequence[object], value)
+        else:
+            raw_items = (value,)
+        for raw_item in raw_items:
+            text = _safe_text(raw_item)
+            if text is not None and text not in names:
+                names.append(text)
+    return names
+
+
 def _hypothesis_manifest_ref(hypothesis_id: object) -> str | None:
     text = _safe_text(hypothesis_id)
     if text is None:
@@ -1328,7 +1345,15 @@ def _runtime_ledger_paper_probation_import_plan(
         hypothesis_id = _safe_text(candidate.get("hypothesis_id"))
         candidate_id = _safe_text(candidate.get("candidate_id"))
         strategy_family = _safe_text(candidate.get("strategy_family"))
+        strategy_id = _safe_text(candidate.get("strategy_id"))
+        candidate_strategy_name = _safe_text(candidate.get("strategy_name"))
         strategy_name = _runtime_ledger_paper_probation_strategy_name(candidate)
+        strategy_lookup_names = _strategy_lookup_names(
+            candidate.get("strategy_lookup_names"),
+            strategy_name,
+            candidate_strategy_name,
+            _strategy_name_from_strategy_id(strategy_id),
+        )
         account_label = _safe_text(candidate.get("account")) or "TORGHUT_SIM"
         window_start = _safe_text(candidate.get("bucket_started_at"))
         window_end = _safe_text(candidate.get("bucket_ended_at"))
@@ -1404,6 +1429,9 @@ def _runtime_ledger_paper_probation_import_plan(
             "observed_stage": "paper",
             "strategy_family": strategy_family,
             "strategy_name": strategy_name,
+            "strategy_id": strategy_id or "",
+            "runtime_strategy_name": strategy_name,
+            "strategy_lookup_names": strategy_lookup_names,
             "account_label": account_label,
             "source_dsn_env": _RUNTIME_LEDGER_PAPER_PROBATION_SOURCE_DSN_ENV,
             "dataset_snapshot_ref": dataset_snapshot_ref or "",

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1290,7 +1290,7 @@ def build_runtime_ledger_proof_packet(
         ),
         status=None if runtime_import_due else deferred_until_runtime_import_due,
     )
-    if completion_gate_blockers:
+    if runtime_import_due and completion_gate_blockers:
         _extend_unique(blockers, completion_gate_blockers)
     elif runtime_import_due and not gate_satisfied:
         _extend_unique(blockers, ["doc29_live_scale_gate_not_satisfied"])

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -702,6 +702,106 @@ def _runtime_import_authoritative_observation_count(payload: Mapping[str, Any]) 
     return count
 
 
+def _runtime_import_runtime_observations(
+    payload: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    observations: list[Mapping[str, Any]] = []
+    for item in _runtime_window_import_items(payload):
+        summary = _mapping(item.get("summary"))
+        observation = _mapping(summary.get("runtime_observation"))
+        if observation:
+            observations.append(observation)
+    return observations
+
+
+def _runtime_import_materialization_summary(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    observations = _runtime_import_runtime_observations(payload)
+    source_kinds: list[str] = []
+    authority_reasons: list[str] = []
+    pnl_derivations: list[str] = []
+    materialization_blockers: list[str] = []
+    counts = {
+        "runtime_observation_count": len(observations),
+        "authoritative_observation_count": 0,
+        "runtime_ledger_profit_proof_count": 0,
+        "runtime_ledger_tca_row_count": 0,
+        "runtime_ledger_tca_runtime_bucket_row_count": 0,
+        "runtime_ledger_tca_authoritative_bucket_count": 0,
+        "runtime_ledger_source_execution_materialized_bucket_count": 0,
+        "runtime_ledger_execution_reconstruction_bucket_count": 0,
+        "runtime_ledger_source_bucket_profit_proof_count": 0,
+        "runtime_ledger_durable_bucket_profit_proof_count": 0,
+        "runtime_ledger_artifact_tca_row_count": 0,
+    }
+    profit_proof_authority_reasons = {
+        "runtime_ledger_profit_proof",
+        "runtime_ledger_profit_proof_present",
+    }
+    for observation in observations:
+        if observation.get("authoritative") is True:
+            counts["authoritative_observation_count"] += 1
+        authority_reason = _text(observation.get("authority_reason"))
+        tca_profit_proof_count = _int(
+            observation.get("runtime_ledger_tca_profit_proof_count")
+        )
+        source_profit_proof_count = _int(
+            observation.get("runtime_ledger_source_bucket_profit_proof_count")
+        )
+        durable_profit_proof_count = _int(
+            observation.get("runtime_ledger_durable_bucket_profit_proof_count")
+        )
+        authority_reason_implies_profit_proof = (
+            authority_reason in profit_proof_authority_reasons
+        )
+        profit_proof_count = max(
+            1
+            if _bool(observation.get("runtime_ledger_profit_proof_present"))
+            or authority_reason_implies_profit_proof
+            else 0,
+            tca_profit_proof_count,
+            source_profit_proof_count,
+            durable_profit_proof_count,
+        )
+        counts["runtime_ledger_profit_proof_count"] += profit_proof_count
+        for key in (
+            "runtime_ledger_tca_row_count",
+            "runtime_ledger_tca_runtime_bucket_row_count",
+            "runtime_ledger_tca_authoritative_bucket_count",
+            "runtime_ledger_source_execution_materialized_bucket_count",
+            "runtime_ledger_execution_reconstruction_bucket_count",
+            "runtime_ledger_source_bucket_profit_proof_count",
+            "runtime_ledger_durable_bucket_profit_proof_count",
+            "runtime_ledger_artifact_tca_row_count",
+        ):
+            counts[key] += _int(observation.get(key))
+        _extend_unique(source_kinds, [_text(observation.get("source_kind"))])
+        _extend_unique(authority_reasons, [authority_reason])
+        _extend_unique(
+            pnl_derivations,
+            _text_list(
+                observation.get("runtime_ledger_materialization_pnl_derivations")
+            ),
+        )
+        _extend_unique(
+            materialization_blockers,
+            _text_list(observation.get("runtime_ledger_materialization_blockers")),
+        )
+        _extend_unique(
+            materialization_blockers,
+            _text_list(observation.get("runtime_ledger_target_metadata_blockers")),
+        )
+    return {
+        "schema_version": "torghut.runtime-window-import-materialization-summary.v1",
+        **counts,
+        "source_kinds": source_kinds,
+        "authority_reasons": authority_reasons,
+        "pnl_derivations": pnl_derivations,
+        "blockers": materialization_blockers,
+    }
+
+
 def _first_identity(
     *,
     paper_targets: Sequence[Mapping[str, Any]],
@@ -810,6 +910,7 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
             _extend_unique(actions, ["wait_for_paper_route_settlement_grace"])
         elif blocker in {
             "runtime_window_import_missing",
+            "runtime_window_import_runtime_ledger_materialization_missing",
             "runtime_ledger_bucket_missing",
             "paper_route_runtime_ledger_import_pending",
         }:
@@ -1085,6 +1186,12 @@ def build_runtime_ledger_proof_packet(
     authoritative_observation_count = _runtime_import_authoritative_observation_count(
         runtime_import
     )
+    materialization_summary = _runtime_import_materialization_summary(runtime_import)
+    runtime_import_materialization_ok = not runtime_import_due or (
+        _int(materialization_summary.get("authoritative_observation_count")) > 0
+        and _int(materialization_summary.get("runtime_ledger_profit_proof_count")) > 0
+        and not _text_list(materialization_summary.get("blockers"))
+    )
     runtime_import_ok = (
         runtime_import_due
         and bool(runtime_import)
@@ -1106,6 +1213,7 @@ def build_runtime_ledger_proof_packet(
             "target_count": len(runtime_import_items),
             "runtime_import_due": runtime_import_due,
             "authoritative_observation_count": authoritative_observation_count,
+            "materialization": materialization_summary,
             "proof_blockers": runtime_import_blockers,
             "import_audit_state": _text(import_audit.get("state"), "missing"),
             "import_audit_blockers": import_audit_blockers,
@@ -1127,6 +1235,29 @@ def build_runtime_ledger_proof_packet(
         _extend_unique(blockers, import_audit_blockers)
     elif runtime_import_due and not runtime_import_ok:
         _extend_unique(blockers, ["runtime_window_import_missing"])
+    materialization_blockers = _text_list(materialization_summary.get("blockers"))
+    _check(
+        checks,
+        "runtime_window_import_materialization",
+        passed=runtime_import_materialization_ok,
+        observed=materialization_summary,
+        expected="runtime-window import contains at least one authoritative runtime-ledger profit-proof observation",
+        blockers=materialization_blockers
+        or (
+            []
+            if runtime_import_materialization_ok or not runtime_import_due
+            else ["runtime_window_import_runtime_ledger_materialization_missing"]
+        ),
+        status=None
+        if runtime_import_due
+        else "waiting_for_paper_route_runtime_window_import",
+    )
+    if runtime_import_due and not runtime_import_materialization_ok:
+        _extend_unique(
+            blockers,
+            materialization_blockers
+            or ["runtime_window_import_runtime_ledger_materialization_missing"],
+        )
 
     completion = completion_status or {}
     live_scale_gate = _completion_live_scale_gate(completion)
@@ -1459,6 +1590,7 @@ def build_runtime_ledger_proof_packet(
                 "target_count": len(runtime_import_items),
                 "proof_blockers": runtime_import_blockers,
                 "authoritative_observation_count": authoritative_observation_count,
+                "materialization": materialization_summary,
                 "lineage": runtime_import_lineage,
             },
             "completion_live_scale": {

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -657,6 +657,82 @@ def _runtime_observation_authority_payload(
     }
 
 
+def _runtime_ledger_tca_materialization_metadata(
+    tca_rows: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    bucket_row_count = 0
+    profit_proof_count = 0
+    authoritative_bucket_count = 0
+    source_execution_materialized_count = 0
+    execution_reconstruction_count = 0
+    authority_reasons: list[str] = []
+    pnl_derivations: list[str] = []
+    source_materializations: list[str] = []
+    blockers: list[str] = []
+    for row in tca_rows:
+        bucket = row.get("runtime_ledger_bucket")
+        if not isinstance(bucket, Mapping):
+            continue
+        bucket_payload = {str(key): value for key, value in bucket.items()}
+        bucket_row_count += 1
+        if _runtime_ledger_bucket_profit_proof_present(bucket_payload):
+            profit_proof_count += 1
+        if bool(row.get("authoritative")) or bool(bucket_payload.get("authoritative")):
+            authoritative_bucket_count += 1
+        authority_reason = _text_or_none(
+            row.get("authority_reason") or bucket_payload.get("authority_reason")
+        )
+        if authority_reason is not None:
+            authority_reasons.append(authority_reason)
+        pnl_derivation = _text_or_none(
+            row.get("pnl_derivation") or bucket_payload.get("pnl_derivation")
+        )
+        if pnl_derivation is not None:
+            pnl_derivations.append(pnl_derivation)
+        source_materialization = _text_or_none(
+            bucket_payload.get("source_materialization")
+        )
+        if source_materialization is not None:
+            source_materializations.append(source_materialization)
+        if (
+            authority_reason == "source_execution_runtime_ledger_materialized"
+            or pnl_derivation
+            == "source_execution_lifecycle_materialized_runtime_ledger"
+            or source_materialization == "source_execution_lifecycle"
+        ):
+            source_execution_materialized_count += 1
+        if authority_reason == "execution_reconstruction_not_runtime_ledger_proof":
+            execution_reconstruction_count += 1
+        for blocker_source in (
+            row.get("runtime_ledger_blockers"),
+            row.get("promotion_blocker"),
+            bucket_payload.get("blockers"),
+        ):
+            blockers.extend(_metadata_text_list(blocker_source))
+    return {
+        "runtime_ledger_tca_row_count": len(tca_rows),
+        "runtime_ledger_tca_runtime_bucket_row_count": bucket_row_count,
+        "runtime_ledger_tca_profit_proof_count": profit_proof_count,
+        "runtime_ledger_tca_authoritative_bucket_count": authoritative_bucket_count,
+        "runtime_ledger_source_execution_materialized_bucket_count": (
+            source_execution_materialized_count
+        ),
+        "runtime_ledger_execution_reconstruction_bucket_count": (
+            execution_reconstruction_count
+        ),
+        "runtime_ledger_materialization_authority_reasons": sorted(
+            dict.fromkeys(authority_reasons)
+        ),
+        "runtime_ledger_materialization_pnl_derivations": sorted(
+            dict.fromkeys(pnl_derivations)
+        ),
+        "runtime_ledger_source_materializations": sorted(
+            dict.fromkeys(source_materializations)
+        ),
+        "runtime_ledger_materialization_blockers": sorted(dict.fromkeys(blockers)),
+    }
+
+
 def _strategy_name_candidates(*values: str | None) -> list[str]:
     candidates: list[str] = []
     for value in values:
@@ -853,9 +929,13 @@ def _build_realized_strategy_pnl_rows(
             row["post_cost_expectancy_basis"] = POST_COST_BASIS_EXECUTION_RECONSTRUCTION
             row["post_cost_promotion_eligible"] = False
             row["authoritative"] = False
-            row["authority_reason"] = "execution_reconstruction_not_runtime_ledger_proof"
+            row["authority_reason"] = (
+                "execution_reconstruction_not_runtime_ledger_proof"
+            )
             row["pnl_derivation"] = "execution_reconstructed_from_execution_rows"
-            row["promotion_blocker"] = "execution_reconstruction_not_runtime_ledger_proof"
+            row["promotion_blocker"] = (
+                "execution_reconstruction_not_runtime_ledger_proof"
+            )
             blockers = list(row.get("runtime_ledger_blockers") or [])
             if "execution_reconstruction_not_runtime_ledger_proof" not in blockers:
                 blockers.append("execution_reconstruction_not_runtime_ledger_proof")
@@ -1967,6 +2047,7 @@ def main() -> int:
             source_kind=source_kind,
             tca_rows=tca_rows,
         ),
+        **_runtime_ledger_tca_materialization_metadata(tca_rows),
         "observed_stage": args.observed_stage,
         "evidence_provenance": evidence_provenance,
         "source_kind": source_kind,

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -171,6 +171,16 @@ def _runtime_import(
                         "authority_reason": "runtime_ledger_profit_proof_present"
                         if authoritative
                         else "runtime_without_runtime_ledger_profit_proof",
+                        "runtime_ledger_profit_proof_present": authoritative,
+                        "runtime_ledger_tca_profit_proof_count": 1
+                        if authoritative
+                        else 0,
+                        "runtime_ledger_tca_runtime_bucket_row_count": 1
+                        if authoritative
+                        else 0,
+                        "runtime_ledger_tca_authoritative_bucket_count": 1
+                        if authoritative
+                        else 0,
                     },
                 },
             }
@@ -1015,6 +1025,72 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result["required_actions"],
         )
 
+    def test_packet_surfaces_runtime_import_materialization_summary(self) -> None:
+        runtime_import = _runtime_import()
+        observation = runtime_import["imports"][0]["summary"]["runtime_observation"]
+        assert isinstance(observation, dict)
+        observation.update(
+            {
+                "runtime_ledger_tca_row_count": 2,
+                "runtime_ledger_tca_runtime_bucket_row_count": 1,
+                "runtime_ledger_tca_profit_proof_count": 1,
+                "runtime_ledger_tca_authoritative_bucket_count": 1,
+                "runtime_ledger_source_execution_materialized_bucket_count": 1,
+                "runtime_ledger_execution_reconstruction_bucket_count": 0,
+                "runtime_ledger_materialization_pnl_derivations": [
+                    "source_execution_lifecycle_materialized_runtime_ledger"
+                ],
+                "runtime_ledger_materialization_blockers": [],
+            }
+        )
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertTrue(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        self.assertEqual(
+            materialization[
+                "runtime_ledger_source_execution_materialized_bucket_count"
+            ],
+            1,
+        )
+        self.assertEqual(
+            materialization["pnl_derivations"],
+            ["source_execution_lifecycle_materialized_runtime_ledger"],
+        )
+
+    def test_packet_blocks_runtime_import_without_materialized_runtime_ledger(
+        self,
+    ) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(authoritative=False),
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertIn(
+            "runtime_window_import_runtime_ledger_materialization_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertFalse(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        self.assertIn(
+            "run_runtime_window_import_from_paper_route_target_plan",
+            result["required_actions"],
+        )
+
     def test_packet_waits_on_target_level_settlement_blocker(self) -> None:
         paper = _paper_route_evidence()
         target = paper["next_paper_route_runtime_window_targets"]["targets"][0]
@@ -1058,6 +1134,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 "summary": {
                     "runtime_observation": {
                         "authoritative": True,
+                        "runtime_ledger_profit_proof_present": True,
                     },
                 },
             },

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -651,6 +651,50 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result["required_actions"],
         )
 
+    def test_waiting_packet_defers_doc29_completion_blockers_until_import_due(
+        self,
+    ) -> None:
+        completion = _completion(status="blocked")
+        gate = completion["gates"][0]
+        assert isinstance(gate, dict)
+        gate["blocking_reasons"] = ["live_scale_runtime_ledger_summary_incomplete"]
+        gate["blocked_reason"] = "live_canary_not_satisfied"
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(
+                import_ready=False,
+                import_blockers=["paper_route_session_window_not_open"],
+            ),
+            completion_status=completion,
+            generated_at="2026-05-25T21:05:00+00:00",
+        )
+
+        self.assertEqual(result["verdict"], "waiting_for_runtime_window")
+        self.assertEqual(
+            result["post_cost_proof_authority"]["blocking_reasons"],
+            ["paper_route_session_window_not_open"],
+        )
+        self.assertEqual(
+            result["required_actions"],
+            ["wait_for_regular_session_runtime_window"],
+        )
+        self.assertEqual(
+            result["checks"]["doc29_live_scale_gate"]["status"],
+            "deferred_until_paper_route_runtime_window_import_is_due",
+        )
+        self.assertEqual(
+            result["checks"]["doc29_live_scale_gate"]["observed"]["blockers"],
+            [
+                "live_scale_runtime_ledger_summary_incomplete",
+                "live_canary_not_satisfied",
+            ],
+        )
+        self.assertNotIn(
+            "live_canary_not_satisfied",
+            result["post_cost_proof_authority"]["blocking_reasons"],
+        )
+
     def test_packet_blocks_with_source_activity_audit_before_generic_import_missing(
         self,
     ) -> None:

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -37,6 +37,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _runtime_observation_authority_payload,
     _runtime_ledger_target_metadata_blockers,
     _runtime_ledger_tca_row_from_bucket,
+    _runtime_ledger_tca_materialization_metadata,
     _runtime_ledger_tca_rows_from_durable_buckets,
     _runtime_ledger_tca_rows_from_source_dsn,
     _runtime_ledger_tca_rows_from_artifacts,
@@ -1090,6 +1091,54 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["pnl_basis"], POST_COST_BASIS_RUNTIME_LEDGER)
         self.assertEqual(bucket["source_materialization"], "source_execution_lifecycle")
         self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
+
+    def test_runtime_ledger_tca_materialization_metadata_separates_authority(
+        self,
+    ) -> None:
+        metadata = _runtime_ledger_tca_materialization_metadata(
+            [
+                {
+                    "authoritative": True,
+                    "authority_reason": "source_execution_runtime_ledger_materialized",
+                    "pnl_derivation": (
+                        "source_execution_lifecycle_materialized_runtime_ledger"
+                    ),
+                    "runtime_ledger_bucket": _complete_runtime_ledger_bucket(
+                        source_materialization="source_execution_lifecycle",
+                        authoritative=True,
+                    ),
+                },
+                {
+                    "authoritative": False,
+                    "authority_reason": (
+                        "execution_reconstruction_not_runtime_ledger_proof"
+                    ),
+                    "runtime_ledger_blockers": [
+                        "execution_reconstruction_not_runtime_ledger_proof"
+                    ],
+                    "runtime_ledger_bucket": _complete_runtime_ledger_bucket(
+                        pnl_basis=POST_COST_BASIS_EXECUTION_RECONSTRUCTION,
+                        blockers=["execution_reconstruction_not_runtime_ledger_proof"],
+                    ),
+                },
+            ]
+        )
+
+        self.assertEqual(metadata["runtime_ledger_tca_runtime_bucket_row_count"], 2)
+        self.assertEqual(metadata["runtime_ledger_tca_profit_proof_count"], 1)
+        self.assertEqual(metadata["runtime_ledger_tca_authoritative_bucket_count"], 1)
+        self.assertEqual(
+            metadata["runtime_ledger_source_execution_materialized_bucket_count"],
+            1,
+        )
+        self.assertEqual(
+            metadata["runtime_ledger_execution_reconstruction_bucket_count"],
+            1,
+        )
+        self.assertEqual(
+            metadata["runtime_ledger_materialization_blockers"],
+            ["execution_reconstruction_not_runtime_ledger_proof"],
+        )
 
     def test_build_realized_strategy_pnl_rows_normalizes_nested_runtime_payloads(
         self,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1537,6 +1537,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
         now = datetime(2026, 5, 26, 21, tzinfo=timezone.utc)
         strategy_name = "active-paper-route"
+        target_strategy_name = "69cf50e3-4815-47c2-b802-1efbaac09ecb"
         with Session(self.engine) as session:
             strategy = Strategy(
                 name=strategy_name,
@@ -1677,7 +1678,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
                                 "candidate_id": "candidate-active-route",
                                 "observed_stage": "paper",
                                 "strategy_family": "microbar_pairs",
-                                "strategy_name": strategy_name,
+                                "strategy_name": target_strategy_name,
+                                "strategy_id": "active_paper_route@research",
                                 "account_label": "TORGHUT_SIM",
                                 "source_manifest_ref": "config/trading/hypotheses/h-active-route.json",
                                 "window_start": window_start.isoformat(),
@@ -1717,6 +1719,8 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertFalse(audit["target"]["final_promotion_allowed"])
         self.assertTrue(audit["target"]["source_promotion_allowed"])
         self.assertTrue(audit["target"]["source_final_promotion_allowed"])
+        self.assertEqual(audit["target"]["strategy_name"], target_strategy_name)
+        self.assertIn(strategy_name, audit["target"]["strategy_lookup_names"])
         self.assertFalse(audit["source_activity"]["missing"])
         self.assertEqual(audit["source_activity"]["decision_count"], 1)
         self.assertEqual(audit["source_activity"]["execution_count"], 1)
@@ -2193,6 +2197,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 "observed_stage": "paper",
                 "account_label": "paper",
                 "strategy_name": strategy_name,
+                "strategy_lookup_names": [strategy_name],
                 "strategy_family": "microbar_pairs",
             },
         )

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -735,6 +735,10 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(target["observed_stage"], "paper")
         self.assertEqual(target["strategy_family"], "microbar_cross_sectional_pairs")
         self.assertEqual(target["strategy_name"], "microbar-pairs-vwap-cap-safe")
+        self.assertEqual(
+            target["runtime_strategy_name"], "microbar-pairs-vwap-cap-safe"
+        )
+        self.assertIn("microbar-pairs-vwap-cap-safe", target["strategy_lookup_names"])
         self.assertEqual(target["account_label"], "TORGHUT_SIM")
         self.assertEqual(
             target["source_dsn_env"], "TORGHUT_DURABLE_RUNTIME_LEDGER_SOURCE_DSN"
@@ -789,6 +793,15 @@ class TestSubmissionCouncil(TestCase):
         self.assertEqual(plan["skipped_target_count"], 1)
         target = plan["targets"][0]
         self.assertEqual(target["strategy_name"], "microbar-cross-sectional-pairs-v1")
+        self.assertEqual(
+            target["strategy_id"], "microbar_cross_sectional_pairs_v1@research"
+        )
+        self.assertEqual(
+            target["runtime_strategy_name"], "microbar-cross-sectional-pairs-v1"
+        )
+        self.assertEqual(
+            target["strategy_lookup_names"], ["microbar-cross-sectional-pairs-v1"]
+        )
         self.assertEqual(
             target["source_manifest_ref"],
             "config/trading/hypotheses/h-fallback-01.json",


### PR DESCRIPTION
## Summary

- Adds runtime-ledger materialization metadata to hypothesis runtime-window imports so proof packets can see whether TCA rows came from authoritative runtime-ledger buckets, source-execution materialization, or fallback reconstruction.
- Adds a proof-packet materialization check that fails closed when a due runtime-window import lacks authoritative runtime-ledger profit-proof observations.
- Carries paper-route strategy aliases from live-submission targets into the evidence audit and runtime-window target plan so UUID-like strategy names do not hide real source activity or runtime-ledger buckets.
- Defers doc29 live-scale/canary blockers while the paper-route runtime window is not import-due, so pre-window proof packets report `waiting_for_runtime_window` instead of a false blocked strategy state.
- Replaces third-party PR gate actions, token-authenticated public PR reads, Torghut CI token-authenticated checkout, and aggregate coverage artifact download with local shell/public GitHub reads or direct coverage recomputation so required PR gates do not fail solely because `codeload.github.com` or the Actions token is returning infrastructure errors.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -k "waiting_packet_defers_doc29_completion_blockers_until_import_due or waiting_packet_prioritizes_wait_action_over_drift_repair or packet_waits_before_paper_route_window_is_importable" -q`
- `uv run --frozen pytest tests/test_submission_council.py -k "paper_probation_import_plan" -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k "builder_joins_source_activity_runtime_ledger_and_decisions or runtime_ledger_summary_is_scoped_to_target_stage_account_and_strategy" -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_submission_council.py -q`
- `uv run --frozen pytest tests/test_trading_api.py -k "paper_route_evidence or paper_route_target_plan" -q`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py app/trading/submission_council.py tests/test_paper_route_evidence.py tests/test_submission_council.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py app/trading/submission_council.py tests/test_paper_route_evidence.py tests/test_submission_council.py`
- `uv run --frozen ruff format --check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_import_hypothesis_runtime_windows.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/semantic-commits.yml .github/workflows/semantic-pull-request.yml .github/workflows/torghut-ci.yml .github/workflows/pull-request.yml`
- Local shell validation of the replacement semantic commit/title checks against PR `#8066`.
- Local shell validation of the replacement Torghut changed-file filter against PR `#8066`.
- Local shell validation of unauthenticated public PR file/commit API reads against PR `#8066`.
- Local shell validation of the public Torghut CI checkout flow against PR `#8066` merge ref.
- YAML validation after replacing the aggregate coverage artifact download with direct coverage recomputation.
- Live read-only smoke via pod port-forward: `uv run --frozen python scripts/assemble_runtime_ledger_proof_packet.py --status-url http://127.0.0.1:18180/trading/status --paper-route-evidence-url http://127.0.0.1:18181/trading/paper-route-evidence --completion-url http://127.0.0.1:18180/trading/completion/doc29 --min-runtime-ledger-net-pnl 500 --min-runtime-ledger-daily-net-pnl 500 --min-runtime-ledger-trading-days 1 --output-file /tmp/torghut-runtime-ledger-proof-packet-preopen-after-fix.json --allow-blocked-exit-zero`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
