### PR TITLE
fix(torghut): preserve paper route evidence lineage

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, ROUND_DOWN
-from typing import Any, Optional, cast
+from typing import Any, Literal, Optional, cast
 from uuid import UUID
 
 from sqlalchemy import select
@@ -69,6 +69,7 @@ _PROFITABILITY_PROOF_FLOOR_TCA_MAX_AGE_SECONDS = 86_400
 _SIMPLE_MARKET_CONTEXT_RETRY_INTERVAL = timedelta(seconds=30)
 _PAPER_ROUTE_PROBE_QTY_STEP = Decimal("0.0001")
 _REGULAR_SESSION_MINUTES = 390
+_PAPER_ROUTE_TARGET_PLAN_CACHE_SECONDS = 5
 
 
 def _safe_int(value: object) -> int:
@@ -296,6 +297,16 @@ def _merge_paper_route_probe_lineage(
 
 class SimpleTradingPipeline(TradingPipeline):
     """Minimal signal -> hard-risk -> direct execution lane."""
+
+    _paper_route_target_plan_cache: (
+        tuple[
+            set[str],
+            str | None,
+            list[dict[str, Any]],
+            datetime,
+        ]
+        | None
+    ) = None
 
     def run_once(self) -> None:
         self._label_mature_rejected_signal_outcome_events()
@@ -694,7 +705,7 @@ class SimpleTradingPipeline(TradingPipeline):
         decision: StrategyDecision,
         strategy: Strategy | None = None,
     ) -> bool:
-        if decision.action != "buy":
+        if decision.action not in {"buy", "sell"}:
             return False
         exit_minute = self._paper_route_probe_exit_minute_after_open(
             decision=decision,
@@ -878,6 +889,8 @@ class SimpleTradingPipeline(TradingPipeline):
                     "net_qty": Decimal("0"),
                     "buy_qty": Decimal("0"),
                     "buy_notional": Decimal("0"),
+                    "sell_qty": Decimal("0"),
+                    "sell_notional": Decimal("0"),
                     "latest_entry_at": None,
                     "exit_minute_after_open": None,
                     "paper_route_probe_lineage": {},
@@ -907,21 +920,37 @@ class SimpleTradingPipeline(TradingPipeline):
                         Decimal,
                         exposure["buy_notional"],
                     ) + (filled_qty * avg_fill_price)
-                latest_entry_at = exposure.get("latest_entry_at")
-                execution_created_at = (
-                    execution.created_at
-                    if execution.created_at.tzinfo is not None
-                    else execution.created_at.replace(tzinfo=timezone.utc)
-                ).astimezone(timezone.utc)
-                if not isinstance(latest_entry_at, datetime) or (
-                    execution_created_at > latest_entry_at
-                ):
-                    exposure["latest_entry_at"] = execution_created_at
+            elif side == "sell":
+                exit_minute = self._paper_route_probe_exit_minute_after_open(
+                    decision=decision,
+                    strategy=strategy,
+                )
+                if exit_minute is not None:
+                    exposure["exit_minute_after_open"] = exit_minute
+                avg_fill_price = _optional_decimal(execution.avg_fill_price)
+                if avg_fill_price is not None and avg_fill_price > 0:
+                    exposure["sell_qty"] = (
+                        cast(Decimal, exposure["sell_qty"]) + filled_qty
+                    )
+                    exposure["sell_notional"] = cast(
+                        Decimal,
+                        exposure["sell_notional"],
+                    ) + (filled_qty * avg_fill_price)
+            latest_entry_at = exposure.get("latest_entry_at")
+            execution_created_at = (
+                execution.created_at
+                if execution.created_at.tzinfo is not None
+                else execution.created_at.replace(tzinfo=timezone.utc)
+            ).astimezone(timezone.utc)
+            if not isinstance(latest_entry_at, datetime) or (
+                execution_created_at > latest_entry_at
+            ):
+                exposure["latest_entry_at"] = execution_created_at
 
         decisions: list[StrategyDecision] = []
         for exposure in exposures.values():
             net_qty = cast(Decimal, exposure["net_qty"])
-            if net_qty <= 0:
+            if net_qty == 0:
                 continue
             raw_exit_minute = exposure.get("exit_minute_after_open")
             exit_minute = raw_exit_minute if isinstance(raw_exit_minute, int) else None
