### PR TITLE
chore(analysis): promote image f73721d

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 5e6e1231fca33457a3869d0db76134cf48a7a886
+    newTag: f73721db4bd34071e88fb5513f394497fb19f3f1


### PR DESCRIPTION
Promotes analysis to image `f73721db4bd34071e88fb5513f394497fb19f3f1` after the SemiAnalysis 800VDC guardrail refresh.

Validation:
- `git diff --check`
- `kustomize build argocd/applications/analysis`
- analysis workflow `26511711803` passed validate and build-push
- registry tags `f73721db4bd34071e88fb5513f394497fb19f3f1` and `latest` verified at digest `sha256:4a451141f061c59fdb005a7111ce8cc46946477659948dae033e7ba677f9bc1c`