### PR TITLE
fix(torghut): retry paper route target plan fetch

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -113,7 +113,7 @@ spec:
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_URL
               value: http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS
-              value: "3"
+              value: "5"
             - name: TRADING_KILL_SWITCH_ENABLED
               value: "false"
             - name: TRADING_FEATURE_FLAGS_ENABLED

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1404,6 +1404,30 @@ class Settings(BaseSettings):
         alias="TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL",
         description="Maximum notional per paper route-acquisition probe order.",
     )
+    trading_simple_paper_route_probe_retry_attempt_limit: int = Field(
+        default=2,
+        alias="TRADING_SIMPLE_PAPER_ROUTE_PROBE_RETRY_ATTEMPT_LIMIT",
+        description=(
+            "Maximum times a persisted proof-floor-blocked decision may be reopened "
+            "for bounded paper-route probe submission."
+        ),
+    )
+    trading_simple_paper_route_probe_retry_batch_limit: int = Field(
+        default=4,
+        alias="TRADING_SIMPLE_PAPER_ROUTE_PROBE_RETRY_BATCH_LIMIT",
+        description=(
+            "Maximum persisted proof-floor-blocked decisions to retry in one simple "
+            "pipeline cycle."
+        ),
+    )
+    trading_simple_paper_route_probe_retry_scan_limit: int = Field(
+        default=64,
+        alias="TRADING_SIMPLE_PAPER_ROUTE_PROBE_RETRY_SCAN_LIMIT",
+        description=(
+            "Maximum recent blocked decisions to scan when looking for bounded "
+            "paper-route probe retry candidates."
+        ),
+    )
     trading_paper_route_target_plan_url: Optional[str] = Field(
         default=None,
         alias="TRADING_PAPER_ROUTE_TARGET_PLAN_URL",

--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 from collections.abc import Mapping, Sequence
 from http.client import HTTPConnection, HTTPSConnection
 from typing import Any, cast
@@ -54,6 +55,34 @@ def paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str
 
 
 def fetch_paper_route_target_plan_url(
+    url: str,
+    *,
+    timeout_seconds: float,
+    attempts: int = 1,
+    retry_backoff_seconds: float = 0.25,
+) -> dict[str, Any]:
+    max_attempts = max(int(attempts), 1)
+    result: dict[str, Any] = {}
+    for attempt in range(1, max_attempts + 1):
+        result = _fetch_paper_route_target_plan_url_once(
+            url,
+            timeout_seconds=timeout_seconds,
+        )
+        if not str(result.get("load_error") or "").strip():
+            if attempt > 1:
+                result = dict(result)
+                result["fetch_attempts"] = attempt
+            return result
+        if attempt < max_attempts:
+            time.sleep(max(float(retry_backoff_seconds), 0.0))
+
+    if max_attempts > 1:
+        result = dict(result)
+        result["fetch_attempts"] = max_attempts
+    return result
+
+
+def _fetch_paper_route_target_plan_url_once(
     url: str,
     *,
     timeout_seconds: float,

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -64,6 +64,22 @@ _SIMPLE_MARKET_CONTEXT_RETRY_INTERVAL = timedelta(seconds=30)
 _PAPER_ROUTE_PROBE_QTY_STEP = Decimal("0.0001")
 
 
+def _safe_int(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float | str | Decimal):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    try:
+        return int(cast(Any, value))
+    except (TypeError, ValueError):
+        return 0
+
+
 class SimpleTradingPipeline(TradingPipeline):
     """Minimal signal -> hard-risk -> direct execution lane."""
 
@@ -709,9 +725,17 @@ class SimpleTradingPipeline(TradingPipeline):
         plan = fetch_paper_route_target_plan_url(
             url,
             timeout_seconds=settings.trading_paper_route_target_plan_timeout_seconds,
+            attempts=2,
+            retry_backoff_seconds=0.25,
         )
         load_error = str(plan.get("load_error") or "").strip()
         if load_error:
+            logger.warning(
+                "Paper-route target plan unavailable for bounded probe url=%s error=%s attempts=%s",
+                url,
+                load_error,
+                plan.get("fetch_attempts") or 1,
+            )
             return set(), load_error
         symbols = paper_route_target_plan_probe_symbols(plan)
         if not symbols:
@@ -796,6 +820,91 @@ class SimpleTradingPipeline(TradingPipeline):
             if not settings.trading_simple_submit_enabled
             else None,
         }
+
+    @staticmethod
+    def _paper_route_probe_retry_metadata(
+        decision_row: TradeDecision,
+    ) -> dict[str, object] | None:
+        if decision_row.status != "blocked":
+            return None
+        decision_json_raw = decision_row.decision_json
+        if not isinstance(decision_json_raw, Mapping):
+            return None
+        decision_json = cast(Mapping[str, object], decision_json_raw)
+        if decision_json.get("submission_stage") != "blocked_profitability_proof_floor":
+            return None
+        reason = str(decision_json.get("submission_block_reason") or "").strip()
+        if not reason:
+            return None
+        proof_floor = decision_json.get("profitability_proof_floor")
+        if not isinstance(proof_floor, Mapping):
+            return None
+        return {
+            "previous_submission_stage": "blocked_profitability_proof_floor",
+            "previous_submission_block_reason": reason,
+            "previous_decision_status": "blocked",
+        }
+
+    def _ensure_pending_decision_row(
+        self,
+        *,
+        session: Session,
+        decision: StrategyDecision,
+        strategy: Strategy,
+    ) -> TradeDecision | None:
+        decision_row = self.executor.ensure_decision(
+            session, decision, strategy, self.account_label
+        )
+        retry_metadata = self._paper_route_probe_retry_metadata(decision_row)
+        if retry_metadata is None:
+            return super()._ensure_pending_decision_row(
+                session=session,
+                decision=decision,
+                strategy=strategy,
+            )
+        if self.executor.execution_exists(session, decision_row):
+            return None
+
+        proof_floor = self._profitability_proof_floor(session=session)
+        if self._proof_floor_submission_block_reason(proof_floor) is None:
+            return None
+        probe_context = self._paper_route_probe_context(
+            proof_floor=proof_floor,
+            decision=decision,
+        )
+        if probe_context is None:
+            return None
+        if self._paper_route_probe_reference_price(decision) is None:
+            return None
+
+        decision_row.status = "planned"
+        decision_json = dict(cast(Mapping[str, Any], decision_row.decision_json))
+        retry_attempts = _safe_int(
+            decision_json.get("paper_route_probe_retry_attempts")
+        )
+        decision_json["paper_route_probe_retry_attempts"] = retry_attempts + 1
+        decision_json["paper_route_probe_retry"] = {
+            **retry_metadata,
+            "submission_stage": "paper_route_probe_retry_pending",
+            "symbol": decision.symbol.strip().upper(),
+            "strategy_id": decision.strategy_id,
+            "context": dict(probe_context),
+        }
+        decision_json["submission_stage"] = "paper_route_probe_retry_pending"
+        decision_json.pop("submission_block_reason", None)
+        decision_json.pop("submission_block_atomic", None)
+        decision_row.decision_json = decision_json
+        session.add(decision_row)
+        session.commit()
+        session.refresh(decision_row)
+        logger.warning(
+            "Reopening proof-floor-blocked decision for bounded paper route probe strategy_id=%s decision_id=%s symbol=%s previous_reason=%s",
+            decision.strategy_id,
+            decision_row.id,
+            decision.symbol,
+            retry_metadata["previous_submission_block_reason"],
+        )
+        return decision_row
 
     def _apply_paper_route_probe_cap(
         self,

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal, ROUND_DOWN
 from typing import Any, Optional, cast
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ...config import settings
@@ -25,6 +26,7 @@ from ..paper_route_target_plan import (
 )
 from ..prices import MarketSnapshot
 from ..proof_floor import build_profitability_proof_floor_receipt
+from ..session_context import REGULAR_OPEN_UTC
 from ..simple_risk import (
     position_qty_for_symbol,
     prepare_simple_decision,
@@ -35,6 +37,7 @@ from ..submission_council import (
     load_quant_evidence_status,
 )
 from ..tca import build_tca_gate_inputs
+from ..time_source import trading_now
 from .pipeline import TradingPipeline
 from .pipeline_helpers import (
     _extract_json_error_payload,
@@ -82,6 +85,69 @@ def _safe_int(value: object) -> int:
 
 class SimpleTradingPipeline(TradingPipeline):
     """Minimal signal -> hard-risk -> direct execution lane."""
+
+    def run_once(self) -> None:
+        self._label_mature_rejected_signal_outcome_events()
+        with self.session_factory() as session:
+            self.state.metrics.planned_decision_age_seconds = 0
+            strategies = self._prepare_run_once(session)
+            if not strategies:
+                return
+            self._warm_session_context_from_open(session, strategies=strategies)
+
+            batch = self.ingestor.fetch_signals(session)
+            self._record_ingest_window(batch)
+            if not batch.signals:
+                self._prepare_batch_for_decisions(
+                    session,
+                    batch,
+                    quality_signals=batch.signals,
+                )
+                context = self._build_run_context(session)
+                if context is None:
+                    return
+                _account_snapshot, account, positions, allowed_symbols = context
+                self._process_paper_route_probe_retry_decisions(
+                    session=session,
+                    strategies=strategies,
+                    account=account,
+                    positions=positions,
+                    allowed_symbols=allowed_symbols,
+                )
+                return
+            context = self._build_run_context(session)
+            if context is None:
+                self.ingestor.commit_cursor(session, batch)
+                return
+            account_snapshot, account, positions, allowed_symbols = context
+            quality_signals = self._quality_gate_signals(
+                signals=batch.signals,
+                strategies=strategies,
+                allowed_symbols=allowed_symbols,
+            )
+            if not self._prepare_batch_for_decisions(
+                session,
+                batch,
+                quality_signals=quality_signals,
+            ):
+                return
+            self._process_batch_signals(
+                session=session,
+                batch=batch,
+                strategies=strategies,
+                account_snapshot=account_snapshot,
+                account=account,
+                positions=positions,
+                allowed_symbols=allowed_symbols,
+            )
+            self._process_paper_route_probe_retry_decisions(
+                session=session,
+                strategies=strategies,
+                account=account,
+                positions=positions,
+                allowed_symbols=allowed_symbols,
+            )
+            self.ingestor.commit_cursor(session, batch)
 
     def _live_submission_gate(
         self,
@@ -266,6 +332,136 @@ class SimpleTradingPipeline(TradingPipeline):
                     self.state.metrics.record_decision_rejection_reasons(
                         ["broker_submit_failed"]
                     )
+
+    @staticmethod
+    def _trade_decision_from_retry_row(
+        decision_row: TradeDecision,
+    ) -> StrategyDecision | None:
+        decision_json = decision_row.decision_json
+        if not isinstance(decision_json, Mapping):
+            return None
+        try:
+            return StrategyDecision.model_validate(decision_json)
+        except Exception:
+            logger.warning(
+                "Skipping paper route probe retry with invalid decision payload decision_id=%s",
+                decision_row.id,
+                exc_info=True,
+            )
+            return None
+
+    def _paper_route_probe_retry_session_open(self) -> datetime:
+        now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
+        return datetime.combine(now.date(), REGULAR_OPEN_UTC, tzinfo=timezone.utc)
+
+    def _created_in_current_regular_session(
+        self,
+        decision_row: TradeDecision,
+        decision: StrategyDecision,
+        *,
+        session_open: datetime,
+    ) -> bool:
+        for raw_ts in (decision.event_ts, decision_row.created_at):
+            ts = (
+                raw_ts
+                if raw_ts.tzinfo is not None
+                else raw_ts.replace(tzinfo=timezone.utc)
+            )
+            if ts.astimezone(timezone.utc) >= session_open:
+                return True
+        return False
+
+    def _paper_route_probe_retry_decisions(
+        self,
+        *,
+        session: Session,
+    ) -> list[StrategyDecision]:
+        if not settings.trading_simple_paper_route_probe_enabled:
+            return []
+        batch_limit = max(
+            _safe_int(settings.trading_simple_paper_route_probe_retry_batch_limit),
+            0,
+        )
+        scan_limit = max(
+            _safe_int(settings.trading_simple_paper_route_probe_retry_scan_limit),
+            0,
+        )
+        if batch_limit <= 0 or scan_limit <= 0:
+            return []
+
+        session_open = self._paper_route_probe_retry_session_open()
+        rows = (
+            session.execute(
+                select(TradeDecision)
+                .where(
+                    TradeDecision.status == "blocked",
+                    TradeDecision.alpaca_account_label == self.account_label,
+                )
+                .order_by(TradeDecision.created_at.desc())
+                .limit(scan_limit)
+            )
+            .scalars()
+            .all()
+        )
+        decisions: list[StrategyDecision] = []
+        for decision_row in rows:
+            if len(decisions) >= batch_limit:
+                break
+            if self._paper_route_probe_retry_metadata(decision_row) is None:
+                continue
+            if self.executor.execution_exists(session, decision_row):
+                continue
+            decision = self._trade_decision_from_retry_row(decision_row)
+            if decision is None:
+                continue
+            if not self._created_in_current_regular_session(
+                decision_row,
+                decision,
+                session_open=session_open,
+            ):
+                continue
+            decisions.append(decision)
+        return decisions
+
+    def _process_paper_route_probe_retry_decisions(
+        self,
+        *,
+        session: Session,
+        strategies: list[Strategy],
+        account: dict[str, str],
+        positions: list[dict[str, Any]],
+        allowed_symbols: set[str],
+    ) -> None:
+        decisions = self._paper_route_probe_retry_decisions(session=session)
+        for decision in decisions:
+            self.state.metrics.decisions_total += 1
+            try:
+                submitted = self._handle_decision(
+                    session,
+                    decision,
+                    strategies,
+                    account,
+                    positions,
+                    allowed_symbols,
+                )
+                if submitted is not None:
+                    self._apply_simple_projected_buying_power(
+                        account,
+                        positions,
+                        submitted,
+                    )
+                    self._apply_simple_projected_position(positions, submitted)
+            except Exception:
+                logger.exception(
+                    "Paper route probe retry handling failed strategy_id=%s symbol=%s timeframe=%s",
+                    decision.strategy_id,
+                    decision.symbol,
+                    decision.timeframe,
+                )
+                self.state.metrics.orders_rejected_total += 1
+                self.state.metrics.record_decision_rejection_reasons(
+                    ["broker_submit_failed"]
+                )
 
     def _submission_control_plane_snapshot(
         self,
@@ -836,6 +1032,15 @@ class SimpleTradingPipeline(TradingPipeline):
         reason = str(decision_json.get("submission_block_reason") or "").strip()
         if not reason:
             return None
+        retry_attempts = _safe_int(
+            decision_json.get("paper_route_probe_retry_attempts")
+        )
+        retry_limit = max(
+            _safe_int(settings.trading_simple_paper_route_probe_retry_attempt_limit),
+            0,
+        )
+        if retry_limit <= 0 or retry_attempts >= retry_limit:
+            return None
         proof_floor = decision_json.get("profitability_proof_floor")
         if not isinstance(proof_floor, Mapping):
             return None
@@ -843,6 +1048,7 @@ class SimpleTradingPipeline(TradingPipeline):
             "previous_submission_stage": "blocked_profitability_proof_floor",
             "previous_submission_block_reason": reason,
             "previous_decision_status": "blocked",
+            "previous_paper_route_probe_retry_attempts": retry_attempts,
         }
 
     def _ensure_pending_decision_row(

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -589,7 +589,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertEqual(
             sim_env.get("TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS"),
-            "3",
+            "5",
         )
         self.assertFalse(_manifest_bool(sim_env, "TRADING_SIMULATION_ENABLED"))
         self.assertEqual(sim_env.get("TRADING_UNIVERSE_SOURCE"), "static")

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7311,6 +7311,75 @@ class TestTradingApi(TestCase):
         self.assertEqual(http_error_connection.instances[0].timeout, 0.1)
         self.assertTrue(http_error_connection.instances[0].closed)
 
+        class FlakyConnection:
+            instances: list["FlakyConnection"] = []
+            responses = [
+                FakeResponse(503, b"{}"),
+                FakeResponse(
+                    200,
+                    json.dumps(
+                        {
+                            "runtime_window_import_plan": {
+                                "targets": [
+                                    {
+                                        "candidate_id": "retry-candidate",
+                                        "paper_route_probe_symbols": ["AAPL"],
+                                    }
+                                ]
+                            }
+                        }
+                    ).encode("utf-8"),
+                ),
+            ]
+
+            def __init__(
+                self,
+                hostname: str,
+                port: int | None,
+                *,
+                timeout: float,
+            ) -> None:
+                self.hostname = hostname
+                self.port = port
+                self.timeout = timeout
+                self.closed = False
+                self.instances.append(self)
+
+            def request(
+                self,
+                method: str,
+                path: str,
+                *,
+                headers: dict[str, str],
+            ) -> None:
+                self.request_method = method
+                self.request_path = path
+                self.request_headers = headers
+
+            def getresponse(self) -> FakeResponse:
+                return self.responses[len(self.instances) - 1]
+
+            def close(self) -> None:
+                self.closed = True
+
+        with patch(
+            "app.trading.paper_route_target_plan.HTTPConnection",
+            FlakyConnection,
+        ):
+            retried_plan = shared_fetch_paper_route_target_plan_url(
+                "http://torghut.example",
+                timeout_seconds=1,
+                attempts=2,
+                retry_backoff_seconds=0,
+            )
+        self.assertEqual(retried_plan["fetch_attempts"], 2)
+        self.assertEqual(
+            paper_route_target_plan_probe_symbols(retried_plan),
+            {"AAPL"},
+        )
+        self.assertEqual(len(FlakyConnection.instances), 2)
+        self.assertTrue(all(item.closed for item in FlakyConnection.instances))
+
         for raw, expected in (
             (b"{", "paper_route_target_plan_invalid_json:"),
             (b"[]", "paper_route_target_plan_invalid_payload"),
@@ -7432,6 +7501,28 @@ class TestTradingApi(TestCase):
         )
         self.assertEqual(http_error_connection.instances[0].timeout, 0.1)
         self.assertTrue(http_error_connection.instances[0].closed)
+
+        retry_exhausted_connection = connection_class(503, b"{}")
+        with patch(
+            "app.trading.paper_route_target_plan.HTTPConnection",
+            retry_exhausted_connection,
+        ):
+            self.assertEqual(
+                shared_fetch_paper_route_target_plan_url(
+                    "http://torghut.example/plan?mode=paper",
+                    timeout_seconds=0,
+                    attempts=2,
+                    retry_backoff_seconds=0,
+                ),
+                {
+                    "load_error": "paper_route_target_plan_http_status:503",
+                    "fetch_attempts": 2,
+                },
+            )
+        self.assertEqual(len(retry_exhausted_connection.instances), 2)
+        self.assertTrue(
+            all(item.closed for item in retry_exhausted_connection.instances)
+        )
 
         for raw, expected in (
             (b"{", "paper_route_target_plan_invalid_json:"),

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -53,7 +53,7 @@ from app.trading.ingest import SignalBatch
 from app.trading.reconcile import Reconciler
 from app.trading.risk import RiskEngine
 from app.trading.scheduler.pipeline import TradingPipeline
-from app.trading.scheduler.simple_pipeline import SimpleTradingPipeline
+from app.trading.scheduler.simple_pipeline import SimpleTradingPipeline, _safe_int
 from app.trading.scheduler.pipeline_helpers import (
     _apply_projected_position_decision,
     _build_dspy_lineage,
@@ -778,6 +778,9 @@ class TestTradingPipeline(TestCase):
                 "trading_simple_order_feed_telemetry_enabled",
                 "trading_simple_paper_route_probe_enabled",
                 "trading_simple_paper_route_probe_max_notional",
+                "trading_simple_paper_route_probe_retry_attempt_limit",
+                "trading_simple_paper_route_probe_retry_batch_limit",
+                "trading_simple_paper_route_probe_retry_scan_limit",
                 "trading_paper_route_target_plan_url",
                 "trading_paper_route_target_plan_timeout_seconds",
                 "trading_universe_static_fallback_enabled",
@@ -2884,8 +2887,233 @@ class TestTradingPipeline(TestCase):
                 "previous_submission_stage": "blocked_profitability_proof_floor",
                 "previous_submission_block_reason": "alpha_readiness_not_promotion_eligible",
                 "previous_decision_status": "blocked",
+                "previous_paper_route_probe_retry_attempts": 0,
             },
         )
+
+        from app import config
+
+        config.settings.trading_simple_paper_route_probe_retry_attempt_limit = 1
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_probe_retry_metadata(
+                decision_row(
+                    decision_json={
+                        "submission_stage": "blocked_profitability_proof_floor",
+                        "submission_block_reason": "alpha_readiness_not_promotion_eligible",
+                        "paper_route_probe_retry_attempts": 1,
+                        "profitability_proof_floor": {"route_state": "repair_only"},
+                    }
+                )
+            )
+        )
+
+    def test_simple_pipeline_retry_helpers_filter_invalid_rows_and_limits(
+        self,
+    ) -> None:
+        from app import config
+
+        self.assertEqual(_safe_int(True), 1)
+        self.assertEqual(_safe_int("7"), 7)
+        self.assertEqual(_safe_int("bad"), 0)
+
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        strategy_id = uuid4()
+        invalid_row = TradeDecision(
+            strategy_id=strategy_id,
+            alpaca_account_label="paper",
+            symbol="AAPL",
+            timeframe="1Min",
+            decision_json=["not", "a", "mapping"],
+            status="blocked",
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._trade_decision_from_retry_row(invalid_row)
+        )
+
+        event_ts = datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc)
+        decision = StrategyDecision(
+            strategy_id=str(strategy_id),
+            symbol="AAPL",
+            event_ts=event_ts,
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="paper-route-retry-filter",
+            params={"price": Decimal("100")},
+        )
+        old_row = TradeDecision(
+            strategy_id=strategy_id,
+            alpaca_account_label="paper",
+            symbol="AAPL",
+            timeframe="1Min",
+            decision_json=decision.model_dump(mode="json"),
+            status="blocked",
+            created_at=datetime(2026, 3, 25, 19, 0, tzinfo=timezone.utc),
+        )
+        self.assertFalse(
+            pipeline._created_in_current_regular_session(
+                old_row,
+                decision.model_copy(
+                    update={
+                        "event_ts": datetime(
+                            2026,
+                            3,
+                            25,
+                            19,
+                            0,
+                            tzinfo=timezone.utc,
+                        )
+                    }
+                ),
+                session_open=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
+            )
+        )
+
+        config.settings.trading_simple_paper_route_probe_enabled = False
+        with self.session_local() as session:
+            self.assertEqual(
+                pipeline._paper_route_probe_retry_decisions(session=session), []
+            )
+
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_retry_batch_limit = 0
+        config.settings.trading_simple_paper_route_probe_retry_scan_limit = 16
+        with self.session_local() as session:
+            self.assertEqual(
+                pipeline._paper_route_probe_retry_decisions(session=session), []
+            )
+
+        config.settings.trading_simple_paper_route_probe_retry_batch_limit = 2
+        config.settings.trading_simple_paper_route_probe_retry_attempt_limit = 2
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="simple-paper-proof-floor-retry-filter",
+                description="simple paper retry filter fixtures",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            stale_payload = decision.model_copy(
+                update={
+                    "strategy_id": str(strategy.id),
+                    "event_ts": datetime(2026, 3, 25, 19, 0, tzinfo=timezone.utc),
+                }
+            ).model_dump(mode="json")
+            stale_payload.update(
+                {
+                    "submission_stage": "blocked_profitability_proof_floor",
+                    "submission_block_reason": "alpha_readiness_not_promotion_eligible",
+                    "profitability_proof_floor": {"route_state": "repair_only"},
+                }
+            )
+            stale_row = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json=stale_payload,
+                status="blocked",
+                created_at=datetime(2026, 3, 25, 19, 0, tzinfo=timezone.utc),
+            )
+            invalid_payload_row = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "submission_stage": "blocked_profitability_proof_floor",
+                    "submission_block_reason": "alpha_readiness_not_promotion_eligible",
+                    "profitability_proof_floor": {"route_state": "repair_only"},
+                },
+                status="blocked",
+                created_at=event_ts,
+            )
+            metadata_miss_row = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "submission_stage": "blocked_other",
+                    "submission_block_reason": "alpha_readiness_not_promotion_eligible",
+                    "profitability_proof_floor": {"route_state": "repair_only"},
+                },
+                status="blocked",
+                created_at=event_ts,
+            )
+            executed_payload = decision.model_copy(
+                update={"strategy_id": str(strategy.id)}
+            ).model_dump(mode="json")
+            executed_payload.update(
+                {
+                    "submission_stage": "blocked_profitability_proof_floor",
+                    "submission_block_reason": "alpha_readiness_not_promotion_eligible",
+                    "profitability_proof_floor": {"route_state": "repair_only"},
+                }
+            )
+            executed_row = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json=executed_payload,
+                status="blocked",
+                created_at=event_ts,
+            )
+            session.add_all(
+                [
+                    stale_row,
+                    invalid_payload_row,
+                    metadata_miss_row,
+                    executed_row,
+                ]
+            )
+            session.commit()
+            session.refresh(executed_row)
+            session.add(
+                Execution(
+                    trade_decision_id=executed_row.id,
+                    alpaca_account_label="paper",
+                    alpaca_order_id="order-existing",
+                    client_order_id="client-existing",
+                    symbol="AAPL",
+                    side="buy",
+                    order_type="market",
+                    time_in_force="day",
+                    submitted_qty=Decimal("1"),
+                    status="accepted",
+                    raw_order={},
+                )
+            )
+            session.commit()
+
+            with patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=datetime(2026, 3, 26, 14, 0, tzinfo=timezone.utc),
+            ):
+                self.assertEqual(
+                    pipeline._paper_route_probe_retry_decisions(session=session),
+                    [],
+                )
 
     def test_simple_pipeline_reopens_profit_floor_block_for_bounded_paper_route_retry(
         self,
@@ -3002,6 +3230,7 @@ class TestTradingPipeline(TestCase):
                 retry.get("previous_submission_block_reason"),
                 "alpha_readiness_not_promotion_eligible",
             )
