### PR TITLE
chore(symphony): promote image c458986a

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-27T12:08:27Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-27T12:42:15Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "4f093bb3"
-    digest: sha256:ded585d9928a916e5f11a809cc175201a7a4054baab92f4332727bff31a524b3
+    newTag: "c458986a"
+    digest: sha256:a2f1e8aab3d06dbcd647146b999c4475dce49a255221ae85fb923867963c1170

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-27T12:08:27Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-27T12:42:15Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "4f093bb3"
-    digest: sha256:ded585d9928a916e5f11a809cc175201a7a4054baab92f4332727bff31a524b3
+    newTag: "c458986a"
+    digest: sha256:a2f1e8aab3d06dbcd647146b999c4475dce49a255221ae85fb923867963c1170

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-27T12:08:27Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-27T12:42:15Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "4f093bb3"
-    digest: sha256:ded585d9928a916e5f11a809cc175201a7a4054baab92f4332727bff31a524b3
+    newTag: "c458986a"
+    digest: sha256:a2f1e8aab3d06dbcd647146b999c4475dce49a255221ae85fb923867963c1170


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `c458986a793ec7cd1b08bb158520fd2ba1f82acb`
- Image tag: `c458986a`
- Image digest: `sha256:a2f1e8aab3d06dbcd647146b999c4475dce49a255221ae85fb923867963c1170`