### PR TITLE
chore(analysis): promote image 22e4b83

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 92865142ab3b822fda731eb31575efa670c2f03a
+    newTag: 22e4b83003b0beb34dcfda33483a40f44043acec


### PR DESCRIPTION
## Summary

- Promotes the analysis static-site image to `22e4b83003b0beb34dcfda33483a40f44043acec`.
- Carries the MPWR AI power-management research package into the live analysis deployment.
- Limits the GitOps change to the analysis application image tag.

## Related Issues

None

## Testing

- `scripts/verify-analysis-image.sh 22e4b83003b0beb34dcfda33483a40f44043acec latest`
- `kubectl kustomize argocd/applications/analysis`
- `git diff --check`

## Screenshots (if applicable)

N/A - GitOps image tag only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
