### PR TITLE
fix(torghut): restore sim paper route exits from db positions

### DIFF
--- a/services/torghut/app/trading/execution_adapters.py
+++ b/services/torghut/app/trading/execution_adapters.py
@@ -216,6 +216,32 @@ class SimulationExecutionAdapter:
         self._position_market_value_by_symbol = seeded_market_values
         self._seeded_from_snapshot = True
 
+    def seed_missing_position_snapshot(self, position: Mapping[str, Any]) -> bool:
+        """Restore a single missing simulation position from a durable runtime source."""
+
+        self._sync_runtime_context()
+        symbol = str(position.get('symbol') or '').strip().upper()
+        if not symbol:
+            return False
+        if self._positions_by_symbol.get(symbol, Decimal('0')) != 0:
+            return False
+        raw_qty = position.get('qty') or position.get('quantity')
+        if raw_qty is None:
+            return False
+        try:
+            qty = Decimal(str(raw_qty))
+        except Exception:
+            return False
+        if qty <= 0:
+            return False
+        side = str(position.get('side') or '').strip().lower()
+        signed_qty = -abs(qty) if side == 'short' else qty
+        self._positions_by_symbol[symbol] = signed_qty
+        signed_market_value = _signed_position_market_value(position, side=side)
+        if signed_market_value is not None:
+            self._position_market_value_by_symbol[symbol] = signed_market_value
+        return True
+
     def submit_order(
         self,
         symbol: str,

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -815,9 +815,62 @@ class SimpleTradingPipeline(TradingPipeline):
         return False
 
     @staticmethod
+    def _restore_simulation_paper_route_probe_exit_position(
+        *,
+        positions: list[dict[str, Any]],
+        decision: StrategyDecision,
+        metadata: Mapping[str, Any],
+        price: Decimal | None,
+        execution_adapter: Any | None,
+        trading_mode: str | None,
+    ) -> Decimal | None:
+        if str(trading_mode or "").strip().lower() != "paper":
+            return None
+        if (
+            str(getattr(execution_adapter, "name", "") or "").strip().lower()
+            != "simulation"
+        ):
+            return None
+        db_open_qty = _optional_decimal(metadata.get("db_open_qty"))
+        if db_open_qty is None or db_open_qty <= 0:
+            return None
+        seed_missing = getattr(
+            execution_adapter, "seed_missing_position_snapshot", None
+        )
+        if not callable(seed_missing):
+            return None
+
+        restored_qty = (
+            min(db_open_qty, decision.qty) if decision.qty > 0 else db_open_qty
+        )
+        position: dict[str, Any] = {
+            "symbol": decision.symbol,
+            "qty": str(restored_qty),
+            "side": "long",
+        }
+        if price is not None and price > 0:
+            position["market_value"] = str(restored_qty * price)
+        try:
+            seeded = bool(seed_missing(position))
+        except Exception as exc:
+            logger.warning(
+                "Failed to restore simulation paper route probe exit position symbol=%s error=%s",
+                decision.symbol,
+                exc,
+            )
+            return None
+        if not seeded:
+            return None
+        positions.append(dict(position))
+        return restored_qty
+
+    @staticmethod
     def _prepare_paper_route_probe_exit_position(
         positions: list[dict[str, Any]],
         decision: StrategyDecision,
+        *,
+        execution_adapter: Any | None = None,
+        trading_mode: str | None = None,
     ) -> StrategyDecision | None:
         if SimpleTradingPipeline._paper_route_probe_exit_metadata(decision) is None:
             return decision
@@ -829,11 +882,30 @@ class SimpleTradingPipeline(TradingPipeline):
             cast(Mapping[str, Any], simple_lane.get("quantity_resolution") or {})
         )
         if current_qty <= 0:
-            return None
+            price = _optional_decimal(params.get("price"))
+            restored_qty = (
+                SimpleTradingPipeline._restore_simulation_paper_route_probe_exit_position(
+                    positions=positions,
+                    decision=decision,
+                    metadata=metadata,
+                    price=price,
+                    execution_adapter=execution_adapter,
+                    trading_mode=trading_mode,
+                )
+                if current_qty == 0
+                else None
+            )
+            if restored_qty is None:
+                return None
+            metadata["broker_position_qty"] = str(current_qty)
+            metadata["db_position_qty_fallback"] = True
+            metadata["position_source"] = "source_execution_db_open_qty"
+            current_qty = restored_qty
         if current_qty < decision.qty:
             decision = decision.model_copy(update={"qty": current_qty})
             metadata["qty_capped_to_position"] = True
