### PR TITLE
fix(torghut): require lineage-scoped runtime proof

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -65,6 +65,16 @@ PROMOTION_ONLY_READINESS_BLOCKERS = frozenset(
         "live_runtime_ledger_required",
     }
 )
+SOURCE_LINEAGE_CANDIDATE_KEYS = (
+    "candidate_id",
+    "strategy_candidate_id",
+    "source_candidate_id",
+)
+SOURCE_LINEAGE_HYPOTHESIS_KEYS = (
+    "hypothesis_id",
+    "strategy_hypothesis_id",
+    "source_hypothesis_id",
+)
 
 
 def _as_mapping(value: object) -> dict[str, Any]:
@@ -77,6 +87,91 @@ def _as_sequence(value: object) -> Sequence[object]:
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return cast(Sequence[object], value)
     return ()
+
+
+def _source_payloads(value: object) -> list[Mapping[str, Any]]:
+    payloads: list[Mapping[str, Any]] = []
+
+    def append_payload(candidate: object, *, depth: int) -> None:
+        if not isinstance(candidate, Mapping):
+            return
+        payload = {str(key): item for key, item in cast(Mapping[str, Any], candidate).items()}
+        payloads.append(payload)
+        if depth <= 0:
+            return
+        for nested in payload.values():
+            append_payload(nested, depth=depth - 1)
+
+    append_payload(value, depth=4)
+    return payloads
+
+
+def _source_lineage_values(value: object, keys: Sequence[str]) -> set[str]:
+    values: set[str] = set()
+    for payload in _source_payloads(value):
+        for key in keys:
+            if text := _safe_text(payload.get(key)):
+                values.add(text)
+    return values
+
+
+def _source_decision_lineage_matches(
+    row: TradeDecision,
+    *,
+    candidate_id: str | None,
+    hypothesis_id: str | None,
+) -> bool:
+    payload = row.decision_json
+    if candidate_id is not None and candidate_id not in _source_lineage_values(
+        payload, SOURCE_LINEAGE_CANDIDATE_KEYS
+    ):
+        return False
+    if hypothesis_id is not None and hypothesis_id not in _source_lineage_values(
+        payload, SOURCE_LINEAGE_HYPOTHESIS_KEYS
+    ):
+        return False
+    return True
+
+
+def _source_lineage_blockers(
+    rows: Sequence[TradeDecision],
+    *,
+    candidate_id: str | None,
+    hypothesis_id: str | None,
+) -> list[str]:
+    if not rows:
+        return []
+    blockers: list[str] = []
+    if candidate_id is not None:
+        candidate_values: set[str] = set()
+        for row in rows:
+            candidate_values.update(
+                _source_lineage_values(row.decision_json, SOURCE_LINEAGE_CANDIDATE_KEYS)
+            )
+        if not candidate_values:
+            blockers.append("source_candidate_lineage_missing")
+        elif candidate_id not in candidate_values:
+            blockers.append("source_candidate_lineage_mismatch")
+    if hypothesis_id is not None:
+        hypothesis_values: set[str] = set()
+        for row in rows:
+            hypothesis_values.update(
+                _source_lineage_values(row.decision_json, SOURCE_LINEAGE_HYPOTHESIS_KEYS)
+            )
+        if not hypothesis_values:
+            blockers.append("source_hypothesis_lineage_missing")
+        elif hypothesis_id not in hypothesis_values:
+            blockers.append("source_hypothesis_lineage_mismatch")
+    return blockers
+
+
+def _target_requires_source_lineage(target: Mapping[str, object]) -> bool:
+    source_kind = str(target.get("source_kind") or "").strip().lower().replace("-", "_")
+    return source_kind in {
+        "paper_route_probe_runtime_observed",
+        "paper_runtime_observed",
+        "live_runtime_observed",
+    }
 
 
 def _unique_text_items(value: object) -> list[str]:
