### PR TITLE
fix(arc): fit analysis runners on arm nodes

### DIFF
--- a/argocd/applications/arc/application.yaml
+++ b/argocd/applications/arc/application.yaml
@@ -165,8 +165,8 @@ spec:
           runnerScaleSetName: analysis-arm64
           scaleSetLabels:
             - arc-arm64
-          minRunners: 1
-          maxRunners: 3
+          minRunners: 0
+          maxRunners: 2
           containerMode:
             type: "kubernetes"
             kubernetesModeWorkVolumeClaim:
@@ -223,13 +223,13 @@ spec:
                       docker version
                   resources:
                     requests:
+                      cpu: "1"
+                      memory: "2Gi"
+                      ephemeral-storage: "8Gi"
+                    limits:
                       cpu: "4"
                       memory: "8Gi"
-                      ephemeral-storage: "40Gi"
-                    limits:
-                      cpu: "8"
-                      memory: "16Gi"
-                      ephemeral-storage: "80Gi"
+                      ephemeral-storage: "32Gi"
                   env:
                     - name: ACTIONS_RUNNER_CONTAINER_HOOKS
                       value: /home/runner/k8s/index.js
@@ -255,13 +255,13 @@ spec:
                     - --max-concurrent-uploads=8
                   resources:
                     requests:
-                      cpu: "4"
-                      memory: "8Gi"
-                      ephemeral-storage: "30Gi"
+                      cpu: "1"
+                      memory: "2Gi"
+                      ephemeral-storage: "12Gi"
                     limits:
-                      cpu: "12"
-                      memory: "16Gi"
-                      ephemeral-storage: "50Gi"
+                      cpu: "6"
+                      memory: "10Gi"
+                      ephemeral-storage: "40Gi"
                   env:
                     - name: DOCKER_GROUP_GID
                       value: "123"


### PR DESCRIPTION
## Summary

- Lowers only the `gregkonush/analysis` ARC runner resource requests so pods can schedule on the available arm64 node.
- Sets the analysis scale set to scale from zero with a maximum of two runners.
- Keeps the existing `proompteng/lab` runner scale set unchanged.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `git diff --check`
- `ruby -ryaml -e 'doc = YAML.load_file("argocd/applications/arc/application.yaml"); doc.fetch("spec").fetch("sources").each { |source| next unless source.dig("helm", "releaseName")&.include?("runner-set"); values = source.dig("helm", "valuesObject"); containers = values.dig("template", "spec", "containers"); puts [source.dig("helm", "releaseName"), values["minRunners"], values["maxRunners"], values["runnerScaleSetName"], containers[0].dig("resources", "requests"), containers[1].dig("resources", "requests")].inspect }'`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
