### PR TITLE
fix(torghut): split paper evidence materialization gates

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -41,6 +41,31 @@ _RUNTIME_LEDGER_PROOF_SATISFIED_METADATA_BLOCKERS = frozenset(
         "paper_route_runtime_ledger_import_pending",
     }
 )
+_RUNTIME_WINDOW_IMPORT_CAPITAL_ONLY_BLOCKERS = frozenset(
+    {
+        "candidate_board_promotion_not_allowed",
+        "drift_checks_not_ok",
+        "final_promotion_not_authorized",
+        "final_promotion_not_allowed",
+        "live_runtime_ledger_required",
+        "paper_probation_evidence_collection_only",
+        "paper_stage_evidence_collection_only",
+        "post_cost_expectancy_below_manifest_threshold",
+        "post_cost_expectancy_non_positive",
+        "runtime_ledger_avg_daily_filled_notional_below_target_implied_floor",
+        "runtime_ledger_best_day_share_above_limit",
+        "runtime_ledger_max_intraday_drawdown_above_limit",
+        "runtime_ledger_mean_daily_net_pnl_after_costs_below_target",
+        "runtime_ledger_median_daily_net_pnl_after_costs_below_floor",
+        "runtime_ledger_observed_trading_day_count_below_authority_minimum",
+        "runtime_ledger_p10_daily_net_pnl_after_costs_below_floor",
+        "runtime_ledger_stage_not_live",
+        "runtime_ledger_worst_day_net_pnl_after_costs_below_floor",
+        "sample_count_below_canary_minimum",
+        "slippage_budget_exceeded",
+        "recent_slippage_budget_exceeded",
+    }
+)
 RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
     {
         EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
@@ -680,6 +705,16 @@ def _runtime_window_import_proof_blockers(
         )
 
     return blockers
+
+
+def _runtime_window_import_evidence_blocking_reasons(
+    promotion_blocking_reasons: Sequence[str],
+) -> list[str]:
+    return [
+        reason
+        for reason in promotion_blocking_reasons
+        if reason not in _RUNTIME_WINDOW_IMPORT_CAPITAL_ONLY_BLOCKERS
+    ]
 
 
 def _runtime_ledger_authority_gate_targets(
@@ -1579,8 +1614,11 @@ def persist_observed_runtime_windows(
         )
     )
     promotion_allowed = not promotion_blocking_reasons
+    evidence_blocking_reasons = _runtime_window_import_evidence_blocking_reasons(
+        promotion_blocking_reasons
+    )
     proof_blockers = _runtime_window_import_proof_blockers(
-        promotion_blocking_reasons=promotion_blocking_reasons,
+        promotion_blocking_reasons=evidence_blocking_reasons,
         runtime_payload=runtime_payload,
         candidate_id=candidate_id,
         hypothesis_id=hypothesis_id,
@@ -1609,6 +1647,9 @@ def persist_observed_runtime_windows(
         "runtime_ledger_daily_summary": runtime_ledger_daily_summary,
         "proof_status": proof_status,
         "proof_blockers": proof_blockers,
+        "evidence_blocking_reasons": evidence_blocking_reasons,
+        "capital_promotion_allowed": promotion_allowed,
+        "capital_promotion_blocking_reasons": promotion_blocking_reasons,
     }
     metric_window_rows: list[StrategyHypothesisMetricWindow] = []
     runtime_ledger_rows: list[StrategyRuntimeLedgerBucket] = []
@@ -1767,6 +1808,7 @@ def persist_observed_runtime_windows(
                 **runtime_ledger_daily_summary,
                 "promotion_allowed": promotion_allowed,
                 "promotion_blocking_reasons": promotion_blocking_reasons,
+                "evidence_blocking_reasons": evidence_blocking_reasons,
                 "delay_adjusted_depth_stress": delay_depth_stress_summary,
                 "runtime_observation": runtime_payload,
             },
@@ -1804,6 +1846,7 @@ def persist_observed_runtime_windows(
             "latest_three_within_budget": latest_three_budget_ok,
             "promotion_allowed": promotion_allowed,
             "promotion_blocking_reasons": promotion_blocking_reasons,
+            "evidence_blocking_reasons": evidence_blocking_reasons,
             "delay_adjusted_depth_stress": delay_depth_stress_summary,
             "runtime_observation": runtime_payload,
         },
@@ -1915,6 +1958,7 @@ def persist_observed_runtime_windows(
         "slippage_budget_bps": str(budget),
         "promotion_allowed": promotion_allowed,
         "promotion_blocking_reasons": promotion_blocking_reasons,
+        "evidence_blocking_reasons": evidence_blocking_reasons,
         "proof_status": proof_status,
         "proof_blockers": proof_blockers,
         "runtime_materialization_target": runtime_materialization_target,

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -58,6 +58,18 @@ CAPITAL_PROMOTION_STATUS_BLOCKER_PREFIXES = (
     "promotion_",
     "paper_probation_",
 )
+RUNTIME_IMPORT_MATERIALIZATION_PROMOTION_ONLY_BLOCKERS = frozenset(
+    {
+        "candidate_board_promotion_not_allowed",
+        "final_promotion_not_authorized",
+        "final_promotion_not_allowed",
+        "live_runtime_ledger_required",
+        "paper_probation_evidence_collection_only",
+        "paper_route_runtime_ledger_import_pending",
+        "paper_stage_evidence_collection_only",
+        "runtime_ledger_stage_not_live",
+    }
+)
 
 
 class _ObjectStoreClient(Protocol):
@@ -804,6 +816,18 @@ def _runtime_import_target_blocker_codes(value: object) -> list[str]:
     return blockers
 
 
+def _runtime_import_materialization_metadata_blockers(
+    observation: Mapping[str, Any],
+) -> list[str]:
+    return [
+        blocker
+        for blocker in _text_list(
+            observation.get("runtime_ledger_target_metadata_blockers")
+        )
+        if blocker not in RUNTIME_IMPORT_MATERIALIZATION_PROMOTION_ONLY_BLOCKERS
+    ]
+
+
 def _runtime_import_target_surface_blockers(
     *,
     summary: Mapping[str, Any],
@@ -954,7 +978,7 @@ def _runtime_import_materialization_summary(
         )
         _extend_unique(
             materialization_blockers,
-            _text_list(observation.get("runtime_ledger_target_metadata_blockers")),
+            _runtime_import_materialization_metadata_blockers(observation),
         )
         materialized = (
             observation.get("authoritative") is True

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -1213,6 +1213,38 @@ class TestRuntimeLedgerProofPacket(TestCase):
         )
         self.assertTrue(materialization["materialized_targets"][0]["materialized"])
 
+    def test_packet_does_not_treat_promotion_only_import_metadata_as_unmaterialized(
+        self,
+    ) -> None:
+        runtime_import = _runtime_import()
+        observation = runtime_import["imports"][0]["summary"]["runtime_observation"]
+        assert isinstance(observation, dict)
+        observation["runtime_ledger_target_metadata_blockers"] = [
+            "paper_route_runtime_ledger_import_pending",
+            "live_runtime_ledger_required",
+            "paper_probation_evidence_collection_only",
+        ]
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertTrue(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        self.assertEqual(materialization["materialized_target_count"], 1)
+        self.assertEqual(materialization["unmaterialized_target_count"], 0)
+        self.assertNotIn("live_runtime_ledger_required", materialization["blockers"])
+        self.assertNotIn(
+            "paper_probation_evidence_collection_only",
+            materialization["blockers"],
+        )
+
     def test_packet_blocks_when_any_runtime_import_target_lacks_materialization(
         self,
     ) -> None:

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -589,6 +589,10 @@ class TestRuntimeWindowImport(TestCase):
         )
         self.assertEqual(summary["proof_status"], "blocked")
         self.assertIn(
+            "runtime_ledger_pnl_basis_missing",
+            [item["blocker"] for item in summary["proof_blockers"]],
+        )
+        self.assertNotIn(
             "sample_count_below_canary_minimum",
             [item["blocker"] for item in summary["proof_blockers"]],
         )
@@ -1612,13 +1616,17 @@ class TestRuntimeWindowImport(TestCase):
             "delay_adjusted_depth_stress_missing",
             summary["promotion_blocking_reasons"],
         )
-        self.assertEqual(summary["proof_status"], "blocked")
+        self.assertEqual(summary["proof_status"], "ok")
         proof_blockers = {item["blocker"] for item in summary["proof_blockers"]}
-        self.assertIn("paper_stage_evidence_collection_only", proof_blockers)
-        self.assertIn(
+        self.assertNotIn("paper_stage_evidence_collection_only", proof_blockers)
+        self.assertNotIn(
             "runtime_ledger_mean_daily_net_pnl_after_costs_below_target",
             proof_blockers,
         )
+        self.assertEqual(
+            summary["runtime_materialization_target"]["proof_status"], "ok"
+        )
+        self.assertTrue(summary["runtime_materialization_target"]["materialized"])
         self.assertEqual(
             summary["delay_adjusted_depth_stress"],
             {
@@ -1840,11 +1848,30 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(target["runtime_ledger_closed_trade_count"], 1)
         self.assertEqual(target["runtime_ledger_open_position_count"], 0)
         self.assertEqual(target["materialization_blockers"], [])
+        self.assertEqual(target["proof_status"], "ok")
+        self.assertEqual(target["proof_blockers"], [])
+        self.assertEqual(target["evidence_blocking_reasons"], [])
+        self.assertFalse(target["capital_promotion_allowed"])
+        self.assertIn(
+            "live_runtime_ledger_required",
+            target["capital_promotion_blocking_reasons"],
+        )
+        self.assertIn(
+            "paper_probation_evidence_collection_only",
+            target["capital_promotion_blocking_reasons"],
+        )
         self.assertEqual(len(target["metric_window_ids"]), 1)
         self.assertIsNotNone(target["promotion_decision_id"])
         self.assertEqual(len(target["runtime_ledger_bucket_ids"]), 1)
         self.assertEqual(len(target["evidence_grade_runtime_ledger_bucket_ids"]), 1)
-        self.assertFalse(target["materialized"])
+        self.assertTrue(target["materialized"])
+        self.assertFalse(summary["promotion_allowed"])
+        self.assertIn(
+            "live_runtime_ledger_required",
+            summary["promotion_blocking_reasons"],
+        )
+        self.assertEqual(summary["proof_status"], "ok")
+        self.assertEqual(summary["proof_blockers"], [])
 
     def test_persist_observed_runtime_windows_blocks_claimed_ledger_proof_without_rows(
         self,


### PR DESCRIPTION
## Summary

- Split runtime-window import evidence materialization blockers from capital-promotion blockers.
- Preserve `promotion_allowed=false` for paper evidence/probation targets while allowing persisted evidence-grade runtime-ledger buckets to report materialized.
- Filter promotion-only runtime import metadata out of proof-packet materialization blockers.
- Add regression coverage for zero-notional paper evidence canary imports and proof-packet materialization summaries.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
