### PR TITLE
chore(symphony): promote image 4f093bb3

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-25T20:37:39Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-27T12:08:27Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "f852e406"
-    digest: sha256:6920ad38219eefd6d3852de078694840fbeb70d3153e9888edf2da9035f52737
+    newTag: "4f093bb3"
+    digest: sha256:ded585d9928a916e5f11a809cc175201a7a4054baab92f4332727bff31a524b3

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-25T20:37:39Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-27T12:08:27Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "f852e406"
-    digest: sha256:6920ad38219eefd6d3852de078694840fbeb70d3153e9888edf2da9035f52737
+    newTag: "4f093bb3"
+    digest: sha256:ded585d9928a916e5f11a809cc175201a7a4054baab92f4332727bff31a524b3

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-25T20:37:39Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-27T12:08:27Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "f852e406"
-    digest: sha256:6920ad38219eefd6d3852de078694840fbeb70d3153e9888edf2da9035f52737
+    newTag: "4f093bb3"
+    digest: sha256:ded585d9928a916e5f11a809cc175201a7a4054baab92f4332727bff31a524b3


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `4f093bb32dd755b5c8d0dc48f4767ba054e60483`
- Image tag: `4f093bb3`
- Image digest: `sha256:ded585d9928a916e5f11a809cc175201a7a4054baab92f4332727bff31a524b3`