### PR TITLE
fix(torghut): close paper route probation entries

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -14,7 +14,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ...config import settings
-from ...models import Strategy, TradeDecision
+from ...models import Execution, Strategy, TradeDecision
 from ...strategies.catalog import extract_catalog_metadata
 from ..autonomy import DriftThresholds, detect_drift
 from ..empirical_jobs import build_empirical_jobs_status
@@ -110,6 +110,13 @@ class SimpleTradingPipeline(TradingPipeline):
                 if context is None:
                     return
                 _account_snapshot, account, positions, allowed_symbols = context
+                self._process_paper_route_probe_exit_decisions(
+                    session=session,
+                    strategies=strategies,
+                    account=account,
+                    positions=positions,
+                    allowed_symbols=allowed_symbols,
+                )
                 self._process_paper_route_probe_retry_decisions(
                     session=session,
                     strategies=strategies,
@@ -139,6 +146,13 @@ class SimpleTradingPipeline(TradingPipeline):
                 batch=batch,
                 strategies=strategies,
                 account_snapshot=account_snapshot,
+                account=account,
+                positions=positions,
+                allowed_symbols=allowed_symbols,
+            )
+            self._process_paper_route_probe_exit_decisions(
+                session=session,
+                strategies=strategies,
                 account=account,
                 positions=positions,
                 allowed_symbols=allowed_symbols,
@@ -353,6 +367,19 @@ class SimpleTradingPipeline(TradingPipeline):
             )
             return None
 
+    @staticmethod
+    def _paper_route_probe_exit_metadata(
+        decision: StrategyDecision,
+    ) -> Mapping[str, Any] | None:
+        metadata = decision.params.get("paper_route_probe_exit")
+        if not isinstance(metadata, Mapping):
+            return None
+        metadata_mapping = cast(Mapping[str, Any], metadata)
+        mode = str(metadata_mapping.get("mode") or "").strip()
+        if mode != "paper_route_exit":
+            return None
+        return metadata_mapping
+
     def _paper_route_probe_retry_session_open(self) -> datetime:
         now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
         return datetime.combine(now.date(), REGULAR_OPEN_UTC, tzinfo=timezone.utc)
@@ -516,6 +543,245 @@ class SimpleTradingPipeline(TradingPipeline):
             decisions.append(decision)
         return decisions
 
