### PR TITLE
fix(torghut): preserve paper route exit lineage

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -147,6 +147,153 @@ def _target_plan_lineage(
     }
 
 
+def _lineage_text_values(value: object) -> list[str]:
+    raw_items: Sequence[object]
+    if isinstance(value, str):
+        raw_items = value.split(",")
+    elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        raw_items = cast(Sequence[object], value)
+    else:
+        raw_items = (value,)
+
+    values: list[str] = []
+    for raw_item in raw_items:
+        text = _safe_text(raw_item)
+        if text and text not in values:
+            values.append(text)
+    return values
+
+
+def _merge_unique_texts(target: list[str], values: Sequence[str]) -> None:
+    for value in values:
+        if value not in target:
+            target.append(value)
+
+
+def _paper_route_probe_lineage_from_params(params: Mapping[str, Any]) -> dict[str, Any]:
+    payloads: list[Mapping[str, Any]] = [params]
+    for key in ("paper_route_probe", "paper_route_probe_exit"):
+        value = params.get(key)
+        if isinstance(value, Mapping):
+            payloads.append(cast(Mapping[str, Any], value))
+
+    candidate_ids: list[str] = []
+    hypothesis_ids: list[str] = []
+    strategy_names: list[str] = []
+    lineage_targets: list[dict[str, str]] = []
+    lineage_target_keys: set[tuple[str | None, str | None, str | None]] = set()
+    for payload in payloads:
+        _merge_unique_texts(
+            candidate_ids, _lineage_text_values(payload.get("source_candidate_id"))
+        )
+        _merge_unique_texts(
+            candidate_ids, _lineage_text_values(payload.get("source_candidate_ids"))
+        )
+        _merge_unique_texts(
+            hypothesis_ids, _lineage_text_values(payload.get("source_hypothesis_id"))
+        )
+        _merge_unique_texts(
+            hypothesis_ids, _lineage_text_values(payload.get("source_hypothesis_ids"))
+        )
+        _merge_unique_texts(
+            strategy_names, _lineage_text_values(payload.get("source_strategy_name"))
+        )
+        _merge_unique_texts(
+            strategy_names, _lineage_text_values(payload.get("source_strategy_names"))
+        )
+
+        raw_targets = payload.get("paper_route_probe_lineage_targets")
+        if isinstance(raw_targets, Sequence) and not isinstance(
+            raw_targets, (str, bytes, bytearray)
+        ):
+            for raw_target in cast(Sequence[object], raw_targets):
+                if not isinstance(raw_target, Mapping):
+                    continue
+                lineage_target = _lineage_target_from_mapping(
+                    cast(Mapping[str, object], raw_target)
+                )
+                if not lineage_target:
+                    continue
+                lineage_key = _lineage_target_key(lineage_target)
+                if lineage_key not in lineage_target_keys:
+                    lineage_target_keys.add(lineage_key)
+                    lineage_targets.append(lineage_target)
+
+    lineage: dict[str, Any] = {}
+    if candidate_ids:
+        lineage["source_candidate_ids"] = candidate_ids
+    if hypothesis_ids:
+        lineage["source_hypothesis_ids"] = hypothesis_ids
+    if strategy_names:
+        lineage["source_strategy_names"] = strategy_names
+    if lineage_targets:
+        lineage["paper_route_probe_lineage_targets"] = lineage_targets
+    return lineage
+
+
+def _lineage_target_from_mapping(raw_target: Mapping[str, object]) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in {
+            "candidate_id": _safe_text(raw_target.get("candidate_id")),
+            "hypothesis_id": _safe_text(raw_target.get("hypothesis_id")),
+            "strategy_name": _safe_text(raw_target.get("strategy_name")),
+        }.items()
+        if value
+    }
+
+
+def _lineage_target_key(
+    lineage_target: Mapping[str, str],
+) -> tuple[str | None, str | None, str | None]:
+    return (
+        lineage_target.get("candidate_id"),
+        lineage_target.get("hypothesis_id"),
+        lineage_target.get("strategy_name"),
+    )
+
+
+def _merge_paper_route_probe_lineage(
+    target: dict[str, Any],
+    lineage: Mapping[str, Any],
+) -> None:
+    for key in (
+        "source_candidate_ids",
+        "source_hypothesis_ids",
+        "source_strategy_names",
+    ):
+        values = _lineage_text_values(lineage.get(key))
+        if not values:
+            continue
+        current = target.setdefault(key, [])
+        if isinstance(current, list):
+            _merge_unique_texts(cast(list[str], current), values)
+
+    raw_targets = lineage.get("paper_route_probe_lineage_targets")
+    if not isinstance(raw_targets, Sequence) or isinstance(
+        raw_targets, (str, bytes, bytearray)
+    ):
+        return
+    current_targets = target.setdefault("paper_route_probe_lineage_targets", [])
+    if not isinstance(current_targets, list):
+        return
+    typed_current_targets = cast(list[object], current_targets)
+    existing_keys: set[tuple[str | None, str | None, str | None]] = set()
+    for item in typed_current_targets:
+        if isinstance(item, Mapping):
+            existing_keys.add(_lineage_target_key(cast(Mapping[str, str], item)))
+    for raw_target in cast(Sequence[object], raw_targets):
+        if not isinstance(raw_target, Mapping):
+            continue
+        lineage_target = _lineage_target_from_mapping(
+            cast(Mapping[str, object], raw_target)
+        )
+        lineage_key = _lineage_target_key(lineage_target)
+        if lineage_target and lineage_key not in existing_keys:
+            existing_keys.add(lineage_key)
+            typed_current_targets.append(lineage_target)
+
+
 class SimpleTradingPipeline(TradingPipeline):
     """Minimal signal -> hard-risk -> direct execution lane."""
 