+            self.assertEqual(retry.get("previous_paper_route_probe_retry_attempts"), 0)
             self.assertEqual(retry.get("symbol"), "AAPL")
             self.assertEqual(
                 retry.get("submission_stage"),
@@ -3010,6 +3239,144 @@ class TestTradingPipeline(TestCase):
             context = cast(dict[str, Any], retry.get("context"))
             self.assertEqual(context.get("mode"), "paper_route_acquisition")
             self.assertEqual(context.get("max_notional"), "25.0")
+
+    def test_simple_pipeline_retries_blocked_paper_route_decision_without_new_signal(
+        self,
+    ) -> None:
+        from app import config
+
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_pipeline_mode = "simple"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_max_notional = 25.0
+        config.settings.trading_simple_paper_route_probe_retry_attempt_limit = 2
+        config.settings.trading_simple_paper_route_probe_retry_batch_limit = 4
+        config.settings.trading_simple_paper_route_probe_retry_scan_limit = 16
+        config.settings.trading_paper_route_target_plan_url = ""
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+        config.settings.trading_universe_static_fallback_enabled = True
+        config.settings.trading_universe_static_fallback_symbols_raw = "AAPL"
+
+        proof_floor = {
+            "route_state": "repair_only",
+            "capital_state": "paper",
+            "max_notional": "25",
+            "market_window": {"session_open": True},
+            "blocking_reasons": ["execution_tca_route_universe_empty"],
+            "route_reacquisition_book": {
+                "summary": {"repair_candidate_symbols": ["AAPL"]}
+            },
+        }
+        event_ts = datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc)
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="simple-paper-proof-floor-no-signal-retry",
+                description="simple paper retry after proof floor block without new signal",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=event_ts,
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("1"),
+                rationale="paper-route-retry",
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "paper",
+            )
+            decision_json = dict(cast(Mapping[str, Any], decision_row.decision_json))
+            decision_json.update(
+                {
+                    "submission_stage": "blocked_profitability_proof_floor",
+                    "submission_block_reason": "alpha_readiness_not_promotion_eligible",
+                    "submission_block_atomic": [
+                        "alpha_readiness_not_promotion_eligible"
+                    ],
+                    "profitability_proof_floor": proof_floor,
+                }
+            )
+            decision_row.status = "blocked"
+            decision_row.decision_json = decision_json
+            session.add(decision_row)
+            session.commit()
+
+        alpaca_client = FakeAlpacaClient()
+        ingestor = FakeIngestor([])
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=ingestor,
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+        with (
+            patch.object(
+                SimpleTradingPipeline,
+                "_profitability_proof_floor",
+                return_value=proof_floor,
+            ),
+            patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=datetime(2026, 3, 26, 14, 0, tzinfo=timezone.utc),
+            ),
+        ):
+            pipeline.run_once()
+
+        self.assertEqual(ingestor.committed_batches, 1)
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        self.assertEqual(alpaca_client.submitted[0]["qty"], "0.25")
+        with self.session_local() as session:
+            refreshed = session.execute(select(TradeDecision)).scalar_one()
+            execution = session.execute(select(Execution)).scalar_one()
+            refreshed_json = cast(dict[str, Any], refreshed.decision_json)
+            params = cast(dict[str, Any], refreshed_json.get("params"))
+            paper_route_probe = cast(dict[str, Any], params.get("paper_route_probe"))
+            simple_lane = cast(dict[str, Any], params.get("simple_lane"))
+            retry = cast(dict[str, Any], refreshed_json.get("paper_route_probe_retry"))
+
+            self.assertEqual(refreshed.status, "submitted")
+            self.assertEqual(execution.trade_decision_id, refreshed.id)
+            self.assertEqual(paper_route_probe.get("mode"), "paper_route_acquisition")
+            self.assertEqual(
+                Decimal(str(paper_route_probe.get("capped_notional"))),
+                Decimal("25.000000"),
+            )
+            self.assertEqual(simple_lane.get("paper_route_probe_cap_applied"), True)
+            self.assertEqual(
+                retry.get("previous_submission_block_reason"),
+                "alpha_readiness_not_promotion_eligible",
+            )
+            self.assertEqual(refreshed_json.get("paper_route_probe_retry_attempts"), 1)
 
     def test_simple_pipeline_proof_floor_includes_paper_route_probe_settings(
         self,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import Mock, patch
 from typing import Any, Callable, Mapping, cast
+from uuid import uuid4
 
 from sqlalchemy import create_engine, select
 from sqlalchemy.exc import SQLAlchemyError
@@ -2801,6 +2802,214 @@ class TestTradingPipeline(TestCase):
             )
             self.assertEqual(proof_floor.get("capital_state"), "zero_notional")
             self.assertEqual(control_plane.get("execution_lane"), "simple")
