### PR TITLE
fix(torghut): align hpairs runtime renewal

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -44,7 +44,7 @@ spec:
                   mkdir -p "$(dirname "${RENEWAL_OUTPUT}")" "$(dirname "${PROOF_PACKET_OUTPUT}")"
                   /opt/venv/bin/python scripts/renew_latest_empirical_promotion_jobs.py \
                     --output-dir /tmp/torghut-empirical-renewal \
-                    --strategy-spec-ref intraday_tsmom_v2@research \
+                    --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \
                     --runtime-window-import \
                     --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence \
                     --runtime-window-target-plan-exclusive \
@@ -52,15 +52,15 @@ spec:
                     --runtime-window-target-plan-settlement-seconds 3600 \
                     --runtime-window-targets-from-latest-autoresearch \
                     --runtime-window-targets-from-registry \
-                    --runtime-window-hypothesis-id H-TSMOM-01 \
-                    --runtime-window-candidate-id spec-83161ae16d17828eabcc58cc \
-                    --runtime-window-strategy-family intraday_tsmom_consistent \
-                    --runtime-window-strategy-name intraday-tsmom-profit-v3 \
+                    --runtime-window-hypothesis-id H-PAIRS-01 \
+                    --runtime-window-candidate-id c88421d619759b2cfaa6f4d0 \
+                    --runtime-window-strategy-family microbar_cross_sectional_pairs \
+                    --runtime-window-strategy-name microbar-cross-sectional-pairs-v1 \
                     --runtime-window-account-label TORGHUT_SIM \
                     --runtime-window-observed-stage paper \
                     --runtime-window-source-dsn-env SIM_DB_DSN \
                     --runtime-window-dataset-snapshot-ref portfolio-profit-autoresearch-500-v1 \
-                    --runtime-window-source-manifest-ref config/trading/hypotheses/h-tsmom-01.json \
+                    --runtime-window-source-manifest-ref config/trading/hypotheses/h-pairs-01.json \
                     --json \
                     | tee "${RENEWAL_OUTPUT}"
                   /opt/venv/bin/python scripts/assemble_runtime_ledger_proof_packet.py \

--- a/services/torghut/app/trading/decisions.py
+++ b/services/torghut/app/trading/decisions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import re
 from collections.abc import Mapping
@@ -14,6 +16,7 @@ from ..config import settings
 from ..models import Strategy
 from ..strategies.catalog import extract_catalog_metadata
 from .features import (
+    FeatureVectorV3,
     FeatureNormalizationError,
     SignalFeatures,
     extract_signal_features,
@@ -71,6 +74,44 @@ _LEGACY_BUY_EXIT_ONLY_UNIVERSE_TYPES = {
     "microbar_cross_sectional_pairs_v1",
 }
 _MICROBAR_PAIR_EXIT_RATIONALE = "microbar_cross_sectional_pair_exit"
+
+
+def _feature_vector_with_runtime_position(
+    feature_vector: FeatureVectorV3,
+    *,
+    position_qty: Decimal,
+    position_side: str | None,
+) -> FeatureVectorV3:
+    values = dict(feature_vector.values)
+    values["runtime_position_qty"] = position_qty
+    values["runtime_position_side"] = position_side
+    normalized_payload = {
+        "event_ts": feature_vector.event_ts.isoformat(),
+        "symbol": feature_vector.symbol,
+        "timeframe": feature_vector.timeframe,
+        "seq": feature_vector.seq,
+        "source": feature_vector.source,
+        "feature_schema_version": feature_vector.feature_schema_version,
+        "values": {key: values[key] for key in sorted(values)},
+    }
+    normalization_hash = hashlib.sha256(
+        json.dumps(
+            normalized_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ).encode("utf-8")
+    ).hexdigest()
+    return FeatureVectorV3(
+        event_ts=feature_vector.event_ts,
+        symbol=feature_vector.symbol,
+        timeframe=feature_vector.timeframe,
+        seq=feature_vector.seq,
+        source=feature_vector.source,
+        feature_schema_version=feature_vector.feature_schema_version,
+        values=values,
+        normalization_hash=normalization_hash,
+    )
 
 
 @dataclass(frozen=True)
@@ -215,6 +256,17 @@ class DecisionEngine:
         normalized_payload = self._session_context_tracker.enrich_signal_payload(signal)
         if price is not None and "price" not in normalized_payload:
             normalized_payload["price"] = price
+        runtime_position_qty = _position_qty_for_symbol(actual_positions, signal.symbol)
+        runtime_position_side: str | None = None
+        if runtime_position_qty is not None:
+            normalized_payload["runtime_position_qty"] = str(runtime_position_qty)
+            if runtime_position_qty > 0:
+                runtime_position_side = "long"
+            elif runtime_position_qty < 0:
+                runtime_position_side = "short"
+            else:
+                runtime_position_side = "flat"
+            normalized_payload["runtime_position_side"] = runtime_position_side
         normalized_signal = signal.model_copy(update={"payload": normalized_payload})
         try:
             feature_vector = normalize_feature_vector_v3(normalized_signal)
@@ -226,6 +278,12 @@ class DecisionEngine:
                 fallback_to_legacy=False,
             )
             return []
