### PR TITLE
chore(analysis): promote image 0cf3120

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 92865142ab3b822fda731eb31575efa670c2f03a
+    newTag: 0cf3120ce8dbb6a637cbc5ee4d0bb0e614457755


### PR DESCRIPTION
## Summary

- Promotes the analysis static-site image to latest analysis `main` commit `0cf3120ce8dbb6a637cbc5ee4d0bb0e614457755`.
- Keeps the MPWR package live while also carrying the later ORCL and SNOW packages already on analysis main.
- Limits the GitOps change to the analysis application image tag.

## Related Issues

None

## Testing

- `scripts/verify-analysis-image.sh 0cf3120ce8dbb6a637cbc5ee4d0bb0e614457755 latest`
- `kubectl kustomize argocd/applications/analysis`
- `git diff --check`

## Screenshots (if applicable)

N/A - GitOps image tag only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