@@ -944,14 +973,24 @@ class SimpleTradingPipeline(TradingPipeline):
                 continue
             buy_qty = cast(Decimal, exposure["buy_qty"])
             buy_notional = cast(Decimal, exposure["buy_notional"])
-            avg_entry_price = buy_notional / buy_qty if buy_qty > 0 else None
+            sell_qty = cast(Decimal, exposure["sell_qty"])
+            sell_notional = cast(Decimal, exposure["sell_notional"])
+            exit_action: Literal["buy", "sell"] = "sell" if net_qty > 0 else "buy"
+            exit_qty = abs(net_qty)
+            avg_entry_price = None
+            if net_qty > 0 and buy_qty > 0:
+                avg_entry_price = buy_notional / buy_qty
+            elif net_qty < 0 and sell_qty > 0:
+                avg_entry_price = sell_notional / sell_qty
             params: dict[str, Any] = {
                 "paper_route_probe_exit": {
                     "mode": "paper_route_exit",
                     "source": "filled_paper_route_probe_executions",
                     "symbol": symbol,
                     "strategy_id": str(strategy.id),
-                    "db_open_qty": str(net_qty),
+                    "db_open_qty": str(exit_qty),
+                    "db_open_signed_qty": str(net_qty),
+                    "db_open_side": "long" if net_qty > 0 else "short",
                     "exit_minute_after_open": exit_minute,
                     "effective_exit_minute_after_open": effective_exit_minute,
                     "exit_due_at": exit_due_at.isoformat(),
@@ -968,12 +1007,16 @@ class SimpleTradingPipeline(TradingPipeline):
                     ),
                 },
                 "simple_lane": {
-                    "final_qty": str(net_qty),
-                    "notional": str(net_qty * avg_entry_price)
+                    "final_qty": str(exit_qty),
+                    "notional": str(exit_qty * avg_entry_price)
                     if avg_entry_price is not None
                     else None,
                     "quantity_resolution": {
-                        "reason": "sell_reducing_paper_route_probe_exit",
+                        "reason": (
+                            "sell_reducing_paper_route_probe_exit"
+                            if exit_action == "sell"
+                            else "buy_reducing_paper_route_probe_short_exit"
+                        ),
                         "short_increasing": False,
                         "position_qty": str(net_qty),
                     },
@@ -987,8 +1030,8 @@ class SimpleTradingPipeline(TradingPipeline):
                     symbol=symbol,
                     event_ts=exit_due_at,
                     timeframe=str(exposure["timeframe"] or strategy.base_timeframe),
-                    action="sell",
-                    qty=net_qty,
+                    action=exit_action,
+                    qty=exit_qty,
                     rationale="paper-route-probe-exit",
                     params=params,
                 )
@@ -1021,7 +1064,7 @@ class SimpleTradingPipeline(TradingPipeline):
         exit_due_at_text = exit_due_at.isoformat()
         for row in rows:
             decision = self._trade_decision_from_retry_row(row)
-            if decision is None or decision.action != "sell":
+            if decision is None:
                 continue
             metadata = self._paper_route_probe_exit_metadata(decision)
             if metadata is None:
@@ -1052,6 +1095,9 @@ class SimpleTradingPipeline(TradingPipeline):
         db_open_qty = _optional_decimal(metadata.get("db_open_qty"))
         if db_open_qty is None or db_open_qty <= 0:
             return None
+        open_side = str(metadata.get("db_open_side") or "long").strip().lower()
+        if open_side not in {"long", "short"}:
+            open_side = "long"
         seed_missing = getattr(
             execution_adapter, "seed_missing_position_snapshot", None
         )
@@ -1064,7 +1110,7 @@ class SimpleTradingPipeline(TradingPipeline):
         position: dict[str, Any] = {
             "symbol": decision.symbol,
             "qty": str(restored_qty),
-            "side": "long",
+            "side": open_side,
         }
         if price is not None and price > 0:
             position["market_value"] = str(restored_qty * price)
@@ -1099,7 +1145,10 @@ class SimpleTradingPipeline(TradingPipeline):
         quantity_resolution = dict(
             cast(Mapping[str, Any], simple_lane.get("quantity_resolution") or {})
         )
