### PR TITLE
fix(synthesis): extend alpaca mcp startup timeout

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -26,6 +26,7 @@ spec:
             env:
               FASTMCP_SHOW_SERVER_BANNER: "false"
               FASTMCP_LOG_LEVEL: "ERROR"
+            startup_timeout_sec: 60
         web_search: live
   argsTemplate: []
   secretEnv:
@@ -106,6 +107,7 @@ spec:
         [mcp_servers.alpaca]
         command = "/usr/bin/python3"
         args = ["-u", "/root/alpaca-mcp-stdio-bridge.py"]
+        startup_timeout_sec = 60.0
         env = { FASTMCP_SHOW_SERVER_BANNER = "false", FASTMCP_LOG_LEVEL = "ERROR" }
     - path: /root/alpaca-mcp-stdio-bridge.py
       content: |-

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -613,8 +613,10 @@ describe('synthesis autonomous trader provider', () => {
 
     expect(objectAt(alpaca, 'command')).toBe('/usr/bin/python3')
     expect(objectAt(alpaca, 'args')).toEqual(['-u', '/root/alpaca-mcp-stdio-bridge.py'])
+    expect(objectAt(alpaca, 'startup_timeout_sec')).toBe(60)
     expect(objectAt(codexConfig, 'content')).toContain('command = "/usr/bin/python3"')
     expect(objectAt(codexConfig, 'content')).toContain('args = ["-u", "/root/alpaca-mcp-stdio-bridge.py"]')
+    expect(objectAt(codexConfig, 'content')).toContain('startup_timeout_sec = 60.0')
     expect(objectAt(bridge, 'content')).toContain('Content-Length:')
     expect(objectAt(bridge, 'content')).toContain('/usr/local/bin/alpaca-mcp-server')
     expect(objectAt(bridge, 'content')).toContain('--transport')


### PR DESCRIPTION
## Summary

- Adds a 60 second startup timeout to the Synthesis autonomous trader Alpaca MCP server config.
- Mirrors the working host Codex Alpaca MCP timeout shape in both thread config and injected Codex config.
- Extends the provider smoke test so the timeout remains covered.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "synthesis autonomous trader provider"`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/synthesis > /tmp/synthesis-alpaca-mcp-timeout-render.yaml && kubectl apply --dry-run=server -f /tmp/synthesis-alpaca-mcp-timeout-render.yaml`
- `scripts/agents/validate-agents.sh`
- `bun run lint:argocd`
- `yq e '.spec.inputFiles[] | select(.path == "/root/alpaca-mcp-stdio-bridge.py") | .content' argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml > /tmp/alpaca-mcp-stdio-bridge.py && python3 -m py_compile /tmp/alpaca-mcp-stdio-bridge.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
