### PR TITLE
feat(torghut): add microbar pairs runtime

### DIFF
--- a/.github/workflows/semantic-commits.yml
+++ b/.github/workflows/semantic-commits.yml
@@ -26,6 +26,7 @@ jobs:
         shell: bash
         env:
           GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
@@ -39,6 +40,7 @@ jobs:
             response="$(
               curl -fsSL \
                 -H 'Accept: application/vnd.github+json' \
+                -H "Authorization: Bearer ${GH_TOKEN}" \
                 -H 'X-GitHub-Api-Version: 2022-11-28' \
                 "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}/commits?per_page=100&page=${page}"
             )"

--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -425,7 +425,7 @@ data:
           require_positive_price_for_signal_exit: "true"
       - name: microbar-cross-sectional-pairs-v1
         strategy_id: microbar_cross_sectional_pairs_v1@research
-        strategy_type: microbar_cross_sectional_long_v1
+        strategy_type: microbar_cross_sectional_pairs_v1
         version: 1.0.0
         description: Paper-only H-PAIRS microbar cross-sectional continuation sleeve for the runtime-ledger proof lane; production approval blocked pending live-paper runtime evidence, version=1.0.0
         enabled: true

--- a/services/torghut/app/trading/decisions.py
+++ b/services/torghut/app/trading/decisions.py
@@ -70,6 +70,7 @@ _BUY_EXIT_ONLY_STRATEGY_TYPES = {
 _LEGACY_BUY_EXIT_ONLY_UNIVERSE_TYPES = {
     "microbar_cross_sectional_pairs_v1",
 }
+_MICROBAR_PAIR_EXIT_RATIONALE = "microbar_cross_sectional_pair_exit"
 
 
 @dataclass(frozen=True)
@@ -276,6 +277,7 @@ class DecisionEngine:
             aggregated: bool,
             runtime_target_notional: Decimal | None = None,
             position_isolation_mode: str | None = None,
+            runtime_exit_side: Literal["long", "short"] | None = None,
         ) -> None:
             source_strategies = [
                 strategies_by_id[strategy_id]
@@ -303,6 +305,7 @@ class DecisionEngine:
                 positions=positions_scope,
                 capacity_positions=positions,
                 runtime_target_notional=runtime_target_notional,
+                runtime_exit_side=runtime_exit_side,
             )
 
             def _record_suppression(reason: str) -> None:
@@ -351,6 +354,7 @@ class DecisionEngine:
                 ),
                 positions=positions_scope,
                 policy=trade_policy,
+                runtime_exit_side=runtime_exit_side,
                 state_scope_key=position_state_scope_key,
             ):
                 _record_suppression("runtime_trade_policy_blocked")
@@ -362,9 +366,21 @@ class DecisionEngine:
                 price=price,
                 signal=signal,
                 positions=positions_scope,
+                runtime_exit_side=runtime_exit_side,
             ):
                 _record_suppression("signal_exit_policy_blocked")
                 return
+            position_exit_params = (
+                {
+                    "position_exit": {
+                        "type": "runtime_signal_exit",
+                        "position_side": runtime_exit_side,
+                        "source": "strategy_runtime",
+                    }
+                }
+                if runtime_exit_side is not None
+                else {}
+            )
             decision = StrategyDecision(
                 strategy_id=primary_strategy_id,
                 symbol=symbol,
@@ -378,6 +394,7 @@ class DecisionEngine:
                     _resolve_strategy_time_in_force(
                         strategies=source_strategies,
                         action=direction,
+                        runtime_exit_side=runtime_exit_side,
                     ),
                 ),
                 rationale=",".join(explain),
@@ -436,7 +453,8 @@ class DecisionEngine:
                     forecast_contract=forecast_contract,
                     forecast_audit=forecast_audit,
                 )
-                | {"sizing": sizing_meta},
+                | {"sizing": sizing_meta}
+                | position_exit_params,
             )
             decisions.append(decision)
             self._last_emitted_action_at[
@@ -461,6 +479,7 @@ class DecisionEngine:
                 signal=signal,
                 price=price,
                 decision=decision,
+                runtime_exit_side=runtime_exit_side,
             )
 
         for raw_decision in runtime_eval.raw_intents:
@@ -470,6 +489,10 @@ class DecisionEngine:
             strategy = strategies_by_id.get(primary_strategy_id)
             if strategy is None:
                 continue
+            runtime_exit_side = _runtime_intent_exit_side(
+                action=raw_decision.intent.direction,
+                explain=raw_decision.intent.explain,
+            )
             _append_runtime_intent_decision(
                 primary_strategy_id=primary_strategy_id,
                 source_strategy_ids=[primary_strategy_id],
@@ -481,10 +504,12 @@ class DecisionEngine:
                     positions,
                     strategy_id=primary_strategy_id,
                     action=raw_decision.intent.direction,
+                    runtime_exit_side=runtime_exit_side,
                 ),
                 aggregated=False,
                 runtime_target_notional=raw_decision.intent.target_notional,
                 position_isolation_mode="per_strategy",
+                runtime_exit_side=runtime_exit_side,
             )
 
         for intent in aggregated_intents:
@@ -499,6 +524,10 @@ class DecisionEngine:
                     intent.horizon,
                 )
                 continue
