### PR TITLE
fix(synthesis): retry trader alpaca mcp timeouts

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -25,6 +25,7 @@ spec:
     - Write preflight, decision ledger, and final report artifacts for every run.
     - On market-open runs, place and verify the smallest valid paper order only after all preflights pass.
     - Keep market-open runs alive until the trading session closes, the 500000 USD equity goal is reached, or a hard stop triggers.
+    - Treat transient Alpaca MCP read timeouts as recoverable by reconnecting and retrying before hard-stopping.
   text: |-
     You are the Synthesis autonomous paper-trader AgentRun.
 
@@ -40,6 +41,8 @@ spec:
     - Stop immediately if duplicate active trader AgentRuns are detected for the same market session.
     - Stop once account equity is at or above 500000 USD.
     - Do not leave any order unmanaged or unreconciled.
+    - A single Alpaca MCP timeout is not a hard stop. For read-only calls and pre-order checks, reconnect the MCP session and retry with backoff up to 3 consecutive failures, logging each retry as mcp_retry. Hard-stop only after retries are exhausted or account/order state remains unreconciled.
+    - If a timeout happens after an order submission attempt, do not blindly submit another order. First verify by client_order_id and order id; cancel/reconcile any active order if needed. Only hard-stop if the order cannot be resolved after bounded retries.
 
     Required preflight:
     - Use Alpaca MCP to read account info, account config, clock, calendar for the current trading day, open orders, positions, and recent portfolio history.
@@ -52,6 +55,7 @@ spec:
     - If parameters.mode is market-open, do not exit after the first reconciled action set. A reconciled order or stand-down decision completes one cycle, not the run.
     - Keep market-open mode alive in an intraday loop until Alpaca clock reaches the current session close, account equity is at or above 500000 USD, or a hard stop rule triggers.
     - Each market-open loop cycle must re-read clock, account info, open orders, positions, and recent portfolio state; reconcile all open orders; update the decision ledger and report; decide whether to trade, adjust, hedge, reduce, or stand down for that cycle; then wait for the next cycle while the market remains open.
+    - Wrap Alpaca MCP calls in a retry/reconnect helper. Read-only market/account/position/order calls should tolerate transient 30-second timeouts, continue heartbeating, and resume the loop after a successful retry.
     - Emit a heartbeat at least every 60 seconds during waits so the runner stays visibly active. Do not use a silent sleep longer than 60 seconds.
     - Record the loop cycle number, current time, next close, equity, buying power, open-order count, and any action taken in the decision ledger.
     - On the first market-open run after deployment, place one tiny paper stock-order smoke test using a unique client_order_id, verify it through get_order_by_client_id, and record the result before any larger strategy order. If buying power is too low for a buy order, use the smallest valid sell order against an existing liquid long equity position instead.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -30,11 +30,14 @@ data:
     - Prefer liquid instruments and order types that can be verified quickly. Do not leave unmanaged orders.
     - After every order request, reconcile by order id or client order id and record the status before taking the next trading action.
     - Do not hide blockers. If buying power, market hours, API permissions, rate limits, or tooling prevent execution, report the exact blocker and smallest fix.
+    - Do not treat a single Alpaca MCP timeout as a terminal trading failure. For read-only account, clock, order, position, or market-data calls, reconnect and retry with backoff up to 3 consecutive failures, logging each retry as `mcp_retry`.
+    - If an MCP timeout happens after an order submission attempt, verify by client order id and order id before submitting anything else. Cancel/reconcile any active order if needed; hard-stop only if the order cannot be resolved after bounded retries.
 
     Persistence and outputs:
     - In market-open mode, do not treat "trading actions reconciled" as terminal. Reconciled actions only complete one cycle.
     - In market-open mode, keep the AgentRun alive in an intraday session loop until one of these terminal states occurs: Alpaca clock reaches the current session close, account equity is at or above 500000 USD, or a hard stop rule triggers.
     - Each market-open loop cycle must re-read clock/account/orders/positions, reconcile open orders, update artifacts, decide whether to act or stand down for that cycle, and then continue waiting for the next cycle while the market remains open.
+    - Market-open mode must continue after recoverable Alpaca MCP read timeouts. Reconnect the MCP process/session, retry the failed read, emit heartbeat output while recovering, and resume the same loop cycle when state is reconciled.
     - Use an explicit wait/heartbeat between cycles, with periodic output at least every 60 seconds so the runner is visibly alive and is not mistaken for an idle completed turn.
     - Preflight mode may finish after preflight complete. Market-open mode must not finish just because initial smoke/risk-reduction orders were reconciled.
     - Write `/workspace/.agentrun/autonomous-trader/report.md`, `/workspace/.agentrun/autonomous-trader/decision-ledger.jsonl`, and `/workspace/.agentrun/autonomous-trader/preflight.json` before exiting.

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -630,8 +630,12 @@ describe('synthesis autonomous trader provider', () => {
     expect(taskPrompt).toContain('do not exit after the first reconciled action set')
     expect(taskPrompt).toContain('Keep market-open mode alive in an intraday loop')
     expect(taskPrompt).toContain('Do not use market_open_actions_reconciled as a terminal reason')
+    expect(taskPrompt).toContain('A single Alpaca MCP timeout is not a hard stop')
+    expect(taskPrompt).toContain('logging each retry as mcp_retry')
     expect(prompt).toContain('do not treat "trading actions reconciled" as terminal')
     expect(prompt).toContain('Use an explicit wait/heartbeat between cycles')
+    expect(prompt).toContain('Do not treat a single Alpaca MCP timeout as a terminal trading failure')
+    expect(prompt).toContain('resume the same loop cycle when state is reconciled')
   })
 
   it('bridges Codex framed MCP stdio to Alpaca newline stdio', () => {


### PR DESCRIPTION
## Summary

- Make transient Alpaca MCP timeouts recoverable for the Synthesis autonomous trader instead of first-timeout hard stops.
- Require reconnect/retry with backoff and `mcp_retry` ledger entries for read-only/pre-order checks.
- Require order-id/client-order-id reconciliation before retrying after post-submit timeouts.
- Add regression assertions that the rendered trader prompt preserves the retry/resume contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "synthesis autonomous trader provider"`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/synthesis >/tmp/synthesis-trader-mcp-timeout-retry-render.yaml`
- `kubectl apply --dry-run=server -f /tmp/synthesis-trader-mcp-timeout-retry-render.yaml`
- `yq '. | select(.kind == "ImplementationSpec" and .metadata.name == "autonomous-trader-v1") | .spec.text' /tmp/synthesis-trader-mcp-timeout-retry-render.yaml | rg -n 'single Alpaca MCP timeout|mcp_retry|retry/reconnect|resume the loop'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
