### PR TITLE
chore(agents): promote images 9f513f5c

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: 0c2aff77
-  digest: sha256:69ee0ce03482d9dceeaf561cd42f8f86339e794c7b2ee3b586785ae2ce9a42fd
+  tag: 9f513f5c
+  digest: sha256:2e4ed182b011fef9ac79922324668d4751e896d9c98c47fe299d91331f458912
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,26 +11,26 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: 0c2aff77
-    digest: sha256:4c8e8f941ba9b7203cf48622b4a00bad83f990a58456ced5b4fac4b34a86012b
+    tag: 9f513f5c
+    digest: sha256:22bc78dbe7c1f1fa903b718c6da36cdd8be6b710b5693e2d369e9f46c7b87e84
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: 0c2aff778fab3c4bf85a1f41b2043f6b5caaac2a
-      AGENTS_GITOPS_REVISION: 0c2aff778fab3c4bf85a1f41b2043f6b5caaac2a
-      AGENTS_SOURCE_CI_RUN_ID: "26492056217"
+      AGENTS_SOURCE_HEAD_SHA: 9f513f5c2f4a9a9456d98b26c571d954b0941566
+      AGENTS_GITOPS_REVISION: 9f513f5c2f4a9a9456d98b26c571d954b0941566
+      AGENTS_SOURCE_CI_RUN_ID: "26493728957"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:4c8e8f941ba9b7203cf48622b4a00bad83f990a58456ced5b4fac4b34a86012b
-      AGENTS_SERVING_BUILD_COMMIT: 0c2aff778fab3c4bf85a1f41b2043f6b5caaac2a
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:4c8e8f941ba9b7203cf48622b4a00bad83f990a58456ced5b4fac4b34a86012b
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:22bc78dbe7c1f1fa903b718c6da36cdd8be6b710b5693e2d369e9f46c7b87e84
+      AGENTS_SERVING_BUILD_COMMIT: 9f513f5c2f4a9a9456d98b26c571d954b0941566
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:22bc78dbe7c1f1fa903b718c6da36cdd8be6b710b5693e2d369e9f46c7b87e84
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: 0c2aff77
-    digest: sha256:aba446b5101568f247342586ee3bb40bf6e252b4e7765d23bad2dbd77b5305bb
+    tag: 9f513f5c
+    digest: sha256:469b0e7922a7628b7d32b08461092cd3bad459a88befbc40f6756470342f129a
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun
@@ -85,8 +85,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: 0c2aff77
-    digest: sha256:69ee0ce03482d9dceeaf561cd42f8f86339e794c7b2ee3b586785ae2ce9a42fd
+    tag: 9f513f5c
+    digest: sha256:2e4ed182b011fef9ac79922324668d4751e896d9c98c47fe299d91331f458912
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `9f513f5c2f4a9a9456d98b26c571d954b0941566`
- Image tag: `9f513f5c`
- Agents build run: `26493728957`
- Promotion source: `workflow_run`