### PR TITLE
feat(synthesis): prefill company profiles

### DIFF
--- a/apps/synthesis/src/lib/company-symbols.test.ts
+++ b/apps/synthesis/src/lib/company-symbols.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { extractCompanySymbols, segmentCompanySymbols } from './company-symbols'
+import { extractCompanySymbols, normalizeCompanySymbol, segmentCompanySymbols } from './company-symbols'
 
 describe('company symbol detection', () => {
   test('links known stock symbols and cashtags without linking ordinary all-caps words', () => {
@@ -18,5 +18,10 @@ describe('company symbol detection', () => {
       { kind: 'symbol', text: 'AMD', symbol: 'AMD', href: '/companies/AMD' },
       { kind: 'text', text: ' supply-chain notes' },
     ])
+  })
+
+  test('normalizes explicit public-company ticker symbols beyond the curated extraction list', () => {
+    expect(normalizeCompanySymbol('$brk.b')).toBe('BRK.B')
+    expect(extractCompanySymbols('Watch $BRK.B with NVDA; USA and CPU remain plain words.')).toEqual(['BRK.B', 'NVDA'])
   })
 })

--- a/apps/synthesis/src/lib/company-symbols.ts
+++ b/apps/synthesis/src/lib/company-symbols.ts
@@ -31,15 +31,21 @@ export const knownCompanySymbols = [
 ] as const
 
 const knownCompanySymbolSet = new Set<string>(knownCompanySymbols)
-const symbolPattern = /(^|[^A-Za-z0-9])\$?([A-Z]{2,5})(?=$|[^A-Za-z0-9])/g
+const symbolPattern = /(^|[^A-Za-z0-9])(?<cashtag>\$)?(?<symbol>[A-Z][A-Z0-9.-]{0,9})(?=$|[^A-Za-z0-9])/g
+const publicSymbolPattern = /^[A-Z][A-Z0-9.-]{0,9}$/
 
 export type TextSegment =
   | { kind: 'text'; text: string }
   | { kind: 'symbol'; text: string; symbol: string; href: string }
 
 export const normalizeCompanySymbol = (value: string) => {
-  const symbol = value.trim().replace(/^\$+/, '').toUpperCase()
-  return knownCompanySymbolSet.has(symbol) ? symbol : null
+  const symbol = value.trim().replace(/^\$+/, '').replace(/\s+/g, '').toUpperCase()
+  return publicSymbolPattern.test(symbol) ? symbol : null
+}
+
+export const isKnownCompanySymbol = (value: string) => {
+  const symbol = normalizeCompanySymbol(value)
+  return symbol ? knownCompanySymbolSet.has(symbol) : false
 }
 
 export const companyPath = (symbol: string) => `/companies/${symbol.toUpperCase()}`
@@ -48,8 +54,10 @@ export const extractCompanySymbols = (text: string) => {
   const symbols: string[] = []
   const seen = new Set<string>()
   for (const match of text.matchAll(symbolPattern)) {
-    const symbol = normalizeCompanySymbol(match[2] ?? '')
+    const symbol = normalizeCompanySymbol(match.groups?.symbol ?? '')
+    const isCashtag = Boolean(match.groups?.cashtag)
     if (!symbol || seen.has(symbol)) continue
+    if (!isCashtag && !knownCompanySymbolSet.has(symbol)) continue
     seen.add(symbol)
     symbols.push(symbol)
   }
@@ -61,17 +69,31 @@ export const segmentCompanySymbols = (text: string): TextSegment[] => {
   let lastIndex = 0
   for (const match of text.matchAll(symbolPattern)) {
     const prefix = match[1] ?? ''
-    const token = match[2] ?? ''
+    const cashtag = match.groups?.cashtag ?? ''
+    const token = match.groups?.symbol ?? ''
     const symbol = normalizeCompanySymbol(token)
     const tokenStart = (match.index ?? 0) + prefix.length
-    const tokenEnd = tokenStart + (match[0]?.slice(prefix.length).length ?? token.length)
+    const tokenEnd = tokenStart + cashtag.length + token.length
     if (!symbol) continue
+    if (!cashtag && !knownCompanySymbolSet.has(symbol)) continue
     if (tokenStart > lastIndex) segments.push({ kind: 'text', text: text.slice(lastIndex, tokenStart) })
     segments.push({ kind: 'symbol', text: text.slice(tokenStart, tokenEnd), symbol, href: companyPath(symbol) })
     lastIndex = tokenEnd
   }
   if (lastIndex < text.length) segments.push({ kind: 'text', text: text.slice(lastIndex) })
   return segments.length ? segments : [{ kind: 'text', text }]
+}
+
+export const normalizeCompanySymbols = (values: readonly string[] | null | undefined) => {
+  const symbols: string[] = []
+  const seen = new Set<string>()
+  for (const value of values ?? []) {
+    const symbol = normalizeCompanySymbol(value)
+    if (!symbol || seen.has(symbol)) continue
+    seen.add(symbol)
+    symbols.push(symbol)
+  }
+  return symbols
 }
 
 export const symbolsFromSynthesisItem = (item: SynthesisItem) => {
@@ -89,5 +111,5 @@ export const symbolsFromSynthesisItem = (item: SynthesisItem) => {
   ]
     .filter(Boolean)
     .join(' ')
-  return extractCompanySymbols(text)
+  return normalizeCompanySymbols([...(item.companySymbols ?? []), ...extractCompanySymbols(text)])
 }

--- a/apps/synthesis/src/routes/api/companies/$symbol.ts
+++ b/apps/synthesis/src/routes/api/companies/$symbol.ts
@@ -7,6 +7,10 @@ export const Route = createFileRoute('/api/companies/$symbol')({
         const { handleGetCompany } = await import('~/server/api')
         return handleGetCompany(request, params.symbol)
       },
+      POST: async ({ params, request }: { params: { symbol: string }; request: Request }) => {
+        const { handlePrefillCompany } = await import('~/server/api')
+        return handlePrefillCompany(request, params.symbol)
+      },
     },
   },
 })

--- a/apps/synthesis/src/routes/companies/$symbol.tsx
+++ b/apps/synthesis/src/routes/companies/$symbol.tsx
@@ -1,24 +1,23 @@
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { ArrowLeft, BarChart3, ExternalLink } from 'lucide-react'
-import type { ReactNode } from 'react'
+import { ArrowLeft, ExternalLink } from 'lucide-react'
 
 import { normalizeCompanySymbol } from '~/lib/company-symbols'
-import type { CompanyAnalysis, CompanyMetric } from '~/server/company'
+import type { CompanyProfile } from '~/server/company'
 
 export const Route = createFileRoute('/companies/$symbol')({
   component: CompanyPage,
 })
 
 type CompanyResponse = {
-  company: CompanyAnalysis
+  company: CompanyProfile
 }
 
