### PR TITLE
fix(synthesis): reset detail sidebar scroll on item select

### DIFF
--- a/apps/synthesis/src/lib/detail-scroll.test.ts
+++ b/apps/synthesis/src/lib/detail-scroll.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest'
+
+import { resetDetailScrollToTop } from './detail-scroll'
+
+describe('detail sidebar scroll reset', () => {
+  test('resets only the detail scroll container to the top', () => {
+    const detailScrollContainer = { scrollTop: 540 }
+    const feedScrollContainer = { scrollTop: 320 }
+
+    resetDetailScrollToTop(detailScrollContainer)
+
+    expect(detailScrollContainer.scrollTop).toBe(0)
+    expect(feedScrollContainer.scrollTop).toBe(320)
+  })
+
+  test('allows the detail sidebar to be absent on small viewports', () => {
+    expect(() => resetDetailScrollToTop(null)).not.toThrow()
+  })
+})

--- a/apps/synthesis/src/lib/detail-scroll.ts
+++ b/apps/synthesis/src/lib/detail-scroll.ts
@@ -1,0 +1,6 @@
+type ScrollPosition = Pick<HTMLElement, 'scrollTop'>
+
+export const resetDetailScrollToTop = (scrollContainer: ScrollPosition | null) => {
+  if (!scrollContainer) return
+  scrollContainer.scrollTop = 0
+}

--- a/apps/synthesis/src/routes/index.tsx
+++ b/apps/synthesis/src/routes/index.tsx
@@ -1,7 +1,7 @@
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { ArrowUpRight, ExternalLink, ImageIcon, Newspaper, Search, X } from 'lucide-react'
-import { useEffect, useMemo, useReducer, useState } from 'react'
+import { useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import type {
   ButtonHTMLAttributes,
   HTMLAttributes,
@@ -9,6 +9,7 @@ import type {
   KeyboardEvent,
   MouseEvent,
   ReactNode,
+  Ref,
   UIEvent,
 } from 'react'
 import {
@@ -18,6 +19,7 @@ import {
   reduceImageModalState,
 } from '~/lib/image-modal'
 import { normalizeCompanySymbol, segmentCompanySymbols, symbolsFromSynthesisItem } from '~/lib/company-symbols'
+import { resetDetailScrollToTop } from '~/lib/detail-scroll'
 import { synthesisSearchInputClassName, synthesisSidebarItems } from '~/lib/synthesis-ui-contract'
 import type { FeedResponse, SynthesisAttachment, SynthesisItem } from '~/server/schema'
 
@@ -40,10 +42,15 @@ const topicTabs = [
 
 const cx = (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(' ')
 
-function UiScrollArea({ className, children, ...props }: HTMLAttributes<HTMLDivElement> & { children: ReactNode }) {
+function UiScrollArea({
+  className,
+  children,
+  viewportRef,
+  ...props
+}: HTMLAttributes<HTMLDivElement> & { children: ReactNode; viewportRef?: Ref<HTMLDivElement> }) {
   return (
     <div data-slot="scroll-area" className={cx('relative overflow-hidden', className)} {...props}>
-      <div data-slot="scroll-area-viewport" className="size-full rounded-[inherit]">
+      <div ref={viewportRef} data-slot="scroll-area-viewport" className="size-full rounded-[inherit]">
         {children}
       </div>
     </div>
@@ -483,6 +490,12 @@ function FeedPost({
 }
 
 function DetailPanel({ item, onOpenImage }: { item: SynthesisItem | null; onOpenImage: (imageId: string) => void }) {
+  const scrollViewportRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    resetDetailScrollToTop(scrollViewportRef.current)
+  }, [item?.id])
+
   return (
     <aside className="hidden min-h-0 min-w-0 flex-col bg-black xl:flex">
       <div className="flex h-[57px] shrink-0 items-center justify-between border-b border-[#2f3336] px-5">
@@ -497,7 +510,10 @@ function DetailPanel({ item, onOpenImage }: { item: SynthesisItem | null; onOpen
         ) : null}
       </div>
 
-      <UiScrollArea className="min-h-0 flex-1 [&_[data-slot=scroll-area-viewport]]:overflow-x-hidden [&_[data-slot=scroll-area-viewport]]:overflow-y-auto [&_[data-slot=scroll-area-viewport]]:overscroll-contain">
+      <UiScrollArea
+        viewportRef={scrollViewportRef}
+        className="min-h-0 flex-1 [&_[data-slot=scroll-area-viewport]]:overflow-x-hidden [&_[data-slot=scroll-area-viewport]]:overflow-y-auto [&_[data-slot=scroll-area-viewport]]:overscroll-contain"
+      >
         {item ? <DetailContent item={item} onOpenImage={onOpenImage} /> : <EmptyDetail />}
       </UiScrollArea>
     </aside>


### PR DESCRIPTION
## Summary

- Adds a detail-sidebar scroll reset helper for Synthesis.
- Wires the desktop detail panel viewport ref so changing the selected feed item resets only that panel to the top.
- Adds focused regression coverage for resetting the detail scroll container without touching feed scroll state.

## Related Issues

None

## Testing

- `bun run --filter synthesis test` — pass
- `bun run --filter synthesis lint` — pass
- `bun run --filter synthesis build` — pass

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
