### PR TITLE
fix(torghut): enable hpairs paper strategy

### DIFF
--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -427,13 +427,13 @@ data:
         strategy_id: microbar_cross_sectional_pairs_v1@research
         strategy_type: microbar_cross_sectional_long_v1
         version: 1.0.0
-        description: Research-only microbar cross-sectional continuation/reversal candidate used by the whitepaper autoresearch harness.
-        enabled: false
+        description: Paper-only H-PAIRS microbar cross-sectional continuation sleeve for the runtime-ledger proof lane; production approval blocked pending live-paper runtime evidence, version=1.0.0
+        enabled: true
         base_timeframe: "1Sec"
         universe_type: microbar_cross_sectional_pairs_v1
-        universe_symbols: ["NVDA", "AAPL", "AMZN", "GOOGL", "AVGO", "AMD", "ORCL", "INTC"]
-        max_notional_per_trade: 50000
-        max_position_pct_equity: 6.0
+        universe_symbols: ["AAPL", "AMZN"]
+        max_notional_per_trade: 31590
+        max_position_pct_equity: 1.0
         params:
           entry_minute_after_open: "60"
           exit_minute_after_open: "120"
@@ -441,10 +441,11 @@ data:
           rank_feature: "cross_section_vwap_w5m_rank"
           selection_mode: "continuation"
           top_n: "2"
-          max_gross_exposure_pct_equity: "6.0"
+          max_gross_exposure_pct_equity: "2.0"
           max_pair_legs: "2"
           max_entries_per_session: "1"
           entry_cooldown_seconds: "600"
+          position_isolation_mode: "per_strategy"
       - name: microbar-volume-continuation-long-top2-v11
         strategy_id: microbar_volume_continuation_long_top2@prod
         strategy_type: microbar_cross_sectional_long_v1

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -370,6 +370,7 @@ class TestLiveConfigManifestContract(TestCase):
                 "mean-reversion-exhaustion-short-v1",
                 "washout-rebound-long-v1",
                 "late-day-continuation-long-v1",
+                "microbar-cross-sectional-pairs-v1",
             },
         )
 
@@ -387,6 +388,13 @@ class TestLiveConfigManifestContract(TestCase):
                     cast(list[object], raw_symbols),
                     context=f"{name} universe",
                 )
+            elif name == "microbar-cross-sectional-pairs-v1":
+                self.assertIn("h-pairs", description)
+                self.assertEqual(
+                    tuple(str(symbol) for symbol in cast(list[object], raw_symbols)),
+                    ("AAPL", "AMZN"),
+                    f"{name} must stay aligned to the active H-PAIRS paper-route probe symbols",
+                )
             else:
                 self.assertIn("$300/day", description)
                 _assert_exact_quote_covered_paper_strategy_universe(
@@ -395,15 +403,30 @@ class TestLiveConfigManifestContract(TestCase):
                     context=f"{name} universe",
                 )
             if str(strategy.get("strategy_type")) == "microbar_cross_sectional_long_v1":
+                expected_notional = (
+                    Decimal("31590")
+                    if name == "microbar-cross-sectional-pairs-v1"
+                    else Decimal("50000")
+                )
+                expected_position_pct = (
+                    Decimal("1.0")
+                    if name == "microbar-cross-sectional-pairs-v1"
+                    else Decimal("2.0")
+                )
                 self.assertEqual(
                     _strategy_decimal(strategy, "max_notional_per_trade"),
-                    Decimal("50000"),
+                    expected_notional,
                 )
                 self.assertEqual(
                     _strategy_decimal(strategy, "max_position_pct_equity"),
-                    Decimal("2.0"),
+                    expected_position_pct,
                 )
                 self.assertEqual(params.get("position_isolation_mode"), "per_strategy")
+                if name == "microbar-cross-sectional-pairs-v1":
+                    self.assertEqual(params.get("max_gross_exposure_pct_equity"), "2.0")
+                    self.assertEqual(params.get("max_pair_legs"), "2")
+                    self.assertEqual(params.get("entry_minute_after_open"), "60")
+                    self.assertEqual(params.get("exit_minute_after_open"), "120")
             elif str(strategy.get("strategy_type")) == "intraday_tsmom_v1":
                 self.assertEqual(name, "intraday-tsmom-profit-v3")
                 self.assertEqual(


### PR DESCRIPTION
## Summary

- Enable the H-PAIRS `microbar-cross-sectional-pairs-v1` paper strategy so the active paper-route target can produce matching source decisions, executions, and TCA.
- Restrict the enabled strategy to the current AAPL/AMZN paper-route probe symbols with capped paper-only notional and per-strategy isolation.
- Extend the live manifest contract so future config changes cannot silently disable or expand this proof-lane sleeve.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k 'enabled_paper_sleeves or sim_manifest_runs_paper_live_signal_profile or empirical_promotion_renewal'`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