-        if current_qty <= 0:
+        is_short_exit = decision.action == "buy"
+        effective_position_qty = abs(current_qty)
+        position_missing = current_qty >= 0 if is_short_exit else current_qty <= 0
+        if position_missing:
             price = _optional_decimal(params.get("price"))
             restored_qty = (
                 SimpleTradingPipeline._restore_simulation_paper_route_probe_exit_position(
@@ -1118,12 +1167,15 @@ class SimpleTradingPipeline(TradingPipeline):
             metadata["broker_position_qty"] = str(current_qty)
             metadata["db_position_qty_fallback"] = True
             metadata["position_source"] = "source_execution_db_open_qty"
-            current_qty = restored_qty
-        if current_qty < decision.qty:
-            decision = decision.model_copy(update={"qty": current_qty})
+            current_qty = -restored_qty if is_short_exit else restored_qty
+            effective_position_qty = restored_qty
+        else:
+            effective_position_qty = abs(current_qty)
+        if effective_position_qty < decision.qty:
+            decision = decision.model_copy(update={"qty": effective_position_qty})
             metadata["qty_capped_to_position"] = True
         metadata.setdefault("broker_position_qty", str(current_qty))
-        metadata["effective_position_qty"] = str(current_qty)
+        metadata["effective_position_qty"] = str(effective_position_qty)
 
         quantity_resolution["position_qty"] = str(decision.qty)
         simple_lane["final_qty"] = str(decision.qty)
@@ -1711,6 +1763,80 @@ class SimpleTradingPipeline(TradingPipeline):
             return set(), "paper_route_target_plan_probe_symbols_missing", []
         return symbols, None, paper_route_target_plan_targets(plan)
 
+    def _external_paper_route_target_probe_symbols_cached(
+        self,
+    ) -> tuple[set[str], str | None, list[dict[str, Any]]]:
+        now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
+        cached = self._paper_route_target_plan_cache
+        if cached is not None:
+            symbols, load_error, targets, cached_at = cached
+            if (
+                now - cached_at.astimezone(timezone.utc)
+            ).total_seconds() < _PAPER_ROUTE_TARGET_PLAN_CACHE_SECONDS:
+                return set(symbols), load_error, [dict(target) for target in targets]
+        symbols, load_error, targets = self._external_paper_route_target_probe_symbols()
+        self._paper_route_target_plan_cache = (
+            set(symbols),
+            load_error,
+            [dict(target) for target in targets],
+            now,
+        )
+        return symbols, load_error, targets
+
+    def _paper_route_target_lineage_for_decision(
+        self,
+        decision: StrategyDecision,
+    ) -> dict[str, Any]:
+        if settings.trading_mode != "paper":
+            return {}
+        if not settings.trading_simple_paper_route_probe_enabled:
+            return {}
+        symbol = decision.symbol.strip().upper()
+        if not symbol:
+            return {}
+        target_plan_symbols, target_plan_error, target_plan_targets = (
+            self._external_paper_route_target_probe_symbols_cached()
+        )
+        if target_plan_error or symbol not in target_plan_symbols:
+            return {}
+        lineage = _target_plan_lineage(target_plan_targets, symbol)
+        if not any(
+            lineage.get(key)
+            for key in (
+                "source_candidate_ids",
+                "source_hypothesis_ids",
+                "paper_route_probe_lineage_targets",
+            )
+        ):
+            return {}
+        return {
+            "mode": "paper_route_target_lineage",
+            "source": "external_target_plan_url",
+            "symbol": symbol,
+            "paper_route_target_plan_symbols": sorted(target_plan_symbols),
+            **lineage,
+        }
+
+    def _with_paper_route_target_lineage(
+        self,
+        decision: StrategyDecision,
+    ) -> StrategyDecision:
+        lineage = self._paper_route_target_lineage_for_decision(decision)
+        if not lineage:
+            return decision
+        params = dict(decision.params)
+        existing = params.get("paper_route_target_plan")
+        if isinstance(existing, Mapping):
+            merged_target_plan = dict(cast(Mapping[str, Any], existing))
+            _merge_paper_route_probe_lineage(merged_target_plan, lineage)
+            for key, value in lineage.items():
+                merged_target_plan.setdefault(key, value)
+            params["paper_route_target_plan"] = merged_target_plan
+        else:
+            params["paper_route_target_plan"] = lineage
+        _merge_paper_route_probe_lineage(params, lineage)
+        return decision.model_copy(update={"params": params})
+
     def _paper_route_probe_context(
         self,
         *,
@@ -1858,9 +1984,13 @@ class SimpleTradingPipeline(TradingPipeline):
         decision: StrategyDecision,
         strategy: Strategy,
     ) -> TradeDecision | None:
+        decision = self._with_paper_route_target_lineage(decision)
         decision_row = self.executor.ensure_decision(
             session, decision, strategy, self.account_label
         )
+        if "paper_route_target_plan" in decision.params:
+            self.executor.update_decision_params(session, decision_row, decision.params)
+            self.executor.sync_decision_state(session, decision_row, decision)
         retry_metadata = self._paper_route_probe_retry_metadata(decision_row)
         if retry_metadata is None:
             return super()._ensure_pending_decision_row(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -8,7 +8,7 @@ import tempfile
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import Mock, patch
-from typing import Any, Callable, Mapping, Sequence, cast
+from typing import Any, Callable, Literal, Mapping, Sequence, cast
 from uuid import uuid4
 
 from sqlalchemy import create_engine, select
@@ -831,6 +831,7 @@ class TestTradingPipeline(TestCase):
         self,
         *,
         symbol: str = "AAPL",
+        side: Literal["buy", "sell"] = "buy",
         qty: Decimal = Decimal("2"),
         avg_fill_price: Decimal = Decimal("100"),
         entry_ts: datetime = datetime(2026, 3, 26, 14, 0, tzinfo=timezone.utc),
@@ -904,7 +905,7 @@ class TestTradingPipeline(TestCase):
                 symbol=symbol,
                 event_ts=entry_ts,
                 timeframe="1Min",
-                action="buy",
+                action=side,
                 qty=qty,
                 rationale="paper-route-entry",
                 params=params,
@@ -927,7 +928,7 @@ class TestTradingPipeline(TestCase):
                     alpaca_order_id=f"filled-entry-{symbol.lower()}",
                     client_order_id=decision_row.decision_hash,
                     symbol=symbol,
-                    side="buy",
+                    side=side,
                     order_type="market",
                     time_in_force="day",
                     submitted_qty=qty,
@@ -3810,6 +3811,52 @@ class TestTradingPipeline(TestCase):
             ],
         )
 
+    def test_simple_pipeline_closes_short_paper_route_probe_with_buy_exit(
+        self,
+    ) -> None:
+        self._seed_filled_paper_route_probe_entry(
+            symbol="AMZN",
+            side="sell",
+            source_candidate_ids=("candidate-pairs-a",),
+            source_hypothesis_ids=("H-PAIRS-01",),
+            source_strategy_names=("microbar-cross-sectional-pairs-v1",),
+        )
+        alpaca_client = PositionedAlpacaClient(
+            [{"symbol": "AMZN", "qty": "2", "side": "short"}]
+        )
+
+        self._run_simple_paper_pipeline(
+            alpaca_client=alpaca_client,
+            now=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        self.assertEqual(alpaca_client.submitted[0]["side"], "buy")
+        self.assertEqual(alpaca_client.submitted[0]["qty"], "2.0")
+        with self.session_local() as session:
+            decisions = (
+                session.execute(
+                    select(TradeDecision).order_by(TradeDecision.created_at.asc())
+                )
+                .scalars()
+                .all()
+            )
+            self.assertEqual(len(decisions), 2)
+            exit_payload = cast(dict[str, Any], decisions[-1].decision_json)
+            params = cast(dict[str, Any], exit_payload.get("params"))
+            exit_metadata = cast(
+                dict[str, Any],
+                params.get("paper_route_probe_exit"),
+            )
+
+        self.assertEqual(exit_payload.get("action"), "buy")
+        self.assertEqual(exit_metadata.get("db_open_side"), "short")
+        self.assertEqual(exit_metadata.get("db_open_qty"), "2.00000000")
+        self.assertEqual(
+            exit_metadata.get("source_candidate_ids"), ["candidate-pairs-a"]
+        )
+        self.assertEqual(exit_metadata.get("source_hypothesis_ids"), ["H-PAIRS-01"])
+
     def test_simple_pipeline_closes_late_filled_probe_from_strategy_exit_metadata(
         self,
     ) -> None:
@@ -4869,6 +4916,13 @@ class TestTradingPipeline(TestCase):
                     strategy=exit_bound_strategy,
                 )
             )