+    def _paper_route_probe_exit_decisions(
+        self,
+        *,
+        session: Session,
+    ) -> list[StrategyDecision]:
+        if settings.trading_mode != "paper":
+            return []
+        if not settings.trading_simple_paper_route_probe_enabled:
+            return []
+        now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
+        if not self._is_market_session_open(now):
+            return []
+
+        session_open = datetime.combine(
+            now.date(),
+            REGULAR_OPEN_UTC,
+            tzinfo=timezone.utc,
+        )
+        rows = session.execute(
+            select(Execution, TradeDecision)
+            .join(TradeDecision, Execution.trade_decision_id == TradeDecision.id)
+            .where(
+                Execution.alpaca_account_label == self.account_label,
+                TradeDecision.alpaca_account_label == self.account_label,
+                Execution.status == "filled",
+                Execution.filled_qty > Decimal("0"),
+                Execution.created_at >= session_open,
+            )
+            .order_by(Execution.created_at.asc())
+        ).all()
+        exposures: dict[tuple[str, str], dict[str, Any]] = {}
+        for execution, decision_row in rows:
+            decision = self._trade_decision_from_retry_row(decision_row)
+            if decision is None:
+                continue
+            decision_json = decision_row.decision_json
+            if not isinstance(decision_json, Mapping):
+                continue
+            params = decision.params
+            is_entry = isinstance(params.get("paper_route_probe"), Mapping)
+            is_exit = isinstance(params.get("paper_route_probe_exit"), Mapping)
+            if not is_entry and not is_exit:
+                continue
+            side = str(execution.side or "").strip().lower()
+            if side not in {"buy", "sell"}:
+                continue
+            filled_qty = _optional_decimal(execution.filled_qty)
+            if filled_qty is None or filled_qty <= 0:
+                continue
+            strategy = session.get(Strategy, decision_row.strategy_id)
+            if strategy is None:
+                continue
+            symbol = str(execution.symbol or decision_row.symbol or "").strip().upper()
+            if not symbol:
+                continue
+
+            key = (str(strategy.id), symbol)
+            exposure = exposures.setdefault(
+                key,
+                {
+                    "strategy": strategy,
+                    "symbol": symbol,
+                    "timeframe": decision.timeframe,
+                    "net_qty": Decimal("0"),
+                    "buy_qty": Decimal("0"),
+                    "buy_notional": Decimal("0"),
+                    "latest_entry_at": None,
+                    "exit_minute_after_open": None,
+                },
+            )
+            signed_qty = filled_qty if side == "buy" else -filled_qty
+            exposure["net_qty"] = cast(Decimal, exposure["net_qty"]) + signed_qty
+            if side == "buy":
+                exit_minute = self._paper_route_probe_exit_minute_after_open(
+                    decision=decision,
+                    strategy=strategy,
+                )
+                if exit_minute is not None:
+                    exposure["exit_minute_after_open"] = exit_minute
+                avg_fill_price = _optional_decimal(execution.avg_fill_price)
+                if avg_fill_price is not None and avg_fill_price > 0:
+                    exposure["buy_qty"] = (
+                        cast(Decimal, exposure["buy_qty"]) + filled_qty
+                    )
+                    exposure["buy_notional"] = cast(
+                        Decimal,
+                        exposure["buy_notional"],
+                    ) + (filled_qty * avg_fill_price)
+                latest_entry_at = exposure.get("latest_entry_at")
+                execution_created_at = (
+                    execution.created_at
+                    if execution.created_at.tzinfo is not None
+                    else execution.created_at.replace(tzinfo=timezone.utc)
+                ).astimezone(timezone.utc)
+                if not isinstance(latest_entry_at, datetime) or (
+                    execution_created_at > latest_entry_at
+                ):
+                    exposure["latest_entry_at"] = execution_created_at
+
+        decisions: list[StrategyDecision] = []
+        for exposure in exposures.values():
+            net_qty = cast(Decimal, exposure["net_qty"])
+            if net_qty <= 0:
+                continue
+            raw_exit_minute = exposure.get("exit_minute_after_open")
+            exit_minute = raw_exit_minute if isinstance(raw_exit_minute, int) else None
+            if exit_minute is None:
+                continue
+            effective_exit_minute = min(exit_minute, _REGULAR_SESSION_MINUTES - 1)
+            exit_due_at = session_open + timedelta(minutes=effective_exit_minute)
+            if now < exit_due_at:
+                continue
+            strategy = cast(Strategy, exposure["strategy"])
+            symbol = str(exposure["symbol"])
+            if self._paper_route_probe_exit_already_recorded(
+                session=session,
+                strategy=strategy,
+                symbol=symbol,
+                session_open=session_open,
+                exit_due_at=exit_due_at,
+            ):
+                continue
+            buy_qty = cast(Decimal, exposure["buy_qty"])
+            buy_notional = cast(Decimal, exposure["buy_notional"])
+            avg_entry_price = buy_notional / buy_qty if buy_qty > 0 else None
+            params: dict[str, Any] = {
+                "paper_route_probe_exit": {
+                    "mode": "paper_route_exit",
+                    "source": "filled_paper_route_probe_executions",
+                    "symbol": symbol,
+                    "strategy_id": str(strategy.id),
+                    "db_open_qty": str(net_qty),
+                    "exit_minute_after_open": exit_minute,
+                    "effective_exit_minute_after_open": effective_exit_minute,
+                    "exit_due_at": exit_due_at.isoformat(),
+                    "session_open": session_open.isoformat(),
+                    "latest_entry_at": exposure["latest_entry_at"].isoformat()
+                    if isinstance(exposure.get("latest_entry_at"), datetime)
+                    else None,
+                    "avg_entry_price": str(avg_entry_price)
+                    if avg_entry_price is not None
+                    else None,
+                },
+                "simple_lane": {
+                    "final_qty": str(net_qty),
+                    "notional": str(net_qty * avg_entry_price)
+                    if avg_entry_price is not None
+                    else None,
+                    "quantity_resolution": {
+                        "reason": "sell_reducing_paper_route_probe_exit",
+                        "short_increasing": False,
+                        "position_qty": str(net_qty),
+                    },
+                },
+            }
+            if avg_entry_price is not None:
+                params["price"] = avg_entry_price
+            decisions.append(
+                StrategyDecision(
+                    strategy_id=str(strategy.id),
+                    symbol=symbol,
+                    event_ts=exit_due_at,
+                    timeframe=str(exposure["timeframe"] or strategy.base_timeframe),
+                    action="sell",
+                    qty=net_qty,
+                    rationale="paper-route-probe-exit",
+                    params=params,
+                )
+            )
+        return decisions
+
+    def _paper_route_probe_exit_already_recorded(
+        self,
+        *,
+        session: Session,
+        strategy: Strategy,
+        symbol: str,
+        session_open: datetime,
+        exit_due_at: datetime,
+    ) -> bool:
+        rows = (
+            session.execute(
+                select(TradeDecision)
+                .where(
+                    TradeDecision.strategy_id == strategy.id,
+                    TradeDecision.alpaca_account_label == self.account_label,
+                    TradeDecision.symbol == symbol,
+                    TradeDecision.created_at >= session_open,
+                )
+                .order_by(TradeDecision.created_at.desc())
+            )
+            .scalars()
+            .all()
+        )
+        exit_due_at_text = exit_due_at.isoformat()
+        for row in rows:
+            decision = self._trade_decision_from_retry_row(row)
+            if decision is None or decision.action != "sell":
+                continue
+            metadata = self._paper_route_probe_exit_metadata(decision)
+            if metadata is None:
+                continue
+            if str(metadata.get("exit_due_at") or "") != exit_due_at_text:
+                continue
+            if row.status in {"planned", "submitted", "filled", "rejected"}:
+                return True
+        return False
+
+    @staticmethod
+    def _prepare_paper_route_probe_exit_position(
+        positions: list[dict[str, Any]],
+        decision: StrategyDecision,
+    ) -> StrategyDecision | None:
+        if SimpleTradingPipeline._paper_route_probe_exit_metadata(decision) is None:
+            return decision
+        current_qty = position_qty_for_symbol(positions, decision.symbol)
+        params = dict(decision.params)
+        metadata = dict(cast(Mapping[str, Any], params["paper_route_probe_exit"]))
+        simple_lane = dict(cast(Mapping[str, Any], params.get("simple_lane") or {}))
+        quantity_resolution = dict(
+            cast(Mapping[str, Any], simple_lane.get("quantity_resolution") or {})
+        )
+        if current_qty <= 0:
+            return None
+        if current_qty < decision.qty:
+            decision = decision.model_copy(update={"qty": current_qty})
+            metadata["qty_capped_to_position"] = True
+        metadata["broker_position_qty"] = str(current_qty)
+
+        quantity_resolution["position_qty"] = str(decision.qty)
+        simple_lane["final_qty"] = str(decision.qty)
+        simple_lane["quantity_resolution"] = quantity_resolution
+        price = _optional_decimal(params.get("price"))
+        if price is not None and price > 0:
+            simple_lane["notional"] = str(decision.qty * price)
+        params["paper_route_probe_exit"] = metadata
+        params["simple_lane"] = simple_lane
+        return decision.model_copy(update={"params": params})
+
     def _process_paper_route_probe_retry_decisions(
         self,
         *,
@@ -550,6 +816,52 @@ class SimpleTradingPipeline(TradingPipeline):
                     decision.strategy_id,
                     decision.symbol,
                     decision.timeframe,
+                )
+                self.state.metrics.orders_rejected_total += 1
+                self.state.metrics.record_decision_rejection_reasons(
+                    ["broker_submit_failed"]
+                )
+
+    def _process_paper_route_probe_exit_decisions(
+        self,
+        *,
+        session: Session,
+        strategies: list[Strategy],
+        account: dict[str, str],
+        positions: list[dict[str, Any]],
+        allowed_symbols: set[str],
+    ) -> None:
+        decisions = self._paper_route_probe_exit_decisions(session=session)
+        for decision in decisions:
+            prepared_decision = self._prepare_paper_route_probe_exit_position(
+                positions,
+                decision,
+            )
+            if prepared_decision is None:
+                continue
+            self.state.metrics.decisions_total += 1
+            try:
+                submitted = self._handle_decision(
+                    session,
+                    prepared_decision,
+                    strategies,
+                    account,
+                    positions,
+                    allowed_symbols,
+                )
+                if submitted is not None:
+                    self._apply_simple_projected_buying_power(
+                        account,
+                        positions,
+                        submitted,
+                    )
+                    self._apply_simple_projected_position(positions, submitted)
+            except Exception:
+                logger.exception(
+                    "Paper route probe exit handling failed strategy_id=%s symbol=%s timeframe=%s",
+                    prepared_decision.strategy_id,
+                    prepared_decision.symbol,
+                    prepared_decision.timeframe,
                 )
                 self.state.metrics.orders_rejected_total += 1
                 self.state.metrics.record_decision_rejection_reasons(
@@ -1325,22 +1637,30 @@ class SimpleTradingPipeline(TradingPipeline):
         )
         paper_route_probe_applied = False
         if proof_floor_block_reason is not None:
-            strategy = self._paper_route_probe_strategy(
-                session=session,
-                decision=decision,
-            )
-            probe_context = self._paper_route_probe_context(
-                proof_floor=proof_floor,
-                decision=decision,
-                strategy=strategy,
-            )
-            if probe_context is None or not self._apply_paper_route_probe_cap(
-                session=session,
-                decision=decision,
-                decision_row=decision_row,
-                proof_floor=proof_floor,
-                context=probe_context,
+            if (
+                settings.trading_mode == "paper"
+                and self._paper_route_probe_exit_metadata(decision) is not None
             ):
+                paper_route_probe_applied = True
+            else:
+                strategy = self._paper_route_probe_strategy(
+                    session=session,
+                    decision=decision,
+                )
+                probe_context = self._paper_route_probe_context(
+                    proof_floor=proof_floor,
+                    decision=decision,
+                    strategy=strategy,
+                )
+                if probe_context is not None and self._apply_paper_route_probe_cap(
+                    session=session,
+                    decision=decision,
+                    decision_row=decision_row,
+                    proof_floor=proof_floor,
+                    context=probe_context,
+                ):
+                    paper_route_probe_applied = True
+            if not paper_route_probe_applied:
                 self._block_decision_submission(
                     session=session,
                     decision=decision,
@@ -1353,7 +1673,6 @@ class SimpleTradingPipeline(TradingPipeline):
                     extra_metadata={"profitability_proof_floor": dict(proof_floor)},
                 )
                 return False
-            paper_route_probe_applied = True
         proof_floor_symbol_block_reason = (
             self._proof_floor_symbol_block_reason(
                 proof_floor,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -3718,6 +3718,87 @@ class TestTradingPipeline(TestCase):
             payload = cast(dict[str, Any], decisions[0].decision_json)
             self.assertEqual(payload.get("action"), "buy")
 
+    def test_simple_pipeline_paper_route_exit_helpers_cover_filter_edges(
+        self,
+    ) -> None:
+        from app import config
+
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+
+        decision = StrategyDecision(
+            strategy_id=str(uuid4()),
+            symbol="AAPL",
+            event_ts=datetime(2026, 3, 26, 14, 0, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="sell",
+            qty=Decimal("2"),
+            rationale="paper-route-exit-edge",
+            params={
+                "price": Decimal("100"),
+                "paper_route_probe_exit": {"mode": "not-paper-route-exit"},
+            },
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_probe_exit_metadata(decision)
+        )
+
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: False  # type: ignore[method-assign]
+        with (
+            patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=datetime(2026, 3, 26, 14, 0, tzinfo=timezone.utc),
+            ),
+            self.session_local() as session,
+        ):
+            self.assertEqual(
+                pipeline._paper_route_probe_exit_decisions(session=session), []
+            )
+
+        non_exit_decision = decision.model_copy(
+            update={"params": {"price": Decimal("100")}}
+        )
+        self.assertIs(
+            SimpleTradingPipeline._prepare_paper_route_probe_exit_position(
+                [{"symbol": "AAPL", "qty": "1", "side": "long"}],
+                non_exit_decision,
+            ),
+            non_exit_decision,
+        )
+
+        exit_decision = decision.model_copy(
+            update={
+                "params": {
+                    "price": Decimal("100"),
+                    "paper_route_probe_exit": {"mode": "paper_route_exit"},
+                    "simple_lane": {"quantity_resolution": {}},
+                }
+            }
+        )
+        prepared = SimpleTradingPipeline._prepare_paper_route_probe_exit_position(
+            [{"symbol": "AAPL", "qty": "1", "side": "long"}],
+            exit_decision,
+        )
+        assert prepared is not None
+        self.assertEqual(prepared.qty, Decimal("1"))
+        metadata = cast(dict[str, Any], prepared.params["paper_route_probe_exit"])
+        self.assertEqual(metadata["qty_capped_to_position"], True)
+        self.assertEqual(metadata["broker_position_qty"], "1")
+
     def test_simple_pipeline_proof_floor_includes_paper_route_probe_settings(
         self,
     ) -> None:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -826,6 +826,151 @@ class TestTradingPipeline(TestCase):
         for name, value in self._settings_snapshot.items():
             setattr(config.settings, name, value)
 
+    def _seed_filled_paper_route_probe_entry(
+        self,
+        *,
+        symbol: str = "AAPL",
+        qty: Decimal = Decimal("2"),
+        avg_fill_price: Decimal = Decimal("100"),
+        entry_ts: datetime = datetime(2026, 3, 26, 14, 0, tzinfo=timezone.utc),
+        exit_minute_after_open: str = "120",
+    ) -> None:
+        with self.session_local() as session:
+            strategy = Strategy(
+                name=f"paper-route-exit-{symbol.lower()}",
+                description=(
+                    "paper route exit fixture\n[catalog_metadata]\n"
+                    + json.dumps(
+                        {
+                            "params": {
+                                "entry_minute_after_open": "30",
+                                "exit_minute_after_open": exit_minute_after_open,
+                            }
+                        }
+                    )
+                ),
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=[symbol],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol=symbol,
+                event_ts=entry_ts,
+                timeframe="1Min",
+                action="buy",
+                qty=qty,
+                rationale="paper-route-entry",
+                params={
+                    "price": avg_fill_price,
+                    "exit_minute_after_open": exit_minute_after_open,
+                    "paper_route_probe": {
+                        "mode": "paper_route_acquisition",
+                        "source": "test",
+                        "symbol": symbol,
+                    },
+                },
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "paper",
+            )
+            decision_row.status = "submitted"
+            session.add(decision_row)
+            session.commit()
+            session.refresh(decision_row)
+            session.add(
+                Execution(
+                    trade_decision_id=decision_row.id,
+                    alpaca_account_label="paper",
+                    alpaca_order_id=f"filled-entry-{symbol.lower()}",
+                    client_order_id=decision_row.decision_hash,
+                    symbol=symbol,
+                    side="buy",
+                    order_type="market",
+                    time_in_force="day",
+                    submitted_qty=qty,
+                    filled_qty=qty,
+                    avg_fill_price=avg_fill_price,
+                    status="filled",
+                    raw_order={},
+                    created_at=entry_ts + timedelta(seconds=1),
+                )
+            )
+            session.commit()
+
+    def _run_simple_paper_pipeline(
+        self,
+        *,
+        alpaca_client: FakeAlpacaClient,
+        now: datetime,
+        proof_floor: Mapping[str, object] | None = None,
+    ) -> FakeIngestor:
+        from app import config
+
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_pipeline_mode = "simple"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_max_notional = 25.0
+        config.settings.trading_paper_route_target_plan_url = ""
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+        config.settings.trading_universe_static_fallback_enabled = True
+        config.settings.trading_universe_static_fallback_symbols_raw = "AAPL"
+
+        floor = proof_floor or {
+            "route_state": "repair_only",
+            "capital_state": "paper",
+            "max_notional": "25",
+            "market_window": {"session_open": True},
+            "blocking_reasons": ["execution_tca_route_universe_empty"],
+            "route_reacquisition_book": {
+                "summary": {"paper_route_probe_eligible_symbols": ["AAPL"]}
+            },
+        }
+        ingestor = FakeIngestor([])
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=ingestor,
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+        with (
+            patch.object(
+                SimpleTradingPipeline,
+                "_profitability_proof_floor",
+                return_value=floor,
+            ),
+            patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=now,
+            ),
+        ):
+            pipeline.run_once()
+        return ingestor
+
     def test_ensure_signal_executable_price_backfills_missing_quote_from_snapshot(
         self,
     ) -> None:
@@ -2968,9 +3113,7 @@ class TestTradingPipeline(TestCase):
             SimpleTradingPipeline._paper_route_probe_exit_minute_value("bad")
         )
         self.assertEqual(
-            SimpleTradingPipeline._paper_route_probe_exit_minute_value(
-                Decimal("42.8")
-            ),
+            SimpleTradingPipeline._paper_route_probe_exit_minute_value(Decimal("42.8")),
             42,
         )
         self.assertIsNone(
@@ -3465,6 +3608,115 @@ class TestTradingPipeline(TestCase):
                 "alpha_readiness_not_promotion_eligible",
             )
             self.assertEqual(refreshed_json.get("paper_route_probe_retry_attempts"), 1)
+
+    def test_simple_pipeline_closes_filled_paper_route_probe_after_exit_minute(
+        self,
+    ) -> None:
+        self._seed_filled_paper_route_probe_entry()
+        alpaca_client = PositionedAlpacaClient(
+            [{"symbol": "AAPL", "qty": "2", "side": "long"}]
+        )
+
+        self._run_simple_paper_pipeline(
+            alpaca_client=alpaca_client,
+            now=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        self.assertEqual(alpaca_client.submitted[0]["side"], "sell")
+        self.assertEqual(alpaca_client.submitted[0]["qty"], "2.0")
+        with self.session_local() as session:
+            decisions = (
+                session.execute(
+                    select(TradeDecision).order_by(TradeDecision.created_at.asc())
+                )
+                .scalars()
+                .all()
+            )
+            self.assertEqual(len(decisions), 2)
+            exit_row = decisions[-1]
+            exit_payload = cast(dict[str, Any], exit_row.decision_json)
+            params = cast(dict[str, Any], exit_payload.get("params"))
+            exit_metadata = cast(
+                dict[str, Any],
+                params.get("paper_route_probe_exit"),
+            )
+
+            self.assertEqual(exit_row.status, "submitted")
+            self.assertEqual(exit_payload.get("action"), "sell")
+            self.assertEqual(exit_metadata.get("mode"), "paper_route_exit")
+            self.assertEqual(exit_metadata.get("db_open_qty"), "2.00000000")
+            self.assertEqual(exit_metadata.get("broker_position_qty"), "2")
+            self.assertEqual(
+                exit_metadata.get("exit_due_at"),
+                "2026-03-26T15:30:00+00:00",
+            )
+
+    def test_simple_pipeline_does_not_close_paper_route_probe_before_exit_minute(
+        self,
+    ) -> None:
+        self._seed_filled_paper_route_probe_entry()
+        alpaca_client = PositionedAlpacaClient(
+            [{"symbol": "AAPL", "qty": "2", "side": "long"}]
+        )
+
+        self._run_simple_paper_pipeline(
+            alpaca_client=alpaca_client,
+            now=datetime(2026, 3, 26, 15, 29, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(alpaca_client.submitted, [])
+        with self.session_local() as session:
+            self.assertEqual(session.query(TradeDecision).count(), 1)
+
+    def test_simple_pipeline_does_not_duplicate_paper_route_probe_exit(
+        self,
+    ) -> None:
+        self._seed_filled_paper_route_probe_entry()
+        alpaca_client = PositionedAlpacaClient(
+            [{"symbol": "AAPL", "qty": "2", "side": "long"}]
+        )
+        now = datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc)
+
+        self._run_simple_paper_pipeline(alpaca_client=alpaca_client, now=now)
+        self._run_simple_paper_pipeline(alpaca_client=alpaca_client, now=now)
+
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        with self.session_local() as session:
+            sell_count = (
+                session.execute(
+                    select(TradeDecision).where(TradeDecision.symbol == "AAPL")
+                )
+                .scalars()
+                .all()
+            )
+            self.assertEqual(
+                sum(
+                    1
+                    for decision_row in sell_count
+                    if cast(dict[str, Any], decision_row.decision_json).get("action")
+                    == "sell"
+                ),
+                1,
+            )
+
+    def test_simple_pipeline_does_not_exit_without_broker_inventory(
+        self,
+    ) -> None:
+        self._seed_filled_paper_route_probe_entry()
+        alpaca_client = PositionedAlpacaClient([])
+
+        self._run_simple_paper_pipeline(
+            alpaca_client=alpaca_client,
+            now=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(alpaca_client.submitted, [])
+        with self.session_local() as session:
+            decisions = session.execute(select(TradeDecision)).scalars().all()
+            self.assertEqual(len(decisions), 1)
+            payload = cast(dict[str, Any], decisions[0].decision_json)
+            self.assertEqual(payload.get("action"), "buy")
 
     def test_simple_pipeline_proof_floor_includes_paper_route_probe_settings(
         self,


### PR DESCRIPTION
## Summary

- Adds a paper-only closeout sweep for filled paper-route probe executions after the strategy exit minute.
- Generates reducing sell decisions only when broker inventory exists, so paper-probation entries can become closed runtime-ledger trips without synthetic inventory.
- Lets `paper_route_probe_exit` sells pass the repair-only proof-floor block while keeping live submission gates and acquisition caps intact.
- Adds regression coverage for due closeout, pre-exit no-op, duplicate suppression, and missing-inventory no-op.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'filled_paper_route_probe or duplicate_paper_route_probe_exit or before_exit_minute or without_broker_inventory'`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_route_exit_helpers_cover_filter_edges or closes_filled_paper_route_probe_after_exit_minute or does_not_duplicate_paper_route_probe_exit or does_not_exit_without_broker_inventory' -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `git diff --check HEAD~1..HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
