### PR TITLE
perf(torghut): index cached replay signal rows

### DIFF
--- a/services/torghut/scripts/search_consistent_profitability_frontier.py
+++ b/services/torghut/scripts/search_consistent_profitability_frontier.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import heapq
 import hashlib
 import itertools
 import json
@@ -1438,20 +1439,38 @@ def _prefetch_signal_rows(
 def _cached_iter_signal_rows_factory(
     rows: list[Any],
 ) -> Callable[[replay_mod.ReplayConfig], Iterator[Any]]:
+    rows_by_day: dict[date, list[tuple[int, Any]]] = {}
+    rows_by_day_symbol: dict[date, dict[str, list[tuple[int, Any]]]] = {}
+    for index, row in enumerate(rows):
+        signal_day = row.event_ts.date()
+        indexed_row = (index, row)
+        rows_by_day.setdefault(signal_day, []).append(indexed_row)
+        rows_by_day_symbol.setdefault(signal_day, {}).setdefault(
+            str(row.symbol).upper(), []
+        ).append(indexed_row)
+
     def _iter_signal_rows(config: replay_mod.ReplayConfig) -> Iterator[Any]:
         selected_symbols = (
             {symbol.upper() for symbol in config.symbols} if config.symbols else None
         )
-        for row in rows:
-            signal_day = row.event_ts.date()
-            if signal_day < config.start_date or signal_day > config.end_date:
+        if config.start_date > config.end_date:
+            return
+        for day_offset in range((config.end_date - config.start_date).days + 1):
+            signal_day = config.start_date + timedelta(days=day_offset)
+            if selected_symbols is None:
+                for _, row in rows_by_day.get(signal_day, ()):
+                    yield row
                 continue
-            if (
-                selected_symbols is not None
-                and row.symbol.upper() not in selected_symbols
-            ):
+            day_symbols = rows_by_day_symbol.get(signal_day)
+            if not day_symbols:
                 continue
-            yield row
+            symbol_rows = [
+                iter(day_symbols[symbol])
+                for symbol in selected_symbols
+                if symbol in day_symbols
+            ]
+            for _, row in heapq.merge(*symbol_rows, key=lambda item: item[0]):
+                yield row
 
     return _iter_signal_rows
 

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -24,6 +24,26 @@ from app.trading.models import SignalEnvelope
 import scripts.search_consistent_profitability_frontier as frontier
 
 
+class _GuardedSignalRow:
+    def __init__(
+        self,
+        *,
+        symbol: str,
+        event_ts: datetime,
+        seq: int,
+    ) -> None:
+        self.symbol = symbol
+        self.seq = seq
+        self._event_ts = event_ts
+        self.raise_on_event_ts = False
+
+    @property
+    def event_ts(self) -> datetime:
+        if self.raise_on_event_ts:
+            raise AssertionError("cached iterator should use the prebuilt date index")
+        return self._event_ts
+
+
 def _authoritative_exact_replay_rows() -> list[dict[str, object]]:
     return [
         {
@@ -2029,6 +2049,78 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         )
         filtered = list(iterator(config))
         self.assertEqual([item.symbol for item in filtered], ["NVDA"])
+        self.assertEqual(filtered[0].seq, 2)
+
+    def test_cached_iter_signal_rows_factory_preserves_cross_symbol_order(
+        self,
+    ) -> None:
+        rows = [
+            SimpleNamespace(
+                symbol="NVDA",
+                event_ts=datetime(2026, 3, 23, 14, 0, tzinfo=timezone.utc),
+                seq=1,
+            ),
+            SimpleNamespace(
+                symbol="AMAT",
+                event_ts=datetime(2026, 3, 23, 14, 0, 1, tzinfo=timezone.utc),
+                seq=2,
+            ),
+            SimpleNamespace(
+                symbol="META",
+                event_ts=datetime(2026, 3, 23, 14, 0, 2, tzinfo=timezone.utc),
+                seq=3,
+            ),
+            SimpleNamespace(
+                symbol="NVDA",
+                event_ts=datetime(2026, 3, 24, 14, 0, tzinfo=timezone.utc),
+                seq=4,
+            ),
+        ]
+        iterator = frontier._cached_iter_signal_rows_factory(rows)
+        config = SimpleNamespace(
+            symbols=("amat", "nvda"),
+            start_date=date(2026, 3, 23),
+            end_date=date(2026, 3, 24),
+        )
+
+        filtered = list(iterator(config))
+
+        self.assertEqual([item.symbol for item in filtered], ["NVDA", "AMAT", "NVDA"])
+        self.assertEqual([item.seq for item in filtered], [1, 2, 4])
+
+    def test_cached_iter_signal_rows_factory_uses_index_after_factory(
+        self,
+    ) -> None:
+        rows = [
+            _GuardedSignalRow(
+                symbol="NVDA",
+                event_ts=datetime(2026, 3, 22, 14, 0, tzinfo=timezone.utc),
+                seq=1,
+            ),
+            _GuardedSignalRow(
+                symbol="AMAT",
+                event_ts=datetime(2026, 3, 23, 14, 0, tzinfo=timezone.utc),
+                seq=2,
+            ),
+            _GuardedSignalRow(
+                symbol="META",
+                event_ts=datetime(2026, 3, 24, 14, 0, tzinfo=timezone.utc),
+                seq=3,
+            ),
+        ]
+        iterator = frontier._cached_iter_signal_rows_factory(rows)
+        for row in rows:
+            row.raise_on_event_ts = True
+
+        config = SimpleNamespace(
+            symbols=("AMAT",),
+            start_date=date(2026, 3, 23),
+            end_date=date(2026, 3, 23),
+        )
+
+        filtered = list(iterator(config))
+
+        self.assertEqual([item.symbol for item in filtered], ["AMAT"])
         self.assertEqual(filtered[0].seq, 2)
 
     def test_apply_candidate_to_configmap_with_overrides_updates_top_level_fields(

--- a/services/torghut/tests/test_search_consistent_profitability_frontier.py
+++ b/services/torghut/tests/test_search_consistent_profitability_frontier.py
@@ -2088,6 +2088,56 @@ class TestSearchConsistentProfitabilityFrontier(TestCase):
         self.assertEqual([item.symbol for item in filtered], ["NVDA", "AMAT", "NVDA"])
         self.assertEqual([item.seq for item in filtered], [1, 2, 4])
 
+    def test_cached_iter_signal_rows_factory_returns_all_symbols_without_filter(
+        self,
+    ) -> None:
+        rows = [
+            SimpleNamespace(
+                symbol="NVDA",
+                event_ts=datetime(2026, 3, 23, 14, 0, tzinfo=timezone.utc),
+                seq=1,
+            ),
+            SimpleNamespace(
+                symbol="AMAT",
+                event_ts=datetime(2026, 3, 23, 14, 0, 1, tzinfo=timezone.utc),
+                seq=2,
+            ),
+            SimpleNamespace(
+                symbol="META",
+                event_ts=datetime(2026, 3, 24, 14, 0, tzinfo=timezone.utc),
+                seq=3,
+            ),
+        ]
+        iterator = frontier._cached_iter_signal_rows_factory(rows)
+        config = SimpleNamespace(
+            symbols=(),
+            start_date=date(2026, 3, 23),
+            end_date=date(2026, 3, 24),
+        )
+
+        filtered = list(iterator(config))
+
+        self.assertEqual([item.seq for item in filtered], [1, 2, 3])
+
+    def test_cached_iter_signal_rows_factory_returns_empty_for_inverted_dates(
+        self,
+    ) -> None:
+        rows = [
+            SimpleNamespace(
+                symbol="NVDA",
+                event_ts=datetime(2026, 3, 23, 14, 0, tzinfo=timezone.utc),
+                seq=1,
+            )
+        ]
+        iterator = frontier._cached_iter_signal_rows_factory(rows)
+        config = SimpleNamespace(
+            symbols=(),
+            start_date=date(2026, 3, 24),
+            end_date=date(2026, 3, 23),
+        )
+
+        self.assertEqual(list(iterator(config)), [])
+
     def test_cached_iter_signal_rows_factory_uses_index_after_factory(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Builds a day/symbol index once for prefetched replay signal rows instead of rescanning the full cached row list for every candidate replay.
- Preserves original replay row ordering across selected symbols by merging indexed row streams with their original row ordinal.
- Adds regression coverage that selected-symbol iteration preserves cross-symbol order and uses the prebuilt date index after factory creation.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_search_consistent_profitability_frontier.py -q`
- `uv run --frozen ruff check scripts/search_consistent_profitability_frontier.py tests/test_search_consistent_profitability_frontier.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