+            self.assertIsNone(
+                pipeline._paper_route_probe_context(
+                    proof_floor=proof_floor,
+                    decision=sell_decision,
+                    strategy=exit_bound_strategy,
+                )
+            )
 
         no_route_reason_floor = {
             **proof_floor,
@@ -4973,6 +5027,55 @@ class TestTradingPipeline(TestCase):
                 decision=decision,
             )
         )
+
+    def test_short_paper_route_probe_entry_after_exit_minute_rejected(self) -> None:
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        strategy = Strategy(
+            name="paper-route-short-exit-bound",
+            description=(
+                "paper route short exit-bound fixture\n[catalog_metadata]\n"
+                + json.dumps({"params": {"exit_minute_after_open": "120"}})
+            ),
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AMZN"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        decision = StrategyDecision(
+            strategy_id="strategy-1",
+            symbol="AMZN",
+            event_ts=datetime(2026, 3, 26, 14, 30, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="sell",
+            qty=Decimal("1"),
+            rationale="route-probe-short-entry",
+            params={"price": "200"},
+        )
+
+        with patch(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            return_value=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
+        ):
+            self.assertTrue(
+                pipeline._paper_route_probe_entry_after_exit_minute(
+                    decision=decision,
+                    strategy=strategy,
+                )
+            )
 
     def test_paper_route_probe_context_honors_external_target_plan_scope(self) -> None:
         from app import config
@@ -5097,6 +5200,178 @@ class TestTradingPipeline(TestCase):
                     decision=decision.model_copy(update={"symbol": "AAPL"}),
                 )
             )
