### PR TITLE
chore(torghut): promote image bf56c9a2

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.579.0-186-g288e42c5f
+              value: v0.579.0-197-gbf56c9a20
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 288e42c5fa95565b3d7ca7d93f5aa00d4485f1cc
+              value: bf56c9a20d64926b3f4d3986e65d38927b414cae
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.579.0-186-g288e42c5f
+              value: v0.579.0-197-gbf56c9a20
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 288e42c5fa95565b3d7ca7d93f5aa00d4485f1cc
+              value: bf56c9a20d64926b3f4d3986e65d38927b414cae
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -101,7 +101,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+                  value: sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-28T02:24:42Z"
+        client.knative.dev/updateTimestamp: "2026-05-28T03:05:37Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
           ports:
             - name: http1
               containerPort: 8181
@@ -513,11 +513,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.579.0-186-g288e42c5f
+              value: v0.579.0-197-gbf56c9a20
             - name: TORGHUT_COMMIT
-              value: 288e42c5fa95565b3d7ca7d93f5aa00d4485f1cc
+              value: bf56c9a20d64926b3f4d3986e65d38927b414cae
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+              value: sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-28T02:24:42Z"
+        client.knative.dev/updateTimestamp: "2026-05-28T03:05:37Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
           ports:
             - name: http1
               containerPort: 8181
@@ -332,11 +332,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.579.0-186-g288e42c5f
+              value: v0.579.0-197-gbf56c9a20
             - name: TORGHUT_COMMIT
-              value: 288e42c5fa95565b3d7ca7d93f5aa00d4485f1cc
+              value: bf56c9a20d64926b3f4d3986e65d38927b414cae
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+              value: sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:c8ac69c560d165ea1f674f0ba5cb8df6d328e3cb995008af4d09111bdaf26601
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `bf56c9a20d64926b3f4d3986e65d38927b414cae`
- Image tag: `bf56c9a2`
- Image digest: `sha256:8282ea8fddcfe8c30f71dd9775f6121264eefa99f8cce024067b27d5824e1c70`