### PR TITLE
chore(analysis): promote image 5e6e123

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: e0a66174a3e9aa179986db832c7737baa3fce226
+    newTag: 5e6e1231fca33457a3869d0db76134cf48a7a886


### PR DESCRIPTION
Promotes analysis to registry.ide-newton.ts.net/lab/analysis:5e6e1231fca33457a3869d0db76134cf48a7a886.\n\nValidation:\n- kubectl kustomize argocd/applications/analysis\n- git diff --check\n- analysis GitHub Actions run 26510607894 succeeded on arc-arm64\n- registry tags 5e6e1231fca33457a3869d0db76134cf48a7a886 and latest verified at sha256:47edf2cc1f59a5582e74ecd25dc86f3ec05731672faf59925f94c1c7270380c3