### PR TITLE
fix(torghut): carry paper-route target lineage

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -67,13 +67,19 @@ PROMOTION_ONLY_READINESS_BLOCKERS = frozenset(
 )
 SOURCE_LINEAGE_CANDIDATE_KEYS = (
     "candidate_id",
+    "candidate_ids",
     "strategy_candidate_id",
+    "strategy_candidate_ids",
     "source_candidate_id",
+    "source_candidate_ids",
 )
 SOURCE_LINEAGE_HYPOTHESIS_KEYS = (
     "hypothesis_id",
+    "hypothesis_ids",
     "strategy_hypothesis_id",
+    "strategy_hypothesis_ids",
     "source_hypothesis_id",
+    "source_hypothesis_ids",
 )
 
 
@@ -95,7 +101,9 @@ def _source_payloads(value: object) -> list[Mapping[str, Any]]:
     def append_payload(candidate: object, *, depth: int) -> None:
         if not isinstance(candidate, Mapping):
             return
-        payload = {str(key): item for key, item in cast(Mapping[str, Any], candidate).items()}
+        payload = {
+            str(key): item for key, item in cast(Mapping[str, Any], candidate).items()
+        }
         payloads.append(payload)
         if depth <= 0:
             return
@@ -110,7 +118,14 @@ def _source_lineage_values(value: object, keys: Sequence[str]) -> set[str]:
     values: set[str] = set()
     for payload in _source_payloads(value):
         for key in keys:
-            if text := _safe_text(payload.get(key)):
+            raw_value = payload.get(key)
+            if isinstance(raw_value, Sequence) and not isinstance(
+                raw_value, (str, bytes, bytearray)
+            ):
+                for item in cast(Sequence[object], raw_value):
+                    if text := _safe_text(item):
+                        values.add(text)
+            elif text := _safe_text(raw_value):
                 values.add(text)
     return values
 