@@ -733,8 +880,15 @@ class SimpleTradingPipeline(TradingPipeline):
                     "buy_notional": Decimal("0"),
                     "latest_entry_at": None,
                     "exit_minute_after_open": None,
+                    "paper_route_probe_lineage": {},
                 },
             )
+            lineage = _paper_route_probe_lineage_from_params(params)
+            if lineage:
+                exposure_lineage = cast(
+                    dict[str, Any], exposure["paper_route_probe_lineage"]
+                )
+                _merge_paper_route_probe_lineage(exposure_lineage, lineage)
             signed_qty = filled_qty if side == "buy" else -filled_qty
             exposure["net_qty"] = cast(Decimal, exposure["net_qty"]) + signed_qty
             if side == "buy":
@@ -809,6 +963,9 @@ class SimpleTradingPipeline(TradingPipeline):
                     "avg_entry_price": str(avg_entry_price)
                     if avg_entry_price is not None
                     else None,
+                    **cast(
+                        dict[str, Any], exposure.get("paper_route_probe_lineage") or {}
+                    ),
                 },
                 "simple_lane": {
                     "final_qty": str(net_qty),

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -8,7 +8,7 @@ import tempfile
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import Mock, patch
-from typing import Any, Callable, Mapping, cast
+from typing import Any, Callable, Mapping, Sequence, cast
 from uuid import uuid4
 
 from sqlalchemy import create_engine, select
@@ -836,6 +836,9 @@ class TestTradingPipeline(TestCase):
         entry_ts: datetime = datetime(2026, 3, 26, 14, 0, tzinfo=timezone.utc),
         exit_minute_after_open: str = "120",
         include_decision_exit_minute: bool = True,
+        source_candidate_ids: Sequence[str] | None = None,
+        source_hypothesis_ids: Sequence[str] | None = None,
+        source_strategy_names: Sequence[str] | None = None,
     ) -> None:
         with self.session_local() as session:
             strategy = Strategy(
@@ -869,6 +872,31 @@ class TestTradingPipeline(TestCase):
                     "symbol": symbol,
                 },
             }
