### PR TITLE
fix(torghut): scope paper route targets to strategy universe

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -625,10 +625,10 @@ def _declared_target_probe_symbols(target: Mapping[str, object]) -> list[str]:
 
 
 def _target_uses_current_probe_scope(target: Mapping[str, object]) -> bool:
-    if (
-        _safe_text(target.get("paper_route_probe_scope_authority"))
-        == "external_target_plan"
-    ):
+    if _safe_text(target.get("paper_route_probe_scope_authority")) in {
+        "external_target_plan",
+        "strategy_universe",
+    }:
         return False
     source_kind = _safe_text(target.get("source_kind"))
     handoff = _safe_text(target.get("handoff"))
@@ -651,6 +651,33 @@ def _target_probe_symbols(
     if symbols:
         return symbols
     return _paper_route_probe_symbols(probe)
+
+
+def _strategy_universe_symbols(
+    session: Session,
+    *,
+    strategy_lookup_names: Sequence[str],
+) -> list[str]:
+    if not strategy_lookup_names:
+        return []
+    rows = session.execute(
+        select(Strategy.name, Strategy.universe_symbols).where(
+            Strategy.name.in_(list(strategy_lookup_names))
+        )
+    ).all()
+    universe_by_name = {
+        str(name): universe_symbols for name, universe_symbols in rows if name
+    }
+    for strategy_name in strategy_lookup_names:
+        raw_symbols = universe_by_name.get(strategy_name)
+        symbols: list[str] = []
+        for item in _as_sequence(raw_symbols):
+            symbol = str(item).strip().upper()
+            if symbol and symbol not in symbols:
+                symbols.append(symbol)
+        if symbols:
+            return symbols
+    return []
 
 
 def _next_session_probe_notional(probe: Mapping[str, object]) -> str:
@@ -892,6 +919,7 @@ def _runtime_window_import_health_gate_summary(
 
 def _next_paper_route_runtime_window_targets(
     *,
+    session: Session,
     targets: Sequence[Mapping[str, Any]],
     probe: Mapping[str, object],
     live_submission_gate: Mapping[str, Any],
@@ -943,12 +971,6 @@ def _next_paper_route_runtime_window_targets(
     skipped_targets: list[dict[str, object]] = []
     planned_keys: set[tuple[object, ...]] = set()
     for target in targets:
-        target_probe_symbols = _target_probe_symbols(target, probe)
-        target_probe_ready = (
-            bool(probe.get("configured_enabled"))
-            and _safe_decimal(next_notional) > 0
-            and bool(target_probe_symbols)
-        )
         hypothesis_id = _safe_text(target.get("hypothesis_id"))
         candidate_id = _safe_text(target.get("candidate_id"))
         strategy_family = _safe_text(target.get("strategy_family"))
@@ -962,6 +984,28 @@ def _next_paper_route_runtime_window_targets(
             runtime_strategy_name,
             strategy_name,
             _strategy_name_from_strategy_id(strategy_id),
+        )
+        raw_target_probe_symbols = _target_probe_symbols(target, probe)
+        strategy_universe_symbols = _strategy_universe_symbols(
+            session,
+            strategy_lookup_names=strategy_lookup_names,
+        )
+        target_probe_symbols = raw_target_probe_symbols
+        out_of_strategy_scope_symbols: list[str] = []
+        missing_strategy_universe_symbols: list[str] = []
+        if strategy_universe_symbols:
+            (
+                target_probe_symbols,
+                out_of_strategy_scope_symbols,
+                missing_strategy_universe_symbols,
+            ) = _scope_probe_symbols_to_target_plan(
+                raw_target_probe_symbols,
+                scope_symbols=strategy_universe_symbols,
+            )
+        target_probe_ready = (
+            bool(probe.get("configured_enabled"))
+            and _safe_decimal(next_notional) > 0
+            and bool(target_probe_symbols)
         )
         source_manifest_ref = _safe_text(target.get("source_manifest_ref"))
         missing = [
@@ -1008,6 +1052,8 @@ def _next_paper_route_runtime_window_targets(
         paper_route_probe_scope_authority = _safe_text(
             target.get("paper_route_probe_scope_authority")
         )
+        if strategy_universe_symbols:
+            paper_route_probe_scope_authority = "strategy_universe"
         planned_target: dict[str, object] = {
             "hypothesis_id": hypothesis_id,
             "candidate_id": candidate_id,
@@ -1038,6 +1084,15 @@ def _next_paper_route_runtime_window_targets(
             "window_end": _isoformat(window_end),
             "paper_route_probe_symbols": target_probe_symbols,
             "paper_route_probe_symbol_count": len(target_probe_symbols),
+            "paper_route_probe_raw_target_symbols": raw_target_probe_symbols,
+            "paper_route_probe_strategy_scope_applied": bool(strategy_universe_symbols),
+            "paper_route_probe_strategy_universe_symbols": (strategy_universe_symbols),
+            "paper_route_probe_out_of_strategy_scope_symbols": (
+                out_of_strategy_scope_symbols
+            ),
+            "paper_route_probe_missing_strategy_universe_symbols": (
+                missing_strategy_universe_symbols
+            ),
             "paper_route_probe_next_session_max_notional": next_notional,
             "paper_route_probe_window_start": _isoformat(window_start),
             "paper_route_probe_window_end": _isoformat(window_end),
@@ -2197,6 +2252,7 @@ def build_paper_route_evidence_audit(
         for target in targets
     ]
     next_targets = _next_paper_route_runtime_window_targets(
+        session=session,
         targets=targets,
         probe=probe,
         live_submission_gate=live_submission_gate,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1490,6 +1490,114 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertNotIn("INTC", next_audit_target["paper_route_probe_symbols"])
 
+    def test_next_window_targets_are_scoped_to_strategy_universe(self) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            session.add(
+                Strategy(
+                    name="microbar-cross-sectional-pairs-v1",
+                    description="pairs runtime strategy",
+                    enabled=True,
+                    base_timeframe="1Sec",
+                    universe_type="microbar_cross_sectional_pairs_v1",
+                    universe_symbols=["AAPL", "AMZN"],
+                )
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": True,
+                    "reason": "non_live_mode",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": (
+                            "torghut.next-paper-route-runtime-window-targets.v1"
+                        ),
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-hpairs",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                                "runtime_strategy_name": "candidate-runtime-name",
+                                "strategy_lookup_names": [
+                                    "candidate-runtime-name",
+                                    "microbar-cross-sectional-pairs-v1",
+                                ],
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_route_probe_symbols": [
+                                    "AAPL",
+                                    "AMZN",
+                                    "INTC",
+                                    "NVDA",
+                                ],
+                                "paper_route_target_plan_source": (
+                                    "external_target_plan_url"
+                                ),
+                                "paper_route_probe_scope_authority": (
+                                    "external_target_plan"
+                                ),
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": False,
+                        "next_session_max_notional": "63180",
+                        "eligible_symbol_count": 4,
+                        "eligible_symbols": ["AAPL", "AMZN", "INTC", "NVDA"],
+                        "active_symbols": [],
+                        "blocking_reasons": ["market_session_closed"],
+                    },
+                },
+                generated_at=window_start - timedelta(days=2),
+            )
+
+        target = payload["next_paper_route_runtime_window_targets"]["targets"][0]
+        self.assertEqual(target["paper_route_probe_symbols"], ["AAPL", "AMZN"])
+        self.assertEqual(
+            target["paper_route_probe_raw_target_symbols"],
+            ["AAPL", "AMZN", "INTC", "NVDA"],
+        )
+        self.assertTrue(target["paper_route_probe_strategy_scope_applied"])
+        self.assertEqual(
+            target["paper_route_probe_strategy_universe_symbols"],
+            ["AAPL", "AMZN"],
+        )
+        self.assertEqual(
+            target["paper_route_probe_out_of_strategy_scope_symbols"],
+            ["INTC", "NVDA"],
+        )
+        self.assertEqual(
+            target["paper_route_probe_missing_strategy_universe_symbols"], []
+        )
+        self.assertEqual(
+            target["paper_route_probe_scope_authority"], "strategy_universe"
+        )
+        next_audit_target = payload["next_runtime_window_target_audits"][0]["target"]
+        self.assertEqual(
+            next_audit_target["paper_route_probe_symbols"], ["AAPL", "AMZN"]
+        )
+        self.assertNotIn("INTC", next_audit_target["paper_route_probe_symbols"])
+
     def test_external_target_plan_probe_reports_missing_scope_and_plan_error(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Scope next paper-route runtime-window target symbols to the resolved strategy universe before import handoff.
- Preserve raw target symbols and emit strategy-scope diagnostics for excluded or missing symbols.
- Keep promotion authority and runtime-ledger proof gates unchanged.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'strategy_universe or external_target_plan_scope_is_preserved or builder_exports_next_paper_route_runtime_window_targets'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
