### PR TITLE
fix(torghut): materialize observed runtime ledger fills

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -556,17 +556,7 @@ def _runtime_window_source_kind_is_informational(
         )
     ):
         return True
-    scope = (
-        str(
-            target_metadata.get("paper_probation_authorization_scope")
-            or target_metadata.get("evidence_scope")
-            or ""
-        )
-        .strip()
-        .lower()
-        .replace("-", "_")
-    )
-    return scope == "evidence_collection_only"
+    return False
 
 
 _AUTHORITATIVE_RUNTIME_LEDGER_MATERIALIZATION_SOURCE_KINDS = frozenset(

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -773,14 +773,37 @@ def _build_realized_strategy_pnl_rows(
     event_times: list[datetime] = []
     for row in execution_rows:
         computed_at = row.get("computed_at")
-        price = _decimal_or_none(row.get("avg_fill_price"))
+        execution_created_at = row.get("execution_created_at")
+        fill_event_at = (
+            execution_created_at
+            if isinstance(execution_created_at, datetime)
+            else computed_at
+        )
+        price = _first_decimal(
+            row,
+            "avg_fill_price",
+            "filled_avg_price",
+            "filled_average_price",
+            "average_fill_price",
+            "fill_price",
+            "filled_price",
+        )
         signed_qty = _execution_signed_qty(
-            side=row.get("side"), qty=row.get("filled_qty")
+            side=_first_text(row, "side", "order_side"),
+            qty=_first_decimal(
+                row,
+                "filled_qty",
+                "filled_quantity",
+                "qty",
+                "quantity",
+            ),
         )
         symbol = str(row.get("symbol") or "").strip().upper()
         if not symbol or not isinstance(computed_at, datetime):
             continue
         event_times.append(computed_at)
+        if isinstance(fill_event_at, datetime):
+            event_times.append(fill_event_at)
         decision_id = _first_text(
             row, "decision_id", "trade_decision_id", "decision_hash"
         )
@@ -867,7 +890,11 @@ def _build_realized_strategy_pnl_rows(
         )
         ledger_rows.append(
             RuntimeLedgerFill(
-                executed_at=computed_at,
+                executed_at=(
+                    fill_event_at
+                    if isinstance(fill_event_at, datetime)
+                    else computed_at
+                ),
                 event_type="fill",
                 decision_id=decision_id,
                 order_id=order_id,
@@ -875,7 +902,7 @@ def _build_realized_strategy_pnl_rows(
                 cost_model_hash=common_ledger_fields["cost_model_hash"],
                 lineage_hash=common_ledger_fields["lineage_hash"],
                 replay_data_hash=common_ledger_fields["replay_data_hash"],
-                side=str(row.get("side") or ""),
+                side=_first_text(row, "side", "order_side") or "",
                 filled_qty=abs(signed_qty),
                 avg_fill_price=price,
                 cost_amount=cost_amount,

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -1216,6 +1216,78 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertGreaterEqual(len(bucket["cost_model_hash_counts"]), 1)
         self.assertGreaterEqual(len(bucket["lineage_hash_counts"]), 1)
 
+    def test_build_realized_strategy_pnl_rows_uses_raw_order_fill_fields(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "execution_created_at": datetime(
+                        2026, 3, 6, 15, 45, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_audit_json": {
+                        "fees": {
+                            "cost_amount": "0.20",
+                            "cost_basis": "broker_reported_commission_and_fees",
+                        },
+                        "lineage": {"runtime_window_id": "paper-route-session"},
+                    },
+                    "raw_order": {
+                        "side": "buy",
+                        "filled_qty": "1",
+                        "filled_avg_price": "100",
+                        "execution_policy": {"selected_order_type": "limit"},
+                        "cost_model": {"source": "broker_reported"},
+                    },
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 50, tzinfo=timezone.utc),
+                    "execution_created_at": datetime(
+                        2026, 3, 6, 15, 55, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_audit_json": {
+                        "fees": {
+                            "cost_amount": "0.10",
+                            "cost_basis": "broker_reported_commission_and_fees",
+                        },
+                        "lineage": {"runtime_window_id": "paper-route-session"},
+                    },
+                    "raw_order": {
+                        "side": "sell",
+                        "filled_qty": "1",
+                        "filled_avg_price": "101",
+                        "execution_policy": {"selected_order_type": "limit"},
+                        "cost_model": {"source": "broker_reported"},
+                    },
+                },
+            ]
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(
+            rows[0]["computed_at"], datetime(2026, 3, 6, 15, 55, tzinfo=timezone.utc)
+        )
+        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.70"))
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["fill_count"], 2)
+        self.assertEqual(bucket["filled_notional"], "201")
+        self.assertNotIn("runtime_fills_missing", bucket["blockers"])
+        self.assertNotIn("filled_notional_missing", bucket["blockers"])
+        self.assertNotIn("explicit_cost_missing", bucket["blockers"])
+        self.assertEqual(
+            bucket["blockers"],
+            ["execution_reconstruction_not_runtime_ledger_proof"],
+        )
+
     def test_build_realized_strategy_pnl_rows_materializes_audit_only_runtime_metadata(
         self,
     ) -> None:

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -755,10 +755,18 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 target_metadata={"paper_route_probe_symbols": ["AAPL"]},
             )
         )
