### PR TITLE
fix(arc): avoid analysis runner name collision

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -162,7 +162,7 @@ spec:
             namespace: arc
           githubConfigUrl: https://github.com/gregkonush/analysis
           githubConfigSecret: github-token
-          runnerScaleSetName: arc-arm64
+          runnerScaleSetName: analysis-arm64
           scaleSetLabels:
             - arc-arm64
           minRunners: 1


### PR DESCRIPTION
## Summary

- Renames the analysis ARC runner scale-set resource to `analysis-arm64`.
- Keeps the exposed workflow label as `arc-arm64`, so the analysis workflow remains unchanged.
- Avoids colliding with the existing `arc-arm64` scale-set resources for `proompteng/lab`.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check`
- `ruby -ryaml -e 'doc = YAML.load_file("argocd/applications/arc/application.yaml"); doc.fetch("spec").fetch("sources").each { |source| next unless source.dig("helm", "releaseName")&.include?("runner-set"); puts [source.dig("helm", "releaseName"), source.dig("helm", "valuesObject", "githubConfigUrl"), source.dig("helm", "valuesObject", "runnerScaleSetName"), source.dig("helm", "valuesObject", "scaleSetLabels")&.join(",")].join(" ") }'`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
