### PR TITLE
chore(torghut): promote image 87821313

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.576.2-66-g92d5e003d
+              value: v0.577.0-4-g878213134
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 92d5e003d9a6e2dc15f1b52d1ae77a9095b8accb
+              value: 8782131347471f928c85409f51064107592f4a90
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.576.2-66-g92d5e003d
+              value: v0.577.0-4-g878213134
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 92d5e003d9a6e2dc15f1b52d1ae77a9095b8accb
+              value: 8782131347471f928c85409f51064107592f4a90
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -100,7 +100,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+                  value: sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-26T14:34:22Z"
+        client.knative.dev/updateTimestamp: "2026-05-26T15:31:42Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
           ports:
             - name: http1
               containerPort: 8181
@@ -503,11 +503,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.576.2-66-g92d5e003d
+              value: v0.577.0-4-g878213134
             - name: TORGHUT_COMMIT
-              value: 92d5e003d9a6e2dc15f1b52d1ae77a9095b8accb
+              value: 8782131347471f928c85409f51064107592f4a90
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+              value: sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-26T14:34:22Z"
+        client.knative.dev/updateTimestamp: "2026-05-26T15:31:42Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
           ports:
             - name: http1
               containerPort: 8181
@@ -322,11 +322,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.576.2-66-g92d5e003d
+              value: v0.577.0-4-g878213134
             - name: TORGHUT_COMMIT
-              value: 92d5e003d9a6e2dc15f1b52d1ae77a9095b8accb
+              value: 8782131347471f928c85409f51064107592f4a90
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+              value: sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:611963a6b003ae5f4bff3b880f3037e62a4f8e2412b3e5bc7ebc3e74bd305f78
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `8782131347471f928c85409f51064107592f4a90`
- Image tag: `87821313`
- Image digest: `sha256:ce3e3fd3b48cf26875cad8ad2af0144345ba18bed12f7116add9de267fbd769a`