### PR TITLE
fix(torghut): require scoped runtime materialization proof

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -105,7 +105,7 @@ spec:
             - name: TRADING_SIMPLE_SUBMIT_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED
-              value: "false"
+              value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
@@ -217,9 +217,11 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TRADING_ORDER_FEED_TOPIC
-              value: torghut.sim.trade-updates.v1
+              value: torghut.trade-updates.v1
             - name: TRADING_ORDER_FEED_GROUP_ID
               value: torghut-order-feed-sim-default
+            - name: TRADING_ORDER_FEED_AUTO_OFFSET_RESET
+              value: earliest
             - name: TRADING_ORDER_FEED_TOPIC_V2
               value: ""
             - name: TRADING_SIMULATION_ORDER_UPDATES_TOPIC

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -211,6 +211,25 @@ def _hash_count(value: Any) -> int:
     return sum(1 for key in mapping.keys() if str(key).strip())
 
 
+def _persisted_runtime_ledger_bucket_evidence_grade(
+    row: StrategyRuntimeLedgerBucket,
+) -> bool:
+    blockers = _string_list(row.blockers_json)
+    return (
+        row.pnl_basis == POST_COST_PNL_BASIS
+        and int(row.fill_count or 0) > 0
+        and int(row.submitted_order_count or 0) > 0
+        and int(row.closed_trade_count or 0) > 0
+        and int(row.open_position_count or 0) == 0
+        and row.filled_notional > 0
+        and row.post_cost_expectancy_bps is not None
+        and _hash_count(row.execution_policy_hash_counts) > 0
+        and _hash_count(row.cost_model_hash_counts) > 0
+        and _hash_count(row.lineage_hash_counts) > 0
+        and not blockers
+    )
+
+
 def _runtime_ledger_bucket_blockers(bucket: Mapping[str, Any]) -> list[str]:
     blockers = _string_list(bucket.get("blockers"))
     ledger_schema_version = _text(bucket.get("ledger_schema_version"))
@@ -1437,7 +1456,7 @@ def persist_observed_runtime_windows(
         window_end=import_window_end,
     )
     proof_status = "blocked" if proof_blockers else "ok"
