### PR TITLE
fix(torghut): persist runtime ledger execution metadata

### DIFF
--- a/services/torghut/app/snapshots.py
+++ b/services/torghut/app/snapshots.py
@@ -14,10 +14,36 @@ from sqlalchemy.orm import Session
 
 from .alpaca_client import TorghutAlpacaClient
 from .models import Execution, PositionSnapshot, coerce_json_payload
-from .trading.route_metadata import coerce_route_text, coerce_route_int, normalize_route_provenance
+from .trading.route_metadata import (
+    coerce_route_text,
+    coerce_route_int,
+    normalize_route_provenance,
+)
 from .trading.simulation import resolve_simulation_context
 
 logger = logging.getLogger(__name__)
+
+_RUNTIME_COST_AMOUNT_FIELDS = (
+    "cost_amount",
+    "explicit_cost",
+    "commission",
+    "fees",
+    "fee_amount",
+    "broker_fee",
+)
+_RUNTIME_COST_BASIS_FIELDS = (
+    "cost_basis",
+    "cost_source",
+    "fee_basis",
+    "commission_basis",
+    "broker_fee_basis",
+)
+_BROKER_COST_BASIS_BY_FIELD = {
+    "commission": "broker_reported_commission",
+    "fees": "broker_reported_fees",
+    "fee_amount": "broker_reported_fees",
+    "broker_fee": "broker_reported_fees",
+}
 
 
 def snapshot_account_and_positions(
@@ -96,7 +122,9 @@ def sync_order_to_db(
         resolved_fallback_count=resolved_fallback_count,
     )
     if existing is not None:
-        return _persist_existing_execution(session=session, existing=existing, data=data)
+        return _persist_existing_execution(
+            session=session, existing=existing, data=data
+        )
 
     execution = Execution(**data)
     session.add(execution)
@@ -115,7 +143,9 @@ def sync_order_to_db(
         )
         if existing is None:
             raise
-        return _persist_existing_execution(session=session, existing=existing, data=data)
+        return _persist_existing_execution(
+            session=session, existing=existing, data=data
+        )
 
 
 def _resolve_execution_route_metadata(
@@ -240,6 +270,11 @@ def _build_execution_payload(
     if simulation_context is not None:
         audit_payload["simulation_context"] = simulation_context
         raw_order_payload["simulation_context"] = simulation_context
+    _attach_runtime_ledger_cost_payload(
+        order_response=order_response,
+        audit_payload=audit_payload,
+        raw_order_payload=raw_order_payload,
+    )
 
     return {
         "trade_decision_id": trade_decision_id,
@@ -276,6 +311,7 @@ def _persist_existing_execution(
     existing: Execution,
     data: dict[str, Any],
 ) -> Execution:
+    data = _preserve_existing_execution_audit(existing=existing, data=data)
     for key, value in data.items():
         setattr(existing, key, value)
     session.add(existing)
@@ -284,11 +320,89 @@ def _persist_existing_execution(
     return existing
 
 
+def _attach_runtime_ledger_cost_payload(
+    *,
+    order_response: Mapping[str, Any],
+    audit_payload: dict[str, Any],
+    raw_order_payload: dict[str, Any],
+) -> None:
+    cost_payload = _runtime_ledger_cost_payload_from_order(order_response)
+    if cost_payload is None:
+        return
+
+    audit_payload.setdefault("runtime_ledger_cost", cost_payload)
+    raw_order_payload.setdefault("runtime_ledger_cost", cost_payload)
+    audit_payload.setdefault("cost_amount", cost_payload["cost_amount"])
+    audit_payload.setdefault("cost_basis", cost_payload["cost_basis"])
+    raw_order_payload.setdefault("cost_amount", cost_payload["cost_amount"])
+    raw_order_payload.setdefault("cost_basis", cost_payload["cost_basis"])
+
+    fee_model = {
+        "source": "broker_order_response",
+        "source_field": cost_payload["source_field"],
+        "cost_basis": cost_payload["cost_basis"],
+    }
+    audit_payload.setdefault("fee_model", fee_model)
+    raw_order_payload.setdefault("fee_model", fee_model)
+
+
+def _runtime_ledger_cost_payload_from_order(
+    order_response: Mapping[str, Any],
+) -> dict[str, str] | None:
+    basis = _first_text(order_response, *_RUNTIME_COST_BASIS_FIELDS)
+    for amount_key in _RUNTIME_COST_AMOUNT_FIELDS:
+        amount = _optional_decimal(order_response.get(amount_key))
+        if amount is None or amount < 0:
+            continue
+        resolved_basis = basis or _BROKER_COST_BASIS_BY_FIELD.get(amount_key)
+        if resolved_basis is None:
+            continue
+        return {
+            "cost_amount": str(amount),
+            "cost_basis": resolved_basis,
+            "source_field": amount_key,
+        }
+    return None
+
+
+def _preserve_existing_execution_audit(
+    *,
+    existing: Execution,
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    existing_audit = existing.execution_audit_json
+    incoming_audit = data.get("execution_audit_json")
+    if not isinstance(existing_audit, Mapping):
+        return data
+    merged = {
+        str(key): value
+        for key, value in cast(Mapping[object, Any], existing_audit).items()
+    }
+    if isinstance(incoming_audit, Mapping):
+        merged.update(
+            {
+                str(key): value
+                for key, value in cast(Mapping[object, Any], incoming_audit).items()
+            }
+        )
+    updated = dict(data)
+    updated["execution_audit_json"] = coerce_json_payload(merged)
+    return updated
+
+
 def _coerce_text(value: Any) -> Optional[str]:
     if value is None:
         return None
     if isinstance(value, str):
         return value.strip() or None
+    return None
+
+
+def _first_text(payload: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        text = _coerce_text(payload.get(key))
+        if text is not None:
+            return text
     return None
 
 

--- a/services/torghut/app/trading/execution.py
+++ b/services/torghut/app/trading/execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import time
@@ -33,13 +34,68 @@ from .quantity_rules import (
     qty_step_for_symbol,
     resolve_quantity_resolution,
 )
-from .simulation import resolve_event_persisted_at, resolve_simulation_context, simulation_context_enabled
+from .simulation import (
+    resolve_event_persisted_at,
+    resolve_simulation_context,
+    simulation_context_enabled,
+)
 from .time_source import trading_now
 from .tca import upsert_execution_tca_metric
 
 logger = logging.getLogger(__name__)
 
 _SHORTING_METADATA_CACHE_TTL_SECONDS = 30.0
+_EXECUTION_POLICY_HASH_KEYS = (
+    "execution_policy_hash",
+    "execution_policy_sha256",
+    "policy_hash",
+)
+_COST_MODEL_HASH_KEYS = (
+    "cost_model_hash",
+    "cost_model_sha256",
+    "fee_model_hash",
+)
+_COST_MODEL_PAYLOAD_KEYS = (
+    "cost_model",
+    "cost_model_config",
+    "transaction_cost_model",
+    "fee_model",
+    "fees_model",
+    "market_impact_cost_model",
+    "proportional_cost_model",
+)
+_LINEAGE_HASH_KEYS = (
+    "lineage_hash",
+    "candidate_lineage_hash",
+    "replay_lineage_hash",
+)
+_LINEAGE_PAYLOAD_KEYS = (
+    "lineage",
+    "candidate_lineage",
+    "source_lineage",
+    "runtime_lineage",
+    "replay_lineage",
+)
+_RUNTIME_COST_PAYLOAD_KEYS = (
+    "runtime_ledger_cost",
+    "execution_cost",
+    "explicit_execution_cost",
+)
+_RUNTIME_COST_AMOUNT_KEYS = (
+    "cost_amount",
+    "explicit_cost",
+    "commission",
+    "fees",
+    "fee_amount",
+    "broker_fee",
+)
+_RUNTIME_COST_BASIS_KEYS = (
+    "cost_basis",
+    "cost_source",
+    "fee_basis",
+    "commission_basis",
+    "broker_fee_basis",
+)
 
 
 class OrderExecutor:
@@ -282,6 +338,7 @@ class OrderExecutor:
         execution_metadata = _extract_execution_metadata(
             decision,
             decision_row=decision_row,
+            execution_policy_context=execution_policy_context,
         )
         if execution_metadata is not None:
             existing_audit = order_payload.get("_execution_audit")
@@ -353,6 +410,7 @@ class OrderExecutor:
         execution_metadata = _extract_execution_metadata(
             decision,
             decision_row=decision_row,
+            execution_policy_context=execution_policy_context,
         )
         if execution_metadata is not None:
             existing_audit = existing_payload.get("_execution_audit")
@@ -412,7 +470,9 @@ class OrderExecutor:
                 or conflicting_order.get("order_type")
                 or "unknown"
             ).lower()
-            existing_order_side = str(conflicting_order.get("side") or "unknown").lower()
+            existing_order_side = str(
+                conflicting_order.get("side") or "unknown"
+            ).lower()
             payload = {
                 "source": "broker_precheck",
                 "code": "precheck_opposite_side_open_order",
@@ -661,9 +721,7 @@ class OrderExecutor:
                 continue
             held_for_open_sells += remaining_qty
             existing_order_id = (
-                order.get("id")
-                or order.get("order_id")
-                or order.get("client_order_id")
+                order.get("id") or order.get("order_id") or order.get("client_order_id")
             )
             if existing_order_id is not None:
                 existing_order_ids.append(str(existing_order_id))
@@ -687,7 +745,9 @@ class OrderExecutor:
                 "position_qty": None,
                 "held_for_open_sells": str(held_for_open_sells),
                 "available_qty": None,
-                "existing_order_id": existing_order_ids[0] if existing_order_ids else None,
+                "existing_order_id": existing_order_ids[0]
+                if existing_order_ids
+                else None,
                 "existing_order_ids": existing_order_ids,
             }
         if position_qty <= 0:
@@ -1183,6 +1243,84 @@ def _coerce_json(value: Any) -> dict[str, Any]:
     return {}
 
 
+def _copy_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        str(key): coerce_json_payload(item)
+        for key, item in cast(Mapping[object, Any], value).items()
+    }
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return str(value)
+    return str(value)
+
+
+def _stable_payload_hash(value: Mapping[str, Any] | None) -> str | None:
+    if not isinstance(value, Mapping) or not value:
+        return None
+    encoded = json.dumps(
+        _copy_mapping(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_json_default,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _first_param_value(
+    params_candidates: Sequence[Mapping[str, Any]],
+    *keys: str,
+) -> Any | None:
+    for params in params_candidates:
+        for key in keys:
+            if key in params and params.get(key) is not None:
+                return params.get(key)
+    return None
+
+
+def _first_param_text(
+    params_candidates: Sequence[Mapping[str, Any]],
+    *keys: str,
+) -> str | None:
+    for params in params_candidates:
+        for key in keys:
+            value = params.get(key)
+            text = str(value or "").strip()
+            if text:
+                return text
+    return None
+
+
+def _first_param_mapping(
+    params_candidates: Sequence[Mapping[str, Any]],
+    *keys: str,
+) -> dict[str, Any] | None:
+    for params in params_candidates:
+        for key in keys:
+            value = params.get(key)
+            if isinstance(value, Mapping):
+                return _copy_mapping(cast(Mapping[str, Any], value))
+    return None
+
+
+def _first_mapping_value(payload: Mapping[str, Any], *keys: str) -> Any | None:
+    for key in keys:
+        if key in payload and payload.get(key) is not None:
+            return payload.get(key)
+    return None
+
+
+def _first_mapping_text(payload: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        text = str(payload.get(key) or "").strip()
+        if text:
+            return text
+    return None
+
+
 def _coerce_string_list(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
@@ -1209,8 +1347,12 @@ def _merge_decision_metadata(
         return
     for key, value in metadata_update.items():
         if key == "control_plane_snapshot" and isinstance(value, Mapping):
-            existing_snapshot = _coerce_json(decision_json.get("control_plane_snapshot"))
-            for snapshot_key, snapshot_value in cast(Mapping[object, Any], value).items():
+            existing_snapshot = _coerce_json(
+                decision_json.get("control_plane_snapshot")
+            )
+            for snapshot_key, snapshot_value in cast(
+                Mapping[object, Any], value
+            ).items():
                 existing_snapshot[str(snapshot_key)] = coerce_json_payload(
                     snapshot_value
                 )
@@ -1236,30 +1378,51 @@ def _normalize_reject_reason(reason: str) -> _NormalizedRejectReason:
     if normalized == "llm_error" or normalized.startswith("llm_error"):
         return _NormalizedRejectReason("llm_error", "runtime", "llm_review")
     if normalized == "market_context_block" or normalized.startswith("market_context_"):
-        return _NormalizedRejectReason("market_context_block", "market_context", "market_context")
+        return _NormalizedRejectReason(
+            "market_context_block", "market_context", "market_context"
+        )
     if normalized == "symbol_capacity_exhausted":
-        return _NormalizedRejectReason("symbol_capacity_exhausted", "capacity", "portfolio_sizing")
+        return _NormalizedRejectReason(
+            "symbol_capacity_exhausted", "capacity", "portfolio_sizing"
+        )
     if normalized == "qty_below_min":
         return _NormalizedRejectReason("qty_below_min", "capacity", "portfolio_sizing")
     if normalized == "max_position_pct_exceeded":
-        return _NormalizedRejectReason("max_position_pct_exceeded", "policy", "risk_engine")
+        return _NormalizedRejectReason(
+            "max_position_pct_exceeded", "policy", "risk_engine"
+        )
     if normalized.startswith("runtime_uncertainty_gate_"):
         return _NormalizedRejectReason(normalized, "policy", "runtime_uncertainty_gate")
     if "code=precheck_sell_qty_exceeds_available" in normalized:
-        return _NormalizedRejectReason("sell_inventory_unavailable", "broker_precheck", "broker_precheck")
-    if "code=shorting_metadata_unavailable" in normalized or "code=local_account_metadata_unavailable" in normalized:
-        return _NormalizedRejectReason("shorting_metadata_unavailable", "broker_precheck", "local_pre_submit")
+        return _NormalizedRejectReason(
+            "sell_inventory_unavailable", "broker_precheck", "broker_precheck"
+        )
+    if (
+        "code=shorting_metadata_unavailable" in normalized
+        or "code=local_account_metadata_unavailable" in normalized
+    ):
+        return _NormalizedRejectReason(
+            "shorting_metadata_unavailable", "broker_precheck", "local_pre_submit"
+        )
     if normalized.startswith("local_pre_submit_rejected"):
-        return _NormalizedRejectReason("broker_precheck_rejected", "broker_precheck", "local_pre_submit")
+        return _NormalizedRejectReason(
+            "broker_precheck_rejected", "broker_precheck", "local_pre_submit"
+        )
     if normalized.startswith("broker_precheck_rejected"):
-        return _NormalizedRejectReason("broker_precheck_rejected", "broker_precheck", "broker_precheck")
+        return _NormalizedRejectReason(
+            "broker_precheck_rejected", "broker_precheck", "broker_precheck"
+        )
     if normalized.startswith("llm_"):
         return _NormalizedRejectReason(normalized, "policy", "llm_review")
     return _NormalizedRejectReason(normalized, "runtime", "scheduler")
 
 
 def _normalize_reject_reasons(reason: str) -> list[_NormalizedRejectReason]:
-    return [_normalize_reject_reason(part.strip()) for part in reason.split(";") if part.strip()]
+    return [
+        _normalize_reject_reason(part.strip())
+        for part in reason.split(";")
+        if part.strip()
+    ]
 
 
 def _normalize_submission_block_reasons(reason: str) -> list[str]:
@@ -1301,8 +1464,12 @@ def _decision_state_payload(decision: StrategyDecision) -> dict[str, Any]:
         "qty": str(decision.qty),
         "order_type": decision.order_type,
         "time_in_force": decision.time_in_force,
-        "limit_price": str(decision.limit_price) if decision.limit_price is not None else None,
-        "stop_price": str(decision.stop_price) if decision.stop_price is not None else None,
+        "limit_price": str(decision.limit_price)
+        if decision.limit_price is not None
+        else None,
+        "stop_price": str(decision.stop_price)
+        if decision.stop_price is not None
+        else None,
     }
 
 
@@ -1415,18 +1582,22 @@ def _extract_execution_policy_context(
     ):
         return {}
     context: dict[str, Any] = {
-        'selected_order_type': str(
-            policy_map.get('selected_order_type') or decision.order_type
+        "selected_order_type": str(
+            policy_map.get("selected_order_type") or decision.order_type
         ),
-        'adaptive': adaptive_payload,
+        "adaptive": adaptive_payload,
     }
     if isinstance(execution_advisor, Mapping):
         context["execution_advisor"] = {
-            str(key): value for key, value in cast(Mapping[str, Any], execution_advisor).items()
+            str(key): value
+            for key, value in cast(Mapping[str, Any], execution_advisor).items()
         }
     elif isinstance(decision_params.get("execution_advisor"), Mapping):
         context["execution_advisor"] = {
-            str(key): value for key, value in cast(Mapping[str, Any], decision_params.get("execution_advisor")).items()
+            str(key): value
+            for key, value in cast(
+                Mapping[str, Any], decision_params.get("execution_advisor")
+            ).items()
         }
 
     if isinstance(execution_microstructure, Mapping):
@@ -1484,7 +1655,7 @@ def _resolve_submission_simulation_context(
 
 
 def _simulation_queue_context_from_execution_policy(
-    execution_policy_context: Mapping[str, Any] | None
+    execution_policy_context: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     if not isinstance(execution_policy_context, Mapping):
         return {}
@@ -1560,11 +1731,13 @@ def _nonnegative_decimal(value: Any) -> Decimal | None:
     return parsed
 
 
-def _attach_execution_policy_context(execution: Execution, context: dict[str, Any]) -> None:
+def _attach_execution_policy_context(
+    execution: Execution, context: dict[str, Any]
+) -> None:
     if not context:
         return
     raw_order = _coerce_json(execution.raw_order)
-    raw_order['execution_policy'] = context
+    raw_order["execution_policy"] = context
     execution.raw_order = raw_order
 
 
@@ -1598,6 +1771,7 @@ def _extract_execution_metadata(
     decision: StrategyDecision,
     *,
     decision_row: Optional[TradeDecision] = None,
+    execution_policy_context: Mapping[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     persisted_params: Mapping[str, Any] = {}
     if decision_row is not None:
@@ -1606,6 +1780,7 @@ def _extract_execution_metadata(
         if isinstance(params_value, Mapping):
             persisted_params = cast(Mapping[str, Any], params_value)
 
+    params_candidates = (persisted_params, decision.params)
     execution_lane = persisted_params.get("execution_lane") or decision.params.get(
         "execution_lane"
     )
@@ -1617,6 +1792,63 @@ def _extract_execution_metadata(
         metadata["execution_lane"] = str(execution_lane)
     if submit_path is not None:
         metadata["submit_path"] = str(submit_path)
+
+    if execution_policy_context:
+        policy_context = _copy_mapping(execution_policy_context)
+        metadata["execution_policy"] = policy_context
+        execution_policy_hash = _first_param_text(
+            params_candidates, *_EXECUTION_POLICY_HASH_KEYS
+        ) or _stable_payload_hash(policy_context)
+    else:
+        execution_policy_hash = _first_param_text(
+            params_candidates, *_EXECUTION_POLICY_HASH_KEYS
+        )
+    if execution_policy_hash is not None:
+        metadata["execution_policy_hash"] = execution_policy_hash
+
+    cost_model_payload = _first_param_mapping(
+        params_candidates, *_COST_MODEL_PAYLOAD_KEYS
+    )
+    cost_model_hash = _first_param_text(params_candidates, *_COST_MODEL_HASH_KEYS)
+    if cost_model_payload is not None:
+        metadata["cost_model"] = cost_model_payload
+        cost_model_hash = cost_model_hash or _stable_payload_hash(cost_model_payload)
+    if cost_model_hash is not None:
+        metadata["cost_model_hash"] = cost_model_hash
+
+    lineage_payload = _first_param_mapping(params_candidates, *_LINEAGE_PAYLOAD_KEYS)
+    lineage_hash = _first_param_text(params_candidates, *_LINEAGE_HASH_KEYS)
+    if lineage_payload is not None:
+        metadata["lineage"] = lineage_payload
+        lineage_hash = lineage_hash or _stable_payload_hash(lineage_payload)
+    if lineage_hash is not None:
+        metadata["lineage_hash"] = lineage_hash
+    candidate_evaluation_key = _first_param_text(
+        params_candidates, "candidate_evaluation_key"
+    )
+    if candidate_evaluation_key is not None:
+        metadata["candidate_evaluation_key"] = candidate_evaluation_key
+    replay_data_hash = _first_param_text(
+        params_candidates,
+        "replay_data_hash",
+        "replay_tape_content_sha256",
+        "dataset_snapshot_hash",
+        "source_query_digest",
+    )
+    if replay_data_hash is not None:
+        metadata["replay_data_hash"] = replay_data_hash
+
+    cost_payload = _first_param_mapping(params_candidates, *_RUNTIME_COST_PAYLOAD_KEYS)
+    if cost_payload is not None:
+        metadata["runtime_ledger_cost"] = cost_payload
+        cost_amount = _first_mapping_value(cost_payload, *_RUNTIME_COST_AMOUNT_KEYS)
+        cost_basis = _first_mapping_text(cost_payload, *_RUNTIME_COST_BASIS_KEYS)
+    else:
+        cost_amount = _first_param_value(params_candidates, *_RUNTIME_COST_AMOUNT_KEYS)
+        cost_basis = _first_param_text(params_candidates, *_RUNTIME_COST_BASIS_KEYS)
+    if cost_amount is not None and cost_basis is not None:
+        metadata["cost_amount"] = cost_amount
+        metadata["cost_basis"] = cost_basis
     return metadata or None
 
 
@@ -1642,10 +1874,14 @@ def _apply_execution_status(
             if isinstance(simulation_payload, Mapping)
             else None
         )
-        signal_event_ts = simulation_context.get("signal_event_ts") if simulation_context is not None else None
+        signal_event_ts = (
+            simulation_context.get("signal_event_ts")
+            if simulation_context is not None
+            else None
+        )
         if isinstance(signal_event_ts, str) and signal_event_ts.strip():
             normalized = (
-                f'{signal_event_ts[:-1]}+00:00'
+                f"{signal_event_ts[:-1]}+00:00"
                 if signal_event_ts.endswith("Z")
                 else signal_event_ts
             )
@@ -1668,27 +1904,26 @@ def _persist_lean_shadow_event(
     order_payload: Mapping[str, Any],
     decision: StrategyDecision,
 ) -> None:
-    raw_shadow = order_payload.get('_lean_shadow')
+    raw_shadow = order_payload.get("_lean_shadow")
     if not isinstance(raw_shadow, Mapping):
         return
     shadow = cast(Mapping[str, Any], raw_shadow)
 
-    parity_status = str(shadow.get('parity_status') or 'unknown').strip() or 'unknown'
+    parity_status = str(shadow.get("parity_status") or "unknown").strip() or "unknown"
     event = LeanExecutionShadowEvent(
-        correlation_id=str(order_payload.get('_execution_correlation_id') or '').strip() or None,
+        correlation_id=str(order_payload.get("_execution_correlation_id") or "").strip()
+        or None,
         trade_decision_id=execution.trade_decision_id,
         execution_id=execution.id,
         symbol=decision.symbol,
         side=decision.action,
         qty=decision.qty,
-        intent_notional=_optional_decimal(shadow.get('intent_notional')),
-        simulated_fill_price=_optional_decimal(shadow.get('simulated_fill_price')),
-        simulated_slippage_bps=_optional_decimal(shadow.get('simulated_slippage_bps')),
-        parity_delta_bps=_optional_decimal(shadow.get('parity_delta_bps')),
+        intent_notional=_optional_decimal(shadow.get("intent_notional")),
+        simulated_fill_price=_optional_decimal(shadow.get("simulated_fill_price")),
+        simulated_slippage_bps=_optional_decimal(shadow.get("simulated_slippage_bps")),
+        parity_delta_bps=_optional_decimal(shadow.get("parity_delta_bps")),
         parity_status=parity_status,
-        failure_taxonomy=(
-            str(shadow.get('failure_taxonomy') or '').strip() or None
-        ),
+        failure_taxonomy=(str(shadow.get("failure_taxonomy") or "").strip() or None),
         simulation_json=coerce_json_payload(dict(shadow)),
     )
     session.add(event)

--- a/services/torghut/tests/test_execution_runtime_metadata_coverage.py
+++ b/services/torghut/tests/test_execution_runtime_metadata_coverage.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest import TestCase
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from app.models import Base, Execution, LeanExecutionShadowEvent, TradeDecision
+from app.trading.execution import (
+    _apply_execution_status,
+    _extract_execution_metadata,
+    _json_default,
+    _normalize_reject_reason,
+    _persist_lean_shadow_event,
+    _stable_payload_hash,
+)
+from app.trading.models import StrategyDecision
+
+
+class TestExecutionRuntimeMetadataCoverage(TestCase):
+    def test_stable_payload_hash_handles_empty_and_non_json_scalars(self) -> None:
+        self.assertIsNone(_stable_payload_hash(None))
+        self.assertIsNone(_stable_payload_hash({}))
+        self.assertEqual(
+            _json_default(datetime(2026, 2, 10, 15, 30, tzinfo=timezone.utc)),
+            "2026-02-10T15:30:00+00:00",
+        )
+        self.assertEqual(_json_default(Decimal("0.125")), "0.125")
+        self.assertTrue(_json_default(object()).startswith("<object object at "))
+
+        payload_hash = _stable_payload_hash(
+            {
+                "event_ts": datetime(2026, 2, 10, 15, 30, tzinfo=timezone.utc),
+                "cost": Decimal("0.125"),
+            }
+        )
+
+        self.assertIsNotNone(payload_hash)
+        assert payload_hash is not None
+        self.assertEqual(len(payload_hash), 64)
+
+    def test_extract_execution_metadata_captures_direct_hashes_and_cost_fields(
+        self,
+    ) -> None:
+        decision = StrategyDecision(
+            strategy_id="strategy-1",
+            symbol="AAPL",
+            event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1.0"),
+            params={
+                "execution_policy_hash": "policy-sha",
+                "cost_model_hash": "cost-model-sha",
+                "lineage_hash": "lineage-sha",
+                "candidate_evaluation_key": "candidate-eval-1",
+                "source_query_digest": "dataset-sha",
+                "commission": "0.42",
+                "cost_basis": "broker_reported_commission",
+            },
+        )
+
+        metadata = _extract_execution_metadata(decision)
+
+        assert isinstance(metadata, dict)
+        self.assertEqual(metadata.get("execution_policy_hash"), "policy-sha")
+        self.assertEqual(metadata.get("cost_model_hash"), "cost-model-sha")
+        self.assertEqual(metadata.get("lineage_hash"), "lineage-sha")
+        self.assertEqual(metadata.get("candidate_evaluation_key"), "candidate-eval-1")
+        self.assertEqual(metadata.get("replay_data_hash"), "dataset-sha")
+        self.assertEqual(metadata.get("cost_amount"), "0.42")
+        self.assertEqual(metadata.get("cost_basis"), "broker_reported_commission")
+
+    def test_extract_execution_metadata_prefers_persisted_runtime_payload(self) -> None:
+        decision = StrategyDecision(
+            strategy_id="strategy-1",
+            symbol="AAPL",
+            event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1.0"),
+            params={
+                "execution_cost": {
+                    "fee_amount": "9.99",
+                    "fee_basis": "transient_wrong_basis",
+                },
+            },
+        )
+        decision_row = TradeDecision(
+            strategy_id=uuid.uuid4(),
+            alpaca_account_label="paper",
+            symbol="AAPL",
+            timeframe="1Min",
+            decision_json={
+                "params": {
+                    "execution_cost": {
+                        "fee_amount": "0.07",
+                        "fee_basis": "broker_reported_fees",
+                    },
+                }
+            },
+            rationale=None,
+            status="planned",
+            decision_hash="runtime-cost",
+        )
+
+        metadata = _extract_execution_metadata(decision, decision_row=decision_row)
+
+        assert isinstance(metadata, dict)
+        self.assertEqual(
+            metadata.get("runtime_ledger_cost"),
+            {"fee_amount": "0.07", "fee_basis": "broker_reported_fees"},
+        )
+        self.assertEqual(metadata.get("cost_amount"), "0.07")
+        self.assertEqual(metadata.get("cost_basis"), "broker_reported_fees")
+
+    def test_normalize_reject_reason_material_taxonomy_edges(self) -> None:
+        cases = {
+            "market_context_stale": (
+                "market_context_block",
+                "market_context",
+                "market_context",
+            ),
+            "symbol_capacity_exhausted": (
+                "symbol_capacity_exhausted",
+                "capacity",
+                "portfolio_sizing",
+            ),
+            "max_position_pct_exceeded": (
+                "max_position_pct_exceeded",
+                "policy",
+                "risk_engine",
+            ),
+            "local_pre_submit_rejected code=shorting_metadata_unavailable": (
+                "shorting_metadata_unavailable",
+                "broker_precheck",
+                "local_pre_submit",
+            ),
+            "broker_precheck_rejected code=precheck_sell_qty_exceeds_available": (
+                "sell_inventory_unavailable",
+                "broker_precheck",
+                "broker_precheck",
+            ),
+            "broker_precheck_rejected": (
+                "broker_precheck_rejected",
+                "broker_precheck",
+                "broker_precheck",
+            ),
+        }
+
+        for reason, expected in cases.items():
+            with self.subTest(reason=reason):
+                normalized = _normalize_reject_reason(reason)
+                self.assertEqual(
+                    (
+                        normalized.atomic_reason,
+                        normalized.reject_class,
+                        normalized.reject_origin,
+                    ),
+                    expected,
+                )
+
+    def test_apply_execution_status_uses_simulation_signal_timestamp(self) -> None:
+        decision_row = TradeDecision(
+            strategy_id=uuid.uuid4(),
+            alpaca_account_label="paper",
+            symbol="AAPL",
+            timeframe="1Min",
+            decision_json={"symbol": "AAPL"},
+            rationale=None,
+            status="planned",
+            decision_hash="signal-timestamp",
+        )
+        execution = Execution(
+            alpaca_account_label="paper",
+            alpaca_order_id="filled-sim-order",
+            client_order_id="signal-timestamp",
+            symbol="AAPL",
+            side="buy",
+            order_type="market",
+            time_in_force="day",
+            submitted_qty=Decimal("1"),
+            filled_qty=Decimal("1"),
+            status="filled",
+            raw_order={},
+        )
+        execution.simulation_json = {"signal_event_ts": "2026-02-10T15:30:00Z"}
+
+        _apply_execution_status(decision_row, execution, "paper")
+
+        self.assertEqual(
+            decision_row.executed_at,
+            datetime(2026, 2, 10, 15, 30, tzinfo=timezone.utc),
+        )
+
+    def test_persist_lean_shadow_event_records_unknown_parity_status(self) -> None:
+        engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+        Base.metadata.create_all(engine)
+        try:
+            with Session(engine) as session:
+                execution = Execution(
+                    alpaca_account_label="paper",
+                    alpaca_order_id="lean-shadow-order",
+                    client_order_id="lean-shadow",
+                    symbol="AAPL",
+                    side="buy",
+                    order_type="market",
+                    time_in_force="day",
+                    submitted_qty=Decimal("2"),
+                    filled_qty=Decimal("2"),
+                    status="filled",
+                    raw_order={},
+                )
+                session.add(execution)
+                session.flush()
+
+                decision = StrategyDecision(
+                    strategy_id="strategy-1",
+                    symbol="AAPL",
+                    event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+                    timeframe="1Min",
+                    action="buy",
+                    qty=Decimal("2.0"),
+                    params={"price": Decimal("100")},
+                )
+
+                _persist_lean_shadow_event(
+                    session,
+                    execution=execution,
+                    order_payload={
+                        "_execution_correlation_id": "corr-lean",
+                        "_lean_shadow": {
+                            "intent_notional": "200",
+                            "parity_status": "   ",
+                        },
+                    },
+                    decision=decision,
+                )
+                session.commit()
+
+                event = session.execute(select(LeanExecutionShadowEvent)).scalar_one()
+                self.assertEqual(event.correlation_id, "corr-lean")
+                self.assertEqual(event.parity_status, "unknown")
+                self.assertEqual(event.intent_notional, Decimal("200"))
+        finally:
+            engine.dispose()

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -1216,6 +1216,81 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertGreaterEqual(len(bucket["cost_model_hash_counts"]), 1)
         self.assertGreaterEqual(len(bucket["lineage_hash_counts"]), 1)
 
+    def test_build_realized_strategy_pnl_rows_materializes_audit_only_runtime_metadata(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_audit_json": {
+                        "execution_policy": {
+                            "selected_order_type": "limit",
+                            "adaptive": {"max_participation_rate": "0.05"},
+                        },
+                        "cost_model": {
+                            "source": "broker_reported",
+                            "commission_bps": "0",
+                        },
+                        "lineage": {
+                            "candidate_id": "H-PAIRS-LIVE-PAPER",
+                            "runtime_window_id": "2026-03-06-paper",
+                        },
+                        "runtime_ledger_cost": {
+                            "cost_amount": "0.20",
+                            "cost_basis": "broker_reported_commission",
+                        },
+                    },
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_audit_json": {
+                        "execution_policy": {
+                            "selected_order_type": "limit",
+                            "adaptive": {"max_participation_rate": "0.05"},
+                        },
+                        "cost_model": {
+                            "source": "broker_reported",
+                            "commission_bps": "0",
+                        },
+                        "lineage": {
+                            "candidate_id": "H-PAIRS-LIVE-PAPER",
+                            "runtime_window_id": "2026-03-06-paper",
+                        },
+                        "runtime_ledger_cost": {
+                            "cost_amount": "0.10",
+                            "cost_basis": "broker_reported_commission",
+                        },
+                    },
+                },
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["authoritative"], True)
+        self.assertEqual(
+            rows[0]["authority_reason"],
+            "source_execution_runtime_ledger_materialized",
+        )
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["blockers"], [])
+        self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
+
     def test_runtime_ledger_tca_row_separates_explicit_cost_from_slippage(
         self,
     ) -> None:

--- a/services/torghut/tests/test_order_idempotency.py
+++ b/services/torghut/tests/test_order_idempotency.py
@@ -1347,6 +1347,73 @@ class TestOrderIdempotency(TestCase):
             assert isinstance(execution_microstructure, dict)
             self.assertEqual(execution_microstructure.get('state_valid'), True)
 
+    def test_submit_order_persists_runtime_ledger_metadata_in_audit(self) -> None:
+        with self.session_local() as session:
+            strategy = Strategy(
+                name='demo',
+                description='demo',
+                enabled=True,
+                base_timeframe='1Min',
+                universe_type='static',
+                universe_symbols=['AAPL'],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol='AAPL',
+                event_ts=datetime(2026, 2, 10, tzinfo=timezone.utc),
+                timeframe='1Min',
+                action='buy',
+                qty=Decimal('1.0'),
+                params={
+                    'price': Decimal('100'),
+                    'execution_policy': {
+                        'selected_order_type': 'limit',
+                        'adaptive': {
+                            'applied': True,
+                            'max_participation_rate': '0.05',
+                        },
+                    },
+                    'cost_model': {
+                        'source': 'broker_reported',
+                        'commission_bps': '0',
+                    },
+                    'candidate_lineage': {
+                        'candidate_id': 'H-PAIRS-LIVE-PAPER',
+                        'runtime_window_id': '2026-02-10-paper',
+                    },
+                    'runtime_ledger_cost': {
+                        'cost_amount': '0',
+                        'cost_basis': 'broker_reported_commission',
+                    },
+                },
+            )
+
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(session, decision, strategy, 'paper')
+            execution = executor.submit_order(
+                session, FakeAlpacaClient(), decision, decision_row, 'paper'
+            )
+            assert execution is not None
+            audit = execution.execution_audit_json
+            assert isinstance(audit, dict)
+
+            execution_policy = audit.get('execution_policy')
+            assert isinstance(execution_policy, dict)
+            self.assertEqual(execution_policy.get('selected_order_type'), 'limit')
+            self.assertTrue(audit.get('execution_policy_hash'))
+            self.assertTrue(audit.get('cost_model_hash'))
+            self.assertTrue(audit.get('lineage_hash'))
+            self.assertEqual(audit.get('cost_amount'), '0')
+            self.assertEqual(audit.get('cost_basis'), 'broker_reported_commission')
+            runtime_cost = audit.get('runtime_ledger_cost')
+            assert isinstance(runtime_cost, dict)
+            self.assertEqual(runtime_cost.get('cost_amount'), '0')
+            self.assertEqual(runtime_cost.get('cost_basis'), 'broker_reported_commission')
+
     def test_submit_order_falls_back_to_transient_execution_policy_context(self) -> None:
         with self.session_local() as session:
             strategy = Strategy(

--- a/services/torghut/tests/test_snapshot_runtime_cost_coverage.py
+++ b/services/torghut/tests/test_snapshot_runtime_cost_coverage.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models import Base, Execution
+from app.snapshots import (
+    _preserve_existing_execution_audit,
+    _runtime_ledger_cost_payload_from_order,
+    sync_order_to_db,
+)
+
+
+class TestSnapshotRuntimeCostCoverage(TestCase):
+    def test_runtime_cost_requires_basis_for_unknown_amount_field(self) -> None:
+        self.assertIsNone(
+            _runtime_ledger_cost_payload_from_order({"cost_amount": "0.25"})
+        )
+
+    def test_runtime_cost_uses_explicit_basis_for_unknown_amount_field(self) -> None:
+        payload = _runtime_ledger_cost_payload_from_order(
+            {
+                "cost_amount": "0.25",
+                "cost_basis": "broker_reported_fees",
+            }
+        )
+
+        self.assertEqual(
+            payload,
+            {
+                "cost_amount": "0.25",
+                "cost_basis": "broker_reported_fees",
+                "source_field": "cost_amount",
+            },
+        )
+
+    def test_runtime_cost_skips_negative_amount_and_uses_broker_basis(self) -> None:
+        payload = _runtime_ledger_cost_payload_from_order(
+            {
+                "cost_amount": "-1",
+                "commission": "0",
+            }
+        )
+
+        self.assertEqual(
+            payload,
+            {
+                "cost_amount": "0",
+                "cost_basis": "broker_reported_commission",
+                "source_field": "commission",
+            },
+        )
+
+    def test_preserve_existing_execution_audit_ignores_non_mapping_audit(self) -> None:
+        data = {"execution_audit_json": {"cost_basis": "broker_reported_fees"}}
+        existing = Execution(
+            alpaca_account_label="paper",
+            alpaca_order_id="order-non-mapping-audit",
+            symbol="AAPL",
+            side="buy",
+            order_type="market",
+            time_in_force="day",
+            submitted_qty=Decimal("1"),
+            filled_qty=Decimal("0"),
+            status="accepted",
+            execution_audit_json=None,
+            raw_order={},
+        )
+
+        self.assertIs(
+            _preserve_existing_execution_audit(existing=existing, data=data),
+            data,
+        )
+
+    def test_sync_order_integrity_race_updates_existing_order(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            engine = create_engine(
+                f"sqlite+pysqlite:///{Path(tmpdir) / 'torghut.db'}",
+                future=True,
+            )
+            Base.metadata.create_all(engine)
+            try:
+                with Session(engine) as session:
+                    original_commit = session.commit
+                    state = {"raced": False}
+
+                    def racing_commit() -> None:
+                        if not state["raced"]:
+                            state["raced"] = True
+                            with Session(engine) as competing_session:
+                                competing_session.add(
+                                    Execution(
+                                        alpaca_account_label="paper",
+                                        alpaca_order_id="race-order",
+                                        symbol="AAPL",
+                                        side="buy",
+                                        order_type="market",
+                                        time_in_force="day",
+                                        submitted_qty=Decimal("1"),
+                                        filled_qty=Decimal("0"),
+                                        status="accepted",
+                                        raw_order={},
+                                    )
+                                )
+                                competing_session.commit()
+                        original_commit()
+
+                    session.commit = racing_commit  # type: ignore[method-assign]
+
+                    execution = sync_order_to_db(
+                        session,
+                        {
+                            "id": "race-order",
+                            "symbol": "AAPL",
+                            "side": "buy",
+                            "type": "market",
+                            "time_in_force": "day",
+                            "qty": "1",
+                            "filled_qty": "1",
+                            "filled_avg_price": "100",
+                            "status": "filled",
+                            "commission": "0",
+                        },
+                    )
+
+                    self.assertEqual(execution.alpaca_order_id, "race-order")
+                    self.assertEqual(execution.status, "filled")
+                    self.assertEqual(execution.filled_qty, Decimal("1.00000000"))
+            except IntegrityError:
+                self.fail("sync_order_to_db did not recover the unique-order race")
+            finally:
+                engine.dispose()

--- a/services/torghut/tests/test_snapshots.py
+++ b/services/torghut/tests/test_snapshots.py
@@ -237,3 +237,86 @@ class TestSnapshots(TestCase):
             self.assertEqual(simulation_context.get('simulation_run_id'), 'sim-2026-02-27-01')
             self.assertEqual(simulation_context.get('dataset_event_id'), 'evt-1')
             self.assertEqual(raw_order.get('simulation_context'), simulation_context)
+
+    def test_sync_order_to_db_preserves_execution_audit_metadata_on_update(self) -> None:
+        with Session(self.engine) as session:
+            execution = sync_order_to_db(
+                session,
+                {
+                    'id': 'order-runtime-audit',
+                    'symbol': 'AAPL',
+                    'side': 'buy',
+                    'type': 'market',
+                    'time_in_force': 'day',
+                    'qty': '1',
+                    'filled_qty': '0',
+                    'status': 'accepted',
+                    '_execution_audit': {
+                        'execution_policy_hash': 'policy-sha',
+                        'cost_model_hash': 'cost-sha',
+                        'lineage_hash': 'lineage-sha',
+                        'runtime_ledger_cost': {
+                            'cost_amount': '0',
+                            'cost_basis': 'broker_reported_commission',
+                        },
+                    },
+                },
+            )
+
+            updated = sync_order_to_db(
+                session,
+                {
+                    'id': 'order-runtime-audit',
+                    'symbol': 'AAPL',
+                    'side': 'buy',
+                    'type': 'market',
+                    'time_in_force': 'day',
+                    'qty': '1',
+                    'filled_qty': '1',
+                    'filled_avg_price': '100',
+                    'status': 'filled',
+                },
+            )
+
+            self.assertEqual(updated.id, execution.id)
+            audit = updated.execution_audit_json
+            self.assertIsInstance(audit, dict)
+            assert isinstance(audit, dict)
+            self.assertEqual(audit.get('execution_policy_hash'), 'policy-sha')
+            self.assertEqual(audit.get('cost_model_hash'), 'cost-sha')
+            self.assertEqual(audit.get('lineage_hash'), 'lineage-sha')
+            cost = audit.get('runtime_ledger_cost')
+            self.assertIsInstance(cost, dict)
+            assert isinstance(cost, dict)
+            self.assertEqual(cost.get('cost_amount'), '0')
+            self.assertEqual(cost.get('cost_basis'), 'broker_reported_commission')
+
+    def test_sync_order_to_db_normalizes_explicit_broker_cost_metadata(self) -> None:
+        with Session(self.engine) as session:
+            execution = sync_order_to_db(
+                session,
+                {
+                    'id': 'order-runtime-cost',
+                    'symbol': 'AAPL',
+                    'side': 'buy',
+                    'type': 'market',
+                    'time_in_force': 'day',
+                    'qty': '1',
+                    'filled_qty': '1',
+                    'filled_avg_price': '100',
+                    'status': 'filled',
+                    'commission': '0',
+                },
+            )
+
+            audit = execution.execution_audit_json
+            self.assertIsInstance(audit, dict)
+            assert isinstance(audit, dict)
+            cost = audit.get('runtime_ledger_cost')
+            self.assertIsInstance(cost, dict)
+            assert isinstance(cost, dict)
+            self.assertEqual(cost.get('cost_amount'), '0')
+            self.assertEqual(cost.get('cost_basis'), 'broker_reported_commission')
+            self.assertEqual(audit.get('cost_amount'), '0')
+            self.assertEqual(audit.get('cost_basis'), 'broker_reported_commission')
+            self.assertIn('fee_model', audit)


### PR DESCRIPTION
## Summary

- Persists execution policy, cost-model, lineage, and explicit runtime-cost metadata into `execution_audit_json` during order submit/backfill.
- Normalizes explicit broker-reported commission/fee fields into runtime-ledger cost metadata without inventing costs when broker data is absent.
- Preserves existing execution audit metadata across order status/fill updates so reconcile does not erase runtime-ledger proof context.
- Adds importer coverage proving audit-only execution metadata can materialize authoritative source runtime-ledger buckets when all proof fields are present.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_snapshots.py tests/test_order_idempotency.py tests/test_import_hypothesis_runtime_windows.py -k 'runtime_ledger_metadata or execution_policy_context or audit_only_runtime_metadata or nested_runtime_payloads or source_runtime_ledger or preserves_execution_audit or explicit_broker_cost' -q`
- `uv run --frozen ruff check app tests scripts migrations`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
