### PR TITLE
fix(torghut): backfill live target-plan quotes

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -141,11 +141,15 @@ spec:
             - name: TRADING_PRICE_TABLE
               value: torghut.ta_microbars
             - name: TRADING_EXECUTABLE_QUOTE_LOOKBACK_SECONDS
-              value: "60"
+              value: "300"
             - name: TRADING_EXECUTABLE_QUOTE_FORWARD_SECONDS
-              value: "0"
+              value: "60"
             - name: TRADING_ALPACA_QUOTE_FALLBACK_ENABLED
-              value: "false"
+              value: "true"
+            - name: TRADING_ALPACA_QUOTE_FEED
+              value: iex
+            - name: TRADING_ALPACA_QUOTE_MAX_AGE_SECONDS
+              value: "20"
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SECONDS
               value: "300"
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SIGNALS

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -630,15 +630,23 @@ class TestLiveConfigManifestContract(TestCase):
             _load_torghut_knative_env().get(
                 "TRADING_EXECUTABLE_QUOTE_LOOKBACK_SECONDS"
             ),
-            "60",
+            "300",
         )
         self.assertEqual(
             _load_torghut_knative_env().get("TRADING_EXECUTABLE_QUOTE_FORWARD_SECONDS"),
-            "0",
+            "60",
         )
         self.assertEqual(
             _load_torghut_knative_env().get("TRADING_ALPACA_QUOTE_FALLBACK_ENABLED"),
-            "false",
+            "true",
+        )
+        self.assertEqual(
+            _load_torghut_knative_env().get("TRADING_ALPACA_QUOTE_FEED"),
+            "iex",
+        )
+        self.assertEqual(
+            _load_torghut_knative_env().get("TRADING_ALPACA_QUOTE_MAX_AGE_SECONDS"),
+            "20",
         )
         self.assertEqual(
             sim_env.get("TRADING_UNIVERSE_STATIC_FALLBACK_SYMBOLS"),
@@ -1109,7 +1117,9 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertEqual(
             env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"), "63180"
         )
-        self.assertFalse(_manifest_bool(env, "TRADING_ALPACA_QUOTE_FALLBACK_ENABLED"))
+        self.assertTrue(_manifest_bool(env, "TRADING_ALPACA_QUOTE_FALLBACK_ENABLED"))
+        self.assertEqual(env.get("TRADING_ALPACA_QUOTE_FEED"), "iex")
+        self.assertEqual(env.get("TRADING_ALPACA_QUOTE_MAX_AGE_SECONDS"), "20")
         self.assertFalse(_manifest_bool(env, "TRADING_AUTONOMY_ENABLED"))
         self.assertFalse(_manifest_bool(env, "TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION"))
         self.assertFalse(_manifest_bool(env, "TRADING_KILL_SWITCH_ENABLED"))


### PR DESCRIPTION
## Summary

- Enables real Alpaca latest-quote backfill on the non-submitting live Torghut target-plan lane.
- Matches the live target-plan lane quote lookback/forward window to the paper route lane so recent executable quotes can clear quote-quality checks.
- Updates the live manifest contract test to keep this proof-path configuration explicit while live order submission remains disabled.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen pytest tests/test_prices.py -q`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-kustomize-render.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
