### PR TITLE
fix(synthesis): keep trader running on external fills

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -26,6 +26,8 @@ spec:
     - On market-open runs, place and verify the smallest valid paper order only after all preflights pass.
     - Keep market-open runs alive until the trading session closes, the 500000 USD equity goal is reached, or a hard stop triggers.
     - Treat transient Alpaca MCP read timeouts as recoverable by reconnecting and retrying before hard-stopping.
+    - Treat existing positions and same-session fills from outside this run as current account state when open orders are reconciled.
+    - Treat zero buying power, zero daytrading buying power, and rejected no-order submissions as stand-down, reduce, close, or monitor conditions instead of terminal failures.
   text: |-
     You are the Synthesis autonomous paper-trader AgentRun.
 
@@ -43,6 +45,9 @@ spec:
     - Do not leave any order unmanaged or unreconciled.
     - A single Alpaca MCP timeout is not a hard stop. For read-only calls and pre-order checks, reconnect the MCP session and retry with backoff up to 3 consecutive failures, logging each retry as mcp_retry. Hard-stop only after retries are exhausted or account/order state remains unreconciled.
     - If a timeout happens after an order submission attempt, do not blindly submit another order. First verify by client_order_id and order id; cancel/reconcile any active order if needed. Only hard-stop if the order cannot be resolved after bounded retries.
+    - Do not hard-stop solely because fills or positions were not created by this run. If open orders are zero or reconciled and account reads are consistent, adopt them as current state, record external_fill_detected, and continue managing, reducing, closing, or monitoring them.
+    - Do not hard-stop solely because buying_power, options_buying_power, or daytrading_buying_power is zero. Stand down, monitor, or reduce/close positions if allowed by Alpaca and justified; continue the loop until market close, target reached, or a real hard stop.
+    - Do not hard-stop solely on an order rejection before order creation when client_order_id lookup confirms no order and open orders are zero. Record order_rejected_no_order_created with the rejection reason and continue the loop.
 
     Required preflight:
     - Use Alpaca MCP to read account info, account config, clock, calendar for the current trading day, open orders, positions, and recent portfolio history.
@@ -55,6 +60,7 @@ spec:
     - If parameters.mode is market-open, do not exit after the first reconciled action set. A reconciled order or stand-down decision completes one cycle, not the run.
     - Keep market-open mode alive in an intraday loop until Alpaca clock reaches the current session close, account equity is at or above 500000 USD, or a hard stop rule triggers.
     - Each market-open loop cycle must re-read clock, account info, open orders, positions, and recent portfolio state; reconcile all open orders; update the decision ledger and report; decide whether to trade, adjust, hedge, reduce, or stand down for that cycle; then wait for the next cycle while the market remains open.
+    - Each cycle must absorb account changes since the last cycle, including external fills and position changes, as current account state. Preserve active open-order reconciliation as the safety boundary.
     - Wrap Alpaca MCP calls in a retry/reconnect helper. Read-only market/account/position/order calls should tolerate transient 30-second timeouts, continue heartbeating, and resume the loop after a successful retry.
     - Emit a heartbeat at least every 60 seconds during waits so the runner stays visibly active. Do not use a silent sleep longer than 60 seconds.
     - Record the loop cycle number, current time, next close, equity, buying power, open-order count, and any action taken in the decision ledger.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -32,11 +32,15 @@ data:
     - Do not hide blockers. If buying power, market hours, API permissions, rate limits, or tooling prevent execution, report the exact blocker and smallest fix.
     - Do not treat a single Alpaca MCP timeout as a terminal trading failure. For read-only account, clock, order, position, or market-data calls, reconnect and retry with backoff up to 3 consecutive failures, logging each retry as `mcp_retry`.
     - If an MCP timeout happens after an order submission attempt, verify by client order id and order id before submitting anything else. Cancel/reconcile any active order if needed; hard-stop only if the order cannot be resolved after bounded retries.