@@ -156,7 +171,9 @@ def _source_lineage_blockers(
         hypothesis_values: set[str] = set()
         for row in rows:
             hypothesis_values.update(
-                _source_lineage_values(row.decision_json, SOURCE_LINEAGE_HYPOTHESIS_KEYS)
+                _source_lineage_values(
+                    row.decision_json, SOURCE_LINEAGE_HYPOTHESIS_KEYS
+                )
             )
         if not hypothesis_values:
             blockers.append("source_hypothesis_lineage_missing")

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, ROUND_DOWN
 from typing import Any, Optional, cast
@@ -25,6 +25,7 @@ from ..models import SignalEnvelope, StrategyDecision
 from ..paper_route_target_plan import (
     fetch_paper_route_target_plan_url,
     paper_route_target_plan_probe_symbols,
+    paper_route_target_plan_targets,
 )
 from ..prices import MarketSnapshot
 from ..proof_floor import build_profitability_proof_floor_receipt
@@ -84,6 +85,66 @@ def _safe_int(value: object) -> int:
         return int(cast(Any, value))
     except (TypeError, ValueError):
         return 0
+
+
+def _safe_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _target_symbols(target: Mapping[str, Any]) -> set[str]:
+    raw_symbols = target.get("paper_route_probe_symbols")
+    if isinstance(raw_symbols, str):
+        values = raw_symbols.split(",")
+    elif isinstance(raw_symbols, Sequence) and not isinstance(
+        raw_symbols, (str, bytes, bytearray)
+    ):
+        values = cast(Sequence[object], raw_symbols)
+    else:
+        values = ()
+    return {symbol for raw in values if (symbol := str(raw).strip().upper())}
+
+
+def _target_plan_lineage(
+    targets: list[dict[str, Any]], symbol: str
+) -> dict[str, object]:
+    normalized_symbol = symbol.strip().upper()
+    lineage_targets: list[dict[str, str]] = []
+    candidate_ids: list[str] = []
+    hypothesis_ids: list[str] = []
+    strategy_names: list[str] = []
+    for target in targets:
+        target_symbols = _target_symbols(target)
+        if target_symbols and normalized_symbol not in target_symbols:
+            continue
+        candidate_id = _safe_text(target.get("candidate_id"))
+        hypothesis_id = _safe_text(target.get("hypothesis_id"))
+        strategy_name = _safe_text(target.get("strategy_name"))
+        item = {
+            key: value
+            for key, value in {
+                "candidate_id": candidate_id,
+                "hypothesis_id": hypothesis_id,
+                "strategy_name": strategy_name,
+            }.items()
+            if value
+        }
+        if item:
+            lineage_targets.append(item)
+        if candidate_id and candidate_id not in candidate_ids:
+            candidate_ids.append(candidate_id)
+        if hypothesis_id and hypothesis_id not in hypothesis_ids:
+            hypothesis_ids.append(hypothesis_id)
+        if strategy_name and strategy_name not in strategy_names:
+            strategy_names.append(strategy_name)
+    return {
+        "paper_route_probe_lineage_targets": lineage_targets,
+        "source_candidate_ids": candidate_ids,
+        "source_hypothesis_ids": hypothesis_ids,
+        "source_strategy_names": strategy_names,
+    }
 
 
 class SimpleTradingPipeline(TradingPipeline):
@@ -1465,10 +1526,14 @@ class SimpleTradingPipeline(TradingPipeline):
         return True
 
     @staticmethod
-    def _external_paper_route_target_probe_symbols() -> tuple[set[str], str | None]:
+    def _external_paper_route_target_probe_symbols() -> tuple[
+        set[str],
+        str | None,
+        list[dict[str, Any]],
+    ]:
         url = str(settings.trading_paper_route_target_plan_url or "").strip()
         if not url:
-            return set(), None
+            return set(), None, []
         plan = fetch_paper_route_target_plan_url(
             url,
             timeout_seconds=settings.trading_paper_route_target_plan_timeout_seconds,
@@ -1483,11 +1548,11 @@ class SimpleTradingPipeline(TradingPipeline):
                 load_error,
                 plan.get("fetch_attempts") or 1,
             )
-            return set(), load_error
+            return set(), load_error, []
         symbols = paper_route_target_plan_probe_symbols(plan)
         if not symbols:
-            return set(), "paper_route_target_plan_probe_symbols_missing"
-        return symbols, None
+            return set(), "paper_route_target_plan_probe_symbols_missing", []
+        return symbols, None, paper_route_target_plan_targets(plan)
 
     def _paper_route_probe_context(
         self,
@@ -1542,7 +1607,7 @@ class SimpleTradingPipeline(TradingPipeline):
             if str(item).strip()
         }
         symbol = decision.symbol.strip().upper()
-        target_plan_symbols, target_plan_error = (
+        target_plan_symbols, target_plan_error, target_plan_targets = (
             self._external_paper_route_target_probe_symbols()
         )
         if target_plan_error:
@@ -1585,6 +1650,7 @@ class SimpleTradingPipeline(TradingPipeline):
             "paper_route_target_plan_source": "external_target_plan_url"
             if target_plan_symbols
             else None,
+            **_target_plan_lineage(target_plan_targets, symbol),
             "exit_minute_after_open": exit_minute,
             "effective_exit_minute_after_open": effective_exit_minute,
             "exit_due_at": exit_due_at,

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -73,13 +73,19 @@ _RUNTIME_LEDGER_EQUITY_DENOMINATOR_KEYS = (
 )
 SOURCE_LINEAGE_CANDIDATE_KEYS = (
     "candidate_id",
+    "candidate_ids",
     "strategy_candidate_id",
+    "strategy_candidate_ids",
     "source_candidate_id",
+    "source_candidate_ids",
 )
 SOURCE_LINEAGE_HYPOTHESIS_KEYS = (
     "hypothesis_id",
+    "hypothesis_ids",
     "strategy_hypothesis_id",
+    "strategy_hypothesis_ids",
     "source_hypothesis_id",
+    "source_hypothesis_ids",
 )
 
 
@@ -225,9 +231,18 @@ def _text_values(row: Mapping[str, object], *keys: str) -> set[str]:
     values: set[str] = set()
     for payload in _row_payloads(row):
         for key in keys:
-            text = str(payload.get(key) or "").strip()
-            if text:
-                values.add(text)
+            raw_value = payload.get(key)
+            if isinstance(raw_value, Sequence) and not isinstance(
+                raw_value, (str, bytes, bytearray)
+            ):
+                for item in raw_value:
+                    text = str(item or "").strip()
+                    if text:
+                        values.add(text)
+            else:
+                text = str(raw_value or "").strip()
+                if text:
+                    values.add(text)
     return values
 
 

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -44,6 +44,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _runtime_window_import_proof_hygiene_blockers,
     _runtime_window_source_kind_is_informational,
     _source_kind_allows_runtime_ledger_materialization,
+    _source_row_matches_lineage,
     _source_activity_missing_summary,
     _stable_payload_digest,
     _strategy_name_candidates,
@@ -359,6 +360,35 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             args.target_metadata_json, '{"paper_probation_authorized":true}'
         )
         self.assertEqual(args.json, True)
+
+    def test_source_row_lineage_accepts_plural_target_plan_ids(self) -> None:
+        row = {
+            "decision_json": {
+                "params": {
+                    "paper_route_probe": {
+                        "source_candidate_ids": ["candidate-pairs-a"],
+                        "source_hypothesis_ids": ["H-PAIRS-01"],
+                    }
+                }
+            }
+        }
+
+        self.assertTrue(
+            _source_row_matches_lineage(
+                row,
+                candidate_id="candidate-pairs-a",
+                hypothesis_id="H-PAIRS-01",
+                require_source_lineage=True,
+            )
+        )
+        self.assertFalse(
+            _source_row_matches_lineage(
+                row,
+                candidate_id="candidate-other",
+                hypothesis_id="H-PAIRS-01",
+                require_source_lineage=True,
+            )
+        )
 
     def test_runtime_ledger_profit_proof_rejects_malformed_bucket_payload(
         self,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -2100,6 +2100,60 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 },
                 generated_at=now,
             )
