### PR TITLE
fix(torghut): widen runtime symbol columns

### DIFF
--- a/services/torghut/app/models/entities.py
+++ b/services/torghut/app/models/entities.py
@@ -24,6 +24,9 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from .base import Base, GUID, JSONType
 
 
+MARKET_SYMBOL_MAX_LENGTH = 64
+
+
 class TimestampMixin:
     """Mixin providing created_at and updated_at timestamps."""
 
@@ -89,7 +92,9 @@ class TradeDecision(Base, CreatedAtMixin):
     alpaca_account_label: Mapped[str] = mapped_column(
         String(length=64), nullable=False, server_default=text("'paper'")
     )
-    symbol: Mapped[str] = mapped_column(String(length=16), nullable=False)
+    symbol: Mapped[str] = mapped_column(
+        String(length=MARKET_SYMBOL_MAX_LENGTH), nullable=False
+    )
     timeframe: Mapped[str] = mapped_column(String(length=16), nullable=False)
     decision_json: Mapped[Any] = mapped_column(JSONType, nullable=False)
     rationale: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
@@ -143,7 +148,9 @@ class Execution(Base, TimestampMixin):
     client_order_id: Mapped[Optional[str]] = mapped_column(
         String(length=128), nullable=True
     )
-    symbol: Mapped[str] = mapped_column(String(length=16), nullable=False)
+    symbol: Mapped[str] = mapped_column(
+        String(length=MARKET_SYMBOL_MAX_LENGTH), nullable=False
+    )
     side: Mapped[str] = mapped_column(String(length=8), nullable=False)
     order_type: Mapped[str] = mapped_column(String(length=32), nullable=False)
     time_in_force: Mapped[str] = mapped_column(String(length=16), nullable=False)
@@ -238,7 +245,9 @@ class ExecutionOrderEvent(Base, CreatedAtMixin):
     event_ts: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
-    symbol: Mapped[Optional[str]] = mapped_column(String(length=16), nullable=True)
+    symbol: Mapped[Optional[str]] = mapped_column(
+        String(length=MARKET_SYMBOL_MAX_LENGTH), nullable=True
+    )
     alpaca_order_id: Mapped[Optional[str]] = mapped_column(
         String(length=128), nullable=True
     )
@@ -1118,7 +1127,9 @@ class RejectedSignalOutcomeEvent(Base, TimestampMixin):
     paper_source: Mapped[str] = mapped_column(String(length=128), nullable=False)
     paper_claim_id: Mapped[str] = mapped_column(String(length=128), nullable=False)
     account_label: Mapped[str] = mapped_column(String(length=64), nullable=False)
-    symbol: Mapped[str] = mapped_column(String(length=16), nullable=False)
+    symbol: Mapped[str] = mapped_column(
+        String(length=MARKET_SYMBOL_MAX_LENGTH), nullable=False
+    )
     event_ts: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     timeframe: Mapped[str] = mapped_column(String(length=16), nullable=False)
     seq: Mapped[Optional[str]] = mapped_column(String(length=64), nullable=True)
@@ -2710,7 +2721,9 @@ class ExecutionTCAMetric(Base, TimestampMixin):
     alpaca_account_label: Mapped[Optional[str]] = mapped_column(
         String(length=64), nullable=True
     )
