### PR TITLE
fix(torghut): split paper position tags by strategy

### DIFF
--- a/services/torghut/app/trading/scheduler/pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline.py
@@ -763,8 +763,8 @@ class TradingPipeline:
 
         tagged_positions: list[dict[str, Any]] = []
         for position in positions:
-            tagged_positions.append(
-                self._attach_strategy_position_tag(
+            tagged_positions.extend(
+                self._attach_strategy_position_tags(
                     position,
                     exposures=exposures,
                     session_open=session_open,
@@ -790,14 +790,30 @@ class TradingPipeline:
         exposures: Mapping[str, Mapping[str, Mapping[str, Any]]],
         session_open: datetime,
     ) -> dict[str, Any]:
+        tagged_positions = TradingPipeline._attach_strategy_position_tags(
+            position,
+            exposures=exposures,
+            session_open=session_open,
+        )
+        if len(tagged_positions) == 1:
+            return tagged_positions[0]
+        return position
+
+    @staticmethod
+    def _attach_strategy_position_tags(
+        position: dict[str, Any],
+        *,
+        exposures: Mapping[str, Mapping[str, Mapping[str, Any]]],
+        session_open: datetime,
+    ) -> list[dict[str, Any]]:
         if str(position.get("strategy_id") or "").strip():
-            return position
+            return [position]
         symbol = _normalized_symbol(position.get("symbol"))
         if not symbol:
-            return position
+            return [position]
         symbol_exposures = exposures.get(symbol)
         if not symbol_exposures:
-            return position
+            return [position]
         raw_qty = (
             position.get("qty")
             or position.get("quantity")
@@ -806,7 +822,7 @@ class TradingPipeline:
         )
         position_qty = _optional_decimal(raw_qty)
         if position_qty is None or position_qty <= 0:
-            return position
+            return [position]
         side = str(position.get("side") or "").strip().lower()
         signed_position_qty = -position_qty if side == "short" else position_qty
         same_side_exposures = [
@@ -818,7 +834,13 @@ class TradingPipeline:
             )
         ]
         if len(same_side_exposures) != 1:
-            return position
+            split_positions = TradingPipeline._split_strategy_position_tags(
+                position,
+                same_side_exposures=same_side_exposures,
+                signed_position_qty=signed_position_qty,
+                session_open=session_open,
+            )
+            return split_positions or [position]
 
         strategy_id, exposure = same_side_exposures[0]
         exposure_qty = cast(Decimal, exposure.get("qty") or Decimal("0"))
@@ -826,12 +848,79 @@ class TradingPipeline:
             abs(abs(exposure_qty) - abs(signed_position_qty))
             > _STRATEGY_POSITION_TAG_TOLERANCE
         ):
-            return position
+            return [position]
 
+        return [
+            TradingPipeline._strategy_tagged_position(
+                position,
+                strategy_id=strategy_id,
+                exposure=exposure,
+                qty=position_qty,
+                side=side,
+                session_open=session_open,
+            )
+        ]
+
+    @staticmethod
+    def _split_strategy_position_tags(
+        position: dict[str, Any],
+        *,
+        same_side_exposures: list[tuple[str, Mapping[str, Any]]],
+        signed_position_qty: Decimal,
+        session_open: datetime,
+    ) -> list[dict[str, Any]]:
+        if len(same_side_exposures) <= 1:
+            return []
+        exposure_total = sum(
+            (
+                cast(Decimal, exposure.get("qty") or Decimal("0"))
+                for _strategy_id, exposure in same_side_exposures
+            ),
+            Decimal("0"),
+        )
+        if (
+            abs(abs(exposure_total) - abs(signed_position_qty))
+            > _STRATEGY_POSITION_TAG_TOLERANCE
+        ):
+            return []
+        side = "short" if signed_position_qty < 0 else "long"
+        split_positions: list[dict[str, Any]] = []
+        for strategy_id, exposure in same_side_exposures:
+            exposure_qty = cast(Decimal, exposure.get("qty") or Decimal("0"))
+            if exposure_qty == 0:
+                continue
+            split_positions.append(
+                TradingPipeline._strategy_tagged_position(
+                    position,
+                    strategy_id=strategy_id,
+                    exposure=exposure,
+                    qty=abs(exposure_qty),
+                    side=side,
+                    session_open=session_open,
+                    split_from_aggregate=True,
+                )
+            )
+        return split_positions
+
+    @staticmethod
+    def _strategy_tagged_position(
+        position: dict[str, Any],
+        *,
+        strategy_id: str,
+        exposure: Mapping[str, Any],
+        qty: Decimal,
+        side: str,
+        session_open: datetime,
+        split_from_aggregate: bool = False,
+    ) -> dict[str, Any]:
         tagged = dict(position)
         tagged["strategy_id"] = strategy_id
+        tagged["qty"] = str(qty)
+        tagged["side"] = side or "long"
         tagged["strategy_position_source"] = "current_session_filled_executions"
         tagged["strategy_position_session_open"] = session_open.isoformat()
+        if split_from_aggregate:
+            tagged["strategy_position_split_from_aggregate"] = True
         latest_execution_at = exposure.get("latest_execution_at")
         if isinstance(latest_execution_at, datetime):
             tagged["strategy_position_latest_execution_at"] = (

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -9395,6 +9395,111 @@ class TestTradingPipeline(TestCase):
 
         self.assertNotIn("strategy_id", positions[0])
 
+    def test_resolve_execution_context_positions_splits_multi_strategy_symbol_position(
+        self,
+    ) -> None:
+        session_open = datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc)
+        with self.session_local() as session:
+            strategies = [
+                Strategy(
+                    name="microbar-cross-sectional-pairs-v1",
+                    description="runtime isolated paper proof",
+                    enabled=True,
+                    base_timeframe="1Sec",
+                    universe_type="microbar_cross_sectional_pairs_v1",
+                    universe_symbols=["AAPL"],
+                ),
+                Strategy(
+                    name="microbar-volume-continuation-long-top2-chip-v1",
+                    description="runtime isolated paper proof",
+                    enabled=True,
+                    base_timeframe="1Sec",
+                    universe_type="microbar_cross_sectional_pairs_v1",
+                    universe_symbols=["AAPL"],
+                ),
+            ]
+            session.add_all(strategies)
+            session.commit()
+            for strategy in strategies:
+                session.refresh(strategy)
+
+            for index, (strategy, qty, price) in enumerate(
+                [
+                    (strategies[0], Decimal("1.25"), Decimal("100")),
+                    (strategies[1], Decimal("2.75"), Decimal("104")),
+                ],
+                start=1,
+            ):
+                decision = TradeDecision(
+                    strategy_id=strategy.id,
+                    alpaca_account_label="paper",
+                    symbol="AAPL",
+                    timeframe="1Sec",
+                    decision_json={"action": "buy"},
+                    rationale="paper-route-entry",
+                    status="filled",
+                    created_at=session_open + timedelta(minutes=60 + index),
+                )
+                session.add(decision)
+                session.commit()
+                session.refresh(decision)
+                session.add(
+                    Execution(
+                        trade_decision_id=decision.id,
+                        alpaca_account_label="paper",
+                        alpaca_order_id=f"paper-aapl-{index}",
+                        client_order_id=f"paper-aapl-{index}-client",
+                        symbol="AAPL",
+                        side="buy",
+                        order_type="market",
+                        time_in_force="day",
+                        submitted_qty=qty,
+                        filled_qty=qty,
+                        avg_fill_price=price,
+                        status="filled",
+                        raw_order={},
+                        created_at=session_open + timedelta(minutes=61 + index),
+                        updated_at=session_open + timedelta(minutes=61 + index),
+                    )
+                )
+            session.commit()
+
+            pipeline = TradingPipeline.__new__(TradingPipeline)
+            pipeline.account_label = "paper"
+
+            class AdapterWithoutOpenOrders:
+                name = "test"
+
+                def list_orders(self, status: str = "all") -> list[dict[str, str]]:
+                    return []
+
+            pipeline.execution_adapter = AdapterWithoutOpenOrders()
+
+            with patch(
+                "app.trading.scheduler.pipeline.trading_now",
+                return_value=session_open + timedelta(minutes=150),
+            ):
+                positions = pipeline._resolve_execution_context_positions(
+                    [{"symbol": "AAPL", "qty": "4.00", "side": "long"}],
+                    session=session,
+                )
+
+        self.assertEqual(len(positions), 2)
+        self.assertEqual(
+            {position["strategy_id"] for position in positions},
+            {str(strategy.id) for strategy in strategies},
+        )
+        self.assertEqual(
+            {Decimal(str(position["qty"])) for position in positions},
+            {Decimal("1.25"), Decimal("2.75")},
+        )
+        self.assertTrue(
+            all(
+                position["strategy_position_split_from_aggregate"]
+                for position in positions
+            )
+        )
+
     def test_attach_current_session_strategy_position_tags_fails_closed_on_query_error(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Split aggregate broker positions into per-strategy synthetic positions when same-session fills from multiple strategies exactly reconcile to the broker quantity.
- Preserve the existing single-strategy tagging path and fail closed when exposures are ambiguous or do not reconcile.
- Add a regression test for the AAPL-style case where two isolated strategies own pieces of the same paper position.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py -k "position_tags or split_multi_strategy_symbol_position or mismatched_fill or reconstructs_avg_entry"`
- `uv run --frozen pytest tests/test_trading_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Live read-only verification before the fix showed 2026-05-26 paper `executions` for AAPL from multiple strategies, zero `strategy_runtime_ledger_buckets`, and open AAPL position inventory that could not be assigned to a single strategy.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
