### PR TITLE
chore(symphony): promote image 8662ef9c

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-27T13:13:25Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-27T14:37:22Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "4eb351b4"
-    digest: sha256:7dc4659ea10138627643b78c392892b27ab35eb46eb8e51299ee1828e49d2718
+    newTag: "8662ef9c"
+    digest: sha256:2066dc09b1d5cf29029bb55835f1e5e68afbf9a3134988d9d73bc0c28a61a198

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-27T13:13:25Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-27T14:37:22Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "4eb351b4"
-    digest: sha256:7dc4659ea10138627643b78c392892b27ab35eb46eb8e51299ee1828e49d2718
+    newTag: "8662ef9c"
+    digest: sha256:2066dc09b1d5cf29029bb55835f1e5e68afbf9a3134988d9d73bc0c28a61a198

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-27T13:13:25Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-27T14:37:22Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "4eb351b4"
-    digest: sha256:7dc4659ea10138627643b78c392892b27ab35eb46eb8e51299ee1828e49d2718
+    newTag: "8662ef9c"
+    digest: sha256:2066dc09b1d5cf29029bb55835f1e5e68afbf9a3134988d9d73bc0c28a61a198


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `8662ef9c391650ac4c217bb273721ec6a4c27f08`
- Image tag: `8662ef9c`
- Image digest: `sha256:2066dc09b1d5cf29029bb55835f1e5e68afbf9a3134988d9d73bc0c28a61a198`