### PR TITLE
fix(torghut): bound quote fallback load

### DIFF
--- a/argocd/applications/feature-flags/gitops/default/features.yaml
+++ b/argocd/applications/feature-flags/gitops/default/features.yaml
@@ -80,6 +80,11 @@ flags:
     description: Enables paper-safe Alpaca latest-quote fallback when executable signal quotes are missing.
     type: BOOLEAN_FLAG_TYPE
     enabled: false
+  - key: torghut_trading_alpaca_quote_fallback_market_session_required
+    name: Torghut Trading Alpaca Quote Fallback Market Session Required
+    description: Suppresses Alpaca latest-quote fallback outside regular market hours.
+    type: BOOLEAN_FLAG_TYPE
+    enabled: true
   - key: torghut_trading_autonomy_enabled
     name: Torghut Trading Autonomy Enabled
     description: Enables autonomous lane orchestration in Torghut.

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -169,6 +169,12 @@ spec:
               value: iex
             - name: TRADING_ALPACA_QUOTE_MAX_AGE_SECONDS
               value: "20"
+            - name: TRADING_ALPACA_QUOTE_FALLBACK_MARKET_SESSION_REQUIRED
+              value: "true"
+            - name: TRADING_ALPACA_QUOTE_FALLBACK_BACKOFF_SECONDS
+              value: "60"
+            - name: TRADING_OPTIONS_CATALOG_FRESHNESS_CACHE_SECONDS
+              value: "30"
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SECONDS
               value: "300"
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SIGNALS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -150,6 +150,12 @@ spec:
               value: iex
             - name: TRADING_ALPACA_QUOTE_MAX_AGE_SECONDS
               value: "20"
+            - name: TRADING_ALPACA_QUOTE_FALLBACK_MARKET_SESSION_REQUIRED
+              value: "true"
+            - name: TRADING_ALPACA_QUOTE_FALLBACK_BACKOFF_SECONDS
+              value: "60"
+            - name: TRADING_OPTIONS_CATALOG_FRESHNESS_CACHE_SECONDS
+              value: "30"
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SECONDS
               value: "300"
             - name: TRADING_SESSION_CONTEXT_WARMUP_MAX_SIGNALS

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -50,6 +50,9 @@ FEATURE_FLAG_BOOLEAN_KEY_BY_FIELD: dict[str, str] = {
     "trading_execution_advisor_enabled": "torghut_trading_execution_advisor_enabled",
     "trading_execution_advisor_live_apply_enabled": "torghut_trading_execution_advisor_live_apply_enabled",
     "trading_alpaca_quote_fallback_enabled": "torghut_trading_alpaca_quote_fallback_enabled",
+    "trading_alpaca_quote_fallback_market_session_required": (
+        "torghut_trading_alpaca_quote_fallback_market_session_required"
+    ),
     "trading_simulation_enabled": "torghut_trading_simulation_enabled",
     "trading_allow_shorts": "torghut_trading_allow_shorts",
     "trading_fractional_equities_enabled": "torghut_trading_fractional_equities_enabled",
@@ -459,6 +462,32 @@ class Settings(BaseSettings):
         default=20,
         alias="TRADING_ALPACA_QUOTE_MAX_AGE_SECONDS",
         description="Reject Alpaca fallback quotes older than this many seconds.",
+    )
+    trading_alpaca_quote_fallback_market_session_required: bool = Field(
+        default=True,
+        alias="TRADING_ALPACA_QUOTE_FALLBACK_MARKET_SESSION_REQUIRED",
+        description=(
+            "Suppress Alpaca latest-quote executable backfill outside the regular "
+            "equity market session. This keeps proof lanes fail-closed and avoids "
+            "provider churn when closed-market quotes are not executable."
+        ),
+    )
+    trading_alpaca_quote_fallback_backoff_seconds: int = Field(
+        default=60,
+        alias="TRADING_ALPACA_QUOTE_FALLBACK_BACKOFF_SECONDS",
+        description=(
+            "Per-symbol cooldown after Alpaca latest-quote fallback is unavailable "
+            "or rejected, so repeated scheduler probes do not hammer the provider."
+        ),
+    )
+    trading_options_catalog_freshness_cache_seconds: int = Field(
+        default=0,
+        alias="TRADING_OPTIONS_CATALOG_FRESHNESS_CACHE_SECONDS",
+        description=(
+            "Short in-process cache TTL for options catalog freshness summaries. "
+            "Caching unavailable summaries keeps status probes bounded while "
+            "preserving fail-closed evidence semantics."
+        ),
     )
     trading_poll_ms: int = Field(default=5000, alias="TRADING_POLL_MS")
     trading_reconcile_ms: int = Field(default=15000, alias="TRADING_RECONCILE_MS")

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -7,6 +7,7 @@ import time
 from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from contextlib import asynccontextmanager
