### PR TITLE
fix(torghut): stop stale paper route entry retries

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -8,12 +8,14 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, ROUND_DOWN
 from typing import Any, Optional, cast
+from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ...config import settings
 from ...models import Strategy, TradeDecision
+from ...strategies.catalog import extract_catalog_metadata
 from ..autonomy import DriftThresholds, detect_drift
 from ..empirical_jobs import build_empirical_jobs_status
 from ..feature_quality import FeatureQualityThresholds, evaluate_feature_batch_quality
@@ -65,6 +67,7 @@ _PAPER_ROUTE_PROBE_REASONS = {
 _PROFITABILITY_PROOF_FLOOR_TCA_MAX_AGE_SECONDS = 86_400
 _SIMPLE_MARKET_CONTEXT_RETRY_INTERVAL = timedelta(seconds=30)
 _PAPER_ROUTE_PROBE_QTY_STEP = Decimal("0.0001")
+_REGULAR_SESSION_MINUTES = 390
 
 
 def _safe_int(value: object) -> int:
@@ -354,6 +357,82 @@ class SimpleTradingPipeline(TradingPipeline):
         now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
         return datetime.combine(now.date(), REGULAR_OPEN_UTC, tzinfo=timezone.utc)
 
+    @staticmethod
+    def _paper_route_probe_strategy(
+        *,
+        session: Session,
+        decision: StrategyDecision,
+    ) -> Strategy | None:
+        try:
+            strategy_id = UUID(decision.strategy_id)
+        except (TypeError, ValueError):
+            return None
+        return session.get(Strategy, strategy_id)
+
+    @staticmethod
+    def _paper_route_probe_exit_minute_value(raw_value: object) -> int | None:
+        if raw_value is None:
+            return None
+        if isinstance(raw_value, str):
+            text = raw_value.strip().lower()
+            if not text:
+                return None
+            if text == "close":
+                return _REGULAR_SESSION_MINUTES
+            try:
+                return max(0, int(Decimal(text)))
+            except Exception:
+                return None
+        try:
+            return max(0, int(cast(Any, raw_value)))
+        except (TypeError, ValueError, ArithmeticError):
+            return None
+
+    @staticmethod
+    def _paper_route_probe_exit_minute_after_open(
+        *,
+        decision: StrategyDecision,
+        strategy: Strategy | None = None,
+    ) -> int | None:
+        direct_exit_minute = SimpleTradingPipeline._paper_route_probe_exit_minute_value(
+            decision.params.get("exit_minute_after_open")
+        )
+        if direct_exit_minute is not None:
+            return direct_exit_minute
+        if strategy is None:
+            return None
+        metadata = extract_catalog_metadata(strategy.description)
+        metadata_params = metadata.get("params")
+        if not isinstance(metadata_params, Mapping):
+            return None
+        params = cast(Mapping[str, object], metadata_params)
+        return SimpleTradingPipeline._paper_route_probe_exit_minute_value(
+            params.get("exit_minute_after_open")
+        )
+
+    def _paper_route_probe_entry_after_exit_minute(
+        self,
+        *,
+        decision: StrategyDecision,
+        strategy: Strategy | None = None,
+    ) -> bool:
+        if decision.action != "buy":
+            return False
+        exit_minute = self._paper_route_probe_exit_minute_after_open(
+            decision=decision,
+            strategy=strategy,
+        )
+        if exit_minute is None:
+            return False
+        now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
+        session_open = datetime.combine(
+            now.date(),
+            REGULAR_OPEN_UTC,
+            tzinfo=timezone.utc,
+        )
+        minutes_elapsed = int((now - session_open).total_seconds() // 60)
+        return minutes_elapsed >= exit_minute
+
     def _created_in_current_regular_session(
         self,
         decision_row: TradeDecision,
@@ -419,6 +498,20 @@ class SimpleTradingPipeline(TradingPipeline):
                 decision,
                 session_open=session_open,
             ):
+                continue
+            strategy = self._paper_route_probe_strategy(
+                session=session,
+                decision=decision,
+            )
+            if self._paper_route_probe_entry_after_exit_minute(
+                decision=decision,
+                strategy=strategy,
+            ):
+                logger.warning(
+                    "Skipping stale paper route probe entry retry after strategy exit minute strategy_id=%s symbol=%s",
+                    decision.strategy_id,
+                    decision.symbol,
+                )
                 continue
             decisions.append(decision)
         return decisions
@@ -943,6 +1036,7 @@ class SimpleTradingPipeline(TradingPipeline):
         *,
         proof_floor: Mapping[str, object],
         decision: StrategyDecision,
+        strategy: Strategy | None = None,
     ) -> dict[str, object] | None:
         if settings.trading_mode != "paper":
             return None
@@ -960,6 +1054,11 @@ class SimpleTradingPipeline(TradingPipeline):
         if cap is None or cap <= 0:
             return None
         if not self._proof_floor_market_session_open(proof_floor):
+            return None
+        if self._paper_route_probe_entry_after_exit_minute(
+            decision=decision,
+            strategy=strategy,
+        ):
             return None
 
         blocking_reasons = {
@@ -1077,6 +1176,7 @@ class SimpleTradingPipeline(TradingPipeline):
         probe_context = self._paper_route_probe_context(
             proof_floor=proof_floor,
             decision=decision,
+            strategy=strategy,
         )
         if probe_context is None:
             return None
@@ -1225,9 +1325,14 @@ class SimpleTradingPipeline(TradingPipeline):
         )
         paper_route_probe_applied = False
         if proof_floor_block_reason is not None:
+            strategy = self._paper_route_probe_strategy(
+                session=session,
+                decision=decision,
+            )
             probe_context = self._paper_route_probe_context(
                 proof_floor=proof_floor,
                 decision=decision,
+                strategy=strategy,
             )
             if probe_context is None or not self._apply_paper_route_probe_cap(
                 session=session,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -2954,6 +2954,41 @@ class TestTradingPipeline(TestCase):
             rationale="paper-route-retry-filter",
             params={"price": Decimal("100")},
         )
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_probe_exit_minute_value(None)
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_probe_exit_minute_value("")
+        )
+        self.assertEqual(
+            SimpleTradingPipeline._paper_route_probe_exit_minute_value("close"),
+            390,
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_probe_exit_minute_value("bad")
+        )
+        self.assertEqual(
+            SimpleTradingPipeline._paper_route_probe_exit_minute_value(
+                Decimal("42.8")
+            ),
+            42,
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_probe_exit_minute_value(object())
+        )
+        self.assertEqual(
+            SimpleTradingPipeline._paper_route_probe_exit_minute_after_open(
+                decision=decision.model_copy(
+                    update={
+                        "params": {
+                            "price": Decimal("100"),
+                            "exit_minute_after_open": "45",
+                        }
+                    }
+                )
+            ),
+            45,
+        )
         old_row = TradeDecision(
             strategy_id=strategy_id,
             alpaca_account_label="paper",
@@ -2999,6 +3034,14 @@ class TestTradingPipeline(TestCase):
         config.settings.trading_simple_paper_route_probe_retry_batch_limit = 2
         config.settings.trading_simple_paper_route_probe_retry_attempt_limit = 2
         with self.session_local() as session:
+            self.assertIsNone(
+                pipeline._paper_route_probe_strategy(
+                    session=session,
+                    decision=decision.model_copy(
+                        update={"strategy_id": "not-a-valid-uuid"}
+                    ),
+                )
+            )
             strategy = Strategy(
                 name="simple-paper-proof-floor-retry-filter",
                 description=(
@@ -3923,6 +3966,30 @@ class TestTradingPipeline(TestCase):
                 decision=decision,
             )
         )
+
+        exit_bound_strategy = Strategy(
+            name="paper-route-exit-bound",
+            description=(
+                "paper route exit-bound fixture\n[catalog_metadata]\n"
+                + json.dumps({"params": {"exit_minute_after_open": "120"}})
+            ),
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["NVDA"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        with patch(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            return_value=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
+        ):
+            self.assertIsNone(
+                pipeline._paper_route_probe_context(
+                    proof_floor=proof_floor,
+                    decision=decision,
+                    strategy=exit_bound_strategy,
+                )
+            )
 
         no_route_reason_floor = {
             **proof_floor,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -3001,7 +3001,17 @@ class TestTradingPipeline(TestCase):
         with self.session_local() as session:
             strategy = Strategy(
                 name="simple-paper-proof-floor-retry-filter",
-                description="simple paper retry filter fixtures",
+                description=(
+                    "simple paper retry filter fixtures\n[catalog_metadata]\n"
+                    + json.dumps(
+                        {
+                            "params": {
+                                "entry_minute_after_open": "60",
+                                "exit_minute_after_open": "120",
+                            }
+                        }
+                    )
+                ),
                 enabled=True,
                 base_timeframe="1Min",
                 universe_type="static",
@@ -3109,6 +3119,41 @@ class TestTradingPipeline(TestCase):
             with patch(
                 "app.trading.scheduler.simple_pipeline.trading_now",
                 return_value=datetime(2026, 3, 26, 14, 0, tzinfo=timezone.utc),
+            ):
+                self.assertEqual(
+                    pipeline._paper_route_probe_retry_decisions(session=session),
+                    [],
+                )
+
+            stale_after_exit_payload = decision.model_copy(
+                update={
+                    "strategy_id": str(strategy.id),
+                    "event_ts": datetime(2026, 3, 26, 14, 30, tzinfo=timezone.utc),
+                }
+            ).model_dump(mode="json")
+            stale_after_exit_payload.update(
+                {
+                    "submission_stage": "blocked_profitability_proof_floor",
+                    "submission_block_reason": "alpha_readiness_not_promotion_eligible",
+                    "profitability_proof_floor": {"route_state": "repair_only"},
+                }
+            )
+            session.add(
+                TradeDecision(
+                    strategy_id=strategy.id,
+                    alpaca_account_label="paper",
+                    symbol="AAPL",
+                    timeframe="1Min",
+                    decision_json=stale_after_exit_payload,
+                    status="blocked",
+                    created_at=datetime(2026, 3, 26, 14, 30, tzinfo=timezone.utc),
+                )
+            )
+            session.commit()
+
+            with patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
             ):
                 self.assertEqual(
                     pipeline._paper_route_probe_retry_decisions(session=session),


### PR DESCRIPTION
## Summary

- Prevent paper-route probe retry buys from opening new exposure after the strategy exit minute.
- Resolve exit-minute limits from decision params first, then strategy catalog metadata, so catalog-backed sleeves are covered.
- Preserve sell/reducing exit behavior and add regression coverage for stale retry filtering.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py -k "retry_helpers_filter_invalid_rows_and_limits or reopens_profit_floor_block_for_bounded_paper_route_retry or retries_blocked_paper_route_decision_without_new_signal or paper_route_probe_context_rejects_unsafe_profiles" -q`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
