### PR TITLE
fix(synthesis): set trader goal without budget

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml
@@ -14,7 +14,7 @@ spec:
   implementationSpecRef:
     name: autonomous-trader-v1
   goal:
-    objective: Grow the Alpaca paper account to 500000 USD actual account equity using autonomous stock or option trading through Alpaca MCP.
+    objective: Reach 500000 USD account equity in the Alpaca paper account using autonomous stock, ETF, or option day trading through Alpaca MCP.
   vcsRef:
     name: github
   vcsPolicy:

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -28,7 +28,7 @@ spec:
     You are the Synthesis autonomous paper-trader AgentRun.
 
     Goal:
-    - Grow the Alpaca paper account toward 500000 USD account equity through autonomous day trading.
+    - Reach 500000 USD account equity in the Alpaca paper account through autonomous day trading.
     - Use any Alpaca-supported paper-account operation when justified by the setup, including opening, closing, reducing, hedging, or reversing stock, ETF, and option positions.
     - There is no 2-3 week hold-time requirement. Prefer intraday decisions: enter, exit, scale, or stand down based on current signal quality, liquidity, account constraints, and risk.
     - Report account equity, buying power, margin fields, and exposure separately. Use buying power and Alpaca-supported paper margin mechanics for execution when appropriate, but do not blur those fields in the report.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -12,6 +12,7 @@ data:
 
     Mission:
     - Operate as an autonomous day-trading agent for the Synthesis Alpaca paper account.
+    - Reach 500000 USD account equity in the Alpaca paper account.
     - Use any Alpaca-supported paper-account operation that is justified by the current setup, including opening, closing, reducing, hedging, or reversing stock, ETF, and option positions.
 
     Operating requirements:

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -595,6 +595,19 @@ describe('scheduled AgentRun templates', () => {
 })
 
 describe('synthesis autonomous trader provider', () => {
+  it('sets the trader goal to reach 500000 without a token budget', () => {
+    const template = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'AgentRun')
+    const spec = objectAt(template, 'spec')
+    const goal = objectAt(spec, 'goal') as Record<string, unknown>
+
+    expect(objectAt(goal, 'objective')).toBe(
+      'Reach 500000 USD account equity in the Alpaca paper account using autonomous stock, ETF, or option day trading through Alpaca MCP.',
+    )
+    expect(Object.hasOwn(goal, 'tokenBudget')).toBe(false)
+  })
+
   it('keeps the trader prompt aligned with day-trading authority', () => {
     const promptConfig = readYamlObjects(
       'argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml',
@@ -606,9 +619,12 @@ describe('synthesis autonomous trader provider', () => {
     const taskPrompt = objectAt(objectAt(implSpec, 'spec'), 'text')
 
     expect(prompt).toContain('autonomous day-trading agent')
+    expect(prompt).toContain('Reach 500000 USD account equity')
     expect(prompt).toContain('closing, reducing, hedging, or reversing')
     expect(prompt).not.toContain('Target the requested account value as actual paper account equity')
     expect(prompt).not.toContain('Hold-time target is 2-3 weeks')
+    expect(taskPrompt).toContain('Reach 500000 USD account equity')
+    expect(taskPrompt).not.toContain('toward 500000 USD account equity')
     expect(taskPrompt).toContain('There is no 2-3 week hold-time requirement')
     expect(taskPrompt).toContain('You may buy, sell, close, reduce, hedge, reverse, or stand down')
   })


### PR DESCRIPTION
## Summary

- Sets the Synthesis autonomous trader AgentRun goal to reach `500000 USD` account equity.
- Keeps the trader run unbounded by omitting `spec.goal.tokenBudget` entirely.
- Adds smoke coverage that rejects a token budget on the autonomous trader template.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "synthesis autonomous trader provider"`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/synthesis >/tmp/synthesis-trader-goal-no-budget-render.yaml`
- `yq '. | select(.kind == "AgentRun" and .metadata.name == "autonomous-trader-template") | has("spec.goal.tokenBudget")' /tmp/synthesis-trader-goal-no-budget-render.yaml`
- `kubectl apply --dry-run=server -f /tmp/synthesis-trader-goal-no-budget-render.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