+        if runtime_position_qty is not None:
+            feature_vector = _feature_vector_with_runtime_position(
+                feature_vector,
+                position_qty=runtime_position_qty,
+                position_side=runtime_position_side,
+            )
 
         runtime_eval = self.strategy_runtime.evaluate_all(
             strategies, feature_vector, timeframe=timeframe

--- a/services/torghut/app/trading/strategy_runtime.py
+++ b/services/torghut/app/trading/strategy_runtime.py
@@ -218,6 +218,10 @@ def _microbar_rank_universe_size(
     return _microbar_universe_size(context=context, params=params)
 
 
+def _microbar_runtime_position_qty(features: FeatureVectorV3) -> Decimal | None:
+    return _decimal(features.values.get("runtime_position_qty"))
+
+
 def _microbar_required_features(params: dict[str, Any]) -> tuple[str, ...]:
     required = ["session_minutes_elapsed"]
     rank_feature = str(params.get("rank_feature") or "").strip()
@@ -227,10 +231,6 @@ def _microbar_required_features(params: dict[str, Any]) -> tuple[str, ...]:
     if gate_feature:
         required.append(gate_feature)
     return tuple(dict.fromkeys(required))
-
-
-def _opposite_action(action: Literal["buy", "sell"]) -> Literal["buy", "sell"]:
-    return "sell" if action == "buy" else "buy"
 
 
 def _evaluate_microbar_cross_sectional(
@@ -375,6 +375,78 @@ def _evaluate_microbar_cross_sectional(
                 ),
             )
 
+    if pair_mode and is_exit:
+        position_qty = _microbar_runtime_position_qty(features)
+        if position_qty is None:
+            return PluginEvaluationResult(
+                intent=None,
+                trace=_generic_plugin_trace(
+                    context=context,
+                    gate="pair_position_exit",
+                    passed=False,
+                    gate_context={
+                        "reason": "missing_runtime_position_qty",
+                        "minutes_elapsed": minutes_elapsed,
+                        "exit_minute_after_open": exit_minute,
+                    },
+                ),
+            )
+        if position_qty == 0:
+            return PluginEvaluationResult(
+                intent=None,
+                trace=_generic_plugin_trace(
+                    context=context,
+                    gate="pair_position_exit",
+                    passed=False,
+                    gate_context={
+                        "reason": "flat_runtime_position",
+                        "minutes_elapsed": minutes_elapsed,
+                        "exit_minute_after_open": exit_minute,
+                        "runtime_position_qty": position_qty,
+                    },
+                ),
+            )
+        position_side = "long" if position_qty > 0 else "short"
+        position_exit_action: Literal["buy", "sell"] = (
+            "sell" if position_qty > 0 else "buy"
+        )
+        rationale = (
+            "microbar_cross_sectional_pair_exit",
+            str(params.get("signal_motif") or "").strip().lower(),
+            "exit_basis:runtime_position",
+            f"position_side:{position_side}",
+        )
+        required_features = (
+            "session_minutes_elapsed",
+            "runtime_position_qty",
+        )
+        return PluginEvaluationResult(
+            intent=StrategyIntent(
+                strategy_id=context.strategy_id,
+                symbol=context.symbol,
+                direction=position_exit_action,
+                confidence=Decimal("0.51"),
+                target_notional=_resolved_target_notional(params),
+                horizon=context.timeframe,
+                explain=rationale,
+                feature_snapshot_hash=features.normalization_hash,
+                required_features=required_features,
+            ),
+            trace=_generic_plugin_trace(
+                context=context,
+                gate="pair_position_exit",
+                passed=True,
+                action=position_exit_action,
+                rationale=rationale,
+                gate_context={
+                    "minutes_elapsed": minutes_elapsed,
+                    "exit_minute_after_open": exit_minute,
+                    "runtime_position_qty": position_qty,
+                    "position_side": position_side,
+                },
+            ),
+        )
+
     rank_feature = str(params.get("rank_feature") or "").strip()
     rank_value = _decimal(features.values.get(rank_feature))
     if rank_value is None:
@@ -448,17 +520,9 @@ def _evaluate_microbar_cross_sectional(
             comparator = "lte"
             threshold_value = low_threshold
         should_trade = selected_entry_action is not None
-        resolved_action = (
-            _opposite_action(selected_entry_action)
-            if is_exit and selected_entry_action is not None
-            else selected_entry_action
-        )
+        resolved_action: Literal["buy", "sell"] | None = selected_entry_action
         rationale = (
-            (
-                "microbar_cross_sectional_pair_exit"
-                if is_exit
-                else "microbar_cross_sectional_pair_entry"
-            ),
+            "microbar_cross_sectional_pair_entry",
             str(params.get("signal_motif") or "").strip().lower(),
             f"selection_mode:{selection_mode}",
             f"rank_feature:{rank_feature}",
@@ -488,7 +552,7 @@ def _evaluate_microbar_cross_sectional(
         )
         trace = _generic_plugin_trace(
             context=context,
-            gate="pair_time_exit" if is_exit else "pair_rank_selection",
+            gate="pair_rank_selection",
             passed=should_trade,
             action=resolved_action if should_trade else None,
             rationale=rationale if should_trade else (),
@@ -521,8 +585,9 @@ def _evaluate_microbar_cross_sectional(
                 "pair_side": pair_side,
             },
         )
-        if not should_trade or resolved_action is None:
+        if not should_trade:
             return PluginEvaluationResult(intent=None, trace=trace)
+        assert resolved_action is not None
         rank_distance = (
             rank_value - threshold_value
             if comparator == "gte"

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -229,15 +229,17 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--runtime-window-autoresearch-scan-limit", type=int, default=20
     )
-    parser.add_argument("--runtime-window-hypothesis-id", default="H-TSMOM-01")
-    parser.add_argument("--runtime-window-candidate-id", default="")
+    parser.add_argument("--runtime-window-hypothesis-id", default="H-PAIRS-01")
+    parser.add_argument(
+        "--runtime-window-candidate-id", default="c88421d619759b2cfaa6f4d0"
+    )
     parser.add_argument(
         "--runtime-window-strategy-family",
-        default="intraday_tsmom_consistent",
+        default="microbar_cross_sectional_pairs",
     )
     parser.add_argument(
         "--runtime-window-strategy-name",
-        default="intraday-tsmom-profit-v3",
+        default="microbar-cross-sectional-pairs-v1",
     )
     parser.add_argument("--runtime-window-account-label", default="TORGHUT_SIM")
     parser.add_argument(
@@ -253,7 +255,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--runtime-window-sample-minutes", type=int, default=5)
     parser.add_argument(
         "--runtime-window-source-manifest-ref",
-        default="config/trading/hypotheses/h-tsmom-01.json",
+        default="config/trading/hypotheses/h-pairs-01.json",
     )
     parser.add_argument(
         "--runtime-window-source-kind", default="paper_runtime_observed"
@@ -877,7 +879,7 @@ def _runtime_window_targets(
         if not plan_targets:
             raise RuntimeError("runtime_window_target_plan_required_but_empty")
     plan_exclusive = bool(getattr(args, "runtime_window_target_plan_exclusive", False))
-    fallback_enabled = not (plan_exclusive and plan_targets)
+    fallback_enabled = not plan_exclusive
     autoresearch_targets = (
         _latest_autoresearch_runtime_window_targets(args) if fallback_enabled else []
     )
@@ -890,6 +892,8 @@ def _runtime_window_targets(
         and not autoresearch_targets
         and not registry_targets
     ):
+        if plan_exclusive:
+            return []
         specs = [""]
     targets: list[RuntimeWindowImportTarget] = []
     for spec in specs:

--- a/services/torghut/tests/test_decisions.py
+++ b/services/torghut/tests/test_decisions.py
@@ -2438,8 +2438,8 @@ class TestDecisionEngine(TestCase):
                 "vwap_w5m": 100,
                 "session_minutes_elapsed": 120,
                 "cross_section_continuation_breadth": 0.5,
-                "cross_section_session_open_rank": 1,
-                "cross_section_vwap_w5m_rank": 1,
+                "cross_section_session_open_rank": 0.5,
+                "cross_section_vwap_w5m_rank": 0.5,
             },
         )
 
@@ -2541,8 +2541,8 @@ class TestDecisionEngine(TestCase):
                 "vwap_w5m": 100,
                 "session_minutes_elapsed": 120,
                 "cross_section_continuation_breadth": 0.5,
-                "cross_section_session_open_rank": 0,
-                "cross_section_vwap_w5m_rank": 0,
+                "cross_section_session_open_rank": 0.5,
+                "cross_section_vwap_w5m_rank": 0.5,
             },
         )
 

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -892,7 +892,22 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--runtime-window-target-plan-settlement-seconds 3600", args)
         self.assertIn("--runtime-window-targets-from-latest-autoresearch", args)
         self.assertIn("--runtime-window-targets-from-registry", args)
-        self.assertIn("--runtime-window-hypothesis-id H-TSMOM-01", args)
+        self.assertIn(
+            "--strategy-spec-ref microbar_cross_sectional_pairs_v1@research", args
+        )
+        self.assertIn("--runtime-window-hypothesis-id H-PAIRS-01", args)
+        self.assertIn("--runtime-window-candidate-id c88421d619759b2cfaa6f4d0", args)
+        self.assertIn(
+            "--runtime-window-strategy-family microbar_cross_sectional_pairs", args
+        )
+        self.assertIn(
+            "--runtime-window-strategy-name microbar-cross-sectional-pairs-v1", args
+        )
+        self.assertIn(
+            "--runtime-window-source-manifest-ref config/trading/hypotheses/h-pairs-01.json",
+            args,
+        )
+        self.assertNotIn("--runtime-window-hypothesis-id H-TSMOM-01", args)
         self.assertNotIn("--runtime-window-target hypothesis_id=", args)
         self.assertIn("--runtime-window-account-label TORGHUT_SIM", args)
         self.assertIn("--runtime-window-observed-stage paper", args)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -618,7 +618,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual([target.hypothesis_id for target in targets], ["H-PAIRS-01"])
         self.assertEqual(targets[0].candidate_id, "cand-plan")
 
-    def test_runtime_window_target_plan_exclusive_allows_fallback_when_plan_empty(
+    def test_runtime_window_target_plan_exclusive_blocks_fallback_when_plan_empty(
         self,
     ) -> None:
         plan_path = Path(self.tmp_dir) / "candidate-board.json"
@@ -665,13 +665,11 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             renewal,
             "_latest_autoresearch_runtime_window_targets",
             return_value=[fallback_target],
-        ):
+        ) as latest_autoresearch:
             targets = renewal._runtime_window_targets(args)
 
-        self.assertEqual(
-            [target.hypothesis_id for target in targets],
-            ["H-FALLBACK-01"],
-        )
+        latest_autoresearch.assert_not_called()
+        self.assertEqual(targets, [])
 
     def test_runtime_window_target_plan_required_fails_closed_when_plan_empty(
         self,

--- a/services/torghut/tests/test_strategy_runtime.py
+++ b/services/torghut/tests/test_strategy_runtime.py
@@ -5996,6 +5996,7 @@ class TestStrategyRuntimeMicrobarCoverage(TestCase):
                 {
                     "session_minutes_elapsed": 120,
                     "cross_section_vwap_w5m_rank": Decimal("1"),
+                    "runtime_position_qty": Decimal("10"),
                 }
             ),
         )
@@ -6010,6 +6011,7 @@ class TestStrategyRuntimeMicrobarCoverage(TestCase):
                 {
                     "session_minutes_elapsed": 120,
                     "cross_section_vwap_w5m_rank": Decimal("0"),
+                    "runtime_position_qty": Decimal("-10"),
                 }
             ),
         )