+            runtime_exit_side = _runtime_intent_exit_side(
+                action=intent.direction,
+                explain=intent.explain,
+            )
             _append_runtime_intent_decision(
                 primary_strategy_id=primary_strategy_id,
                 source_strategy_ids=source_strategy_ids,
@@ -507,10 +536,13 @@ class DecisionEngine:
                 explain=intent.explain,
                 feature_snapshot_hashes=list(intent.feature_snapshot_hashes),
                 positions_scope=(
-                    actual_positions if intent.direction == "sell" else positions
+                    actual_positions
+                    if runtime_exit_side is not None or intent.direction == "sell"
+                    else positions
                 ),
                 aggregated=True,
                 runtime_target_notional=intent.target_notional,
+                runtime_exit_side=runtime_exit_side,
             )
         for isolated_strategy_id in sorted(isolated_strategy_ids):
             strategy = strategies_by_id.get(isolated_strategy_id)
@@ -1408,6 +1440,7 @@ def _resolve_qty_for_aggregated(
     positions: Optional[list[dict[str, Any]]],
     capacity_positions: Optional[list[dict[str, Any]]] = None,
     runtime_target_notional: Decimal | None = None,
+    runtime_exit_side: Literal["long", "short"] | None = None,
 ) -> tuple[Decimal, dict[str, Any]]:
     default_qty = Decimal(str(settings.trading_default_qty))
     if price is None or price <= 0:
