### PR TITLE
fix(synthesis): keep trader agent running through session

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -24,6 +24,7 @@ spec:
     - Report account equity, buying power, margin fields, and exposure separately so progress and execution capacity stay clear.
     - Write preflight, decision ledger, and final report artifacts for every run.
     - On market-open runs, place and verify the smallest valid paper order only after all preflights pass.
+    - Keep market-open runs alive until the trading session closes, the 500000 USD equity goal is reached, or a hard stop triggers.
   text: |-
     You are the Synthesis autonomous paper-trader AgentRun.
 
@@ -48,6 +49,11 @@ spec:
     Trading loop:
     - If parameters.mode is preflight, create only a non-marketable paper limit order smoke test and cancel it after order id/client id verification. Do not leave an open order.
     - If parameters.mode is market-open, wait until Alpaca clock says the equity market is open. If it never opens during this run, write a report and exit without trading.
+    - If parameters.mode is market-open, do not exit after the first reconciled action set. A reconciled order or stand-down decision completes one cycle, not the run.
+    - Keep market-open mode alive in an intraday loop until Alpaca clock reaches the current session close, account equity is at or above 500000 USD, or a hard stop rule triggers.
+    - Each market-open loop cycle must re-read clock, account info, open orders, positions, and recent portfolio state; reconcile all open orders; update the decision ledger and report; decide whether to trade, adjust, hedge, reduce, or stand down for that cycle; then wait for the next cycle while the market remains open.
+    - Emit a heartbeat at least every 60 seconds during waits so the runner stays visibly active. Do not use a silent sleep longer than 60 seconds.
+    - Record the loop cycle number, current time, next close, equity, buying power, open-order count, and any action taken in the decision ledger.
     - On the first market-open run after deployment, place one tiny paper stock-order smoke test using a unique client_order_id, verify it through get_order_by_client_id, and record the result before any larger strategy order. If buying power is too low for a buy order, use the smallest valid sell order against an existing liquid long equity position instead.
     - Build a ranked intraday action list from current positions, liquid watchlist names, market snapshots, technical analysis, catalysts, macro context, spread/liquidity checks, and portfolio risk.
     - Use Python and any needed installed packages or temporary scripts for scans, indicators, options-chain scoring, position sizing, and risk/reward math.
@@ -59,3 +65,4 @@ spec:
     - Append every decision, tool preflight result, order intent, order request summary, order status, and account-equity update to /workspace/.agentrun/autonomous-trader/decision-ledger.jsonl.
     - Write /workspace/.agentrun/autonomous-trader/report.md with: session mode, market-open status, account equity, buying power, exposure, positions, orders placed/canceled/filled, strategy rationale, current distance to 500000 USD equity, and next action.
     - Report explicitly whether the run placed an order, canceled an order, filled an order, or skipped trading because a stop rule triggered.
+    - In market-open mode, the final report must state the terminal reason as exactly one of: target_reached, market_closed, or hard_stop. Do not use market_open_actions_reconciled as a terminal reason.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -32,6 +32,10 @@ data:
     - Do not hide blockers. If buying power, market hours, API permissions, rate limits, or tooling prevent execution, report the exact blocker and smallest fix.
 
     Persistence and outputs:
-    - Continue until the run reaches a clear terminal state: preflight complete, market-open trading actions reconciled, a hard stop triggered, or the configured session window ends.
+    - In market-open mode, do not treat "trading actions reconciled" as terminal. Reconciled actions only complete one cycle.
+    - In market-open mode, keep the AgentRun alive in an intraday session loop until one of these terminal states occurs: Alpaca clock reaches the current session close, account equity is at or above 500000 USD, or a hard stop rule triggers.
+    - Each market-open loop cycle must re-read clock/account/orders/positions, reconcile open orders, update artifacts, decide whether to act or stand down for that cycle, and then continue waiting for the next cycle while the market remains open.
+    - Use an explicit wait/heartbeat between cycles, with periodic output at least every 60 seconds so the runner is visibly alive and is not mistaken for an idle completed turn.
+    - Preflight mode may finish after preflight complete. Market-open mode must not finish just because initial smoke/risk-reduction orders were reconciled.
     - Write `/workspace/.agentrun/autonomous-trader/report.md`, `/workspace/.agentrun/autonomous-trader/decision-ledger.jsonl`, and `/workspace/.agentrun/autonomous-trader/preflight.json` before exiting.
-    - Finish only after the artifacts summarize account state, actions taken, order ids or skipped-order reasons, and next market-open readiness.
+    - Finish only after the market-open terminal state is true and the artifacts summarize final account state, actions taken, order ids or skipped-order reasons, and next market-open readiness.

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -627,6 +627,11 @@ describe('synthesis autonomous trader provider', () => {
     expect(taskPrompt).not.toContain('toward 500000 USD account equity')
     expect(taskPrompt).toContain('There is no 2-3 week hold-time requirement')
     expect(taskPrompt).toContain('You may buy, sell, close, reduce, hedge, reverse, or stand down')
+    expect(taskPrompt).toContain('do not exit after the first reconciled action set')
+    expect(taskPrompt).toContain('Keep market-open mode alive in an intraday loop')
+    expect(taskPrompt).toContain('Do not use market_open_actions_reconciled as a terminal reason')
+    expect(prompt).toContain('do not treat "trading actions reconciled" as terminal')
+    expect(prompt).toContain('Use an explicit wait/heartbeat between cycles')
   })
 
   it('bridges Codex framed MCP stdio to Alpaca newline stdio', () => {


### PR DESCRIPTION
## Summary

- Tightens the autonomous trader prompt so market-open runs do not finish after the first reconciled action cycle.
- Requires market-open runs to keep an intraday loop alive until market close, target equity, or hard stop.
- Adds regression expectations so future prompt edits preserve the no-token-budget goal and session-loop contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "synthesis autonomous trader provider"`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/synthesis >/tmp/synthesis-session-loop-render.yaml`
- `kubectl apply --dry-run=server -f /tmp/synthesis-session-loop-render.yaml`
- `yq '. | select(.kind == "AgentRun" and .metadata.name == "autonomous-trader-template") | .spec.goal | has("tokenBudget")' /tmp/synthesis-session-loop-render.yaml`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
