### PR TITLE
fix(torghut): admit hpairs paper probation sleeves

### DIFF
--- a/services/torghut/app/trading/hypotheses.py
+++ b/services/torghut/app/trading/hypotheses.py
@@ -420,6 +420,7 @@ class HypothesisManifest(BaseModel):
     lane_id: str
     strategy_family: str
     candidate_id: str | None = None
+    paper_probation_candidate_ids: list[str] = Field(default_factory=list)
     strategy_id: str | None = None
     dataset_snapshot_ref: str | None = None
     initial_state: Literal["shadow", "blocked"] = "shadow"
@@ -443,6 +444,7 @@ class HypothesisManifest(BaseModel):
         "required_feature_sets",
         "required_dependency_capabilities",
         "segment_dependencies",
+        "paper_probation_candidate_ids",
         "rollback_triggers",
         "promotion_gates",
         mode="before",

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -1091,12 +1091,12 @@ def _runtime_ledger_target_reason_codes(
     manifest: Mapping[str, object],
 ) -> list[str]:
     reasons: list[str] = []
-    expected_candidate = _safe_text(manifest.get("candidate_id"))
+    expected_candidates = _runtime_ledger_manifest_candidate_ids(manifest)
     actual_candidate = _safe_text(payload.get("candidate_id"))
-    if expected_candidate is not None:
+    if expected_candidates:
         if actual_candidate is None:
             reasons.append("runtime_ledger_candidate_missing")
-        elif actual_candidate != expected_candidate:
+        elif actual_candidate not in expected_candidates:
             reasons.append("runtime_ledger_candidate_mismatch")
 
     expected_family = _normalized_strategy_family(manifest.get("strategy_family"))
@@ -1108,6 +1108,24 @@ def _runtime_ledger_target_reason_codes(
     ):
         reasons.append("runtime_ledger_strategy_family_mismatch")
     return reasons