+            decision.decision_json = {
+                "action": "sell",
+                "qty": "1",
+                "params": {
+                    "paper_route_probe": {
+                        "source_candidate_ids": ["candidate-pairs-a"],
+                        "source_hypothesis_ids": ["H-PAIRS-01"],
+                    }
+                },
+            }
+            session.add(decision)
+            session.commit()
+            matched_payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": "1",
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-pairs-a",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                                "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": ["AAPL"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                    },
+                },
+                generated_at=now,
+            )
 
         source_activity = payload["targets"][0]["source_activity"]
         self.assertTrue(source_activity["lineage_required"])
@@ -2120,6 +2174,16 @@ class TestPaperRouteEvidenceAudit(TestCase):
             payload["targets"][0]["readiness"]["evidence_collection_blockers"],
         )
         self.assertEqual(payload["summary"]["target_with_source_activity_count"], 0)
+        matched_source_activity = matched_payload["targets"][0]["source_activity"]
+        self.assertEqual(matched_source_activity["raw_decision_count"], 1)
+        self.assertEqual(matched_source_activity["lineage_matched_decision_count"], 1)
+        self.assertEqual(matched_source_activity["decision_count"], 1)
+        self.assertEqual(matched_source_activity["execution_count"], 1)
+        self.assertEqual(matched_source_activity["tca_sample_count"], 1)
+        self.assertFalse(matched_source_activity["missing"])
+        self.assertEqual(
+            matched_payload["summary"]["target_with_source_activity_count"], 1
+        )
 
     def test_runtime_import_audit_counts_selected_targets_not_raw_plan_noise(
         self,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -4886,7 +4886,22 @@ class TestTradingPipeline(TestCase):
 
         with patch(
             "app.trading.scheduler.simple_pipeline.fetch_paper_route_target_plan_url",
-            return_value={"targets": [{"paper_route_probe_symbols": ["AAPL"]}]},
+            return_value={
+                "targets": [
+                    {
+                        "paper_route_probe_symbols": ["AAPL"],
+                        "candidate_id": "candidate-pairs-a",
+                        "hypothesis_id": "H-PAIRS-01",
+                        "strategy_name": "pairs-runtime-a",
+                    },
+                    {
+                        "paper_route_probe_symbols": ["MSFT"],
+                        "candidate_id": "candidate-other",
+                        "hypothesis_id": "H-OTHER",
+                        "strategy_name": "other-runtime",
+                    },
+                ]
+            },
         ):
             self.assertIsNone(
                 pipeline._paper_route_probe_context(
@@ -4902,11 +4917,28 @@ class TestTradingPipeline(TestCase):
         self.assertIsNotNone(scoped_context)
         assert scoped_context is not None
         self.assertEqual(
-            scoped_context.get("paper_route_target_plan_symbols"), ["AAPL"]
+            scoped_context.get("paper_route_target_plan_symbols"), ["AAPL", "MSFT"]
         )
         self.assertEqual(
             scoped_context.get("paper_route_target_plan_source"),
             "external_target_plan_url",
+        )
+        self.assertEqual(
+            scoped_context.get("source_candidate_ids"), ["candidate-pairs-a"]
+        )
+        self.assertEqual(scoped_context.get("source_hypothesis_ids"), ["H-PAIRS-01"])
+        self.assertEqual(
+            scoped_context.get("source_strategy_names"), ["pairs-runtime-a"]
+        )
+        self.assertEqual(
+            scoped_context.get("paper_route_probe_lineage_targets"),
+            [
+                {
+                    "candidate_id": "candidate-pairs-a",
+                    "hypothesis_id": "H-PAIRS-01",
+                    "strategy_name": "pairs-runtime-a",
+                }
+            ],
         )
 
         with patch(


### PR DESCRIPTION
## Summary

- Carries external paper-route target-plan candidate, hypothesis, and strategy lineage into bounded probe decision metadata.
- Teaches paper-route evidence audit and runtime-window import lineage readers to match plural lineage fields without weakening candidate-specific proof checks.
- Adds regression coverage for target-plan lineage propagation and source-activity matching.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k paper_route_probe`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_import_hypothesis_runtime_windows.py tests/test_trading_pipeline.py -k 'paper_route_probe or paper_route_source_activity_requires_candidate_lineage or source_row_lineage_accepts_plural_target_plan_ids'`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py app/trading/paper_route_evidence.py scripts/import_hypothesis_runtime_windows.py tests/test_trading_pipeline.py tests/test_paper_route_evidence.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py app/trading/paper_route_evidence.py scripts/import_hypothesis_runtime_windows.py tests/test_trading_pipeline.py tests/test_paper_route_evidence.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
