### PR TITLE
chore(torghut): promote image a6c01592

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.579.0-7-ge5c0c317e
+              value: v0.579.0-12-ga6c015926
             - name: TORGHUT_OPTIONS_COMMIT
-              value: e5c0c317e96262cf9804a7066842e43f3003bc15
+              value: a6c0159262e3fe72d0153c95dae00fd072972a45
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.579.0-7-ge5c0c317e
+              value: v0.579.0-12-ga6c015926
             - name: TORGHUT_OPTIONS_COMMIT
-              value: e5c0c317e96262cf9804a7066842e43f3003bc15
+              value: a6c0159262e3fe72d0153c95dae00fd072972a45
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -101,7 +101,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+                  value: sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-27T06:17:42Z"
+        client.knative.dev/updateTimestamp: "2026-05-27T07:04:16Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
           ports:
             - name: http1
               containerPort: 8181
@@ -503,11 +503,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.579.0-7-ge5c0c317e
+              value: v0.579.0-12-ga6c015926
             - name: TORGHUT_COMMIT
-              value: e5c0c317e96262cf9804a7066842e43f3003bc15
+              value: a6c0159262e3fe72d0153c95dae00fd072972a45
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+              value: sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-27T06:17:42Z"
+        client.knative.dev/updateTimestamp: "2026-05-27T07:04:16Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
           ports:
             - name: http1
               containerPort: 8181
@@ -326,11 +326,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.579.0-7-ge5c0c317e
+              value: v0.579.0-12-ga6c015926
             - name: TORGHUT_COMMIT
-              value: e5c0c317e96262cf9804a7066842e43f3003bc15
+              value: a6c0159262e3fe72d0153c95dae00fd072972a45
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+              value: sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:9e9736895b7e3cb547eebd9b4bf60528e99ad77a59acbaece84dc12094d59731
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `a6c0159262e3fe72d0153c95dae00fd072972a45`
- Image tag: `a6c01592`
- Image digest: `sha256:8504f6b14d52e8bb2b8c5801a18e97af0f1542503362621be333e2eb853720ff`