### PR TITLE
chore(analysis): promote image 63bd810

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 9bf5ffca57a5f6a3b28531c061828293220edcbe
+    newTag: 63bd8104bc234417b07e0e3a03d32dfbc24eb362


### PR DESCRIPTION
## Summary

- Promotes the private analysis site image to `63bd8104bc234417b07e0e3a03d32dfbc24eb362`.
- Keeps the existing Argo CD analysis application and Tailscale exposure unchanged.
- Touches only `argocd/applications/analysis/kustomization.yaml`.

## Related Issues

None

## Testing

- `kubectl kustomize /Users/gregkonush/github.com/lab/argocd/applications/analysis`
- `/Users/gregkonush/github.com/analysis/scripts/verify-analysis-image.sh 63bd8104bc234417b07e0e3a03d32dfbc24eb362 latest`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
