### PR TITLE
ci: allow analysis release PR automerge

### DIFF
--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -64,6 +64,7 @@ jobs:
             "argocd/applications/synthesis/kustomization.yaml"
             "argocd/applications/bumba/kustomization.yaml"
             "argocd/applications/khoshut/kustomization.yaml"
+            "argocd/applications/analysis/kustomization.yaml"
             "argocd/applications/bilig/kustomization.yaml"
           )
 


### PR DESCRIPTION
## Summary
- add analysis kustomization to the release PR automerge allowlist
- closes the ImageUpdater release branch gap for the analysis app

## Verification
- git diff --check