### PR TITLE
fix(synthesis): bridge alpaca mcp stdio framing

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -19,13 +19,10 @@ spec:
       threadConfig:
         mcp_servers:
           alpaca:
-            command: /usr/bin/env
+            command: /usr/bin/python3
             args:
-              - FASTMCP_SHOW_SERVER_BANNER=false
-              - FASTMCP_LOG_LEVEL=ERROR
-              - /usr/local/bin/alpaca-mcp-server
-              - --transport
-              - stdio
+              - -u
+              - /root/alpaca-mcp-stdio-bridge.py
             env:
               FASTMCP_SHOW_SERVER_BANNER: "false"
               FASTMCP_LOG_LEVEL: "ERROR"
@@ -107,9 +104,89 @@ spec:
         trust_level = "trusted"
 
         [mcp_servers.alpaca]
-        command = "/usr/bin/env"
-        args = ["FASTMCP_SHOW_SERVER_BANNER=false", "FASTMCP_LOG_LEVEL=ERROR", "/usr/local/bin/alpaca-mcp-server", "--transport", "stdio"]
+        command = "/usr/bin/python3"
+        args = ["-u", "/root/alpaca-mcp-stdio-bridge.py"]
         env = { FASTMCP_SHOW_SERVER_BANNER = "false", FASTMCP_LOG_LEVEL = "ERROR" }
+    - path: /root/alpaca-mcp-stdio-bridge.py
+      content: |-
+        import os
+        import subprocess
+        import sys
+        import threading
+
+        child_env = dict(os.environ)
+        child_env["FASTMCP_SHOW_SERVER_BANNER"] = "false"
+        child_env["FASTMCP_LOG_LEVEL"] = "ERROR"
+
+        child = subprocess.Popen(
+            ["/usr/local/bin/alpaca-mcp-server", "--transport", "stdio"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=sys.stderr,
+            env=child_env,
+        )
+
+        mode_lock = threading.Lock()
+        output_mode = "line"
+
+        def set_output_mode(mode):
+            global output_mode
+            with mode_lock:
+                output_mode = mode
+
+        def get_output_mode():
+            with mode_lock:
+                return output_mode
+
+        def read_client_message():
+            line = sys.stdin.buffer.readline()
+            if not line:
+                return None
+            if line.lower().startswith(b"content-length:"):
+                set_output_mode("framed")
+                length = int(line.split(b":", 1)[1].strip())
+                while True:
+                    header = sys.stdin.buffer.readline()
+                    if header in (b"\r\n", b"\n", b""):
+                        break
+                return sys.stdin.buffer.read(length)
+            set_output_mode("line")
+            return line.rstrip(b"\r\n")
+
+        def client_to_child():
+            assert child.stdin is not None
+            while True:
+                message = read_client_message()
+                if message is None:
+                    break
+                if not message:
+                    continue
+                child.stdin.write(message + b"\n")
+                child.stdin.flush()
+            child.stdin.close()
+
+        def child_to_client():
+            assert child.stdout is not None
+            for line in child.stdout:
+                payload = line.rstrip(b"\r\n")
+                if not payload:
+                    continue
+                if get_output_mode() == "framed":
+                    sys.stdout.buffer.write(b"Content-Length: " + str(len(payload)).encode("ascii") + b"\r\n\r\n")
+                    sys.stdout.buffer.write(payload)
+                else:
+                    sys.stdout.buffer.write(payload + b"\n")
+                sys.stdout.buffer.flush()
+
+        threads = [
+            threading.Thread(target=client_to_child, daemon=True),
+            threading.Thread(target=child_to_client, daemon=True),
+        ]
+        for thread in threads:
+            thread.start()
+
+        exit_code = child.wait()
+        sys.exit(exit_code)
   outputArtifacts:
     - name: autonomous-trader-report
       path: /workspace/.agentrun/autonomous-trader/report.md

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -594,6 +594,34 @@ describe('scheduled AgentRun templates', () => {
   })
 })
 
+describe('synthesis autonomous trader provider', () => {
+  it('bridges Codex framed MCP stdio to Alpaca newline stdio', () => {
+    const provider = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'AgentProvider')
+    const spec = objectAt(provider, 'spec')
+    const codex = objectAt(objectAt(spec, 'adapter'), 'codex')
+    const threadConfig = objectAt(codex, 'threadConfig')
+    const alpaca = objectAt(objectAt(threadConfig, 'mcp_servers'), 'alpaca')
+    const inputFiles = objectAt(spec, 'inputFiles') as Record<string, unknown>[] | undefined
+    const codexConfig = (inputFiles ?? []).find(
+      (inputFile) => objectAt(inputFile, 'path') === '/root/.codex/config.toml',
+    )
+    const bridge = (inputFiles ?? []).find(
+      (inputFile) => objectAt(inputFile, 'path') === '/root/alpaca-mcp-stdio-bridge.py',
+    )
+
+    expect(objectAt(alpaca, 'command')).toBe('/usr/bin/python3')
+    expect(objectAt(alpaca, 'args')).toEqual(['-u', '/root/alpaca-mcp-stdio-bridge.py'])
+    expect(objectAt(codexConfig, 'content')).toContain('command = "/usr/bin/python3"')
+    expect(objectAt(codexConfig, 'content')).toContain('args = ["-u", "/root/alpaca-mcp-stdio-bridge.py"]')
+    expect(objectAt(bridge, 'content')).toContain('Content-Length:')
+    expect(objectAt(bridge, 'content')).toContain('/usr/local/bin/alpaca-mcp-server')
+    expect(objectAt(bridge, 'content')).toContain('--transport')
+    expect(objectAt(bridge, 'content')).toContain('stdio')
+  })
+})
+
 describe('kubectl error classification', () => {
   it('treats fresh-kind API resets as transient instead of RBAC failures', () => {
     const error = `E0306 08:40:45.536606   21508 memcache.go:265] couldn't get current server API group list: Get "https://127.0.0.1:45497/api?timeout=32s": read tcp 127.0.0.1:46302->127.0.0.1:45497: read: connection reset by peer - error from a previous attempt: read tcp 127.0.0.1:46300->127.0.0.1:45497: read: connection reset by peer


### PR DESCRIPTION
## Summary

- Adds a small Python stdio bridge for the Synthesis autonomous trader Alpaca MCP server.
- Converts Codex app-server `Content-Length` framed MCP messages to Alpaca/FastMCP newline-delimited JSON and frames Alpaca responses back for Codex.
- Points both live thread config and `/root/.codex/config.toml` at the bridge.
- Adds a regression test that keeps the Synthesis provider wired to the bridge.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "synthesis autonomous trader provider"`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `yq e '.spec.inputFiles[] | select(.path == "/root/alpaca-mcp-stdio-bridge.py") | .content' argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml > /tmp/alpaca-mcp-stdio-bridge.py && python3 -m py_compile /tmp/alpaca-mcp-stdio-bridge.py`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/synthesis > /tmp/synthesis-alpaca-mcp-bridge-render.yaml && kubectl apply --dry-run=server -f /tmp/synthesis-alpaca-mcp-bridge-render.yaml`
- `scripts/agents/validate-agents.sh`
- `bun run lint:argocd`
- Live diagnosis: direct framed input to `alpaca-mcp-server --transport stdio` produced FastMCP JSON parse errors, while newline input succeeded; this bridge adapts that framing mismatch.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
