### PR TITLE
fix(torghut): import runtime evidence by event time

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -1002,11 +1002,17 @@ def _build_realized_strategy_pnl_rows(
             event_times.append(event_time)
     for row in execution_rows:
         computed_at = row.get("computed_at")
+        execution_event_at = row.get("execution_event_at")
         execution_created_at = row.get("execution_created_at")
         fill_event_at = (
             execution_created_at
             if isinstance(execution_created_at, datetime)
             else computed_at
+        )
+        if isinstance(execution_event_at, datetime):
+            fill_event_at = execution_event_at
+        ledger_computed_at = (
+            fill_event_at if isinstance(fill_event_at, datetime) else computed_at
         )
         price = _first_decimal(
             row,
@@ -1028,9 +1034,9 @@ def _build_realized_strategy_pnl_rows(
             ),
         )
         symbol = str(row.get("symbol") or "").strip().upper()
-        if not symbol or not isinstance(computed_at, datetime):
+        if not symbol or not isinstance(ledger_computed_at, datetime):
             continue
-        event_times.append(computed_at)
+        event_times.append(ledger_computed_at)
         if isinstance(fill_event_at, datetime):
             event_times.append(fill_event_at)
         decision_id = _first_text(
@@ -1044,7 +1050,7 @@ def _build_realized_strategy_pnl_rows(
             "execution_correlation_id",
         )
         common_ledger_fields = {
-            "executed_at": computed_at,
+            "executed_at": ledger_computed_at,
             "account_label": str(row.get("account_label") or "") or None,
             "strategy_id": str(row.get("strategy_id") or "") or None,
             "symbol": symbol,
@@ -1109,7 +1115,7 @@ def _build_realized_strategy_pnl_rows(
                 executed_at=(
                     fill_event_at
                     if isinstance(fill_event_at, datetime)
-                    else computed_at
+                    else ledger_computed_at
                 ),
                 event_type="fill",
                 decision_id=decision_id,
@@ -1926,6 +1932,12 @@ def _query_timestamps(
                 f"""
                 select
                     d.created_at,
+                    coalesce(
+                        e.order_feed_last_event_ts,
+                        e.last_update_at,
+                        e.updated_at,
+                        e.created_at
+                    ) as execution_event_at,
                     e.created_at,
                     e.symbol,
                     e.side,
@@ -1947,13 +1959,30 @@ def _query_timestamps(
                 left join execution_tca_metrics t on t.execution_id = e.id
                 where s.name = any(%s)
                   and d.alpaca_account_label = %s
-                  and d.created_at >= %s
-                  and d.created_at < %s
+                  and e.alpaca_account_label = %s
+                  and coalesce(
+                        e.order_feed_last_event_ts,
+                        e.last_update_at,
+                        e.updated_at,
+                        e.created_at
+                      ) >= %s
+                  and coalesce(
+                        e.order_feed_last_event_ts,
+                        e.last_update_at,
+                        e.updated_at,
+                        e.created_at
+                      ) < %s
                   {execution_symbol_clause}
-                order by d.created_at
+                order by coalesce(
+                    e.order_feed_last_event_ts,
+                    e.last_update_at,
+                    e.updated_at,
+                    e.created_at
+                )
                 """,
                 (
                     strategy_names,
+                    account_label,
                     account_label,
                     window_start,
                     window_end,
@@ -1962,25 +1991,27 @@ def _query_timestamps(
             )
             execution_rows = [
                 {
-                    "computed_at": row[0],
-                    "execution_created_at": row[1],
-                    "symbol": row[2],
-                    "side": row[3],
-                    "filled_qty": row[4],
-                    "avg_fill_price": row[5],
-                    "shortfall_notional": row[6],
-                    "execution_audit_json": row[7],
-                    "raw_order": row[8],
-                    "account_label": row[9],
-                    "strategy_id": row[10],
-                    "decision_hash": row[11],
-                    "decision_json": row[12],
-                    "alpaca_order_id": row[13],
-                    "client_order_id": row[14],
-                    "order_status": row[15],
+                    "decision_created_at": row[0],
+                    "computed_at": row[1],
+                    "execution_event_at": row[1],
+                    "execution_created_at": row[2],
+                    "symbol": row[3],
+                    "side": row[4],
+                    "filled_qty": row[5],
+                    "avg_fill_price": row[6],
+                    "shortfall_notional": row[7],
+                    "execution_audit_json": row[8],
+                    "raw_order": row[9],
+                    "account_label": row[10],
+                    "strategy_id": row[11],
+                    "decision_hash": row[12],
+                    "decision_json": row[13],
+                    "alpaca_order_id": row[14],
+                    "client_order_id": row[15],
+                    "order_status": row[16],
                 }
                 for row in cur.fetchall()
-                if row[0] is not None
+                if row[1] is not None
             ]
             execution_rows = [
                 row
@@ -1994,9 +2025,9 @@ def _query_timestamps(
             ]
             executions = []
             for row in execution_rows:
-                computed_at = row.get("computed_at")
-                if isinstance(computed_at, datetime):
-                    executions.append(computed_at)
+                execution_event_at = row.get("execution_event_at")
+                if isinstance(execution_event_at, datetime):
+                    executions.append(execution_event_at)
             cur.execute(
                 f"""
                 select
@@ -2022,13 +2053,15 @@ def _query_timestamps(
                 join strategies s on s.id = d.strategy_id
                 where s.name = any(%s)
                   and d.alpaca_account_label = %s
-                  and d.created_at >= %s
-                  and d.created_at < %s
+                  and oe.alpaca_account_label = %s
+                  and coalesce(oe.event_ts, oe.created_at) >= %s
+                  and coalesce(oe.event_ts, oe.created_at) < %s
                   {order_event_symbol_clause}
                 order by coalesce(oe.event_ts, oe.created_at), oe.created_at
                 """,
                 (
                     strategy_names,
+                    account_label,
                     account_label,
                     window_start,
                     window_end,
@@ -2069,7 +2102,7 @@ def _query_timestamps(
             cur.execute(
                 f"""
                 select
-                    d.created_at,
+                    t.computed_at,
                     abs(coalesce(t.realized_shortfall_bps, t.slippage_bps)) as abs_slippage_bps,
                     (-coalesce(t.realized_shortfall_bps, t.slippage_bps)) as post_cost_expectancy_bps,
                     d.decision_hash,
@@ -2080,13 +2113,15 @@ def _query_timestamps(
                 join strategies s on s.id = d.strategy_id
                 where s.name = any(%s)
                   and d.alpaca_account_label = %s
-                  and d.created_at >= %s
-                  and d.created_at < %s
+                  and coalesce(t.alpaca_account_label, e.alpaca_account_label, d.alpaca_account_label) = %s
+                  and t.computed_at >= %s
+                  and t.computed_at < %s
                   {execution_symbol_clause}
-                order by d.created_at
+                order by t.computed_at
                 """,
                 (
                     strategy_names,
+                    account_label,
                     account_label,
                     window_start,
                     window_end,

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -67,6 +67,7 @@ class _FakeCursor:
             ],
             [
                 (
+                    datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
                     datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     "AAPL",
@@ -1469,6 +1470,60 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
 
+    def test_build_realized_strategy_pnl_rows_prefers_execution_event_time(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    "execution_created_at": datetime(
+                        2026, 3, 6, 14, 30, 5, tzinfo=timezone.utc
+                    ),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 35, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    "execution_created_at": datetime(
+                        2026, 3, 6, 14, 30, 10, tzinfo=timezone.utc
+                    ),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 40, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ]
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(
+            rows[0]["computed_at"], datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc)
+        )
+        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.70"))
+
     def test_build_realized_strategy_pnl_rows_materializes_audit_only_runtime_metadata(
         self,
     ) -> None:
@@ -1750,17 +1805,28 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         tca_query, _ = cursor.executed[3]
         execution_query, _ = cursor.executed[1]
         self.assertIn("left join execution_tca_metrics", execution_query)
-        self.assertIn("d.created_at >= %s", execution_query)
-        self.assertIn("d.created_at < %s", execution_query)
-        self.assertNotIn("e.created_at >= %s", execution_query)
+        self.assertIn("e.alpaca_account_label = %s", execution_query)
+        self.assertIn("e.order_feed_last_event_ts", execution_query)
+        self.assertIn("e.last_update_at", execution_query)
+        self.assertIn("e.updated_at", execution_query)
+        self.assertIn("e.created_at", execution_query)
+        self.assertNotIn("and d.created_at >= %s", execution_query)
+        self.assertNotIn("and d.created_at < %s", execution_query)
         self.assertIn("from execution_order_events oe", order_event_query)
-        self.assertIn("d.created_at >= %s", order_event_query)
-        self.assertIn("d.created_at < %s", order_event_query)
-        self.assertIn("select\n                    d.created_at", tca_query)
-        self.assertIn("d.created_at >= %s", tca_query)
-        self.assertIn("d.created_at < %s", tca_query)
-        self.assertNotIn("e.created_at >= %s", tca_query)
-        self.assertNotIn("t.computed_at >= %s", tca_query)
+        self.assertIn("oe.alpaca_account_label = %s", order_event_query)
+        self.assertIn("coalesce(oe.event_ts, oe.created_at) >= %s", order_event_query)
+        self.assertIn("coalesce(oe.event_ts, oe.created_at) < %s", order_event_query)
+        self.assertNotIn("and d.created_at >= %s", order_event_query)
+        self.assertNotIn("and d.created_at < %s", order_event_query)
+        self.assertIn("select\n                    t.computed_at", tca_query)
+        self.assertIn(
+            "coalesce(t.alpaca_account_label, e.alpaca_account_label, d.alpaca_account_label) = %s",
+            tca_query,
+        )
+        self.assertIn("t.computed_at >= %s", tca_query)
+        self.assertIn("t.computed_at < %s", tca_query)
+        self.assertNotIn("and d.created_at >= %s", tca_query)
+        self.assertNotIn("and d.created_at < %s", tca_query)
 
     def test_query_timestamps_filters_to_target_symbols_when_configured(
         self,
@@ -1832,6 +1898,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 (
                     datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
                     datetime(2026, 3, 6, 14, 35, 30, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 14, 35, 30, tzinfo=timezone.utc),
                     "AAPL",
                     "buy",
                     Decimal("1"),
@@ -1852,6 +1919,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 ),
                 (
                     datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 14, 36, 30, tzinfo=timezone.utc),
                     datetime(2026, 3, 6, 14, 36, 30, tzinfo=timezone.utc),
                     "AAPL",
                     "buy",
@@ -1946,7 +2014,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
 
         self.assertEqual(decisions, [datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)])
         self.assertEqual(
-            executions, [datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)]
+            executions, [datetime(2026, 3, 6, 14, 35, 30, tzinfo=timezone.utc)]
         )
         proxy_rows = [
             row


### PR DESCRIPTION
## Summary

- Import execution evidence into runtime-window proof buckets by actual order-feed/fill event time instead of decision creation time.
- Scope execution/order-event/TCA source rows to the requested Alpaca account so cross-account runtime evidence cannot materialize into the wrong proof packet.
- Add regression coverage for event-time ledger materialization and SQL source-window filters.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