+from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from http.client import HTTPConnection, HTTPSConnection
@@ -200,6 +201,10 @@ LEAN_LANE_MANAGER = LeanLaneManager()
 WHITEPAPER_WORKFLOW = WhitepaperWorkflowService()
 _TRADING_DEPENDENCY_HEALTH_CACHE_LOCK = Lock()
 _TRADING_DEPENDENCY_HEALTH_CACHE: dict[str, dict[str, object]] = {}
+_OPTIONS_CATALOG_FRESHNESS_CACHE_LOCK = Lock()
+_OPTIONS_CATALOG_FRESHNESS_CACHE: dict[
+    tuple[str, ...], tuple[datetime, dict[str, object]]
+] = {}
 _ALPACA_HEALTH_CACHE_LOCK = Lock()
 _ALPACA_HEALTH_STATE: dict[str, object] = {}
 
@@ -5341,6 +5346,54 @@ def _route_claim_symbols(profit_signal_quorum: Mapping[str, Any]) -> tuple[str, 
     return tuple(sorted(symbols))
 
 
+def _load_cached_options_catalog_freshness_summary(
+    cache_key: tuple[str, ...],
+) -> dict[str, object] | None:
+    ttl_seconds = max(0, settings.trading_options_catalog_freshness_cache_seconds)
+    if ttl_seconds <= 0:
+        return None
+    now = datetime.now(timezone.utc)
+    with _OPTIONS_CATALOG_FRESHNESS_CACHE_LOCK:
+        cache_entry = _OPTIONS_CATALOG_FRESHNESS_CACHE.get(cache_key)
+        if cache_entry is None:
+            return None
+        cached_at, cached_payload = cache_entry
+        age_seconds = (now - cached_at).total_seconds()
+        if age_seconds >= ttl_seconds:
+            _OPTIONS_CATALOG_FRESHNESS_CACHE.pop(cache_key, None)
+            return None
+    payload = deepcopy(cached_payload)
+    payload["cache"] = {
+        "hit": True,
+        "cached_at": cached_at,
+        "age_seconds": age_seconds,
+        "ttl_seconds": ttl_seconds,
+    }
+    return payload
+
+
+def _store_options_catalog_freshness_summary(
+    cache_key: tuple[str, ...],
+    payload: dict[str, object],
+) -> dict[str, object]:
+    ttl_seconds = max(0, settings.trading_options_catalog_freshness_cache_seconds)
+    if ttl_seconds <= 0:
+        return payload
+    cached_at = datetime.now(timezone.utc)
+    cache_payload = deepcopy(payload)
+    cache_payload.pop("cache", None)
+    with _OPTIONS_CATALOG_FRESHNESS_CACHE_LOCK:
+        _OPTIONS_CATALOG_FRESHNESS_CACHE[cache_key] = (cached_at, cache_payload)
+    payload = deepcopy(cache_payload)
+    payload["cache"] = {
+        "hit": False,
+        "cached_at": cached_at,
+        "age_seconds": 0.0,
+        "ttl_seconds": ttl_seconds,
+    }
+    return payload
+
+
 def _load_options_catalog_freshness_summary(
     session: Session, *, route_symbols: Sequence[str] | None = None
 ) -> dict[str, object]:
@@ -5353,6 +5406,9 @@ def _load_options_catalog_freshness_summary(
             }
         )
     )
+    cached_payload = _load_cached_options_catalog_freshness_summary(scoped_symbols)
+    if cached_payload is not None:
+        return cached_payload
     try:
         session.execute(text("SET LOCAL statement_timeout = 500"))
         if scoped_symbols:
@@ -5454,10 +5510,15 @@ WHERE status = 'active'
             zero_open_interest_count = int(row["zero_open_interest_count"] or 0)
     except SQLAlchemyError as exc:
         logger.warning("Options catalog freshness summary unavailable: %s", exc)
