### PR TITLE
feat(torghut): add factor acceptance harness

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from typing import Any, Literal, Mapping, Sequence, cast
 
 from app.trading.discovery.capital_budget import estimate_capital_pressure
+from app.trading.discovery.factor_acceptance import build_factor_acceptance_artifact
 from app.trading.discovery.hypothesis_cards import HypothesisCard
 from app.trading.semiconductor_universe import (
     LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE as LIVE_SIGNAL_COVERED_SEMICONDUCTOR_UNIVERSE,
@@ -3243,6 +3244,125 @@ def _paper_mechanism_haystack(card: HypothesisCard) -> str:
     return f"{_hypothesis_haystack(card)} {validation_text}".lower()
 
 
+def _requires_factor_acceptance_harness(card: HypothesisCard) -> bool:
+    haystack = _paper_mechanism_haystack(card)
+    return any(
+        token in haystack
+        for token in (
+            "rankic",
+            "rank ic",
+            "rank-ir",
+            "rank ir",
+            "information coefficient",
+            "factor mining",
+            "factor discovery",
+            "factor screener",
+            "alpha factor",
+            "signal discovery",
+            "llm signal",
+            "quantitative signal discovery",
+            "adaptive factor",
+            "chain-of-alpha",
+            "alphacrafter",
+            "alpha-r1",
+            "r&d-agent-quant",
+            "rd-agent-quant",
+            "factorminer",
+        )
+    )
+
+
+def _factor_acceptance_dependencies(
+    card: HypothesisCard, strategy_overrides: Mapping[str, Any]
+) -> tuple[str, ...]:
+    params = _mapping(strategy_overrides.get("params"))
+    dependencies: list[str] = []
+    for key in ("rank_feature", "gate_feature"):
+        value = _string(params.get(key))
+        if value:
+            dependencies.append(value)
+    dependencies.extend(card.required_features)
+    return tuple(dict.fromkeys(item for item in dependencies if item))
+
+
+def _factor_acceptance_expression(strategy_overrides: Mapping[str, Any]) -> str:
+    params = _mapping(strategy_overrides.get("params"))
+    rank_feature = _string(params.get("rank_feature"))
+    gate_feature = _string(params.get("gate_feature"))
+    if rank_feature and gate_feature:
+        return f"{rank_feature}|gated_by:{gate_feature}"
+    if rank_feature:
+        return rank_feature
+    return "candidate_family_score"
+
+
+def _apply_factor_acceptance_harness(
+    *,
+    card: HypothesisCard,
+    feature_contract: dict[str, Any],
+    parameter_space: dict[str, Any],
+    strategy_overrides: Mapping[str, Any],
+    hard_vetoes: dict[str, Any],
+    promotion_contract: dict[str, Any],
+) -> None:
+    if not _requires_factor_acceptance_harness(card):
+        return
+    artifact = build_factor_acceptance_artifact(
+        factor_expression=_factor_acceptance_expression(strategy_overrides),
+        source_idea="2025_2026_signal_discovery_rankic_acceptance_harness",
+        allowed_feature_dependencies=_factor_acceptance_dependencies(
+            card, strategy_overrides
+        ),
+        train_window={"source": "runtime_replay_required"},
+        test_window={"source": "holdout_or_live_paper_required"},
+        sample_count=0,
+        candidate_count=1,
+    )
+    feature_contract["factor_acceptance_artifact"] = artifact
+    feature_contract["factor_acceptance_policy"] = (
+        "deterministic_rankic_rankir_cost_stress_fail_closed"
+    )
+    overlay_ids = [
+        str(item)
+        for item in cast(
+            Sequence[Any], parameter_space.get("mechanism_overlay_ids") or []
+        )
+    ]
+    if "rankic_factor_acceptance_harness" not in overlay_ids:
+        overlay_ids.append("rankic_factor_acceptance_harness")
+    parameter_space["mechanism_overlay_ids"] = overlay_ids
+    hard_vetoes.update(
+        {
+            "required_factor_acceptance_artifact": True,
+            "required_factor_acceptance_status": "accepted",
+            "required_factor_acceptance_min_rank_ic": artifact["thresholds"][
+                "min_rank_ic"
+            ],
+            "required_factor_acceptance_min_rank_ir": artifact["thresholds"][
+                "min_rank_ir"
+            ],
+            "required_factor_acceptance_max_deflated_p_value": artifact["thresholds"][
+                "max_deflated_p_value"
+            ],
+            "required_factor_acceptance_min_sample_count": artifact["thresholds"][
+                "min_sample_count"
+            ],
+            "required_factor_acceptance_cost_stressed_positive": True,
+        }
+    )
+    promotion_contract.update(
+        {
+            "requires_factor_acceptance_artifact": True,
+            "requires_feature_dependency_parity": True,
+            "requires_rankic_rankir_holdout_acceptance": True,
+            "requires_multiple_testing_penalty": True,
+            "requires_cost_stressed_factor_expectancy": True,
+            "rejects_llm_generated_factor_without_deterministic_acceptance": True,
+            "rejects_factor_acceptance_as_live_promotion_proof": True,
+        }
+    )
+
+
 def _mechanism_overlays_for_card(card: HypothesisCard) -> dict[str, Any]:
     haystack = _paper_mechanism_haystack(card)
     overlay_ids: list[str] = []
@@ -5594,6 +5714,14 @@ def compile_candidate_specs(
                 hard_vetoes.update(_mapping(mechanism_overlays.get("hard_vetoes")))
                 promotion_contract.update(
                     _mapping(mechanism_overlays.get("promotion_contract"))
+                )
+                _apply_factor_acceptance_harness(
+                    card=card,
+                    feature_contract=feature_contract,
+                    parameter_space=parameter_space,
+                    strategy_overrides=strategy_overrides,
+                    hard_vetoes=hard_vetoes,
+                    promotion_contract=promotion_contract,
                 )
                 base_payload = {
                     "hypothesis_id": card.hypothesis_id,

--- a/services/torghut/app/trading/discovery/factor_acceptance.py
+++ b/services/torghut/app/trading/discovery/factor_acceptance.py
@@ -1,0 +1,156 @@
+"""Deterministic acceptance artifacts for mined alpha factors."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any, Mapping, Sequence
+
+from app.trading.features import FEATURE_VECTOR_V3_VALUE_FIELDS
+
+
+FACTOR_ACCEPTANCE_SCHEMA_VERSION = "torghut.factor-acceptance-artifact.v1"
+
+
+@dataclass(frozen=True)
+class FactorAcceptanceThresholds:
+    min_sample_count: int = 60
+    min_rank_ic: Decimal = Decimal("0.03")
+    min_rank_ir: Decimal = Decimal("0.25")
+    max_deflated_p_value: Decimal = Decimal("0.05")
+    min_cost_stressed_net_expectancy_bps: Decimal = Decimal("0.01")
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "min_sample_count": self.min_sample_count,
+            "min_rank_ic": str(self.min_rank_ic),
+            "min_rank_ir": str(self.min_rank_ir),
+            "max_deflated_p_value": str(self.max_deflated_p_value),
+            "min_cost_stressed_net_expectancy_bps": str(
+                self.min_cost_stressed_net_expectancy_bps
+            ),
+        }
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _string_sequence(value: Sequence[str] | None) -> tuple[str, ...]:
+    if not value:
+        return ()
+    return tuple(
+        dict.fromkeys(str(item).strip() for item in value if str(item).strip())
+    )
+
+
+def _stable_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def build_factor_acceptance_artifact(
+    *,
+    factor_expression: str,
+    source_idea: str,
+    allowed_feature_dependencies: Sequence[str],
+    train_window: Mapping[str, Any] | None = None,
+    test_window: Mapping[str, Any] | None = None,
+    sample_count: int = 0,
+    candidate_count: int = 1,
+    rank_ic: Decimal | str | float | None = None,
+    rank_ir: Decimal | str | float | None = None,
+    p_value: Decimal | str | float | None = None,
+    gross_expectancy_bps: Decimal | str | float | None = None,
+    cost_stress_bps: Decimal | str | float | None = None,
+    available_feature_fields: Sequence[str] = FEATURE_VECTOR_V3_VALUE_FIELDS,
+    thresholds: FactorAcceptanceThresholds = FactorAcceptanceThresholds(),
+) -> dict[str, Any]:
+    """Build a fail-closed factor acceptance artifact.
+
+    This mirrors recent signal-discovery systems by accepting factor ideas only
+    after deterministic feature availability, RankIC/RankIR, multiple-testing,
+    and cost-stress checks. It never authorizes live promotion by itself.
+    """
+
+    dependencies = _string_sequence(allowed_feature_dependencies)
+    available_features = set(_string_sequence(available_feature_fields))
+    missing_dependencies = sorted(
+        dependency
+        for dependency in dependencies
+        if dependency not in available_features
+    )
+    rank_ic_value = _decimal(rank_ic)
+    rank_ir_value = _decimal(rank_ir)
+    p_value_value = _decimal(p_value)
+    gross_expectancy = _decimal(gross_expectancy_bps)
+    cost_stress = _decimal(cost_stress_bps)
+    resolved_candidate_count = max(int(candidate_count), 1)
+    deflated_p_value = (
+        p_value_value * Decimal(resolved_candidate_count)
+        if p_value_value is not None
+        else None
+    )
+    cost_stressed_net = (
+        gross_expectancy - abs(cost_stress)
+        if gross_expectancy is not None and cost_stress is not None
+        else None
+    )
+
+    rejection_reasons: list[str] = []
+    if missing_dependencies:
+        rejection_reasons.append("feature_dependency_missing")
+    if sample_count < thresholds.min_sample_count:
+        rejection_reasons.append("sample_count_below_floor")
+    if rank_ic_value is None or rank_ic_value < thresholds.min_rank_ic:
+        rejection_reasons.append("rank_ic_below_floor")
+    if rank_ir_value is None or rank_ir_value < thresholds.min_rank_ir:
+        rejection_reasons.append("rank_ir_below_floor")
+    if deflated_p_value is None or deflated_p_value > thresholds.max_deflated_p_value:
+        rejection_reasons.append("deflated_p_value_above_floor")
+    if (
+        cost_stressed_net is None
+        or cost_stressed_net < thresholds.min_cost_stressed_net_expectancy_bps
+    ):
+        rejection_reasons.append("cost_stressed_expectancy_non_positive")
+
+    status = "accepted" if not rejection_reasons else "rejected"
+    payload: dict[str, Any] = {
+        "schema_version": FACTOR_ACCEPTANCE_SCHEMA_VERSION,
+        "status": status,
+        "factor_expression": factor_expression,
+        "source_idea": source_idea,
+        "allowed_feature_dependencies": list(dependencies),
+        "missing_feature_dependencies": missing_dependencies,
+        "train_window": dict(train_window or {}),
+        "test_window": dict(test_window or {}),
+        "sample_count": sample_count,
+        "candidate_count": resolved_candidate_count,
+        "rank_ic": str(rank_ic_value) if rank_ic_value is not None else None,
+        "rank_ir": str(rank_ir_value) if rank_ir_value is not None else None,
+        "p_value": str(p_value_value) if p_value_value is not None else None,
+        "deflated_p_value": str(deflated_p_value)
+        if deflated_p_value is not None
+        else None,
+        "gross_expectancy_bps": str(gross_expectancy)
+        if gross_expectancy is not None
+        else None,
+        "cost_stress_bps": str(cost_stress) if cost_stress is not None else None,
+        "cost_stressed_net_expectancy_bps": str(cost_stressed_net)
+        if cost_stressed_net is not None
+        else None,
+        "thresholds": thresholds.to_payload(),
+        "rejection_reasons": rejection_reasons,
+        "acceptance_policy": "rankic_rankir_cost_stress_fail_closed",
+        "promotion_scope": "research_paper_probation_only",
+        "does_not_authorize_live_promotion": True,
+    }
+    payload["lineage_hash"] = _stable_hash(payload)
+    return payload

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -10,6 +10,7 @@ from app.trading.discovery.candidate_specs import (
     candidate_spec_from_payload,
     compile_candidate_specs,
 )
+from app.trading.discovery.factor_acceptance import build_factor_acceptance_artifact
 from app.trading.discovery.hypothesis_cards import (
     HYPOTHESIS_CARD_SCHEMA_VERSION,
     HypothesisCard,
@@ -31,6 +32,134 @@ def _capital_profile(spec: candidate_specs_module.CandidateSpec) -> object:
 
 
 class TestCandidateSpecs(TestCase):
+    def test_factor_acceptance_artifact_accepts_rankic_cost_stressed_factor(
+        self,
+    ) -> None:
+        artifact = build_factor_acceptance_artifact(
+            factor_expression="cross_section_recent_15m_return_rank",
+            source_idea="nvidia_signal_discovery_rankic_acceptance",
+            allowed_feature_dependencies=[
+                "cross_section_recent_15m_return_rank",
+                "spread_bps",
+            ],
+            train_window={"start": "2026-01-02", "end": "2026-03-31"},
+            test_window={"start": "2026-04-01", "end": "2026-04-30"},
+            sample_count=144,
+            candidate_count=4,
+            rank_ic=Decimal("0.061"),
+            rank_ir=Decimal("0.71"),
+            p_value=Decimal("0.006"),
+            gross_expectancy_bps=Decimal("5.2"),
+            cost_stress_bps=Decimal("1.8"),
+        )
+
+        self.assertEqual(artifact["status"], "accepted")
+        self.assertEqual(artifact["rejection_reasons"], [])
+        self.assertEqual(artifact["deflated_p_value"], "0.024")
+        self.assertEqual(artifact["cost_stressed_net_expectancy_bps"], "3.4")
+        self.assertTrue(artifact["does_not_authorize_live_promotion"])
+        self.assertEqual(
+            artifact["lineage_hash"],
+            build_factor_acceptance_artifact(
+                factor_expression="cross_section_recent_15m_return_rank",
+                source_idea="nvidia_signal_discovery_rankic_acceptance",
+                allowed_feature_dependencies=[
+                    "cross_section_recent_15m_return_rank",
+                    "spread_bps",
+                ],
+                train_window={"start": "2026-01-02", "end": "2026-03-31"},
+                test_window={"start": "2026-04-01", "end": "2026-04-30"},
+                sample_count=144,
+                candidate_count=4,
+                rank_ic=Decimal("0.061"),
+                rank_ir=Decimal("0.71"),
+                p_value=Decimal("0.006"),
+                gross_expectancy_bps=Decimal("5.2"),
+                cost_stress_bps=Decimal("1.8"),
+            )["lineage_hash"],
+        )
+
+    def test_factor_acceptance_artifact_rejects_missing_features_low_ic_and_cost(
+        self,
+    ) -> None:
+        artifact = build_factor_acceptance_artifact(
+            factor_expression="unavailable_alt_data_factor",
+            source_idea="rankic_factor_acceptance_negative_case",
+            allowed_feature_dependencies=[
+                "unavailable_alt_data_factor",
+                "cross_section_recent_15m_return_rank",
+            ],
+            sample_count=12,
+            candidate_count=8,
+            rank_ic=Decimal("0.01"),
+            rank_ir=Decimal("0.10"),
+            p_value=Decimal("0.02"),
+            gross_expectancy_bps=Decimal("1.0"),
+            cost_stress_bps=Decimal("1.5"),
+        )
+
+        self.assertEqual(artifact["status"], "rejected")
+        self.assertIn("feature_dependency_missing", artifact["rejection_reasons"])
+        self.assertIn("sample_count_below_floor", artifact["rejection_reasons"])
+        self.assertIn("rank_ic_below_floor", artifact["rejection_reasons"])
+        self.assertIn("rank_ir_below_floor", artifact["rejection_reasons"])
+        self.assertIn("deflated_p_value_above_floor", artifact["rejection_reasons"])
+        self.assertIn(
+            "cost_stressed_expectancy_non_positive",
+            artifact["rejection_reasons"],
+        )
+
+    def test_rankic_signal_discovery_claim_adds_fail_closed_factor_harness(
+        self,
+    ) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-nvidia-signal-discovery",
+            claims=[
+                {
+                    "claim_id": "rankic-factor-mining",
+                    "claim_type": "feature_recipe",
+                    "claim_text": (
+                        "NVIDIA quantitative signal discovery and FactorMiner style "
+                        "factor mining require RankIC, RankIR, p-value and cost "
+                        "stress acceptance before alpha factors enter paper routing."
+                    ),
+                    "data_requirements": [
+                        "cross_section_recent_15m_return_rank",
+                        "spread_bps",
+                    ],
+                    "confidence": "0.82",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+        first = specs[0]
+        artifact = first.feature_contract["factor_acceptance_artifact"]
+
+        self.assertIn(
+            "rankic_factor_acceptance_harness",
+            first.parameter_space["mechanism_overlay_ids"],
+        )
+        self.assertEqual(artifact["status"], "rejected")
+        self.assertIn("rank_ic_below_floor", artifact["rejection_reasons"])
+        self.assertTrue(first.hard_vetoes["required_factor_acceptance_artifact"])
+        self.assertEqual(
+            first.hard_vetoes["required_factor_acceptance_status"],
+            "accepted",
+        )
+        self.assertTrue(
+            first.promotion_contract[
+                "rejects_llm_generated_factor_without_deterministic_acceptance"
+            ]
+        )
+        self.assertTrue(
+            first.promotion_contract[
+                "rejects_factor_acceptance_as_live_promotion_proof"
+            ]
+        )
+
     def test_profile_rank_floor_handles_invalid_params_and_universe_fallbacks(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Add a deterministic `torghut.factor-acceptance-artifact.v1` builder for mined alpha factors.
- Wire RankIC/RankIR, multiple-testing, feature-dependency, and cost-stress acceptance metadata into whitepaper candidate specs.
- Keep factor-discovery output paper-probation only: the new contract explicitly rejects live promotion without runtime-ledger/live-paper proof.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/discovery/factor_acceptance.py app/trading/discovery/candidate_specs.py tests/test_candidate_specs.py`
- `uv run --frozen ruff check app/trading/discovery/factor_acceptance.py app/trading/discovery/candidate_specs.py tests/test_candidate_specs.py`
- `uv run --frozen pytest tests/test_candidate_specs.py -k 'factor_acceptance or rankic'`
- `uv run --frozen pytest tests/test_candidate_specs.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