-    symbol: Mapped[str] = mapped_column(String(length=16), nullable=False)
+    symbol: Mapped[str] = mapped_column(
+        String(length=MARKET_SYMBOL_MAX_LENGTH), nullable=False
+    )
     side: Mapped[str] = mapped_column(String(length=8), nullable=False)
     arrival_price: Mapped[Optional[Decimal]] = mapped_column(
         Numeric(20, 8), nullable=True

--- a/services/torghut/migrations/versions/0035_widen_market_symbol_columns.py
+++ b/services/torghut/migrations/versions/0035_widen_market_symbol_columns.py
@@ -1,0 +1,74 @@
+"""Widen runtime market symbol columns for OCC option contracts.
+
+Revision ID: 0035_widen_market_symbol_columns
+Revises: 0034_strategy_runtime_ledger_buckets
+Create Date: 2026-05-27 13:20:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+from sqlalchemy.engine.reflection import Inspector
+
+
+revision = "0035_widen_market_symbol_columns"
+down_revision = "0034_strategy_runtime_ledger_buckets"
+branch_labels = None
+depends_on = None
+
+
+MARKET_SYMBOL_COLUMNS = (
+    ("trade_decisions", "symbol", False),
+    ("executions", "symbol", False),
+    ("execution_order_events", "symbol", True),
+    ("rejected_signal_outcome_events", "symbol", False),
+    ("execution_tca_metrics", "symbol", False),
+)
+
+
+def _column_type_length(
+    inspector: Inspector, table_name: str, column_name: str
+) -> tuple[bool, int | None]:
+    for column in inspector.get_columns(table_name):
+        if column["name"] != column_name:
+            continue
+        column_type = column.get("type")
+        length = getattr(column_type, "length", None)
+        return True, int(length) if isinstance(length, int) else None
+    return False, None
+
+
+def _alter_symbols(target_length: int, existing_length: int, *, widen: bool) -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    for table_name, column_name, nullable in MARKET_SYMBOL_COLUMNS:
+        if not inspector.has_table(table_name):
+            continue
+        has_column, current_length = _column_type_length(
+            inspector, table_name, column_name
+        )
+        if not has_column:
+            continue
+        if current_length is not None:
+            if widen and current_length >= target_length:
+                continue
+            if not widen and current_length <= target_length:
+                continue
+        op.alter_column(
+            table_name,
+            column_name,
+            existing_type=sa.String(length=existing_length),
+            type_=sa.String(length=target_length),
+            existing_nullable=nullable,
+        )
+
+
+def upgrade() -> None:
+    _alter_symbols(target_length=64, existing_length=16, widen=True)
+
+
+def downgrade() -> None:
+    _alter_symbols(target_length=16, existing_length=64, widen=False)

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -13,7 +13,15 @@ from unittest.mock import patch
 from kafka import TopicPartition
 
 from app.config import settings
-from app.models import Base, Execution, ExecutionOrderEvent, Strategy, TradeDecision
+from app.models import (
+    Base,
+    Execution,
+    ExecutionOrderEvent,
+    ExecutionTCAMetric,
+    RejectedSignalOutcomeEvent,
+    Strategy,
+    TradeDecision,
+)
 from app.trading.order_feed import (
     OrderFeedIngestor,
     apply_order_event_to_execution,
@@ -172,6 +180,47 @@ class TestOrderFeed(TestCase):
         session.commit()
         session.refresh(execution)
         return execution
+
+    def test_runtime_symbol_columns_allow_occ_option_contracts(self) -> None:
+        for model in (
+            TradeDecision,
+            Execution,
+            ExecutionOrderEvent,
+            RejectedSignalOutcomeEvent,
+            ExecutionTCAMetric,
+        ):
+            symbol_column = model.__table__.c.symbol
+            self.assertEqual(
+                symbol_column.type.length,
+                64,
+                f"{model.__tablename__}.symbol must support OCC option symbols",
+            )
+
+    def test_option_order_feed_symbol_persists_full_occ_symbol(self) -> None:
+        option_symbol = "AMZN260529P00270000"
+        self.assertGreater(len(option_symbol), 16)
+        payload = (
+            b'{"channel":"trade_updates","payload":{"event":"fill","timestamp":"2026-02-01T10:00:00Z",'
+            b'"order":{"id":"option-order-1","client_order_id":"option-client-1",'
+            b'"symbol":"AMZN260529P00270000","status":"filled","qty":"1","filled_qty":"1",'
+            b'"filled_avg_price":"2.15"}},"seq":10}'
+        )
+        record = FakeRecord(value=payload, offset=55)
+
+        with Session(self.engine) as session:
+            normalized = normalize_order_feed_record(
+                record,
+                default_topic="torghut.trade-updates.v1",
+                default_account_label="paper",
+            )
+            assert normalized.event is not None
+            self.assertEqual(normalized.event.symbol, option_symbol)
+
+            persisted, is_duplicate = persist_order_event(session, normalized.event)
+            session.commit()
+
+            self.assertFalse(is_duplicate)
+            self.assertEqual(persisted.symbol, option_symbol)
 
     def test_cross_account_order_feed_normalization_defaults_do_not_crosstalk(
         self,


### PR DESCRIPTION
## Summary

- Widen Torghut runtime market-symbol columns to 64 characters so OCC option contract symbols do not truncate or crash order-feed ingestion.
- Add Alembic migration `0035_widen_market_symbol_columns` for trade decisions, executions, order-feed events, rejected signal outcomes, and TCA metrics.
- Add order-feed regression coverage for an OCC-style option symbol and schema assertions for runtime symbol columns.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_order_feed.py -q`
- `uv run --frozen pytest tests/test_check_migration_graph.py -q`
- `uv run --frozen pytest tests/test_order_feed.py tests/test_check_migration_graph.py -q`
- `uv run --frozen ruff check app/models/entities.py migrations/versions/0035_widen_market_symbol_columns.py tests/test_order_feed.py`
- `uv run --frozen ruff format --check app/models/entities.py migrations/versions/0035_widen_market_symbol_columns.py tests/test_order_feed.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen alembic heads`
- `git diff --check`

## Screenshots (if applicable)

N/A - backend schema and ingestion change.

## Breaking Changes

None. This adds a forward Alembic migration that widens existing varchar columns.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