-        return {
-            "status": "unavailable",
-            "reason_codes": ["options_catalog_freshness_summary_unavailable"],
-        }
+        return _store_options_catalog_freshness_summary(
+            scoped_symbols,
+            {
+                "status": "unavailable",
+                "scope": "route_symbols" if scoped_symbols else "global",
+                "route_symbols": list(scoped_symbols),
+                "reason_codes": ["options_catalog_freshness_summary_unavailable"],
+            },
+        )
 
     route_symbol_freshness = {
         str(scoped_row["underlying_symbol"]).strip().upper(): {
@@ -5488,20 +5549,23 @@ WHERE status = 'active'
         }
         for scoped_row in scoped_rows
     }
-    return {
-        "status": "current" if active_contracts > 0 else "missing",
-        "scope": "route_symbols" if scoped_symbols else "global",
-        "active_contracts": active_contracts,
-        "newest_last_seen_ts": newest_last_seen_ts,
-        "missing_provider_updated_ts_count": missing_provider_updated_ts_count,
-        "provider_updated_ts_present": missing_provider_updated_ts_count == 0
-        and newest_provider_updated_ts is not None,
-        "newest_provider_updated_ts": newest_provider_updated_ts,
-        "missing_close_price_count": missing_close_price_count,
-        "zero_open_interest_count": zero_open_interest_count,
-        "route_symbols": list(scoped_symbols),
-        "route_symbol_freshness": route_symbol_freshness,
-    }
+    return _store_options_catalog_freshness_summary(
+        scoped_symbols,
+        {
+            "status": "current" if active_contracts > 0 else "missing",
+            "scope": "route_symbols" if scoped_symbols else "global",
+            "active_contracts": active_contracts,
+            "newest_last_seen_ts": newest_last_seen_ts,
+            "missing_provider_updated_ts_count": missing_provider_updated_ts_count,
+            "provider_updated_ts_present": missing_provider_updated_ts_count == 0
+            and newest_provider_updated_ts is not None,
+            "newest_provider_updated_ts": newest_provider_updated_ts,
+            "missing_close_price_count": missing_close_price_count,
+            "zero_open_interest_count": zero_open_interest_count,
+            "route_symbols": list(scoped_symbols),
+            "route_symbol_freshness": route_symbol_freshness,
+        },
+    )
 
 
 def _resolve_tca_scope_symbols(

--- a/services/torghut/app/trading/prices.py
+++ b/services/torghut/app/trading/prices.py
@@ -10,11 +10,13 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from http.client import HTTPConnection, HTTPSConnection
+from time import monotonic
 from typing import Any, Optional, cast
 from urllib.parse import urlencode, urlsplit
 
 from ..config import settings
 from .clickhouse import normalize_symbol, to_datetime64
+from .market_session import market_session_is_open
 from .models import SignalEnvelope
 
 logger = logging.getLogger(__name__)
@@ -112,6 +114,8 @@ class ClickHousePriceFetcher(PriceFetcher):
         alpaca_quote_feed: Optional[str] = None,
         alpaca_quote_timeout_seconds: Optional[float] = None,
         alpaca_quote_max_age_seconds: Optional[int] = None,
+        alpaca_quote_fallback_market_session_required: Optional[bool] = None,
+        alpaca_quote_fallback_backoff_seconds: Optional[int] = None,
     ) -> None:
         self.url = (url or settings.trading_clickhouse_url or "").rstrip("/")
         self.username = username or settings.trading_clickhouse_username
@@ -164,7 +168,19 @@ class ClickHousePriceFetcher(PriceFetcher):
             if alpaca_quote_max_age_seconds is not None
             else settings.trading_alpaca_quote_max_age_seconds,
         )
+        self.alpaca_quote_fallback_market_session_required = (
+            settings.trading_alpaca_quote_fallback_market_session_required
+            if alpaca_quote_fallback_market_session_required is None
+            else alpaca_quote_fallback_market_session_required
+        )
+        self.alpaca_quote_fallback_backoff_seconds = max(
+            0,
+            alpaca_quote_fallback_backoff_seconds
+            if alpaca_quote_fallback_backoff_seconds is not None
+            else settings.trading_alpaca_quote_fallback_backoff_seconds,
+        )
         self._columns: Optional[set[str]] = None
+        self._alpaca_quote_fallback_backoff: dict[str, tuple[float, str]] = {}
 
     def fetch_price(self, signal: SignalEnvelope) -> Optional[Decimal]:
         if not self.url:
