### PR TITLE
chore(analysis): promote image 9bf5ffc

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: c32cef0737710ab269b36e920d4c43c4dc8ea129
+    newTag: 9bf5ffca57a5f6a3b28531c061828293220edcbe


### PR DESCRIPTION
## Summary

- Promotes the `analysis` Argo CD application to image tag `9bf5ffca57a5f6a3b28531c061828293220edcbe`.
- Keeps the existing private registry image name and only changes the immutable tag in the analysis kustomization.
- Publishes the SNPS research package that was built and pushed by the self-hosted `analysis-image` GitHub Actions workflow.

## Related Issues

None

## Testing

- `kubectl kustomize /Users/gregkonush/github.com/lab/argocd/applications/analysis`
- `rg -n 'registry.ide-newton.ts.net/lab/analysis:9bf5ffca57a5f6a3b28531c061828293220edcbe' /tmp/analysis-kustomize.yaml`
- `/Users/gregkonush/github.com/analysis/scripts/verify-analysis-image.sh 9bf5ffca57a5f6a3b28531c061828293220edcbe latest`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
