### PR TITLE
chore(symphony): promote image 4eb351b4

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-27T12:42:15Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-27T13:13:25Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c458986a"
-    digest: sha256:a2f1e8aab3d06dbcd647146b999c4475dce49a255221ae85fb923867963c1170
+    newTag: "4eb351b4"
+    digest: sha256:7dc4659ea10138627643b78c392892b27ab35eb46eb8e51299ee1828e49d2718

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-27T12:42:15Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-27T13:13:25Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c458986a"
-    digest: sha256:a2f1e8aab3d06dbcd647146b999c4475dce49a255221ae85fb923867963c1170
+    newTag: "4eb351b4"
+    digest: sha256:7dc4659ea10138627643b78c392892b27ab35eb46eb8e51299ee1828e49d2718

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-27T12:42:15Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-27T13:13:25Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c458986a"
-    digest: sha256:a2f1e8aab3d06dbcd647146b999c4475dce49a255221ae85fb923867963c1170
+    newTag: "4eb351b4"
+    digest: sha256:7dc4659ea10138627643b78c392892b27ab35eb46eb8e51299ee1828e49d2718


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `4eb351b4d2d3eb7665bcc924dc614932da87cdf9`
- Image tag: `4eb351b4`
- Image digest: `sha256:7dc4659ea10138627643b78c392892b27ab35eb46eb8e51299ee1828e49d2718`