-        metadata["broker_position_qty"] = str(current_qty)
+        metadata.setdefault("broker_position_qty", str(current_qty))
+        metadata["effective_position_qty"] = str(current_qty)
 
         quantity_resolution["position_qty"] = str(decision.qty)
         simple_lane["final_qty"] = str(decision.qty)
@@ -899,6 +971,8 @@ class SimpleTradingPipeline(TradingPipeline):
             prepared_decision = self._prepare_paper_route_probe_exit_position(
                 positions,
                 decision,
+                execution_adapter=self.execution_adapter,
+                trading_mode=settings.trading_mode,
             )
             if prepared_decision is None:
                 continue

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -917,6 +917,7 @@ class TestTradingPipeline(TestCase):
         *,
         alpaca_client: FakeAlpacaClient,
         now: datetime,
+        execution_adapter: Any | None = None,
         proof_floor: Mapping[str, object] | None = None,
         signals: list[SignalEnvelope] | None = None,
     ) -> FakeIngestor:
@@ -954,7 +955,7 @@ class TestTradingPipeline(TestCase):
             decision_engine=DecisionEngine(),
             risk_engine=RiskEngine(),
             executor=OrderExecutor(),
-            execution_adapter=alpaca_client,
+            execution_adapter=execution_adapter or alpaca_client,
             reconciler=Reconciler(),
             universe_resolver=UniverseResolver(),
             state=TradingState(),
@@ -3927,6 +3928,182 @@ class TestTradingPipeline(TestCase):
             self.assertEqual(len(decisions), 1)
             payload = cast(dict[str, Any], decisions[0].decision_json)
             self.assertEqual(payload.get("action"), "buy")