@@ -6023,6 +6025,109 @@ class TestStrategyRuntimeMicrobarCoverage(TestCase):
         self.assertIn(
             "microbar_cross_sectional_pair_exit",
             high_rank_exit.intent.rationale,
+        )
+        self.assertIn("exit_basis:runtime_position", high_rank_exit.intent.rationale)
+
+    def test_microbar_cross_sectional_pairs_plugin_exits_by_position_after_rank_drift(
+        self,
+    ) -> None:
+        plugin = MicrobarCrossSectionalPairsPlugin()
+        params = {
+            "entry_minute_after_open": "60",
+            "exit_minute_after_open": "120",
+            "signal_motif": "vwap_close_continuation",
+            "rank_feature": "cross_section_vwap_w5m_rank",
+            "selection_mode": "continuation",
+            "top_n": "2",
+            "max_pair_legs": "2",
+        }
+
+        long_exit = plugin.evaluate(
+            self._context(
+                params=params, strategy_type="microbar_cross_sectional_pairs_v1"
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 120,
+                    "cross_section_vwap_w5m_rank": Decimal("0.5"),
+                    "runtime_position_qty": Decimal("3"),
+                }
+            ),
+        )
+        short_exit = plugin.evaluate(
+            self._context(
+                params=params, strategy_type="microbar_cross_sectional_pairs_v1"
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 120,
+                    "cross_section_vwap_w5m_rank": Decimal("0.5"),
+                    "runtime_position_qty": Decimal("-2"),
+                }
+            ),
+        )
+
+        self.assertIsNotNone(long_exit.intent)
+        self.assertIsNotNone(short_exit.intent)
+        assert long_exit.intent is not None
+        assert short_exit.intent is not None
+        self.assertEqual(long_exit.intent.action, "sell")
+        self.assertEqual(short_exit.intent.action, "buy")
+        self.assertIn("position_side:long", long_exit.intent.rationale)
+        self.assertIn("position_side:short", short_exit.intent.rationale)
+        assert long_exit.trace is not None
+        self.assertEqual(long_exit.trace.gates[0].gate, "pair_position_exit")
+
+    def test_microbar_cross_sectional_pairs_plugin_fails_closed_without_exit_position(
+        self,
+    ) -> None:
+        plugin = MicrobarCrossSectionalPairsPlugin()
+        params = {
+            "entry_minute_after_open": "60",
+            "exit_minute_after_open": "120",
+            "signal_motif": "vwap_close_continuation",
+            "rank_feature": "cross_section_vwap_w5m_rank",
+            "selection_mode": "continuation",
+            "max_pair_legs": "2",
+        }
+
+        missing_position = plugin.evaluate(
+            self._context(
+                params=params, strategy_type="microbar_cross_sectional_pairs_v1"
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 120,
+                    "cross_section_vwap_w5m_rank": Decimal("1"),
+                }
+            ),
+        )
+        flat_position = plugin.evaluate(
+            self._context(
+                params=params, strategy_type="microbar_cross_sectional_pairs_v1"
+            ),
+            _test_feature_vector(
+                {
+                    "session_minutes_elapsed": 120,
+                    "cross_section_vwap_w5m_rank": Decimal("1"),
+                    "runtime_position_qty": Decimal("0"),
+                }
+            ),
+        )
+
+        self.assertIsNone(missing_position.intent)
+        self.assertIsNone(flat_position.intent)
+        assert missing_position.trace is not None
+        assert flat_position.trace is not None
+        self.assertEqual(missing_position.trace.first_failed_gate, "pair_position_exit")
+        self.assertEqual(flat_position.trace.first_failed_gate, "pair_position_exit")
+        self.assertEqual(
+            missing_position.trace.gates[0].context["reason"],
+            "missing_runtime_position_qty",
+        )
+        self.assertEqual(
+            flat_position.trace.gates[0].context["reason"],
+            "flat_runtime_position",
         )
 
     def test_microbar_cross_sectional_pairs_plugin_respects_max_pair_legs(


### PR DESCRIPTION
## Summary

- Aligns the empirical promotion renewal CronJob and fallback defaults to the active H-PAIRS candidate instead of the stale H-TSMOM fallback.
- Makes microbar cross-sectional pair exits close from real runtime position side, so rank drift at exit time no longer leaves legs open.
- Fails closed when pair exits lack runtime position state and prevents exclusive target-plan mode from falling back to autoresearch or registry targets when the plan is empty.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_strategy_runtime.py tests/test_decisions.py -k 'microbar_cross_sectional_pairs or microbar_pairs_signal_exit' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_strategy_runtime.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/decisions.py app/trading/strategy_runtime.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_strategy_runtime.py tests/test_decisions.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/decisions.py app/trading/strategy_runtime.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_strategy_runtime.py tests/test_decisions.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && git diff --check`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
