### PR TITLE
fix(torghut): require order-feed fill lifecycle authority

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -61,6 +61,11 @@ _RUNTIME_LEDGER_DECISION_EVENTS = frozenset(
 _RUNTIME_LEDGER_FILL_EVENTS = frozenset(
     {"fill", "filled", "partial_fill", "partially_filled"}
 )
+ORDER_FEED_FILL_LIFECYCLE_MISSING_BLOCKER = "order_feed_fill_lifecycle_missing"
+ORDER_FEED_FILL_LIFECYCLE_INCOMPLETE_BLOCKER = "order_feed_fill_lifecycle_incomplete"
+ORDER_FEED_FILL_LIFECYCLE_ORDER_ID_MISSING_BLOCKER = (
+    "order_feed_fill_lifecycle_order_id_missing"
+)
 _RUNTIME_LEDGER_EQUITY_DENOMINATOR_KEYS = (
     "account_equity",
     "portfolio_equity",
@@ -982,6 +987,78 @@ def _runtime_lifecycle_ledger_row(
     }
 
 
+def _runtime_order_id(row: Mapping[str, object]) -> str | None:
+    return _first_text(
+        row,
+        "order_id",
+        "alpaca_order_id",
+        "client_order_id",
+        "execution_correlation_id",
+    )
+
+
+def _execution_row_has_fill(row: Mapping[str, object]) -> bool:
+    filled_qty = _first_decimal(
+        row,
+        "filled_qty",
+        "filled_quantity",
+        "qty",
+        "quantity",
+    )
+    avg_fill_price = _first_decimal(
+        row,
+        "avg_fill_price",
+        "filled_avg_price",
+        "filled_average_price",
+        "average_fill_price",
+        "fill_price",
+        "filled_price",
+    )
+    return (
+        filled_qty is not None
+        and filled_qty > 0
+        and avg_fill_price is not None
+        and avg_fill_price > 0
+    )
+
+
+def _order_feed_fill_lifecycle_blockers(
+    *,
+    execution_rows: list[dict[str, object]],
+    order_lifecycle_rows: list[dict[str, object]] | None,
+) -> list[str]:
+    expected_order_ids: set[str] = set()
+    missing_execution_order_id = False
+    for row in execution_rows:
+        if not _execution_row_has_fill(row):
+            continue
+        order_id = _runtime_order_id(row)
+        if order_id is None:
+            missing_execution_order_id = True
+            continue
+        expected_order_ids.add(order_id)
+
+    if not expected_order_ids and not missing_execution_order_id:
+        return []
+
+    observed_fill_order_ids = {
+        order_id
+        for row in order_lifecycle_rows or []
+        if _runtime_ledger_event_type({str(key): value for key, value in row.items()})
+        in _RUNTIME_LEDGER_FILL_EVENTS
+        if (order_id := _runtime_order_id(row)) is not None
+    }
+
+    blockers: list[str] = []
+    if missing_execution_order_id:
+        blockers.append(ORDER_FEED_FILL_LIFECYCLE_ORDER_ID_MISSING_BLOCKER)
+    if not observed_fill_order_ids:
+        blockers.append(ORDER_FEED_FILL_LIFECYCLE_MISSING_BLOCKER)
+    elif expected_order_ids - observed_fill_order_ids:
+        blockers.append(ORDER_FEED_FILL_LIFECYCLE_INCOMPLETE_BLOCKER)
+    return blockers
+
+
 def _build_realized_strategy_pnl_rows(
     execution_rows: list[dict[str, object]],
     *,
@@ -992,6 +1069,10 @@ def _build_realized_strategy_pnl_rows(
     ledger_rows: list[RuntimeLedgerFill | dict[str, object]] = []
     event_times: list[datetime] = []
     event_sourced_lifecycle_rows = 0
+    order_feed_fill_lifecycle_blockers = _order_feed_fill_lifecycle_blockers(
+        execution_rows=execution_rows,
+        order_lifecycle_rows=order_lifecycle_rows,
+    )
     for row in decision_lifecycle_rows or []:
         lifecycle_row = _runtime_lifecycle_ledger_row(row, event_type="decision")
         if lifecycle_row is None:
@@ -1177,6 +1258,7 @@ def _build_realized_strategy_pnl_rows(
         event_sourced_runtime_ledger = (
             allow_authoritative_runtime_ledger_materialization
             and event_sourced_lifecycle_rows > 0
+            and not order_feed_fill_lifecycle_blockers
             and isinstance(bucket_payload, Mapping)
             and _runtime_ledger_bucket_profit_proof_present(bucket_payload)
         )
@@ -1208,6 +1290,9 @@ def _build_realized_strategy_pnl_rows(
                 "execution_reconstruction_not_runtime_ledger_proof"
             )
             blockers = list(row.get("runtime_ledger_blockers") or [])
+            for blocker in order_feed_fill_lifecycle_blockers:
+                if blocker not in blockers:
+                    blockers.append(blocker)
             if "execution_reconstruction_not_runtime_ledger_proof" not in blockers:
                 blockers.append("execution_reconstruction_not_runtime_ledger_proof")
             row["runtime_ledger_blockers"] = blockers

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -1267,6 +1267,30 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
                 },
+                {
+                    "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "event_ts": datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
             ],
             allow_authoritative_runtime_ledger_materialization=True,
         )
@@ -1290,6 +1314,125 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["account_equity"], "10000")
         self.assertEqual(bucket["account_equity_source"], "equity")
         self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
+
+    def test_build_realized_strategy_pnl_rows_requires_order_feed_fill_lifecycle(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            decision_lifecycle_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 34, tzinfo=timezone.utc),
+                    "event_type": "decision",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "decision_json": {"account": {"equity": "10000"}},
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 39, tzinfo=timezone.utc),
+                    "event_type": "decision",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "decision_json": {"account": {"equity": "10000"}},
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            order_lifecycle_rows=[
+                {
+                    "event_ts": datetime(2026, 3, 6, 14, 34, 1, tzinfo=timezone.utc),
+                    "event_type": "new",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "event_ts": datetime(2026, 3, 6, 14, 39, 1, tzinfo=timezone.utc),
+                    "event_type": "new",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
+        self.assertEqual(rows[0]["authoritative"], False)
+        self.assertEqual(
+            rows[0]["authority_reason"],
+            "execution_reconstruction_not_runtime_ledger_proof",
+        )
+        self.assertIn(
+            "order_feed_fill_lifecycle_incomplete",
+            rows[0]["runtime_ledger_blockers"],
+        )
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertIn("order_feed_fill_lifecycle_incomplete", bucket["blockers"])
+        self.assertEqual(bucket["pnl_basis"], POST_COST_BASIS_EXECUTION_RECONSTRUCTION)
+        self.assertEqual(bucket["authoritative"], False)
 
     def test_runtime_ledger_tca_materialization_metadata_separates_authority(
         self,


### PR DESCRIPTION
## Summary

- Requires observed order-feed fill lifecycle events before source execution rows can become authoritative runtime-ledger proof.
- Keeps execution-row PnL reconstruction available as non-authoritative fallback with explicit lifecycle blockers.
- Adds regression coverage for both fully corroborated order-feed fill lifecycle and incomplete lifecycle evidence.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'build_realized_strategy_pnl_rows_authorizes_event_sourced_lifecycle or build_realized_strategy_pnl_rows_requires_order_feed_fill_lifecycle'`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
