### PR TITLE
feat(torghut): rank replay frontier by drawdown risk

### DIFF
--- a/services/torghut/app/trading/evaluation_trace.py
+++ b/services/torghut/app/trading/evaluation_trace.py
@@ -290,6 +290,9 @@ class SweepCandidateResult:
     holdout_total_net: Decimal
     active_holdout_days: int
     max_holdout_drawdown_day: Decimal
+    holdout_max_drawdown: Decimal
+    holdout_max_drawdown_pct_equity: Decimal | None
+    holdout_p10_daily_net: Decimal
     profit_factor: Decimal | None
     wins: int
     losses: int
@@ -309,6 +312,11 @@ class SweepCandidateResult:
             "holdout_total_net": str(self.holdout_total_net),
             "active_holdout_days": self.active_holdout_days,
             "max_holdout_drawdown_day": str(self.max_holdout_drawdown_day),
+            "holdout_max_drawdown": str(self.holdout_max_drawdown),
+            "holdout_max_drawdown_pct_equity": str(self.holdout_max_drawdown_pct_equity)
+            if self.holdout_max_drawdown_pct_equity is not None
+            else None,
+            "holdout_p10_daily_net": str(self.holdout_p10_daily_net),
             "profit_factor": str(self.profit_factor)
             if self.profit_factor is not None
             else None,

--- a/services/torghut/app/trading/reporting.py
+++ b/services/torghut/app/trading/reporting.py
@@ -6,7 +6,7 @@ import json
 import hashlib
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from decimal import Decimal
+from decimal import Decimal, ROUND_FLOOR
 from pathlib import Path
 from typing import Any, Literal, Mapping, Optional, cast
 
@@ -959,6 +959,8 @@ class ProfitabilityConstraintPolicy:
     holdout_target_net_per_day: Decimal = Decimal("250")
     min_active_holdout_days: int = 3
     max_worst_holdout_day_loss: Decimal = Decimal("150")
+    max_holdout_drawdown_pct_equity: Decimal | None = Decimal("0.05")
+    min_holdout_p10_daily_net: Decimal | None = None
     min_profit_factor: Decimal = Decimal("1.5")
     require_training_decisions: bool = True
     require_holdout_decisions: bool = True
@@ -968,6 +970,7 @@ class ProfitabilityConstraintPolicy:
 class ReplayProfitabilitySummary:
     start_date: str
     end_date: str
+    start_equity: Decimal | None
     trading_day_count: int
     net_pnl: Decimal
     net_per_day: Decimal
@@ -977,8 +980,40 @@ class ReplayProfitabilitySummary:
     wins: int
     losses: int
     worst_day_net: Decimal
+    p10_daily_net: Decimal
+    max_drawdown: Decimal
+    max_drawdown_pct_equity: Decimal | None
     profit_factor: Decimal | None
     daily_net: dict[str, Decimal]
