### PR TITLE
fix(torghut): create renewal proof output dir

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -41,6 +41,7 @@ spec:
                   cd /app
                   RENEWAL_OUTPUT=/tmp/torghut-empirical-renewal/runtime-window-renewal.json
                   PROOF_PACKET_OUTPUT=/tmp/torghut-empirical-renewal/runtime-ledger-proof-packet.json
+                  mkdir -p "$(dirname "${RENEWAL_OUTPUT}")" "$(dirname "${PROOF_PACKET_OUTPUT}")"
                   /opt/venv/bin/python scripts/renew_latest_empirical_promotion_jobs.py \
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref intraday_tsmom_v2@research \

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -903,6 +903,10 @@ class TestLiveConfigManifestContract(TestCase):
             "PROOF_PACKET_OUTPUT=/tmp/torghut-empirical-renewal/runtime-ledger-proof-packet.json",
             args,
         )
+        self.assertIn(
+            'mkdir -p "$(dirname "${RENEWAL_OUTPUT}")" "$(dirname "${PROOF_PACKET_OUTPUT}")"',
+            args,
+        )
         self.assertIn("scripts/assemble_runtime_ledger_proof_packet.py", args)
         self.assertIn(
             "--status-service-base-url http://torghut.torghut.svc.cluster.local",


### PR DESCRIPTION
## Summary

- Ensure the Torghut empirical promotion renewal CronJob creates its proof-output parent directory before piping renewal JSON through `tee`.
- Keep the runtime-ledger proof packet output in the same directory so packet assembly can read the renewal import file instead of failing before proof assembly.
- Add a live manifest contract assertion for the output-directory setup.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k 'empirical_promotion_renewal' -q`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