+
+    def test_paper_decision_persists_external_target_lineage_without_gate_bypass(
+        self,
+    ) -> None:
+        from app import config
+
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = (
+            "http://torghut.local/trading/paper-route-evidence"
+        )
+        config.settings.trading_paper_route_target_plan_timeout_seconds = 1.0
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 3, 26, 14, 30, tzinfo=timezone.utc),
+                timeframe="1Sec",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": "100"},
+            )
+            with patch(
+                "app.trading.scheduler.simple_pipeline.fetch_paper_route_target_plan_url",
+                return_value={
+                    "targets": [
+                        {
+                            "paper_route_probe_symbols": ["AAPL"],
+                            "candidate_id": "candidate-pairs-a",
+                            "hypothesis_id": "H-PAIRS-01",
+                            "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        }
+                    ]
+                },
+            ):
+                row = pipeline._ensure_pending_decision_row(
+                    session=session,
+                    decision=decision,
+                    strategy=strategy,
+                )
+
+            self.assertIsNotNone(row)
+            assert row is not None
+            payload = cast(dict[str, Any], row.decision_json)
+            params = cast(dict[str, Any], payload.get("params"))
+            target_plan = cast(dict[str, Any], params.get("paper_route_target_plan"))
+
+        self.assertEqual(params.get("source_candidate_ids"), ["candidate-pairs-a"])
+        self.assertEqual(params.get("source_hypothesis_ids"), ["H-PAIRS-01"])
+        self.assertEqual(target_plan.get("mode"), "paper_route_target_lineage")
+        self.assertEqual(
+            target_plan.get("paper_route_probe_lineage_targets"),
+            [
+                {
+                    "candidate_id": "candidate-pairs-a",
+                    "hypothesis_id": "H-PAIRS-01",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                }
+            ],
+        )
+        self.assertNotIn("paper_route_probe", params)
+
+    def test_paper_decision_persists_external_target_lineage_existing_row(
+        self,
+    ) -> None:
+        from app import config
+
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = (
+            "http://torghut.local/trading/paper-route-evidence"
+        )
+        config.settings.trading_paper_route_target_plan_timeout_seconds = 1.0
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AMZN"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AMZN",
+                event_ts=datetime(2026, 3, 26, 14, 31, tzinfo=timezone.utc),
+                timeframe="1Sec",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": "200"},
+            )
+            existing = pipeline.executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                pipeline.account_label,
+            )
+            existing_payload = cast(dict[str, Any], existing.decision_json)
+            existing_params = cast(dict[str, Any], existing_payload.get("params"))
+            self.assertNotIn("paper_route_target_plan", existing_params)
+
+            with patch(
+                "app.trading.scheduler.simple_pipeline.fetch_paper_route_target_plan_url",
+                return_value={
+                    "targets": [
+                        {
+                            "paper_route_probe_symbols": ["AMZN"],
+                            "candidate_id": "candidate-pairs-a",
+                            "hypothesis_id": "H-PAIRS-01",
+                            "strategy_name": "microbar-cross-sectional-pairs-v1",
+                        }
+                    ]
+                },
+            ):
+                row = pipeline._ensure_pending_decision_row(
+                    session=session,
+                    decision=decision,
+                    strategy=strategy,
+                )
+
+            self.assertIsNotNone(row)
+            assert row is not None
+            self.assertEqual(row.id, existing.id)
+            session.refresh(row)
+            payload = cast(dict[str, Any], row.decision_json)
+            params = cast(dict[str, Any], payload.get("params"))
+            target_plan = cast(dict[str, Any], params.get("paper_route_target_plan"))
+
+        self.assertEqual(params.get("source_candidate_ids"), ["candidate-pairs-a"])
+        self.assertEqual(params.get("source_hypothesis_ids"), ["H-PAIRS-01"])
+        self.assertEqual(target_plan.get("mode"), "paper_route_target_lineage")
+        self.assertNotIn("paper_route_probe", params)
 
     def test_paper_route_probe_short_increasing_sell_classification(self) -> None:
         decision = StrategyDecision(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -4238,6 +4238,16 @@ class TestTradingPipeline(TestCase):
             def seed_missing_position_snapshot(self, _position: object) -> bool:
                 raise RuntimeError("seed failed")
 
+        class RecordingSeedAdapter:
+            name = "simulation"
+
+            def __init__(self) -> None:
+                self.positions: list[dict[str, Any]] = []
+
+            def seed_missing_position_snapshot(self, position: object) -> bool:
+                self.positions.append(dict(cast(Mapping[str, Any], position)))
+                return True
+
         base_kwargs = {
             "positions": [],
             "decision": decision,
@@ -4279,6 +4289,25 @@ class TestTradingPipeline(TestCase):
                 **{**base_kwargs, "trading_mode": "paper"}
             )
         )
