### PR TITLE
fix(torghut): backfill stale embedded quotes

### DIFF
--- a/services/torghut/app/trading/scheduler/pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline.py
@@ -74,6 +74,7 @@ from ..quote_quality import (
     QuoteQualityPolicy,
     QuoteQualityStatus,
     SignalQuoteQualityTracker,
+    assess_signal_quote_quality,
 )
 from ..quantity_rules import (
     min_qty_for_symbol,
@@ -1380,7 +1381,14 @@ class TradingPipeline:
                 nested_key="ask_px",
             )
         )
+        embedded_quote_status: QuoteQualityStatus | None = None
         if price is not None and bid is not None and ask is not None:
+            embedded_quote_status = assess_signal_quote_quality(
+                signal=signal,
+                previous_price=None,
+                policy=self._signal_quote_quality.policy,
+            )
+        if embedded_quote_status is not None and embedded_quote_status.valid:
             return signal
         snapshot = self.price_fetcher.fetch_market_snapshot(signal)
         if snapshot is None:
@@ -1388,6 +1396,11 @@ class TradingPipeline:
         payload = dict(signal.payload)
         snapshot_has_executable_quote = (
             snapshot.bid is not None and snapshot.ask is not None
+        )
+        replace_embedded_quote = (
+            snapshot_has_executable_quote
+            and embedded_quote_status is not None
+            and not embedded_quote_status.valid
         )
         if snapshot.price is not None and (
             price is None or snapshot_has_executable_quote
@@ -1401,14 +1414,14 @@ class TradingPipeline:
                 payload["spread_bps"] = (
                     abs(snapshot.spread) / snapshot.price
                 ) * Decimal("10000")
-        if bid is None and snapshot.bid is not None:
+        if (bid is None or replace_embedded_quote) and snapshot.bid is not None:
             payload["imbalance_bid_px"] = snapshot.bid
-        if ask is None and snapshot.ask is not None:
+        if (ask is None or replace_embedded_quote) and snapshot.ask is not None:
             payload["imbalance_ask_px"] = snapshot.ask
         if (
             snapshot_has_executable_quote
             and snapshot.spread is not None
-            and payload.get("imbalance_spread") is None
+            and (payload.get("imbalance_spread") is None or replace_embedded_quote)
         ):
             payload["imbalance_spread"] = snapshot.spread
         if payload == signal.payload:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -1146,6 +1146,58 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(enriched.payload.get("imbalance_ask_px"), Decimal("100.01"))
         self.assertTrue(pipeline._signal_quote_quality.assess(enriched).valid)
 
+    def test_ensure_signal_executable_price_replaces_wide_embedded_quote_with_snapshot(
+        self,
+    ) -> None:
+        alpaca_client = FakeAlpacaClient()
+        pipeline = TradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+            price_fetcher=FakePriceFetcher(
+                Decimal("308.20"),
+                spread=Decimal("0.02"),
+                bid=Decimal("308.19"),
+                ask=Decimal("308.21"),
+            ),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 14, 31, tzinfo=timezone.utc),
+            symbol="AAPL",
+            payload={
+                "price": Decimal("308.21"),
+                "spread": Decimal("5.98"),
+                "spread_bps": Decimal("194.02355537"),
+                "imbalance_bid_px": Decimal("305.22"),
+                "imbalance_ask_px": Decimal("311.20"),
+                "imbalance_spread": Decimal("5.98"),
+                "macd": {"macd": Decimal("1.1"), "signal": Decimal("0.4")},
+            },
+            timeframe="1Sec",
+        )
+
+        enriched = pipeline._ensure_signal_executable_price(signal)
+
+        self.assertEqual(enriched.payload.get("price"), Decimal("308.20"))
+        self.assertEqual(enriched.payload.get("spread"), Decimal("0.02"))
+        self.assertEqual(
+            enriched.payload.get("spread_bps"),
+            Decimal("0.6489292667099286177806619079"),
+        )
+        self.assertEqual(enriched.payload.get("imbalance_spread"), Decimal("0.02"))
+        self.assertEqual(enriched.payload.get("imbalance_bid_px"), Decimal("308.19"))
+        self.assertEqual(enriched.payload.get("imbalance_ask_px"), Decimal("308.21"))
+        self.assertTrue(pipeline._signal_quote_quality.assess(enriched).valid)
+
     def test_ensure_signal_executable_price_backfills_missing_price_from_snapshot(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Replaces wide or invalid embedded imbalance quote bounds with a fresh executable market snapshot before the scheduler quote-quality gate runs.
- Preserves fail-closed quote-quality behavior when no valid executable snapshot is available.
- Adds regression coverage for the live-observed AAPL-style failure mode where a wide embedded quote was blocking paper-route source activity before decision evaluation.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -k 'wide_embedded_quote or stale_spread or backfills_missing_quote' -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_quote_quality.py tests/property/test_quote_quality_properties.py tests/test_trading_pipeline.py -q`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
