### PR TITLE
fix(torghut): use adverse shortfall for route TCA

### DIFF
--- a/services/torghut/app/trading/proof_floor.py
+++ b/services/torghut/app/trading/proof_floor.py
@@ -226,10 +226,21 @@ def _tca_symbol_routes(
             continue
         order_count = _int(row.get("order_count"))
         avg_abs_slippage = _decimal(row.get("avg_abs_slippage_bps"))
+        avg_realized_shortfall = _decimal(row.get("avg_realized_shortfall_bps"))
+        route_adverse_slippage = (
+            max(avg_realized_shortfall, Decimal("0"))
+            if avg_realized_shortfall is not None
+            else avg_abs_slippage
+        )
         symbol_payload: dict[str, object] = {
             "symbol": symbol,
             "order_count": order_count,
             "avg_abs_slippage_bps": _decimal_text(avg_abs_slippage),
+            "avg_realized_shortfall_bps": _decimal_text(avg_realized_shortfall),
+            "route_adverse_slippage_bps": _decimal_text(route_adverse_slippage),
+            "route_slippage_basis": "signed_realized_shortfall_bps"
+            if avg_realized_shortfall is not None
+            else "avg_abs_slippage_bps_fallback",
             "max_abs_slippage_bps": _decimal_text(
                 _decimal(row.get("max_abs_slippage_bps"))
             ),
@@ -241,8 +252,8 @@ def _tca_symbol_routes(
         route_guardrail = route_slippage_guardrail or slippage_guardrail
         if (
             route_guardrail is not None
-            and avg_abs_slippage is not None
-            and avg_abs_slippage > route_guardrail
+            and route_adverse_slippage is not None
+            and route_adverse_slippage > route_guardrail
         ):
             blocked_symbols.append(symbol_payload)
             continue

--- a/services/torghut/app/trading/route_reacquisition.py
+++ b/services/torghut/app/trading/route_reacquisition.py
@@ -139,7 +139,7 @@ def _record_from_symbol(
         symbol_payload.get("filled_execution_count"),
         _int(symbol_payload.get("order_count")),
     )
-    return {
+    payload: dict[str, object] = {
         "symbol": symbol,
         "account_label": account_label,
         "state": state,
@@ -169,6 +169,15 @@ def _record_from_symbol(
         "rollback_trigger": reason,
         "next_repair_action": _next_action(state=state, reason=reason),
     }
+    for key in (
+        "avg_realized_shortfall_bps",
+        "route_adverse_slippage_bps",
+        "route_slippage_basis",
+    ):
+        value = symbol_payload.get(key)
+        if value is not None:
+            payload[key] = value
+    return payload
 
 
 def _missing_record(
@@ -223,6 +232,14 @@ def _repair_candidate(record: Mapping[str, object], *, rank: int) -> dict[str, o
         "paper_probe_notional_limit": "0",
         "next_repair_action": _text(record.get("next_repair_action")),
     }
+    for key in (
+        "avg_realized_shortfall_bps",
+        "route_adverse_slippage_bps",
+        "route_slippage_basis",
+    ):
+        value = record.get(key)
+        if value is not None:
+            payload[key] = value
     paper_route_probe = _mapping(record.get("paper_route_probe"))
     if paper_route_probe and bool(paper_route_probe.get("eligible")):
         payload["paper_route_probe"] = dict(paper_route_probe)

--- a/services/torghut/tests/test_profitability_proof_floor.py
+++ b/services/torghut/tests/test_profitability_proof_floor.py
@@ -744,6 +744,116 @@ def test_execution_tca_route_universe_uses_widest_hypothesis_guardrail() -> None
     assert receipt["blocking_reasons"] == []
 
 
+def test_execution_tca_route_universe_uses_adverse_signed_shortfall() -> None:
+    receipt = build_profitability_proof_floor_receipt(
+        account_label="TORGHUT_SIM",
+        torghut_revision="torghut-sim-00757",
+        trading_mode="paper",
+        market_session_open=True,
+        live_submission_gate={
+            "allowed": True,
+            "reason": "non_live_mode",
+            "blocked_reasons": [],
+            "capital_stage": "paper",
+        },
+        hypothesis_payload={
+            "summary": {
+                "hypotheses_total": 2,
+                "promotion_eligible_total": 2,
+                "rollback_required_total": 0,
+                "state_totals": {"promotion_eligible": 2},
+            },
+            "items": [
+                {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "reasons": [],
+                    "promotion_contract": {"max_avg_abs_slippage_bps": "8"},
+                },
+                {
+                    "hypothesis_id": "H-CONT-01",
+                    "reasons": [],
+                    "promotion_contract": {"max_avg_abs_slippage_bps": "12"},
+                },
+            ],
+        },
+        empirical_jobs_status=_healthy_empirical_jobs(),
+        quant_evidence=_healthy_quant_evidence(),
+        market_context_status=_healthy_market_context(),
+        tca_summary={
+            **_fresh_tca_summary(avg_abs_slippage_bps="28"),
+            "scope_symbols": ["AAPL", "NVDA", "ORCL"],
+            "scope_symbol_count": 3,
+            "symbol_breakdown": [
+                {
+                    "symbol": "AAPL",
+                    "order_count": 1,
+                    "avg_abs_slippage_bps": "28.05213012",
+                    "avg_realized_shortfall_bps": "-28.05213012",
+                    "max_abs_slippage_bps": "28.05213012",
+                    "last_computed_at": NOW.isoformat(),
+                },
+                {
+                    "symbol": "NVDA",
+                    "order_count": 1,
+                    "avg_abs_slippage_bps": "25",
+                    "avg_realized_shortfall_bps": "25",
+                    "max_abs_slippage_bps": "25",
+                    "last_computed_at": NOW.isoformat(),
+                },
+                {
+                    "symbol": "ORCL",
+                    "order_count": 0,
+                    "avg_abs_slippage_bps": None,
+                    "avg_realized_shortfall_bps": None,
+                    "max_abs_slippage_bps": None,
+                    "last_computed_at": None,
+                },
+            ],
+        },
+        simple_lane_status=_simple_lane_status(),
+        now=NOW,
+    )
+
+    tca_dimension = next(
+        item
+        for item in receipt["proof_dimensions"]
+        if item["dimension"] == "execution_tca"
+    )
+    source_ref = cast(Mapping[str, Any], tca_dimension["source_ref"])
+    symbol_routes = cast(Mapping[str, Any], source_ref["symbol_routes"])
+
+    assert tca_dimension["state"] == "pass"
+    assert tca_dimension["reason"] == "execution_tca_route_universe_exclusions_applied"
+    assert source_ref["aggregate_reason"] == "execution_tca_slippage_guardrail_exceeded"
+    assert symbol_routes["route_slippage_guardrail_bps"] == "12"
+    assert symbol_routes["routeable_symbol_count"] == 1
+    assert symbol_routes["routeable_symbols"][0]["symbol"] == "AAPL"
+    assert (
+        symbol_routes["routeable_symbols"][0]["avg_abs_slippage_bps"]
+        == "28.05213012"
+    )
+    assert (
+        symbol_routes["routeable_symbols"][0]["avg_realized_shortfall_bps"]
+        == "-28.05213012"
+    )
+    assert symbol_routes["routeable_symbols"][0]["route_adverse_slippage_bps"] == "0"
+    assert (
+        symbol_routes["routeable_symbols"][0]["route_slippage_basis"]
+        == "signed_realized_shortfall_bps"
+    )
+    assert symbol_routes["blocked_symbol_count"] == 1
+    assert symbol_routes["blocked_symbols"][0]["symbol"] == "NVDA"
+    assert symbol_routes["blocked_symbols"][0]["route_adverse_slippage_bps"] == "25"
+
+    route_book = cast(Mapping[str, Any], receipt["route_reacquisition_book"])
+    route_summary = cast(Mapping[str, Any], route_book["summary"])
+    route_records = cast(list[Mapping[str, Any]], route_book["records"])
+    assert route_summary["candidate_symbols"] == ["AAPL"]
+    aapl_record = next(item for item in route_records if item["symbol"] == "AAPL")
+    assert aapl_record["state"] == "routeable"
+    assert aapl_record["route_adverse_slippage_bps"] == "0"
+
+
 def test_execution_tca_route_universe_requires_symbol_filter_before_unblock() -> None:
     simple_lane_status = {
         **_simple_lane_status(),


### PR DESCRIPTION
## Summary

- Change route-universe TCA filtering to use adverse signed realized shortfall for route inclusion while preserving absolute slippage diagnostics.
- Expose `avg_realized_shortfall_bps`, `route_adverse_slippage_bps`, and `route_slippage_basis` in route records when the source data exists.
- Add a regression test matching the live H-PAIRS/AAPL case where high absolute slippage came from favorable price improvement and should not exclude the symbol from paper-route evidence collection.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_profitability_proof_floor.py tests/test_route_reacquisition.py tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_external_target_plan_scope_is_preserved_in_next_window_audit tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_external_target_plan_probe_reports_missing_scope_and_plan_error tests/test_trading_pipeline.py::TestTradingPipeline::test_paper_route_probe_context_honors_external_target_plan_scope -q`
- `uv run --frozen ruff check app/trading/proof_floor.py app/trading/route_reacquisition.py tests/test_profitability_proof_floor.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Replayed the current `torghut-sim` `/trading/status` payload through the patched proof-floor builder and confirmed AAPL moves to routeable/probing with `route_adverse_slippage_bps=0`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