+            paper_route_probe = cast(dict[str, Any], params["paper_route_probe"])
+            if source_candidate_ids:
+                paper_route_probe["source_candidate_ids"] = list(source_candidate_ids)
+            if source_hypothesis_ids:
+                paper_route_probe["source_hypothesis_ids"] = list(source_hypothesis_ids)
+            if source_strategy_names:
+                paper_route_probe["source_strategy_names"] = list(source_strategy_names)
+            if source_candidate_ids or source_hypothesis_ids or source_strategy_names:
+                paper_route_probe["paper_route_probe_lineage_targets"] = [
+                    {
+                        key: value
+                        for key, value in {
+                            "candidate_id": (
+                                list(source_candidate_ids or []) or [None]
+                            )[0],
+                            "hypothesis_id": (
+                                list(source_hypothesis_ids or []) or [None]
+                            )[0],
+                            "strategy_name": (
+                                list(source_strategy_names or []) or [None]
+                            )[0],
+                        }.items()
+                        if value is not None
+                    }
+                ]
             if include_decision_exit_minute:
                 params["exit_minute_after_open"] = exit_minute_after_open
             decision = StrategyDecision(
@@ -3673,6 +3701,62 @@ class TestTradingPipeline(TestCase):
                 exit_metadata.get("exit_due_at"),
                 "2026-03-26T15:30:00+00:00",
             )
+
+    def test_simple_pipeline_carries_paper_route_lineage_to_exit_decision(
+        self,
+    ) -> None:
+        self._seed_filled_paper_route_probe_entry(
+            source_candidate_ids=("candidate-pairs-a",),
+            source_hypothesis_ids=("H-PAIRS-01",),
+            source_strategy_names=("microbar-cross-sectional-pairs-v1",),
+        )
+        alpaca_client = PositionedAlpacaClient(
+            [{"symbol": "AAPL", "qty": "2", "side": "long"}]
+        )
+
+        self._run_simple_paper_pipeline(
+            alpaca_client=alpaca_client,
+            now=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
+        )
+
+        with self.session_local() as session:
+            decisions = (
+                session.execute(
+                    select(TradeDecision).order_by(TradeDecision.created_at.asc())
+                )
+                .scalars()
+                .all()
+            )
+            self.assertEqual(len(decisions), 2)
+            exit_payload = cast(dict[str, Any], decisions[-1].decision_json)
+            params = cast(dict[str, Any], exit_payload.get("params"))
+            exit_metadata = cast(
+                dict[str, Any],
+                params.get("paper_route_probe_exit"),
+            )
+
+        self.assertEqual(
+            exit_metadata.get("source_candidate_ids"),
+            ["candidate-pairs-a"],
+        )
+        self.assertEqual(
+            exit_metadata.get("source_hypothesis_ids"),
+            ["H-PAIRS-01"],
+        )
+        self.assertEqual(
+            exit_metadata.get("source_strategy_names"),
+            ["microbar-cross-sectional-pairs-v1"],
+        )
+        self.assertEqual(
+            exit_metadata.get("paper_route_probe_lineage_targets"),
+            [
+                {
+                    "candidate_id": "candidate-pairs-a",
+                    "hypothesis_id": "H-PAIRS-01",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                }
+            ],
+        )
 
     def test_simple_pipeline_closes_late_filled_probe_from_strategy_exit_metadata(
         self,


### PR DESCRIPTION
## Summary

- Preserve paper-route target lineage from filled entry decisions when generating paper-route exit decisions.
- Copy source candidate IDs, source hypothesis IDs, source strategy names, and lineage target records into `params.paper_route_probe_exit` for downstream evidence/import matching.
- Add regression coverage proving exit decisions keep H-PAIRS lineage instead of becoming unmatched runtime-ledger rows.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff format app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py::TestTradingPipeline::test_simple_pipeline_carries_paper_route_lineage_to_exit_decision tests/test_trading_pipeline.py::TestTradingPipeline::test_simple_pipeline_closes_filled_paper_route_probe_after_exit_minute`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
