### PR TITLE
chore(analysis): promote image eed925d

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 0cf3120ce8dbb6a637cbc5ee4d0bb0e614457755
+    newTag: eed925d67762ad52808d99c349d716d02426daae


### PR DESCRIPTION
## Summary

- Promotes the analysis service image to `eed925d67762ad52808d99c349d716d02426daae`.
- Publishes the refreshed SemiAnalysis 800VDC evidence hooks to the live analysis site.
- Keeps the deployment on the existing `analysis` image path and namespace.

## Related Issues

None

## Testing

- `scripts/verify-analysis-image.sh eed925d67762ad52808d99c349d716d02426daae latest`
- `git diff --check`
- `kubectl kustomize argocd/applications/analysis`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
