### PR TITLE
chore(analysis): promote image dec9c243

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: d96696b96d156ff400c8664fa6e6c7c5ac13eeff
+    newTag: dec9c243797f75160fbd5cb4a76034f1fab7d74d


### PR DESCRIPTION
## Summary

- Promotes the `analysis` GitOps image tag to `dec9c243797f75160fbd5cb4a76034f1fab7d74d`.
- Keeps the change scoped to `argocd/applications/analysis/kustomization.yaml`.
- Lets Argo CD roll out the already published image after merge.

## Related Issues

None

## Testing

- `git diff --check`
- `kubectl kustomize argocd/applications/analysis`
- Upstream `gregkonush/analysis` workflow `analysis-image` run `26532044526` passed validate, build, push, and registry-tag verification for `dec9c243797f75160fbd5cb4a76034f1fab7d74d`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
