### PR TITLE
fix(torghut): require authoritative runtime profit proof

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -725,6 +725,8 @@ def _runtime_import_materialization_summary(
     counts = {
         "runtime_observation_count": len(observations),
         "authoritative_observation_count": 0,
+        "authoritative_runtime_ledger_profit_proof_count": 0,
+        "non_authoritative_runtime_ledger_profit_proof_count": 0,
         "runtime_ledger_profit_proof_count": 0,
         "runtime_ledger_tca_row_count": 0,
         "runtime_ledger_tca_runtime_bucket_row_count": 0,
@@ -765,6 +767,14 @@ def _runtime_import_materialization_summary(
             durable_profit_proof_count,
         )
         counts["runtime_ledger_profit_proof_count"] += profit_proof_count
+        if observation.get("authoritative") is True:
+            counts["authoritative_runtime_ledger_profit_proof_count"] += (
+                profit_proof_count
+            )
+        else:
+            counts["non_authoritative_runtime_ledger_profit_proof_count"] += (
+                profit_proof_count
+            )
         for key in (
             "runtime_ledger_tca_row_count",
             "runtime_ledger_tca_runtime_bucket_row_count",
@@ -1189,7 +1199,12 @@ def build_runtime_ledger_proof_packet(
     materialization_summary = _runtime_import_materialization_summary(runtime_import)
     runtime_import_materialization_ok = not runtime_import_due or (
         _int(materialization_summary.get("authoritative_observation_count")) > 0
-        and _int(materialization_summary.get("runtime_ledger_profit_proof_count")) > 0
+        and _int(
+            materialization_summary.get(
+                "authoritative_runtime_ledger_profit_proof_count"
+            )
+        )
+        > 0
         and not _text_list(materialization_summary.get("blockers"))
     )
     runtime_import_ok = (

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -1107,8 +1107,93 @@ class TestRuntimeLedgerProofPacket(TestCase):
             1,
         )
         self.assertEqual(
+            materialization["authoritative_runtime_ledger_profit_proof_count"],
+            1,
+        )
+        self.assertEqual(
+            materialization["non_authoritative_runtime_ledger_profit_proof_count"],
+            0,
+        )
+        self.assertEqual(
             materialization["pnl_derivations"],
             ["source_execution_lifecycle_materialized_runtime_ledger"],
+        )
+
+    def test_packet_blocks_when_profit_proof_is_only_non_authoritative(
+        self,
+    ) -> None:
+        runtime_import = _runtime_import()
+        first_observation = runtime_import["imports"][0]["summary"][
+            "runtime_observation"
+        ]
+        assert isinstance(first_observation, dict)
+        first_observation.update(
+            {
+                "authoritative": True,
+                "authority_reason": "runtime_without_runtime_ledger_profit_proof",
+                "runtime_ledger_profit_proof_present": False,
+                "runtime_ledger_tca_profit_proof_count": 0,
+                "runtime_ledger_tca_authoritative_bucket_count": 0,
+            }
+        )
+        runtime_import["imports"].append(
+            {
+                "status": "ok",
+                "proof_status": "ok",
+                "proof_blockers": [],
+                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                "hypothesis_id": "H-PAIRS-01",
+                "observed_stage": "paper",
+                "strategy_family": "microbar_cross_sectional_pairs",
+                "strategy_name": "microbar-pairs-vwap-cap-safe",
+                "account_label": "TORGHUT_SIM",
+                "window_start": "2026-05-26T13:30:00+00:00",
+                "window_end": "2026-05-26T20:00:00+00:00",
+                "summary": {
+                    "promotion_allowed": False,
+                    "runtime_observation": {
+                        "authoritative": False,
+                        "authority_reason": "simulation_source_replay_only",
+                        "runtime_ledger_profit_proof_present": True,
+                        "runtime_ledger_tca_profit_proof_count": 1,
+                    },
+                },
+            }
+        )
+        runtime_import["target_count"] = 2
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(result["ok"])
+        self.assertFalse(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        self.assertEqual(
+            materialization["authoritative_observation_count"],
+            1,
+        )
+        self.assertEqual(
+            materialization["runtime_ledger_profit_proof_count"],
+            1,
+        )
+        self.assertEqual(
+            materialization["authoritative_runtime_ledger_profit_proof_count"],
+            0,
+        )
+        self.assertEqual(
+            materialization["non_authoritative_runtime_ledger_profit_proof_count"],
+            1,
+        )
+        self.assertIn(
+            "runtime_window_import_runtime_ledger_materialization_missing",
+            result["promotion_authority"]["blocking_reasons"],
         )
 
     def test_packet_blocks_runtime_import_without_materialized_runtime_ledger(


### PR DESCRIPTION
## Summary

- Requires runtime-window import materialization to include an authoritative runtime-ledger profit-proof observation, not just any authoritative observation plus a separate non-authoritative profit proof.
- Surfaces authoritative and non-authoritative runtime-ledger profit-proof counts in the proof packet materialization summary.
- Adds a regression test that keeps promotion authority blocked when profit proof is only present on a non-authoritative observation.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff format --check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
