### PR TITLE
feat(analysis): add Argo CD app

### DIFF
--- a/argocd/applications/analysis/deployment.yaml
+++ b/argocd/applications/analysis/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: analysis
+  namespace: analysis
+  labels:
+    app: analysis
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: analysis
+  template:
+    metadata:
+      labels:
+        app: analysis
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      containers:
+        - name: analysis
+          image: registry.ide-newton.ts.net/lab/analysis
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL

--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - tailscale-service.yaml
+images:
+  - name: registry.ide-newton.ts.net/lab/analysis
+    newName: registry.ide-newton.ts.net/lab/analysis
+    newTag: 6ecf28eb27b938467f68366d66cbd06f5271a0af

--- a/argocd/applications/analysis/service.yaml
+++ b/argocd/applications/analysis/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: analysis
+  namespace: analysis
+spec:
+  selector:
+    app: analysis
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/argocd/applications/analysis/tailscale-service.yaml
+++ b/argocd/applications/analysis/tailscale-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: analysis-tailscale
+  namespace: analysis
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: analysis
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app: analysis
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/argocd/applications/argocd/base/image-updater-product.yaml
+++ b/argocd/applications/argocd/base/image-updater-product.yaml
@@ -77,6 +77,24 @@ spec:
           manifestTargets:
             kustomize:
               name: registry.ide-newton.ts.net/lab/docs
+    - namePattern: analysis
+      writeBackConfig:
+        method: git:secret:argocd/image-updater-git-ssh
+        gitConfig:
+          repository: git@github.com:proompteng/lab.git
+          branch: main:release/{{.SHA256}}
+          writeBackTarget: kustomization:/argocd/applications/analysis
+      images:
+        - alias: analysis
+          imageName: registry.ide-newton.ts.net/lab/analysis:latest
+          commonUpdateSettings:
+            updateStrategy: newest-build
+            allowTags: 'regexp:^[0-9a-f]{40}$'
+            platforms:
+              - linux/arm64
+          manifestTargets:
+            kustomize:
+              name: registry.ide-newton.ts.net/lab/analysis
     - namePattern: sag
       writeBackConfig:
         method: git:secret:argocd/image-updater-git-ssh

--- a/argocd/applicationsets/product.yaml
+++ b/argocd/applicationsets/product.yaml
@@ -56,6 +56,14 @@ spec:
                   argocd.argoproj.io/sync-wave: "5"
                 automation: auto
                 enabled: "true"
+              - name: analysis
+                path: argocd/applications/analysis
+                namespace: analysis
+                renderWithLovely: false
+                annotations:
+                  argocd.argoproj.io/sync-wave: "5"
+                automation: auto
+                enabled: "true"
               - name: homepage
                 path: argocd/applications/homepage
                 namespace: homepage


### PR DESCRIPTION
## Summary

- Adds an `analysis` Argo CD app with Deployment, ClusterIP Service, and Tailscale LoadBalancer exposure.
- Registers `analysis` in the product ApplicationSet with automated sync enabled.
- Adds Argo CD ImageUpdater coverage for `registry.ide-newton.ts.net/lab/analysis` commit-SHA image tags.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/analysis`
- `kubectl kustomize argocd/applications/argocd | rg -n "name: product-image-updater|analysis|registry.ide-newton.ts.net/lab/analysis"`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
