### PR TITLE
chore(torghut): promote image 93936882

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.578.0-2-gb081531b5
+              value: v0.578.0-9-g939368827
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b081531b5c0e4d4d73bcb8a4b1bbbcffed5e85a7
+              value: 9393688271a79ddb8bfaded0a0b38959a8f17bf9
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.578.0-2-gb081531b5
+              value: v0.578.0-9-g939368827
             - name: TORGHUT_OPTIONS_COMMIT
-              value: b081531b5c0e4d4d73bcb8a4b1bbbcffed5e85a7
+              value: 9393688271a79ddb8bfaded0a0b38959a8f17bf9
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -101,7 +101,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+                  value: sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-27T01:27:17Z"
+        client.knative.dev/updateTimestamp: "2026-05-27T02:44:45Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
           ports:
             - name: http1
               containerPort: 8181
@@ -503,11 +503,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.578.0-2-gb081531b5
+              value: v0.578.0-9-g939368827
             - name: TORGHUT_COMMIT
-              value: b081531b5c0e4d4d73bcb8a4b1bbbcffed5e85a7
+              value: 9393688271a79ddb8bfaded0a0b38959a8f17bf9
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+              value: sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-27T01:27:17Z"
+        client.knative.dev/updateTimestamp: "2026-05-27T02:44:45Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
           ports:
             - name: http1
               containerPort: 8181
@@ -326,11 +326,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.578.0-2-gb081531b5
+              value: v0.578.0-9-g939368827
             - name: TORGHUT_COMMIT
-              value: b081531b5c0e4d4d73bcb8a4b1bbbcffed5e85a7
+              value: 9393688271a79ddb8bfaded0a0b38959a8f17bf9
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+              value: sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f0af86721c69c8765c0994191a968ef7301a77b81835e89e43e6e690693f8a34
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `9393688271a79ddb8bfaded0a0b38959a8f17bf9`
- Image tag: `93936882`
- Image digest: `sha256:1d96381a2edfdcbcbefd967c8b01e7960bd7ca4a375011d418f1f06c6bb9d905`