### PR TITLE
fix(agents): bundle alpaca mcp in codex runner

### DIFF
--- a/services/agents/Dockerfile.codex-runner
+++ b/services/agents/Dockerfile.codex-runner
@@ -3,6 +3,8 @@
 ARG BUN_VERSION=1.3.14
 ARG BUN_BASE_IMAGE=oven/bun
 ARG NODE_VERSION=24.11.1
+ARG UV_VERSION=0.11.14
+ARG ALPACA_MCP_SERVER_VERSION=2.0.1
 
 FROM node:${NODE_VERSION}-bookworm-slim AS node-runtime
 
@@ -59,6 +61,8 @@ RUN printf '%s\n' '{"type":"module","dependencies":{"effect":"3.21.2"}}' > packa
 FROM ${BUN_BASE_IMAGE}:${BUN_VERSION}-slim
 
 ARG CODEX_AUTH_CHECKSUM=unspecified
+ARG UV_VERSION
+ARG ALPACA_MCP_SERVER_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive \
     WORKSPACE=/workspace \
@@ -89,7 +93,13 @@ RUN set -eux; \
       jq \
       openssh-client \
       python3 \
+      python3-pip \
     && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --break-system-packages --no-cache-dir "uv==${UV_VERSION}" \
+    && uv tool install "alpaca-mcp-server==${ALPACA_MCP_SERVER_VERSION}" \
+    && ln -sf /root/.local/bin/alpaca-mcp-server /usr/local/bin/alpaca-mcp-server \
+    && test -x /usr/local/bin/alpaca-mcp-server
 
 RUN mkdir -p "$WORKSPACE" /root/.codex "$BUN_INSTALL_CACHE_DIR"
 

--- a/services/agents/src/runner/codex-runner-image-layout.test.ts
+++ b/services/agents/src/runner/codex-runner-image-layout.test.ts
@@ -63,6 +63,14 @@ describe('Agents Codex runner image layout', () => {
     expect(content).not.toContain('npm/bin/npx-cli.js')
   })
 
+  it('bundles the Alpaca MCP server for trading AgentRuns', () => {
+    const content = finalStage()
+
+    expect(content).toContain('uv tool install "alpaca-mcp-server==${ALPACA_MCP_SERVER_VERSION}"')
+    expect(content).toContain('ln -sf /root/.local/bin/alpaca-mcp-server /usr/local/bin/alpaca-mcp-server')
+    expect(content).toContain('test -x /usr/local/bin/alpaca-mcp-server')
+  })
+
   it('smoke-tests the bundled runner during the final image build', () => {
     const content = finalStage()
 


### PR DESCRIPTION
## Summary

- Installs `uv` and `alpaca-mcp-server==2.0.1` in the Agents Codex runner image.
- Exposes the MCP binary at `/usr/local/bin/alpaca-mcp-server`, matching existing AgentProvider configs and docs.
- Adds a runner image layout regression test for the Alpaca MCP binary.

## Related Issues

None

## Testing

- `bun test services/agents/src/runner/codex-runner-image-layout.test.ts`
- Live validation finding: `synthesis/autonomous-trader-preflight-20260527-0328` started the runner but Alpaca MCP failed with `No such file or directory` for `/usr/local/bin/alpaca-mcp-server`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