+
+    def test_simple_pipeline_retry_metadata_requires_prior_profit_floor_block(
+        self,
+    ) -> None:
+        def decision_row(
+            *,
+            status: str = "blocked",
+            decision_json: object,
+        ) -> TradeDecision:
+            return TradeDecision(
+                strategy_id=uuid4(),
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json=decision_json,
+                status=status,
+            )
+
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_probe_retry_metadata(
+                decision_row(
+                    status="planned",
+                    decision_json={
+                        "submission_stage": "blocked_profitability_proof_floor",
+                        "submission_block_reason": "alpha_readiness_not_promotion_eligible",
+                        "profitability_proof_floor": {},
+                    },
+                )
+            )
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_probe_retry_metadata(
+                decision_row(decision_json=["not", "a", "mapping"])
+            )
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_probe_retry_metadata(
+                decision_row(
+                    decision_json={
+                        "submission_stage": "blocked_other",
+                        "submission_block_reason": "alpha_readiness_not_promotion_eligible",
+                        "profitability_proof_floor": {},
+                    }
+                )
+            )
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_probe_retry_metadata(
+                decision_row(
+                    decision_json={
+                        "submission_stage": "blocked_profitability_proof_floor",
+                        "submission_block_reason": "",
+                        "profitability_proof_floor": {},
+                    }
+                )
+            )
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_probe_retry_metadata(
+                decision_row(
+                    decision_json={
+                        "submission_stage": "blocked_profitability_proof_floor",
+                        "submission_block_reason": "alpha_readiness_not_promotion_eligible",
+                        "profitability_proof_floor": "not-a-mapping",
+                    }
+                )
+            )
+        )
+        self.assertEqual(
+            SimpleTradingPipeline._paper_route_probe_retry_metadata(
+                decision_row(
+                    decision_json={
+                        "submission_stage": "blocked_profitability_proof_floor",
+                        "submission_block_reason": "alpha_readiness_not_promotion_eligible",
+                        "profitability_proof_floor": {"route_state": "repair_only"},
+                    }
+                )
+            ),
+            {
+                "previous_submission_stage": "blocked_profitability_proof_floor",
+                "previous_submission_block_reason": "alpha_readiness_not_promotion_eligible",
+                "previous_decision_status": "blocked",
+            },
+        )
+
+    def test_simple_pipeline_reopens_profit_floor_block_for_bounded_paper_route_retry(
+        self,
+    ) -> None:
+        from app import config
+
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_max_notional = 25.0
+        config.settings.trading_paper_route_target_plan_url = ""
+
+        proof_floor = {
+            "route_state": "repair_only",
+            "capital_state": "paper",
+            "max_notional": "25",
+            "market_window": {"session_open": True},
+            "blocking_reasons": ["execution_tca_route_universe_empty"],
+            "route_reacquisition_book": {
+                "summary": {"repair_candidate_symbols": ["AAPL"]}
+            },
+        }
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="simple-paper-proof-floor-retry",
+                description="simple paper retry after proof floor block",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("1"),
+                rationale="paper-route-retry",
+                params={"price": Decimal("100")},
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "paper",
+            )
+            decision_json = dict(cast(Mapping[str, Any], decision_row.decision_json))
+            decision_json.update(
+                {
+                    "submission_stage": "blocked_profitability_proof_floor",
+                    "submission_block_reason": "alpha_readiness_not_promotion_eligible",
+                    "submission_block_atomic": [
+                        "alpha_readiness_not_promotion_eligible"
+                    ],
+                    "profitability_proof_floor": proof_floor,
+                }
+            )
+            decision_row.status = "blocked"
+            decision_row.decision_json = decision_json
+            session.add(decision_row)
+            session.commit()
+            session.refresh(decision_row)
+
+            pipeline = SimpleTradingPipeline(
+                alpaca_client=FakeAlpacaClient(),
+                order_firewall=OrderFirewall(FakeAlpacaClient()),
+                ingestor=FakeIngestor([]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=executor,
+                execution_adapter=FakeAlpacaClient(),
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=TradingState(),
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+
+            with patch.object(
+                pipeline,
+                "_profitability_proof_floor",
+                return_value=proof_floor,
+            ):
+                pending = pipeline._ensure_pending_decision_row(
+                    session=session,
+                    decision=decision,
+                    strategy=strategy,
+                )
+
+            self.assertIsNotNone(pending)
+            assert pending is not None
+            self.assertEqual(pending.id, decision_row.id)
+            refreshed = session.get(TradeDecision, decision_row.id)
+            assert refreshed is not None
+            self.assertEqual(refreshed.status, "planned")
+            refreshed_json = cast(dict[str, Any], refreshed.decision_json)
+            self.assertEqual(
+                refreshed_json.get("submission_stage"),
+                "paper_route_probe_retry_pending",
+            )
+            self.assertNotIn("submission_block_reason", refreshed_json)
+            self.assertNotIn("submission_block_atomic", refreshed_json)
+            self.assertEqual(refreshed_json.get("paper_route_probe_retry_attempts"), 1)
+            retry = cast(dict[str, Any], refreshed_json.get("paper_route_probe_retry"))
+            self.assertEqual(
+                retry.get("previous_submission_block_reason"),
+                "alpha_readiness_not_promotion_eligible",
+            )
+            self.assertEqual(retry.get("symbol"), "AAPL")
+            self.assertEqual(
+                retry.get("submission_stage"),
+                "paper_route_probe_retry_pending",
+            )
+            context = cast(dict[str, Any], retry.get("context"))
+            self.assertEqual(context.get("mode"), "paper_route_acquisition")
+            self.assertEqual(context.get("max_notional"), "25.0")
 
     def test_simple_pipeline_proof_floor_includes_paper_route_probe_settings(
         self,


### PR DESCRIPTION
## Summary

- Adds retry support to the shared paper-route target-plan fetcher so transient live-service fetch failures do not silently drop bounded sim probes.
- Logs target-plan fetch failures from the simple paper-route probe gate with the URL, load error, and attempt count.
- Reopens persisted proof-floor-blocked paper decisions when the current proof floor still allows a bounded paper-route probe, including no-new-signal cycles after the ingest cursor has already advanced.
- Adds configurable retry attempt, batch, and scan limits for persisted paper-route probe retries.
- Increases the Torghut sim target-plan fetch timeout from 3s to 5s through GitOps and updates the manifest contract test.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_api.py::TestTradingApi::test_shared_paper_route_target_plan_helpers_validate_response -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q -k 'paper_route_probe or proof_floor or retry_metadata or retry_helpers'`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k 'sim_manifest_runs_paper_live_signal_profile' -q`
- `uv run --frozen pytest --cov=app --cov=scripts --cov-report=xml --cov-fail-under=0 tests/test_trading_api.py tests/test_trading_pipeline.py -k 'shared_paper_route_target_plan_helpers_validate_response or fetch_paper_route_target_plan_url_validates_response or retry_metadata_requires_prior_profit_floor_block or retry_helpers_filter_invalid_rows_and_limits or reopens_profit_floor_block_for_bounded_paper_route_retry or retries_blocked_paper_route_decision_without_new_signal or paper_route_probe_context_honors_external_target_plan_scope or simple_pipeline_allows_bounded_paper_route_probe_for_tca_repair or simple_pipeline_paper_route_probe_can_repair_symbol_outside_candidates' -q && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen ruff format --check app/config.py app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py tests/test_trading_api.py`
- `uv run --frozen ruff check app/config.py app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py tests/test_trading_api.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
