### PR TITLE
fix(torghut): require event-sourced ledger lifecycle

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -690,9 +690,12 @@ def _runtime_ledger_tca_materialization_metadata(
             source_materializations.append(source_materialization)
         if (
             authority_reason == "source_execution_runtime_ledger_materialized"
+            or authority_reason == "event_sourced_runtime_ledger_profit_proof"
             or pnl_derivation
             == "source_execution_lifecycle_materialized_runtime_ledger"
+            or pnl_derivation == "execution_order_events_runtime_ledger"
             or source_materialization == "source_execution_lifecycle"
+            or source_materialization == "execution_order_events"
         ):
             source_execution_materialized_count += 1
         if authority_reason == "execution_reconstruction_not_runtime_ledger_proof":
@@ -816,13 +819,122 @@ def _runtime_execution_cost_basis(
     return None
 
 
+def _runtime_lifecycle_ledger_row(
+    row: Mapping[str, object],
+    *,
+    event_type: str,
+) -> dict[str, object] | None:
+    event_time = _runtime_ledger_row_time(
+        {str(key): value for key, value in row.items()}
+    )
+    if event_time is None:
+        return None
+    symbol = _first_text(row, "symbol", "order_symbol")
+    return {
+        "executed_at": event_time,
+        "event_type": event_type,
+        "account_label": _first_text(row, "account_label", "alpaca_account_label"),
+        "strategy_id": _first_text(row, "strategy_id", "strategy_name"),
+        "symbol": symbol.strip().upper() if symbol is not None else None,
+        "decision_id": _first_text(
+            row,
+            "decision_id",
+            "trade_decision_id",
+            "decision_hash",
+        ),
+        "order_id": _first_text(
+            row,
+            "order_id",
+            "alpaca_order_id",
+            "client_order_id",
+            "execution_correlation_id",
+        ),
+        "execution_policy_hash": _first_text(
+            row,
+            "execution_policy_hash",
+            "execution_policy_sha256",
+            "policy_hash",
+            "execution_idempotency_key",
+        )
+        or _first_payload_digest(
+            row,
+            "execution_policy",
+            "execution_policy_context",
+            "execution_advisor",
+            "_execution_advice_provenance",
+            "decision_json",
+            "raw_event",
+        ),
+        "cost_model_hash": _first_text(
+            row,
+            "cost_model_hash",
+            "fee_model_hash",
+            "cost_model_sha256",
+        )
+        or _first_payload_digest(
+            row,
+            "cost_model",
+            "cost_model_config",
+            "transaction_cost_model",
+            "fee_model",
+            "fees_model",
+            "model",
+            "decision_json",
+            "raw_event",
+        ),
+        "lineage_hash": _first_text(
+            row,
+            "lineage_hash",
+            "candidate_lineage_hash",
+            "replay_lineage_hash",
+            "candidate_evaluation_key",
+            "event_fingerprint",
+        )
+        or _first_lineage_digest(row),
+        "replay_data_hash": _first_text(
+            row,
+            "replay_data_hash",
+            "replay_tape_content_sha256",
+            "dataset_snapshot_hash",
+            "source_query_digest",
+            "source_offset",
+        ),
+    }
+
+
 def _build_realized_strategy_pnl_rows(
     execution_rows: list[dict[str, object]],
     *,
+    decision_lifecycle_rows: list[dict[str, object]] | None = None,
+    order_lifecycle_rows: list[dict[str, object]] | None = None,
     allow_authoritative_runtime_ledger_materialization: bool = False,
 ) -> list[dict[str, object]]:
     ledger_rows: list[RuntimeLedgerFill | dict[str, object]] = []
     event_times: list[datetime] = []
+    event_sourced_lifecycle_rows = 0
+    for row in decision_lifecycle_rows or []:
+        lifecycle_row = _runtime_lifecycle_ledger_row(row, event_type="decision")
+        if lifecycle_row is None:
+            continue
+        ledger_rows.append(lifecycle_row)
+        event_sourced_lifecycle_rows += 1
+        event_time = lifecycle_row.get("executed_at")
+        if isinstance(event_time, datetime):
+            event_times.append(event_time)
+    for row in order_lifecycle_rows or []:
+        event_type = _runtime_ledger_event_type(
+            {str(key): value for key, value in row.items()}
+        )
+        if event_type in _RUNTIME_LEDGER_FILL_EVENTS:
+            continue
+        lifecycle_row = _runtime_lifecycle_ledger_row(row, event_type=event_type)
+        if lifecycle_row is None:
+            continue
+        ledger_rows.append(lifecycle_row)
+        event_sourced_lifecycle_rows += 1
+        event_time = lifecycle_row.get("executed_at")
+        if isinstance(event_time, datetime):
+            event_times.append(event_time)
     for row in execution_rows:
         computed_at = row.get("computed_at")
         execution_created_at = row.get("execution_created_at")
@@ -915,12 +1027,6 @@ def _build_realized_strategy_pnl_rows(
                 "source_query_digest",
             ),
         }
-        if decision_id is not None:
-            ledger_rows.append({**common_ledger_fields, "event_type": "decision"})
-        if order_id is not None:
-            ledger_rows.append(
-                {**common_ledger_fields, "event_type": "order_submitted"}
-            )
         if price is None or price <= 0 or signed_qty == 0:
             continue
         filled_qty = abs(signed_qty)
@@ -975,28 +1081,23 @@ def _build_realized_strategy_pnl_rows(
             computed_at=unique_times[-1],
         )
         bucket_payload = row.get("runtime_ledger_bucket")
-        source_execution_materialized = (
+        event_sourced_runtime_ledger = (
             allow_authoritative_runtime_ledger_materialization
+            and event_sourced_lifecycle_rows > 0
             and isinstance(bucket_payload, Mapping)
             and _runtime_ledger_bucket_profit_proof_present(bucket_payload)
         )
-        if source_execution_materialized:
+        if event_sourced_runtime_ledger:
             row["authoritative"] = True
-            row["authority_reason"] = "source_execution_runtime_ledger_materialized"
-            row["pnl_derivation"] = (
-                "source_execution_lifecycle_materialized_runtime_ledger"
-            )
+            row["authority_reason"] = "event_sourced_runtime_ledger_profit_proof"
+            row["pnl_derivation"] = "execution_order_events_runtime_ledger"
             if isinstance(bucket_payload, Mapping):
                 row["runtime_ledger_bucket"] = {
                     **dict(bucket_payload),
                     "authoritative": True,
-                    "authority_reason": (
-                        "source_execution_runtime_ledger_materialized"
-                    ),
-                    "pnl_derivation": (
-                        "source_execution_lifecycle_materialized_runtime_ledger"
-                    ),
-                    "source_materialization": "source_execution_lifecycle",
+                    "authority_reason": "event_sourced_runtime_ledger_profit_proof",
+                    "pnl_derivation": "execution_order_events_runtime_ledger",
+                    "source_materialization": "execution_order_events",
                 }
         else:
             row["post_cost_expectancy_basis"] = POST_COST_BASIS_EXECUTION_RECONSTRUCTION
@@ -1654,6 +1755,8 @@ def _query_timestamps(
     executions: list[datetime] = []
     tca_rows: list[dict[str, object]] = []
     execution_rows: list[dict[str, object]] = []
+    decision_lifecycle_rows: list[dict[str, object]] = []
+    order_lifecycle_rows: list[dict[str, object]] = []
     symbol_filter = _metadata_symbol_list(symbols or ())
     decision_symbol_clause = (
         "\n                  and upper(d.symbol) = any(%s)" if symbol_filter else ""
@@ -1664,17 +1767,32 @@ def _query_timestamps(
         if symbol_filter
         else ""
     )
+    order_event_symbol_clause = (
+        "\n                  and upper(d.symbol) = any(%s)"
+        "\n                  and upper(coalesce(oe.symbol, e.symbol, d.symbol)) = any(%s)"
+        if symbol_filter
+        else ""
+    )
     decision_symbol_params: tuple[object, ...] = (
         (symbol_filter,) if symbol_filter else ()
     )
     execution_symbol_params: tuple[object, ...] = (
         (symbol_filter, symbol_filter) if symbol_filter else ()
     )
+    order_event_symbol_params: tuple[object, ...] = (
+        (symbol_filter, symbol_filter) if symbol_filter else ()
+    )
     with psycopg.connect(dsn) as conn:
         with conn.cursor() as cur:
             cur.execute(
                 f"""
-                select d.created_at
+                select
+                    d.created_at,
+                    d.symbol,
+                    d.alpaca_account_label,
+                    s.name,
+                    d.decision_hash,
+                    d.decision_json
                 from trade_decisions d
                 join strategies s on s.id = d.strategy_id
                 where s.name = any(%s)
@@ -1694,7 +1812,24 @@ def _query_timestamps(
                     *decision_symbol_params,
                 ),
             )
-            decisions = [row[0] for row in cur.fetchall() if row[0] is not None]
+            decision_lifecycle_rows = [
+                {
+                    "computed_at": row[0],
+                    "event_type": "decision",
+                    "symbol": row[1],
+                    "account_label": row[2],
+                    "strategy_id": row[3],
+                    "decision_hash": row[4],
+                    "decision_json": row[5],
+                }
+                for row in cur.fetchall()
+                if row[0] is not None
+            ]
+            decisions = []
+            for row in decision_lifecycle_rows:
+                computed_at = row.get("computed_at")
+                if isinstance(computed_at, datetime):
+                    decisions.append(computed_at)
             cur.execute(
                 f"""
                 select
@@ -1763,6 +1898,65 @@ def _query_timestamps(
             cur.execute(
                 f"""
                 select
+                    coalesce(oe.event_ts, oe.created_at),
+                    oe.symbol,
+                    oe.alpaca_account_label,
+                    s.name,
+                    d.decision_hash,
+                    d.decision_json,
+                    oe.alpaca_order_id,
+                    oe.client_order_id,
+                    oe.event_type,
+                    oe.status,
+                    oe.event_fingerprint,
+                    oe.source_topic,
+                    oe.source_partition,
+                    oe.source_offset,
+                    oe.raw_event
+                from execution_order_events oe
+                left join executions e on e.id = oe.execution_id
+                join trade_decisions d
+                  on d.id = coalesce(oe.trade_decision_id, e.trade_decision_id)
+                join strategies s on s.id = d.strategy_id
+                where s.name = any(%s)
+                  and d.alpaca_account_label = %s
+                  and d.created_at >= %s
+                  and d.created_at < %s
+                  {order_event_symbol_clause}
+                order by coalesce(oe.event_ts, oe.created_at), oe.created_at
+                """,
+                (
+                    strategy_names,
+                    account_label,
+                    window_start,
+                    window_end,
+                    *order_event_symbol_params,
+                ),
+            )
+            order_lifecycle_rows = [
+                {
+                    "event_ts": row[0],
+                    "symbol": row[1],
+                    "account_label": row[2],
+                    "strategy_id": row[3],
+                    "decision_hash": row[4],
+                    "decision_json": row[5],
+                    "alpaca_order_id": row[6],
+                    "client_order_id": row[7],
+                    "event_type": row[8],
+                    "order_status": row[9],
+                    "event_fingerprint": row[10],
+                    "source_topic": row[11],
+                    "source_partition": row[12],
+                    "source_offset": row[13],
+                    "raw_event": row[14],
+                }
+                for row in cur.fetchall()
+                if row[0] is not None
+            ]
+            cur.execute(
+                f"""
+                select
                     d.created_at,
                     abs(coalesce(t.realized_shortfall_bps, t.slippage_bps)) as abs_slippage_bps,
                     (-coalesce(t.realized_shortfall_bps, t.slippage_bps)) as post_cost_expectancy_bps
@@ -1799,6 +1993,8 @@ def _query_timestamps(
     tca_rows.extend(
         _build_realized_strategy_pnl_rows(
             execution_rows,
+            decision_lifecycle_rows=decision_lifecycle_rows,
+            order_lifecycle_rows=order_lifecycle_rows,
             allow_authoritative_runtime_ledger_materialization=(
                 allow_authoritative_runtime_ledger_materialization
             ),

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -55,7 +55,16 @@ class _FakeCursor:
     def __init__(self) -> None:
         self.executed: list[tuple[str, tuple[object, ...]]] = []
         self._results = [
-            [(datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),)],
+            [
+                (
+                    datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "AAPL",
+                    "TORGHUT_SIM",
+                    "intraday_tsmom_v1@paper",
+                    "decision-sha",
+                    {},
+                )
+            ],
             [
                 (
                     datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
@@ -77,6 +86,28 @@ class _FakeCursor:
                     "alpaca-order-1",
                     "client-order-1",
                     "filled",
+                )
+            ],
+            [
+                (
+                    datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+                    "AAPL",
+                    "TORGHUT_SIM",
+                    "intraday_tsmom_v1@paper",
+                    "decision-sha",
+                    {},
+                    "alpaca-order-1",
+                    "client-order-1",
+                    "new",
+                    "new",
+                    "event-fingerprint-1",
+                    "alpaca-trade-updates",
+                    0,
+                    1,
+                    {
+                        "execution_policy": {"selected_order_type": "market"},
+                        "cost_model": {"source": "broker_reported"},
+                    },
                 )
             ],
             [
@@ -1036,17 +1067,26 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             "execution_reconstruction_not_runtime_ledger_proof",
         )
         self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.70"))
-        self.assertEqual(
-            rows[0]["post_cost_expectancy_bps"],
-            Decimal("34.82587064676616915422885572"),
-        )
+        self.assertIsNone(rows[0]["post_cost_expectancy_bps"])
         self.assertEqual(rows[0]["authoritative"], False)
         self.assertEqual(
             rows[0]["authority_reason"],
             "execution_reconstruction_not_runtime_ledger_proof",
         )
+        self.assertIn(
+            "runtime_decision_lifecycle_missing",
+            rows[0]["runtime_ledger_blockers"],
+        )
+        self.assertIn(
+            "submitted_order_lifecycle_missing",
+            rows[0]["runtime_ledger_blockers"],
+        )
+        self.assertIn(
+            "fill_order_submission_missing",
+            rows[0]["runtime_ledger_blockers"],
+        )
 
-    def test_build_realized_strategy_pnl_rows_can_materialize_source_runtime_ledger(
+    def test_build_realized_strategy_pnl_rows_cannot_materialize_source_lifecycle(
         self,
     ) -> None:
         rows = _build_realized_strategy_pnl_rows(
@@ -1085,20 +1125,133 @@ class TestImportHypothesisRuntimeWindows(TestCase):
 
         self.assertEqual(len(rows), 1)
         self.assertEqual(
+            rows[0]["post_cost_expectancy_basis"],
+            POST_COST_BASIS_EXECUTION_RECONSTRUCTION,
+        )
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
+        self.assertEqual(rows[0]["authoritative"], False)
+        self.assertEqual(
+            rows[0]["authority_reason"],
+            "execution_reconstruction_not_runtime_ledger_proof",
+        )
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["pnl_basis"], POST_COST_BASIS_EXECUTION_RECONSTRUCTION)
+        self.assertEqual(bucket["authoritative"], False)
+        self.assertNotIn("source_materialization", bucket)
+        self.assertIn("runtime_decision_lifecycle_missing", bucket["blockers"])
+        self.assertIn("submitted_order_lifecycle_missing", bucket["blockers"])
+        self.assertIn("fill_order_submission_missing", bucket["blockers"])
+        self.assertIn(
+            "execution_reconstruction_not_runtime_ledger_proof",
+            bucket["blockers"],
+        )
+        self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
+
+    def test_build_realized_strategy_pnl_rows_authorizes_event_sourced_lifecycle(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            decision_lifecycle_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 34, tzinfo=timezone.utc),
+                    "event_type": "decision",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 39, tzinfo=timezone.utc),
+                    "event_type": "decision",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            order_lifecycle_rows=[
+                {
+                    "event_ts": datetime(2026, 3, 6, 14, 34, 1, tzinfo=timezone.utc),
+                    "event_type": "new",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "event_ts": datetime(2026, 3, 6, 14, 39, 1, tzinfo=timezone.utc),
+                    "event_type": "new",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(
             rows[0]["post_cost_expectancy_basis"], POST_COST_BASIS_RUNTIME_LEDGER
         )
         self.assertEqual(rows[0]["post_cost_promotion_eligible"], True)
         self.assertEqual(rows[0]["authoritative"], True)
         self.assertEqual(
             rows[0]["authority_reason"],
-            "source_execution_runtime_ledger_materialized",
+            "event_sourced_runtime_ledger_profit_proof",
         )
         bucket = rows[0]["runtime_ledger_bucket"]
         self.assertIsInstance(bucket, dict)
         assert isinstance(bucket, dict)
         self.assertEqual(bucket["blockers"], [])
         self.assertEqual(bucket["pnl_basis"], POST_COST_BASIS_RUNTIME_LEDGER)
-        self.assertEqual(bucket["source_materialization"], "source_execution_lifecycle")
+        self.assertEqual(bucket["source_materialization"], "execution_order_events")
         self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
 
     def test_runtime_ledger_tca_materialization_metadata_separates_authority(
@@ -1215,9 +1368,12 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         bucket = rows[0]["runtime_ledger_bucket"]
         self.assertIsInstance(bucket, dict)
         assert isinstance(bucket, dict)
-        self.assertEqual(
+        self.assertIn("runtime_decision_lifecycle_missing", bucket["blockers"])
+        self.assertIn("submitted_order_lifecycle_missing", bucket["blockers"])
+        self.assertIn("fill_order_submission_missing", bucket["blockers"])
+        self.assertIn(
+            "execution_reconstruction_not_runtime_ledger_proof",
             bucket["blockers"],
-            ["execution_reconstruction_not_runtime_ledger_proof"],
         )
         self.assertEqual(bucket["pnl_basis"], POST_COST_BASIS_EXECUTION_RECONSTRUCTION)
         self.assertEqual(bucket["authoritative"], False)
@@ -1281,10 +1437,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
 
         self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0]["authoritative"], True)
+        self.assertEqual(rows[0]["authoritative"], False)
         self.assertEqual(
             rows[0]["authority_reason"],
-            "source_execution_runtime_ledger_materialized",
+            "execution_reconstruction_not_runtime_ledger_proof",
         )
         self.assertEqual(
             rows[0]["computed_at"], datetime(2026, 3, 6, 15, 55, tzinfo=timezone.utc)
@@ -1298,8 +1454,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertNotIn("runtime_fills_missing", bucket["blockers"])
         self.assertNotIn("filled_notional_missing", bucket["blockers"])
         self.assertNotIn("explicit_cost_missing", bucket["blockers"])
-        self.assertEqual(bucket["blockers"], [])
-        self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
+        self.assertIn("runtime_decision_lifecycle_missing", bucket["blockers"])
+        self.assertIn("submitted_order_lifecycle_missing", bucket["blockers"])
+        self.assertIn("fill_order_submission_missing", bucket["blockers"])
+        self.assertIn(
+            "execution_reconstruction_not_runtime_ledger_proof",
+            bucket["blockers"],
+        )
+        self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
 
     def test_build_realized_strategy_pnl_rows_materializes_audit_only_runtime_metadata(
         self,
@@ -1365,16 +1527,22 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
 
         self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0]["authoritative"], True)
+        self.assertEqual(rows[0]["authoritative"], False)
         self.assertEqual(
             rows[0]["authority_reason"],
-            "source_execution_runtime_ledger_materialized",
+            "execution_reconstruction_not_runtime_ledger_proof",
         )
         bucket = rows[0]["runtime_ledger_bucket"]
         self.assertIsInstance(bucket, dict)
         assert isinstance(bucket, dict)
-        self.assertEqual(bucket["blockers"], [])
-        self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
+        self.assertIn("runtime_decision_lifecycle_missing", bucket["blockers"])
+        self.assertIn("submitted_order_lifecycle_missing", bucket["blockers"])
+        self.assertIn("fill_order_submission_missing", bucket["blockers"])
+        self.assertIn(
+            "execution_reconstruction_not_runtime_ledger_proof",
+            bucket["blockers"],
+        )
+        self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
 
     def test_build_realized_strategy_pnl_rows_uses_decision_impact_cost_model(
         self,
@@ -1419,18 +1587,24 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
 
         self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0]["authoritative"], True)
+        self.assertEqual(rows[0]["authoritative"], False)
         bucket = rows[0]["runtime_ledger_bucket"]
         self.assertIsInstance(bucket, dict)
         assert isinstance(bucket, dict)
-        self.assertEqual(bucket["blockers"], [])
+        self.assertIn("runtime_decision_lifecycle_missing", bucket["blockers"])
+        self.assertIn("submitted_order_lifecycle_missing", bucket["blockers"])
+        self.assertIn("fill_order_submission_missing", bucket["blockers"])
+        self.assertIn(
+            "execution_reconstruction_not_runtime_ledger_proof",
+            bucket["blockers"],
+        )
         self.assertEqual(
             bucket["cost_basis_counts"],
             {"decision_impact_assumptions_total_cost_bps": 2},
         )
         self.assertEqual(bucket["cost_amount"], "0.201")
         self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.799"))
-        self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
+        self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
 
     def test_runtime_ledger_tca_row_separates_explicit_cost_from_slippage(
         self,
@@ -1554,7 +1728,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(tca_rows[0]["post_cost_promotion_eligible"], False)
         self.assertEqual(tca_rows[1]["post_cost_promotion_eligible"], False)
         self.assertIn("unclosed_position", tca_rows[1]["runtime_ledger_blockers"])
-        self.assertEqual(len(cursor.executed), 3)
+        self.assertEqual(len(cursor.executed), 4)
         decision_query, decision_params = cursor.executed[0]
         self.assertIn("s.name = any(%s)", decision_query)
         self.assertIn("d.status = any(%s)", decision_query)
@@ -1566,12 +1740,16 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             decision_params[2],
             list(EXECUTION_ELIGIBLE_DECISION_STATUSES),
         )
-        tca_query, _ = cursor.executed[2]
+        order_event_query, _ = cursor.executed[2]
+        tca_query, _ = cursor.executed[3]
         execution_query, _ = cursor.executed[1]
         self.assertIn("left join execution_tca_metrics", execution_query)
         self.assertIn("d.created_at >= %s", execution_query)
         self.assertIn("d.created_at < %s", execution_query)
         self.assertNotIn("e.created_at >= %s", execution_query)
+        self.assertIn("from execution_order_events oe", order_event_query)
+        self.assertIn("d.created_at >= %s", order_event_query)
+        self.assertIn("d.created_at < %s", order_event_query)
         self.assertIn("select\n                    d.created_at", tca_query)
         self.assertIn("d.created_at >= %s", tca_query)
         self.assertIn("d.created_at < %s", tca_query)
@@ -1599,15 +1777,22 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 symbols=[" aapl ", "AAPL"],
             )
 
-        self.assertEqual(len(cursor.executed), 3)
+        self.assertEqual(len(cursor.executed), 4)
         decision_query, decision_params = cursor.executed[0]
         execution_query, execution_params = cursor.executed[1]
-        tca_query, tca_params = cursor.executed[2]
+        order_event_query, order_event_params = cursor.executed[2]
+        tca_query, tca_params = cursor.executed[3]
         self.assertIn("upper(d.symbol) = any(%s)", decision_query)
         self.assertEqual(decision_params[-1], ["AAPL"])
         self.assertIn("upper(d.symbol) = any(%s)", execution_query)
         self.assertIn("upper(e.symbol) = any(%s)", execution_query)
         self.assertEqual(execution_params[-2:], (["AAPL"], ["AAPL"]))
+        self.assertIn("upper(d.symbol) = any(%s)", order_event_query)
+        self.assertIn(
+            "upper(coalesce(oe.symbol, e.symbol, d.symbol)) = any(%s)",
+            order_event_query,
+        )
+        self.assertEqual(order_event_params[-2:], (["AAPL"], ["AAPL"]))
         self.assertIn("upper(d.symbol) = any(%s)", tca_query)
         self.assertIn("upper(e.symbol) = any(%s)", tca_query)
         self.assertEqual(tca_params[-2:], (["AAPL"], ["AAPL"]))


### PR DESCRIPTION
## Summary

- Stops reconstructed execution rows from fabricating decision/order lifecycle proof for runtime-ledger authority.
- Adds linked `trade_decisions` and `execution_order_events` rows into runtime-window import ledger construction.
- Allows authoritative source-execution runtime-ledger materialization only when real event-sourced lifecycle rows and costed closed fills satisfy the runtime-ledger proof contract.
- Updates importer tests to cover both fail-closed reconstruction and the event-sourced authority path.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
