### PR TITLE
chore(analysis): promote image b0e69ed

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: f73721db4bd34071e88fb5513f394497fb19f3f1
+    newTag: b0e69ede7c4a7ea86774c1665709fd4b78fa6fe9


### PR DESCRIPTION
Promotes analysis to image `b0e69ede7c4a7ea86774c1665709fd4b78fa6fe9` after the Dell AI server deployment package.

Validation:
- `git diff --check`
- `kustomize build argocd/applications/analysis`
- analysis workflow `26512729264` passed validate and build-push
- registry tags `b0e69ede7c4a7ea86774c1665709fd4b78fa6fe9` and `latest` verified at digest `sha256:b5a1d90a33c4282b1528573d4c5cb3fcaaf33f1120a1220abc12c50f6fcc4a44`