@@ -322,14 +338,33 @@ class ClickHousePriceFetcher(PriceFetcher):
     def _fetch_alpaca_latest_quote_row(self, *, symbol: str) -> dict[str, Any] | None:
         if not self.alpaca_quote_fallback_enabled:
             return None
+        if self._alpaca_quote_fallback_backoff_active(symbol=symbol):
+            return None
+        if (
+            self.alpaca_quote_fallback_market_session_required
+            and not market_session_is_open(None)
+        ):
+            self._backoff_alpaca_quote_fallback(
+                symbol=symbol,
+                reason="market_session_closed",
+            )
+            return None
         if not self.alpaca_api_key_id or not self.alpaca_api_secret_key:
             logger.warning(
                 "Alpaca latest quote fallback disabled by missing credentials symbol=%s",
                 symbol,
             )
+            self._backoff_alpaca_quote_fallback(
+                symbol=symbol,
+                reason="missing_credentials",
+            )
             return None
         quote = self._fetch_alpaca_latest_quote(symbol=symbol)
         if quote is None:
+            self._backoff_alpaca_quote_fallback(
+                symbol=symbol,
+                reason="quote_unavailable",
+            )
             return None
         bid = _optional_decimal(quote.get("bp") or quote.get("bid_price"))
         ask = _optional_decimal(quote.get("ap") or quote.get("ask_price"))
@@ -337,9 +372,17 @@ class ClickHousePriceFetcher(PriceFetcher):
             logger.info(
                 "Alpaca latest quote fallback rejected invalid quote symbol=%s", symbol
             )
+            self._backoff_alpaca_quote_fallback(
+                symbol=symbol,
+                reason="invalid_quote",
+            )
             return None
         spread_bps = _quote_spread_bps(bid=bid, ask=ask)
         if spread_bps is None:
+            self._backoff_alpaca_quote_fallback(
+                symbol=symbol,
+                reason="invalid_spread",
+            )
             return None
         if spread_bps > settings.trading_signal_max_executable_spread_bps:
             logger.info(
@@ -347,12 +390,17 @@ class ClickHousePriceFetcher(PriceFetcher):
                 symbol,
                 spread_bps,
             )
+            self._backoff_alpaca_quote_fallback(symbol=symbol, reason="wide_quote")
             return None
         quote_ts = _parse_ts(quote.get("t") or quote.get("timestamp"))
         if quote_ts is None:
             logger.info(
                 "Alpaca latest quote fallback rejected missing timestamp symbol=%s",
                 symbol,
+            )
+            self._backoff_alpaca_quote_fallback(
+                symbol=symbol,
+                reason="missing_timestamp",
             )
             return None
         if quote_ts.tzinfo is None:
@@ -369,6 +417,7 @@ class ClickHousePriceFetcher(PriceFetcher):
                 symbol,
                 quote_age,
             )
+            self._backoff_alpaca_quote_fallback(symbol=symbol, reason="stale_quote")
             return None
         return {
             "event_ts": quote_ts.isoformat(),
@@ -376,6 +425,34 @@ class ClickHousePriceFetcher(PriceFetcher):
             "imbalance_ask_px": ask,
             "imbalance_spread": ask - bid,
         }