+
+
+def _runtime_ledger_manifest_candidate_ids(
+    manifest: Mapping[str, object],
+) -> set[str]:
+    candidates: set[str] = set()
+    primary_candidate = _safe_text(manifest.get("candidate_id"))
+    if primary_candidate is not None:
+        candidates.add(primary_candidate)
+    raw_probation_candidates = manifest.get("paper_probation_candidate_ids")
+    if isinstance(raw_probation_candidates, Sequence) and not isinstance(
+        raw_probation_candidates, (str, bytes, bytearray)
+    ):
+        for raw_candidate in cast(Sequence[object], raw_probation_candidates):
+            candidate = _safe_text(raw_candidate)
+            if candidate is not None:
+                candidates.add(candidate)
+    return candidates
 
 
 def _runtime_ledger_repair_reason_codes(

--- a/services/torghut/config/trading/hypotheses/h-pairs-01.json
+++ b/services/torghut/config/trading/hypotheses/h-pairs-01.json
@@ -4,6 +4,10 @@
   "lane_id": "microbar-cross-sectional-pairs",
   "strategy_family": "microbar_cross_sectional_pairs",
   "candidate_id": "c88421d619759b2cfaa6f4d0",
+  "paper_probation_candidate_ids": [
+    "c88421d619759b2cfaa6f4d0",
+    "3e49d7da73ac2456c3eecb02"
+  ],
   "strategy_id": "microbar_cross_sectional_pairs_v1@research",
   "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
   "initial_state": "blocked",

--- a/services/torghut/tests/test_hypotheses.py
+++ b/services/torghut/tests/test_hypotheses.py
@@ -246,6 +246,11 @@ class TestHypothesisReadiness(TestCase):
                         "hypothesis_id": "H-CONT-01",
                         "lane_id": "continuation",
                         "strategy_family": "intraday_continuation",
+                        "paper_probation_candidate_ids": [
+                            " secondary-candidate ",
+                            "primary-candidate",
+                            "primary-candidate",
+                        ],
                         "initial_state": "shadow",
                         "expected_gross_edge_bps": "6",
                         "max_allowed_slippage_bps": "12",
@@ -263,6 +268,10 @@ class TestHypothesisReadiness(TestCase):
         self.assertTrue(result.loaded)
         self.assertEqual(len(result.items), 1)
         self.assertEqual(result.items[0].hypothesis_id, "H-CONT-01")
+        self.assertEqual(
+            result.items[0].paper_probation_candidate_ids,
+            ["primary-candidate", "secondary-candidate"],
+        )
         self.assertEqual(result.errors, [])
 
     def test_compile_hypothesis_runtime_statuses_stays_shadow_without_feature_and_evidence(

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -515,11 +515,15 @@ class TestSubmissionCouncil(TestCase):
                 strategy_id: str,
                 strategy_family: str,
                 segment_dependencies: list[str] | None = None,
+                paper_probation_candidate_ids: list[str] | None = None,
             ) -> None:
                 self.hypothesis_id = hypothesis_id
                 self._payload = {
                     "hypothesis_id": hypothesis_id,
                     "candidate_id": candidate_id,
+                    "paper_probation_candidate_ids": list(
+                        paper_probation_candidate_ids or []
+                    ),
                     "strategy_id": strategy_id,
                     "strategy_family": strategy_family,
                     "lane_id": strategy_family,
@@ -546,6 +550,10 @@ class TestSubmissionCouncil(TestCase):
                     candidate_id="c88421d619759b2cfaa6f4d0",
                     strategy_id="microbar_cross_sectional_pairs_v1@research",
                     strategy_family="microbar_cross_sectional_pairs",
+                    paper_probation_candidate_ids=[
+                        "c88421d619759b2cfaa6f4d0",
+                        "3e49d7da73ac2456c3eecb02",
+                    ],
                 ),
                 _RegistryItem(
                     hypothesis_id="H-REV-01",
@@ -618,6 +626,36 @@ class TestSubmissionCouncil(TestCase):
                         execution_policy_hash_counts={"policy": 2},
                         cost_model_hash_counts={"cost": 2},
                         lineage_hash_counts={"lineage": 2},
+                        blockers_json=[],
+                    ),
+                    StrategyRuntimeLedgerBucket(
+                        run_id="pairs-reversal-runtime",
+                        candidate_id="3e49d7da73ac2456c3eecb02",
+                        hypothesis_id="H-PAIRS-01",
+                        observed_stage="paper",
+                        bucket_started_at=now - timedelta(minutes=75),
+                        bucket_ended_at=now - timedelta(minutes=60),
+                        account_label="TORGHUT_SIM",
+                        runtime_strategy_name="microbar-pairs-vwap-reversal",
+                        strategy_family="microbar_cross_sectional_pairs",
+                        fill_count=1,
+                        decision_count=1,
+                        submitted_order_count=1,
+                        cancelled_order_count=0,
+                        rejected_order_count=0,
+                        unfilled_order_count=0,
+                        closed_trade_count=1,
+                        open_position_count=0,
+                        filled_notional=Decimal("316509.62015600"),
+                        gross_strategy_pnl=Decimal("555.25627600"),
+                        cost_amount=Decimal("123.22325790"),
+                        net_strategy_pnl_after_costs=Decimal("432.03301810"),
+                        post_cost_expectancy_bps=Decimal("13.64991743"),
+                        ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={"policy": 1},
+                        cost_model_hash_counts={"cost": 1},
+                        lineage_hash_counts={"lineage": 1},
                         blockers_json=[],
                     ),
                 ]
@@ -707,16 +745,20 @@ class TestSubmissionCouncil(TestCase):
             "runtime_ledger_candidate_mismatch", candidates[0]["reason_codes"]
         )
         paper_candidates = gate["runtime_ledger_paper_probation_candidates"]
