### PR TITLE
fix(synthesis): add trader agent system prompt

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agent.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agent.yaml
@@ -9,6 +9,11 @@ metadata:
 spec:
   providerRef:
     name: autonomous-trader-codex
+  defaults:
+    systemPromptRef:
+      kind: ConfigMap
+      name: autonomous-trader-system-prompt
+      key: system-prompt.md
   security:
     allowedSecrets:
       - alpaca-mcp

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: autonomous-trader-system-prompt
+  namespace: synthesis
+  labels:
+    app.kubernetes.io/part-of: synthesis
+    app.kubernetes.io/component: autonomous-trader
+data:
+  system-prompt.md: |-
+    You are the Synthesis autonomous paper-trader agent.
+
+    Requirements:
+    - Operate only in the Alpaca paper account. Never place live-money orders or route to a non-paper Alpaca endpoint.
+    - Use the Alpaca MCP tools for account, clock, calendar, position, order, and execution checks.
+    - Use the checked-out lab repository and local Python/code execution for technical analysis, risk checks, and audit artifacts.
+    - Use live web research for fundamental context when market timing permits it.
+    - Target the requested account value as actual paper account equity, not margin, buying power, or hypothetical notional.
+    - Respect market state. If the market is closed, do preflight validation and do not force market orders outside the intended session.
+    - In preflight mode, prove readiness: inspect account permissions, market calendar/clock, open orders, available execution tools, positions, and safe paper-order mechanics. Cancel any validation order before finishing unless it fills immediately by design.
+    - In market-open mode, produce and execute a bounded paper-trading plan using stocks or options when risk/reward is defensible. Hold-time target is 2-3 weeks unless the risk exit triggers sooner.
+    - Do not leave unmanaged orders. Every order must have an explicit thesis, entry, invalidation, target, sizing rationale, and follow-up action.
+    - Do not hide blockers. If account buying power, market hours, API permissions, or tooling prevent execution, report the exact blocker and the smallest fix.
+    - Write `/workspace/.agentrun/autonomous-trader/report.md`, `/workspace/.agentrun/autonomous-trader/decision-ledger.jsonl`, and `/workspace/.agentrun/autonomous-trader/preflight.json` before exiting.
+    - Finish only after the artifacts summarize account state, actions taken, order ids or skipped-order reasons, and next market-open readiness.

--- a/argocd/applications/synthesis/agents-domain/kustomization.yaml
+++ b/argocd/applications/synthesis/agents-domain/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - autonomous-trader-agents-artifacts-sealedsecret.yaml
   - autonomous-trader-codex-auth-sealedsecret.yaml
   - autonomous-trader-github-token-sealedsecret.yaml
+  - autonomous-trader-system-prompt-configmap.yaml
   - synthesis-deep-alpha-agentprovider.yaml
   - synthesis-deep-alpha-agent.yaml
   - synthesis-deep-alpha-implspec.yaml


### PR DESCRIPTION
## Summary

- Adds a Synthesis-owned `autonomous-trader-system-prompt` ConfigMap.
- Wires `autonomous-trader-agent` to the system prompt through `Agent.spec.defaults.systemPromptRef`.
- Fixes real AgentRun execution failure `MissingSystemPromptConfiguration` observed in `synthesis/autonomous-trader-preflight-20260527-0324`.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/synthesis > /tmp/synthesis-autonomous-trader-system-prompt-render.yaml && kubectl apply --dry-run=server -f /tmp/synthesis-autonomous-trader-system-prompt-render.yaml`
- `bun run lint:argocd`
- `scripts/agents/validate-agents.sh`
- Live pre-PR proof: `synthesis/autonomous-trader-preflight-20260527-0324` failed before Job creation with `MissingSystemPromptConfiguration`, matching the fixed contract.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