-        self.assertFalse(
+        self.assertTrue(
             _source_kind_allows_runtime_ledger_materialization(
                 source_kind="paper_runtime_observed",
                 target_metadata={"evidence_scope": "evidence_collection_only"},
+            )
+        )
+        self.assertFalse(
+            _runtime_window_source_kind_is_informational(
+                source_kind="paper_route_probe_runtime_observed",
+                target_metadata={
+                    "paper_probation_authorization_scope": "evidence_collection_only"
+                },
             )
         )
 
@@ -1267,10 +1275,16 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                         "cost_model": {"source": "broker_reported"},
                     },
                 },
-            ]
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
         )
 
         self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["authoritative"], True)
+        self.assertEqual(
+            rows[0]["authority_reason"],
+            "source_execution_runtime_ledger_materialized",
+        )
         self.assertEqual(
             rows[0]["computed_at"], datetime(2026, 3, 6, 15, 55, tzinfo=timezone.utc)
         )
@@ -1283,10 +1297,8 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertNotIn("runtime_fills_missing", bucket["blockers"])
         self.assertNotIn("filled_notional_missing", bucket["blockers"])
         self.assertNotIn("explicit_cost_missing", bucket["blockers"])
-        self.assertEqual(
-            bucket["blockers"],
-            ["execution_reconstruction_not_runtime_ledger_proof"],
-        )
+        self.assertEqual(bucket["blockers"], [])
+        self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
 
     def test_build_realized_strategy_pnl_rows_materializes_audit_only_runtime_metadata(
         self,
@@ -2506,6 +2518,12 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             dataset_snapshot_ref="source-runtime-ledger-snapshot",
             target_metadata_json=json.dumps(
                 {
+                    "paper_probation_authorized": True,
+                    "paper_probation_authorization_scope": ("evidence_collection_only"),
+                    "evidence_collection_stage": "paper",
+                    "promotion_allowed": False,
+                    "final_promotion_authorized": False,
+                    "final_promotion_allowed": False,
                     "runtime_ledger_target_metadata_blockers": [
                         "paper_route_runtime_ledger_import_pending"
                     ],


### PR DESCRIPTION
## Summary

- Materializes source execution fills from nested broker/raw-order payload fields when top-level execution columns are sparse.
- Uses `execution_created_at` as the fill event timestamp so runtime-ledger buckets reflect actual fill time instead of decision time.
- Allows observed runtime sources to materialize runtime-ledger proof even when target metadata is paper evidence collection only; promotion remains blocked by paper/final promotion gates until the higher-level proof authority passes.
- Adds regressions for nested `raw_order` fills, explicit fee/cost basis, policy/cost-model/lineage extraction, and evidence-scope materialization.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py tests/test_evidence_epochs.py -q`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