-async function fetchCompany(symbol: string): Promise<CompanyAnalysis> {
+async function fetchCompany(symbol: string): Promise<CompanyProfile> {
   const response = await fetch(`/api/companies/${encodeURIComponent(symbol)}`)
   if (!response.ok) {
     const payload = (await response.json().catch(() => null)) as { error?: string } | null
-    throw new Error(payload?.error ?? `company analysis unavailable: ${response.status}`)
+    throw new Error(payload?.error ?? `company profile unavailable: ${response.status}`)
   }
   const payload = (await response.json()) as CompanyResponse
   return payload.company
@@ -49,98 +48,140 @@ function CompanyPage() {
               <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#71767b]">Company</p>
               <h1 className="mt-1 text-3xl font-semibold tracking-[-0.02em] sm:text-4xl">{symbol}</h1>
             </div>
-            <a
-              href={`https://www.alphavantage.co/query?function=OVERVIEW&symbol=${encodeURIComponent(symbol)}`}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-2 rounded-md border border-[#2f3336] px-3 py-2 text-sm text-[#a6a6a6] transition-colors hover:border-[#1d9bf0]/60 hover:text-[#e7e9ea]"
-            >
-              Market source
-              <ExternalLink className="size-4" />
-            </a>
+            <span className="rounded-full border border-[#2f3336] px-3 py-1 font-mono text-xs text-[#a6a6a6]">
+              Synthesis profile
+            </span>
           </div>
         </header>
 
         <section className="flex-1 px-4 py-5 sm:px-6">
           {company.isLoading ? <CompanyLoading /> : company.error ? <CompanyError error={company.error} /> : null}
-          {company.data ? <CompanyAnalysisView company={company.data} /> : null}
+          {company.data ? <CompanyProfileView company={company.data} /> : null}
         </section>
       </div>
     </main>
   )
 }
 
-function CompanyAnalysisView({ company }: { company: CompanyAnalysis }) {
+export function CompanyProfileView({ company }: { company: CompanyProfile }) {
+  const identity = [company.exchange, company.category, company.sector, company.industry].filter(Boolean).join(' · ')
   return (
     <div className="grid gap-5">
       <section className="rounded-lg border border-[#2f3336] bg-[#080808] p-4 sm:p-5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h2 className="text-2xl font-semibold tracking-[-0.01em]">{company.identity.name}</h2>
-            <p className="mt-1 text-sm text-[#71767b]">
-              {[company.identity.exchange, company.identity.sector, company.identity.industry]
-                .filter(Boolean)
-                .join(' · ')}
-            </p>
+            <h2 className="text-2xl font-semibold tracking-[-0.01em]">{company.companyName}</h2>
+            {identity ? <p className="mt-1 text-sm text-[#71767b]">{identity}</p> : null}
           </div>
           <span className="rounded-full border border-[#2f3336] px-3 py-1 font-mono text-xs text-[#a6a6a6]">
-            {company.source}
+            confidence {Math.round(company.confidence.score * 100)}%
           </span>
         </div>
-        {company.identity.description ? (
-          <p className="mt-4 max-w-4xl text-[15px] leading-7 text-[#d8dadd]">{company.identity.description}</p>
+        {company.description ? (
+          <p className="mt-4 max-w-4xl text-[15px] leading-7 text-[#d8dadd]">{company.description}</p>
         ) : null}
-        <p className="mt-4 font-mono text-xs text-[#71767b]">Updated {new Date(company.updatedAt).toLocaleString()}</p>
+        <dl className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <ProfileFact label="CEO" value={company.ceo} />
+          <ProfileFact label="Employees" value={formatNumber(company.employees)} />
+          <ProfileFact label="Headquarters" value={company.headquarters} />
+          <ProfileFact label="Address" value={company.address} />
+          <ProfileFact label="Established" value={company.establishedAt} />
+          <ProfileFact label="Incorporated" value={company.incorporatedAt} />
+        </dl>
+        <p className="mt-4 font-mono text-xs text-[#71767b]">
+          Updated {formatDateTime(company.updatedAt)} · Stale after{' '}
+          {company.staleness.staleAfter ? formatDateTime(company.staleness.staleAfter) : 'not set'}
+        </p>
       </section>
 
-      <div className="grid gap-5 lg:grid-cols-3">
-        <MetricSection
-          icon={<BarChart3 className="size-4" />}
-          title="Fundamental analysis"
-          metrics={company.fundamentals}
-        />
-        <MetricSection title="Technical analysis" metrics={company.technicals} />
-        <MetricSection title="Financial analysis" metrics={company.financials} />
-      </div>
+      {company.quoteContext ? (
+        <section className="rounded-lg border border-[#2f3336] bg-[#080808] p-4 sm:p-5">
+          <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-[#a6a6a6]">Optional quote context</h3>
+            <span className="font-mono text-xs text-[#71767b]">{company.quoteContext.source}</span>
+          </div>
+          <dl className="grid gap-3 sm:grid-cols-3">
+            <ProfileFact label="Price" value={formatCurrency(company.quoteContext.price)} />
+            <ProfileFact label="Bid" value={formatCurrency(company.quoteContext.bid)} />
+            <ProfileFact label="Ask" value={formatCurrency(company.quoteContext.ask)} />
+          </dl>
+          <p className="mt-3 font-mono text-xs text-[#71767b]">
+            Quote time {company.quoteContext.timestamp ? formatDateTime(company.quoteContext.timestamp) : 'unknown'}
+          </p>
+        </section>
+      ) : null}
+
+      <section className="rounded-lg border border-[#2f3336] bg-[#080808] p-4 sm:p-5">
+        <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[#a6a6a6]">Source provenance</h3>
+        <div className="grid gap-3">
+          {company.dataSources.map((source) => (
+            <div
+              key={`${source.name}-${source.url ?? 'local'}`}
+              className="rounded-md border border-[#202327] px-3 py-3"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                {source.url ? (
+                  <a
+                    href={source.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex max-w-full items-center gap-2 text-sm font-semibold text-[#e7e9ea] transition-colors hover:text-[#1d9bf0]"
+                  >
+                    <span className="truncate">{source.name}</span>
+                    <ExternalLink className="size-3.5 shrink-0" />
+                  </a>
+                ) : (
+                  <span className="text-sm font-semibold text-[#e7e9ea]">{source.name}</span>
+                )}
+                <span className="font-mono text-xs text-[#71767b]">{formatDateTime(source.retrievedAt)}</span>
+              </div>
+              {source.fields.length ? (
+                <p className="mt-2 text-xs leading-5 text-[#71767b]">Fields: {source.fields.join(', ')}</p>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </section>
     </div>
   )
 }
 
-function MetricSection({ icon, title, metrics }: { icon?: ReactNode; title: string; metrics: CompanyMetric[] }) {
+function ProfileFact({ label, value }: { label: string; value: string | null }) {
   return (
-    <section className="rounded-lg border border-[#2f3336] bg-[#080808] p-4">
-      <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-[#a6a6a6]">
-        {icon}
-        {title}
-      </h3>
-      {metrics.length ? (
-        <dl className="grid gap-2">
-          {metrics.map((metric) => (
-            <div
-              key={metric.label}
-              className="flex items-baseline justify-between gap-3 border-t border-[#202327] pt-2"
-            >
-              <dt className="text-sm text-[#71767b]">{metric.label}</dt>
-              <dd className="text-right font-mono text-sm text-[#e7e9ea]">{metric.value}</dd>
-            </div>
-          ))}
-        </dl>
-      ) : (
-        <p className="text-sm leading-6 text-[#71767b]">Current market-data fields are unavailable.</p>
-      )}
-    </section>
+    <div className="rounded-md border border-[#202327] bg-black/30 px-3 py-2">
+      <dt className="text-xs font-semibold uppercase tracking-wide text-[#71767b]">{label}</dt>
+      <dd className="mt-1 text-sm leading-6 text-[#e7e9ea]">{value ?? 'unknown'}</dd>
+    </div>
   )
+}
+
+const formatNumber = (value: number | null) => {
+  if (value == null) return null
+  return new Intl.NumberFormat('en-US').format(value)
+}
+
+const formatCurrency = (value: number | null) => {
+  if (value == null) return null
+  return new Intl.NumberFormat('en-US', { currency: 'USD', maximumFractionDigits: 2, style: 'currency' }).format(value)
+}
+
+const formatDateTime = (value: string) => {
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(parsed)
 }
 
 function CompanyLoading() {
   return (
-    <div className="grid gap-4" aria-label="Loading company analysis">
-      <div className="h-36 rounded-lg border border-[#2f3336] bg-[#080808] animate-pulse" />
-      <div className="grid gap-4 lg:grid-cols-3">
-        {Array.from({ length: 3 }, (_, index) => (
-          <div key={index} className="h-64 rounded-lg border border-[#2f3336] bg-[#080808] animate-pulse" />
-        ))}
-      </div>
+    <div className="grid gap-4" aria-label="Loading company profile">
+      <div className="h-72 rounded-lg border border-[#2f3336] bg-[#080808] animate-pulse" />
+      <div className="h-64 rounded-lg border border-[#2f3336] bg-[#080808] animate-pulse" />
     </div>
   )
 }

--- a/apps/synthesis/src/routes/companies/-company-page.test.tsx
+++ b/apps/synthesis/src/routes/companies/-company-page.test.tsx
@@ -1,0 +1,67 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, test } from 'vitest'
+
+import { segmentCompanySymbols } from '~/lib/company-symbols'
+import type { CompanyProfile } from '~/server/company'
+
+import { CompanyProfileView } from './$symbol'
+
+const company: CompanyProfile = {
+  symbol: 'NVDA',
+  companyName: 'NVIDIA Corporation',
+  exchange: 'NASDAQ',
+  category: 'Common Stock',
+  sector: 'Technology',
+  industry: 'Semiconductors',
+  ceo: 'Jensen Huang',
+  employees: 42000,
+  headquarters: 'Santa Clara, California',
+  address: '2788 San Tomas Expressway, Santa Clara, CA 95051',
+  establishedAt: '1993',
+  incorporatedAt: null,
+  description: 'Accelerated computing and AI infrastructure company.',
+  dataSources: [
+    {
+      name: 'Webull',
+      url: null,
+      retrievedAt: '2026-05-26T20:00:00.000Z',
+      fields: ['companyName', 'description'],
+    },
+  ],
+  quoteContext: {
+    source: 'Alpaca Market Data',
+    price: 123.45,
+    bid: 123.4,
+    ask: 123.5,
+    timestamp: '2026-05-26T19:59:00.000Z',
+    retrievedAt: '2026-05-26T20:00:00.000Z',
+  },
+  updatedAt: '2026-05-26T20:00:00.000Z',
+  confidence: { score: 0.9, level: 'high', reasons: ['test'] },
+  staleness: {
+    asOf: '2026-05-26T20:00:00.000Z',
+    staleAfter: '2026-06-25T20:00:00.000Z',
+    stale: false,
+  },
+}
+
+describe('company page rendering', () => {
+  test('renders normalized company profile fields, provenance, and optional quote context', () => {
+    const html = renderToStaticMarkup(<CompanyProfileView company={company} />)
+
+    expect(html).toContain('NVIDIA Corporation')
+    expect(html).toContain('Jensen Huang')
+    expect(html).toContain('Source provenance')
+    expect(html).toContain('Webull')
+    expect(html).toContain('Optional quote context')
+    expect(html).toContain('$123.45')
+  })
+
+  test('renders item ticker mentions as internal Synthesis company links', () => {
+    expect(segmentCompanySymbols('NVDA and $AMD')).toEqual([
+      { kind: 'symbol', text: 'NVDA', symbol: 'NVDA', href: '/companies/NVDA' },
+      { kind: 'text', text: ' and ' },
+      { kind: 'symbol', text: '$AMD', symbol: 'AMD', href: '/companies/AMD' },
+    ])
+  })
+})

--- a/apps/synthesis/src/server/__tests__/company.test.ts
+++ b/apps/synthesis/src/server/__tests__/company.test.ts
@@ -1,49 +1,171 @@
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
-import { handleGetCompany } from '../api'
-import { setCompanyDataProviderForTests } from '../company'
+import { handleGetCompany, handlePrefillCompany, handleSubmitItem } from '../api'
+import {
+  enrichCompanyProfile,
+  normalizeWebullCompanyProfile,
+  setCompanyProfileProviderForTests,
+  setCompanyQuoteContextProviderForTests,
+} from '../company'
+import { setSynthesisEmbeddingProviderForTests } from '../embeddings'
+import { createInMemorySynthesisStore, setSynthesisStoreForTests } from '../store'
 
-describe('company analysis API', () => {
+const token = 'test-synthesis-token'
+
+describe('company profile prefill', () => {
+  beforeEach(() => {
+    process.env.SYNTHESIS_API_TOKEN = token
+    process.env.SYNTHESIS_EMBEDDING_DIMENSION = '3'
+    process.env.SYNTHESIS_EMBEDDING_MODEL = 'local-test-embedding'
+    setSynthesisEmbeddingProviderForTests(async ({ config }) => ({
+      embedding: [1, 0, 0],
+      model: config.model,
+      dimension: config.dimension,
+    }))
+    setSynthesisStoreForTests(createInMemorySynthesisStore())
+  })
+
   afterEach(() => {
-    setCompanyDataProviderForTests(null)
+    delete process.env.SYNTHESIS_API_TOKEN
+    delete process.env.SYNTHESIS_EMBEDDING_DIMENSION
+    delete process.env.SYNTHESIS_EMBEDDING_MODEL
+    setCompanyProfileProviderForTests(null)
+    setCompanyQuoteContextProviderForTests(null)
+    setSynthesisEmbeddingProviderForTests(null)
+    setSynthesisStoreForTests(null)
   })
 
-  test('fails closed when live market data provider is not configured', async () => {
-    const response = await handleGetCompany(new Request('http://synthesis.test/api/companies/NVDA'), 'NVDA')
-    const payload = await response.json()
+  test('normalizes Webull company profile payloads into Synthesis profile fields', () => {
+    const profile = normalizeWebullCompanyProfile('nvda', {
+      companyName: 'NVIDIA Corporation',
+      exchangeCode: 'NASDAQ',
+      securityType: 'Common Stock',
+      sectorName: 'Technology',
+      industryName: 'Semiconductors',
+      chiefExecutiveOfficer: 'Jensen Huang',
+      fullTimeEmployees: '42,000',
+      headquarter: 'Santa Clara, California',
+      companyAddress: '2788 San Tomas Expressway, Santa Clara, CA 95051',
+      founded: '1993',
+      businessDescription: 'Accelerated computing and AI infrastructure company.',
+    })
 
-    expect(response.status).toBe(503)
-    expect(payload.error).toContain('not configured')
+    expect(profile).toMatchObject({
+      symbol: 'NVDA',
+      companyName: 'NVIDIA Corporation',
+      exchange: 'NASDAQ',
+      category: 'Common Stock',
+      sector: 'Technology',
+      industry: 'Semiconductors',
+      ceo: 'Jensen Huang',
+      employees: 42000,
+      headquarters: 'Santa Clara, California',
+    })
+    expect(profile?.dataSources[0].name).toBe('Webull')
+    expect(profile?.confidence.level).toBe('high')
   })
 
-  test('returns provider-backed company identity, fundamental, technical, and financial analysis', async () => {
-    setCompanyDataProviderForTests({
-      async getCompanyAnalysis(symbol) {
+  test('prefers provider-backed profile data and attaches optional Alpaca quote context', async () => {
+    setCompanyProfileProviderForTests({
+      async getCompanyProfile(symbol) {
+        return normalizeWebullCompanyProfile(symbol, {
+          name: 'Advanced Micro Devices, Inc.',
+          exchange: 'NASDAQ',
+          sector: 'Technology',
+          industry: 'Semiconductors',
+          ceo: 'Lisa Su',
+          description: 'Provider profile.',
+        })
+      },
+    })
+    setCompanyQuoteContextProviderForTests({
+      async getQuoteContext(_symbol) {
         return {
-          symbol,
-          identity: {
-            name: 'NVIDIA Corporation',
-            exchange: 'NASDAQ',
-            sector: 'Technology',
-            industry: 'Semiconductors',
-            description: 'Provider-backed fixture for tests only.',
-          },
-          fundamentals: [{ label: 'Market cap', value: '$3.1T' }],
-          technicals: [{ label: 'RSI 14D', value: '55.4' }],
-          financials: [{ label: 'Revenue TTM', value: '$96B' }],
-          source: 'test-provider',
-          updatedAt: '2026-05-26T00:00:00.000Z',
+          source: 'Alpaca Market Data',
+          price: 123.45,
+          bid: 123.4,
+          ask: 123.5,
+          timestamp: '2026-05-26T20:00:00.000Z',
+          retrievedAt: '2026-05-26T20:00:01.000Z',
         }
       },
     })
 
+    const profile = await enrichCompanyProfile({ symbol: 'AMD', companyName: 'Manual name should not override' })
+
+    expect(profile.companyName).toBe('Advanced Micro Devices, Inc.')
+    expect(profile.quoteContext).toMatchObject({ source: 'Alpaca Market Data', price: 123.45 })
+    expect(profile.dataSources.map((source) => source.name)).toEqual(['Webull', 'Alpaca Market Data'])
+  })
+
+  test('GET prepopulates fixture-backed company profiles when live Webull is unavailable', async () => {
     const response = await handleGetCompany(new Request('http://synthesis.test/api/companies/NVDA'), 'NVDA')
     const payload = await response.json()
 
     expect(response.status).toBe(200)
-    expect(payload.company.identity.name).toBe('NVIDIA Corporation')
-    expect(payload.company.fundamentals).toHaveLength(1)
-    expect(payload.company.technicals).toHaveLength(1)
-    expect(payload.company.financials).toHaveLength(1)
+    expect(payload.company).toMatchObject({
+      symbol: 'NVDA',
+      companyName: 'NVIDIA Corporation',
+      exchange: 'NASDAQ',
+      industry: 'Semiconductors',
+    })
+    expect(payload.company.dataSources[0].name).toContain('NVIDIA')
+  })
+
+  test('POST prefill stores manual official-source seed data when provider has no profile', async () => {
+    setCompanyProfileProviderForTests({
+      async getCompanyProfile() {
+        return null
+      },
+    })
+    const response = await handlePrefillCompany(
+      new Request('http://synthesis.test/api/companies/ACME', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          companyName: 'Acme Robotics, Inc.',
+          exchange: 'NYSE',
+          sector: 'Industrials',
+          dataSources: [{ name: 'NYSE issuer page', url: 'https://example.com/acme', fields: ['companyName'] }],
+        }),
+      }),
+      'ACME',
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(payload.company).toMatchObject({ symbol: 'ACME', companyName: 'Acme Robotics, Inc.', exchange: 'NYSE' })
+  })
+
+  test('submitted items derive company symbols and trigger profile association', async () => {
+    const submitResponse = await handleSubmitItem(
+      new Request('http://synthesis.test/api/items', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          title: 'NVDA and $AMD packaging notes matter for inference clusters',
+          synthesis: 'Company mentions should become internal Synthesis company profile links.',
+          takeaways: ['NVDA demand and AMD roadmap context both matter'],
+          whyValuable: 'It keeps ticker/company context attached to the item.',
+          sourcePosts: [
+            {
+              originalUrl: 'https://x.com/example/status/6101',
+              observedText: 'NVDA and AMD supply-chain commentary',
+            },
+          ],
+          dedupeKey: 'theme:company-prefill-association',
+          score: 0.92,
+          confidence: 0.84,
+        }),
+      }),
+    )
+    const submitPayload = await submitResponse.json()
+    const profileResponse = await handleGetCompany(new Request('http://synthesis.test/api/companies/AMD'), 'AMD')
+    const profilePayload = await profileResponse.json()
+
+    expect(submitResponse.status).toBe(201)
+    expect(submitPayload.item.companySymbols).toEqual(['NVDA', 'AMD'])
+    expect(profileResponse.status).toBe(200)
+    expect(profilePayload.company.companyName).toContain('Advanced Micro Devices')
   })
 })

--- a/apps/synthesis/src/server/__tests__/mcp.test.ts
+++ b/apps/synthesis/src/server/__tests__/mcp.test.ts
@@ -65,6 +65,7 @@ describe('synthesis MCP', () => {
     const submitTool = toolsPayload.result.tools.find((tool: { name: string }) => tool.name === 'synthesis_submit_item')
 
     expect(toolNames).toContain('synthesis_submit_item')
+    expect(toolNames).toContain('synthesis_prefill_company')
     expect(toolNames).not.toContain('synthesis_next_engagement')
     expect(toolNames).not.toContain('synthesis_record_engagement_result')
     expect(submitTool.inputSchema.required).toEqual([
@@ -82,6 +83,7 @@ describe('synthesis MCP', () => {
     expect(submitTool.inputSchema.properties.engagementRecommendation).toBeUndefined()
     expect(submitTool.inputSchema.properties.replyText).toBeUndefined()
     expect(submitTool.inputSchema.properties.embedding).toBeUndefined()
+    expect(submitTool.inputSchema.properties.companySymbols).toBeDefined()
 
     const resourceResponse = await handleMcpRequest(rpc('resources/read', { uri: 'synthesis://config' }))
     const resourcePayload = await resourceResponse.json()
@@ -141,6 +143,20 @@ describe('synthesis MCP', () => {
     const feedPayload = await parseToolJson(await handleMcpRequest(callTool('synthesis_list_feed', { limit: 10 })))
     expect(feedPayload.items).toHaveLength(1)
     expect(feedPayload.items[0].id).toBe(submitPayload.item.id)
+  })
+
+  test('prefills a Synthesis-owned company profile through MCP', async () => {
+    const headers = { authorization: `Bearer ${token}` }
+    const payload = await parseToolJson(
+      await handleMcpRequest(callTool('synthesis_prefill_company', { symbol: 'NVDA' }, headers)),
+    )
+
+    expect(payload.company).toMatchObject({
+      symbol: 'NVDA',
+      companyName: 'NVIDIA Corporation',
+      industry: 'Semiconductors',
+    })
+    expect(payload.company.dataSources.length).toBeGreaterThan(0)
   })
 
   test('rejects old submit arguments at the MCP boundary', async () => {

--- a/apps/synthesis/src/server/api.ts
+++ b/apps/synthesis/src/server/api.ts
@@ -6,7 +6,7 @@ import {
   SubmitItemInputSchema,
 } from './schema'
 import { assetResponseForAttachment } from './assets'
-import { createCompanyDataProvider } from './company'
+import { CompanyProfileHintSchema } from './company'
 import { getSynthesisStore } from './store'
 import { requireAuthorized } from './auth'
 import { badRequest, jsonResponse, notFound, readJson } from './http'
@@ -83,16 +83,33 @@ export const handleListFeed = async (request: Request) => {
 }
 
 export const handleGetCompany = async (_request: Request, symbol: string) => {
-  const provider = createCompanyDataProvider()
-  if (!provider) {
-    return jsonResponse({ error: 'company market data provider is not configured' }, { status: 503 })
+  try {
+    const store = getSynthesisStore()
+    const existing = await store.getCompanyProfile(symbol)
+    const company = existing ?? (await store.prefillCompany({ symbol }))
+    return jsonResponse({ company })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'company profile unavailable'
+    if (message.startsWith('unsupported company symbol')) return badRequest(message)
+    if (message.includes('companyName is required')) return notFound(`company profile unavailable for ${symbol}`)
+    return jsonResponse({ error: message }, { status: 502 })
   }
+}
+
+export const handlePrefillCompany = async (request: Request, symbol: string) => {
+  const unauthorized = requireAuthorized(request)
+  if (unauthorized) return unauthorized
+
+  const raw = await request.json().catch(() => ({}))
+  const parsed = CompanyProfileHintSchema.safeParse({ ...(isRecord(raw) ? raw : {}), symbol })
+  if (!parsed.success) return badRequest('invalid company prefill request body')
 
   try {
-    return jsonResponse({ company: await provider.getCompanyAnalysis(symbol) })
+    return jsonResponse({ company: await getSynthesisStore().prefillCompany(parsed.data) }, { status: 201 })
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'company analysis unavailable'
+    const message = error instanceof Error ? error.message : 'company profile unavailable'
     if (message.startsWith('unsupported company symbol')) return badRequest(message)
+    if (message.includes('companyName is required')) return notFound(`company profile unavailable for ${symbol}`)
     return jsonResponse({ error: message }, { status: 502 })
   }
 }

--- a/apps/synthesis/src/server/company.ts
+++ b/apps/synthesis/src/server/company.ts
@@ -2,244 +2,542 @@ import { z } from 'zod'
 
 import { normalizeCompanySymbol } from '~/lib/company-symbols'
 
-export type CompanyMetric = {
-  label: string
-  value: string
+export type CompanyDataSource = {
+  name: string
+  url: string | null
+  retrievedAt: string
+  fields: string[]
 }
 
-export type CompanyAnalysis = {
-  symbol: string
-  identity: {
-    name: string
-    exchange: string | null
-    sector: string | null
-    industry: string | null
-    description: string | null
-  }
-  fundamentals: CompanyMetric[]
-  technicals: CompanyMetric[]
-  financials: CompanyMetric[]
+export type CompanyConfidence = {
+  score: number
+  level: 'high' | 'medium' | 'low'
+  reasons: string[]
+}
+
+export type CompanyStaleness = {
+  asOf: string
+  staleAfter: string | null
+  stale: boolean
+}
+
+export type CompanyQuoteContext = {
   source: string
+  price: number | null
+  bid: number | null
+  ask: number | null
+  timestamp: string | null
+  retrievedAt: string
+}
+
+export type CompanyProfile = {
+  symbol: string
+  companyName: string
+  exchange: string | null
+  category: string | null
+  sector: string | null
+  industry: string | null
+  ceo: string | null
+  employees: number | null
+  headquarters: string | null
+  address: string | null
+  establishedAt: string | null
+  incorporatedAt: string | null
+  description: string | null
+  dataSources: CompanyDataSource[]
+  quoteContext: CompanyQuoteContext | null
   updatedAt: string
+  confidence: CompanyConfidence
+  staleness: CompanyStaleness
 }
 
-export type CompanyDataProvider = {
-  getCompanyAnalysis(symbol: string): Promise<CompanyAnalysis>
+export type CompanyProfileProvider = {
+  getCompanyProfile(symbol: string): Promise<CompanyProfile | null>
 }
 
-const alphaVantageErrorSchema = z
-  .object({
-    Note: z.string().optional(),
-    Information: z.string().optional(),
-    'Error Message': z.string().optional(),
-  })
-  .passthrough()
+export type CompanyQuoteContextProvider = {
+  getQuoteContext(symbol: string): Promise<CompanyQuoteContext | null>
+}
 
-const overviewSchema = z
+export const CompanyProfileHintSchema = z
   .object({
-    Symbol: z.string().optional(),
-    Name: z.string().optional(),
-    Exchange: z.string().optional(),
-    Sector: z.string().optional(),
-    Industry: z.string().optional(),
-    Description: z.string().optional(),
-    MarketCapitalization: z.string().optional(),
-    PERatio: z.string().optional(),
-    EPS: z.string().optional(),
-    DividendYield: z.string().optional(),
-    Beta: z.string().optional(),
-    AnalystTargetPrice: z.string().optional(),
-    ProfitMargin: z.string().optional(),
-    RevenueTTM: z.string().optional(),
-    EBITDA: z.string().optional(),
-    QuarterlyRevenueGrowthYOY: z.string().optional(),
-    QuarterlyEarningsGrowthYOY: z.string().optional(),
-    GrossProfitTTM: z.string().optional(),
-    FiscalYearEnd: z.string().optional(),
-    '52WeekHigh': z.string().optional(),
-    '52WeekLow': z.string().optional(),
-    '50DayMovingAverage': z.string().optional(),
-    '200DayMovingAverage': z.string().optional(),
+    symbol: z.string().trim().min(1).max(20),
+    companyName: z.string().trim().min(1).max(240).optional(),
+    exchange: z.string().trim().min(1).max(80).optional(),
+    category: z.string().trim().min(1).max(120).optional(),
+    sector: z.string().trim().min(1).max(160).optional(),
+    industry: z.string().trim().min(1).max(200).optional(),
+    ceo: z.string().trim().min(1).max(200).optional(),
+    employees: z.coerce.number().int().positive().optional(),
+    headquarters: z.string().trim().min(1).max(240).optional(),
+    address: z.string().trim().min(1).max(400).optional(),
+    establishedAt: z.string().trim().min(1).max(80).optional(),
+    incorporatedAt: z.string().trim().min(1).max(80).optional(),
+    description: z.string().trim().min(1).max(4_000).optional(),
+    dataSources: z
+      .array(
+        z
+          .object({
+            name: z.string().trim().min(1).max(160),
+            url: z.string().trim().min(1).max(1_000).optional(),
+            fields: z.array(z.string().trim().min(1).max(80)).max(32).default([]),
+          })
+          .strict(),
+      )
+      .max(12)
+      .default([]),
   })
-  .passthrough()
+  .strict()
 
-const quoteSchema = z
-  .object({
-    'Global Quote': z
-      .object({
-        '05. price': z.string().optional(),
-        '09. change': z.string().optional(),
-        '10. change percent': z.string().optional(),
-      })
-      .optional(),
-  })
-  .passthrough()
+export type CompanyProfileHintInput = z.input<typeof CompanyProfileHintSchema>
+export type CompanyProfileHint = z.infer<typeof CompanyProfileHintSchema>
 
-const rsiSchema = z
-  .object({
-    'Technical Analysis: RSI': z.record(z.string(), z.object({ RSI: z.string().optional() })).optional(),
-  })
-  .passthrough()
+const profilePayloadSchema = z.record(z.string(), z.unknown())
 
-const cleanValue = (value: string | null | undefined) => {
-  if (!value || value === 'None' || value === '-' || value === '0') return null
+const cleanText = (value: unknown) => {
+  if (typeof value !== 'string' && typeof value !== 'number') return null
+  const text = String(value).replace(/\s+/g, ' ').trim()
+  if (!text || text === '-' || /^n\/?a$/i.test(text) || /^none$/i.test(text)) return null
+  return text
+}
+
+const cleanNumber = (value: unknown) => {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) return Math.round(value)
+  const text = cleanText(value)
+  if (!text) return null
+  const parsed = Number(text.replace(/,/g, ''))
+  return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed) : null
+}
+
+const pickText = (payload: Record<string, unknown>, keys: string[]) => {
+  for (const key of keys) {
+    const value = cleanText(payload[key])
+    if (value) return value
+  }
+  return null
+}
+
+const pickNumber = (payload: Record<string, unknown>, keys: string[]) => {
+  for (const key of keys) {
+    const value = cleanNumber(payload[key])
+    if (value) return value
+  }
+  return null
+}
+
+const toIso = (value: Date | string | null | undefined) => {
+  if (!value) return null
+  if (value instanceof Date) return value.toISOString()
+  const parsed = new Date(value)
+  if (!Number.isNaN(parsed.getTime())) return parsed.toISOString()
   return value
 }
 
-const formatNumber = (value: string | null | undefined) => {
-  const cleaned = cleanValue(value)
-  if (!cleaned) return null
-  const parsed = Number(cleaned)
-  if (!Number.isFinite(parsed)) return cleaned
-  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(parsed)
+const nowIso = () => new Date().toISOString()
+
+const staleAfterDays = (asOf: string, days: number) => {
+  const parsed = Date.parse(asOf)
+  if (Number.isNaN(parsed)) return null
+  return new Date(parsed + days * 24 * 60 * 60 * 1000).toISOString()
 }
 
-const formatCurrency = (value: string | null | undefined) => {
-  const cleaned = cleanValue(value)
-  if (!cleaned) return null
-  const parsed = Number(cleaned)
-  if (!Number.isFinite(parsed)) return cleaned
-  return new Intl.NumberFormat('en-US', {
-    currency: 'USD',
-    maximumFractionDigits: parsed >= 100 ? 0 : 2,
-    style: 'currency',
-  }).format(parsed)
-}
-
-const formatLargeCurrency = (value: string | null | undefined) => {
-  const cleaned = cleanValue(value)
-  if (!cleaned) return null
-  const parsed = Number(cleaned)
-  if (!Number.isFinite(parsed)) return cleaned
-  return new Intl.NumberFormat('en-US', {
-    currency: 'USD',
-    maximumFractionDigits: 2,
-    notation: 'compact',
-    style: 'currency',
-  }).format(parsed)
-}
-
-const formatPercent = (value: string | null | undefined) => {
-  const cleaned = cleanValue(value)
-  if (!cleaned) return null
-  const withoutPercent = cleaned.replace(/%$/, '')
-  const parsed = Number(withoutPercent)
-  if (!Number.isFinite(parsed)) return cleaned
-  const percent = cleaned.endsWith('%') || Math.abs(parsed) > 1 ? parsed : parsed * 100
-  return `${new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(percent)}%`
-}
-
-const metric = (label: string, value: string | null | undefined): CompanyMetric | null => {
-  const cleaned = cleanValue(value)
-  return cleaned ? { label, value: cleaned } : null
-}
-
-const compactMetrics = (metrics: Array<CompanyMetric | null>) =>
-  metrics.filter((item): item is CompanyMetric => Boolean(item))
-
-const assertAlphaVantagePayload = (payload: unknown, symbol: string) => {
-  const error = alphaVantageErrorSchema.parse(payload)
-  if (error.Note || error.Information || error['Error Message']) {
-    throw new Error(
-      error.Note ?? error.Information ?? error['Error Message'] ?? `market data unavailable for ${symbol}`,
-    )
+const stalenessFor = (asOf: string, days = 30): CompanyStaleness => {
+  const staleAfter = staleAfterDays(asOf, days)
+  return {
+    asOf,
+    staleAfter,
+    stale: staleAfter ? Date.now() > Date.parse(staleAfter) : false,
   }
 }
 
-class AlphaVantageCompanyDataProvider implements CompanyDataProvider {
-  private readonly apiKey: string
+const source = (name: string, url: string | null, fields: string[], retrievedAt = nowIso()): CompanyDataSource => ({
+  name,
+  url,
+  retrievedAt,
+  fields,
+})
+
+const compactSources = (sources: CompanyDataSource[]) => {
+  const seen = new Set<string>()
+  return sources.filter((entry) => {
+    const key = `${entry.name}:${entry.url ?? ''}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+const confidenceFromSource = (provider: string, fields: Array<string | number | null>) => {
+  const populated = fields.filter((value) => value != null && value !== '').length
+  const sourceScore = provider === 'Webull' ? 0.52 : provider === 'manual' ? 0.45 : 0.34
+  const score = Math.min(0.98, Number((sourceScore + Math.min(populated, 8) * 0.055).toFixed(2)))
+  return {
+    score,
+    level: score >= 0.82 ? 'high' : score >= 0.62 ? 'medium' : 'low',
+    reasons: [`${provider} profile source`, `${populated} normalized profile fields populated`],
+  } satisfies CompanyConfidence
+}
+
+const fixtureProfiles: Record<string, Omit<CompanyProfile, 'quoteContext' | 'updatedAt' | 'staleness'>> = {
+  NVDA: {
+    symbol: 'NVDA',
+    companyName: 'NVIDIA Corporation',
+    exchange: 'NASDAQ',
+    category: 'Common Stock',
+    sector: 'Technology',
+    industry: 'Semiconductors',
+    ceo: 'Jensen Huang',
+    employees: 42000,
+    headquarters: 'Santa Clara, California, United States',
+    address: '2788 San Tomas Expressway, Santa Clara, CA 95051',
+    establishedAt: '1993',
+    incorporatedAt: null,
+    description:
+      'NVIDIA is an accelerated computing and AI infrastructure company spanning GPUs, networking, systems, and software for data center, gaming, professional visualization, automotive, and edge workloads.',
+    dataSources: [
+      source(
+        'NVIDIA in Brief',
+        'https://www.nvidia.com/content/dam/en-zz/Solutions/about-nvidia/corporate-nvidia-in-brief.pdf',
+        ['companyName', 'ceo', 'employees', 'establishedAt', 'description'],
+      ),
+      source('NVIDIA Investor Relations', 'https://investor.nvidia.com/governance/management-team/default.aspx', [
+        'ceo',
+      ]),
+    ],
+    confidence: {
+      score: 0.78,
+      level: 'medium',
+      reasons: ['static fixture from issuer/investor sources', 'used when live Webull profile is unavailable'],
+    },
+  },
+  AMD: {
+    symbol: 'AMD',
+    companyName: 'Advanced Micro Devices, Inc.',
+    exchange: 'NASDAQ',
+    category: 'Common Stock',
+    sector: 'Technology',
+    industry: 'Semiconductors',
+    ceo: 'Lisa Su',
+    employees: null,
+    headquarters: 'Santa Clara, California, United States',
+    address: '2485 Augustine Drive, Santa Clara, CA 95054',
+    establishedAt: '1969',
+    incorporatedAt: null,
+    description:
+      'AMD designs high-performance and adaptive computing products including CPUs, GPUs, accelerators, FPGAs, and embedded processors for data center, client, gaming, and embedded markets.',
+    dataSources: [
+      source('AMD Corporate', 'https://www.amd.com/en/corporate.html', ['companyName', 'establishedAt', 'description']),
+      source('AMD Leadership', 'https://www.amd.com/en/corporate/leadership-lisa-su', ['ceo']),
+      source('AMD Investor Relations', 'https://ir.amd.com/governance', ['ceo']),
+    ],
+    confidence: {
+      score: 0.76,
+      level: 'medium',
+      reasons: ['static fixture from issuer/investor sources', 'used when live Webull profile is unavailable'],
+    },
+  },
+}
+
+export const normalizeWebullCompanyProfile = (symbol: string, payload: unknown): CompanyProfile | null => {
+  const normalized = normalizeCompanySymbol(symbol)
+  if (!normalized) throw new Error(`unsupported company symbol: ${symbol}`)
+  const record = profilePayloadSchema.safeParse(payload)
+  if (!record.success) return null
+  const nestedProfile = profilePayloadSchema.safeParse(record.data.profile)
+  const nestedData = profilePayloadSchema.safeParse(record.data.data)
+  const data = nestedProfile.success ? nestedProfile.data : nestedData.success ? nestedData.data : record.data
+  const companyName = pickText(data, ['companyName', 'name', 'shortName', 'enName', 'tickerName', 'securityName'])
+  if (!companyName) return null
+
+  const updatedAt = nowIso()
+  const exchange = pickText(data, ['exchange', 'exchangeCode', 'exchangeName', 'market', 'marketName'])
+  const category = pickText(data, ['category', 'securityType', 'type', 'instrumentType'])
+  const sector = pickText(data, ['sector', 'sectorName'])
+  const industry = pickText(data, ['industry', 'industryName'])
+  const ceo = pickText(data, ['ceo', 'chiefExecutiveOfficer', 'chairman', 'leader'])
+  const employees = pickNumber(data, ['employees', 'employeeTotal', 'fullTimeEmployees', 'numberOfEmployees'])
+  const headquarters = pickText(data, ['headquarters', 'headquarter', 'hq', 'city'])
+  const address = pickText(data, ['address', 'officeAddress', 'companyAddress'])
+  const establishedAt = pickText(data, ['establishedAt', 'established', 'founded', 'foundedDate'])
+  const incorporatedAt = pickText(data, ['incorporatedAt', 'incorporated', 'incorporationDate'])
+  const description = pickText(data, ['description', 'profile', 'companyProfile', 'businessDescription', 'intro'])
+
+  return {
+    symbol: normalized,
+    companyName,
+    exchange,
+    category,
+    sector,
+    industry,
+    ceo,
+    employees,
+    headquarters,
+    address,
+    establishedAt,
+    incorporatedAt,
+    description,
+    dataSources: [
+      source('Webull', null, [
+        'companyName',
+        'exchange',
+        'category',
+        'sector',
+        'industry',
+        'ceo',
+        'employees',
+        'headquarters',
+        'address',
+        'establishedAt',
+        'incorporatedAt',
+        'description',
+      ]),
+    ],
+    quoteContext: null,
+    updatedAt,
+    confidence: confidenceFromSource('Webull', [
+      companyName,
+      exchange,
+      category,
+      sector,
+      industry,
+      ceo,
+      employees,
+      headquarters,
+      address,
+      establishedAt,
+      incorporatedAt,
+      description,
+    ]),
+    staleness: stalenessFor(updatedAt),
+  }
+}
+
+class WebullBridgeCompanyProfileProvider implements CompanyProfileProvider {
+  private readonly endpoint: string
   private readonly fetchImpl: typeof fetch
 
-  constructor(apiKey: string, fetchImpl: typeof fetch = fetch) {
-    this.apiKey = apiKey
+  constructor(endpoint: string, fetchImpl: typeof fetch = fetch) {
+    this.endpoint = endpoint
     this.fetchImpl = fetchImpl
   }
 
-  async getCompanyAnalysis(symbol: string): Promise<CompanyAnalysis> {
+  async getCompanyProfile(symbol: string): Promise<CompanyProfile | null> {
     const normalized = normalizeCompanySymbol(symbol)
     if (!normalized) throw new Error(`unsupported company symbol: ${symbol}`)
+    const url = new URL(this.endpoint)
+    url.searchParams.set('symbol', normalized)
+    const response = await this.fetchImpl(url)
+    if (response.status === 404) return null
+    if (!response.ok) throw new Error(`Webull company profile bridge failed: ${response.status}`)
+    const payload: unknown = await response.json()
+    return normalizeWebullCompanyProfile(normalized, payload)
+  }
+}
 
-    const [overviewPayload, quotePayload, rsiPayload] = await Promise.all([
-      this.request({ function: 'OVERVIEW', symbol: normalized }),
-      this.request({ function: 'GLOBAL_QUOTE', symbol: normalized }),
-      this.request({ function: 'RSI', symbol: normalized, interval: 'daily', time_period: '14', series_type: 'close' }),
-    ])
-
-    const overview = overviewSchema.parse(overviewPayload)
-    const quote = quoteSchema.parse(quotePayload)['Global Quote']
-    const rsiEntries = rsiSchema.parse(rsiPayload)['Technical Analysis: RSI'] ?? {}
-    const latestRsi = Object.keys(rsiEntries)
-      .sort()
-      .reverse()
-      .map((key) => rsiEntries[key]?.RSI)
-      .find(Boolean)
-
-    if (!overview.Name) throw new Error(`market data unavailable for ${normalized}`)
-
+class FixtureCompanyProfileProvider implements CompanyProfileProvider {
+  async getCompanyProfile(symbol: string): Promise<CompanyProfile | null> {
+    const normalized = normalizeCompanySymbol(symbol)
+    if (!normalized) throw new Error(`unsupported company symbol: ${symbol}`)
+    const fixture = fixtureProfiles[normalized]
+    if (!fixture) return null
+    const updatedAt = nowIso()
     return {
-      symbol: normalized,
-      identity: {
-        name: overview.Name,
-        exchange: cleanValue(overview.Exchange),
-        sector: cleanValue(overview.Sector),
-        industry: cleanValue(overview.Industry),
-        description: cleanValue(overview.Description),
-      },
-      fundamentals: compactMetrics([
-        metric('Market cap', formatLargeCurrency(overview.MarketCapitalization)),
-        metric('P/E ratio', formatNumber(overview.PERatio)),
-        metric('EPS', formatCurrency(overview.EPS)),
-        metric('Dividend yield', formatPercent(overview.DividendYield)),
-        metric('Profit margin', formatPercent(overview.ProfitMargin)),
-        metric('Beta', formatNumber(overview.Beta)),
-        metric('Analyst target', formatCurrency(overview.AnalystTargetPrice)),
-      ]),
-      technicals: compactMetrics([
-        metric('Last price', formatCurrency(quote?.['05. price'])),
-        metric('Change', formatCurrency(quote?.['09. change'])),
-        metric('Change %', formatPercent(quote?.['10. change percent'])),
-        metric('RSI 14D', formatNumber(latestRsi)),
-        metric('52W high', formatCurrency(overview['52WeekHigh'])),
-        metric('52W low', formatCurrency(overview['52WeekLow'])),
-        metric('50D average', formatCurrency(overview['50DayMovingAverage'])),
-        metric('200D average', formatCurrency(overview['200DayMovingAverage'])),
-      ]),
-      financials: compactMetrics([
-        metric('Revenue TTM', formatLargeCurrency(overview.RevenueTTM)),
-        metric('EBITDA', formatLargeCurrency(overview.EBITDA)),
-        metric('Gross profit TTM', formatLargeCurrency(overview.GrossProfitTTM)),
-        metric('Revenue growth YoY', formatPercent(overview.QuarterlyRevenueGrowthYOY)),
-        metric('Earnings growth YoY', formatPercent(overview.QuarterlyEarningsGrowthYOY)),
-        metric('Fiscal year end', cleanValue(overview.FiscalYearEnd)),
-      ]),
-      source: 'Alpha Vantage',
-      updatedAt: new Date().toISOString(),
+      ...fixture,
+      dataSources: fixture.dataSources.map((entry) => ({ ...entry, retrievedAt: updatedAt })),
+      quoteContext: null,
+      updatedAt,
+      staleness: stalenessFor(updatedAt),
     }
   }
+}
 
-  private async request(params: Record<string, string>) {
-    const url = new URL('https://www.alphavantage.co/query')
-    for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value)
-    url.searchParams.set('apikey', this.apiKey)
+class ChainedCompanyProfileProvider implements CompanyProfileProvider {
+  private readonly providers: CompanyProfileProvider[]
 
-    const response = await this.fetchImpl(url)
-    if (!response.ok) throw new Error(`Alpha Vantage request failed: ${response.status}`)
-    const payload: unknown = await response.json()
-    assertAlphaVantagePayload(payload, params.symbol ?? 'unknown')
-    return payload
+  constructor(providers: CompanyProfileProvider[]) {
+    this.providers = providers
+  }
+
+  async getCompanyProfile(symbol: string): Promise<CompanyProfile | null> {
+    let lastError: Error | null = null
+    for (const provider of this.providers) {
+      try {
+        const profile = await provider.getCompanyProfile(symbol)
+        if (profile) return profile
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error))
+      }
+    }
+    if (lastError && this.providers.length === 1) throw lastError
+    return null
   }
 }
 
-let providerForTests: CompanyDataProvider | null = null
+class AlpacaQuoteContextProvider implements CompanyQuoteContextProvider {
+  private readonly apiKeyId: string
+  private readonly apiSecretKey: string
+  private readonly feed: string | null
+  private readonly fetchImpl: typeof fetch
 
-export const createCompanyDataProvider = (): CompanyDataProvider | null => {
-  if (providerForTests) return providerForTests
+  constructor(apiKeyId: string, apiSecretKey: string, feed: string | null, fetchImpl: typeof fetch = fetch) {
+    this.apiKeyId = apiKeyId
+    this.apiSecretKey = apiSecretKey
+    this.feed = feed
+    this.fetchImpl = fetchImpl
+  }
 
-  const apiKey = process.env.SYNTHESIS_ALPHA_VANTAGE_API_KEY?.trim()
-  if (!apiKey) return null
-  return new AlphaVantageCompanyDataProvider(apiKey)
+  async getQuoteContext(symbol: string): Promise<CompanyQuoteContext | null> {
+    const normalized = normalizeCompanySymbol(symbol)
+    if (!normalized) throw new Error(`unsupported company symbol: ${symbol}`)
+    const url = new URL(`https://data.alpaca.markets/v2/stocks/${encodeURIComponent(normalized)}/quotes/latest`)
+    if (this.feed) url.searchParams.set('feed', this.feed)
+    const response = await this.fetchImpl(url, {
+      headers: {
+        'APCA-API-KEY-ID': this.apiKeyId,
+        'APCA-API-SECRET-KEY': this.apiSecretKey,
+      },
+    })
+    if (response.status === 403 || response.status === 404) return null
+    if (!response.ok) throw new Error(`Alpaca quote context failed: ${response.status}`)
+    const payload = (await response.json()) as { quote?: Record<string, unknown> }
+    const quote = payload.quote
+    if (!quote) return null
+    return {
+      source: 'Alpaca Market Data',
+      price: cleanNumber(quote.ap) ?? cleanNumber(quote.bp),
+      ask: cleanNumber(quote.ap),
+      bid: cleanNumber(quote.bp),
+      timestamp: toIso(cleanText(quote.t)),
+      retrievedAt: nowIso(),
+    }
+  }
 }
 
-export const setCompanyDataProviderForTests = (provider: CompanyDataProvider | null) => {
-  providerForTests = provider
+let profileProviderForTests: CompanyProfileProvider | null = null
+let quoteProviderForTests: CompanyQuoteContextProvider | null = null
+
+export const createCompanyProfileProvider = (): CompanyProfileProvider => {
+  if (profileProviderForTests) return profileProviderForTests
+
+  const providers: CompanyProfileProvider[] = []
+  const webullBridgeEndpoint = process.env.SYNTHESIS_WEBULL_PROFILE_ENDPOINT?.trim()
+  if (webullBridgeEndpoint) providers.push(new WebullBridgeCompanyProfileProvider(webullBridgeEndpoint))
+  providers.push(new FixtureCompanyProfileProvider())
+  return new ChainedCompanyProfileProvider(providers)
 }
+
+export const createCompanyQuoteContextProvider = (): CompanyQuoteContextProvider | null => {
+  if (quoteProviderForTests) return quoteProviderForTests
+  const apiKeyId = process.env.SYNTHESIS_ALPACA_API_KEY_ID?.trim() ?? process.env.APCA_API_KEY_ID?.trim()
+  const apiSecretKey = process.env.SYNTHESIS_ALPACA_API_SECRET_KEY?.trim() ?? process.env.APCA_API_SECRET_KEY?.trim()
+  if (!apiKeyId || !apiSecretKey) return null
+  return new AlpacaQuoteContextProvider(apiKeyId, apiSecretKey, process.env.SYNTHESIS_ALPACA_DATA_FEED?.trim() || null)
+}
+
+export const setCompanyProfileProviderForTests = (provider: CompanyProfileProvider | null) => {
+  profileProviderForTests = provider
+}
+
+export const setCompanyQuoteContextProviderForTests = (provider: CompanyQuoteContextProvider | null) => {
+  quoteProviderForTests = provider
+}
+
+export const companyProfileFromHints = (input: CompanyProfileHintInput): CompanyProfile => {
+  const hints = CompanyProfileHintSchema.parse(input)
+  const normalized = normalizeCompanySymbol(hints.symbol)
+  if (!normalized) throw new Error(`unsupported company symbol: ${hints.symbol}`)
+  if (!hints.companyName) throw new Error(`companyName is required when seeding ${normalized} without provider data`)
+  const updatedAt = nowIso()
+  const sources = hints.dataSources.length
+    ? hints.dataSources.map((entry) => source(entry.name, entry.url ?? null, entry.fields, updatedAt))
+    : [source('manual seed', null, ['companyName', 'description'], updatedAt)]
+
+  return {
+    symbol: normalized,
+    companyName: hints.companyName,
+    exchange: hints.exchange ?? null,
+    category: hints.category ?? null,
+    sector: hints.sector ?? null,
+    industry: hints.industry ?? null,
+    ceo: hints.ceo ?? null,
+    employees: hints.employees ?? null,
+    headquarters: hints.headquarters ?? null,
+    address: hints.address ?? null,
+    establishedAt: hints.establishedAt ?? null,
+    incorporatedAt: hints.incorporatedAt ?? null,
+    description: hints.description ?? null,
+    dataSources: sources,
+    quoteContext: null,
+    updatedAt,
+    confidence: confidenceFromSource('manual', [
+      hints.companyName,
+      hints.exchange,
+      hints.category,
+      hints.sector,
+      hints.industry,
+      hints.ceo,
+      hints.employees ?? null,
+      hints.headquarters,
+      hints.address,
+      hints.establishedAt,
+      hints.incorporatedAt,
+      hints.description,
+    ]),
+    staleness: stalenessFor(updatedAt),
+  }
+}
+
+export const mergeCompanyProfileHints = (profile: CompanyProfile, input: CompanyProfileHintInput): CompanyProfile => {
+  const hints = CompanyProfileHintSchema.parse(input)
+  const updatedAt = nowIso()
+  const dataSources = compactSources([
+    ...profile.dataSources,
+    ...hints.dataSources.map((entry) => source(entry.name, entry.url ?? null, entry.fields, updatedAt)),
+  ])
+  return {
+    ...profile,
+    companyName: profile.companyName || hints.companyName || profile.symbol,
+    exchange: profile.exchange ?? hints.exchange ?? null,
+    category: profile.category ?? hints.category ?? null,
+    sector: profile.sector ?? hints.sector ?? null,
+    industry: profile.industry ?? hints.industry ?? null,
+    ceo: profile.ceo ?? hints.ceo ?? null,
+    employees: profile.employees ?? hints.employees ?? null,
+    headquarters: profile.headquarters ?? hints.headquarters ?? null,
+    address: profile.address ?? hints.address ?? null,
+    establishedAt: profile.establishedAt ?? hints.establishedAt ?? null,
+    incorporatedAt: profile.incorporatedAt ?? hints.incorporatedAt ?? null,
+    description: profile.description ?? hints.description ?? null,
+    dataSources,
+    updatedAt,
+    staleness: stalenessFor(updatedAt),
+  }
+}
+
+export const enrichCompanyProfile = async (
+  input: CompanyProfileHintInput,
+  provider = createCompanyProfileProvider(),
+  quoteProvider = createCompanyQuoteContextProvider(),
+): Promise<CompanyProfile> => {
+  const hints = CompanyProfileHintSchema.parse(input)
+  const normalized = normalizeCompanySymbol(hints.symbol)
+  if (!normalized) throw new Error(`unsupported company symbol: ${hints.symbol}`)
+  const providerProfile = await provider.getCompanyProfile(normalized)
+  const baseProfile = providerProfile
+    ? mergeCompanyProfileHints(providerProfile, hints)
+    : companyProfileFromHints(hints)
+  const quoteContext = quoteProvider ? await quoteProvider.getQuoteContext(normalized).catch(() => null) : null
+  return {
+    ...baseProfile,
+    quoteContext,
+    dataSources: quoteContext
+      ? compactSources([
+          ...baseProfile.dataSources,
+          source(quoteContext.source, null, ['quoteContext'], quoteContext.retrievedAt),
+        ])
+      : baseProfile.dataSources,
+  }
+}
+
+// Backward-compatible alias for older tests/imports from the alpha-analysis implementation.
+export const setCompanyDataProviderForTests = setCompanyProfileProviderForTests

--- a/apps/synthesis/src/server/mcp.ts
+++ b/apps/synthesis/src/server/mcp.ts
@@ -1,4 +1,5 @@
 import { isAuthorized } from './auth'
+import { CompanyProfileHintSchema } from './company'
 import { jsonResponse } from './http'
 import {
   ListFeedInputSchema,
@@ -40,6 +41,7 @@ const mutatingTools = new Set([
   'synthesis_start_run',
   'synthesis_submit_item',
   'synthesis_submit_batch',
+  'synthesis_prefill_company',
   'synthesis_record_feedback',
 ])
 
@@ -153,6 +155,13 @@ const toolsListResult = {
               additionalProperties: false,
             },
           },
+          companySymbols: {
+            type: 'array',
+            items: { type: 'string' },
+            maxItems: 16,
+            description:
+              'Optional normalized public-company tickers/cashtags to associate with the item. The server also derives known symbols from item text, tags, and source posts.',
+          },
           dedupeKey: { type: 'string' },
           topicTags: { type: 'array', items: { type: 'string' } },
           score: { type: 'number', minimum: 0, maximum: 1 },
@@ -172,6 +181,44 @@ const toolsListResult = {
           items: { type: 'array', items: { type: 'object' }, minItems: 1, maxItems: 50 },
         },
         required: ['items'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'synthesis_prefill_company',
+      description:
+        'Populate or refresh a Synthesis-owned normalized public-company profile keyed by stock symbol. Prefers Webull-backed provider data when the runtime bridge is configured, can attach optional Alpaca quote context, and falls back to official-source/manual hints or local fixtures when available.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          symbol: { type: 'string', description: 'Ticker or cashtag such as NVDA or $AMD.' },
+          companyName: { type: 'string', description: 'Optional official company name for manual fallback.' },
+          exchange: { type: 'string' },
+          category: { type: 'string' },
+          sector: { type: 'string' },
+          industry: { type: 'string' },
+          ceo: { type: 'string' },
+          employees: { type: 'integer', minimum: 1 },
+          headquarters: { type: 'string' },
+          address: { type: 'string' },
+          establishedAt: { type: 'string' },
+          incorporatedAt: { type: 'string' },
+          description: { type: 'string' },
+          dataSources: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                url: { type: 'string' },
+                fields: { type: 'array', items: { type: 'string' } },
+              },
+              required: ['name'],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ['symbol'],
         additionalProperties: false,
       },
     },
@@ -296,6 +343,11 @@ const buildConfigResource = (request: Request) => ({
           objectStorageBackedWhenConfigured: true,
           sourceMediaRequiresExtractedVisualNotes: true,
         },
+        companies: {
+          appOwnedProfiles: true,
+          primaryProfileSource: 'Webull when configured; local official-source fixtures/manual hints otherwise',
+          quoteContext: 'optional Alpaca market-data read only; never required for static prefill',
+        },
       },
       tools: toolsListResult.tools,
     },
@@ -337,6 +389,11 @@ const handleToolCall = async (
       const parsed = SubmitBatchInputSchema.safeParse(args)
       if (!parsed.success) return invalidParams(id, 'Invalid synthesis_submit_batch input')
       return asJsonRpcResponse(id, toTextToolResult({ ok: true, ...(await store.submitBatch(parsed.data)) }))
+    }
+    if (name === 'synthesis_prefill_company') {
+      const parsed = CompanyProfileHintSchema.safeParse(args)
+      if (!parsed.success) return invalidParams(id, 'Invalid synthesis_prefill_company input')
+      return asJsonRpcResponse(id, toTextToolResult({ ok: true, company: await store.prefillCompany(parsed.data) }))
     }
     if (name === 'synthesis_list_feed') {
       const parsed = ListFeedInputSchema.safeParse(args)

--- a/apps/synthesis/src/server/schema.ts
+++ b/apps/synthesis/src/server/schema.ts
@@ -91,6 +91,7 @@ export const SubmitItemInputSchema = z
     attachments: z.array(AttachmentInputSchema).max(16).default([]),
     generatedAttachments: z.array(AttachmentInputSchema).max(8).default([]),
     dedupeKey: z.string().trim().min(1).max(240),
+    companySymbols: z.array(z.string().trim().min(1).max(20)).max(16).default([]),
     topicTags: z.array(TopicTagSchema).max(16).default([]),
     score: z.coerce.number().min(0).max(1),
     confidence: z.coerce.number().min(0).max(1),
@@ -170,6 +171,7 @@ export type SynthesisItem = {
   attachments: SynthesisAttachment[]
   generatedAttachments: SynthesisAttachment[]
   embedding: SynthesisEmbedding | null
+  companySymbols: string[]
   topicTags: string[]
   score: number
   confidence: number

--- a/apps/synthesis/src/server/store.ts
+++ b/apps/synthesis/src/server/store.ts
@@ -1,9 +1,11 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { Pool, type PoolClient } from 'pg'
 
+import { extractCompanySymbols, normalizeCompanySymbols } from '~/lib/company-symbols'
 import { deriveTopicTagsFromItemContent } from '~/lib/tags'
 
 import { materializeAttachments, normalizeAttachmentInputs } from './assets'
+import { enrichCompanyProfile, type CompanyProfile, type CompanyProfileHintInput } from './company'
 import {
   buildEmbeddingText,
   cosineSimilarity,
@@ -36,6 +38,9 @@ export type SynthesisStore = {
   listFeed(input: ListFeedInput): Promise<FeedResponse>
   getItem(id: string): Promise<SynthesisItem | null>
   getAttachment(id: string): Promise<SynthesisAttachment | null>
+  getCompanyProfile(symbol: string): Promise<CompanyProfile | null>
+  upsertCompanyProfile(profile: CompanyProfile): Promise<CompanyProfile>
+  prefillCompany(input: CompanyProfileHintInput): Promise<CompanyProfile>
   recordFeedback(input: RecordFeedbackInput): Promise<FeedbackEvent>
 }
 
@@ -163,6 +168,7 @@ type NormalizedSubmitItem = {
   summary: string
   whyValuable: string | null
   evidence: string[]
+  companySymbols: string[]
   topicTags: string[]
   score: number
   confidence: number
@@ -199,6 +205,8 @@ const mergeAttachments = (left: SynthesisAttachment[], right: SynthesisAttachmen
   return [...attachments.values()]
 }
 
+const mergeCompanySymbols = (left: string[], right: string[]) => normalizeCompanySymbols([...left, ...right])
+
 const digestKey = (value: string) => createHash('sha256').update(value).digest('base64url').slice(0, 24)
 
 const embeddingBackfillLimit = () => {
@@ -224,6 +232,19 @@ const normalizeSubmitItem = async (input: SubmitItemInput): Promise<NormalizedSu
     }),
   )
   const generatedAttachments = attachments.filter((attachment) => attachment.generated)
+  const derivedSymbols = extractCompanySymbols(
+    [
+      input.title,
+      input.synthesis,
+      input.whyValuable,
+      ...input.takeaways,
+      ...input.topicTags,
+      ...sourcePosts.flatMap((source) => [source.observedText, source.authorHandle, source.authorName]),
+      ...input.factChecks.flatMap((factCheck) => [factCheck.claim, factCheck.explanation]),
+    ]
+      .filter(Boolean)
+      .join(' '),
+  )
 
   return {
     runId: input.runId,
@@ -239,6 +260,7 @@ const normalizeSubmitItem = async (input: SubmitItemInput): Promise<NormalizedSu
     summary: input.synthesis,
     whyValuable: input.whyValuable,
     evidence: input.factChecks.map((factCheck) => `${factCheck.status}: ${factCheck.claim}`),
+    companySymbols: normalizeCompanySymbols([...input.companySymbols, ...derivedSymbols]),
     topicTags: deriveTopicTagsFromItemContent({
       title: input.title,
       synthesis: input.synthesis,
@@ -265,6 +287,7 @@ class InMemorySynthesisStore implements SynthesisStore {
   private posts = new Map<string, CanonicalXPost & { observedText: string }>()
   private itemByDedupeKey = new Map<string, string>()
   private items = new Map<string, SynthesisItem>()
+  private companyProfiles = new Map<string, CompanyProfile>()
   private embeddingVectors = new Map<string, number[]>()
   private feedbackEvents = new Map<string, FeedbackEvent>()
   private interestWeights = new Map<string, number>()
@@ -303,6 +326,7 @@ class InMemorySynthesisStore implements SynthesisStore {
     const sourcePosts = mergeSourcePosts(existing?.sourcePosts ?? [], normalized.sourcePosts)
     const attachments = mergeAttachments(existing?.attachments ?? [], normalized.attachments)
     const generatedAttachments = attachments.filter((attachment) => attachment.generated)
+    const companySymbols = mergeCompanySymbols(existing?.companySymbols ?? [], normalized.companySymbols)
     const embeddingRecord = await createSynthesisEmbedding(
       buildEmbeddingText({
         title: normalized.title,
@@ -338,6 +362,7 @@ class InMemorySynthesisStore implements SynthesisStore {
       attachments,
       generatedAttachments,
       embedding: embeddingMetadata(embeddingRecord),
+      companySymbols,
       topicTags: normalized.topicTags,
       score: normalized.score,
       confidence: normalized.confidence,
@@ -348,6 +373,7 @@ class InMemorySynthesisStore implements SynthesisStore {
     this.itemByDedupeKey.set(normalized.dedupeKey, item.id)
     this.items.set(item.id, item)
     this.embeddingVectors.set(item.id, embeddingRecord.embedding)
+    await this.prefillCompanySymbols(companySymbols)
 
     return {
       item,
@@ -409,6 +435,29 @@ class InMemorySynthesisStore implements SynthesisStore {
     return null
   }
 
+  async getCompanyProfile(symbol: string): Promise<CompanyProfile | null> {
+    const normalized = normalizeCompanySymbols([symbol])[0]
+    if (!normalized) throw new Error(`unsupported company symbol: ${symbol}`)
+    return this.companyProfiles.get(normalized) ?? null
+  }
+
+  async upsertCompanyProfile(profile: CompanyProfile): Promise<CompanyProfile> {
+    this.companyProfiles.set(profile.symbol, profile)
+    return profile
+  }
+
+  async prefillCompany(input: CompanyProfileHintInput): Promise<CompanyProfile> {
+    const profile = await enrichCompanyProfile(input)
+    return this.upsertCompanyProfile(profile)
+  }
+
+  private async prefillCompanySymbols(symbols: string[]) {
+    for (const symbol of symbols) {
+      if (this.companyProfiles.has(symbol)) continue
+      await this.prefillCompany({ symbol }).catch(() => undefined)
+    }
+  }
+
   async recordFeedback(input: RecordFeedbackInput): Promise<FeedbackEvent> {
     const item = this.items.get(input.id)
     if (!item) throw new Error(`Unknown synthesis item: ${input.id}`)
@@ -458,6 +507,7 @@ type ItemRow = {
   embedding_dimension: number | string | null
   embedding_input_hash: string | null
   embedding_created_at: Date | string | null
+  company_symbols: unknown
   topic_tags: unknown
   score: number | string
   confidence: number | string
@@ -548,6 +598,7 @@ const mapItemRow = (row: ItemRow): SynthesisItem => {
             createdAt: toIso(row.embedding_created_at) ?? nowIso(),
           }
         : null,
+    companySymbols: normalizeCompanySymbols(parseJsonArray(row.company_symbols)),
     topicTags,
     score: Number(row.score),
     confidence: Number(row.confidence),
@@ -651,6 +702,7 @@ class PostgresSynthesisStore implements SynthesisStore {
       const sourcePosts = mergeSourcePosts(existing?.sourcePosts ?? [], normalized.sourcePosts)
       const attachments = mergeAttachments(existing?.attachments ?? [], normalized.attachments)
       const generatedAttachments = attachments.filter((attachment) => attachment.generated)
+      const companySymbols = mergeCompanySymbols(existing?.companySymbols ?? [], normalized.companySymbols)
       const embeddingRecord = await createSynthesisEmbedding(
         buildEmbeddingText({
           title: normalized.title,
@@ -666,11 +718,11 @@ class PostgresSynthesisStore implements SynthesisStore {
       const result = await client.query<{ id: string }>(
         `INSERT INTO synthesis_items (
           id, run_id, x_post_key, dedupe_key, title, synthesis, takeaways, source_posts, fact_checks, attachments,
-          generated_attachments, media_urls, summary, why_valuable, evidence, topic_tags, score, confidence
+          generated_attachments, media_urls, summary, why_valuable, evidence, company_symbols, topic_tags, score, confidence
         )
         VALUES (
           $1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9::jsonb, $10::jsonb, $11::jsonb, $12::jsonb,
-          $13, $14, $15::jsonb, $16::jsonb, $17, $18
+          $13, $14, $15::jsonb, $16::jsonb, $17::jsonb, $18, $19
         )
         ON CONFLICT (dedupe_key) DO UPDATE SET
           run_id = EXCLUDED.run_id,
@@ -685,6 +737,7 @@ class PostgresSynthesisStore implements SynthesisStore {
           summary = EXCLUDED.summary,
           why_valuable = EXCLUDED.why_valuable,
           evidence = EXCLUDED.evidence,
+          company_symbols = EXCLUDED.company_symbols,
           topic_tags = EXCLUDED.topic_tags,
           score = EXCLUDED.score,
           confidence = EXCLUDED.confidence,
@@ -706,6 +759,7 @@ class PostgresSynthesisStore implements SynthesisStore {
           normalized.summary,
           normalized.whyValuable,
           JSON.stringify(normalized.evidence),
+          JSON.stringify(companySymbols),
           JSON.stringify(normalized.topicTags),
           normalized.score,
           normalized.confidence,
@@ -745,6 +799,16 @@ class PostgresSynthesisStore implements SynthesisStore {
         )
       }
 
+      await client.query(`DELETE FROM synthesis_item_companies WHERE item_id = $1`, [result.rows[0].id])
+      for (const symbol of companySymbols) {
+        await client.query(
+          `INSERT INTO synthesis_item_companies (item_id, symbol)
+           VALUES ($1, $2)
+           ON CONFLICT (item_id, symbol) DO NOTHING`,
+          [result.rows[0].id, symbol],
+        )
+      }
+
       await this.upsertEmbedding(client, result.rows[0].id, embeddingRecord)
 
       const itemResult = await client.query<ItemRow>(
@@ -753,6 +817,7 @@ class PostgresSynthesisStore implements SynthesisStore {
       )
       const item = mapItemRow(itemResult.rows[0])
       await client.query('COMMIT')
+      await this.prefillCompanySymbols(item.companySymbols)
       return { item }
     } catch (error) {
       await client.query('ROLLBACK')
@@ -845,6 +910,35 @@ class PostgresSynthesisStore implements SynthesisStore {
     return result.rows[0] ? mapAttachmentRow(result.rows[0]) : null
   }
 
+  async getCompanyProfile(symbol: string): Promise<CompanyProfile | null> {
+    await this.ensureSchema()
+    const normalized = normalizeCompanySymbols([symbol])[0]
+    if (!normalized) throw new Error(`unsupported company symbol: ${symbol}`)
+    const result = await this.pool.query<{ profile: unknown }>(
+      `SELECT profile FROM synthesis_company_profiles WHERE symbol = $1`,
+      [normalized],
+    )
+    return result.rows[0]?.profile ? (result.rows[0].profile as CompanyProfile) : null
+  }
+
+  async upsertCompanyProfile(profile: CompanyProfile): Promise<CompanyProfile> {
+    await this.ensureSchema()
+    await this.pool.query(
+      `INSERT INTO synthesis_company_profiles (symbol, profile, updated_at)
+       VALUES ($1, $2::jsonb, $3::timestamptz)
+       ON CONFLICT (symbol) DO UPDATE SET
+         profile = EXCLUDED.profile,
+         updated_at = EXCLUDED.updated_at`,
+      [profile.symbol, JSON.stringify(profile), profile.updatedAt],
+    )
+    return profile
+  }
+
+  async prefillCompany(input: CompanyProfileHintInput): Promise<CompanyProfile> {
+    const profile = await enrichCompanyProfile(input)
+    return this.upsertCompanyProfile(profile)
+  }
+
   async recordFeedback(input: RecordFeedbackInput): Promise<FeedbackEvent> {
     await this.ensureSchema()
     const item = await this.getItem(input.id)
@@ -881,7 +975,7 @@ class PostgresSynthesisStore implements SynthesisStore {
       ${alias}.takeaways, ${alias}.source_posts, ${alias}.fact_checks, ${alias}.attachments,
       ${alias}.generated_attachments, p.canonical_url, p.x_post_id, p.author_handle, p.author_name, p.posted_at,
       p.last_observed_at, p.observed_text, ${alias}.media_urls, ${alias}.summary, ${alias}.why_valuable,
-      ${alias}.evidence, ${alias}.topic_tags, ${alias}.score, ${alias}.confidence, ${alias}.created_at,
+      ${alias}.evidence, ${alias}.company_symbols, ${alias}.topic_tags, ${alias}.score, ${alias}.confidence, ${alias}.created_at,
       ${alias}.updated_at, e.model AS embedding_model, e.dimension AS embedding_dimension,
       e.input_hash AS embedding_input_hash, e.created_at AS embedding_created_at`
   }
@@ -912,6 +1006,14 @@ class PostgresSynthesisStore implements SynthesisStore {
         embeddingRecord.createdAt,
       ],
     )
+  }
+
+  private async prefillCompanySymbols(symbols: string[]) {
+    for (const symbol of symbols) {
+      const existing = await this.getCompanyProfile(symbol).catch(() => null)
+      if (existing) continue
+      await this.prefillCompany({ symbol }).catch(() => undefined)
+    }
   }
 
   private async backfillMissingTopicTags() {
@@ -1018,6 +1120,7 @@ class PostgresSynthesisStore implements SynthesisStore {
         summary text NOT NULL,
         why_valuable text,
         evidence jsonb NOT NULL DEFAULT '[]'::jsonb,
+        company_symbols jsonb NOT NULL DEFAULT '[]'::jsonb,
         topic_tags jsonb NOT NULL DEFAULT '[]'::jsonb,
         score double precision NOT NULL CHECK (score >= 0 AND score <= 1),
         confidence double precision NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
@@ -1034,6 +1137,7 @@ class PostgresSynthesisStore implements SynthesisStore {
       ALTER TABLE synthesis_items ADD COLUMN IF NOT EXISTS fact_checks jsonb NOT NULL DEFAULT '[]'::jsonb;
       ALTER TABLE synthesis_items ADD COLUMN IF NOT EXISTS attachments jsonb NOT NULL DEFAULT '[]'::jsonb;
       ALTER TABLE synthesis_items ADD COLUMN IF NOT EXISTS generated_attachments jsonb NOT NULL DEFAULT '[]'::jsonb;
+      ALTER TABLE synthesis_items ADD COLUMN IF NOT EXISTS company_symbols jsonb NOT NULL DEFAULT '[]'::jsonb;
       ALTER TABLE synthesis_items DROP COLUMN IF EXISTS engagement_recommendation;
       ALTER TABLE synthesis_items DROP COLUMN IF EXISTS engagement_status;
       ALTER TABLE synthesis_items DROP COLUMN IF EXISTS reply_text;
@@ -1079,6 +1183,19 @@ class PostgresSynthesisStore implements SynthesisStore {
         created_at timestamptz NOT NULL DEFAULT now()
       );
 
+      CREATE TABLE IF NOT EXISTS synthesis_company_profiles (
+        symbol text PRIMARY KEY,
+        profile jsonb NOT NULL,
+        updated_at timestamptz NOT NULL DEFAULT now()
+      );
+
+      CREATE TABLE IF NOT EXISTS synthesis_item_companies (
+        item_id text NOT NULL REFERENCES synthesis_items(id) ON DELETE CASCADE,
+        symbol text NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        PRIMARY KEY (item_id, symbol)
+      );
+
       DROP TABLE IF EXISTS engagement_actions;
 
       CREATE TABLE IF NOT EXISTS feedback_events (
@@ -1110,6 +1227,7 @@ class PostgresSynthesisStore implements SynthesisStore {
       CREATE INDEX IF NOT EXISTS synthesis_item_sources_x_post_idx ON synthesis_item_sources (x_post_key);
       CREATE INDEX IF NOT EXISTS synthesis_attachments_item_idx ON synthesis_attachments (item_id);
       CREATE INDEX IF NOT EXISTS synthesis_item_embeddings_model_idx ON synthesis_item_embeddings (model, dimension);
+      CREATE INDEX IF NOT EXISTS synthesis_item_companies_symbol_idx ON synthesis_item_companies (symbol);
     `)
     await this.backfillMissingTopicTags()
     await this.backfillMissingEmbeddings()

--- a/apps/synthesis/vitest.config.ts
+++ b/apps/synthesis/vitest.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    include: ['src/{lib,server}/**/*.test.ts'],
+    include: ['src/{lib,server}/**/*.test.ts', 'src/routes/**/*.test.tsx'],
   },
 })

--- a/docs/synthesis-company-prefill.md
+++ b/docs/synthesis-company-prefill.md
@@ -1,0 +1,19 @@
+# Synthesis Company Profile Prefill
+
+Synthesis stores first-class company profiles keyed by normalized public ticker symbols. Curated/xcurate items can pass an optional `companySymbols` array to `synthesis_submit_item` / `synthesis_submit_batch`; the server also derives known ticker and cashtag mentions from item titles, synthesis text, takeaways, tags, fact checks, and source-post text.
+
+When a company symbol is associated with an item, Synthesis attempts to prefill the app-owned profile and links ticker mentions to `/companies/{SYMBOL}` instead of making an external market-data site the primary experience.
+
+## MCP workflow
+
+- Use `synthesis_prefill_company` for explicit enrichment or refresh. Required input: `symbol` (for example `NVDA` or `$AMD`).
+- Optional manual seed fields are accepted for official-source fallback: `companyName`, `exchange`, `category`, `sector`, `industry`, `ceo`, `employees`, `headquarters`, `address`, `establishedAt`, `incorporatedAt`, `description`, and `dataSources`.
+- `synthesis_submit_item` remains strict and does not accept legacy raw-post top-level fields. If company context is important, include `companySymbols`; otherwise the server derives symbols from the synthesized item and source posts.
+
+## Providers
+
+- Webull profile data is the preferred business-profile source when a runtime bridge is configured with `SYNTHESIS_WEBULL_PROFILE_ENDPOINT`. The endpoint must return the payload shape supplied by `mcp__webull__.get_company_profile(symbol)` or a compatible object; Synthesis normalizes it at the provider boundary.
+- Alpaca is read-only optional quote context. Configure `SYNTHESIS_ALPACA_API_KEY_ID` / `SYNTHESIS_ALPACA_API_SECRET_KEY` (or `APCA_API_KEY_ID` / `APCA_API_SECRET_KEY`) to attach latest quote fields. It is never required for static profile prefill and Synthesis does not place orders.
+- Local official-source fixtures currently cover `NVDA` and `AMD` so tests and cold-start profile pages do not depend on live provider access.
+
+The Codex host MCP tool `mcp__webull__.get_company_profile(symbol)` is not callable from the deployed app process by itself; production Webull integration needs a small bridge endpoint or runtime adapter that exposes that tool result to Synthesis through `SYNTHESIS_WEBULL_PROFILE_ENDPOINT`.


### PR DESCRIPTION
## Summary

- Adds Synthesis-owned company profiles keyed by normalized ticker symbols, including provenance, confidence/staleness metadata, NVDA/AMD fixture fallback, Webull bridge normalization, and optional read-only Alpaca quote context.
- Adds strict `companySymbols` item association/derivation, automatic profile prefill on submit, REST prefill/get handlers, and the `synthesis_prefill_company` MCP tool.
- Updates internal company pages to render profile fields, source provenance, and optional quote context while keeping ticker links inside Synthesis.
- Documents the xcurate/Synthesis company enrichment workflow and the required Webull bridge runtime integration.

## Related Issues

None

## Testing

- `bun run --filter synthesis test` — passed (34 tests)
- `bun run --filter synthesis lint` — passed
- `bun run --filter synthesis build` — passed
- `PORT=4173 SYNTHESIS_STORAGE=memory bun run --filter synthesis start` plus `curl -fsS http://localhost:4173/api/companies/NVDA` and `curl -fsS http://localhost:4173/companies/NVDA` — passed; API returned the fixture-backed NVIDIA profile and the company route served successfully.

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Existing strict Synthesis item payloads remain valid; `companySymbols` is optional. Postgres storage auto-creates the new profile/association table and `company_symbols` column through the existing app schema bootstrap.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