@@ -1076,6 +1171,9 @@ def _strategy_source_activity(
     symbols: Sequence[str],
     window_start: datetime,
     window_end: datetime,
+    candidate_id: str | None = None,
+    hypothesis_id: str | None = None,
+    require_source_lineage: bool = False,
 ) -> dict[str, object]:
     symbol_filters = [
         str(item).strip().upper() for item in symbols if str(item).strip()
@@ -1087,6 +1185,12 @@ def _strategy_source_activity(
             "strategy_lookup_names": [],
             "account_label": account_label,
             "symbols": symbol_filters,
+            "lineage_required": require_source_lineage,
+            "expected_candidate_id": candidate_id,
+            "expected_hypothesis_id": hypothesis_id,
+            "raw_decision_count": 0,
+            "lineage_matched_decision_count": 0,
+            "lineage_blockers": [],
             "decision_count": 0,
             "execution_count": 0,
             "filled_execution_count": 0,
@@ -1118,6 +1222,26 @@ def _strategy_source_activity(
             decision_stmt.order_by(TradeDecision.created_at.desc()).limit(500)
         ).scalars()
     )
+    raw_decision_count = len(decision_rows)
+    lineage_blockers = (
+        _source_lineage_blockers(
+            decision_rows,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+        )
+        if require_source_lineage
+        else []
+    )
+    if require_source_lineage:
+        decision_rows = [
+            row
+            for row in decision_rows
+            if _source_decision_lineage_matches(
+                row,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+            )
+        ]
     decision_ids = [row.id for row in decision_rows]
     execution_rows: list[Execution] = []
     if decision_ids:
@@ -1178,11 +1302,18 @@ def _strategy_source_activity(
         missing_reasons.append("source_executions_missing")
     if tca_sample_count <= 0:
         missing_reasons.append("source_tca_missing")
+    missing_reasons.extend(lineage_blockers)
     return {
         "strategy_name": strategy_name,
         "strategy_lookup_names": strategy_filters,
         "account_label": account_label,
         "symbols": symbol_filters,
+        "lineage_required": require_source_lineage,
+        "expected_candidate_id": candidate_id,
+        "expected_hypothesis_id": hypothesis_id,
+        "raw_decision_count": raw_decision_count,
+        "lineage_matched_decision_count": decision_count,
+        "lineage_blockers": lineage_blockers,
         "decision_count": decision_count,
         "execution_count": execution_count,
         "filled_execution_count": filled_execution_count,
@@ -1596,6 +1727,9 @@ def _target_audit(
         symbols=_target_probe_symbols(target, probe),
         window_start=window_start,
         window_end=window_end,
+        candidate_id=candidate_id,
+        hypothesis_id=hypothesis_id,
+        require_source_lineage=_target_requires_source_lineage(target),
     )
     rejected_signal_activity = _rejected_signal_activity(
         session,

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1701,7 +1701,7 @@ def build_runtime_ledger_proof_packet(
         "paper_route_session_settlement_pending",
         "paper_route_import_not_ready",
     }
-    if post_cost_proof_allowed and not capital_status_blockers:
+    if post_cost_proof_allowed and not promotion_prerequisite_blockers:
         verdict = "promotion_authority_allowed"
         reason = "runtime_ledger_live_paper_post_cost_proof_satisfied"
         promotion_reason = reason

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -71,6 +71,16 @@ _RUNTIME_LEDGER_EQUITY_DENOMINATOR_KEYS = (
     "net_liquidation",
     "net_liquidation_value",
 )
+SOURCE_LINEAGE_CANDIDATE_KEYS = (
+    "candidate_id",
+    "strategy_candidate_id",
+    "source_candidate_id",
+)
+SOURCE_LINEAGE_HYPOTHESIS_KEYS = (
+    "hypothesis_id",
+    "strategy_hypothesis_id",
+    "source_hypothesis_id",
+)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -209,6 +219,36 @@ def _first_text(row: Mapping[str, object], *keys: str) -> str | None:
             if text:
                 return text
     return None
+
+
+def _text_values(row: Mapping[str, object], *keys: str) -> set[str]:
+    values: set[str] = set()
+    for payload in _row_payloads(row):
+        for key in keys:
+            text = str(payload.get(key) or "").strip()
+            if text:
+                values.add(text)
+    return values
+
+
+def _source_row_matches_lineage(
+    row: Mapping[str, object],
+    *,
+    candidate_id: str | None,
+    hypothesis_id: str | None,
+    require_source_lineage: bool,
+) -> bool:
+    if not require_source_lineage:
+        return True
+    if candidate_id is not None and candidate_id not in _text_values(
+        row, *SOURCE_LINEAGE_CANDIDATE_KEYS
+    ):
+        return False
+    if hypothesis_id is not None and hypothesis_id not in _text_values(
+        row, *SOURCE_LINEAGE_HYPOTHESIS_KEYS
+    ):
+        return False
+    return True
 
 
 def _runtime_ledger_equity_denominator_from_rows(
@@ -1786,6 +1826,9 @@ def _query_timestamps(
     window_start: datetime,
     window_end: datetime,
     symbols: Sequence[str] | None = None,
+    candidate_id: str | None = None,
+    hypothesis_id: str | None = None,
+    require_source_lineage: bool = False,
     allow_authoritative_runtime_ledger_materialization: bool = False,
 ) -> tuple[list[datetime], list[datetime], list[dict[str, object]]]:
     if not strategy_names:
@@ -1864,6 +1907,16 @@ def _query_timestamps(
                 for row in cur.fetchall()
                 if row[0] is not None
             ]
+            decision_lifecycle_rows = [
+                row
+                for row in decision_lifecycle_rows
+                if _source_row_matches_lineage(
+                    row,
+                    candidate_id=candidate_id,
+                    hypothesis_id=hypothesis_id,
+                    require_source_lineage=require_source_lineage,
+                )
+            ]
             decisions = []
             for row in decision_lifecycle_rows:
                 computed_at = row.get("computed_at")
@@ -1929,6 +1982,16 @@ def _query_timestamps(
                 for row in cur.fetchall()
                 if row[0] is not None
             ]
+            execution_rows = [
+                row
+                for row in execution_rows
+                if _source_row_matches_lineage(
+                    row,
+                    candidate_id=candidate_id,
+                    hypothesis_id=hypothesis_id,
+                    require_source_lineage=require_source_lineage,
+                )
+            ]
             executions = []
             for row in execution_rows:
                 computed_at = row.get("computed_at")
@@ -1993,12 +2056,24 @@ def _query_timestamps(
                 for row in cur.fetchall()
                 if row[0] is not None
             ]
+            order_lifecycle_rows = [
+                row
+                for row in order_lifecycle_rows
+                if _source_row_matches_lineage(
+                    row,
+                    candidate_id=candidate_id,
+                    hypothesis_id=hypothesis_id,
+                    require_source_lineage=require_source_lineage,
+                )
+            ]
             cur.execute(
                 f"""
                 select
                     d.created_at,
                     abs(coalesce(t.realized_shortfall_bps, t.slippage_bps)) as abs_slippage_bps,
-                    (-coalesce(t.realized_shortfall_bps, t.slippage_bps)) as post_cost_expectancy_bps
+                    (-coalesce(t.realized_shortfall_bps, t.slippage_bps)) as post_cost_expectancy_bps,
+                    d.decision_hash,
+                    d.decision_json
                 from execution_tca_metrics t
                 join executions e on e.id = t.execution_id
                 join trade_decisions d on d.id = e.trade_decision_id
@@ -2023,11 +2098,23 @@ def _query_timestamps(
                     "computed_at": row[0],
                     "abs_slippage_bps": row[1] or Decimal("0"),
                     "post_cost_expectancy_bps": row[2] or Decimal("0"),
+                    "decision_hash": row[3],
+                    "decision_json": row[4],
                     "post_cost_expectancy_basis": POST_COST_BASIS_TCA_PROXY,
                     "post_cost_promotion_eligible": False,
                 }
                 for row in cur.fetchall()
                 if row[0] is not None
+            ]
+            tca_rows = [
+                row
+                for row in tca_rows
+                if _source_row_matches_lineage(
+                    row,
+                    candidate_id=candidate_id,
+                    hypothesis_id=hypothesis_id,
+                    require_source_lineage=require_source_lineage,
+                )
             ]
     tca_rows.extend(
         _build_realized_strategy_pnl_rows(
@@ -2181,6 +2268,9 @@ def main() -> int:
             window_start=window_start,
             window_end=window_end,
             symbols=source_activity_symbols,
+            candidate_id=args.candidate_id.strip() or None,
+            hypothesis_id=args.hypothesis_id,
+            require_source_lineage=allow_authoritative_runtime_ledger_materialization,
             allow_authoritative_runtime_ledger_materialization=(
                 allow_authoritative_runtime_ledger_materialization
             ),

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -456,6 +456,59 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result["required_actions"],
         )
 
+    def test_packet_splits_post_cost_proof_from_paper_route_promotion_gate(
+        self,
+    ) -> None:
+        evidence = _paper_route_evidence()
+        plan = evidence["next_paper_route_runtime_window_targets"]
+        assert isinstance(plan, dict)
+        target = plan["targets"][0]
+        assert isinstance(target, dict)
+        target["drift_ok"] = "false"
+        target["drift_reason"] = "drift_live_promotion_ineligible"
+        target["runtime_window_import_health_gate"] = {
+            "schema_version": "torghut.runtime-window-import-health-gate.v1",
+            "dependency_quorum_decision": "allow",
+            "continuity_ok": "true",
+            "drift_ok": "false",
+            "drift_reason": "drift_live_promotion_ineligible",
+            "blockers": [],
+            "promotion_blockers": ["drift_checks_not_ok"],
+        }
+        target["runtime_window_import_health_gate_blockers"] = []
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=evidence,
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(),
+            min_runtime_ledger_net_pnl=Decimal("500"),
+            min_runtime_ledger_daily_net_pnl=Decimal("500"),
+            min_runtime_ledger_trading_days=1,
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertTrue(result["post_cost_proof_authority"]["allowed"], result)
+        self.assertEqual(result["post_cost_proof_authority"]["blocking_reasons"], [])
+        self.assertEqual(
+            result["verdict"],
+            "post_cost_proof_authority_allowed_capital_promotion_blocked",
+        )
+        self.assertFalse(result["capital_promotion_authority"]["allowed"])
+        self.assertEqual(
+            result["capital_promotion_authority"]["blocking_reasons"],
+            ["drift_checks_not_ok"],
+        )
+        self.assertFalse(result["promotion_authority"]["allowed"])
+        self.assertEqual(
+            result["promotion_authority"]["failed_checks"],
+            ["paper_route_promotion_health_gate"],
+        )
+        self.assertIn(
+            "drift_checks_not_ok",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+
     def test_cli_uploads_durable_proof_packet_artifact_with_runtime_run_id(
         self,
     ) -> None:

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -115,6 +115,8 @@ class _FakeCursor:
                     datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     Decimal("1.25"),
                     Decimal("0.50"),
+                    "decision-sha",
+                    {},
                 )
             ],
         ]
@@ -1800,6 +1802,160 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIn("upper(d.symbol) = any(%s)", tca_query)
         self.assertIn("upper(e.symbol) = any(%s)", tca_query)
         self.assertEqual(tca_params[-2:], (["AAPL"], ["AAPL"]))
+
+    def test_query_timestamps_requires_source_lineage_for_candidate_import(
+        self,
+    ) -> None:
+        cursor = _FakeCursor()
+        matched_json = {"candidate_id": "cand-a", "hypothesis_id": "H-A"}
+        unscoped_json: dict[str, object] = {}
+        cursor._results = [
+            [
+                (
+                    datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "AAPL",
+                    "TORGHUT_SIM",
+                    "microbar-cross-sectional-pairs-v1",
+                    "decision-matched",
+                    matched_json,
+                ),
+                (
+                    datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "AAPL",
+                    "TORGHUT_SIM",
+                    "microbar-cross-sectional-pairs-v1",
+                    "decision-unscoped",
+                    unscoped_json,
+                ),
+            ],
+            [
+                (
+                    datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 14, 35, 30, tzinfo=timezone.utc),
+                    "AAPL",
+                    "buy",
+                    Decimal("1"),
+                    Decimal("100"),
+                    Decimal("0.01"),
+                    {
+                        "cost_amount": "0.01",
+                        "cost_basis": "broker_reported_commission_and_fees",
+                    },
+                    {},
+                    "TORGHUT_SIM",
+                    "microbar-cross-sectional-pairs-v1",
+                    "decision-matched",
+                    matched_json,
+                    "alpaca-order-matched",
+                    "client-order-matched",
+                    "filled",
+                ),
+                (
+                    datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 14, 36, 30, tzinfo=timezone.utc),
+                    "AAPL",
+                    "buy",
+                    Decimal("1"),
+                    Decimal("100"),
+                    Decimal("0.01"),
+                    {},
+                    {},
+                    "TORGHUT_SIM",
+                    "microbar-cross-sectional-pairs-v1",
+                    "decision-unscoped",
+                    unscoped_json,
+                    "alpaca-order-unscoped",
+                    "client-order-unscoped",
+                    "filled",
+                ),
+            ],
+            [
+                (
+                    datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+                    "AAPL",
+                    "TORGHUT_SIM",
+                    "microbar-cross-sectional-pairs-v1",
+                    "decision-matched",
+                    matched_json,
+                    "alpaca-order-matched",
+                    "client-order-matched",
+                    "new",
+                    "new",
+                    "event-fingerprint-matched",
+                    "alpaca-trade-updates",
+                    0,
+                    1,
+                    {
+                        "execution_policy": {"selected_order_type": "market"},
+                        "cost_model": {"source": "broker_reported"},
+                    },
+                ),
+                (
+                    datetime(2026, 3, 6, 14, 36, 1, tzinfo=timezone.utc),
+                    "AAPL",
+                    "TORGHUT_SIM",
+                    "microbar-cross-sectional-pairs-v1",
+                    "decision-unscoped",
+                    unscoped_json,
+                    "alpaca-order-unscoped",
+                    "client-order-unscoped",
+                    "new",
+                    "new",
+                    "event-fingerprint-unscoped",
+                    "alpaca-trade-updates",
+                    0,
+                    2,
+                    {},
+                ),
+            ],
+            [
+                (
+                    datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    Decimal("1.25"),
+                    Decimal("0.50"),
+                    "decision-matched",
+                    matched_json,
+                ),
+                (
+                    datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    Decimal("9.99"),
+                    Decimal("-9.99"),
+                    "decision-unscoped",
+                    unscoped_json,
+                ),
+            ],
+        ]
+        connection = _FakeConnection(cursor)
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+
+        with patch(
+            "scripts.import_hypothesis_runtime_windows.psycopg.connect",
+            return_value=connection,
+        ):
+            decisions, executions, tca_rows = _query_timestamps(
+                dsn="postgresql://example",
+                strategy_names=["microbar-cross-sectional-pairs-v1"],
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+                window_end=window_end,
+                candidate_id="cand-a",
+                hypothesis_id="H-A",
+                require_source_lineage=True,
+            )
+
+        self.assertEqual(decisions, [datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)])
+        self.assertEqual(
+            executions, [datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)]
+        )
+        proxy_rows = [
+            row
+            for row in tca_rows
+            if row.get("post_cost_expectancy_basis") == POST_COST_BASIS_TCA_PROXY
+        ]
+        self.assertEqual(len(proxy_rows), 1)
+        self.assertEqual(proxy_rows[0]["decision_hash"], "decision-matched")
+        self.assertEqual(proxy_rows[0]["post_cost_expectancy_bps"], Decimal("0.50"))
 
     def test_query_timestamps_requires_strategy_name_candidates(self) -> None:
         window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -847,7 +847,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 alpaca_account_label="TORGHUT_SIM",
                 symbol="AAPL",
                 timeframe="1Min",
-                decision_json={"action": "buy", "qty": "2"},
+                decision_json={
+                    "action": "buy",
+                    "qty": "2",
+                    "candidate_id": "candidate-ledger-audit",
+                    "hypothesis_id": "H-LEDGER-AUDIT",
+                },
                 rationale="paper route ledger audit fixture",
                 status="executed",
                 created_at=window_start + timedelta(minutes=10),
@@ -1135,7 +1140,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 alpaca_account_label="TORGHUT_SIM",
                 symbol="AAPL",
                 timeframe="1Min",
-                decision_json={"action": "buy", "qty": "1"},
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "candidate_id": "candidate-post-window",
+                    "hypothesis_id": "H-POST-WINDOW",
+                },
                 rationale="post window fixture",
                 status="executed",
                 created_at=window_end + timedelta(minutes=5),
@@ -1278,7 +1288,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 alpaca_account_label="TORGHUT_SIM",
                 symbol="INTC",
                 timeframe="1Min",
-                decision_json={"action": "buy", "qty": "1"},
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "candidate_id": "candidate-refreshed-probe",
+                    "hypothesis_id": "H-REFRESHED-PROBE",
+                },
                 rationale="refreshed probe symbol fixture",
                 status="executed",
                 created_at=window_start + timedelta(minutes=5),
@@ -1696,7 +1711,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 alpaca_account_label="TORGHUT_SIM",
                 symbol="AAPL",
                 timeframe="1Min",
-                decision_json={"action": "buy", "qty": "2"},
+                decision_json={
+                    "action": "buy",
+                    "qty": "2",
+                    "candidate_id": "candidate-active-route",
+                    "hypothesis_id": "H-ACTIVE-ROUTE",
+                },
                 rationale="paper route fixture",
                 status="executed",
                 created_at=window_start + timedelta(minutes=10),
@@ -1964,6 +1984,143 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertFalse(import_audit["promotion_authority"]["allowed"])
 
+    def test_paper_route_source_activity_requires_candidate_lineage(self) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        now = datetime(2026, 5, 26, 21, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                description="base strategy source activity",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={"action": "sell", "qty": "1"},
+                rationale="unscoped base-strategy source activity",
+                status="executed",
+                created_at=window_start + timedelta(minutes=10),
+                executed_at=window_start + timedelta(minutes=11),
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="unscoped-paper-route-order",
+                client_order_id="unscoped-paper-route-client",
+                symbol="AAPL",
+                side="sell",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=window_start + timedelta(minutes=12),
+                updated_at=window_start + timedelta(minutes=12),
+                last_update_at=window_start + timedelta(minutes=12),
+            )
+            session.add(execution)
+            session.flush()
+            session.add(
+                ExecutionTCAMetric(
+                    execution_id=execution.id,
+                    trade_decision_id=decision.id,
+                    strategy_id=strategy.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    symbol="AAPL",
+                    side="sell",
+                    arrival_price=Decimal("101"),
+                    avg_fill_price=Decimal("100"),
+                    filled_qty=Decimal("1"),
+                    signed_qty=Decimal("-1"),
+                    slippage_bps=Decimal("5"),
+                    shortfall_notional=Decimal("1"),
+                    realized_shortfall_bps=Decimal("5"),
+                    churn_qty=Decimal("0"),
+                    churn_ratio=Decimal("0"),
+                    computed_at=window_start + timedelta(minutes=13),
+                    created_at=window_start + timedelta(minutes=13),
+                    updated_at=window_start + timedelta(minutes=13),
+                )
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": "1",
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-pairs-a",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                                "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": ["AAPL"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                    },
+                },
+                generated_at=now,
+            )
+
+        source_activity = payload["targets"][0]["source_activity"]
+        self.assertTrue(source_activity["lineage_required"])
+        self.assertEqual(source_activity["raw_decision_count"], 1)
+        self.assertEqual(source_activity["decision_count"], 0)
+        self.assertEqual(source_activity["execution_count"], 0)
+        self.assertEqual(source_activity["tca_sample_count"], 0)
+        self.assertEqual(
+            source_activity["lineage_blockers"],
+            ["source_candidate_lineage_missing", "source_hypothesis_lineage_missing"],
+        )
+        self.assertIn(
+            "source_candidate_lineage_missing",
+            payload["targets"][0]["readiness"]["evidence_collection_blockers"],
+        )
+        self.assertIn(
+            "source_hypothesis_lineage_missing",
+            payload["targets"][0]["readiness"]["evidence_collection_blockers"],
+        )
+        self.assertEqual(payload["summary"]["target_with_source_activity_count"], 0)
+
     def test_runtime_import_audit_counts_selected_targets_not_raw_plan_noise(
         self,
     ) -> None:
@@ -1989,7 +2146,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 alpaca_account_label="TORGHUT_SIM",
                 symbol="AAPL",
                 timeframe="1Min",
-                decision_json={"action": "buy", "qty": "2"},
+                decision_json={
+                    "action": "buy",
+                    "qty": "2",
+                    "candidate_id": "candidate-selected-route",
+                    "hypothesis_id": "H-SELECTED-ROUTE",
+                },
                 rationale="selected paper route fixture",
                 status="executed",
                 created_at=window_start + timedelta(minutes=10),


### PR DESCRIPTION
## Summary

- Requires proof-grade paper-route source rows to carry the expected candidate and hypothesis lineage before they can count as target source activity.
- Filters runtime-window imports to lineage-matched decision, execution, order-event, and TCA rows so base-strategy fills cannot be attributed to multiple candidates.
- Extends runtime proof packet and import tests for lineage-scoped blocking and candidate-mismatch failure modes.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_import_hypothesis_runtime_windows.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py scripts/import_hypothesis_runtime_windows.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_paper_route_evidence.py tests/test_import_hypothesis_runtime_windows.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
