### PR TITLE
fix(torghut): require runtime proof materialization

### DIFF
--- a/services/torghut/app/trading/execution_policy.py
+++ b/services/torghut/app/trading/execution_policy.py
@@ -848,6 +848,11 @@ class ExecutionPolicy:
                 price=price,
                 spread=spread,
             )
+            and not _should_keep_market_order_for_pair_runtime_exit(
+                decision,
+                price=price,
+                spread=spread,
+            )
         ):
             selected_order_type = "limit"
             limit_price = _near_touch_limit_price(price, spread, decision.action)
@@ -891,42 +896,16 @@ def _should_keep_market_order_for_high_conviction_entry(
     if decision.params.get("position_exit") is not None:
         return False
 
-    runtime_payload_raw = decision.params.get("strategy_runtime")
-    if not isinstance(runtime_payload_raw, Mapping):
-        return False
-    runtime_payload = cast(Mapping[str, Any], runtime_payload_raw)
-    raw_sources = runtime_payload.get("source_strategy_runtime")
-    if not isinstance(raw_sources, list):
-        return False
-    raw_sources_list = cast(list[Any], raw_sources)
-    source_strategy_runtime: list[Mapping[str, Any]] = []
-    for source_item in raw_sources_list:
-        if isinstance(source_item, Mapping):
-            source_strategy_runtime.append(cast(Mapping[str, Any], source_item))
-    strategy_types = {
-        str(source_runtime.get("strategy_type") or "").strip()
-        for source_runtime in source_strategy_runtime
-    }
-    strategy_types.discard("")
+    strategy_types = _decision_strategy_runtime_types(decision)
     if not strategy_types:
         return False
 
-    execution_features_raw = decision.params.get("execution_features")
-    execution_features: Mapping[str, Any]
-    if isinstance(execution_features_raw, Mapping):
-        execution_features = cast(Mapping[str, Any], execution_features_raw)
-    else:
-        execution_features = {}
-
-    spread_bps = _optional_decimal(execution_features.get("spread_bps"))
-    if (
-        spread_bps is None
-        and spread is not None
-        and spread > 0
-        and price is not None
-        and price > 0
-    ):
-        spread_bps = (spread / price) * Decimal("10000")
+    execution_features = _decision_execution_features(decision)
+    spread_bps = _decision_spread_bps(
+        price=price,
+        spread=spread,
+        execution_features=execution_features,
+    )
     if spread_bps is None or spread_bps > HIGH_CONVICTION_MARKET_SPREAD_BPS_MAX:
         return False
 
@@ -971,20 +950,103 @@ def _should_keep_market_order_for_high_conviction_entry(
         "microbar_cross_sectional_short_v1",
         "microbar_cross_sectional_pairs_v1",
     } & strategy_types:
-        rationale_tokens = {
-            token.strip().lower()
-            for token in str(decision.rationale or "").split(",")
-            if token.strip()
-        }
         return bool(
             {
                 "microbar_cross_sectional_entry",
                 "microbar_cross_sectional_pair_entry",
             }
-            & rationale_tokens
+            & _decision_rationale_tokens(decision)
         )
 
     return False
+
+
+def _should_keep_market_order_for_pair_runtime_exit(
+    decision: StrategyDecision,
+    *,
+    price: Decimal | None,
+    spread: Decimal | None,
+) -> bool:
+    if decision.order_type != "market":
+        return False
+
+    position_exit_raw = decision.params.get("position_exit")
+    if not isinstance(position_exit_raw, Mapping):
+        return False
+    position_exit = cast(Mapping[str, Any], position_exit_raw)
+    if str(position_exit.get("type") or "").strip().lower() != "runtime_signal_exit":
+        return False
+
+    strategy_types = _decision_strategy_runtime_types(decision)
+    if "microbar_cross_sectional_pairs_v1" not in strategy_types:
+        return False
+    if "microbar_cross_sectional_pair_exit" not in _decision_rationale_tokens(decision):
+        return False
+
+    spread_bps = _decision_spread_bps(
+        price=price,
+        spread=spread,
+        execution_features=_decision_execution_features(decision),
+    )
+    return (
+        spread_bps is not None and spread_bps <= HIGH_CONVICTION_MARKET_SPREAD_BPS_MAX
+    )
+
+
+def _decision_strategy_runtime_types(decision: StrategyDecision) -> set[str]:
+    runtime_payload_raw = decision.params.get("strategy_runtime")
+    if not isinstance(runtime_payload_raw, Mapping):
+        return set()
+    runtime_payload = cast(Mapping[str, Any], runtime_payload_raw)
+    raw_sources = runtime_payload.get("source_strategy_runtime")
+    if not isinstance(raw_sources, list):
+        return set()
+    raw_sources_list = cast(list[Any], raw_sources)
+    source_strategy_runtime: list[Mapping[str, Any]] = []
+    for source_item in raw_sources_list:
+        if isinstance(source_item, Mapping):
+            source_strategy_runtime.append(cast(Mapping[str, Any], source_item))
+    strategy_types = {
+        str(source_runtime.get("strategy_type") or "").strip()
+        for source_runtime in source_strategy_runtime
+    }
+    strategy_types.discard("")
+    return strategy_types
+
+
+def _decision_execution_features(
+    decision: StrategyDecision,
+) -> Mapping[str, Any]:
+    execution_features_raw = decision.params.get("execution_features")
+    if isinstance(execution_features_raw, Mapping):
+        return cast(Mapping[str, Any], execution_features_raw)
+    return {}
+
+
+def _decision_spread_bps(
+    *,
+    price: Decimal | None,
+    spread: Decimal | None,
+    execution_features: Mapping[str, Any],
+) -> Decimal | None:
+    spread_bps = _optional_decimal(execution_features.get("spread_bps"))
+    if (
+        spread_bps is None
+        and spread is not None
+        and spread > 0
+        and price is not None
+        and price > 0
+    ):
+        spread_bps = (spread / price) * Decimal("10000")
+    return spread_bps
+
+
+def _decision_rationale_tokens(decision: StrategyDecision) -> set[str]:
+    return {
+        token.strip().lower()
+        for token in str(decision.rationale or "").split(",")
+        if token.strip()
+    }
 
 
 def _near_touch_limit_price(

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -1148,7 +1148,9 @@ def _runtime_ledger_daily_summary_from_observed_buckets(
         )
 
     if equity_denominators and max_intraday_drawdown > 0:
-        equity_denominator, equity_source = min(equity_denominators, key=lambda item: item[0])
+        equity_denominator, equity_source = min(
+            equity_denominators, key=lambda item: item[0]
+        )
         summary["runtime_ledger_drawdown_pct_equity"] = str(
             max_intraday_drawdown / equity_denominator
         )
@@ -1435,6 +1437,27 @@ def persist_observed_runtime_windows(
         window_end=import_window_end,
     )
     proof_status = "blocked" if proof_blockers else "ok"
+    runtime_materialization_target = {
+        "candidate_id": candidate_id,
+        "hypothesis_id": hypothesis_id,
+        "observed_stage": observed_stage,
+        "strategy_family": manifest.strategy_family,
+        "account_label": _text(runtime_payload.get("account_label")),
+        "strategy_name": _text(runtime_payload.get("strategy_name")),
+        "window_start": import_window_start.isoformat(),
+        "window_end": import_window_end.isoformat(),
+        "runtime_ledger_profit_proof_present": bool(
+            runtime_payload.get("runtime_ledger_profit_proof_present")
+        ),
+        "runtime_ledger_notional_weighted_sample_count": runtime_ledger_sample_count,
+        "runtime_ledger_filled_notional": str(runtime_ledger_filled_notional),
+        "runtime_ledger_net_strategy_pnl_after_costs": str(
+            runtime_ledger_net_strategy_pnl_after_costs
+        ),
+        "runtime_ledger_daily_summary": runtime_ledger_daily_summary,
+        "proof_status": proof_status,
+        "proof_blockers": proof_blockers,
+    }
     running_session_samples = 0
     for bucket in sorted_buckets:
         running_session_samples += bucket.market_session_count
@@ -1669,6 +1692,7 @@ def persist_observed_runtime_windows(
         "promotion_blocking_reasons": promotion_blocking_reasons,
         "proof_status": proof_status,
         "proof_blockers": proof_blockers,
+        "runtime_materialization_target": runtime_materialization_target,
         "runtime_observation": runtime_payload,
         "delay_adjusted_depth_stress": delay_depth_stress_summary,
     }

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -714,17 +714,77 @@ def _runtime_import_runtime_observations(
     return observations
 
 
+def _runtime_import_target_materialization_ref(
+    *,
+    item: Mapping[str, Any],
+    observation: Mapping[str, Any],
+    profit_proof_count: int,
+    materialized: bool,
+    blockers: Sequence[str],
+) -> dict[str, Any]:
+    summary = _mapping(item.get("summary"))
+
+    def first_text(*keys: str) -> str:
+        for source in (item, summary, observation):
+            for key in keys:
+                value = _text(source.get(key))
+                if value:
+                    return value
+        return ""
+
+    ref: dict[str, Any] = {
+        "materialized": materialized,
+        "candidate_id": first_text("candidate_id"),
+        "hypothesis_id": first_text("hypothesis_id"),
+        "observed_stage": first_text("observed_stage"),
+        "strategy_family": first_text("strategy_family"),
+        "strategy_name": first_text("strategy_name", "runtime_strategy_name"),
+        "account_label": first_text("account_label"),
+        "window_start": first_text("window_start", "window_started_at"),
+        "window_end": first_text("window_end", "window_ended_at"),
+        "authoritative": observation.get("authoritative") is True,
+        "authority_reason": _text(observation.get("authority_reason")),
+        "source_kind": _text(observation.get("source_kind")),
+        "runtime_ledger_profit_proof_count": profit_proof_count,
+        "runtime_ledger_tca_row_count": _int(
+            observation.get("runtime_ledger_tca_row_count")
+        ),
+        "runtime_ledger_tca_authoritative_bucket_count": _int(
+            observation.get("runtime_ledger_tca_authoritative_bucket_count")
+        ),
+        "runtime_ledger_source_execution_materialized_bucket_count": _int(
+            observation.get("runtime_ledger_source_execution_materialized_bucket_count")
+        ),
+        "runtime_ledger_filled_notional": _text(
+            observation.get("runtime_ledger_filled_notional")
+        ),
+        "runtime_ledger_net_strategy_pnl_after_costs": _text(
+            observation.get("runtime_ledger_net_strategy_pnl_after_costs")
+        ),
+        "blockers": list(blockers),
+    }
+    return {key: value for key, value in ref.items() if value not in ("", [], None)}
+
+
 def _runtime_import_materialization_summary(
     payload: Mapping[str, Any],
 ) -> dict[str, Any]:
+    items = _runtime_window_import_items(payload)
     observations = _runtime_import_runtime_observations(payload)
     source_kinds: list[str] = []
     authority_reasons: list[str] = []
     pnl_derivations: list[str] = []
     materialization_blockers: list[str] = []
+    materialized_targets: list[dict[str, Any]] = []
+    unmaterialized_targets: list[dict[str, Any]] = []
     counts = {
+        "declared_target_count": _int(payload.get("target_count"), len(items)),
+        "import_item_count": len(items),
         "runtime_observation_count": len(observations),
         "authoritative_observation_count": 0,
+        "materialized_target_count": 0,
+        "unmaterialized_target_count": 0,
+        "missing_target_import_count": 0,
         "authoritative_runtime_ledger_profit_proof_count": 0,
         "non_authoritative_runtime_ledger_profit_proof_count": 0,
         "runtime_ledger_profit_proof_count": 0,
@@ -741,7 +801,23 @@ def _runtime_import_materialization_summary(
         "runtime_ledger_profit_proof",
         "runtime_ledger_profit_proof_present",
     }
-    for observation in observations:
+    for item in items:
+        summary = _mapping(item.get("summary"))
+        observation = _mapping(summary.get("runtime_observation"))
+        target_blockers: list[str] = []
+        if not observation:
+            target_blockers.append("runtime_window_import_runtime_observation_missing")
+            unmaterialized_targets.append(
+                _runtime_import_target_materialization_ref(
+                    item=item,
+                    observation={},
+                    profit_proof_count=0,
+                    materialized=False,
+                    blockers=target_blockers,
+                )
+            )
+            _extend_unique(materialization_blockers, target_blockers)
+            continue
         if observation.get("authoritative") is True:
             counts["authoritative_observation_count"] += 1
         authority_reason = _text(observation.get("authority_reason"))
@@ -786,6 +862,12 @@ def _runtime_import_materialization_summary(
             "runtime_ledger_artifact_tca_row_count",
         ):
             counts[key] += _int(observation.get(key))
+        if observation.get("authoritative") is not True:
+            target_blockers.append(
+                "runtime_window_import_observation_not_authoritative"
+            )
+        if profit_proof_count <= 0:
+            target_blockers.append("runtime_window_import_target_profit_proof_missing")
         _extend_unique(source_kinds, [_text(observation.get("source_kind"))])
         _extend_unique(authority_reasons, [authority_reason])
         _extend_unique(
@@ -802,9 +884,51 @@ def _runtime_import_materialization_summary(
             materialization_blockers,
             _text_list(observation.get("runtime_ledger_target_metadata_blockers")),
         )
+        materialized = (
+            observation.get("authoritative") is True and profit_proof_count > 0
+        )
+        target_ref = _runtime_import_target_materialization_ref(
+            item=item,
+            observation=observation,
+            profit_proof_count=profit_proof_count,
+            materialized=materialized,
+            blockers=target_blockers,
+        )
+        if materialized:
+            counts["materialized_target_count"] += 1
+            materialized_targets.append(target_ref)
+        else:
+            unmaterialized_targets.append(target_ref)
+            _extend_unique(materialization_blockers, target_blockers)
+    counts["unmaterialized_target_count"] = len(unmaterialized_targets)
+    counts["missing_target_import_count"] = max(
+        0,
+        counts["declared_target_count"] - counts["import_item_count"],
+    )
+    if counts["missing_target_import_count"] > 0:
+        _extend_unique(
+            materialization_blockers,
+            ["runtime_window_import_target_count_mismatch"],
+        )
+    if unmaterialized_targets:
+        _extend_unique(
+            materialization_blockers,
+            ["runtime_window_import_target_materialization_missing"],
+        )
+    if (
+        counts["authoritative_runtime_ledger_profit_proof_count"] <= 0
+        or counts["unmaterialized_target_count"] > 0
+        or counts["missing_target_import_count"] > 0
+    ):
+        _extend_unique(
+            materialization_blockers,
+            ["runtime_window_import_runtime_ledger_materialization_missing"],
+        )
     return {
         "schema_version": "torghut.runtime-window-import-materialization-summary.v1",
         **counts,
+        "materialized_targets": materialized_targets,
+        "unmaterialized_targets": unmaterialized_targets,
         "source_kinds": source_kinds,
         "authority_reasons": authority_reasons,
         "pnl_derivations": pnl_derivations,
@@ -1205,6 +1329,9 @@ def build_runtime_ledger_proof_packet(
             )
         )
         > 0
+        and _int(materialization_summary.get("materialized_target_count")) > 0
+        and _int(materialization_summary.get("unmaterialized_target_count")) == 0
+        and _int(materialization_summary.get("missing_target_import_count")) == 0
         and not _text_list(materialization_summary.get("blockers"))
     )
     runtime_import_ok = (
@@ -1256,7 +1383,7 @@ def build_runtime_ledger_proof_packet(
         "runtime_window_import_materialization",
         passed=runtime_import_materialization_ok,
         observed=materialization_summary,
-        expected="runtime-window import contains at least one authoritative runtime-ledger profit-proof observation",
+        expected="every runtime-window import target contains authoritative runtime-ledger profit-proof materialization",
         blockers=materialization_blockers
         or (
             []

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -1118,6 +1118,185 @@ class TestRuntimeLedgerProofPacket(TestCase):
             materialization["pnl_derivations"],
             ["source_execution_lifecycle_materialized_runtime_ledger"],
         )
+        self.assertEqual(materialization["materialized_target_count"], 1)
+        self.assertEqual(materialization["unmaterialized_target_count"], 0)
+        self.assertEqual(
+            materialization["materialized_targets"][0]["candidate_id"],
+            "c88421d619759b2cfaa6f4d0",
+        )
+        self.assertTrue(materialization["materialized_targets"][0]["materialized"])
+
+    def test_packet_blocks_when_any_runtime_import_target_lacks_materialization(
+        self,
+    ) -> None:
+        runtime_import = _runtime_import()
+        runtime_import["imports"].append(
+            {
+                "status": "ok",
+                "proof_status": "ok",
+                "proof_blockers": [],
+                "candidate_id": "cand-missing-proof",
+                "hypothesis_id": "H-PAIRS-01",
+                "observed_stage": "paper",
+                "strategy_family": "microbar_cross_sectional_pairs",
+                "strategy_name": "microbar-pairs-vwap-cap-safe",
+                "account_label": "TORGHUT_SIM",
+                "window_start": "2026-05-26T13:30:00+00:00",
+                "window_end": "2026-05-26T20:00:00+00:00",
+                "summary": {
+                    "promotion_allowed": False,
+                    "runtime_observation": {
+                        "authoritative": True,
+                        "authority_reason": "runtime_without_runtime_ledger_profit_proof",
+                        "runtime_ledger_profit_proof_present": False,
+                        "runtime_ledger_tca_profit_proof_count": 0,
+                        "runtime_ledger_tca_authoritative_bucket_count": 0,
+                    },
+                },
+            }
+        )
+        runtime_import["target_count"] = 2
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(result["ok"])
+        self.assertFalse(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        self.assertEqual(materialization["materialized_target_count"], 1)
+        self.assertEqual(materialization["unmaterialized_target_count"], 1)
+        self.assertEqual(
+            materialization["unmaterialized_targets"][0]["candidate_id"],
+            "cand-missing-proof",
+        )
+        self.assertIn(
+            "runtime_window_import_target_materialization_missing",
+            materialization["blockers"],
+        )
+        self.assertIn(
+            "runtime_window_import_target_materialization_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+
+    def test_packet_blocks_when_runtime_import_target_has_no_observation(
+        self,
+    ) -> None:
+        runtime_import = _runtime_import()
+        runtime_import["imports"][0]["summary"].pop("runtime_observation")
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(result["ok"])
+        self.assertFalse(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        self.assertEqual(materialization["materialized_target_count"], 0)
+        self.assertEqual(materialization["unmaterialized_target_count"], 1)
+        self.assertEqual(
+            materialization["unmaterialized_targets"][0]["candidate_id"],
+            "c88421d619759b2cfaa6f4d0",
+        )
+        self.assertIn(
+            "runtime_window_import_runtime_observation_missing",
+            materialization["blockers"],
+        )
+        self.assertIn(
+            "runtime_window_import_runtime_observation_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+
+    def test_packet_blocks_when_runtime_import_target_count_is_incomplete(
+        self,
+    ) -> None:
+        runtime_import = _runtime_import()
+        observation = runtime_import["imports"][0]["summary"]["runtime_observation"]
+        assert isinstance(observation, dict)
+        observation.update(
+            {
+                "runtime_ledger_profit_proof_present": True,
+                "runtime_ledger_tca_profit_proof_count": 1,
+                "runtime_ledger_tca_authoritative_bucket_count": 1,
+            }
+        )
+        runtime_import["target_count"] = 2
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(result["ok"])
+        self.assertFalse(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        self.assertEqual(materialization["materialized_target_count"], 1)
+        self.assertEqual(materialization["missing_target_import_count"], 1)
+        self.assertIn(
+            "runtime_window_import_target_count_mismatch",
+            materialization["blockers"],
+        )
+        self.assertIn(
+            "runtime_window_import_target_count_mismatch",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+
+    def test_packet_blocks_when_runtime_import_target_lacks_observation(
+        self,
+    ) -> None:
+        runtime_import = _runtime_import()
+        first_import = runtime_import["imports"][0]
+        assert isinstance(first_import, dict)
+        first_summary = first_import["summary"]
+        assert isinstance(first_summary, dict)
+        first_summary.pop("runtime_observation")
+        runtime_import["target_count"] = 2
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(result["ok"])
+        self.assertFalse(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        self.assertEqual(materialization["materialized_target_count"], 0)
+        self.assertEqual(materialization["unmaterialized_target_count"], 1)
+        self.assertEqual(materialization["missing_target_import_count"], 1)
+        self.assertIn(
+            "runtime_window_import_runtime_observation_missing",
+            materialization["unmaterialized_targets"][0]["blockers"],
+        )
+        self.assertIn(
+            "runtime_window_import_target_count_mismatch",
+            materialization["blockers"],
+        )
+        self.assertIn(
+            "runtime_window_import_target_materialization_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
 
     def test_packet_blocks_when_profit_proof_is_only_non_authoritative(
         self,

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -1399,6 +1399,36 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result["required_actions"],
         )
 
+    def test_packet_materialization_marks_non_authoritative_empty_target(
+        self,
+    ) -> None:
+        runtime_import = _runtime_import(authoritative=False)
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(result["ok"])
+        self.assertEqual(materialization["materialized_target_count"], 0)
+        self.assertEqual(materialization["unmaterialized_target_count"], 1)
+        self.assertIn(
+            "runtime_window_import_observation_not_authoritative",
+            materialization["unmaterialized_targets"][0]["blockers"],
+        )
+        self.assertIn(
+            "runtime_window_import_target_profit_proof_missing",
+            materialization["unmaterialized_targets"][0]["blockers"],
+        )
+        self.assertIn(
+            "runtime_window_import_target_materialization_missing",
+            materialization["blockers"],
+        )
+
     def test_packet_waits_on_target_level_settlement_blocker(self) -> None:
         paper = _paper_route_evidence()
         target = paper["next_paper_route_runtime_window_targets"]["targets"][0]

--- a/services/torghut/tests/test_execution_policy.py
+++ b/services/torghut/tests/test_execution_policy.py
@@ -542,6 +542,48 @@ class TestExecutionPolicy(TestCase):
         self.assertEqual(outcome.decision.order_type, "market")
         self.assertIsNone(outcome.decision.limit_price)
 
+    def test_microbar_cross_sectional_pairs_signal_exit_keeps_market_order(
+        self,
+    ) -> None:
+        policy = ExecutionPolicy(config=_config(prefer_limit=True))
+        decision = _decision(
+            action="sell",
+            qty=Decimal("1"),
+            price=Decimal("189.24"),
+            order_type="market",
+        ).model_copy(
+            update={
+                "rationale": "microbar_cross_sectional_pair_exit,pair_side:high_rank",
+                "params": {
+                    "price": Decimal("189.24"),
+                    "spread": Decimal("0.04"),
+                    "execution_features": {
+                        "spread_bps": Decimal("2.11"),
+                    },
+                    "position_exit": {
+                        "type": "runtime_signal_exit",
+                        "position_side": "long",
+                        "source": "strategy_runtime",
+                    },
+                    "strategy_runtime": {
+                        "source_strategy_runtime": [
+                            {"strategy_type": "microbar_cross_sectional_pairs_v1"}
+                        ]
+                    },
+                },
+            }
+        )
+
+        outcome = policy.evaluate(
+            decision,
+            strategy=None,
+            positions=[{"symbol": "AAPL", "qty": Decimal("1")}],
+            market_snapshot=None,
+        )
+
+        self.assertEqual(outcome.decision.order_type, "market")
+        self.assertIsNone(outcome.decision.limit_price)
+
     def test_limit_and_stop_prices_are_quantized(self) -> None:
         decision = _decision(
             action="sell",

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -1677,6 +1677,16 @@ class TestRuntimeWindowImport(TestCase):
             "paper_probation_evidence_collection_only",
             summary["promotion_blocking_reasons"],
         )
+        target = summary["runtime_materialization_target"]
+        self.assertEqual(target["candidate_id"], "cand-paper-route")
+        self.assertEqual(target["hypothesis_id"], "H-PAIRS-01")
+        self.assertTrue(target["runtime_ledger_profit_proof_present"])
+        self.assertEqual(target["runtime_ledger_notional_weighted_sample_count"], 1)
+        self.assertEqual(target["runtime_ledger_filled_notional"], "200")
+        self.assertEqual(
+            target["runtime_ledger_net_strategy_pnl_after_costs"],
+            "0.80",
+        )
 
     def test_persist_observed_runtime_windows_blocks_zero_activity_evidence(
         self,


### PR DESCRIPTION
## Summary

- Adds per-target runtime-window import materialization records to proof packets.
- Fails promotion authority when any declared runtime import target lacks authoritative runtime-ledger profit proof.
- Keeps H-PAIRS runtime signal exits as market orders under the existing high-conviction spread cap so paper-route pair legs can close instead of sitting as passive limits.
- Covers mixed, missing, and non-authoritative materialization cases plus pair-exit execution policy with regression tests.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_execution_policy.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_runtime_window_import.py -q`
- `uv run --frozen pytest tests/test_execution_policy.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_runtime_window_import.py --cov --cov-branch --cov-fail-under=0 --cov-report=xml:coverage.xml --cov-report= -q && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90 --base-ref origin/main`
- `uv run --frozen ruff format --check app/trading/execution_policy.py tests/test_execution_policy.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff check app/trading/execution_policy.py tests/test_execution_policy.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
