### PR TITLE
fix(torghut): close stale paper route probe fills

### DIFF
--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -1428,6 +1428,14 @@ class Settings(BaseSettings):
             "paper-route probe retry candidates."
         ),
     )
+    trading_simple_paper_route_probe_exit_lookback_hours: int = Field(
+        default=72,
+        alias="TRADING_SIMPLE_PAPER_ROUTE_PROBE_EXIT_LOOKBACK_HOURS",
+        description=(
+            "How far back the simple paper-route probe exit repair path scans for "
+            "filled paper probe entries that missed their configured exit minute."
+        ),
+    )
     trading_paper_route_target_plan_url: Optional[str] = Field(
         default=None,
         alias="TRADING_PAPER_ROUTE_TARGET_PLAN_URL",
@@ -2346,6 +2354,10 @@ class Settings(BaseSettings):
             (
                 self.trading_simple_paper_route_probe_max_notional,
                 "TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL must be >= 0",
+            ),
+            (
+                self.trading_simple_paper_route_probe_exit_lookback_hours,
+                "TRADING_SIMPLE_PAPER_ROUTE_PROBE_EXIT_LOOKBACK_HOURS must be >= 0",
             ),
             (
                 self.trading_paper_route_target_plan_timeout_seconds,

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -130,6 +130,13 @@ class SimpleTradingPipeline(TradingPipeline):
                 self.ingestor.commit_cursor(session, batch)
                 return
             account_snapshot, account, positions, allowed_symbols = context
+            self._process_paper_route_probe_exit_decisions(
+                session=session,
+                strategies=strategies,
+                account=account,
+                positions=positions,
+                allowed_symbols=allowed_symbols,
+            )
             quality_signals = self._quality_gate_signals(
                 signals=batch.signals,
                 strategies=strategies,
@@ -146,13 +153,6 @@ class SimpleTradingPipeline(TradingPipeline):
                 batch=batch,
                 strategies=strategies,
                 account_snapshot=account_snapshot,
-                account=account,
-                positions=positions,
-                allowed_symbols=allowed_symbols,
-            )
-            self._process_paper_route_probe_exit_decisions(
-                session=session,
-                strategies=strategies,
                 account=account,
                 positions=positions,
                 allowed_symbols=allowed_symbols,
@@ -426,6 +426,20 @@ class SimpleTradingPipeline(TradingPipeline):
         )
         if direct_exit_minute is not None:
             return direct_exit_minute
+        probe_metadata = decision.params.get("paper_route_probe")
+        if isinstance(probe_metadata, Mapping):
+            probe_mapping = cast(Mapping[str, object], probe_metadata)
+            for key in (
+                "exit_minute_after_open",
+                "effective_exit_minute_after_open",
+            ):
+                metadata_exit_minute = (
+                    SimpleTradingPipeline._paper_route_probe_exit_minute_value(
+                        probe_mapping.get(key)
+                    )
+                )
+                if metadata_exit_minute is not None:
+                    return metadata_exit_minute
         if strategy is None:
             return None
         metadata = extract_catalog_metadata(strategy.description)
@@ -436,6 +450,35 @@ class SimpleTradingPipeline(TradingPipeline):
         return SimpleTradingPipeline._paper_route_probe_exit_minute_value(
             params.get("exit_minute_after_open")
         )
+
+    @staticmethod
+    def _paper_route_probe_session_open(value: datetime) -> datetime:
+        ts = (
+            value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        ).astimezone(timezone.utc)
+        return datetime.combine(ts.date(), REGULAR_OPEN_UTC, tzinfo=timezone.utc)
+
+    @staticmethod
+    def _paper_route_probe_exit_session_open(
+        *,
+        decision: StrategyDecision,
+        fallback: datetime,
+    ) -> datetime:
+        metadata = SimpleTradingPipeline._paper_route_probe_exit_metadata(decision)
+        if metadata is not None:
+            raw_session_open = metadata.get("session_open")
+            if isinstance(raw_session_open, datetime):
+                return SimpleTradingPipeline._paper_route_probe_session_open(
+                    raw_session_open
+                )
+            raw_text = str(raw_session_open or "").strip()
+            if raw_text:
+                try:
+                    parsed = datetime.fromisoformat(raw_text.replace("Z", "+00:00"))
+                    return SimpleTradingPipeline._paper_route_probe_session_open(parsed)
+                except ValueError:
+                    pass
+        return SimpleTradingPipeline._paper_route_probe_session_open(fallback)
 
     def _paper_route_probe_entry_after_exit_minute(
         self,
@@ -561,6 +604,15 @@ class SimpleTradingPipeline(TradingPipeline):
             REGULAR_OPEN_UTC,
             tzinfo=timezone.utc,
         )
+        exit_lookback_hours = max(
+            0,
+            _safe_int(settings.trading_simple_paper_route_probe_exit_lookback_hours),
+        )
+        lookback_start = (
+            now - timedelta(hours=exit_lookback_hours)
+            if exit_lookback_hours > 0
+            else session_open
+        )
         rows = session.execute(
             select(Execution, TradeDecision)
             .join(TradeDecision, Execution.trade_decision_id == TradeDecision.id)
@@ -569,11 +621,11 @@ class SimpleTradingPipeline(TradingPipeline):
                 TradeDecision.alpaca_account_label == self.account_label,
                 Execution.status == "filled",
                 Execution.filled_qty > Decimal("0"),
-                Execution.created_at >= session_open,
+                Execution.created_at >= lookback_start,
             )
             .order_by(Execution.created_at.asc())
         ).all()
-        exposures: dict[tuple[str, str], dict[str, Any]] = {}
+        exposures: dict[tuple[str, str, str], dict[str, Any]] = {}
         for execution, decision_row in rows:
             decision = self._trade_decision_from_retry_row(decision_row)
             if decision is None:
@@ -599,13 +651,22 @@ class SimpleTradingPipeline(TradingPipeline):
             if not symbol:
                 continue
 
-            key = (str(strategy.id), symbol)
+            entry_session_open = (
+                self._paper_route_probe_session_open(decision.event_ts)
+                if is_entry
+                else self._paper_route_probe_exit_session_open(
+                    decision=decision,
+                    fallback=decision.event_ts,
+                )
+            )
+            key = (str(strategy.id), symbol, entry_session_open.isoformat())
             exposure = exposures.setdefault(
                 key,
                 {
                     "strategy": strategy,
                     "symbol": symbol,
                     "timeframe": decision.timeframe,
+                    "session_open": entry_session_open,
                     "net_qty": Decimal("0"),
                     "buy_qty": Decimal("0"),
                     "buy_notional": Decimal("0"),
@@ -652,7 +713,8 @@ class SimpleTradingPipeline(TradingPipeline):
             if exit_minute is None:
                 continue
             effective_exit_minute = min(exit_minute, _REGULAR_SESSION_MINUTES - 1)
-            exit_due_at = session_open + timedelta(minutes=effective_exit_minute)
+            entry_session_open = cast(datetime, exposure["session_open"])
+            exit_due_at = entry_session_open + timedelta(minutes=effective_exit_minute)
             if now < exit_due_at:
                 continue
             strategy = cast(Strategy, exposure["strategy"])
@@ -661,7 +723,7 @@ class SimpleTradingPipeline(TradingPipeline):
                 session=session,
                 strategy=strategy,
                 symbol=symbol,
-                session_open=session_open,
+                session_open=entry_session_open,
                 exit_due_at=exit_due_at,
             ):
                 continue
@@ -678,7 +740,8 @@ class SimpleTradingPipeline(TradingPipeline):
                     "exit_minute_after_open": exit_minute,
                     "effective_exit_minute_after_open": effective_exit_minute,
                     "exit_due_at": exit_due_at.isoformat(),
-                    "session_open": session_open.isoformat(),
+                    "session_open": entry_session_open.isoformat(),
+                    "stale_exit_repair": entry_session_open.date() < now.date(),
                     "latest_entry_at": exposure["latest_entry_at"].isoformat()
                     if isinstance(exposure.get("latest_entry_at"), datetime)
                     else None,
@@ -1372,6 +1435,23 @@ class SimpleTradingPipeline(TradingPipeline):
             strategy=strategy,
         ):
             return None
+        exit_minute = self._paper_route_probe_exit_minute_after_open(
+            decision=decision,
+            strategy=strategy,
+        )
+        effective_exit_minute: int | None = None
+        exit_due_at: str | None = None
+        if exit_minute is not None:
+            effective_exit_minute = min(exit_minute, _REGULAR_SESSION_MINUTES - 1)
+            now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
+            session_open = datetime.combine(
+                now.date(),
+                REGULAR_OPEN_UTC,
+                tzinfo=timezone.utc,
+            )
+            exit_due_at = (
+                session_open + timedelta(minutes=effective_exit_minute)
+            ).isoformat()
 
         blocking_reasons = {
             str(item).strip()
@@ -1422,6 +1502,9 @@ class SimpleTradingPipeline(TradingPipeline):
             "paper_route_target_plan_source": "external_target_plan_url"
             if target_plan_symbols
             else None,
+            "exit_minute_after_open": exit_minute,
+            "effective_exit_minute_after_open": effective_exit_minute,
+            "exit_due_at": exit_due_at,
             "simple_submit_enabled": settings.trading_simple_submit_enabled,
             "simple_submit_bypass_scope": "paper_route_probe_only"
             if not settings.trading_simple_submit_enabled

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -233,6 +233,10 @@ def _first_payload_digest(row: Mapping[str, object], *keys: str) -> str | None:
 
 
 _LINEAGE_CONTEXT_KEYS = (
+    "strategy_id",
+    "primary_declared_strategy_id",
+    "source_declared_strategy_ids",
+    "paper_route_target_plan_source",
     "simulation_run_id",
     "dataset_id",
     "dataset_snapshot_ref",
@@ -754,6 +758,64 @@ def _execution_signed_qty(*, side: Any, qty: Any) -> Decimal:
     return Decimal("0")
 
 
+def _runtime_execution_cost_amount(
+    row: Mapping[str, object],
+    *,
+    filled_notional: Decimal,
+) -> Decimal | None:
+    explicit_cost = _first_decimal(
+        row,
+        "cost_amount",
+        "explicit_cost",
+        "commission",
+        "fees",
+        "fee_amount",
+        "broker_fee",
+    )
+    if explicit_cost is not None:
+        return explicit_cost
+    total_cost_bps = _first_decimal(
+        row,
+        "total_cost_bps",
+        "estimated_total_cost_bps",
+        "explicit_cost_bps",
+        "execution_total_cost_bps",
+    )
+    if total_cost_bps is None or total_cost_bps < 0 or filled_notional <= 0:
+        return None
+    return filled_notional * total_cost_bps / Decimal("10000")
+
+
+def _runtime_execution_cost_basis(
+    row: Mapping[str, object],
+    *,
+    cost_amount: Decimal | None,
+) -> str | None:
+    cost_basis = _first_text(
+        row,
+        "cost_basis",
+        "cost_source",
+        "fee_basis",
+        "commission_basis",
+        "broker_fee_basis",
+    )
+    if cost_basis is not None:
+        return cost_basis
+    if (
+        cost_amount is not None
+        and _first_decimal(
+            row,
+            "total_cost_bps",
+            "estimated_total_cost_bps",
+            "explicit_cost_bps",
+            "execution_total_cost_bps",
+        )
+        is not None
+    ):
+        return "decision_impact_assumptions_total_cost_bps"
+    return None
+
+
 def _build_realized_strategy_pnl_rows(
     execution_rows: list[dict[str, object]],
     *,
@@ -861,22 +923,15 @@ def _build_realized_strategy_pnl_rows(
             )
         if price is None or price <= 0 or signed_qty == 0:
             continue
-        cost_amount = _first_decimal(
+        filled_qty = abs(signed_qty)
+        filled_notional = filled_qty * price
+        cost_amount = _runtime_execution_cost_amount(
             row,
-            "cost_amount",
-            "explicit_cost",
-            "commission",
-            "fees",
-            "fee_amount",
-            "broker_fee",
+            filled_notional=filled_notional,
         )
-        cost_basis = _first_text(
+        cost_basis = _runtime_execution_cost_basis(
             row,
-            "cost_basis",
-            "cost_source",
-            "fee_basis",
-            "commission_basis",
-            "broker_fee_basis",
+            cost_amount=cost_amount,
         )
         ledger_rows.append(
             RuntimeLedgerFill(
@@ -893,8 +948,9 @@ def _build_realized_strategy_pnl_rows(
                 lineage_hash=common_ledger_fields["lineage_hash"],
                 replay_data_hash=common_ledger_fields["replay_data_hash"],
                 side=_first_text(row, "side", "order_side") or "",
-                filled_qty=abs(signed_qty),
+                filled_qty=filled_qty,
                 avg_fill_price=price,
+                filled_notional=filled_notional,
                 cost_amount=cost_amount,
                 cost_basis=cost_basis,
                 account_label=str(row.get("account_label") or "") or None,
@@ -1654,6 +1710,7 @@ def _query_timestamps(
                     e.alpaca_account_label,
                     s.name,
                     d.decision_hash,
+                    d.decision_json,
                     e.alpaca_order_id,
                     e.client_order_id,
                     e.status
@@ -1690,9 +1747,10 @@ def _query_timestamps(
                     "account_label": row[9],
                     "strategy_id": row[10],
                     "decision_hash": row[11],
-                    "alpaca_order_id": row[12],
-                    "client_order_id": row[13],
-                    "order_status": row[14],
+                    "decision_json": row[12],
+                    "alpaca_order_id": row[13],
+                    "client_order_id": row[14],
+                    "order_status": row[15],
                 }
                 for row in cur.fetchall()
                 if row[0] is not None

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -73,6 +73,7 @@ class _FakeCursor:
                     "TORGHUT_SIM",
                     "intraday_tsmom_v1@paper",
                     "decision-sha",
+                    {},
                     "alpaca-order-1",
                     "client-order-1",
                     "filled",
@@ -1373,6 +1374,62 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIsInstance(bucket, dict)
         assert isinstance(bucket, dict)
         self.assertEqual(bucket["blockers"], [])
+        self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
+
+    def test_build_realized_strategy_pnl_rows_uses_decision_impact_cost_model(
+        self,
+    ) -> None:
+        decision_json = {
+            "params": {
+                "execution_policy": {"selected_order_type": "market"},
+                "impact_assumptions": {
+                    "model": {
+                        "commission_bps": "0",
+                        "impact_bps_at_full_participation": "50",
+                    },
+                    "estimate": {"total_cost_bps": "10"},
+                },
+                "simulation_context": {"dataset_id": "runtime-paper-session"},
+            }
+        }
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "decision_json": decision_json,
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "decision_json": decision_json,
+                },
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["authoritative"], True)
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["blockers"], [])
+        self.assertEqual(
+            bucket["cost_basis_counts"],
+            {"decision_impact_assumptions_total_cost_bps": 2},
+        )
+        self.assertEqual(bucket["cost_amount"], "0.201")
+        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.799"))
         self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
 
     def test_runtime_ledger_tca_row_separates_explicit_cost_from_slippage(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -781,6 +781,7 @@ class TestTradingPipeline(TestCase):
                 "trading_simple_paper_route_probe_retry_attempt_limit",
                 "trading_simple_paper_route_probe_retry_batch_limit",
                 "trading_simple_paper_route_probe_retry_scan_limit",
+                "trading_simple_paper_route_probe_exit_lookback_hours",
                 "trading_paper_route_target_plan_url",
                 "trading_paper_route_target_plan_timeout_seconds",
                 "trading_universe_static_fallback_enabled",
@@ -834,6 +835,7 @@ class TestTradingPipeline(TestCase):
         avg_fill_price: Decimal = Decimal("100"),
         entry_ts: datetime = datetime(2026, 3, 26, 14, 0, tzinfo=timezone.utc),
         exit_minute_after_open: str = "120",
+        include_decision_exit_minute: bool = True,
     ) -> None:
         with self.session_local() as session:
             strategy = Strategy(
@@ -859,6 +861,16 @@ class TestTradingPipeline(TestCase):
             session.commit()
             session.refresh(strategy)
 
+            params: dict[str, Any] = {
+                "price": avg_fill_price,
+                "paper_route_probe": {
+                    "mode": "paper_route_acquisition",
+                    "source": "test",
+                    "symbol": symbol,
+                },
+            }
+            if include_decision_exit_minute:
+                params["exit_minute_after_open"] = exit_minute_after_open
             decision = StrategyDecision(
                 strategy_id=str(strategy.id),
                 symbol=symbol,
@@ -867,15 +879,7 @@ class TestTradingPipeline(TestCase):
                 action="buy",
                 qty=qty,
                 rationale="paper-route-entry",
-                params={
-                    "price": avg_fill_price,
-                    "exit_minute_after_open": exit_minute_after_open,
-                    "paper_route_probe": {
-                        "mode": "paper_route_acquisition",
-                        "source": "test",
-                        "symbol": symbol,
-                    },
-                },
+                params=params,
             )
             executor = OrderExecutor()
             decision_row = executor.ensure_decision(
@@ -914,6 +918,7 @@ class TestTradingPipeline(TestCase):
         alpaca_client: FakeAlpacaClient,
         now: datetime,
         proof_floor: Mapping[str, object] | None = None,
+        signals: list[SignalEnvelope] | None = None,
     ) -> FakeIngestor:
         from app import config
 
@@ -941,7 +946,7 @@ class TestTradingPipeline(TestCase):
                 "summary": {"paper_route_probe_eligible_symbols": ["AAPL"]}
             },
         }
-        ingestor = FakeIngestor([])
+        ingestor = FakeIngestor(signals or [])
         pipeline = SimpleTradingPipeline(
             alpaca_client=alpaca_client,
             order_firewall=OrderFirewall(alpaca_client),
@@ -3132,6 +3137,21 @@ class TestTradingPipeline(TestCase):
             ),
             45,
         )
+        self.assertEqual(
+            SimpleTradingPipeline._paper_route_probe_exit_minute_after_open(
+                decision=decision.model_copy(
+                    update={
+                        "params": {
+                            "price": Decimal("100"),
+                            "paper_route_probe": {
+                                "exit_minute_after_open": "120",
+                            },
+                        }
+                    }
+                )
+            ),
+            120,
+        )
         old_row = TradeDecision(
             strategy_id=strategy_id,
             alpaca_account_label="paper",
@@ -3651,6 +3671,126 @@ class TestTradingPipeline(TestCase):
                 exit_metadata.get("exit_due_at"),
                 "2026-03-26T15:30:00+00:00",
             )
+
+    def test_simple_pipeline_closes_late_filled_probe_from_strategy_exit_metadata(
+        self,
+    ) -> None:
+        self._seed_filled_paper_route_probe_entry(
+            entry_ts=datetime(2026, 3, 26, 15, 45, tzinfo=timezone.utc),
+            include_decision_exit_minute=False,
+        )
+        alpaca_client = PositionedAlpacaClient(
+            [{"symbol": "AAPL", "qty": "2", "side": "long"}]
+        )
+
+        self._run_simple_paper_pipeline(
+            alpaca_client=alpaca_client,
+            now=datetime(2026, 3, 26, 15, 46, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        self.assertEqual(alpaca_client.submitted[0]["side"], "sell")
+        with self.session_local() as session:
+            decisions = (
+                session.execute(
+                    select(TradeDecision).order_by(TradeDecision.created_at.asc())
+                )
+                .scalars()
+                .all()
+            )
+            self.assertEqual(len(decisions), 2)
+            exit_payload = cast(dict[str, Any], decisions[-1].decision_json)
+            params = cast(dict[str, Any], exit_payload.get("params"))
+            exit_metadata = cast(
+                dict[str, Any],
+                params.get("paper_route_probe_exit"),
+            )
+            self.assertEqual(
+                exit_metadata.get("exit_due_at"),
+                "2026-03-26T15:30:00+00:00",
+            )
+
+    def test_simple_pipeline_closes_probe_even_when_signal_preparation_blocks(
+        self,
+    ) -> None:
+        self._seed_filled_paper_route_probe_entry()
+        alpaca_client = PositionedAlpacaClient(
+            [{"symbol": "AAPL", "qty": "2", "side": "long"}]
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
+            ingest_ts=datetime(2026, 3, 26, 15, 31, 5, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Min",
+            seq=1,
+            payload={
+                "feature_schema_version": "3.0.0",
+                "macd": {"macd": 1.2, "signal": 0.5},
+                "rsi14": 25,
+                "price": 100,
+            },
+        )
+
+        with patch.object(
+            SimpleTradingPipeline,
+            "_prepare_batch_for_decisions",
+            return_value=False,
+        ):
+            self._run_simple_paper_pipeline(
+                alpaca_client=alpaca_client,
+                now=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
+                signals=[signal],
+            )
+
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        self.assertEqual(alpaca_client.submitted[0]["side"], "sell")
+
+    def test_simple_pipeline_repairs_stale_paper_route_probe_exit_next_session(
+        self,
+    ) -> None:
+        self._seed_filled_paper_route_probe_entry(
+            entry_ts=datetime(2026, 3, 26, 18, 40, tzinfo=timezone.utc),
+            exit_minute_after_open="120",
+        )
+        alpaca_client = PositionedAlpacaClient(
+            [{"symbol": "AAPL", "qty": "2", "side": "long"}]
+        )
+
+        self._run_simple_paper_pipeline(
+            alpaca_client=alpaca_client,
+            now=datetime(2026, 3, 27, 14, 31, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        self.assertEqual(alpaca_client.submitted[0]["side"], "sell")
+        with self.session_local() as session:
+            exit_row = (
+                session.execute(
+                    select(TradeDecision)
+                    .where(TradeDecision.symbol == "AAPL")
+                    .order_by(TradeDecision.created_at.desc())
+                )
+                .scalars()
+                .first()
+            )
+            assert exit_row is not None
+            exit_payload = cast(dict[str, Any], exit_row.decision_json)
+            params = cast(dict[str, Any], exit_payload.get("params"))
+            exit_metadata = cast(
+                dict[str, Any],
+                params.get("paper_route_probe_exit"),
+            )
+
+            self.assertEqual(exit_payload.get("action"), "sell")
+            self.assertEqual(
+                exit_metadata.get("session_open"),
+                "2026-03-26T13:30:00+00:00",
+            )
+            self.assertEqual(
+                exit_metadata.get("exit_due_at"),
+                "2026-03-26T15:30:00+00:00",
+            )
+            self.assertEqual(exit_metadata.get("stale_exit_repair"), True)
 
     def test_simple_pipeline_does_not_close_paper_route_probe_before_exit_minute(
         self,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -3792,6 +3792,76 @@ class TestTradingPipeline(TestCase):
             )
             self.assertEqual(exit_metadata.get("stale_exit_repair"), True)
 
+    def test_paper_route_probe_exit_session_open_prefers_exit_metadata(
+        self,
+    ) -> None:
+        decision = StrategyDecision(
+            strategy_id="strategy-1",
+            symbol="AAPL",
+            event_ts=datetime(2026, 3, 26, 18, 40, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="sell",
+            qty=Decimal("1"),
+            rationale="paper-route-exit",
+            params={
+                "paper_route_probe_exit": {
+                    "mode": "paper_route_exit",
+                    "session_open": datetime(
+                        2026,
+                        3,
+                        25,
+                        16,
+                        tzinfo=timezone.utc,
+                    ),
+                }
+            },
+        )
+        fallback = datetime(2026, 3, 27, 14, 31, tzinfo=timezone.utc)
+
+        self.assertEqual(
+            SimpleTradingPipeline._paper_route_probe_exit_session_open(
+                decision=decision,
+                fallback=fallback,
+            ),
+            datetime(2026, 3, 25, 13, 30, tzinfo=timezone.utc),
+        )
+
+        parsed_text_decision = decision.model_copy(
+            update={
+                "params": {
+                    "paper_route_probe_exit": {
+                        "mode": "paper_route_exit",
+                        "session_open": "2026-03-24T17:55:00Z",
+                    }
+                }
+            }
+        )
+        self.assertEqual(
+            SimpleTradingPipeline._paper_route_probe_exit_session_open(
+                decision=parsed_text_decision,
+                fallback=fallback,
+            ),
+            datetime(2026, 3, 24, 13, 30, tzinfo=timezone.utc),
+        )
+
+        invalid_text_decision = decision.model_copy(
+            update={
+                "params": {
+                    "paper_route_probe_exit": {
+                        "mode": "paper_route_exit",
+                        "session_open": "not-a-timestamp",
+                    }
+                }
+            }
+        )
+        self.assertEqual(
+            SimpleTradingPipeline._paper_route_probe_exit_session_open(
+                decision=invalid_text_decision,
+                fallback=fallback,
+            ),
+            datetime(2026, 3, 27, 13, 30, tzinfo=timezone.utc),
+        )
+
     def test_simple_pipeline_does_not_close_paper_route_probe_before_exit_minute(
         self,
     ) -> None:
@@ -4451,6 +4521,26 @@ class TestTradingPipeline(TestCase):
             universe_type="static",
             universe_symbols=["NVDA"],
             max_notional_per_trade=Decimal("1000"),
+        )
+        with patch(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            return_value=datetime(2026, 3, 26, 14, 0, tzinfo=timezone.utc),
+        ):
+            exit_bound_probe_context = pipeline._paper_route_probe_context(
+                proof_floor=proof_floor,
+                decision=decision,
+                strategy=exit_bound_strategy,
+            )
+        self.assertIsNotNone(exit_bound_probe_context)
+        assert exit_bound_probe_context is not None
+        self.assertEqual(exit_bound_probe_context.get("exit_minute_after_open"), 120)
+        self.assertEqual(
+            exit_bound_probe_context.get("effective_exit_minute_after_open"),
+            120,
+        )
+        self.assertEqual(
+            exit_bound_probe_context.get("exit_due_at"),
+            "2026-03-26T15:30:00+00:00",
         )
         with patch(
             "app.trading.scheduler.simple_pipeline.trading_now",


### PR DESCRIPTION
## Summary

- Closes stale paper-route probe fills by scanning a bounded lookback window and generating sell exits against the original entry-session exit deadline.
- Persists exit timing metadata on probe entries and records stale-exit repair metadata on generated exits.
- Imports decision-level execution policy, impact-cost model, and lineage context so closed source executions can materialize post-cost runtime-ledger buckets without treating TCA shortfall as PnL.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k "paper_route_probe_exit" -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k "paper_route_probe" -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k "realized_strategy_pnl_rows or runtime_ledger_tca_row_separates" -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k "realized_strategy_pnl_rows or runtime_ledger_tca_row_separates or runtime_window" -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen pytest tests/test_config.py -q`
- `uv run --frozen ruff check app/config.py app/trading/scheduler/simple_pipeline.py scripts/import_hypothesis_runtime_windows.py tests/test_trading_pipeline.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff format --check app/config.py app/trading/scheduler/simple_pipeline.py scripts/import_hypothesis_runtime_windows.py tests/test_trading_pipeline.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