@@ -1447,11 +1480,11 @@ def _resolve_qty_for_aggregated(
     position_qty = _position_qty_for_symbol(positions, symbol)
     normalized_action = action.strip().lower()
     exit_only_sell = (
-        _treats_sell_as_exit_only_any(strategies) and normalized_action == "sell"
-    )
+        _treats_sell_as_exit_only_any(strategies) or runtime_exit_side == "long"
+    ) and normalized_action == "sell"
     exit_only_buy = (
-        _treats_buy_as_exit_only_any(strategies) and normalized_action == "buy"
-    )
+        _treats_buy_as_exit_only_any(strategies) or runtime_exit_side == "short"
+    ) and normalized_action == "buy"
     if exit_only_sell and position_qty is not None and position_qty <= 0:
         return Decimal("0"), {
             "method": budget_method,
@@ -2029,6 +2062,7 @@ def _positions_for_strategy_action(
     *,
     strategy_id: str,
     action: str,
+    runtime_exit_side: Literal["long", "short"] | None = None,
 ) -> Optional[list[dict[str, Any]]]:
     if not positions:
         return positions
@@ -2037,7 +2071,7 @@ def _positions_for_strategy_action(
         for position in positions
         if str(position.get("strategy_id") or "").strip() == strategy_id
     ]
-    if action.strip().lower() == "sell":
+    if runtime_exit_side is not None or action.strip().lower() == "sell":
         return _actual_positions_only(tagged_positions)
     if tagged_positions:
         return tagged_positions
@@ -2712,6 +2746,7 @@ def _passes_runtime_trade_policy(
     positions: Optional[list[dict[str, Any]]],
     policy: Mapping[str, int | Decimal],
     position_exit_type: str | None = None,
+    runtime_exit_side: Literal["long", "short"] | None = None,
     state_scope_key: str | None = None,
 ) -> bool:
     normalized_action = action.strip().lower()
@@ -2721,11 +2756,11 @@ def _passes_runtime_trade_policy(
         symbol=symbol,
         position_owner=position_owner,
     )
-    entry_action = _is_entry_action_for_strategies(
+    entry_action = runtime_exit_side is None and _is_entry_action_for_strategies(
         strategies=strategies,
         action=normalized_action,
     )
-    exit_action = _is_exit_action_for_strategies(
+    exit_action = runtime_exit_side is not None or _is_exit_action_for_strategies(
         strategies=strategies,
         action=normalized_action,
     )
@@ -2862,10 +2897,13 @@ def _resolve_strategy_time_in_force(
     *,
     strategies: list[Strategy],
     action: str,
+    runtime_exit_side: Literal["long", "short"] | None = None,
 ) -> str:
     normalized_action = str(action or "").strip().lower()
     param_key = (
-        "entry_time_in_force"
+        "exit_time_in_force"
+        if runtime_exit_side is not None
+        else "entry_time_in_force"
         if _is_entry_action_for_strategies(
             strategies=strategies, action=normalized_action
         )
@@ -2933,6 +2971,7 @@ def _record_runtime_trade_policy_decision(
     signal: SignalEnvelope,
     price: Decimal | None,
     decision: StrategyDecision,
+    runtime_exit_side: Literal["long", "short"] | None = None,
 ) -> None:
     normalized_action = action.strip().lower()
     state = _resolve_runtime_trade_policy_session_state(
@@ -2941,11 +2980,11 @@ def _record_runtime_trade_policy_decision(
         symbol=symbol,
         position_owner=position_owner,
     )
-    entry_action = _is_entry_action_for_strategies(
+    entry_action = runtime_exit_side is None and _is_entry_action_for_strategies(
         strategies=strategies,
         action=normalized_action,
     )
-    exit_side = _exit_position_side_for_strategies(
+    exit_side = runtime_exit_side or _exit_position_side_for_strategies(
         strategies=strategies,
         action=normalized_action,
     )
@@ -3001,9 +3040,10 @@ def _passes_signal_exit_policy(
     price: Optional[Decimal],
     signal: SignalEnvelope,
     positions: Optional[list[dict[str, Any]]],
+    runtime_exit_side: Literal["long", "short"] | None = None,
 ) -> bool:
     normalized_action = action.strip().lower()
-    exit_side = _exit_position_side_for_strategies(
+    exit_side = runtime_exit_side or _exit_position_side_for_strategies(
         strategies=strategies,
         action=normalized_action,
     )
@@ -3034,6 +3074,22 @@ def _passes_signal_exit_policy(
         strategies=strategies,
         realized_bps=realized_bps,
     )
+
+
+def _runtime_intent_exit_side(
+    *,
+    action: str,
+    explain: tuple[str, ...],
+) -> Literal["long", "short"] | None:
+    tokens = {str(item).strip().lower() for item in explain if str(item).strip()}
+    if _MICROBAR_PAIR_EXIT_RATIONALE not in tokens:
+        return None
+    normalized_action = action.strip().lower()
+    if normalized_action == "sell":
+        return "long"
+    if normalized_action == "buy":
+        return "short"
+    return None
 
 
 def _default_trailing_stop_requires_structure_loss(

--- a/services/torghut/app/trading/execution_policy.py
+++ b/services/torghut/app/trading/execution_policy.py
@@ -969,13 +969,20 @@ def _should_keep_market_order_for_high_conviction_entry(
     if {
         "microbar_cross_sectional_long_v1",
         "microbar_cross_sectional_short_v1",
+        "microbar_cross_sectional_pairs_v1",
     } & strategy_types:
         rationale_tokens = {
             token.strip().lower()
             for token in str(decision.rationale or "").split(",")
             if token.strip()
         }
-        return "microbar_cross_sectional_entry" in rationale_tokens
+        return bool(
+            {
+                "microbar_cross_sectional_entry",
+                "microbar_cross_sectional_pair_entry",
+            }
+            & rationale_tokens
+        )
 
     return False
 

--- a/services/torghut/app/trading/strategy_runtime.py
+++ b/services/torghut/app/trading/strategy_runtime.py
@@ -186,6 +186,23 @@ def _microbar_rank_thresholds(
     return (low_threshold, high_threshold)
 
 
+def _microbar_pair_max_legs(params: dict[str, Any]) -> int:
+    raw_max_legs = _decimal(params.get("max_pair_legs"))
+    if raw_max_legs is None:
+        return 2
+    return int(raw_max_legs)
+
+
+def _microbar_pair_side_count(
+    *,
+    universe_size: int,
+    max_pair_legs: int,
+) -> int:
+    if universe_size < 2 or max_pair_legs < 2:
+        return 0
+    return max(1, min(universe_size // 2, max_pair_legs // 2))
+
+
 def _microbar_rank_universe_size(
     *,
     context: "StrategyContext",
@@ -212,12 +229,17 @@ def _microbar_required_features(params: dict[str, Any]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(required))
 
 
+def _opposite_action(action: Literal["buy", "sell"]) -> Literal["buy", "sell"]:
+    return "sell" if action == "buy" else "buy"
+
+
 def _evaluate_microbar_cross_sectional(
     *,
     context: "StrategyContext",
     features: FeatureVectorV3,
     entry_action: Literal["buy", "sell"],
     exit_action: Literal["buy", "sell"],
+    pair_mode: bool = False,
 ) -> PluginEvaluationResult:
     params = context.params
     minutes_elapsed = _microbar_minutes_elapsed(context=context, features=features)
@@ -240,7 +262,8 @@ def _evaluate_microbar_cross_sectional(
     entry_window_end = entry_minute + entry_window_minutes
     if exit_minute is not None:
         entry_window_end = min(entry_window_end, max(entry_minute, exit_minute - 1))
-    if exit_minute is not None and minutes_elapsed >= exit_minute:
+    is_exit = exit_minute is not None and minutes_elapsed >= exit_minute
+    if is_exit and not pair_mode:
         rationale = (
             "microbar_time_exit",
             str(params.get("signal_motif") or "").strip().lower(),
@@ -270,7 +293,9 @@ def _evaluate_microbar_cross_sectional(
             ),
         )
 
-    if minutes_elapsed < entry_minute or minutes_elapsed > entry_window_end:
+    if not is_exit and (
+        minutes_elapsed < entry_minute or minutes_elapsed > entry_window_end
+    ):
         return PluginEvaluationResult(
             intent=None,
             trace=_generic_plugin_trace(
@@ -290,7 +315,7 @@ def _evaluate_microbar_cross_sectional(
     gate_value = _decimal(features.values.get(gate_feature)) if gate_feature else None
     gate_min = _decimal(params.get("gate_min"))
     gate_max = _decimal(params.get("gate_max"))
-    if gate_feature:
+    if gate_feature and not is_exit:
         passed_min = gate_min is None or (
             gate_value is not None and gate_value >= gate_min
         )
@@ -374,10 +399,153 @@ def _evaluate_microbar_cross_sectional(
         features=features,
         rank_feature=rank_feature,
     )
+    max_pair_legs = _microbar_pair_max_legs(params)
+    pair_side_count = (
+        _microbar_pair_side_count(
+            universe_size=universe_size,
+            max_pair_legs=max_pair_legs,
+        )
+        if pair_mode
+        else 0
+    )
+    if pair_mode and pair_side_count <= 0:
+        return PluginEvaluationResult(
+            intent=None,
+            trace=_generic_plugin_trace(
+                context=context,
+                gate="pair_leg_selection",
+                passed=False,
+                gate_context={
+                    "reason": "invalid_pair_leg_count",
+                    "max_pair_legs": max_pair_legs,
+                    "universe_size": universe_size,
+                },
+            ),
+        )
     low_threshold, high_threshold = _microbar_rank_thresholds(
         universe_size=universe_size,
-        top_n=top_n,
+        top_n=pair_side_count if pair_mode else top_n,
     )
+    if pair_mode:
+        high_entry_action: Literal["buy", "sell"] = (
+            "sell" if selection_mode == "reversal" else "buy"
+        )
+        low_entry_action: Literal["buy", "sell"] = (
+            "buy" if selection_mode == "reversal" else "sell"
+        )
+        selected_entry_action: Literal["buy", "sell"] | None = None
+        pair_side: str | None = None
+        comparator = "gte"
+        threshold_value = high_threshold
+        if rank_value >= high_threshold:
+            selected_entry_action = high_entry_action
+            pair_side = "high_rank"
+            comparator = "gte"
+            threshold_value = high_threshold
+        elif rank_value <= low_threshold:
+            selected_entry_action = low_entry_action
+            pair_side = "low_rank"
+            comparator = "lte"
+            threshold_value = low_threshold
+        should_trade = selected_entry_action is not None
+        resolved_action = (
+            _opposite_action(selected_entry_action)
+            if is_exit and selected_entry_action is not None
+            else selected_entry_action
+        )
+        rationale = (
+            (
+                "microbar_cross_sectional_pair_exit"
+                if is_exit
+                else "microbar_cross_sectional_pair_entry"
+            ),
+            str(params.get("signal_motif") or "").strip().lower(),
+            f"selection_mode:{selection_mode}",
+            f"rank_feature:{rank_feature}",
+            f"pair_side:{pair_side or 'none'}",
+            f"pair_side_count:{pair_side_count}",
+            f"max_pair_legs:{max_pair_legs}",
+        )
+        failed_thresholds = (
+            ThresholdTrace(
+                metric=rank_feature,
+                comparator="min_gte",
+                value=rank_value,
+                threshold=high_threshold,
+                passed=False,
+                missing_policy="fail_closed",
+                distance_to_pass=max(Decimal("0"), high_threshold - rank_value),
+            ),
+            ThresholdTrace(
+                metric=rank_feature,
+                comparator="max_lte",
+                value=rank_value,
+                threshold=low_threshold,
+                passed=False,
+                missing_policy="fail_closed",
+                distance_to_pass=max(Decimal("0"), rank_value - low_threshold),
+            ),
+        )
+        trace = _generic_plugin_trace(
+            context=context,
+            gate="pair_time_exit" if is_exit else "pair_rank_selection",
+            passed=should_trade,
+            action=resolved_action if should_trade else None,
+            rationale=rationale if should_trade else (),
+            thresholds=(
+                (
+                    ThresholdTrace(
+                        metric=rank_feature,
+                        comparator=("min_gte" if comparator == "gte" else "max_lte"),
+                        value=rank_value,
+                        threshold=threshold_value,
+                        passed=should_trade,
+                        missing_policy="fail_closed",
+                        distance_to_pass=Decimal("0"),
+                    ),
+                )
+                if should_trade
+                else failed_thresholds
+            ),
+            gate_context={
+                "minutes_elapsed": minutes_elapsed,
+                "entry_minute_after_open": entry_minute,
+                "entry_window_minutes": entry_window_minutes,
+                "entry_window_end_minute_after_open": entry_window_end,
+                "exit_minute_after_open": exit_minute,
+                "selection_mode": selection_mode,
+                "top_n": top_n,
+                "universe_size": universe_size,
+                "pair_side_count": pair_side_count,
+                "max_pair_legs": max_pair_legs,
+                "pair_side": pair_side,
+            },
+        )
+        if not should_trade or resolved_action is None:
+            return PluginEvaluationResult(intent=None, trace=trace)
+        rank_distance = (
+            rank_value - threshold_value
+            if comparator == "gte"
+            else threshold_value - rank_value
+        )
+        confidence = min(
+            Decimal("0.95"), Decimal("0.55") + max(Decimal("0"), rank_distance)
+        )
+        return PluginEvaluationResult(
+            intent=StrategyIntent(
+                strategy_id=context.strategy_id,
+                symbol=context.symbol,
+                direction=resolved_action,
+                confidence=confidence,
+                target_notional=_resolved_target_notional(params),
+                horizon=context.timeframe,
+                explain=rationale,
+                feature_snapshot_hash=features.normalization_hash,
+                required_features=_microbar_required_features(params),
+            ),
+            trace=trace,
+        )
+
     should_trade = False
     comparator = "gte"
     threshold_value = high_threshold
@@ -681,6 +849,7 @@ class StrategyRegistry:
             "mean_reversion_exhaustion_short_v1": MeanReversionExhaustionShortPlugin(),
             "microbar_cross_sectional_long_v1": MicrobarCrossSectionalLongPlugin(),
             "microbar_cross_sectional_short_v1": MicrobarCrossSectionalShortPlugin(),
+            "microbar_cross_sectional_pairs_v1": MicrobarCrossSectionalPairsPlugin(),
             "washout_rebound_long_v1": WashoutReboundLongPlugin(),
             "late_day_continuation_long_v1": LateDayContinuationLongPlugin(),
             "end_of_day_reversal_long_v1": EndOfDayReversalLongPlugin(),
@@ -1625,6 +1794,32 @@ class MicrobarCrossSectionalShortPlugin:
             features=features,
             entry_action="sell",
             exit_action="buy",
+        )
+
+
+class MicrobarCrossSectionalPairsPlugin:
+    plugin_id = "microbar_cross_sectional_pairs"
+    version = "1.0.0"
+    required_features: tuple[str, ...] = (
+        "price",
+        "macd",
+        "macd_signal",
+        "rsi14",
+        "session_minutes_elapsed",
+        "cross_section_continuation_breadth",
+        "cross_section_session_open_rank",
+        "cross_section_vwap_w5m_rank",
+    )
+
+    def evaluate(
+        self, context: StrategyContext, features: FeatureVectorV3
+    ) -> PluginEvaluationResult:
+        return _evaluate_microbar_cross_sectional(
+            context=context,
+            features=features,
+            entry_action="buy",
+            exit_action="sell",
+            pair_mode=True,
         )
 
 

--- a/services/torghut/config/trading/families/microbar_cross_sectional_pairs_v1.yaml
+++ b/services/torghut/config/trading/families/microbar_cross_sectional_pairs_v1.yaml
@@ -51,7 +51,7 @@ default_hard_vetoes:
   required_min_cash: '0'
   required_min_regime_slice_pass_rate: '0'
 default_selection_objectives:
-  target_net_pnl_per_day: '300'
+  target_net_pnl_per_day: '500'
   require_positive_day_ratio: '0.75'
 runtime_harness:
   family: microbar_cross_sectional_pairs

--- a/services/torghut/tests/test_decisions.py
+++ b/services/torghut/tests/test_decisions.py
@@ -2385,6 +2385,213 @@ class TestDecisionEngine(TestCase):
             "short",
         )
 
+    def test_scheduler_runtime_microbar_pairs_signal_exit_sells_long_leg_quantity(
+        self,
+    ) -> None:
+        strategy_id = uuid.uuid4()
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=strategy_id,
+            name="microbar-pairs-runtime",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="microbar-pairs-runtime",
+                    strategy_id="microbar_cross_sectional_pairs_v1@research",
+                    strategy_type="microbar_cross_sectional_pairs_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="microbar_cross_sectional_pairs_v1",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("100"),
+                    params={
+                        "entry_minute_after_open": "60",
+                        "exit_minute_after_open": "120",
+                        "signal_motif": "vwap_close_continuation",
+                        "rank_feature": "cross_section_vwap_w5m_rank",
+                        "selection_mode": "continuation",
+                        "max_pair_legs": "2",
+                        "position_isolation_mode": "per_strategy",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("100"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 15, 30, 0, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 101,
+                "spread": 0.02,
+                "imbalance_bid_px": 100.99,
+                "imbalance_ask_px": 101.01,
+                "macd": 0.010,
+                "macd_signal": 0.008,
+                "rsi14": 56.4,
+                "vwap_w5m": 100,
+                "session_minutes_elapsed": 120,
+                "cross_section_continuation_breadth": 0.5,
+                "cross_section_session_open_rank": 1,
+                "cross_section_vwap_w5m_rank": 1,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            engine.evaluate(
+                signal.model_copy(
+                    update={
+                        "symbol": "AMZN",
+                        "payload": {
+                            **signal.payload,
+                            "price": 99,
+                            "imbalance_bid_px": 98.99,
+                            "imbalance_ask_px": 99.01,
+                            "vwap_w5m": 100,
+                        },
+                    }
+                ),
+                [strategy],
+                positions=[],
+            )
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "strategy_id": str(strategy_id),
+                        "symbol": "AAPL",
+                        "qty": "0.25",
+                        "side": "long",
+                        "market_value": "25.25",
+                        "avg_entry_price": "100",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "sell")
+        self.assertEqual(decisions[0].qty, Decimal("0.25"))
+        self.assertIn("microbar_cross_sectional_pair_exit", decisions[0].rationale)
+        position_exit = decisions[0].params.get("position_exit")
+        assert isinstance(position_exit, dict)
+        self.assertEqual(position_exit.get("type"), "runtime_signal_exit")
+        self.assertEqual(position_exit.get("position_side"), "long")
+
+    def test_scheduler_runtime_microbar_pairs_signal_exit_covers_short_leg_quantity(
+        self,
+    ) -> None:
+        strategy_id = uuid.uuid4()
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=strategy_id,
+            name="microbar-pairs-runtime",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="microbar-pairs-runtime",
+                    strategy_id="microbar_cross_sectional_pairs_v1@research",
+                    strategy_type="microbar_cross_sectional_pairs_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="microbar_cross_sectional_pairs_v1",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("100"),
+                    params={
+                        "entry_minute_after_open": "60",
+                        "exit_minute_after_open": "120",
+                        "signal_motif": "vwap_close_continuation",
+                        "rank_feature": "cross_section_vwap_w5m_rank",
+                        "selection_mode": "continuation",
+                        "max_pair_legs": "2",
+                        "position_isolation_mode": "per_strategy",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("100"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 15, 30, 0, tzinfo=timezone.utc),
+            symbol="AMZN",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 99,
+                "spread": 0.02,
+                "imbalance_bid_px": 98.99,
+                "imbalance_ask_px": 99.01,
+                "macd": 0.010,
+                "macd_signal": 0.008,
+                "rsi14": 56.4,
+                "vwap_w5m": 100,
+                "session_minutes_elapsed": 120,
+                "cross_section_continuation_breadth": 0.5,
+                "cross_section_session_open_rank": 0,
+                "cross_section_vwap_w5m_rank": 0,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+            patch.object(settings, "trading_allow_shorts", True),
+        ):
+            engine.evaluate(
+                signal.model_copy(
+                    update={
+                        "symbol": "AAPL",
+                        "payload": {
+                            **signal.payload,
+                            "price": 101,
+                            "imbalance_bid_px": 100.99,
+                            "imbalance_ask_px": 101.01,
+                            "vwap_w5m": 100,
+                        },
+                    }
+                ),
+                [strategy],
+                positions=[],
+            )
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "strategy_id": str(strategy_id),
+                        "symbol": "AMZN",
+                        "qty": "0.25",
+                        "side": "short",
+                        "market_value": "-24.75",
+                        "avg_entry_price": "100",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "buy")
+        self.assertEqual(decisions[0].qty, Decimal("0.25"))
+        self.assertIn("microbar_cross_sectional_pair_exit", decisions[0].rationale)
+        position_exit = decisions[0].params.get("position_exit")
+        assert isinstance(position_exit, dict)
+        self.assertEqual(position_exit.get("type"), "runtime_signal_exit")
+        self.assertEqual(position_exit.get("position_side"), "short")
+
     def test_scheduler_runtime_isolated_buy_cooldown_is_scoped_per_strategy(
         self,
     ) -> None:

--- a/services/torghut/tests/test_execution_policy.py
+++ b/services/torghut/tests/test_execution_policy.py
@@ -507,6 +507,41 @@ class TestExecutionPolicy(TestCase):
         self.assertEqual(outcome.decision.order_type, "market")
         self.assertIsNone(outcome.decision.limit_price)
 
+    def test_microbar_cross_sectional_pairs_entry_keeps_market_order(self) -> None:
+        policy = ExecutionPolicy(config=_config(prefer_limit=True))
+        decision = _decision(
+            action="buy",
+            qty=Decimal("1"),
+            price=Decimal("189.24"),
+            order_type="market",
+        ).model_copy(
+            update={
+                "rationale": "microbar_cross_sectional_pair_entry,pair_side:high_rank",
+                "params": {
+                    "price": Decimal("189.24"),
+                    "spread": Decimal("0.04"),
+                    "execution_features": {
+                        "spread_bps": Decimal("2.11"),
+                    },
+                    "strategy_runtime": {
+                        "source_strategy_runtime": [
+                            {"strategy_type": "microbar_cross_sectional_pairs_v1"}
+                        ]
+                    },
+                },
+            }
+        )
+
+        outcome = policy.evaluate(
+            decision,
+            strategy=None,
+            positions=[],
+            market_snapshot=None,
+        )
+
+        self.assertEqual(outcome.decision.order_type, "market")
+        self.assertIsNone(outcome.decision.limit_price)
+
     def test_limit_and_stop_prices_are_quantized(self) -> None:
         decision = _decision(
             action="sell",

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -403,30 +403,33 @@ class TestLiveConfigManifestContract(TestCase):
                     context=f"{name} universe",
                 )
             if str(strategy.get("strategy_type")) == "microbar_cross_sectional_long_v1":
-                expected_notional = (
-                    Decimal("31590")
-                    if name == "microbar-cross-sectional-pairs-v1"
-                    else Decimal("50000")
-                )
-                expected_position_pct = (
-                    Decimal("1.0")
-                    if name == "microbar-cross-sectional-pairs-v1"
-                    else Decimal("2.0")
-                )
                 self.assertEqual(
                     _strategy_decimal(strategy, "max_notional_per_trade"),
-                    expected_notional,
+                    Decimal("50000"),
                 )
                 self.assertEqual(
                     _strategy_decimal(strategy, "max_position_pct_equity"),
-                    expected_position_pct,
+                    Decimal("2.0"),
                 )
                 self.assertEqual(params.get("position_isolation_mode"), "per_strategy")
-                if name == "microbar-cross-sectional-pairs-v1":
-                    self.assertEqual(params.get("max_gross_exposure_pct_equity"), "2.0")
-                    self.assertEqual(params.get("max_pair_legs"), "2")
-                    self.assertEqual(params.get("entry_minute_after_open"), "60")
-                    self.assertEqual(params.get("exit_minute_after_open"), "120")
+            elif (
+                str(strategy.get("strategy_type"))
+                == "microbar_cross_sectional_pairs_v1"
+            ):
+                self.assertEqual(name, "microbar-cross-sectional-pairs-v1")
+                self.assertEqual(
+                    _strategy_decimal(strategy, "max_notional_per_trade"),
+                    Decimal("31590"),
+                )
+                self.assertEqual(
+                    _strategy_decimal(strategy, "max_position_pct_equity"),
+                    Decimal("1.0"),
+                )
+                self.assertEqual(params.get("position_isolation_mode"), "per_strategy")
+                self.assertEqual(params.get("max_gross_exposure_pct_equity"), "2.0")
+                self.assertEqual(params.get("max_pair_legs"), "2")
+                self.assertEqual(params.get("entry_minute_after_open"), "60")
+                self.assertEqual(params.get("exit_minute_after_open"), "120")
             elif str(strategy.get("strategy_type")) == "intraday_tsmom_v1":
                 self.assertEqual(name, "intraday-tsmom-profit-v3")
                 self.assertEqual(

--- a/services/torghut/tests/test_strategy_runtime.py
+++ b/services/torghut/tests/test_strategy_runtime.py
@@ -24,8 +24,10 @@ from app.trading.research_sleeves import (
 from app.trading.strategy_runtime import (
     LegacyMacdRsiPlugin,
     MicrobarCrossSectionalLongPlugin,
+    MicrobarCrossSectionalPairsPlugin,
     MicrobarCrossSectionalShortPlugin,
     StrategyContext,
+    StrategyDefinition,
     StrategyIntent,
     StrategyRegistry,
     StrategyRuntime,
@@ -5462,6 +5464,7 @@ class TestStrategyRuntimeMicrobarCoverage(TestCase):
         params: dict[str, object] | None = None,
         event_ts: str = "2026-03-24T14:30:00+00:00",
         strategy_type: str = "microbar_cross_sectional_long_v1",
+        symbol: str = "META",
         strategy_spec: dict[str, object] | None = None,
     ) -> StrategyContext:
         return StrategyContext(
@@ -5471,7 +5474,7 @@ class TestStrategyRuntimeMicrobarCoverage(TestCase):
             strategy_type=strategy_type,
             strategy_version="1.0.0",
             event_ts=event_ts,
-            symbol="META",
+            symbol=symbol,
             timeframe="1Sec",
             params=dict(params or {}),
             trace_enabled=True,
@@ -5922,6 +5925,201 @@ class TestStrategyRuntimeMicrobarCoverage(TestCase):
         self.assertIsNotNone(continuation_sell.intent)
         assert continuation_sell.intent is not None
         self.assertEqual(continuation_sell.intent.action, "sell")
+
+    def test_microbar_cross_sectional_pairs_plugin_emits_balanced_pair_sides(
+        self,
+    ) -> None:
+        plugin = MicrobarCrossSectionalPairsPlugin()
+        params = {
+            "entry_minute_after_open": "60",
+            "exit_minute_after_open": "120",
+            "signal_motif": "vwap_close_continuation",
+            "rank_feature": "cross_section_vwap_w5m_rank",
+            "selection_mode": "continuation",
+            "top_n": "2",
+            "max_pair_legs": "2",
+        }
+
+        high_rank_entry = plugin.evaluate(
+            self._context(
+                params=params,
+                strategy_type="microbar_cross_sectional_pairs_v1",
+                symbol="AAPL",
+                strategy_spec={"universe_symbols": ["AAPL", "AMZN"]},
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 60,
+                    "cross_section_vwap_w5m_rank": Decimal("1"),
+                }
+            ),
+        )
+        low_rank_entry = plugin.evaluate(
+            self._context(
+                params=params,
+                strategy_type="microbar_cross_sectional_pairs_v1",
+                symbol="AMZN",
+                strategy_spec={"universe_symbols": ["AAPL", "AMZN"]},
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 60,
+                    "cross_section_vwap_w5m_rank": Decimal("0"),
+                }
+            ),
+        )
+
+        self.assertIsNotNone(high_rank_entry.intent)
+        self.assertIsNotNone(low_rank_entry.intent)
+        assert high_rank_entry.intent is not None
+        assert low_rank_entry.intent is not None
+        self.assertEqual(high_rank_entry.intent.action, "buy")
+        self.assertEqual(low_rank_entry.intent.action, "sell")
+        self.assertEqual(
+            high_rank_entry.intent.target_notional,
+            low_rank_entry.intent.target_notional,
+        )
+        self.assertIn("pair_side:high_rank", high_rank_entry.intent.rationale)
+        self.assertIn("pair_side:low_rank", low_rank_entry.intent.rationale)
+        self.assertIn("max_pair_legs:2", high_rank_entry.intent.rationale)
+        assert high_rank_entry.trace is not None
+        self.assertEqual(high_rank_entry.trace.gates[0].context["pair_side_count"], 1)
+
+        high_rank_exit = plugin.evaluate(
+            self._context(
+                params=params,
+                strategy_type="microbar_cross_sectional_pairs_v1",
+                symbol="AAPL",
+                strategy_spec={"universe_symbols": ["AAPL", "AMZN"]},
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 120,
+                    "cross_section_vwap_w5m_rank": Decimal("1"),
+                }
+            ),
+        )
+        low_rank_exit = plugin.evaluate(
+            self._context(
+                params=params,
+                strategy_type="microbar_cross_sectional_pairs_v1",
+                symbol="AMZN",
+                strategy_spec={"universe_symbols": ["AAPL", "AMZN"]},
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 120,
+                    "cross_section_vwap_w5m_rank": Decimal("0"),
+                }
+            ),
+        )
+
+        self.assertIsNotNone(high_rank_exit.intent)
+        self.assertIsNotNone(low_rank_exit.intent)
+        assert high_rank_exit.intent is not None
+        assert low_rank_exit.intent is not None
+        self.assertEqual(high_rank_exit.intent.action, "sell")
+        self.assertEqual(low_rank_exit.intent.action, "buy")
+        self.assertIn(
+            "microbar_cross_sectional_pair_exit",
+            high_rank_exit.intent.rationale,
+        )
+
+    def test_microbar_cross_sectional_pairs_plugin_respects_max_pair_legs(
+        self,
+    ) -> None:
+        plugin = MicrobarCrossSectionalPairsPlugin()
+        middle_rank = plugin.evaluate(
+            self._context(
+                params={
+                    "entry_minute_after_open": "60",
+                    "signal_motif": "vwap_close_continuation",
+                    "rank_feature": "cross_section_vwap_w5m_rank",
+                    "selection_mode": "continuation",
+                    "top_n": "3",
+                    "max_pair_legs": "2",
+                    "universe_size": "6",
+                },
+                strategy_type="microbar_cross_sectional_pairs_v1",
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 60,
+                    "cross_section_vwap_w5m_rank": Decimal("0.80"),
+                }
+            ),
+        )
+        self.assertIsNone(middle_rank.intent)
+        assert middle_rank.trace is not None
+        self.assertEqual(middle_rank.trace.first_failed_gate, "pair_rank_selection")
+        self.assertEqual(middle_rank.trace.gates[0].context["pair_side_count"], 1)
+        self.assertEqual(middle_rank.trace.gates[0].context["max_pair_legs"], 2)
+
+        invalid_pair = plugin.evaluate(
+            self._context(
+                params={
+                    "entry_minute_after_open": "60",
+                    "signal_motif": "vwap_close_continuation",
+                    "rank_feature": "cross_section_vwap_w5m_rank",
+                    "selection_mode": "continuation",
+                    "max_pair_legs": "1",
+                    "universe_size": "6",
+                },
+                strategy_type="microbar_cross_sectional_pairs_v1",
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 60,
+                    "cross_section_vwap_w5m_rank": Decimal("1"),
+                }
+            ),
+        )
+        self.assertIsNone(invalid_pair.intent)
+        assert invalid_pair.trace is not None
+        self.assertEqual(invalid_pair.trace.first_failed_gate, "pair_leg_selection")
+
+        reversal_high_rank = plugin.evaluate(
+            self._context(
+                params={
+                    "entry_minute_after_open": "60",
+                    "signal_motif": "vwap_close_reversal",
+                    "rank_feature": "cross_section_vwap_w5m_rank",
+                    "selection_mode": "reversal",
+                    "max_pair_legs": "2",
+                    "universe_size": "2",
+                },
+                strategy_type="microbar_cross_sectional_pairs_v1",
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 60,
+                    "cross_section_vwap_w5m_rank": Decimal("1"),
+                }
+            ),
+        )
+        self.assertIsNotNone(reversal_high_rank.intent)
+        assert reversal_high_rank.intent is not None
+        self.assertEqual(reversal_high_rank.intent.action, "sell")
+
+    def test_strategy_registry_resolves_microbar_pairs_alias(self) -> None:
+        registry = StrategyRegistry()
+        definition = StrategyDefinition(
+            strategy_id="strategy-1",
+            strategy_name="microbar-cross-sectional-pairs-v1",
+            declared_strategy_id="microbar_cross_sectional_pairs_v1@research",
+            strategy_type="microbar_cross_sectional_pairs_v1",
+            version="1.0.0",
+            params={},
+            feature_requirements=(),
+            risk_profile="paper",
+            execution_profile="paper",
+            enabled=True,
+            base_timeframe="1Sec",
+        )
+
+        plugin = registry.resolve(definition)
+
+        self.assertIsInstance(plugin, MicrobarCrossSectionalPairsPlugin)
 
 
 class TestMeanReversionExhaustionShortSleeveCoverage(TestCase):


### PR DESCRIPTION
## Summary

- Adds a dedicated `microbar_cross_sectional_pairs_v1` runtime plugin that emits balanced long/short H-PAIRS legs, respects `max_pair_legs`, and uses pair-specific entry/exit rationales.
- Threads pair signal exits through DecisionEngine sizing so long legs sell owned long quantity and short legs buy to cover owned short quantity.
- Keeps high-conviction pair entries as market orders in execution policy, wires the live H-PAIRS strategy config to the pairs runtime, and updates the family target to `$500/day`.
- Adds runtime, DecisionEngine, execution policy, and live config manifest coverage for the paired H-PAIRS path.
- Authenticates the semantic-commit workflow's GitHub API call so the PR commit checker does not fail on an unauthenticated 403.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/strategy_runtime.py app/trading/decisions.py app/trading/execution_policy.py tests/test_strategy_runtime.py tests/test_decisions.py tests/test_execution_policy.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/strategy_runtime.py app/trading/decisions.py app/trading/execution_policy.py tests/test_strategy_runtime.py tests/test_decisions.py tests/test_execution_policy.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen pytest tests/test_strategy_runtime.py tests/test_decisions.py tests/test_execution_policy.py tests/test_live_config_manifest_contract.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check HEAD~1..HEAD`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/semantic-commits.yml"); puts "yaml ok"'`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
