### PR TITLE
feat(torghut): attach replay factor acceptance metadata

### DIFF
--- a/services/torghut/app/trading/discovery/factor_acceptance.py
+++ b/services/torghut/app/trading/discovery/factor_acceptance.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
-from typing import Any, Mapping, Sequence
+from typing import Any, Iterable, Mapping, Sequence, cast
 
 from app.trading.features import FEATURE_VECTOR_V3_VALUE_FIELDS
 
@@ -43,6 +43,19 @@ def _decimal(value: Any) -> Decimal | None:
         return None
 
 
+def _int(value: Any) -> int:
+    try:
+        return int(float(str(value or 0)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in cast(Mapping[Any, Any], value).items()}
+
+
 def _string_sequence(value: Sequence[str] | None) -> tuple[str, ...]:
     if not value:
         return ()
@@ -54,6 +67,142 @@ def _string_sequence(value: Sequence[str] | None) -> tuple[str, ...]:
 def _stable_hash(payload: Mapping[str, Any]) -> str:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _scorecard_decimal(
+    scorecard: Mapping[str, Any],
+    fold_metrics: Sequence[Mapping[str, Any]],
+    keys: Sequence[str],
+) -> Decimal | None:
+    for key in keys:
+        value = _decimal(scorecard.get(key))
+        if value is not None:
+            return value
+    fold_values = [
+        value
+        for fold in fold_metrics
+        for key in keys
+        if (value := _decimal(fold.get(key))) is not None
+    ]
+    if not fold_values:
+        return None
+    return sum(fold_values, Decimal("0")) / Decimal(len(fold_values))
+
+
+def _scorecard_sample_count(
+    scorecard: Mapping[str, Any],
+    fold_metrics: Sequence[Mapping[str, Any]],
+) -> int:
+    sample_keys = (
+        "factor_sample_count",
+        "rank_ic_sample_count",
+        "sample_count",
+        "market_limit_order_mix_sample_count",
+        "limit_fill_probability_sample_count",
+        "decision_count",
+        "trade_decision_count",
+        "runtime_decision_count",
+        "filled_count",
+        "fill_count",
+        "filled_order_count",
+        "closed_trade_count",
+        "trading_day_count",
+    )
+    scorecard_count = max(_int(scorecard.get(key)) for key in sample_keys)
+    fold_count = sum(
+        max(_int(fold.get(key)) for key in sample_keys) for fold in fold_metrics
+    )
+    return max(scorecard_count, fold_count)
+
+
+def _rank_ir_from_folds(fold_metrics: Sequence[Mapping[str, Any]]) -> Decimal | None:
+    rank_ic_values = [
+        value
+        for fold in fold_metrics
+        if (
+            value := _scorecard_decimal(
+                fold,
+                (),
+                (
+                    "rank_ic",
+                    "rank_ic_mean",
+                    "factor_rank_ic",
+                    "holdout_rank_ic",
+                    "information_coefficient",
+                ),
+            )
+        )
+        is not None
+    ]
+    if len(rank_ic_values) < 2:
+        return None
+    mean = sum(rank_ic_values, Decimal("0")) / Decimal(len(rank_ic_values))
+    variance = sum((value - mean) ** 2 for value in rank_ic_values) / Decimal(
+        len(rank_ic_values) - 1
+    )
+    if variance <= 0:
+        return None
+    return mean / variance.sqrt()
+
+
+def _expectancy_bps_from_scorecard(scorecard: Mapping[str, Any]) -> Decimal | None:
+    direct = _scorecard_decimal(
+        scorecard,
+        (),
+        (
+            "factor_post_cost_expectancy_bps",
+            "post_cost_expectancy_bps",
+            "net_expectancy_bps",
+            "realized_strategy_pnl_after_explicit_costs_bps",
+            "cost_stressed_net_expectancy_bps",
+        ),
+    )
+    if direct is not None:
+        return direct
+    net_pnl_per_day = _scorecard_decimal(
+        scorecard,
+        (),
+        (
+            "net_pnl_per_day",
+            "market_impact_stress_net_pnl_per_day",
+            "delay_adjusted_depth_stress_net_pnl_per_day",
+            "post_cost_net_pnl_after_queue_position_survival_fill_stress",
+        ),
+    )
+    filled_notional_per_day = _scorecard_decimal(
+        scorecard,
+        (),
+        (
+            "avg_filled_notional_per_day",
+            "daily_filled_notional",
+            "filled_notional_per_day",
+        ),
+    )
+    if net_pnl_per_day is None or filled_notional_per_day is None:
+        return None
+    if filled_notional_per_day <= 0:
+        return None
+    return (net_pnl_per_day / filled_notional_per_day) * Decimal("10000")
+
+
+def _window_payload(
+    scorecard: Mapping[str, Any], keys: Iterable[str]
+) -> dict[str, Any]:
+    for key in keys:
+        value = _mapping(scorecard.get(key))
+        if value:
+            return value
+    replay_lineage = _mapping(scorecard.get("replay_lineage"))
+    replay_coverage = _mapping(
+        scorecard.get("replay_window_coverage")
+        or replay_lineage.get("replay_window_coverage")
+    )
+    if replay_coverage:
+        return {
+            "source": "replay_window_coverage",
+            **replay_coverage,
+        }
+    return {"source": "scorecard_missing_window_metadata"}
 
 
 def build_factor_acceptance_artifact(
@@ -72,6 +221,8 @@ def build_factor_acceptance_artifact(
     cost_stress_bps: Decimal | str | float | None = None,
     available_feature_fields: Sequence[str] = FEATURE_VECTOR_V3_VALUE_FIELDS,
     thresholds: FactorAcceptanceThresholds = FactorAcceptanceThresholds(),
+    expectancy_basis: str | None = None,
+    evidence_metadata: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a fail-closed factor acceptance artifact.
 
@@ -152,5 +303,133 @@ def build_factor_acceptance_artifact(
         "promotion_scope": "research_paper_probation_only",
         "does_not_authorize_live_promotion": True,
     }
+    if expectancy_basis:
+        payload["expectancy_basis"] = expectancy_basis
+    if evidence_metadata:
+        payload["evidence_metadata"] = dict(evidence_metadata)
     payload["lineage_hash"] = _stable_hash(payload)
     return payload
+
+
+def build_factor_acceptance_artifact_from_scorecard(
+    *,
+    factor_expression: str,
+    source_idea: str,
+    allowed_feature_dependencies: Sequence[str],
+    scorecard: Mapping[str, Any],
+    fold_metrics: Sequence[Mapping[str, Any]] = (),
+    candidate_count: int = 1,
+    candidate_spec_id: str | None = None,
+    candidate_id: str | None = None,
+    evidence_bundle_id: str | None = None,
+    available_feature_fields: Sequence[str] = FEATURE_VECTOR_V3_VALUE_FIELDS,
+    thresholds: FactorAcceptanceThresholds = FactorAcceptanceThresholds(),
+) -> dict[str, Any]:
+    """Build factor acceptance from replay/live-paper scorecard evidence.
+
+    Missing RankIC/RankIR/p-value/cost inputs still reject. This function only
+    upgrades the metadata source from static compile-time placeholders to real
+    replay/runtime scorecards when those fields are present.
+    """
+
+    resolved_candidate_count = max(
+        _int(scorecard.get("factor_candidate_count"))
+        or _int(scorecard.get("tested_candidate_count"))
+        or _int(scorecard.get("candidate_count"))
+        or candidate_count,
+        1,
+    )
+    p_value = _scorecard_decimal(
+        scorecard,
+        fold_metrics,
+        (
+            "factor_p_value",
+            "rank_ic_p_value",
+            "p_value_two_sided",
+            "p_value",
+        ),
+    )
+    if p_value is None:
+        deflated_p_value = _scorecard_decimal(
+            scorecard,
+            fold_metrics,
+            (
+                "factor_deflated_p_value",
+                "deflated_p_value",
+            ),
+        )
+        if deflated_p_value is not None:
+            p_value = deflated_p_value / Decimal(resolved_candidate_count)
+
+    rank_ir = _scorecard_decimal(
+        scorecard,
+        fold_metrics,
+        (
+            "rank_ir",
+            "rank_ic_ir",
+            "factor_rank_ir",
+            "holdout_rank_ir",
+            "information_ratio",
+        ),
+    )
+    if rank_ir is None:
+        rank_ir = _rank_ir_from_folds(fold_metrics)
+
+    cost_stress_bps = _scorecard_decimal(
+        scorecard,
+        fold_metrics,
+        (
+            "factor_cost_stress_bps",
+            "cost_stress_bps",
+            "nonlinear_market_impact_stress_cost_bps",
+            "market_impact_stress_cost_bps",
+            "order_type_opportunity_cost_bps",
+        ),
+    )
+    artifact = build_factor_acceptance_artifact(
+        factor_expression=factor_expression,
+        source_idea=source_idea,
+        allowed_feature_dependencies=allowed_feature_dependencies,
+        train_window=_window_payload(scorecard, ("train_window", "training_window")),
+        test_window=_window_payload(
+            scorecard,
+            (
+                "test_window",
+                "holdout_window",
+                "second_oos_window",
+                "live_paper_window",
+            ),
+        ),
+        sample_count=_scorecard_sample_count(scorecard, fold_metrics),
+        candidate_count=resolved_candidate_count,
+        rank_ic=_scorecard_decimal(
+            scorecard,
+            fold_metrics,
+            (
+                "rank_ic",
+                "rank_ic_mean",
+                "factor_rank_ic",
+                "holdout_rank_ic",
+                "information_coefficient",
+            ),
+        ),
+        rank_ir=rank_ir,
+        p_value=p_value,
+        gross_expectancy_bps=_expectancy_bps_from_scorecard(scorecard),
+        cost_stress_bps=cost_stress_bps,
+        available_feature_fields=available_feature_fields,
+        thresholds=thresholds,
+        expectancy_basis="scorecard_post_cost_expectancy_bps_minus_additional_stress",
+        evidence_metadata={
+            "source": "replay_or_live_paper_scorecard",
+            "candidate_spec_id": candidate_spec_id,
+            "candidate_id": candidate_id,
+            "evidence_bundle_id": evidence_bundle_id,
+            "scorecard_keys": sorted(str(key) for key in scorecard.keys()),
+            "fold_metric_count": len(fold_metrics),
+        },
+    )
+    artifact["lineage_hash"] = _stable_hash(
+        {key: value for key, value in artifact.items() if key != "lineage_hash"}
+    )
+    return artifact

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -50,6 +50,9 @@ from app.trading.discovery.evidence_bundles import (
     evidence_bundle_from_frontier_candidate,
     evidence_bundle_from_payload,
 )
+from app.trading.discovery.factor_acceptance import (
+    build_factor_acceptance_artifact_from_scorecard,
+)
 from app.trading.discovery.fast_replay import build_fast_replay_preview
 from app.trading.discovery.hypothesis_cards import HypothesisCard
 from app.trading.discovery.mlx_snapshot import build_mlx_snapshot_manifest
@@ -9978,6 +9981,102 @@ def _candidate_board_runtime_window_import_plan(
     }
 
 
+def _candidate_factor_acceptance_replay_metadata(
+    *,
+    spec: CandidateSpec,
+    evidence: CandidateEvidenceBundle | None,
+    candidate_count: int,
+) -> dict[str, Any]:
+    static_artifact = _mapping(spec.feature_contract.get("factor_acceptance_artifact"))
+    if not static_artifact:
+        return {}
+
+    if evidence is None:
+        artifact = {
+            **static_artifact,
+            "status": "rejected",
+            "rejection_reasons": list(
+                dict.fromkeys(
+                    [
+                        *_string_list_from_value(
+                            static_artifact.get("rejection_reasons")
+                        ),
+                        "replay_evidence_missing",
+                    ]
+                )
+            ),
+            "promotion_scope": "research_paper_probation_only",
+            "does_not_authorize_live_promotion": True,
+        }
+        evidence_status = "missing"
+        candidate_id = ""
+        evidence_bundle_id = ""
+    else:
+        artifact = build_factor_acceptance_artifact_from_scorecard(
+            factor_expression=_string(static_artifact.get("factor_expression"))
+            or "candidate_family_score",
+            source_idea=_string(static_artifact.get("source_idea"))
+            or "2025_2026_signal_discovery_rankic_acceptance_harness",
+            allowed_feature_dependencies=_string_list_from_value(
+                static_artifact.get("allowed_feature_dependencies")
+            )
+            or _string_list_from_value(spec.feature_contract.get("required_features")),
+            scorecard=evidence.objective_scorecard,
+            fold_metrics=evidence.fold_metrics,
+            candidate_count=max(1, candidate_count),
+            candidate_spec_id=spec.candidate_spec_id,
+            candidate_id=evidence.candidate_id,
+            evidence_bundle_id=evidence.evidence_bundle_id,
+        )
+        evidence_status = "replayed"
+        candidate_id = evidence.candidate_id
+        evidence_bundle_id = evidence.evidence_bundle_id
+
+    return {
+        "schema_version": "torghut.factor-acceptance-replay-metadata.v1",
+        "candidate_spec_id": spec.candidate_spec_id,
+        "candidate_id": candidate_id,
+        "evidence_bundle_id": evidence_bundle_id,
+        "evidence_status": evidence_status,
+        "status": _string(artifact.get("status")) or "rejected",
+        "rejection_reasons": _string_list_from_value(artifact.get("rejection_reasons")),
+        "lineage_hash": _string(artifact.get("lineage_hash")),
+        "replay_artifact": artifact,
+        "static_compile_artifact_lineage_hash": _string(
+            static_artifact.get("lineage_hash")
+        ),
+        "promotion_scope": "research_paper_probation_only",
+        "promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "does_not_authorize_live_promotion": True,
+    }
+
+
+def _candidate_board_factor_acceptance_summary(
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    metadata_rows = [
+        _mapping(row.get("factor_acceptance_replay_metadata"))
+        for row in rows
+        if _mapping(row.get("factor_acceptance_replay_metadata"))
+    ]
+    accepted = [
+        row for row in metadata_rows if _string(row.get("status")) == "accepted"
+    ]
+    return {
+        "schema_version": "torghut.factor-acceptance-board-summary.v1",
+        "candidate_count": len(metadata_rows),
+        "accepted_count": len(accepted),
+        "rejected_count": len(metadata_rows) - len(accepted),
+        "promotion_allowed": False,
+        "final_promotion_authorized": False,
+        "scope": "research_paper_probation_only",
+        "accepted_candidate_spec_ids": [
+            _string(row.get("candidate_spec_id")) for row in accepted
+        ],
+    }
+
+
 def _candidate_board_payload(
     *,
     epoch_id: str,
@@ -10007,6 +10106,15 @@ def _candidate_board_payload(
         for sleeve in _list_of_mappings(portfolio_payload.get("sleeves"))
         if _string(sleeve.get("candidate_spec_id"))
     }
+    factor_acceptance_candidate_count = max(
+        _candidate_board_int_field(
+            _mapping(candidate_selection.get("budget")),
+            "compiled_candidate_count",
+        ),
+        len(candidate_specs),
+        len(evidence_bundles),
+        1,
+    )
     rows: list[dict[str, Any]] = []
     for spec in candidate_specs:
         selection = selection_by_spec.get(spec.candidate_spec_id, {})
@@ -10100,6 +10208,13 @@ def _candidate_board_payload(
         runtime_ledger_artifact_ref = _string(
             scorecard.get("runtime_ledger_artifact_ref")
             or exact_replay_ledger_artifact_ref
+        )
+        factor_acceptance_replay_metadata = (
+            _candidate_factor_acceptance_replay_metadata(
+                spec=spec,
+                evidence=evidence,
+                candidate_count=factor_acceptance_candidate_count,
+            )
         )
         rows.append(
             {
@@ -10342,6 +10457,13 @@ def _candidate_board_payload(
                     queue_position_survival_summary
                 ),
                 "predictability_decay_stress": predictability_decay_summary,
+                "factor_acceptance_replay_metadata": (
+                    factor_acceptance_replay_metadata
+                ),
+                "factor_acceptance_status": _string(
+                    factor_acceptance_replay_metadata.get("status")
+                ),
+                "factor_acceptance_promotion_allowed": False,
                 "evidence_lineage": evidence_lineage,
                 "replay_window_coverage": replay_window_coverage,
                 "blockers": blockers,
@@ -10427,6 +10549,7 @@ def _candidate_board_payload(
             paper_probation_candidates=paper_probation_candidates,
             promotion_subject=promotion_subject,
         ),
+        "factor_acceptance_summary": _candidate_board_factor_acceptance_summary(rows),
         "double_oos_summary": _candidate_board_double_oos_summary(rows),
         "best_portfolio_candidate_id": _string(
             portfolio_payload.get("portfolio_candidate_id")

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -11,6 +11,9 @@ from app.trading.discovery.candidate_specs import (
     compile_candidate_specs,
 )
 from app.trading.discovery.factor_acceptance import build_factor_acceptance_artifact
+from app.trading.discovery.factor_acceptance import (
+    build_factor_acceptance_artifact_from_scorecard,
+)
 from app.trading.discovery.hypothesis_cards import (
     HYPOTHESIS_CARD_SCHEMA_VERSION,
     HypothesisCard,
@@ -108,6 +111,45 @@ class TestCandidateSpecs(TestCase):
             "cost_stressed_expectancy_non_positive",
             artifact["rejection_reasons"],
         )
+
+    def test_factor_acceptance_artifact_from_scorecard_uses_replay_metrics(
+        self,
+    ) -> None:
+        artifact = build_factor_acceptance_artifact_from_scorecard(
+            factor_expression="cross_section_session_open_rank",
+            source_idea="runtime_replay_rankic_factor_acceptance",
+            allowed_feature_dependencies=[
+                "cross_section_session_open_rank",
+                "spread_bps",
+            ],
+            scorecard={
+                "rank_ic": "0.061",
+                "rank_ir": "0.71",
+                "p_value": "0.006",
+                "factor_candidate_count": 4,
+                "decision_count": 144,
+                "net_pnl_per_day": "34",
+                "avg_filled_notional_per_day": "100000",
+                "market_impact_stress_cost_bps": "1.8",
+                "train_window": {"start": "2026-01-02", "end": "2026-03-31"},
+                "holdout_window": {"start": "2026-04-01", "end": "2026-04-30"},
+            },
+            candidate_spec_id="spec-rankic",
+            candidate_id="candidate-rankic",
+            evidence_bundle_id="ev-rankic",
+        )
+
+        self.assertEqual(artifact["status"], "accepted")
+        self.assertEqual(artifact["sample_count"], 144)
+        self.assertEqual(artifact["candidate_count"], 4)
+        self.assertEqual(artifact["deflated_p_value"], "0.024")
+        self.assertEqual(artifact["cost_stressed_net_expectancy_bps"], "1.60000")
+        self.assertEqual(
+            artifact["evidence_metadata"]["source"],
+            "replay_or_live_paper_scorecard",
+        )
+        self.assertEqual(artifact["promotion_scope"], "research_paper_probation_only")
+        self.assertTrue(artifact["does_not_authorize_live_promotion"])
 
     def test_rankic_signal_discovery_claim_adds_fail_closed_factor_harness(
         self,

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -336,6 +336,105 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             promotion_contract={},
         )
 
+    def test_candidate_board_adds_factor_acceptance_replay_metadata(self) -> None:
+        spec = replace(
+            self._candidate_spec("spec-factor-acceptance"),
+            feature_contract={
+                "mechanism": "rankic signal discovery",
+                "required_features": ("cross_section_session_open_rank", "spread_bps"),
+                "factor_acceptance_artifact": {
+                    "status": "rejected",
+                    "factor_expression": "cross_section_session_open_rank",
+                    "source_idea": "static_rankic_compile_contract",
+                    "allowed_feature_dependencies": [
+                        "cross_section_session_open_rank",
+                        "spread_bps",
+                    ],
+                    "rejection_reasons": ["rank_ic_below_floor"],
+                    "lineage_hash": "static-factor-lineage",
+                },
+            },
+            parameter_space={
+                "mechanism_overlay_ids": ["rankic_factor_acceptance_harness"]
+            },
+        )
+        evidence = runner.CandidateEvidenceBundle(
+            schema_version="torghut.candidate-evidence-bundle.v1",
+            evidence_bundle_id="ev-factor-acceptance",
+            candidate_id="candidate-factor-acceptance",
+            candidate_spec_id=spec.candidate_spec_id,
+            dataset_snapshot_id="snapshot-factor-acceptance",
+            feature_spec_hash="feature-hash",
+            code_commit="commit-sha",
+            replay_artifact_refs=("replay-factor.json",),
+            objective_scorecard={
+                "rank_ic": "0.061",
+                "rank_ir": "0.71",
+                "p_value": "0.006",
+                "decision_count": 144,
+                "net_pnl_per_day": "34",
+                "avg_filled_notional_per_day": "100000",
+                "market_impact_stress_cost_bps": "1.8",
+                "train_window": {"start": "2026-01-02", "end": "2026-03-31"},
+                "holdout_window": {"start": "2026-04-01", "end": "2026-04-30"},
+            },
+            fold_metrics=(),
+            stress_metrics=(),
+            cost_calibration={},
+            null_comparator={},
+            promotion_readiness={},
+        )
+
+        board = runner._candidate_board_payload(
+            epoch_id="epoch-factor-acceptance",
+            output_dir=Path("/tmp/torghut-factor-acceptance"),
+            target=Decimal("500"),
+            candidate_specs=[spec],
+            candidate_selection={
+                "budget": {"compiled_candidate_count": 4},
+                "rows": [
+                    {
+                        "candidate_spec_id": spec.candidate_spec_id,
+                        "selected_for_replay": True,
+                        "selection_reason": "top_k",
+                        "rank": 1,
+                    }
+                ],
+            },
+            pre_replay_proposal_rows=[
+                {
+                    "candidate_spec_id": spec.candidate_spec_id,
+                    "rank": 1,
+                    "proposal_score": "0.9",
+                }
+            ],
+            proposal_rows=[
+                {
+                    "candidate_spec_id": spec.candidate_spec_id,
+                    "rank": 1,
+                    "proposal_score": "0.9",
+                }
+            ],
+            evidence_bundles=[evidence],
+            portfolio=None,
+            promotion_readiness={"promotable": False},
+            runtime_closure={"status": "blocked"},
+        )
+
+        row = board["rows"][0]
+        metadata = row["factor_acceptance_replay_metadata"]
+        artifact = metadata["replay_artifact"]
+
+        self.assertEqual(board["factor_acceptance_summary"]["accepted_count"], 1)
+        self.assertEqual(metadata["status"], "accepted")
+        self.assertEqual(metadata["evidence_status"], "replayed")
+        self.assertFalse(metadata["promotion_allowed"])
+        self.assertFalse(metadata["final_promotion_authorized"])
+        self.assertEqual(artifact["deflated_p_value"], "0.024")
+        self.assertEqual(artifact["cost_stressed_net_expectancy_bps"], "1.60000")
+        self.assertFalse(row["factor_acceptance_promotion_allowed"])
+        self.assertEqual(board["current_answer"], "no_promotion_ready_candidate")
+
     def test_candidate_feedback_metadata_preserves_runtime_params_for_closure(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds replay/live-paper scorecard-derived factor acceptance artifacts for RankIC-style signal-discovery candidates.
- Threads the replay factor acceptance overlay into the autoresearch candidate board without rewriting candidate spec IDs.
- Keeps factor acceptance scoped to research/paper-probation metadata with `promotion_allowed=false` and `final_promotion_authorized=false`.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/discovery/factor_acceptance.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_candidate_specs.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff format --check app/trading/discovery/factor_acceptance.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_candidate_specs.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen ruff check app/trading/discovery/factor_acceptance.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_candidate_specs.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv run --frozen pytest tests/test_candidate_specs.py -k factor_acceptance -q`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k factor_acceptance_replay_metadata -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