+
+    def _alpaca_quote_fallback_backoff_active(self, *, symbol: str) -> bool:
+        backoff = self._alpaca_quote_fallback_backoff.get(symbol)
+        if backoff is None:
+            return False
+        expires_at, _reason = backoff
+        if monotonic() < expires_at:
+            return True
+        self._alpaca_quote_fallback_backoff.pop(symbol, None)
+        return False
+
+    def _backoff_alpaca_quote_fallback(self, *, symbol: str, reason: str) -> None:
+        if self.alpaca_quote_fallback_backoff_seconds <= 0:
+            return
+        now = monotonic()
+        previous = self._alpaca_quote_fallback_backoff.get(symbol)
+        self._alpaca_quote_fallback_backoff[symbol] = (
+            now + self.alpaca_quote_fallback_backoff_seconds,
+            reason,
+        )
+        if previous is not None and previous[0] > now:
+            return
+        logger.info(
+            "Alpaca latest quote fallback backoff symbol=%s reason=%s seconds=%s",
+            symbol,
+            reason,
+            self.alpaca_quote_fallback_backoff_seconds,
+        )
 
     def _fetch_alpaca_latest_quote(self, *, symbol: str) -> Mapping[str, Any] | None:
         params: dict[str, str] = {}

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -655,6 +655,18 @@ class TestLiveConfigManifestContract(TestCase):
             "20",
         )
         self.assertEqual(
+            sim_env.get("TRADING_ALPACA_QUOTE_FALLBACK_MARKET_SESSION_REQUIRED"),
+            "true",
+        )
+        self.assertEqual(
+            sim_env.get("TRADING_ALPACA_QUOTE_FALLBACK_BACKOFF_SECONDS"),
+            "60",
+        )
+        self.assertEqual(
+            sim_env.get("TRADING_OPTIONS_CATALOG_FRESHNESS_CACHE_SECONDS"),
+            "30",
+        )
+        self.assertEqual(
             _load_torghut_knative_env().get(
                 "TRADING_EXECUTABLE_QUOTE_LOOKBACK_SECONDS"
             ),
@@ -675,6 +687,24 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertEqual(
             _load_torghut_knative_env().get("TRADING_ALPACA_QUOTE_MAX_AGE_SECONDS"),
             "20",
+        )
+        self.assertEqual(
+            _load_torghut_knative_env().get(
+                "TRADING_ALPACA_QUOTE_FALLBACK_MARKET_SESSION_REQUIRED"
+            ),
+            "true",
+        )
+        self.assertEqual(
+            _load_torghut_knative_env().get(
+                "TRADING_ALPACA_QUOTE_FALLBACK_BACKOFF_SECONDS"
+            ),
+            "60",
+        )
+        self.assertEqual(
+            _load_torghut_knative_env().get(
+                "TRADING_OPTIONS_CATALOG_FRESHNESS_CACHE_SECONDS"
+            ),
+            "30",
         )
         self.assertEqual(
             sim_env.get("TRADING_UNIVERSE_STATIC_FALLBACK_SYMBOLS"),
@@ -1167,6 +1197,11 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertTrue(_manifest_bool(env, "TRADING_ALPACA_QUOTE_FALLBACK_ENABLED"))
         self.assertEqual(env.get("TRADING_ALPACA_QUOTE_FEED"), "iex")
         self.assertEqual(env.get("TRADING_ALPACA_QUOTE_MAX_AGE_SECONDS"), "20")
+        self.assertTrue(
+            _manifest_bool(env, "TRADING_ALPACA_QUOTE_FALLBACK_MARKET_SESSION_REQUIRED")
+        )
+        self.assertEqual(env.get("TRADING_ALPACA_QUOTE_FALLBACK_BACKOFF_SECONDS"), "60")
+        self.assertEqual(env.get("TRADING_OPTIONS_CATALOG_FRESHNESS_CACHE_SECONDS"), "30")
         self.assertFalse(_manifest_bool(env, "TRADING_AUTONOMY_ENABLED"))
         self.assertFalse(_manifest_bool(env, "TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION"))
         self.assertFalse(_manifest_bool(env, "TRADING_KILL_SWITCH_ENABLED"))

--- a/services/torghut/tests/test_prices.py
+++ b/services/torghut/tests/test_prices.py
@@ -41,7 +41,12 @@ class RoutingClickHousePriceFetcher(ClickHousePriceFetcher):
         quote_forward_seconds: int = 0,
         alpaca_quote: dict[str, object] | None = None,
         alpaca_quote_fallback_enabled: bool | None = None,
+        alpaca_quote_fallback_market_session_required: bool = False,
+        alpaca_quote_fallback_backoff_seconds: int = 60,
     ) -> None:
+        alpaca_credentials_enabled = (
+            alpaca_quote is not None or alpaca_quote_fallback_enabled is True
+        )
         super().__init__(
             url="http://example",
             table="torghut.ta_microbars",
@@ -54,14 +59,21 @@ class RoutingClickHousePriceFetcher(ClickHousePriceFetcher):
                 else alpaca_quote_fallback_enabled
             ),
             alpaca_data_api_base_url="https://data.example",
-            alpaca_api_key_id="key" if alpaca_quote is not None else None,
-            alpaca_api_secret_key="secret" if alpaca_quote is not None else None,
+            alpaca_api_key_id="key" if alpaca_credentials_enabled else None,
+            alpaca_api_secret_key="secret" if alpaca_credentials_enabled else None,
             alpaca_quote_max_age_seconds=120,
+            alpaca_quote_fallback_market_session_required=(
+                alpaca_quote_fallback_market_session_required
+            ),
+            alpaca_quote_fallback_backoff_seconds=(
+                alpaca_quote_fallback_backoff_seconds
+            ),
         )
         self.price_rows = price_rows
         self.quote_rows = quote_rows
         self.fail_quote_query = fail_quote_query
         self.alpaca_quote = alpaca_quote
