### PR TITLE
fix(synthesis): launch alpaca mcp with env command

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -19,8 +19,11 @@ spec:
       threadConfig:
         mcp_servers:
           alpaca:
-            command: /usr/local/bin/alpaca-mcp-server
+            command: /usr/bin/env
             args:
+              - FASTMCP_SHOW_SERVER_BANNER=false
+              - FASTMCP_LOG_LEVEL=ERROR
+              - /usr/local/bin/alpaca-mcp-server
               - --transport
               - stdio
             env:
@@ -104,8 +107,8 @@ spec:
         trust_level = "trusted"
 
         [mcp_servers.alpaca]
-        command = "/usr/local/bin/alpaca-mcp-server"
-        args = ["--transport", "stdio"]
+        command = "/usr/bin/env"
+        args = ["FASTMCP_SHOW_SERVER_BANNER=false", "FASTMCP_LOG_LEVEL=ERROR", "/usr/local/bin/alpaca-mcp-server", "--transport", "stdio"]
         env = { FASTMCP_SHOW_SERVER_BANNER = "false", FASTMCP_LOG_LEVEL = "ERROR" }
   outputArtifacts:
     - name: autonomous-trader-report


### PR DESCRIPTION
## Summary

- Launches the Synthesis autonomous trader Alpaca MCP server through `/usr/bin/env`.
- Embeds FastMCP banner/log suppression directly in the command arguments so MCP startup does not depend on Codex app-server honoring the server `env` table.
- Keeps explicit `--transport stdio` for the official Alpaca MCP server.

## Related Issues

None

## Testing

- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/synthesis > /tmp/synthesis-alpaca-mcp-env-command-render.yaml && kubectl apply --dry-run=server -f /tmp/synthesis-alpaca-mcp-env-command-render.yaml`
- `bun run lint:argocd`
- `scripts/agents/validate-agents.sh`
- Live in-pod probe returned a clean JSON-RPC initialize response using `/usr/bin/env FASTMCP_SHOW_SERVER_BANNER=false FASTMCP_LOG_LEVEL=ERROR /usr/local/bin/alpaca-mcp-server --transport stdio`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