+
+    def test_simple_pipeline_restores_simulation_exit_position_from_db_open_qty(
+        self,
+    ) -> None:
+        self._seed_filled_paper_route_probe_entry()
+        alpaca_client = PositionedAlpacaClient([])
+        execution_adapter = SimulationExecutionAdapter(
+            bootstrap_servers=None,
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+            topic="torghut.sim.trade-updates.v1",
+            account_label="paper",
+            simulation_run_id="paper-route-exit-test",
+            dataset_id="paper-route-exit-test",
+        )
+
+        self._run_simple_paper_pipeline(
+            alpaca_client=alpaca_client,
+            execution_adapter=execution_adapter,
+            now=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
+        )
+
+        with self.session_local() as session:
+            decisions = (
+                session.execute(
+                    select(TradeDecision).order_by(TradeDecision.created_at.asc())
+                )
+                .scalars()
+                .all()
+            )
+            executions = (
+                session.execute(select(Execution).order_by(Execution.created_at.asc()))
+                .scalars()
+                .all()
+            )
+
+        self.assertEqual(
+            [
+                cast(dict[str, Any], row.decision_json).get("action")
+                for row in decisions
+            ],
+            ["buy", "sell"],
+        )
+        self.assertEqual([execution.side for execution in executions], ["buy", "sell"])
+        self.assertEqual(execution_adapter.list_positions(), [])
+
+        exit_payload = cast(dict[str, Any], decisions[-1].decision_json)
+        params = cast(dict[str, Any], exit_payload.get("params"))
+        exit_metadata = cast(dict[str, Any], params.get("paper_route_probe_exit"))
+        self.assertEqual(exit_metadata.get("broker_position_qty"), "0")
+        self.assertEqual(exit_metadata.get("db_position_qty_fallback"), True)
+        self.assertEqual(
+            exit_metadata.get("position_source"),
+            "source_execution_db_open_qty",
+        )
+        self.assertEqual(exit_metadata.get("effective_position_qty"), "2.00000000")
+
+    def test_simulation_seed_missing_position_snapshot_fail_closed_edges(
+        self,
+    ) -> None:
+        execution_adapter = SimulationExecutionAdapter(
+            bootstrap_servers=None,
+            security_protocol=None,
+            sasl_mechanism=None,
+            sasl_username=None,
+            sasl_password=None,
+            topic="torghut.sim.trade-updates.v1",
+            account_label="paper",
+            simulation_run_id="paper-route-exit-test",
+            dataset_id="paper-route-exit-test",
+        )
+
+        self.assertFalse(execution_adapter.seed_missing_position_snapshot({}))
+        self.assertFalse(
+            execution_adapter.seed_missing_position_snapshot({"symbol": "AAPL"})
+        )
+        self.assertFalse(
+            execution_adapter.seed_missing_position_snapshot(
+                {"symbol": "AAPL", "qty": "bad"}
+            )
+        )
+        self.assertFalse(
+            execution_adapter.seed_missing_position_snapshot(
+                {"symbol": "AAPL", "qty": "0"}
+            )
+        )
+        self.assertTrue(
+            execution_adapter.seed_missing_position_snapshot(
+                {"symbol": "AAPL", "qty": "2", "side": "long"}
+            )
+        )
+        self.assertFalse(
+            execution_adapter.seed_missing_position_snapshot(
+                {"symbol": "AAPL", "qty": "1", "side": "long"}
+            )
+        )
+
+    def test_restore_simulation_exit_position_fail_closed_edges(self) -> None:
+        decision = StrategyDecision(
+            strategy_id=str(uuid4()),
+            symbol="AAPL",
+            event_ts=datetime(2026, 3, 26, 14, 0, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="sell",
+            qty=Decimal("2"),
+            rationale="paper-route-exit-edge",
+            params={},
+        )
+
+        class NonCallableSeedAdapter:
+            name = "simulation"
+
+        class FalseSeedAdapter:
+            name = "simulation"
+
+            def seed_missing_position_snapshot(self, _position: object) -> bool:
+                return False
+
+        class RaisingSeedAdapter:
+            name = "simulation"
+
+            def seed_missing_position_snapshot(self, _position: object) -> bool:
+                raise RuntimeError("seed failed")
+
+        base_kwargs = {
+            "positions": [],
+            "decision": decision,
+            "metadata": {"db_open_qty": "2"},
+            "price": Decimal("100"),
+            "execution_adapter": FalseSeedAdapter(),
+        }
+
+        self.assertIsNone(
+            SimpleTradingPipeline._restore_simulation_paper_route_probe_exit_position(
+                **{**base_kwargs, "trading_mode": "live"}
+            )
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._restore_simulation_paper_route_probe_exit_position(
+                **{
+                    **base_kwargs,
+                    "trading_mode": "paper",
+                    "execution_adapter": FakeAlpacaClient(),
+                }
+            )
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._restore_simulation_paper_route_probe_exit_position(
+                **{**base_kwargs, "trading_mode": "paper", "metadata": {}}
+            )
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._restore_simulation_paper_route_probe_exit_position(
+                **{
+                    **base_kwargs,
+                    "trading_mode": "paper",
+                    "execution_adapter": NonCallableSeedAdapter(),
+                }
+            )
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._restore_simulation_paper_route_probe_exit_position(
+                **{**base_kwargs, "trading_mode": "paper"}
+            )
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._restore_simulation_paper_route_probe_exit_position(
+                **{
+                    **base_kwargs,
+                    "trading_mode": "paper",
+                    "execution_adapter": RaisingSeedAdapter(),
+                }
+            )
+        )
 
     def test_simple_pipeline_paper_route_exit_helpers_cover_filter_edges(
         self,


### PR DESCRIPTION
## Summary

- Restores missing simulation positions from durable paper-route DB open quantity before submitting stale probe exits.
- Keeps the fallback scoped to `TRADING_MODE=paper` plus the simulation execution adapter; non-simulation adapters still require real broker inventory.
- Stamps fallback metadata so runtime-ledger imports can distinguish DB-backed exit closure from broker snapshot inventory.
- Adds regression coverage for the sim restart gap and fail-closed restore edges.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/trading/execution_adapters.py app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k "paper_route or seed_missing_position or restore_simulation_exit_position" -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Read-only live check: `torghut-sim` still has filled DB paper-route buys without exit sells on promoted image `9393688271a79ddb8bfaded0a0b38959a8f17bf9`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