+        self.alpaca_quote_calls = 0
         self.queries: list[str] = []
 
     def _resolve_columns(self) -> set[str] | None:
@@ -77,6 +89,7 @@ class RoutingClickHousePriceFetcher(ClickHousePriceFetcher):
 
     def _fetch_alpaca_latest_quote(self, *, symbol: str) -> dict[str, object] | None:
         _ = symbol
+        self.alpaca_quote_calls += 1
         return self.alpaca_quote
 
 
@@ -326,6 +339,23 @@ class TestClickHousePriceFetcher(TestCase):
 
         self.assertIsNone(quote)
 
+    def test_fetch_market_snapshot_backs_off_missing_alpaca_credentials(
+        self,
+    ) -> None:
+        fetcher = ClickHousePriceFetcher(
+            url="http://example",
+            table="torghut.ta_microbars",
+            alpaca_quote_fallback_enabled=True,
+            alpaca_quote_fallback_backoff_seconds=60,
+        )
+        fetcher.alpaca_api_key_id = None
+        fetcher.alpaca_api_secret_key = None
+
+        quote = fetcher._fetch_alpaca_latest_quote_row(symbol="AMZN")
+
+        self.assertIsNone(quote)
+        self.assertTrue(fetcher._alpaca_quote_fallback_backoff_active(symbol="AMZN"))
+
     def test_fetch_market_snapshot_ignores_empty_alpaca_latest_quote(
         self,
     ) -> None:
@@ -344,6 +374,79 @@ class TestClickHousePriceFetcher(TestCase):
         snapshot = fetcher.fetch_market_snapshot(signal)
 
         self.assertIsNone(snapshot)