+    - Do not hard-stop solely because fills or positions were not created by this run. If open orders are zero or reconciled and account reads are consistent, adopt them as current state, record `external_fill_detected`, and continue managing, reducing, closing, or monitoring them.
+    - Do not hard-stop solely because buying power, options buying power, or daytrading buying power is zero. Stand down, monitor, or reduce/close positions if allowed by Alpaca and justified; continue the loop until market close, target reached, or a real hard stop.
+    - Do not hard-stop solely on an order rejection before order creation when client order id lookup confirms no order and open orders are zero. Record `order_rejected_no_order_created` with the rejection reason and continue the loop.
 
     Persistence and outputs:
     - In market-open mode, do not treat "trading actions reconciled" as terminal. Reconciled actions only complete one cycle.
     - In market-open mode, keep the AgentRun alive in an intraday session loop until one of these terminal states occurs: Alpaca clock reaches the current session close, account equity is at or above 500000 USD, or a hard stop rule triggers.
     - Each market-open loop cycle must re-read clock/account/orders/positions, reconcile open orders, update artifacts, decide whether to act or stand down for that cycle, and then continue waiting for the next cycle while the market remains open.
+    - Each cycle must absorb account changes since the last cycle, including external fills and position changes, as current account state. Keep active open-order reconciliation as the safety boundary.
     - Market-open mode must continue after recoverable Alpaca MCP read timeouts. Reconnect the MCP process/session, retry the failed read, emit heartbeat output while recovering, and resume the same loop cycle when state is reconciled.
     - Use an explicit wait/heartbeat between cycles, with periodic output at least every 60 seconds so the runner is visibly alive and is not mistaken for an idle completed turn.
     - Preflight mode may finish after preflight complete. Market-open mode must not finish just because initial smoke/risk-reduction orders were reconciled.

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -632,10 +632,16 @@ describe('synthesis autonomous trader provider', () => {
     expect(taskPrompt).toContain('Do not use market_open_actions_reconciled as a terminal reason')
     expect(taskPrompt).toContain('A single Alpaca MCP timeout is not a hard stop')
     expect(taskPrompt).toContain('logging each retry as mcp_retry')
+    expect(taskPrompt).toContain('adopt them as current state, record external_fill_detected')
+    expect(taskPrompt).toContain('daytrading_buying_power is zero')
+    expect(taskPrompt).toContain('Record order_rejected_no_order_created')
     expect(prompt).toContain('do not treat "trading actions reconciled" as terminal')
     expect(prompt).toContain('Use an explicit wait/heartbeat between cycles')
     expect(prompt).toContain('Do not treat a single Alpaca MCP timeout as a terminal trading failure')
     expect(prompt).toContain('resume the same loop cycle when state is reconciled')
+    expect(prompt).toContain('adopt them as current state, record `external_fill_detected`')
+    expect(prompt).toContain('daytrading buying power is zero')
+    expect(prompt).toContain('Record `order_rejected_no_order_created`')
   })
 
   it('bridges Codex framed MCP stdio to Alpaca newline stdio', () => {


### PR DESCRIPTION
## Summary

- Keeps the Synthesis autonomous trader loop running when the account has same-session fills or positions created outside the AgentRun.
- Treats zero buying power / zero daytrading buying power and rejected no-order submissions as stand-down, reduce, close, or monitor conditions instead of terminal failures.
- Adds smoke-test assertions so the checked-in trader prompt keeps the external-state continuation contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "synthesis autonomous trader provider"`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/synthesis >/tmp/synthesis-trader-external-state-render.yaml`
- `kubectl apply --dry-run=server -f /tmp/synthesis-trader-external-state-render.yaml`
- `yq '. | select(.kind == "ImplementationSpec" and .metadata.name == "autonomous-trader-v1") | .spec.text' /tmp/synthesis-trader-external-state-render.yaml | rg -n 'external_fill_detected|order_rejected_no_order_created|daytrading_buying_power|not created by this run'`
- `yq '. | select(.kind == "ConfigMap" and .metadata.name == "autonomous-trader-system-prompt") | .data."system-prompt.md"' /tmp/synthesis-trader-external-state-render.yaml | rg -n 'external_fill_detected|order_rejected_no_order_created|daytrading buying power|not created by this run'`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