-        self.assertEqual(gate["paper_probation_eligible_total"], 1)
-        self.assertEqual(gate["runtime_ledger_paper_probation_eligible_total"], 1)
+        self.assertEqual(gate["paper_probation_eligible_total"], 2)
+        self.assertEqual(gate["runtime_ledger_paper_probation_eligible_total"], 2)
         self.assertIn(
             "paper_probation_evidence_collection_only", gate["blocked_reasons"]
         )
         self.assertNotIn("segment_market-context_blocked", gate["blocked_reasons"])
         self.assertNotIn("market_context_stale", gate["blocked_reasons"])
         self.assertNotIn("market_context_domain_news_stale", gate["blocked_reasons"])
-        self.assertEqual(len(paper_candidates), 1)
+        self.assertEqual(len(paper_candidates), 2)
         self.assertEqual(paper_candidates[0]["hypothesis_id"], "H-PAIRS-01")
+        self.assertEqual(paper_candidates[1]["hypothesis_id"], "H-PAIRS-01")
+        self.assertEqual(
+            paper_candidates[1]["candidate_id"], "3e49d7da73ac2456c3eecb02"
+        )
         self.assertEqual(
             paper_candidates[0]["paper_probation_scope"], "evidence_collection_only"
         )
@@ -727,7 +769,7 @@ class TestSubmissionCouncil(TestCase):
             import_plan["schema_version"],
             "torghut.runtime-ledger-paper-probation-import-plan.v1",
         )
-        self.assertEqual(import_plan["target_count"], 1)
+        self.assertEqual(import_plan["target_count"], 2)
         self.assertEqual(import_plan["skipped_target_count"], 0)
         target = import_plan["targets"][0]
         self.assertEqual(target["hypothesis_id"], "H-PAIRS-01")
@@ -740,6 +782,13 @@ class TestSubmissionCouncil(TestCase):
         )
         self.assertIn("microbar-pairs-vwap-cap-safe", target["strategy_lookup_names"])
         self.assertEqual(target["account_label"], "TORGHUT_SIM")
+        self.assertEqual(
+            import_plan["targets"][1]["candidate_id"], "3e49d7da73ac2456c3eecb02"
+        )
+        self.assertEqual(
+            import_plan["targets"][1]["strategy_name"],
+            "microbar-pairs-vwap-reversal",
+        )
         self.assertEqual(
             target["source_dsn_env"], "TORGHUT_DURABLE_RUNTIME_LEDGER_SOURCE_DSN"
         )
@@ -764,7 +813,11 @@ class TestSubmissionCouncil(TestCase):
         )
         self.assertNotIn("runtime_ledger_artifact_refs", target)
         self.assertNotIn("runtime_ledger_artifact_row_count", target)
-        self.assertEqual(candidates[1]["hypothesis_id"], "H-CONT-01")
+        self.assertEqual(candidates[1]["hypothesis_id"], "H-PAIRS-01")
+        self.assertEqual(candidates[1]["candidate_id"], "3e49d7da73ac2456c3eecb02")
+        self.assertTrue(
+            any(candidate["hypothesis_id"] == "H-CONT-01" for candidate in candidates)
+        )
 
     def test_runtime_ledger_paper_probation_import_plan_falls_back_and_skips_incomplete_targets(
         self,


### PR DESCRIPTION
## Summary

- Adds `paper_probation_candidate_ids` to the Torghut hypothesis manifest schema so vetted paper sleeves survive registry validation.
- Allows runtime-ledger repair targeting to accept either the primary hypothesis candidate or an explicitly listed paper-probation candidate.
- Adds the two ledger-backed H-PAIRS candidates to the H-PAIRS manifest for evidence collection only, with tests proving both appear in the import plan while final promotion remains blocked.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_submission_council.py -k 'paper_probation or runtime_ledger'`
- `uv run --frozen pytest tests/test_hypotheses.py -k 'hypothesis_registry or paper_probation or reads_directory_payloads'`
- `uv run --frozen pytest tests/test_submission_council.py tests/test_hypotheses.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