+        self.assertEqual(fetcher.alpaca_quote_calls, 1)
+
+    def test_fetch_market_snapshot_backs_off_empty_alpaca_latest_quote(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc),
+            symbol="AMZN",
+            payload={},
+        )
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[],
+            alpaca_quote=None,
+            alpaca_quote_fallback_enabled=True,
+            alpaca_quote_fallback_backoff_seconds=60,
+        )
+
+        self.assertIsNone(fetcher.fetch_market_snapshot(signal))
+        self.assertIsNone(fetcher.fetch_market_snapshot(signal))
+
+        self.assertEqual(fetcher.alpaca_quote_calls, 1)
+
+    def test_fetch_market_snapshot_skips_alpaca_latest_quote_when_market_closed(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc),
+            symbol="AMZN",
+            payload={},
+        )
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[],
+            alpaca_quote={
+                "t": datetime.now(timezone.utc).isoformat(),
+                "bp": "185.10",
+                "ap": "185.14",
+            },
+            alpaca_quote_fallback_market_session_required=True,
+        )
+
+        with patch("app.trading.prices.market_session_is_open", return_value=False):
+            snapshot = fetcher.fetch_market_snapshot(signal)
+
+        self.assertIsNone(snapshot)
+        self.assertEqual(fetcher.alpaca_quote_calls, 0)
+
+    def test_fetch_market_snapshot_reuses_active_market_closed_backoff(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc),
+            symbol="AMZN",
+            payload={},
+        )
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[],
+            alpaca_quote={
+                "t": datetime.now(timezone.utc).isoformat(),
+                "bp": "185.10",
+                "ap": "185.14",
+            },
+            alpaca_quote_fallback_market_session_required=True,
+        )
+
+        with patch("app.trading.prices.market_session_is_open", return_value=False):
+            self.assertIsNone(fetcher.fetch_market_snapshot(signal))
+            self.assertIsNone(fetcher.fetch_market_snapshot(signal))
+
+        self.assertEqual(fetcher.alpaca_quote_calls, 0)
+        self.assertTrue(fetcher._alpaca_quote_fallback_backoff_active(symbol="AMZN"))
 
     def test_fetch_market_snapshot_rejects_invalid_alpaca_latest_quote(
         self,
@@ -366,6 +469,86 @@ class TestClickHousePriceFetcher(TestCase):
         snapshot = fetcher.fetch_market_snapshot(signal)
 
         self.assertIsNone(snapshot)
+
+    def test_fetch_market_snapshot_rejects_invalid_alpaca_quote_spread(
+        self,
+    ) -> None:
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc),
+            symbol="AMZN",
+            payload={},
+        )
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[],
+            alpaca_quote={
+                "t": datetime.now(timezone.utc).isoformat(),
+                "bp": "185.10",
+                "ap": "185.14",
+            },
+        )
+
+        with patch("app.trading.prices._quote_spread_bps", return_value=None):
+            snapshot = fetcher.fetch_market_snapshot(signal)
+
+        self.assertIsNone(snapshot)
+        self.assertTrue(fetcher._alpaca_quote_fallback_backoff_active(symbol="AMZN"))
+
+    def test_alpaca_quote_fallback_backoff_expires_and_can_be_disabled(
+        self,
+    ) -> None:
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[],
+            alpaca_quote=None,
+            alpaca_quote_fallback_enabled=True,
+            alpaca_quote_fallback_backoff_seconds=60,
+        )
+        fetcher._alpaca_quote_fallback_backoff["AMZN"] = (0.0, "expired")
+
+        self.assertFalse(fetcher._alpaca_quote_fallback_backoff_active(symbol="AMZN"))
+        self.assertNotIn("AMZN", fetcher._alpaca_quote_fallback_backoff)
+
+        disabled_fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[],
+            alpaca_quote=None,
+            alpaca_quote_fallback_enabled=True,
+            alpaca_quote_fallback_backoff_seconds=0,
+        )
+        disabled_fetcher._backoff_alpaca_quote_fallback(
+            symbol="AMZN",
+            reason="quote_unavailable",
+        )
+
+        self.assertNotIn("AMZN", disabled_fetcher._alpaca_quote_fallback_backoff)
+
+    def test_alpaca_quote_fallback_backoff_refreshes_active_entry_quietly(
+        self,
+    ) -> None:
+        fetcher = RoutingClickHousePriceFetcher(
+            price_rows=[],
+            quote_rows=[],
+            alpaca_quote=None,
+            alpaca_quote_fallback_enabled=True,
+            alpaca_quote_fallback_backoff_seconds=60,
+        )
+
+        fetcher._backoff_alpaca_quote_fallback(
+            symbol="AMZN",
+            reason="quote_unavailable",
+        )
+        first_expires_at, _first_reason = fetcher._alpaca_quote_fallback_backoff["AMZN"]
+        fetcher._backoff_alpaca_quote_fallback(
+            symbol="AMZN",
+            reason="wide_quote",
+        )
+        second_expires_at, second_reason = fetcher._alpaca_quote_fallback_backoff[
+            "AMZN"
+        ]
+
+        self.assertGreaterEqual(second_expires_at, first_expires_at)
+        self.assertEqual(second_reason, "wide_quote")
 
     def test_fetch_market_snapshot_rejects_alpaca_latest_quote_without_timestamp(
         self,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from app.db import get_session
 from app.main import (
     _ALPACA_HEALTH_STATE,
+    _OPTIONS_CATALOG_FRESHNESS_CACHE,
     _TRADING_DEPENDENCY_HEALTH_CACHE,
     _build_hypothesis_runtime_payload,
     _assert_dspy_cutover_migration_guard,
@@ -239,10 +240,22 @@ class _OptionsFreshnessSession:
         )
 
 
+class _FailingOptionsFreshnessSession:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object | None]] = []
+
+    def execute(
+        self, statement: object, params: object | None = None
+    ) -> _ExecuteResult:
+        self.calls.append((str(statement), params))
+        raise SQLAlchemyError("statement timeout")
+
+
 class TestTradingApi(TestCase):
     def setUp(self) -> None:
         _TRADING_DEPENDENCY_HEALTH_CACHE.clear()
         _ALPACA_HEALTH_STATE.clear()
+        _OPTIONS_CATALOG_FRESHNESS_CACHE.clear()
         engine = create_engine(
             "sqlite+pysqlite:///:memory:",
             future=True,
@@ -481,6 +494,84 @@ class TestTradingApi(TestCase):
             ),
             1,
         )
