### PR TITLE
fix(synthesis): quiet alpaca mcp stdio

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -20,6 +20,12 @@ spec:
         mcp_servers:
           alpaca:
             command: /usr/local/bin/alpaca-mcp-server
+            args:
+              - --transport
+              - stdio
+            env:
+              FASTMCP_SHOW_SERVER_BANNER: "false"
+              FASTMCP_LOG_LEVEL: "ERROR"
         web_search: live
   argsTemplate: []
   secretEnv:
@@ -60,6 +66,8 @@ spec:
     CODEX_MARKET_CONTEXT_OVERALL_TIMEOUT_SECONDS: "21600"
     CODEX_MAX_SESSION_ATTEMPTS: "1"
     CODEX_MODEL: gpt-5.5
+    FASTMCP_LOG_LEVEL: "ERROR"
+    FASTMCP_SHOW_SERVER_BANNER: "false"
     HOME: /root
   inputFiles:
     - path: /root/.codex/config.toml
@@ -97,6 +105,8 @@ spec:
 
         [mcp_servers.alpaca]
         command = "/usr/local/bin/alpaca-mcp-server"
+        args = ["--transport", "stdio"]
+        env = { FASTMCP_SHOW_SERVER_BANNER = "false", FASTMCP_LOG_LEVEL = "ERROR" }
   outputArtifacts:
     - name: autonomous-trader-report
       path: /workspace/.agentrun/autonomous-trader/report.md


### PR DESCRIPTION
## Summary

- Forces the Synthesis autonomous trader Alpaca MCP server to stdio mode.
- Suppresses FastMCP banner and log output on stdout so Codex receives clean JSON-RPC during MCP initialization.
- Fixes the live `autonomous-trader-preflight-20260527-0404` handshake failure seen after the runner image started shipping `alpaca-mcp-server`.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/synthesis > /tmp/synthesis-alpaca-mcp-quiet-render.yaml && kubectl apply --dry-run=server -f /tmp/synthesis-alpaca-mcp-quiet-render.yaml`
- `bun run lint:argocd`
- `scripts/agents/validate-agents.sh`
- Live in-pod probe returned a clean JSON-RPC initialize response with `FASTMCP_SHOW_SERVER_BANNER=false FASTMCP_LOG_LEVEL=ERROR alpaca-mcp-server --transport stdio`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
