### PR TITLE
chore(agents): promote images 9c18bdde

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: 9f9295e4
-  digest: sha256:a767b6461878dedf8804f7f31a24b0d424e0e8952b32479bad5e9cb7d564f005
+  tag: 9c18bdde
+  digest: sha256:3b15ea0fb026dd804f3f6ed3f9672b84fe4109796960f5006ad9f7458e9a97cf
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,26 +11,26 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: 9f9295e4
-    digest: sha256:e6371221c67e522e5757530dae328de8212acda1f49df576e99c78a965cae598
+    tag: 9c18bdde
+    digest: sha256:d771b02966b0f58cef46977a450d7d091650df1bcbf2cc205df77fabaffd8e33
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: 9f9295e433c174841e72b263060337cad248f328
-      AGENTS_GITOPS_REVISION: 9f9295e433c174841e72b263060337cad248f328
-      AGENTS_SOURCE_CI_RUN_ID: "26489503839"
+      AGENTS_SOURCE_HEAD_SHA: 9c18bdde1ff5d0b609dd356e694d6d4f34d95e2f
+      AGENTS_GITOPS_REVISION: 9c18bdde1ff5d0b609dd356e694d6d4f34d95e2f
+      AGENTS_SOURCE_CI_RUN_ID: "26490853267"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:e6371221c67e522e5757530dae328de8212acda1f49df576e99c78a965cae598
-      AGENTS_SERVING_BUILD_COMMIT: 9f9295e433c174841e72b263060337cad248f328
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:e6371221c67e522e5757530dae328de8212acda1f49df576e99c78a965cae598
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:d771b02966b0f58cef46977a450d7d091650df1bcbf2cc205df77fabaffd8e33
+      AGENTS_SERVING_BUILD_COMMIT: 9c18bdde1ff5d0b609dd356e694d6d4f34d95e2f
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:d771b02966b0f58cef46977a450d7d091650df1bcbf2cc205df77fabaffd8e33
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: 9f9295e4
-    digest: sha256:3b76f68ea026368706d14d969ed4fe394cca271d1e065496ad4a1fc5c724c3fd
+    tag: 9c18bdde
+    digest: sha256:9c5abc3cb2a5b74ed9899f95dd00d1152b4716d0c9d3a2096a31042be6281b42
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun
@@ -85,8 +85,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: 9f9295e4
-    digest: sha256:a767b6461878dedf8804f7f31a24b0d424e0e8952b32479bad5e9cb7d564f005
+    tag: 9c18bdde
+    digest: sha256:3b15ea0fb026dd804f3f6ed3f9672b84fe4109796960f5006ad9f7458e9a97cf
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `9c18bdde1ff5d0b609dd356e694d6d4f34d95e2f`
- Image tag: `9c18bdde`
- Agents build run: `26490853267`
- Promotion source: `workflow_run`