+
+    def test_options_catalog_freshness_summary_caches_unavailable_route_scope(
+        self,
+    ) -> None:
+        original_cache_seconds = settings.trading_options_catalog_freshness_cache_seconds
+        settings.trading_options_catalog_freshness_cache_seconds = 30
+        self.addCleanup(
+            setattr,
+            settings,
+            "trading_options_catalog_freshness_cache_seconds",
+            original_cache_seconds,
+        )
+        fake_session = _FailingOptionsFreshnessSession()
+
+        first = _load_options_catalog_freshness_summary(
+            fake_session,  # type: ignore[arg-type]
+            route_symbols=["AAPL"],
+        )
+        second = _load_options_catalog_freshness_summary(
+            fake_session,  # type: ignore[arg-type]
+            route_symbols=["AAPL"],
+        )
+
+        self.assertEqual(first["status"], "unavailable")
+        self.assertEqual(second["status"], "unavailable")
+        self.assertEqual(first["route_symbols"], ["AAPL"])
+        self.assertEqual(second["route_symbols"], ["AAPL"])
+        self.assertEqual(len(fake_session.calls), 1)
+        first_cache = first.get("cache")
+        second_cache = second.get("cache")
+        self.assertIsInstance(first_cache, dict)
+        self.assertIsInstance(second_cache, dict)
+        assert isinstance(first_cache, dict)
+        assert isinstance(second_cache, dict)
+        self.assertEqual(first_cache["hit"], False)
+        self.assertEqual(second_cache["hit"], True)
+
+    def test_options_catalog_freshness_summary_expires_cached_route_scope(
+        self,
+    ) -> None:
+        original_cache_seconds = settings.trading_options_catalog_freshness_cache_seconds
+        settings.trading_options_catalog_freshness_cache_seconds = 1
+        self.addCleanup(
+            setattr,
+            settings,
+            "trading_options_catalog_freshness_cache_seconds",
+            original_cache_seconds,
+        )
+        _OPTIONS_CATALOG_FRESHNESS_CACHE[(("AAPL",),)] = (
+            datetime.now(timezone.utc) - timedelta(seconds=2),
+            {
+                "status": "unavailable",
+                "scope": "route_symbols",
+                "route_symbols": ["AAPL"],
+                "reason": "old",
+            },
+        )
+        fake_session = _OptionsFreshnessSession()
+
+        payload = _load_options_catalog_freshness_summary(
+            fake_session,  # type: ignore[arg-type]
+            route_symbols=["AAPL"],
+        )
+
+        self.assertEqual(payload["status"], "current")
+        self.assertEqual(payload["scope"], "route_symbols")
+        self.assertEqual(payload["route_symbols"], ["AAPL"])
+        self.assertEqual(
+            sum(
+                "FROM torghut_options_contract_catalog" in sql
+                for sql, _params in fake_session.calls
+            ),
+            1,
+        )
+        cache = payload.get("cache")
+        self.assertIsInstance(cache, dict)
+        assert isinstance(cache, dict)
+        self.assertEqual(cache["hit"], False)
 
     def test_route_image_proof_summary_preserves_route_workload_status(self) -> None:
         payload = _build_route_image_proof_summary(


### PR DESCRIPTION
## Summary

- Adds per-symbol cooldown and regular-market-session suppression for Alpaca latest-quote fallback so closed-market probes and rejected quotes do not repeatedly hit the provider.
- Adds a short, explicit GitOps-configured cache for options catalog freshness summaries, including unavailable summaries, while preserving fail-closed evidence semantics.
- Updates Torghut live/sim manifests, feature-flag contracts, and regression tests for quote fallback throttling, options freshness caching, and manifest coverage.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_config.py::TestConfig::test_feature_flag_map_covers_all_boolean_runtime_gates tests/test_config.py::TestConfig::test_torghut_feature_flag_manifest_matches_config_mapping tests/test_prices.py tests/test_trading_api.py::TestTradingApi::test_options_catalog_freshness_summary_includes_route_symbol_scope tests/test_trading_api.py::TestTradingApi::test_options_catalog_freshness_summary_uses_global_scan_without_route_scope tests/test_trading_api.py::TestTradingApi::test_options_catalog_freshness_summary_caches_unavailable_route_scope tests/test_trading_api.py::TestTradingApi::test_options_catalog_freshness_summary_expires_cached_route_scope tests/test_live_config_manifest_contract.py -q`
- `uv run --frozen ruff check app/config.py app/trading/prices.py app/main.py tests/test_config.py tests/test_prices.py tests/test_trading_api.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
