### PR TITLE
fix(torghut): recreate tca views during symbol migration

### DIFF
--- a/services/torghut/migrations/versions/0035_widen_market_symbol_columns.py
+++ b/services/torghut/migrations/versions/0035_widen_market_symbol_columns.py
@@ -27,6 +27,56 @@ MARKET_SYMBOL_COLUMNS = (
     ("execution_tca_metrics", "symbol", False),
 )
 
+TCA_STRATEGY_VIEW_SQL = """
+CREATE OR REPLACE VIEW public.execution_tca_strategy_agg_v1 AS
+SELECT
+    strategy_id,
+    COALESCE(alpaca_account_label, 'unknown') AS alpaca_account_label,
+    COUNT(*)::BIGINT AS order_count,
+    COUNT(DISTINCT symbol)::BIGINT AS symbol_count,
+    AVG(slippage_bps) AS avg_slippage_bps,
+    AVG(shortfall_notional) AS avg_shortfall_notional,
+    AVG(churn_ratio) AS avg_churn_ratio,
+    percentile_cont(0.95) WITHIN GROUP (ORDER BY slippage_bps)
+        FILTER (WHERE slippage_bps IS NOT NULL) AS p95_slippage_bps,
+    MAX(computed_at) AS last_computed_at
+FROM public.execution_tca_metrics
+GROUP BY strategy_id, COALESCE(alpaca_account_label, 'unknown');
+"""
+
+TCA_SYMBOL_VIEW_SQL = """
+CREATE OR REPLACE VIEW public.execution_tca_symbol_agg_v1 AS
+SELECT
+    strategy_id,
+    COALESCE(alpaca_account_label, 'unknown') AS alpaca_account_label,
+    symbol,
+    COUNT(*)::BIGINT AS order_count,
+    AVG(slippage_bps) AS avg_slippage_bps,
+    AVG(shortfall_notional) AS avg_shortfall_notional,
+    AVG(churn_ratio) AS avg_churn_ratio,
+    percentile_cont(0.95) WITHIN GROUP (ORDER BY slippage_bps)
+        FILTER (WHERE slippage_bps IS NOT NULL) AS p95_slippage_bps,
+    MAX(computed_at) AS last_computed_at
+FROM public.execution_tca_metrics
+GROUP BY strategy_id, COALESCE(alpaca_account_label, 'unknown'), symbol;
+"""
+
+
+def _drop_execution_tca_views() -> None:
+    op.execute("DROP VIEW IF EXISTS public.execution_tca_symbol_agg_v1;")
+    op.execute("DROP VIEW IF EXISTS public.execution_tca_strategy_agg_v1;")
+
+
+def _create_execution_tca_views() -> None:
+    op.execute(TCA_STRATEGY_VIEW_SQL)
+    op.execute(TCA_SYMBOL_VIEW_SQL)
+    op.execute(
+        "GRANT SELECT ON TABLE public.execution_tca_strategy_agg_v1 TO torghut_app;"
+    )
+    op.execute(
+        "GRANT SELECT ON TABLE public.execution_tca_symbol_agg_v1 TO torghut_app;"
+    )
+
 
 def _column_type_length(
     inspector: Inspector, table_name: str, column_name: str
@@ -43,6 +93,9 @@ def _column_type_length(
 def _alter_symbols(target_length: int, existing_length: int, *, widen: bool) -> None:
     bind = op.get_bind()
     inspector = inspect(bind)
+    should_recreate_tca_views = inspector.has_table("execution_tca_metrics")
+    if should_recreate_tca_views:
+        _drop_execution_tca_views()
 
     for table_name, column_name, nullable in MARKET_SYMBOL_COLUMNS:
         if not inspector.has_table(table_name):
@@ -64,6 +117,9 @@ def _alter_symbols(target_length: int, existing_length: int, *, widen: bool) -> 
             type_=sa.String(length=target_length),
             existing_nullable=nullable,
         )
+
+    if should_recreate_tca_views:
+        _create_execution_tca_views()
 
 
 def upgrade() -> None:


### PR DESCRIPTION
## Summary

- Fix the Torghut symbol-width migration so it drops and recreates the TCA aggregate views around `execution_tca_metrics.symbol` type changes.
- Preserve the existing TCA view definitions and grants after widening/downgrading the symbol column.
- Addresses the live Argo migration hook failure from `execution_tca_strategy_agg_v1` depending on `execution_tca_metrics.symbol`.

## Related Issues

None

## Testing

- `uv run --frozen ruff format migrations/versions/0035_widen_market_symbol_columns.py`
- `uv run --frozen ruff check migrations/versions/0035_widen_market_symbol_columns.py`
- `uv run --frozen pytest tests/test_check_migration_graph.py -q`
- `uv run --frozen alembic heads`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A - migration-only hotfix.

## Breaking Changes

None. This fixes the existing forward migration so it can apply with dependent TCA views present.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
