### PR TITLE
chore(torghut): promote image db4e7b83

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.579.0-131-g809551ff4
+              value: v0.579.0-146-gdb4e7b83b
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 809551ff4a208cae55bce191361c25efd8ee0be2
+              value: db4e7b83b7a14f34cf5fd58a055f30edae037917
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.579.0-131-g809551ff4
+              value: v0.579.0-146-gdb4e7b83b
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 809551ff4a208cae55bce191361c25efd8ee0be2
+              value: db4e7b83b7a14f34cf5fd58a055f30edae037917
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -101,7 +101,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+                  value: sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-27T21:28:30Z"
+        client.knative.dev/updateTimestamp: "2026-05-27T23:01:36Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
           ports:
             - name: http1
               containerPort: 8181
@@ -507,11 +507,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.579.0-131-g809551ff4
+              value: v0.579.0-146-gdb4e7b83b
             - name: TORGHUT_COMMIT
-              value: 809551ff4a208cae55bce191361c25efd8ee0be2
+              value: db4e7b83b7a14f34cf5fd58a055f30edae037917
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+              value: sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-27T21:28:30Z"
+        client.knative.dev/updateTimestamp: "2026-05-27T23:01:36Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
           ports:
             - name: http1
               containerPort: 8181
@@ -326,11 +326,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.579.0-131-g809551ff4
+              value: v0.579.0-146-gdb4e7b83b
             - name: TORGHUT_COMMIT
-              value: 809551ff4a208cae55bce191361c25efd8ee0be2
+              value: db4e7b83b7a14f34cf5fd58a055f30edae037917
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+              value: sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:f3272377d9f4b9716e22ed4f74d8a313e77edcb3065fce209e2d787df5394047
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `db4e7b83b7a14f34cf5fd58a055f30edae037917`
- Image tag: `db4e7b83`
- Image digest: `sha256:971db6ea25f9c785c35803ffb7b6258b49195fdc7387e8f1ee33bdf7236f61b4`