### PR TITLE
chore(analysis): promote image 14542c75ce87

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: dc4f7e4d43757ffdad7272a518f1a67547bbcaff
+    newTag: 14542c75ce876af29968542c9735f8e65d80907a


### PR DESCRIPTION
## Summary

- Promotes `argocd/applications/analysis` to `registry.ide-newton.ts.net/lab/analysis:14542c75ce876af29968542c9735f8e65d80907a`.
- Keeps rollout in lab GitOps by changing only the analysis kustomize image tag.
- Uses the self-hosted analysis image publish workflow output.

## Related Issues

None

## Testing

- `/Users/gregkonush/github.com/analysis/scripts/verify-analysis-image.sh 14542c75ce876af29968542c9735f8e65d80907a`
- `kubectl kustomize argocd/applications/analysis`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
