### PR TITLE
fix(torghut): import paper-route plan from sim service

### DIFF
--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -22,7 +22,7 @@ The empirical workflow depends on the namespace-local sealed secret
 workflow submissions in `torghut` do not rely on manual secret copies from `argo-workflows`.
 
 The `torghut-empirical-promotion-renewal` CronJob is also the scheduled runtime-ledger proof packet conductor for the
-paper-route proof lane. It first runs `renew_latest_empirical_promotion_jobs.py` with the live
+paper-route proof lane. It first runs `renew_latest_empirical_promotion_jobs.py` with the sim
 `/trading/paper-route-evidence` target plan, then runs `assemble_runtime_ledger_proof_packet.py` and uploads the packet
 under `runtime-ledger-proof-packets/{run_id}`. When the paper-route window is import-ready, the packet now requires the
 live `runtime_window_import_audit` from `/trading/paper-route-evidence` and carries source-activity blockers such as

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -46,7 +46,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref intraday_tsmom_v2@research \
                     --runtime-window-import \
-                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence \
+                    --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence \
                     --runtime-window-target-plan-exclusive \
                     --runtime-window-target-plan-required \
                     --runtime-window-target-plan-settlement-seconds 3600 \

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -3898,7 +3898,7 @@ def _daily_runtime_ledger_portfolio_summary(
     account = account_label.strip()
     stmt = (
         select(StrategyRuntimeLedgerBucket)
-        .where(StrategyRuntimeLedgerBucket.bucket_started_at >= day_start)
+        .where(StrategyRuntimeLedgerBucket.bucket_ended_at >= day_start)
         .where(StrategyRuntimeLedgerBucket.bucket_ended_at <= observed)
         .where(StrategyRuntimeLedgerBucket.account_label == account)
         .order_by(

--- a/services/torghut/tests/test_evidence_epochs.py
+++ b/services/torghut/tests/test_evidence_epochs.py
@@ -293,6 +293,9 @@ class TestEvidenceEpochs(TestCase):
         Base.metadata.create_all(engine)
         session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
         now = datetime.now(timezone.utc)
+        day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        bucket_started_at = day_start - timedelta(minutes=15)
+        bucket_ended_at = max(day_start, now - timedelta(seconds=1))
         with session_local() as session:
             for suffix, observed_stage, account_label, net_pnl in (
                 ("wrong-stage", "live", "paper", Decimal("999")),
@@ -305,8 +308,8 @@ class TestEvidenceEpochs(TestCase):
                         candidate_id=f"candidate-{suffix}",
                         hypothesis_id="H-PORTFOLIO-PROOF",
                         observed_stage=observed_stage,
-                        bucket_started_at=now - timedelta(hours=1),
-                        bucket_ended_at=now - timedelta(minutes=30),
+                        bucket_started_at=bucket_started_at,
+                        bucket_ended_at=bucket_ended_at,
                         account_label=account_label,
                         runtime_strategy_name="portfolio-proof-strategy",
                         strategy_family="portfolio_proof",
@@ -380,6 +383,7 @@ class TestEvidenceEpochs(TestCase):
         Base.metadata.create_all(engine)
         session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
         observed_at = datetime.now(timezone.utc)
+        day_start = observed_at.replace(hour=0, minute=0, second=0, microsecond=0)
         with session_local() as session:
             session.add(
                 StrategyRuntimeLedgerBucket(
@@ -387,8 +391,8 @@ class TestEvidenceEpochs(TestCase):
                     candidate_id="candidate-blocked",
                     hypothesis_id="H-PORTFOLIO-PROOF",
                     observed_stage="paper",
-                    bucket_started_at=observed_at - timedelta(hours=1),
-                    bucket_ended_at=observed_at - timedelta(minutes=30),
+                    bucket_started_at=day_start - timedelta(minutes=15),
+                    bucket_ended_at=max(day_start, observed_at - timedelta(seconds=1)),
                     account_label="paper",
                     runtime_strategy_name="portfolio-proof-strategy",
                     strategy_family="portfolio_proof",

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -814,7 +814,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--max-batches 1", args)
         self.assertIn("--apply", args)
 
-    def test_empirical_promotion_renewal_imports_authoritative_live_paper_plan_and_sim_db(
+    def test_empirical_promotion_renewal_imports_authoritative_sim_paper_plan_and_sim_db(
         self,
     ) -> None:
         spec, container = _load_cronjob_container(
@@ -876,12 +876,12 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn(
             "--runtime-window-target-plan-url "
-            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
         self.assertNotIn(
             "--runtime-window-target-plan-url "
-            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
         self.assertIn("--runtime-window-target-plan-exclusive", args)


### PR DESCRIPTION
## Summary

- Point the scheduled empirical promotion renewal runtime-window import at `torghut-sim` paper-route evidence, where paper-mode source activity is observable.
- Keep the proof packet status and completion checks pointed at live `torghut`, so proof authority remains separated from paper evidence collection.
- Attribute daily runtime-ledger portfolio proof by bucket close time so round trips that cross UTC midnight are not dropped.
- Update the manifest/evidence contract tests and Torghut GitOps README to document the sim target-plan source.

## Related Issues

None

## Testing

- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen pytest tests/test_evidence_epochs.py tests/test_live_config_manifest_contract.py -q`
- `bash -lc 'cd services/torghut && TEST_FILES=$(find tests -name "test_*.py" ! -path "tests/test_run_whitepaper_autoresearch_profit_target.py" -print | sort | awk -v shard=3 -v total=4 "((NR - 1) % total) == shard") && uv run --frozen pytest -n auto --dist=worksteal --maxfail=1 $TEST_FILES -q'`
- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check app/main.py tests/test_evidence_epochs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check app/main.py tests/test_evidence_epochs.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