-    runtime_materialization_target = {
+    runtime_materialization_target: dict[str, Any] = {
         "candidate_id": candidate_id,
         "hypothesis_id": hypothesis_id,
         "observed_stage": observed_stage,
@@ -1458,6 +1477,8 @@ def persist_observed_runtime_windows(
         "proof_status": proof_status,
         "proof_blockers": proof_blockers,
     }
+    metric_window_rows: list[StrategyHypothesisMetricWindow] = []
+    runtime_ledger_rows: list[StrategyRuntimeLedgerBucket] = []
     running_session_samples = 0
     for bucket in sorted_buckets:
         running_session_samples += bucket.market_session_count
@@ -1467,35 +1488,35 @@ def persist_observed_runtime_windows(
             session_samples=running_session_samples,
             manifest=manifest,
         )
-        session.add(
-            StrategyHypothesisMetricWindow(
-                run_id=run_id,
-                candidate_id=candidate_id,
-                hypothesis_id=hypothesis_id,
-                observed_stage=observed_stage,
-                window_started_at=bucket.window_started_at,
-                window_ended_at=bucket.window_ended_at,
-                market_session_count=bucket.market_session_count,
-                decision_count=bucket.decision_count,
-                trade_count=bucket.trade_count,
-                order_count=bucket.order_count,
-                evidence_provenance=evidence_provenance,
-                evidence_maturity="empirically_validated",
-                decision_alignment_ratio=str(bucket.decision_alignment_ratio),
-                avg_abs_slippage_bps=str(bucket.avg_abs_slippage_bps),
-                slippage_budget_bps=str(budget),
-                post_cost_expectancy_bps=str(bucket.post_cost_expectancy_bps),
-                continuity_ok=bucket.continuity_ok,
-                drift_ok=bucket.drift_ok,
-                dependency_quorum_decision=bucket.dependency_quorum_decision,
-                capital_stage=capital_stage,
-                payload_json={
-                    **bucket.payload_json,
-                    "source_manifest_ref": source_manifest_ref or registry.path,
-                    "runtime_observation": runtime_payload,
-                },
-            )
+        metric_window_row = StrategyHypothesisMetricWindow(
+            run_id=run_id,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+            observed_stage=observed_stage,
+            window_started_at=bucket.window_started_at,
+            window_ended_at=bucket.window_ended_at,
+            market_session_count=bucket.market_session_count,
+            decision_count=bucket.decision_count,
+            trade_count=bucket.trade_count,
+            order_count=bucket.order_count,
+            evidence_provenance=evidence_provenance,
+            evidence_maturity="empirically_validated",
+            decision_alignment_ratio=str(bucket.decision_alignment_ratio),
+            avg_abs_slippage_bps=str(bucket.avg_abs_slippage_bps),
+            slippage_budget_bps=str(budget),
+            post_cost_expectancy_bps=str(bucket.post_cost_expectancy_bps),
+            continuity_ok=bucket.continuity_ok,
+            drift_ok=bucket.drift_ok,
+            dependency_quorum_decision=bucket.dependency_quorum_decision,
+            capital_stage=capital_stage,
+            payload_json={
+                **bucket.payload_json,
+                "source_manifest_ref": source_manifest_ref or registry.path,
+                "runtime_observation": runtime_payload,
+            },
         )
+        session.add(metric_window_row)
+        metric_window_rows.append(metric_window_row)
         for ledger_payload in _runtime_ledger_bucket_payloads(bucket.payload_json):
             bucket_started_at = (
                 _parse_observation_datetime(ledger_payload.get("bucket_started_at"))
@@ -1505,78 +1526,72 @@ def persist_observed_runtime_windows(
                 _parse_observation_datetime(ledger_payload.get("bucket_ended_at"))
                 or bucket.window_ended_at
             )
-            session.add(
-                StrategyRuntimeLedgerBucket(
-                    run_id=run_id,
-                    candidate_id=candidate_id,
-                    hypothesis_id=hypothesis_id,
-                    observed_stage=observed_stage,
-                    bucket_started_at=bucket_started_at,
-                    bucket_ended_at=bucket_ended_at,
-                    account_label=_text(ledger_payload.get("account_label"))
-                    or _text(runtime_payload.get("account_label")),
-                    runtime_strategy_name=_text(ledger_payload.get("strategy_id"))
-                    or _text(runtime_payload.get("strategy_name")),
-                    strategy_family=manifest.strategy_family,
-                    fill_count=_observation_int(ledger_payload.get("fill_count")),
-                    decision_count=_observation_int(
-                        ledger_payload.get("decision_count")
-                    ),
-                    submitted_order_count=_observation_int(
-                        ledger_payload.get("submitted_order_count")
-                    ),
-                    cancelled_order_count=_observation_int(
-                        ledger_payload.get("cancelled_order_count")
-                    ),
-                    rejected_order_count=_observation_int(
-                        ledger_payload.get("rejected_order_count")
-                    ),
-                    unfilled_order_count=_observation_int(
-                        ledger_payload.get("unfilled_order_count")
-                    ),
-                    closed_trade_count=_observation_int(
-                        ledger_payload.get("closed_trade_count")
-                    ),
-                    open_position_count=_observation_int(
-                        ledger_payload.get("open_position_count")
-                    ),
-                    filled_notional=_observation_decimal(
-                        ledger_payload.get("filled_notional")
-                    ),
-                    gross_strategy_pnl=_observation_decimal(
-                        ledger_payload.get("gross_strategy_pnl")
-                    ),
-                    cost_amount=_observation_decimal(ledger_payload.get("cost_amount")),
-                    net_strategy_pnl_after_costs=_observation_decimal(
-                        ledger_payload.get("net_strategy_pnl_after_costs")
-                    ),
-                    post_cost_expectancy_bps=_optional_decimal(
-                        ledger_payload.get("post_cost_expectancy_bps")
-                    ),
-                    ledger_schema_version=_text(
-                        ledger_payload.get("ledger_schema_version")
-                    )
-                    or "unknown",
-                    pnl_basis=_text(ledger_payload.get("pnl_basis")) or "unknown",
-                    execution_policy_hash_counts=_mapping(
-                        ledger_payload.get("execution_policy_hash_counts")
-                    )
-                    or None,
-                    cost_model_hash_counts=_mapping(
-                        ledger_payload.get("cost_model_hash_counts")
-                    )
-                    or None,
-                    lineage_hash_counts=_mapping(
-                        ledger_payload.get("lineage_hash_counts")
-                    )
-                    or None,
-                    blockers_json=_string_list(ledger_payload.get("blockers")),
-                    payload_json={
-                        **ledger_payload,
-                        "runtime_ledger_daily_summary": runtime_ledger_daily_summary,
-                    },
+            runtime_ledger_row = StrategyRuntimeLedgerBucket(
+                run_id=run_id,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+                observed_stage=observed_stage,
+                bucket_started_at=bucket_started_at,
+                bucket_ended_at=bucket_ended_at,
+                account_label=_text(ledger_payload.get("account_label"))
+                or _text(runtime_payload.get("account_label")),
+                runtime_strategy_name=_text(ledger_payload.get("strategy_id"))
+                or _text(runtime_payload.get("strategy_name")),
+                strategy_family=manifest.strategy_family,
+                fill_count=_observation_int(ledger_payload.get("fill_count")),
+                decision_count=_observation_int(ledger_payload.get("decision_count")),
+                submitted_order_count=_observation_int(
+                    ledger_payload.get("submitted_order_count")
+                ),
+                cancelled_order_count=_observation_int(
+                    ledger_payload.get("cancelled_order_count")
+                ),
+                rejected_order_count=_observation_int(
+                    ledger_payload.get("rejected_order_count")
+                ),
+                unfilled_order_count=_observation_int(
+                    ledger_payload.get("unfilled_order_count")
+                ),
+                closed_trade_count=_observation_int(
+                    ledger_payload.get("closed_trade_count")
+                ),
+                open_position_count=_observation_int(
+                    ledger_payload.get("open_position_count")
+                ),
+                filled_notional=_observation_decimal(
+                    ledger_payload.get("filled_notional")
+                ),
+                gross_strategy_pnl=_observation_decimal(
+                    ledger_payload.get("gross_strategy_pnl")
+                ),
+                cost_amount=_observation_decimal(ledger_payload.get("cost_amount")),
+                net_strategy_pnl_after_costs=_observation_decimal(
+                    ledger_payload.get("net_strategy_pnl_after_costs")
+                ),
+                post_cost_expectancy_bps=_optional_decimal(
+                    ledger_payload.get("post_cost_expectancy_bps")
+                ),
+                ledger_schema_version=_text(ledger_payload.get("ledger_schema_version"))
+                or "unknown",
+                pnl_basis=_text(ledger_payload.get("pnl_basis")) or "unknown",
+                execution_policy_hash_counts=_mapping(
+                    ledger_payload.get("execution_policy_hash_counts")
                 )
+                or None,
+                cost_model_hash_counts=_mapping(
+                    ledger_payload.get("cost_model_hash_counts")
+                )
+                or None,
+                lineage_hash_counts=_mapping(ledger_payload.get("lineage_hash_counts"))
+                or None,
+                blockers_json=_string_list(ledger_payload.get("blockers")),
+                payload_json={
+                    **ledger_payload,
+                    "runtime_ledger_daily_summary": runtime_ledger_daily_summary,
+                },
             )
+            session.add(runtime_ledger_row)
+            runtime_ledger_rows.append(runtime_ledger_row)
 
     final_capital_stage = _capital_stage_for_runtime_import(
         observed_stage=observed_stage,
@@ -1624,45 +1639,122 @@ def persist_observed_runtime_windows(
             },
         )
     )
-    session.add(
-        StrategyPromotionDecision(
-            run_id=run_id,
-            candidate_id=candidate_id,
-            hypothesis_id=hypothesis_id,
-            promotion_target=observed_stage,
-            state=final_capital_stage,
-            allowed=promotion_allowed,
-            reason_summary=reason_summary,
-            payload_json={
-                "imported": True,
-                "observed_stage": observed_stage,
-                "raw_window_count": raw_window_count,
-                "window_count": inserted,
-                "skipped_zero_activity_window_count": skipped_zero_activity_window_count,
-                "market_session_samples": total_session_samples,
-                "decision_count": total_decision_count,
-                "trade_count": total_trade_count,
-                "order_count": total_order_count,
-                "post_cost_promotion_sample_count": total_post_cost_promotion_sample_count,
-                "post_cost_basis_counts": total_post_cost_basis_counts,
-                "avg_abs_slippage_bps": str(average_slippage),
-                "avg_post_cost_expectancy_bps": str(average_post_cost),
-                "post_cost_expectancy_aggregation": post_cost_expectancy_aggregation,
-                "runtime_ledger_notional_weighted_sample_count": runtime_ledger_sample_count,
-                "runtime_ledger_filled_notional": str(runtime_ledger_filled_notional),
-                "runtime_ledger_net_strategy_pnl_after_costs": str(
-                    runtime_ledger_net_strategy_pnl_after_costs
-                ),
-                **runtime_ledger_daily_summary,
-                "latest_three_within_budget": latest_three_budget_ok,
-                "promotion_allowed": promotion_allowed,
-                "promotion_blocking_reasons": promotion_blocking_reasons,
-                "delay_adjusted_depth_stress": delay_depth_stress_summary,
-                "runtime_observation": runtime_payload,
-            },
-        )
+    promotion_decision_row = StrategyPromotionDecision(
+        run_id=run_id,
+        candidate_id=candidate_id,
+        hypothesis_id=hypothesis_id,
+        promotion_target=observed_stage,
+        state=final_capital_stage,
+        allowed=promotion_allowed,
+        reason_summary=reason_summary,
+        payload_json={
+            "imported": True,
+            "observed_stage": observed_stage,
+            "raw_window_count": raw_window_count,
+            "window_count": inserted,
+            "skipped_zero_activity_window_count": skipped_zero_activity_window_count,
+            "market_session_samples": total_session_samples,
+            "decision_count": total_decision_count,
+            "trade_count": total_trade_count,
+            "order_count": total_order_count,
+            "post_cost_promotion_sample_count": total_post_cost_promotion_sample_count,
+            "post_cost_basis_counts": total_post_cost_basis_counts,
+            "avg_abs_slippage_bps": str(average_slippage),
+            "avg_post_cost_expectancy_bps": str(average_post_cost),
+            "post_cost_expectancy_aggregation": post_cost_expectancy_aggregation,
+            "runtime_ledger_notional_weighted_sample_count": runtime_ledger_sample_count,
+            "runtime_ledger_filled_notional": str(runtime_ledger_filled_notional),
+            "runtime_ledger_net_strategy_pnl_after_costs": str(
+                runtime_ledger_net_strategy_pnl_after_costs
+            ),
+            **runtime_ledger_daily_summary,
+            "latest_three_within_budget": latest_three_budget_ok,
+            "promotion_allowed": promotion_allowed,
+            "promotion_blocking_reasons": promotion_blocking_reasons,
+            "delay_adjusted_depth_stress": delay_depth_stress_summary,
+            "runtime_observation": runtime_payload,
+        },
     )
+    session.add(promotion_decision_row)
     session.flush()
+    evidence_grade_runtime_ledger_rows = [
+        row
+        for row in runtime_ledger_rows
+        if _persisted_runtime_ledger_bucket_evidence_grade(row)
+    ]
+    materialization_counts = {
+        "metric_window_count": len(metric_window_rows),
+        "promotion_decision_count": 1,
+        "runtime_ledger_bucket_count": len(runtime_ledger_rows),
+        "evidence_grade_runtime_ledger_bucket_count": len(
+            evidence_grade_runtime_ledger_rows
+        ),
+        "runtime_ledger_fill_count": sum(
+            max(0, int(row.fill_count or 0)) for row in runtime_ledger_rows
+        ),
+        "runtime_ledger_submitted_order_count": sum(
+            max(0, int(row.submitted_order_count or 0)) for row in runtime_ledger_rows
+        ),
+        "runtime_ledger_closed_trade_count": sum(
+            max(0, int(row.closed_trade_count or 0)) for row in runtime_ledger_rows
+        ),
+        "runtime_ledger_open_position_count": sum(
+            max(0, int(row.open_position_count or 0)) for row in runtime_ledger_rows
+        ),
+    }
+    materialization_blockers: list[str] = []
+    if not metric_window_rows:
+        materialization_blockers.append("runtime_window_import_metric_window_missing")
+    if runtime_payload.get("runtime_ledger_profit_proof_present") is True:
+        if not runtime_ledger_rows:
+            materialization_blockers.append(
+                "runtime_window_import_runtime_ledger_bucket_missing"
+            )
+        if not evidence_grade_runtime_ledger_rows:
+            materialization_blockers.append(
+                "runtime_window_import_evidence_grade_runtime_ledger_bucket_missing"
+            )
+    for blocker in materialization_blockers:
+        if blocker not in {str(item.get("blocker")) for item in proof_blockers}:
+            proof_blockers.append(
+                {
+                    "blocker": blocker,
+                    "hypothesis_id": hypothesis_id,
+                    "candidate_id": candidate_id,
+                    "observed_stage": observed_stage,
+                    "window_start": import_window_start.isoformat(),
+                    "window_end": import_window_end.isoformat(),
+                    "promotion_authority": _text(
+                        runtime_payload.get("promotion_authority")
+                    )
+                    or "unknown",
+                    "authority_reason": _text(runtime_payload.get("authority_reason")),
+                    "runtime_ledger_profit_proof_present": bool(
+                        runtime_payload.get("runtime_ledger_profit_proof_present")
+                    ),
+                    "remediation": (
+                        "Persist the scoped metric window, promotion decision, and "
+                        "evidence-grade runtime-ledger bucket before treating this "
+                        "runtime-window import target as proof."
+                    ),
+                }
+            )
+    proof_status = "blocked" if proof_blockers else "ok"
+    runtime_materialization_target.update(
+        {
+            "proof_status": proof_status,
+            "proof_blockers": proof_blockers,
+            "materialized": not proof_blockers,
+            "materialization_blockers": materialization_blockers,
+            **materialization_counts,
+            "metric_window_ids": [str(row.id) for row in metric_window_rows],
+            "promotion_decision_id": str(promotion_decision_row.id),
+            "runtime_ledger_bucket_ids": [str(row.id) for row in runtime_ledger_rows],
+            "evidence_grade_runtime_ledger_bucket_ids": [
+                str(row.id) for row in evidence_grade_runtime_ledger_rows
+            ],
+        }
+    )
     return {
         "run_id": run_id,
         "candidate_id": candidate_id,

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -723,9 +723,22 @@ def _runtime_import_target_materialization_ref(
     blockers: Sequence[str],
 ) -> dict[str, Any]:
     summary = _mapping(item.get("summary"))
+    materialization_target = _mapping(summary.get("runtime_materialization_target"))
+    materialization_counts = {
+        "metric_window_count": _int(materialization_target.get("metric_window_count")),
+        "promotion_decision_count": _int(
+            materialization_target.get("promotion_decision_count")
+        ),
+        "runtime_ledger_bucket_count": _int(
+            materialization_target.get("runtime_ledger_bucket_count")
+        ),
+        "evidence_grade_runtime_ledger_bucket_count": _int(
+            materialization_target.get("evidence_grade_runtime_ledger_bucket_count")
+        ),
+    }
 
     def first_text(*keys: str) -> str:
-        for source in (item, summary, observation):
+        for source in (item, summary, materialization_target, observation):
             for key in keys:
                 value = _text(source.get(key))
                 if value:
@@ -761,9 +774,61 @@ def _runtime_import_target_materialization_ref(
         "runtime_ledger_net_strategy_pnl_after_costs": _text(
             observation.get("runtime_ledger_net_strategy_pnl_after_costs")
         ),
+        **materialization_counts,
+        "metric_window_ids": _text_list(
+            materialization_target.get("metric_window_ids")
+        ),
+        "promotion_decision_id": _text(
+            materialization_target.get("promotion_decision_id")
+        ),
+        "runtime_ledger_bucket_ids": _text_list(
+            materialization_target.get("runtime_ledger_bucket_ids")
+        ),
+        "evidence_grade_runtime_ledger_bucket_ids": _text_list(
+            materialization_target.get("evidence_grade_runtime_ledger_bucket_ids")
+        ),
         "blockers": list(blockers),
     }
     return {key: value for key, value in ref.items() if value not in ("", [], None)}
+
+
+def _runtime_import_target_blocker_codes(value: object) -> list[str]:
+    blockers: list[str] = []
+    for item in _sequence(value):
+        if isinstance(item, Mapping):
+            blocker = _text(item.get("blocker"))
+        else:
+            blocker = _text(item)
+        if blocker:
+            blockers.append(blocker)
+    return blockers
+
+
+def _runtime_import_target_surface_blockers(
+    *,
+    summary: Mapping[str, Any],
+    profit_proof_count: int,
+) -> list[str]:
+    target = _mapping(summary.get("runtime_materialization_target"))
+    if not target:
+        return ["runtime_window_import_materialization_target_missing"]
+    blockers = _text_list(target.get("materialization_blockers"))
+    if _int(target.get("metric_window_count")) <= 0:
+        blockers.append("runtime_window_import_metric_window_missing")
+    if _int(target.get("promotion_decision_count")) <= 0:
+        blockers.append("runtime_window_import_promotion_decision_missing")
+    if profit_proof_count > 0:
+        if _int(target.get("runtime_ledger_bucket_count")) <= 0:
+            blockers.append("runtime_window_import_runtime_ledger_bucket_missing")
+        if _int(target.get("evidence_grade_runtime_ledger_bucket_count")) <= 0:
+            blockers.append(
+                "runtime_window_import_evidence_grade_runtime_ledger_bucket_missing"
+            )
+    if target.get("materialized") is False:
+        blockers.extend(
+            _runtime_import_target_blocker_codes(target.get("proof_blockers"))
+        )
+    return list(dict.fromkeys(blockers))
 
 
 def _runtime_import_materialization_summary(
@@ -868,6 +933,13 @@ def _runtime_import_materialization_summary(
             )
         if profit_proof_count <= 0:
             target_blockers.append("runtime_window_import_target_profit_proof_missing")
+        _extend_unique(
+            target_blockers,
+            _runtime_import_target_surface_blockers(
+                summary=summary,
+                profit_proof_count=profit_proof_count,
+            ),
+        )
         _extend_unique(source_kinds, [_text(observation.get("source_kind"))])
         _extend_unique(authority_reasons, [authority_reason])
         _extend_unique(
@@ -885,7 +957,9 @@ def _runtime_import_materialization_summary(
             _text_list(observation.get("runtime_ledger_target_metadata_blockers")),
         )
         materialized = (
-            observation.get("authoritative") is True and profit_proof_count > 0
+            observation.get("authoritative") is True
+            and profit_proof_count > 0
+            and not target_blockers
         )
         target_ref = _runtime_import_target_materialization_ref(
             item=item,

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -144,8 +144,60 @@ def _runtime_import(
     proof_status: str = "ok",
     proof_blockers: list[str] | None = None,
     authoritative: bool = True,
+    materialization_target: bool = True,
 ) -> dict[str, object]:
     blocker_payloads = [{"blocker": blocker} for blocker in proof_blockers or []]
+    target_payload: dict[str, object] = {
+        "candidate_id": "c88421d619759b2cfaa6f4d0",
+        "hypothesis_id": "H-PAIRS-01",
+        "observed_stage": "paper",
+        "strategy_family": "microbar_cross_sectional_pairs",
+        "strategy_name": "microbar-pairs-vwap-cap-safe",
+        "account_label": "TORGHUT_SIM",
+        "window_start": "2026-05-26T13:30:00+00:00",
+        "window_end": "2026-05-26T20:00:00+00:00",
+        "runtime_ledger_profit_proof_present": authoritative,
+        "runtime_ledger_notional_weighted_sample_count": 1 if authoritative else 0,
+        "runtime_ledger_filled_notional": "50000" if authoritative else "0",
+        "runtime_ledger_net_strategy_pnl_after_costs": "650" if authoritative else "0",
+        "metric_window_count": 1,
+        "promotion_decision_count": 1,
+        "runtime_ledger_bucket_count": 1 if authoritative else 0,
+        "evidence_grade_runtime_ledger_bucket_count": 1 if authoritative else 0,
+        "metric_window_ids": ["metric-window-1"],
+        "promotion_decision_id": "promotion-decision-1",
+        "runtime_ledger_bucket_ids": ["runtime-ledger-bucket-1"]
+        if authoritative
+        else [],
+        "evidence_grade_runtime_ledger_bucket_ids": ["runtime-ledger-bucket-1"]
+        if authoritative
+        else [],
+        "materialization_blockers": []
+        if authoritative
+        else ["runtime_window_import_runtime_ledger_bucket_missing"],
+        "proof_status": proof_status,
+        "proof_blockers": blocker_payloads,
+        "materialized": authoritative and proof_status == "ok" and not blocker_payloads,
+    }
+    summary: dict[str, object] = {
+        "promotion_allowed": authoritative,
+        "runtime_observation": {
+            "authoritative": authoritative,
+            "authority_reason": "runtime_ledger_profit_proof_present"
+            if authoritative
+            else "runtime_without_runtime_ledger_profit_proof",
+            "runtime_ledger_profit_proof_present": authoritative,
+            "runtime_ledger_tca_profit_proof_count": 1 if authoritative else 0,
+            "runtime_ledger_tca_runtime_bucket_row_count": 1 if authoritative else 0,
+            "runtime_ledger_tca_authoritative_bucket_count": 1 if authoritative else 0,
+            "runtime_ledger_filled_notional": "50000" if authoritative else "0",
+            "runtime_ledger_net_strategy_pnl_after_costs": "650"
+            if authoritative
+            else "0",
+        },
+    }
+    if materialization_target:
+        summary["runtime_materialization_target"] = target_payload
     return {
         "status": "ok",
         "proof_status": proof_status,
@@ -164,25 +216,7 @@ def _runtime_import(
                 "account_label": "TORGHUT_SIM",
                 "window_start": "2026-05-26T13:30:00+00:00",
                 "window_end": "2026-05-26T20:00:00+00:00",
-                "summary": {
-                    "promotion_allowed": authoritative,
-                    "runtime_observation": {
-                        "authoritative": authoritative,
-                        "authority_reason": "runtime_ledger_profit_proof_present"
-                        if authoritative
-                        else "runtime_without_runtime_ledger_profit_proof",
-                        "runtime_ledger_profit_proof_present": authoritative,
-                        "runtime_ledger_tca_profit_proof_count": 1
-                        if authoritative
-                        else 0,
-                        "runtime_ledger_tca_runtime_bucket_row_count": 1
-                        if authoritative
-                        else 0,
-                        "runtime_ledger_tca_authoritative_bucket_count": 1
-                        if authoritative
-                        else 0,
-                    },
-                },
+                "summary": summary,
             }
         ],
     }
@@ -1219,6 +1253,35 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result["promotion_authority"]["blocking_reasons"],
         )
 
+    def test_packet_blocks_when_runtime_import_target_lacks_db_materialization_verdict(
+        self,
+    ) -> None:
+        runtime_import = _runtime_import(materialization_target=False)
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(result["ok"])
+        self.assertFalse(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        self.assertEqual(materialization["materialized_target_count"], 0)
+        self.assertEqual(materialization["unmaterialized_target_count"], 1)
+        self.assertIn(
+            "runtime_window_import_materialization_target_missing",
+            materialization["unmaterialized_targets"][0]["blockers"],
+        )
+        self.assertIn(
+            "runtime_window_import_materialization_target_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+
     def test_packet_blocks_when_runtime_import_target_count_is_incomplete(
         self,
     ) -> None:
@@ -1429,6 +1492,56 @@ class TestRuntimeLedgerProofPacket(TestCase):
             materialization["blockers"],
         )
 
+    def test_packet_surfaces_target_materialization_count_and_string_blockers(
+        self,
+    ) -> None:
+        runtime_import = _runtime_import()
+        first_import = runtime_import["imports"][0]
+        assert isinstance(first_import, dict)
+        first_summary = first_import["summary"]
+        assert isinstance(first_summary, dict)
+        target = first_summary["runtime_materialization_target"]
+        assert isinstance(target, dict)
+        target.update(
+            {
+                "metric_window_count": 0,
+                "promotion_decision_count": 0,
+                "runtime_ledger_bucket_count": 0,
+                "evidence_grade_runtime_ledger_bucket_count": 0,
+                "materialization_blockers": [],
+                "proof_blockers": ["source_runtime_ledger_missing"],
+                "materialized": False,
+            }
+        )
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(result["ok"])
+        self.assertEqual(materialization["materialized_target_count"], 0)
+        self.assertEqual(materialization["unmaterialized_target_count"], 1)
+        target_blockers = materialization["unmaterialized_targets"][0]["blockers"]
+        self.assertIn("runtime_window_import_metric_window_missing", target_blockers)
+        self.assertIn(
+            "runtime_window_import_promotion_decision_missing",
+            target_blockers,
+        )
+        self.assertIn(
+            "runtime_window_import_runtime_ledger_bucket_missing",
+            target_blockers,
+        )
+        self.assertIn(
+            "runtime_window_import_evidence_grade_runtime_ledger_bucket_missing",
+            target_blockers,
+        )
+        self.assertIn("source_runtime_ledger_missing", target_blockers)
+
     def test_packet_waits_on_target_level_settlement_blocker(self) -> None:
         paper = _paper_route_evidence()
         target = paper["next_paper_route_runtime_window_targets"]["targets"][0]
@@ -1473,6 +1586,24 @@ class TestRuntimeLedgerProofPacket(TestCase):
                     "runtime_observation": {
                         "authoritative": True,
                         "runtime_ledger_profit_proof_present": True,
+                    },
+                    "runtime_materialization_target": {
+                        "candidate_id": "c88421d619759b2cfaa6f4d0",
+                        "observed_stage": "paper",
+                        "account_label": "TORGHUT_SIM",
+                        "runtime_ledger_profit_proof_present": True,
+                        "metric_window_count": 1,
+                        "promotion_decision_count": 1,
+                        "runtime_ledger_bucket_count": 1,
+                        "evidence_grade_runtime_ledger_bucket_count": 1,
+                        "materialized": True,
+                        "materialization_blockers": [],
+                        "metric_window_ids": ["metric-window-1"],
+                        "promotion_decision_id": "promotion-decision-1",
+                        "runtime_ledger_bucket_ids": ["runtime-ledger-bucket-1"],
+                        "evidence_grade_runtime_ledger_bucket_ids": [
+                            "runtime-ledger-bucket-1"
+                        ],
                     },
                 },
             },

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -579,6 +579,26 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertEqual(sim_env.get("TRADING_MODE"), "paper")
         self.assertEqual(sim_env.get("TRADING_PIPELINE_MODE"), "simple")
         self.assertTrue(_manifest_bool(sim_env, "TRADING_SIMPLE_SUBMIT_ENABLED"))
+        self.assertTrue(_manifest_bool(sim_env, "TRADING_ORDER_FEED_ENABLED"))
+        self.assertTrue(
+            _manifest_bool(sim_env, "TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED"),
+            "paper-route proof cannot materialize execution_order_events without simple order-feed telemetry",
+        )
+        self.assertEqual(
+            sim_env.get("TRADING_ORDER_FEED_TOPIC"),
+            "torghut.trade-updates.v1",
+            "live-paper proof must consume the broker trade-update topic, not the simulation topic",
+        )
+        self.assertEqual(
+            sim_env.get("TRADING_ORDER_FEED_AUTO_OFFSET_RESET"),
+            "earliest",
+            "first rollout must backfill existing broker order events for proof materialization",
+        )
+        self.assertEqual(
+            sim_env.get("TRADING_ORDER_FEED_TOPIC_V2"),
+            "",
+            "v2 broker envelopes carry the producer account label and can prevent TORGHUT_SIM linkage",
+        )
         self.assertTrue(
             _manifest_bool(sim_env, "TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED")
         )

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -1687,6 +1687,82 @@ class TestRuntimeWindowImport(TestCase):
             target["runtime_ledger_net_strategy_pnl_after_costs"],
             "0.80",
         )
+        self.assertEqual(target["metric_window_count"], 1)
+        self.assertEqual(target["promotion_decision_count"], 1)
+        self.assertEqual(target["runtime_ledger_bucket_count"], 1)
+        self.assertEqual(target["evidence_grade_runtime_ledger_bucket_count"], 1)
+        self.assertEqual(target["runtime_ledger_fill_count"], 2)
+        self.assertEqual(target["runtime_ledger_submitted_order_count"], 2)
+        self.assertEqual(target["runtime_ledger_closed_trade_count"], 1)
+        self.assertEqual(target["runtime_ledger_open_position_count"], 0)
+        self.assertEqual(target["materialization_blockers"], [])
+        self.assertEqual(len(target["metric_window_ids"]), 1)
+        self.assertIsNotNone(target["promotion_decision_id"])
+        self.assertEqual(len(target["runtime_ledger_bucket_ids"]), 1)
+        self.assertEqual(len(target["evidence_grade_runtime_ledger_bucket_ids"]), 1)
+        self.assertFalse(target["materialized"])
+
+    def test_persist_observed_runtime_windows_blocks_claimed_ledger_proof_without_rows(
+        self,
+    ) -> None:
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=[
+                (
+                    datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    30,
+                ),
+            ],
+            decision_times=[datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+            execution_times=[datetime(2026, 3, 6, 14, 37, tzinfo=timezone.utc)],
+            tca_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 38, tzinfo=timezone.utc),
+                    "abs_slippage_bps": Decimal("4"),
+                    "post_cost_expectancy_bps": Decimal("40"),
+                    **_runtime_pnl_basis(),
+                },
+            ],
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        with self.session_local() as session:
+            summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-claimed-ledger-proof-without-rows",
+                candidate_id="cand-claimed-ledger",
+                hypothesis_id="H-PAIRS-01",
+                observed_stage="paper",
+                strategy_family="microbar_cross_sectional_pairs",
+                source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+                buckets=buckets,
+                runtime_observation_payload={
+                    "runtime_ledger_profit_proof_present": True,
+                    "promotion_authority": "runtime_ledger_profit_proof_present",
+                },
+            )
+            session.commit()
+
+        target = summary["runtime_materialization_target"]
+        self.assertEqual(target["metric_window_count"], 1)
+        self.assertEqual(target["promotion_decision_count"], 1)
+        self.assertEqual(target["runtime_ledger_bucket_count"], 0)
+        self.assertEqual(target["evidence_grade_runtime_ledger_bucket_count"], 0)
+        self.assertIn(
+            "runtime_window_import_runtime_ledger_bucket_missing",
+            target["materialization_blockers"],
+        )
+        self.assertIn(
+            "runtime_window_import_evidence_grade_runtime_ledger_bucket_missing",
+            target["materialization_blockers"],
+        )
+        self.assertIn(
+            "runtime_window_import_runtime_ledger_bucket_missing",
+            [item["blocker"] for item in target["proof_blockers"]],
+        )
+        self.assertFalse(target["materialized"])
 
     def test_persist_observed_runtime_windows_blocks_zero_activity_evidence(
         self,


### PR DESCRIPTION
## Summary

- Records the actual persisted metric window, promotion decision, and runtime-ledger bucket IDs/counts for each imported runtime-window target.
- Fails proof-packet materialization when a target lacks the scoped DB materialization verdict or evidence-grade runtime-ledger bucket proof.
- Enables `torghut-sim` simple order-feed telemetry through GitOps and points live-paper ingestion at the broker trade-update topic with first-rollout backfill semantics.
- Keeps the v2 broker envelope disabled for `torghut-sim` so producer account labels cannot prevent `TORGHUT_SIM` execution linkage.
- Adds regression coverage for missing materialization verdicts, persisted runtime-ledger refs/counts, and the sim manifest order-feed contract.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_live_config_manifest_contract.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