+        restored_positions: list[dict[str, Any]] = []
+        recording_adapter = RecordingSeedAdapter()
+        self.assertEqual(
+            SimpleTradingPipeline._restore_simulation_paper_route_probe_exit_position(
+                **{
+                    **base_kwargs,
+                    "positions": restored_positions,
+                    "trading_mode": "paper",
+                    "metadata": {"db_open_qty": "3", "db_open_side": "sideways"},
+                    "execution_adapter": recording_adapter,
+                }
+            ),
+            Decimal("2"),
+        )
+        self.assertEqual(
+            recording_adapter.positions,
+            [{"symbol": "AAPL", "qty": "2", "side": "long", "market_value": "200"}],
+        )
+        self.assertEqual(restored_positions, recording_adapter.positions)
         self.assertIsNone(
             SimpleTradingPipeline._restore_simulation_paper_route_probe_exit_position(
                 **{
@@ -5372,6 +5401,151 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(params.get("source_hypothesis_ids"), ["H-PAIRS-01"])
         self.assertEqual(target_plan.get("mode"), "paper_route_target_lineage")
         self.assertNotIn("paper_route_probe", params)
+
+    def test_paper_route_target_lineage_cache_and_existing_plan_merge(self) -> None:
+        from app import config
+
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = (
+            "http://torghut.local/trading/paper-route-evidence"
+        )
+        config.settings.trading_paper_route_target_plan_timeout_seconds = 1.0
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        first = StrategyDecision(
+            strategy_id="strategy-1",
+            symbol="AAPL",
+            event_ts=datetime(2026, 3, 26, 14, 30, tzinfo=timezone.utc),
+            timeframe="1Sec",
+            action="sell",
+            qty=Decimal("1"),
+            params={
+                "price": "100",
+                "paper_route_target_plan": {
+                    "existing": "keep",
+                    "source_candidate_ids": ["candidate-existing"],
+                },
+            },
+        )
+        second = first.model_copy(update={"symbol": "MSFT", "params": {"price": "200"}})
+        fetch = Mock(
+            return_value={
+                "targets": [
+                    {
+                        "paper_route_probe_symbols": ["AAPL"],
+                        "candidate_id": "candidate-aapl",
+                        "hypothesis_id": "H-AAPL",
+                        "strategy_name": "pairs-runtime-a",
+                    },
+                    {
+                        "paper_route_probe_symbols": ["MSFT"],
+                        "candidate_id": "candidate-msft",
+                        "hypothesis_id": "H-MSFT",
+                        "strategy_name": "pairs-runtime-b",
+                    },
+                ]
+            }
+        )
+
+        with (
+            patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=datetime(2026, 3, 26, 14, 31, tzinfo=timezone.utc),
+            ),
+            patch(
+                "app.trading.scheduler.simple_pipeline.fetch_paper_route_target_plan_url",
+                fetch,
+            ),
+        ):
+            enriched_first = pipeline._with_paper_route_target_lineage(first)
+            enriched_second = pipeline._with_paper_route_target_lineage(second)
+
+        self.assertEqual(fetch.call_count, 1)
+        first_params = cast(dict[str, Any], enriched_first.params)
+        first_target_plan = cast(
+            dict[str, Any], first_params.get("paper_route_target_plan")
+        )
+        self.assertEqual(first_target_plan.get("existing"), "keep")
+        self.assertEqual(
+            first_target_plan.get("source_candidate_ids"),
+            ["candidate-existing", "candidate-aapl"],
+        )
+        self.assertEqual(first_params.get("source_candidate_ids"), ["candidate-aapl"])
+        self.assertEqual(first_params.get("source_hypothesis_ids"), ["H-AAPL"])
+        second_params = cast(dict[str, Any], enriched_second.params)
+        second_target_plan = cast(
+            dict[str, Any], second_params.get("paper_route_target_plan")
+        )
+        self.assertEqual(
+            second_target_plan.get("source_candidate_ids"), ["candidate-msft"]
+        )
+        self.assertEqual(second_params.get("source_hypothesis_ids"), ["H-MSFT"])
+        self.assertNotIn("paper_route_probe", first_params)
+        self.assertNotIn("paper_route_probe", second_params)
+
+    def test_paper_route_target_lineage_skips_empty_symbol_and_empty_lineage(
+        self,
+    ) -> None:
+        from app import config
+
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = (
+            "http://torghut.local/trading/paper-route-evidence"
+        )
+        config.settings.trading_paper_route_target_plan_timeout_seconds = 1.0
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        base = StrategyDecision(
+            strategy_id="strategy-1",
+            symbol="AAPL",
+            event_ts=datetime(2026, 3, 26, 14, 30, tzinfo=timezone.utc),
+            timeframe="1Sec",
+            action="sell",
+            qty=Decimal("1"),
+            params={"price": "100"},
+        )
+        fetch = Mock(
+            return_value={"targets": [{"paper_route_probe_symbols": ["AAPL"]}]}
+        )
+
+        blank_symbol = pipeline._with_paper_route_target_lineage(
+            base.model_copy(update={"symbol": "   "})
+        )
+        with patch(
+            "app.trading.scheduler.simple_pipeline.fetch_paper_route_target_plan_url",
+            fetch,
+        ):
+            empty_lineage = pipeline._with_paper_route_target_lineage(base)
+
+        self.assertNotIn("paper_route_target_plan", blank_symbol.params)
+        self.assertNotIn("paper_route_target_plan", empty_lineage.params)
+        self.assertEqual(fetch.call_count, 1)
 
     def test_paper_route_probe_short_increasing_sell_classification(self) -> None:
         decision = StrategyDecision(


### PR DESCRIPTION
## Summary

- Persist paper-route target-plan lineage onto paper decisions so source candidate and hypothesis IDs survive into evidence/import audits.
- Close paper-route probe short exposure with buy-to-cover exits, including DB open-side metadata and simulation fallback position seeding.
- Reject stale sell-side paper-route probe entries after the configured exit minute so evidence collection does not open immediately expired shorts.
- Add regressions for new-row and existing-row lineage persistence, short-exit closure, and stale short-entry rejection.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_decision_persists_external_target_lineage_existing_row or short_paper_route_probe_entry_after_exit_minute'`
- `uv run --frozen pytest tests/test_trading_pipeline.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'source_lineage or quote_rejected or runtime_window_import_audit'`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
