### PR TITLE
chore(analysis): promote image e0a6617

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 63bd8104bc234417b07e0e3a03d32dfbc24eb362
+    newTag: e0a66174a3e9aa179986db832c7737baa3fce226


### PR DESCRIPTION
## Summary

- Promotes the private analysis site image to `e0a66174a3e9aa179986db832c7737baa3fce226`.
- Keeps the existing Argo CD analysis application and Tailscale exposure unchanged.
- Touches only `argocd/applications/analysis/kustomization.yaml`.

## Related Issues

None

## Testing

- `kubectl kustomize /Users/gregkonush/github.com/lab/argocd/applications/analysis`
- `/Users/gregkonush/github.com/analysis/scripts/verify-analysis-image.sh e0a66174a3e9aa179986db832c7737baa3fce226 latest`
- `git diff --check origin/main...HEAD`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