+
+
+def _daily_drawdown(daily_net: Mapping[str, Decimal]) -> Decimal:
+    peak = Decimal("0")
+    cumulative = Decimal("0")
+    max_drawdown = Decimal("0")
+    for day in sorted(daily_net):
+        cumulative += daily_net[day]
+        if cumulative > peak:
+            peak = cumulative
+        drawdown = peak - cumulative
+        if drawdown > max_drawdown:
+            max_drawdown = drawdown
+    return max_drawdown
+
+
+def _daily_quantile_floor(
+    daily_net: Mapping[str, Decimal], quantile: Decimal
+) -> Decimal:
+    values = sorted(daily_net.values())
+    if not values:
+        return Decimal("0")
+    bounded_quantile = min(max(quantile, Decimal("0")), Decimal("1"))
+    index = int(
+        (Decimal(len(values) - 1) * bounded_quantile).to_integral_value(
+            rounding=ROUND_FLOOR
+        )
+    )
+    return values[index]
 
 
 def summarize_replay_profitability(
@@ -1012,12 +1047,20 @@ def summarize_replay_profitability(
         else (Decimal("999999") if positive_total > 0 else None)
     )
     worst_day_net = min(daily_net.values()) if daily_net else Decimal("0")
+    start_equity = _decimal(payload.get("start_equity"))
+    max_drawdown = _daily_drawdown(daily_net)
+    max_drawdown_pct_equity = (
+        max_drawdown / start_equity
+        if start_equity is not None and start_equity > 0
+        else None
+    )
     net_per_day = (
         net_pnl / Decimal(trading_day_count) if trading_day_count > 0 else Decimal("0")
     )
     return ReplayProfitabilitySummary(
         start_date=str(payload.get("start_date") or ""),
         end_date=str(payload.get("end_date") or ""),
+        start_equity=start_equity,
         trading_day_count=trading_day_count,
         net_pnl=net_pnl,
         net_per_day=net_per_day,
@@ -1027,6 +1070,9 @@ def summarize_replay_profitability(
         wins=int(payload.get("wins", 0)),
         losses=int(payload.get("losses", 0)),
         worst_day_net=worst_day_net,
+        p10_daily_net=_daily_quantile_floor(daily_net, Decimal("0.10")),
+        max_drawdown=max_drawdown,
+        max_drawdown_pct_equity=max_drawdown_pct_equity,
         profit_factor=profit_factor,
         daily_net=daily_net,
     )
@@ -1051,6 +1097,20 @@ def score_replay_profitability_candidate(
         ) * Decimal("250")
     if holdout.worst_day_net < -policy.max_worst_holdout_day_loss:
         penalties += abs(holdout.worst_day_net + policy.max_worst_holdout_day_loss)
+    if (
+        policy.max_holdout_drawdown_pct_equity is not None
+        and holdout.max_drawdown_pct_equity is not None
+        and holdout.max_drawdown_pct_equity > policy.max_holdout_drawdown_pct_equity
+    ):
+        equity = holdout.start_equity or Decimal("0")
+        penalties += (
+            holdout.max_drawdown_pct_equity - policy.max_holdout_drawdown_pct_equity
+        ) * equity
+    if (
+        policy.min_holdout_p10_daily_net is not None
+        and holdout.p10_daily_net < policy.min_holdout_p10_daily_net
+    ):
+        penalties += policy.min_holdout_p10_daily_net - holdout.p10_daily_net
     if holdout.profit_factor is None:
         penalties += Decimal("250")
     elif holdout.profit_factor < policy.min_profit_factor:
@@ -1093,6 +1153,9 @@ def score_replay_profitability_candidate(
         holdout_total_net=holdout.net_pnl,
         active_holdout_days=holdout.active_days,
         max_holdout_drawdown_day=abs(min(holdout.worst_day_net, Decimal("0"))),
+        holdout_max_drawdown=holdout.max_drawdown,
+        holdout_max_drawdown_pct_equity=holdout.max_drawdown_pct_equity,
+        holdout_p10_daily_net=holdout.p10_daily_net,
         profit_factor=holdout.profit_factor,
         wins=holdout.wins,
         losses=holdout.losses,

--- a/services/torghut/config/trading/profitability-frontier-breakout.yaml
+++ b/services/torghut/config/trading/profitability-frontier-breakout.yaml
@@ -6,6 +6,7 @@ constraints:
   holdout_target_net_per_day: '250'
   min_active_holdout_days: 3
   max_worst_holdout_day_loss: '150'
+  max_holdout_drawdown_pct_equity: '0.05'
   min_profit_factor: '1.5'
   require_training_decisions: true
   require_holdout_decisions: true

--- a/services/torghut/scripts/search_profitability_frontier.py
+++ b/services/torghut/scripts/search_profitability_frontier.py
@@ -163,6 +163,18 @@ def _load_sweep_config(path: Path) -> dict[str, Any]:
     return payload
 
 
+def _optional_decimal_constraint(
+    constraints: Mapping[str, Any], key: str, *, default: str | None = None
+) -> Decimal | None:
+    value = constraints.get(key, default)
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return Decimal(text)
+
+
 def iter_parameter_candidates(
     parameter_grid: Mapping[str, Iterable[Any]],
 ) -> list[dict[str, Any]]:
@@ -353,6 +365,12 @@ def main() -> int:
         max_worst_holdout_day_loss=Decimal(
             str(constraints.get("max_worst_holdout_day_loss", "150"))
         ),
+        max_holdout_drawdown_pct_equity=_optional_decimal_constraint(
+            constraints, "max_holdout_drawdown_pct_equity", default="0.05"
+        ),
+        min_holdout_p10_daily_net=_optional_decimal_constraint(
+            constraints, "min_holdout_p10_daily_net"
+        ),
         min_profit_factor=Decimal(str(constraints.get("min_profit_factor", "1.5"))),
         require_training_decisions=bool(
             constraints.get("require_training_decisions", True)
@@ -468,6 +486,14 @@ def main() -> int:
             "holdout_target_net_per_day": str(policy.holdout_target_net_per_day),
             "min_active_holdout_days": policy.min_active_holdout_days,
             "max_worst_holdout_day_loss": str(policy.max_worst_holdout_day_loss),
+            "max_holdout_drawdown_pct_equity": str(
+                policy.max_holdout_drawdown_pct_equity
+            )
+            if policy.max_holdout_drawdown_pct_equity is not None
+            else None,
+            "min_holdout_p10_daily_net": str(policy.min_holdout_p10_daily_net)
+            if policy.min_holdout_p10_daily_net is not None
+            else None,
             "min_profit_factor": str(policy.min_profit_factor),
             "require_training_decisions": policy.require_training_decisions,
             "require_holdout_decisions": policy.require_holdout_decisions,

--- a/services/torghut/tests/test_evaluation_report.py
+++ b/services/torghut/tests/test_evaluation_report.py
@@ -233,6 +233,9 @@ class TestEvaluationReport(TestCase):
         self.assertEqual(summary.net_pnl, Decimal("500"))
         self.assertEqual(summary.net_per_day, Decimal("125"))
         self.assertEqual(summary.worst_day_net, Decimal("-100"))
+        self.assertEqual(summary.p10_daily_net, Decimal("-100"))
+        self.assertEqual(summary.max_drawdown, Decimal("100"))
+        self.assertIsNone(summary.max_drawdown_pct_equity)
         self.assertEqual(summary.profit_factor, Decimal("6"))
 
     def test_summarize_replay_profitability_ignores_non_mapping_daily_rows(
@@ -390,3 +393,60 @@ class TestEvaluationReport(TestCase):
         self.assertEqual(candidate.profit_factor, Decimal("0.25"))
         self.assertEqual(candidate.max_holdout_drawdown_day, Decimal("200"))
         self.assertEqual(candidate.score, Decimal("-922.50"))
+
+    def test_score_replay_profitability_candidate_penalizes_tail_and_drawdown_pct(
+        self,
+    ) -> None:
+        candidate = score_replay_profitability_candidate(
+            family="breakout_continuation",
+            strategy_name="breakout-continuation-long-v1",
+            replay_config={"params": {"min_cross_section_continuation_rank": "0.65"}},
+            train_payload={
+                "start_date": "2026-03-03",
+                "end_date": "2026-03-07",
+                "start_equity": "10000",
+                "net_pnl": "1000",
+                "decision_count": 5,
+                "filled_count": 5,
+                "wins": 5,
+                "losses": 0,
+                "daily": {
+                    "2026-03-03": {"net_pnl": "200", "filled_count": 1},
+                    "2026-03-04": {"net_pnl": "200", "filled_count": 1},
+                    "2026-03-05": {"net_pnl": "200", "filled_count": 1},
+                    "2026-03-06": {"net_pnl": "200", "filled_count": 1},
+                    "2026-03-07": {"net_pnl": "200", "filled_count": 1},
+                },
+            },
+            holdout_payload={
+                "start_date": "2026-03-10",
+                "end_date": "2026-03-14",
+                "start_equity": "10000",
+                "net_pnl": "2800",
+                "decision_count": 5,
+                "filled_count": 5,
+                "wins": 4,
+                "losses": 1,
+                "daily": {
+                    "2026-03-10": {"net_pnl": "1000", "filled_count": 1},
+                    "2026-03-11": {"net_pnl": "-1200", "filled_count": 1},
+                    "2026-03-12": {"net_pnl": "1000", "filled_count": 1},
+                    "2026-03-13": {"net_pnl": "1000", "filled_count": 1},
+                    "2026-03-14": {"net_pnl": "1000", "filled_count": 1},
+                },
+            },
+            policy=ProfitabilityConstraintPolicy(
+                holdout_target_net_per_day=Decimal("0"),
+                min_active_holdout_days=5,
+                max_worst_holdout_day_loss=Decimal("2000"),
+                max_holdout_drawdown_pct_equity=Decimal("0.05"),
+                min_holdout_p10_daily_net=Decimal("-1000"),
+                min_profit_factor=Decimal("0"),
+            ),
+        )
+
+        self.assertEqual(candidate.holdout_net_per_day, Decimal("560"))
+        self.assertEqual(candidate.holdout_max_drawdown, Decimal("1200"))
+        self.assertEqual(candidate.holdout_max_drawdown_pct_equity, Decimal("0.12"))
+        self.assertEqual(candidate.holdout_p10_daily_net, Decimal("-1200"))
+        self.assertEqual(candidate.score, Decimal("-340.00"))

--- a/services/torghut/tests/test_evaluation_trace.py
+++ b/services/torghut/tests/test_evaluation_trace.py
@@ -203,6 +203,9 @@ class TestEvaluationTrace(TestCase):
             holdout_total_net=Decimal("258.0"),
             active_holdout_days=2,
             max_holdout_drawdown_day=Decimal("0"),
+            holdout_max_drawdown=Decimal("25.5"),
+            holdout_max_drawdown_pct_equity=Decimal("0.00255"),
+            holdout_p10_daily_net=Decimal("-4.25"),
             profit_factor=None,
             wins=2,
             losses=0,
@@ -214,4 +217,9 @@ class TestEvaluationTrace(TestCase):
             candidate_payload["schema_version"], "torghut.sweep-candidate-result.v1"
         )
         self.assertEqual(candidate_payload["profit_factor"], None)
+        self.assertEqual(candidate_payload["holdout_max_drawdown"], "25.5")
+        self.assertEqual(
+            candidate_payload["holdout_max_drawdown_pct_equity"], "0.00255"
+        )
+        self.assertEqual(candidate_payload["holdout_p10_daily_net"], "-4.25")
         self.assertEqual(candidate_payload["replay_config"]["params"]["rank"], "0.45")

--- a/services/torghut/tests/test_search_profitability_frontier.py
+++ b/services/torghut/tests/test_search_profitability_frontier.py
@@ -115,6 +115,7 @@ class TestSearchProfitabilityFrontier(TestCase):
                         "holdout_target_net_per_day": "250",
                         "min_active_holdout_days": 3,
                         "max_worst_holdout_day_loss": "150",
+                        "max_holdout_drawdown_pct_equity": "0.05",
                         "min_profit_factor": "1.5",
                         "require_training_decisions": True,
                         "require_holdout_decisions": True,
@@ -519,13 +520,16 @@ class TestSearchProfitabilityFrontier(TestCase):
         self.assertIn("toDate(event_ts) <= toDate('2026-03-27')", sql)
 
     def test_resolve_recent_trading_days_filters_partial_trading_day(self) -> None:
-        with patch(
-            "scripts.search_profitability_frontier.resolve_expected_last_trading_day",
-            return_value=date(2026, 5, 21),
-        ), patch(
-            "scripts.search_profitability_frontier._http_query",
-            return_value="2026-05-22\n2026-05-21\n2026-05-20\n",
-        ) as query:
+        with (
+            patch(
+                "scripts.search_profitability_frontier.resolve_expected_last_trading_day",
+                return_value=date(2026, 5, 21),
+            ),
+            patch(
+                "scripts.search_profitability_frontier._http_query",
+                return_value="2026-05-22\n2026-05-21\n2026-05-20\n",
+            ) as query,
+        ):
             days = frontier._resolve_recent_trading_days(
                 clickhouse_http_url="http://example.invalid:8123",
                 clickhouse_username="torghut",
@@ -895,6 +899,11 @@ class TestSearchProfitabilityFrontier(TestCase):
             self.assertEqual(exit_code, 0)
             payload = json.loads(json_output.read_text(encoding="utf-8"))
             self.assertEqual(payload["candidate_count"], 1)
+            self.assertEqual(
+                payload["constraints"]["max_holdout_drawdown_pct_equity"],
+                "0.05",
+            )
+            self.assertIsNone(payload["constraints"]["min_holdout_p10_daily_net"])
             self.assertEqual(
                 payload["top"][0]["replay_config"]["params"][
                     "min_cross_section_continuation_rank"


### PR DESCRIPTION
## Summary

- Adds replay-derived cumulative drawdown and lower-tail daily PnL metrics to profitability candidate summaries.
- Penalizes frontier candidates whose holdout drawdown exceeds a configurable equity percentage or whose p10 daily net falls below a configured floor.
- Threads the new risk-adjusted fields into sweep JSON output and the default breakout frontier constraints without changing live promotion authority.

## Related Issues

None

## Testing

- `uv run --frozen ruff check app/trading/reporting.py app/trading/evaluation_trace.py scripts/search_profitability_frontier.py tests/test_evaluation_report.py tests/test_search_profitability_frontier.py`
- `uv run --frozen ruff format --check app/trading/reporting.py app/trading/evaluation_trace.py scripts/search_profitability_frontier.py tests/test_evaluation_report.py tests/test_search_profitability_frontier.py`
- `uv run --frozen pytest tests/test_evaluation_report.py tests/test_search_profitability_frontier.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
