### PR TITLE
fix(torghut): require authority-grade runtime ledger proof

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -50,6 +50,7 @@ DEFAULT_TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL = (
 RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE = "artifacts/runtime-ledger-proof-packet.json"
 RUNTIME_WINDOW_IMPORT_OUTPUT_FILE = "artifacts/runtime-window-import.json"
 RUNTIME_LEDGER_PROOF_PACKET_ARTIFACT_PREFIX = "runtime-ledger-proof-packets/{run_id}"
+RUNTIME_LEDGER_SUMMARY_ROW_LIMIT = 50
 MIN_RUNTIME_LEDGER_PROOF_NET_PNL = "500"
 MIN_RUNTIME_LEDGER_PROOF_DAILY_NET_PNL = "500"
 MIN_RUNTIME_LEDGER_PROOF_TRADING_DAYS = 1
@@ -1359,24 +1360,43 @@ def _runtime_ledger_summary(
         stmt = stmt.where(
             StrategyRuntimeLedgerBucket.strategy_family == strategy_family
         )
-    rows = list(session.execute(stmt.limit(50)).scalars())
-    filled_notional = sum((row.filled_notional for row in rows), Decimal("0"))
-    net_pnl = sum((row.net_strategy_pnl_after_costs for row in rows), Decimal("0"))
+    queried_rows = list(
+        session.execute(stmt.limit(RUNTIME_LEDGER_SUMMARY_ROW_LIMIT + 1)).scalars()
+    )
+    truncated = len(queried_rows) > RUNTIME_LEDGER_SUMMARY_ROW_LIMIT
+    rows = queried_rows[:RUNTIME_LEDGER_SUMMARY_ROW_LIMIT]
+    evidence_grade_rows = [
+        row for row in rows if _runtime_ledger_bucket_evidence_grade(row)
+    ]
+    filled_notional = sum(
+        (row.filled_notional for row in evidence_grade_rows), Decimal("0")
+    )
+    net_pnl = sum(
+        (row.net_strategy_pnl_after_costs for row in evidence_grade_rows),
+        Decimal("0"),
+    )
     return {
         "bucket_count": len(rows),
-        "evidence_grade_bucket_count": sum(
-            int(_runtime_ledger_bucket_evidence_grade(row)) for row in rows
+        "evidence_grade_bucket_count": len(evidence_grade_rows),
+        "non_evidence_grade_bucket_count": len(rows) - len(evidence_grade_rows),
+        "returned_bucket_count": len(rows),
+        "query_limit": RUNTIME_LEDGER_SUMMARY_ROW_LIMIT,
+        "truncated": truncated,
+        "proof_scope": "evidence_grade_runtime_ledger_buckets_only",
+        "fill_count": sum(
+            max(0, _safe_int(row.fill_count)) for row in evidence_grade_rows
         ),
-        "fill_count": sum(max(0, _safe_int(row.fill_count)) for row in rows),
-        "decision_count": sum(max(0, _safe_int(row.decision_count)) for row in rows),
+        "decision_count": sum(
+            max(0, _safe_int(row.decision_count)) for row in evidence_grade_rows
+        ),
         "submitted_order_count": sum(
-            max(0, _safe_int(row.submitted_order_count)) for row in rows
+            max(0, _safe_int(row.submitted_order_count)) for row in evidence_grade_rows
         ),
         "closed_trade_count": sum(
-            max(0, _safe_int(row.closed_trade_count)) for row in rows
+            max(0, _safe_int(row.closed_trade_count)) for row in evidence_grade_rows
         ),
         "open_position_count": sum(
-            max(0, _safe_int(row.open_position_count)) for row in rows
+            max(0, _safe_int(row.open_position_count)) for row in evidence_grade_rows
         ),
         "filled_notional": _decimal_text(filled_notional),
         "net_strategy_pnl_after_costs": _decimal_text(net_pnl),

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -47,6 +47,13 @@ RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
         "torghut.runtime-ledger-bucket.v1",
     }
 )
+RUNTIME_LEDGER_AUTHORITY_MIN_TRADING_DAYS = 20
+RUNTIME_LEDGER_AUTHORITY_MIN_MEAN_DAILY_NET_PNL = Decimal("500")
+RUNTIME_LEDGER_AUTHORITY_MIN_MEDIAN_DAILY_NET_PNL = Decimal("250")
+RUNTIME_LEDGER_AUTHORITY_MIN_P10_DAILY_NET_PNL = Decimal("-250")
+RUNTIME_LEDGER_AUTHORITY_MIN_WORST_DAY_NET_PNL = Decimal("-750")
+RUNTIME_LEDGER_AUTHORITY_MAX_INTRADAY_DRAWDOWN = Decimal("1500")
+RUNTIME_LEDGER_AUTHORITY_MAX_BEST_DAY_SHARE = Decimal("0.25")
 
 
 @dataclass(frozen=True)
@@ -96,6 +103,13 @@ def _optional_decimal(value: Any) -> Decimal | None:
         return Decimal(text)
     except Exception:
         return None
+
+
+def _decimal_text(value: Decimal) -> str:
+    text = format(value, "f")
+    if "." not in text:
+        return text
+    return text.rstrip("0").rstrip(".") or "0"
 
 
 def _strategy_family_matches(
@@ -668,6 +682,53 @@ def _runtime_window_import_proof_blockers(
     return blockers
 
 
+def _runtime_ledger_authority_gate_targets(
+    *,
+    average_post_cost_bps: Decimal,
+) -> dict[str, Any]:
+    target_implied_notional = (
+        RUNTIME_LEDGER_AUTHORITY_MIN_MEAN_DAILY_NET_PNL
+        * Decimal("10000")
+        / average_post_cost_bps
+        if average_post_cost_bps > 0
+        else None
+    )
+    return {
+        "min_observed_trading_days": RUNTIME_LEDGER_AUTHORITY_MIN_TRADING_DAYS,
+        "min_mean_daily_net_pnl_after_costs": str(
+            RUNTIME_LEDGER_AUTHORITY_MIN_MEAN_DAILY_NET_PNL
+        ),
+        "min_median_daily_net_pnl_after_costs": str(
+            RUNTIME_LEDGER_AUTHORITY_MIN_MEDIAN_DAILY_NET_PNL
+        ),
+        "min_p10_daily_net_pnl_after_costs": str(
+            RUNTIME_LEDGER_AUTHORITY_MIN_P10_DAILY_NET_PNL
+        ),
+        "min_worst_day_net_pnl_after_costs": str(
+            RUNTIME_LEDGER_AUTHORITY_MIN_WORST_DAY_NET_PNL
+        ),
+        "max_intraday_drawdown": str(RUNTIME_LEDGER_AUTHORITY_MAX_INTRADAY_DRAWDOWN),
+        "max_best_day_share": str(RUNTIME_LEDGER_AUTHORITY_MAX_BEST_DAY_SHARE),
+        "target_implied_avg_daily_filled_notional": (
+            _decimal_text(target_implied_notional)
+            if target_implied_notional is not None
+            else None
+        ),
+        "target_implied_avg_daily_filled_notional_basis": (
+            "min_mean_daily_net_pnl_after_costs / observed_post_cost_expectancy_bps"
+            if target_implied_notional is not None
+            else None
+        ),
+    }
+
+
+def _runtime_summary_decimal(
+    runtime_ledger_daily_summary: Mapping[str, Any],
+    key: str,
+) -> Decimal:
+    return _optional_decimal(runtime_ledger_daily_summary.get(key)) or Decimal("0")
+
+
 def _runtime_promotion_blocking_reasons(
     *,
     observed_stage: str,
@@ -681,6 +742,7 @@ def _runtime_promotion_blocking_reasons(
     total_post_cost_basis_counts: Mapping[str, int],
     average_slippage: Decimal,
     average_post_cost: Decimal,
+    runtime_ledger_daily_summary: Mapping[str, Any],
     latest_three_budget_ok: bool,
     all_continuity_ok: bool,
     all_drift_ok: bool,
@@ -723,6 +785,69 @@ def _runtime_promotion_blocking_reasons(
         reasons.append("post_cost_expectancy_non_positive")
     elif average_post_cost < manifest.expected_gross_edge_bps:
         reasons.append("post_cost_expectancy_below_manifest_threshold")
+    observed_trading_days = int(
+        _runtime_summary_decimal(
+            runtime_ledger_daily_summary,
+            "runtime_ledger_observed_trading_day_count",
+        )
+    )
+    mean_daily_net_pnl = _runtime_summary_decimal(
+        runtime_ledger_daily_summary,
+        "runtime_ledger_mean_daily_net_pnl_after_costs",
+    )
+    median_daily_net_pnl = _runtime_summary_decimal(
+        runtime_ledger_daily_summary,
+        "runtime_ledger_median_daily_net_pnl_after_costs",
+    )
+    p10_daily_net_pnl = _runtime_summary_decimal(
+        runtime_ledger_daily_summary,
+        "runtime_ledger_p10_daily_net_pnl_after_costs",
+    )
+    worst_day_net_pnl = _runtime_summary_decimal(
+        runtime_ledger_daily_summary,
+        "runtime_ledger_worst_day_net_pnl_after_costs",
+    )
+    max_intraday_drawdown = _runtime_summary_decimal(
+        runtime_ledger_daily_summary,
+        "runtime_ledger_max_intraday_drawdown",
+    )
+    best_day_share = _optional_decimal(
+        runtime_ledger_daily_summary.get("runtime_ledger_best_day_share")
+    )
+    avg_daily_filled_notional = _runtime_summary_decimal(
+        runtime_ledger_daily_summary,
+        "runtime_ledger_avg_daily_filled_notional",
+    )
+
+    if observed_trading_days < RUNTIME_LEDGER_AUTHORITY_MIN_TRADING_DAYS:
+        reasons.append(
+            "runtime_ledger_observed_trading_day_count_below_authority_minimum"
+        )
+    if mean_daily_net_pnl < RUNTIME_LEDGER_AUTHORITY_MIN_MEAN_DAILY_NET_PNL:
+        reasons.append("runtime_ledger_mean_daily_net_pnl_after_costs_below_target")
+    if median_daily_net_pnl < RUNTIME_LEDGER_AUTHORITY_MIN_MEDIAN_DAILY_NET_PNL:
+        reasons.append("runtime_ledger_median_daily_net_pnl_after_costs_below_floor")
+    if p10_daily_net_pnl < RUNTIME_LEDGER_AUTHORITY_MIN_P10_DAILY_NET_PNL:
+        reasons.append("runtime_ledger_p10_daily_net_pnl_after_costs_below_floor")
+    if worst_day_net_pnl < RUNTIME_LEDGER_AUTHORITY_MIN_WORST_DAY_NET_PNL:
+        reasons.append("runtime_ledger_worst_day_net_pnl_after_costs_below_floor")
+    if max_intraday_drawdown > RUNTIME_LEDGER_AUTHORITY_MAX_INTRADAY_DRAWDOWN:
+        reasons.append("runtime_ledger_max_intraday_drawdown_above_limit")
+    if (
+        best_day_share is not None
+        and best_day_share > RUNTIME_LEDGER_AUTHORITY_MAX_BEST_DAY_SHARE
+    ):
+        reasons.append("runtime_ledger_best_day_share_above_limit")
+    if average_post_cost > 0:
+        target_implied_notional = (
+            RUNTIME_LEDGER_AUTHORITY_MIN_MEAN_DAILY_NET_PNL
+            * Decimal("10000")
+            / average_post_cost
+        )
+        if avg_daily_filled_notional < target_implied_notional:
+            reasons.append(
+                "runtime_ledger_avg_daily_filled_notional_below_target_implied_floor"
+            )
     return reasons
 
 
@@ -1386,6 +1511,13 @@ def persist_observed_runtime_windows(
     else:
         average_post_cost = Decimal("0")
         post_cost_expectancy_aggregation = "no_runtime_ledger_post_cost_rows"
+    runtime_ledger_promotion_gate_targets = _runtime_ledger_authority_gate_targets(
+        average_post_cost_bps=average_post_cost
+    )
+    runtime_ledger_daily_summary = {
+        **runtime_ledger_daily_summary,
+        "runtime_ledger_promotion_gate_targets": runtime_ledger_promotion_gate_targets,
+    }
     average_slippage = (
         sum(
             (
@@ -1410,6 +1542,7 @@ def persist_observed_runtime_windows(
         total_post_cost_basis_counts=total_post_cost_basis_counts,
         average_slippage=average_slippage,
         average_post_cost=average_post_cost,
+        runtime_ledger_daily_summary=runtime_ledger_daily_summary,
         latest_three_budget_ok=latest_three_budget_ok,
         all_continuity_ok=all_continuity_ok,
         all_drift_ok=all_drift_ok,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1773,6 +1773,33 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         lineage_hash_counts={"lineage-a": 1},
                         blockers_json=[],
                     ),
+                    StrategyRuntimeLedgerBucket(
+                        run_id="paper-route-run-2",
+                        candidate_id="candidate-active-route",
+                        hypothesis_id="H-ACTIVE-ROUTE",
+                        observed_stage="paper",
+                        bucket_started_at=window_start,
+                        bucket_ended_at=window_end,
+                        account_label="TORGHUT_SIM",
+                        runtime_strategy_name=strategy_name,
+                        strategy_family="microbar_pairs",
+                        fill_count=50,
+                        decision_count=25,
+                        submitted_order_count=25,
+                        closed_trade_count=0,
+                        open_position_count=1,
+                        filled_notional=Decimal("1000000"),
+                        gross_strategy_pnl=Decimal("110000"),
+                        cost_amount=Decimal("10000"),
+                        net_strategy_pnl_after_costs=Decimal("100000"),
+                        post_cost_expectancy_bps=Decimal("1000"),
+                        ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                        pnl_basis="realized_strategy_pnl_after_explicit_costs",
+                        execution_policy_hash_counts={"policy-a": 25},
+                        cost_model_hash_counts={"cost-a": 25},
+                        lineage_hash_counts={"lineage-a": 25},
+                        blockers_json=["open_position_count_nonzero"],
+                    ),
                     StrategyHypothesisMetricWindow(
                         run_id="paper-route-run-2",
                         candidate_id="candidate-active-route",
@@ -1866,7 +1893,15 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(audit["source_activity"]["execution_count"], 1)
         self.assertEqual(audit["source_activity"]["filled_execution_count"], 1)
         self.assertEqual(audit["source_activity"]["tca_sample_count"], 1)
+        self.assertEqual(audit["runtime_ledger"]["bucket_count"], 2)
         self.assertEqual(audit["runtime_ledger"]["evidence_grade_bucket_count"], 1)
+        self.assertEqual(audit["runtime_ledger"]["non_evidence_grade_bucket_count"], 1)
+        self.assertEqual(
+            audit["runtime_ledger"]["proof_scope"],
+            "evidence_grade_runtime_ledger_buckets_only",
+        )
+        self.assertEqual(audit["runtime_ledger"]["filled_notional"], "200")
+        self.assertEqual(audit["runtime_ledger"]["net_strategy_pnl_after_costs"], "10")
         self.assertEqual(audit["runtime_ledger"]["post_cost_expectancy_bps"], "500")
         self.assertEqual(
             audit["hypothesis_windows"]["evidence_provenance_counts"],

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from unittest import TestCase
 
@@ -1036,7 +1036,100 @@ class TestRuntimeWindowImport(TestCase):
             decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
 
         self.assertEqual(
-            [window.capital_stage for window in windows], ["0.10x canary", "0.50x live"]
+            [window.capital_stage for window in windows], ["shadow", "shadow"]
+        )
+        self.assertEqual(decision.allowed, False)
+        assert decision.payload_json is not None
+        self.assertIn(
+            "runtime_ledger_observed_trading_day_count_below_authority_minimum",
+            decision.payload_json["promotion_blocking_reasons"],
+        )
+        self.assertIn(
+            "runtime_ledger_mean_daily_net_pnl_after_costs_below_target",
+            decision.payload_json["promotion_blocking_reasons"],
+        )
+        self.assertIn(
+            "runtime_ledger_avg_daily_filled_notional_below_target_implied_floor",
+            decision.payload_json["promotion_blocking_reasons"],
+        )
+        self.assertEqual(
+            decision.payload_json["runtime_ledger_promotion_gate_targets"][
+                "target_implied_avg_daily_filled_notional"
+            ],
+            "625000",
+        )
+
+    def test_persist_observed_runtime_windows_allows_authority_grade_live_ledger(
+        self,
+    ) -> None:
+        base_start = datetime(2026, 3, 2, 14, 30, tzinfo=timezone.utc)
+        bucket_ranges = []
+        tca_rows = []
+        decision_times = []
+        execution_times = []
+        for day_index in range(20):
+            window_start = base_start + timedelta(days=day_index)
+            window_end = window_start + timedelta(minutes=30)
+            computed_at = window_start + timedelta(minutes=5)
+            bucket_ranges.append((window_start, window_end, 40))
+            decision_times.append(computed_at)
+            execution_times.append(computed_at + timedelta(minutes=1))
+            tca_rows.append(
+                {
+                    "computed_at": computed_at,
+                    "abs_slippage_bps": Decimal("1"),
+                    "post_cost_expectancy_bps": Decimal("600"),
+                    "runtime_ledger_bucket": _runtime_ledger_bucket(
+                        filled_notional="10000",
+                        gross_strategy_pnl="601",
+                        cost_amount="1",
+                        net_strategy_pnl_after_costs="600",
+                        post_cost_expectancy_bps="600",
+                    ),
+                    **_runtime_pnl_basis(),
+                }
+            )
+        buckets = build_observed_runtime_buckets(
+            bucket_ranges=bucket_ranges,
+            decision_times=decision_times,
+            execution_times=execution_times,
+            tca_rows=tca_rows,
+            continuity_ok=True,
+            drift_ok=True,
+            dependency_quorum_decision="allow",
+        )
+
+        with self.session_local() as session:
+            summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-live-authority-grade",
+                candidate_id="cand-authority-grade",
+                hypothesis_id="H-CONT-01",
+                observed_stage="live",
+                strategy_family="intraday_continuation",
+                source_manifest_ref="config/trading/hypotheses/h-cont-01.json",
+                buckets=buckets,
+            )
+            session.commit()
+            decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
+
+        self.assertEqual(summary["promotion_allowed"], True)
+        self.assertEqual(summary["runtime_ledger_observed_trading_day_count"], 20)
+        self.assertEqual(
+            summary["runtime_ledger_mean_daily_net_pnl_after_costs"], "600"
+        )
+        self.assertEqual(
+            summary["runtime_ledger_median_daily_net_pnl_after_costs"], "600"
+        )
+        self.assertEqual(summary["runtime_ledger_p10_daily_net_pnl_after_costs"], "600")
+        self.assertEqual(summary["runtime_ledger_worst_day_net_pnl_after_costs"], "600")
+        self.assertEqual(summary["runtime_ledger_best_day_share"], "0.05")
+        self.assertEqual(summary["runtime_ledger_avg_daily_filled_notional"], "10000")
+        self.assertEqual(
+            summary["runtime_ledger_promotion_gate_targets"][
+                "target_implied_avg_daily_filled_notional"
+            ],
+            "8333.333333333333333333333333",
         )
         self.assertEqual(decision.allowed, True)
         self.assertEqual(
@@ -1507,14 +1600,24 @@ class TestRuntimeWindowImport(TestCase):
             decision = session.execute(select(StrategyPromotionDecision)).scalar_one()
 
         self.assertEqual(summary["promotion_allowed"], False)
-        self.assertEqual(
+        self.assertIn(
+            "paper_stage_evidence_collection_only",
             summary["promotion_blocking_reasons"],
-            ["paper_stage_evidence_collection_only"],
+        )
+        self.assertIn(
+            "runtime_ledger_observed_trading_day_count_below_authority_minimum",
+            summary["promotion_blocking_reasons"],
+        )
+        self.assertNotIn(
+            "delay_adjusted_depth_stress_missing",
+            summary["promotion_blocking_reasons"],
         )
         self.assertEqual(summary["proof_status"], "blocked")
-        self.assertEqual(
-            [item["blocker"] for item in summary["proof_blockers"]],
-            ["paper_stage_evidence_collection_only"],
+        proof_blockers = {item["blocker"] for item in summary["proof_blockers"]}
+        self.assertIn("paper_stage_evidence_collection_only", proof_blockers)
+        self.assertIn(
+            "runtime_ledger_mean_daily_net_pnl_after_costs_below_target",
+            proof_blockers,
         )
         self.assertEqual(
             summary["delay_adjusted_depth_stress"],


### PR DESCRIPTION
## Summary

- Require authority-grade runtime-ledger promotion proof to pass observed trading-day, daily net PnL, drawdown, best-day concentration, and target-implied filled-notional gates.
- Add explicit runtime-ledger promotion target metadata into runtime-window import payloads so blocked candidates explain the daily-dollar proof gap.
- Scope paper-route runtime-ledger PnL, notional, and lifecycle counts to evidence-grade ledger buckets only, with truncation metadata for bounded DB reads.

## Related Issues

None.

## Testing

- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_window_import.py app/trading/paper_route_evidence.py tests/test_runtime_window_import.py tests/test_paper_route_evidence.py && uv run --frozen ruff check app/trading/runtime_window_import.py app/trading/paper_route_evidence.py tests/test_runtime_window_import.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_window_import.py tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv sync --frozen --extra dev && uv run --frozen pyright --project pyrightconfig.json && uv run --frozen pyright --project pyrightconfig.alpha.json && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None. The change intentionally makes promotion authority stricter for runtime-ledger proof, but it does not require migrations or config changes.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
