### PR TITLE
fix(torghut): harden runtime source proof

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -917,6 +917,52 @@ def _runtime_window_import_health_gate_summary(
     }
 
 
+def _execution_source_strategy_key(
+    *,
+    strategy_id: str | None,
+    strategy_lookup_names: Sequence[str],
+    strategy_name: str | None,
+    runtime_strategy_name: str | None,
+) -> str:
+    strategy_from_id = _strategy_name_from_strategy_id(strategy_id)
+    if strategy_from_id is not None:
+        return strategy_from_id
+    for item in strategy_lookup_names:
+        text = _safe_text(item)
+        if text is not None and text != runtime_strategy_name:
+            return text
+    return _safe_text(strategy_name) or _safe_text(runtime_strategy_name) or ""
+
+
+def _runtime_window_execution_source_key(
+    *,
+    strategy_family: str | None,
+    strategy_id: str | None,
+    strategy_lookup_names: Sequence[str],
+    strategy_name: str | None,
+    runtime_strategy_name: str | None,
+    account_label: str,
+    source_manifest_ref: str | None,
+    window_start: datetime,
+    window_end: datetime,
+    probe_symbols: Sequence[str],
+) -> tuple[object, ...]:
+    return (
+        strategy_family or "",
+        _execution_source_strategy_key(
+            strategy_id=strategy_id,
+            strategy_lookup_names=strategy_lookup_names,
+            strategy_name=strategy_name,
+            runtime_strategy_name=runtime_strategy_name,
+        ),
+        account_label,
+        source_manifest_ref or "",
+        _isoformat(window_start),
+        _isoformat(window_end),
+        tuple(str(symbol).strip().upper() for symbol in probe_symbols),
+    )
+
+
 def _next_paper_route_runtime_window_targets(
     *,
     session: Session,
@@ -970,6 +1016,7 @@ def _next_paper_route_runtime_window_targets(
     planned_targets: list[dict[str, object]] = []
     skipped_targets: list[dict[str, object]] = []
     planned_keys: set[tuple[object, ...]] = set()
+    planned_execution_source_keys: dict[tuple[object, ...], dict[str, object]] = {}
     for target in targets:
         hypothesis_id = _safe_text(target.get("hypothesis_id"))
         candidate_id = _safe_text(target.get("candidate_id"))
@@ -1037,6 +1084,64 @@ def _next_paper_route_runtime_window_targets(
                 }
             )
             continue
+        planned_key = (
+            hypothesis_id,
+            candidate_id,
+            strategy_family,
+            strategy_name,
+            PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
+            source_manifest_ref,
+            _isoformat(window_start),
+            _isoformat(window_end),
+            tuple(target_probe_symbols),
+        )
+        if planned_key in planned_keys:
+            skipped_targets.append(
+                {
+                    "hypothesis_id": hypothesis_id,
+                    "candidate_id": candidate_id,
+                    "reason": "duplicate_next_paper_route_runtime_window_target",
+                    "missing_or_blocking_fields": [
+                        "duplicate_next_paper_route_runtime_window_target"
+                    ],
+                }
+            )
+            continue
+        execution_source_key = _runtime_window_execution_source_key(
+            strategy_family=strategy_family,
+            strategy_id=strategy_id,
+            strategy_lookup_names=strategy_lookup_names,
+            strategy_name=strategy_name,
+            runtime_strategy_name=runtime_strategy_name,
+            account_label=PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
+            source_manifest_ref=source_manifest_ref,
+            window_start=window_start,
+            window_end=window_end,
+            probe_symbols=target_probe_symbols,
+        )
+        existing_execution_source = planned_execution_source_keys.get(
+            execution_source_key
+        )
+        if existing_execution_source is not None:
+            skipped_targets.append(
+                {
+                    "hypothesis_id": hypothesis_id,
+                    "candidate_id": candidate_id,
+                    "reason": (
+                        "duplicate_next_paper_route_runtime_window_execution_source"
+                    ),
+                    "duplicate_of_hypothesis_id": existing_execution_source.get(
+                        "hypothesis_id"
+                    ),
+                    "duplicate_of_candidate_id": existing_execution_source.get(
+                        "candidate_id"
+                    ),
+                    "missing_or_blocking_fields": [
+                        "duplicate_next_paper_route_runtime_window_execution_source"
+                    ],
+                }
+            )
+            continue
         source_account_label = _safe_text(target.get("account_label"))
         health_gate = _runtime_window_import_health_gate(
             target=target,
@@ -1099,6 +1204,15 @@ def _next_paper_route_runtime_window_targets(
             "paper_route_target_plan_source": paper_route_target_plan_source or "",
             "paper_route_probe_scope_authority": paper_route_probe_scope_authority
             or "",
+            "paper_route_execution_source_key": {
+                "strategy_family": strategy_family or "",
+                "strategy": execution_source_key[1],
+                "account_label": PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
+                "source_manifest_ref": source_manifest_ref,
+                "window_start": _isoformat(window_start),
+                "window_end": _isoformat(window_end),
+                "paper_route_probe_symbols": target_probe_symbols,
+            },
             "paper_route_session_readiness_state": _safe_text(
                 session_readiness.get("state")
             )
@@ -1145,30 +1259,8 @@ def _next_paper_route_runtime_window_targets(
             "promotion_gate": "runtime_ledger_live_or_live_paper_required",
             "max_notional": "0",
         }
-        planned_key = (
-            hypothesis_id,
-            candidate_id,
-            strategy_family,
-            strategy_name,
-            planned_target["account_label"],
-            planned_target["source_manifest_ref"],
-            planned_target["window_start"],
-            planned_target["window_end"],
-            tuple(target_probe_symbols),
-        )
-        if planned_key in planned_keys:
-            skipped_targets.append(
-                {
-                    "hypothesis_id": hypothesis_id,
-                    "candidate_id": candidate_id,
-                    "reason": "duplicate_next_paper_route_runtime_window_target",
-                    "missing_or_blocking_fields": [
-                        "duplicate_next_paper_route_runtime_window_target"
-                    ],
-                }
-            )
-            continue
         planned_keys.add(planned_key)
+        planned_execution_source_keys[execution_source_key] = planned_target
         planned_targets.append(planned_target)
     health_gate_summary = _runtime_window_import_health_gate_summary(planned_targets)
     return {

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -908,6 +908,7 @@ def _runtime_lifecycle_ledger_row(
     row: Mapping[str, object],
     *,
     event_type: str,
+    require_complete_fill: bool = False,
 ) -> dict[str, object] | None:
     event_time = _runtime_ledger_row_time(
         {str(key): value for key, value in row.items()}
@@ -915,7 +916,7 @@ def _runtime_lifecycle_ledger_row(
     if event_time is None:
         return None
     symbol = _first_text(row, "symbol", "order_symbol")
-    return {
+    ledger_row: dict[str, object] = {
         "executed_at": event_time,
         "event_type": event_type,
         "account_label": _first_text(row, "account_label", "alpaca_account_label"),
@@ -985,6 +986,70 @@ def _runtime_lifecycle_ledger_row(
             "source_offset",
         ),
     }
+    if event_type in _RUNTIME_LEDGER_FILL_EVENTS:
+        side = _first_text(row, "side", "action", "order_side")
+        filled_qty = _first_decimal(
+            row,
+            "filled_qty",
+            "filled_quantity",
+            "qty",
+            "quantity",
+        )
+        avg_fill_price = _first_decimal(
+            row,
+            "avg_fill_price",
+            "filled_avg_price",
+            "filled_average_price",
+            "average_fill_price",
+            "fill_price",
+            "filled_price",
+            "price",
+        )
+        filled_notional = _first_decimal(
+            row,
+            "filled_notional",
+            "notional",
+            "fill_notional",
+        )
+        if (
+            filled_notional is None
+            and filled_qty is not None
+            and avg_fill_price is not None
+        ):
+            filled_notional = filled_qty * avg_fill_price
+        cost_amount = (
+            _runtime_execution_cost_amount(row, filled_notional=filled_notional)
+            if filled_notional is not None
+            else None
+        )
+        cost_basis = _runtime_execution_cost_basis(row, cost_amount=cost_amount)
+        if require_complete_fill and (
+            side is None
+            or filled_qty is None
+            or filled_qty <= 0
+            or avg_fill_price is None
+            or avg_fill_price <= 0
+            or filled_notional is None
+            or filled_notional <= 0
+            or cost_amount is None
+            or cost_amount < 0
+            or cost_basis is None
+        ):
+            return None
+        if side is not None:
+            ledger_row["side"] = side
+        if filled_qty is not None:
+            ledger_row["filled_qty"] = filled_qty
+        if avg_fill_price is not None:
+            ledger_row["avg_fill_price"] = avg_fill_price
+        if filled_notional is not None:
+            ledger_row["filled_notional"] = filled_notional
+        if cost_amount is not None:
+            ledger_row["cost_amount"] = cost_amount
+        if cost_basis is not None:
+            ledger_row["cost_basis"] = cost_basis
+        ledger_row["source"] = "execution_order_event"
+    return ledger_row
 
 
 def _runtime_order_id(row: Mapping[str, object]) -> str | None:
@@ -1041,13 +1106,27 @@ def _order_feed_fill_lifecycle_blockers(
     if not expected_order_ids and not missing_execution_order_id:
         return []
 
-    observed_fill_order_ids = {
-        order_id
-        for row in order_lifecycle_rows or []
-        if _runtime_ledger_event_type({str(key): value for key, value in row.items()})
-        in _RUNTIME_LEDGER_FILL_EVENTS
-        if (order_id := _runtime_order_id(row)) is not None
-    }
+    observed_fill_order_ids: set[str] = set()
+    complete_fill_order_ids: set[str] = set()
+    for row in order_lifecycle_rows or []:
+        event_type = _runtime_ledger_event_type(
+            {str(key): value for key, value in row.items()}
+        )
+        if event_type not in _RUNTIME_LEDGER_FILL_EVENTS:
+            continue
+        order_id = _runtime_order_id(row)
+        if order_id is None:
+            continue
+        observed_fill_order_ids.add(order_id)
+        if (
+            _runtime_lifecycle_ledger_row(
+                row,
+                event_type=event_type,
+                require_complete_fill=True,
+            )
+            is not None
+        ):
+            complete_fill_order_ids.add(order_id)
 
     blockers: list[str] = []
     if missing_execution_order_id:
@@ -1055,6 +1134,8 @@ def _order_feed_fill_lifecycle_blockers(
     if not observed_fill_order_ids:
         blockers.append(ORDER_FEED_FILL_LIFECYCLE_MISSING_BLOCKER)
     elif expected_order_ids - observed_fill_order_ids:
+        blockers.append(ORDER_FEED_FILL_LIFECYCLE_INCOMPLETE_BLOCKER)
+    elif expected_order_ids - complete_fill_order_ids:
         blockers.append(ORDER_FEED_FILL_LIFECYCLE_INCOMPLETE_BLOCKER)
     return blockers
 
@@ -1069,6 +1150,7 @@ def _build_realized_strategy_pnl_rows(
     ledger_rows: list[RuntimeLedgerFill | dict[str, object]] = []
     event_times: list[datetime] = []
     event_sourced_lifecycle_rows = 0
+    materialized_order_fill_ids: set[str] = set()
     order_feed_fill_lifecycle_blockers = _order_feed_fill_lifecycle_blockers(
         execution_rows=execution_rows,
         order_lifecycle_rows=order_lifecycle_rows,
@@ -1086,13 +1168,19 @@ def _build_realized_strategy_pnl_rows(
         event_type = _runtime_ledger_event_type(
             {str(key): value for key, value in row.items()}
         )
-        if event_type in _RUNTIME_LEDGER_FILL_EVENTS:
-            continue
-        lifecycle_row = _runtime_lifecycle_ledger_row(row, event_type=event_type)
+        lifecycle_row = _runtime_lifecycle_ledger_row(
+            row,
+            event_type=event_type,
+            require_complete_fill=event_type in _RUNTIME_LEDGER_FILL_EVENTS,
+        )
         if lifecycle_row is None:
             continue
         ledger_rows.append(lifecycle_row)
         event_sourced_lifecycle_rows += 1
+        if event_type in _RUNTIME_LEDGER_FILL_EVENTS:
+            order_id = _runtime_order_id(lifecycle_row)
+            if order_id is not None:
+                materialized_order_fill_ids.add(order_id)
         event_time = lifecycle_row.get("executed_at")
         if isinstance(event_time, datetime):
             event_times.append(event_time)
@@ -1132,9 +1220,6 @@ def _build_realized_strategy_pnl_rows(
         symbol = str(row.get("symbol") or "").strip().upper()
         if not symbol or not isinstance(ledger_computed_at, datetime):
             continue
-        event_times.append(ledger_computed_at)
-        if isinstance(fill_event_at, datetime):
-            event_times.append(fill_event_at)
         decision_id = _first_text(
             row, "decision_id", "trade_decision_id", "decision_hash"
         )
@@ -1145,6 +1230,11 @@ def _build_realized_strategy_pnl_rows(
             "client_order_id",
             "execution_correlation_id",
         )
+        if order_id is not None and order_id in materialized_order_fill_ids:
+            continue
+        event_times.append(ledger_computed_at)
+        if isinstance(fill_event_at, datetime):
+            event_times.append(fill_event_at)
         common_ledger_fields = {
             "executed_at": ledger_computed_at,
             "account_label": str(row.get("account_label") or "") or None,

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -1271,6 +1271,11 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
                     "event_type": "filled",
                     "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
                     "decision_hash": "decision-buy",
@@ -1283,6 +1288,11 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "event_ts": datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
                     "event_type": "filled",
                     "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
                     "decision_hash": "decision-sell",
@@ -1412,6 +1422,18 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
                 },
+                {
+                    "event_ts": datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
             ],
             allow_authoritative_runtime_ledger_materialization=True,
         )
@@ -1433,6 +1455,152 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIn("order_feed_fill_lifecycle_incomplete", bucket["blockers"])
         self.assertEqual(bucket["pnl_basis"], POST_COST_BASIS_EXECUTION_RECONSTRUCTION)
         self.assertEqual(bucket["authoritative"], False)
+
+    def test_build_realized_strategy_pnl_rows_materializes_order_feed_fills_once(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 31, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "execution_reconstruction_should_not_count",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 32, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "execution_reconstruction_should_not_count",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            decision_lifecycle_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 34, tzinfo=timezone.utc),
+                    "event_type": "decision",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "decision_json": {"account": {"equity": "10000"}},
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 39, tzinfo=timezone.utc),
+                    "event_type": "decision",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "decision_json": {"account": {"equity": "10000"}},
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            order_lifecycle_rows=[
+                {
+                    "event_ts": datetime(2026, 3, 6, 14, 34, 1, tzinfo=timezone.utc),
+                    "event_type": "new",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "event_ts": datetime(2026, 3, 6, 14, 39, 1, tzinfo=timezone.utc),
+                    "event_type": "new",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "event_ts": datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(
+            rows[0]["computed_at"],
+            datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
+        )
+        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.70"))
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["fill_count"], 2)
+        self.assertEqual(
+            bucket["cost_basis_counts"],
+            {"broker_reported_commission_and_fees": 2},
+        )
+        self.assertEqual(bucket["blockers"], [])
+        self.assertEqual(bucket["source_materialization"], "execution_order_events")
 
     def test_runtime_ledger_tca_materialization_metadata_separates_authority(
         self,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -2293,6 +2293,115 @@ class TestPaperRouteEvidenceAudit(TestCase):
             matched_payload["summary"]["target_with_source_activity_count"], 1
         )
 
+    def test_next_runtime_window_targets_dedupe_same_execution_source(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        now = datetime(2026, 5, 26, 21, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            session.add(
+                Strategy(
+                    name="microbar-cross-sectional-pairs-v1",
+                    description="canonical executable H-PAIRS source strategy",
+                    enabled=True,
+                    base_timeframe="1Sec",
+                    universe_type="static",
+                    universe_symbols=["AAPL", "AMZN"],
+                    created_at=window_start,
+                    updated_at=window_start,
+                )
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": "2",
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-pairs-a",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                                "runtime_strategy_name": "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                                "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                                "strategy_lookup_names": [
+                                    "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                                    "microbar-cross-sectional-pairs-v1",
+                                ],
+                                "account_label": "TORGHUT_SIM",
+                                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                            },
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-pairs-b",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "09fabf57-71ec-44c9-af1a-4d2df98e7d83",
+                                "runtime_strategy_name": "09fabf57-71ec-44c9-af1a-4d2df98e7d83",
+                                "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                                "strategy_lookup_names": [
+                                    "09fabf57-71ec-44c9-af1a-4d2df98e7d83",
+                                    "microbar-cross-sectional-pairs-v1",
+                                ],
+                                "account_label": "TORGHUT_SIM",
+                                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                            },
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL", "AMZN"],
+                        "paper_route_probe_active_symbols": ["AAPL", "AMZN"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                    },
+                },
+                generated_at=now,
+            )
+
+        next_targets = payload["next_paper_route_runtime_window_targets"]
+        self.assertEqual(next_targets["target_count"], 1)
+        self.assertEqual(next_targets["skipped_target_count"], 1)
+        self.assertEqual(next_targets["targets"][0]["candidate_id"], "candidate-pairs-a")
+        self.assertEqual(
+            next_targets["targets"][0]["paper_route_execution_source_key"]["strategy"],
+            "microbar-cross-sectional-pairs-v1",
+        )
+        self.assertEqual(
+            next_targets["skipped_targets"][0]["reason"],
+            "duplicate_next_paper_route_runtime_window_execution_source",
+        )
+        self.assertEqual(
+            next_targets["skipped_targets"][0]["duplicate_of_candidate_id"],
+            "candidate-pairs-a",
+        )
+        import_audit = payload["runtime_window_import_audit"]
+        self.assertEqual(import_audit["counts"]["selected_target_count"], 1)
+        self.assertEqual(
+            import_audit["counts"]["next_runtime_window_target_count"], 1
+        )
+
     def test_runtime_import_audit_counts_selected_targets_not_raw_plan_noise(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Dedupe next paper-route runtime-window targets by executable source strategy, manifest, account, window, and scoped probe symbols.
- Preserve exact duplicate reporting separately from execution-source ambiguity reporting and surface the selected source attribution key.
- Require order-feed fill lifecycle rows to carry complete side, quantity, price, notional, and cost-basis proof before they can satisfy runtime-ledger authority.
- Materialize complete order-feed fill lifecycle rows once and skip duplicate execution-reconstruction fills for the same order IDs.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -k next_runtime_window_targets_dedupe_same_execution_source -q`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'authorizes_event_sourced_lifecycle or requires_order_feed_fill_lifecycle or materializes_order_feed_fills_once' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_paper_route_evidence.py tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
