### PR TITLE
chore(agents): promote images a5b09e11

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: 6e9ce2ff
-  digest: sha256:758111f398a138cc5a5784c7bc26f32bbaf52c765fb08b6f517adff7e4165a75
+  tag: a5b09e11
+  digest: sha256:9c955378a1d05c4a6d9516be6b20f12acadb1aa5561b4426c6de3e21a00100fa
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,26 +11,26 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: 6e9ce2ff
-    digest: sha256:5e44fe6c0cb8f03320778774ce6149fc1e73f9b888112d870a1f3a6bd7f0eb2c
+    tag: a5b09e11
+    digest: sha256:79e3abde0c78741a542c590d0096443a50144b8af68c60b9d43b392dbbab1d4b
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: 6e9ce2ff363a01fa1420a094de20bd44c060d6f6
-      AGENTS_GITOPS_REVISION: 6e9ce2ff363a01fa1420a094de20bd44c060d6f6
-      AGENTS_SOURCE_CI_RUN_ID: "26523518622"
+      AGENTS_SOURCE_HEAD_SHA: a5b09e11056bba541a2ab601420dfae6c4f2e4aa
+      AGENTS_GITOPS_REVISION: a5b09e11056bba541a2ab601420dfae6c4f2e4aa
+      AGENTS_SOURCE_CI_RUN_ID: "26556219936"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:5e44fe6c0cb8f03320778774ce6149fc1e73f9b888112d870a1f3a6bd7f0eb2c
-      AGENTS_SERVING_BUILD_COMMIT: 6e9ce2ff363a01fa1420a094de20bd44c060d6f6
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:5e44fe6c0cb8f03320778774ce6149fc1e73f9b888112d870a1f3a6bd7f0eb2c
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:79e3abde0c78741a542c590d0096443a50144b8af68c60b9d43b392dbbab1d4b
+      AGENTS_SERVING_BUILD_COMMIT: a5b09e11056bba541a2ab601420dfae6c4f2e4aa
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:79e3abde0c78741a542c590d0096443a50144b8af68c60b9d43b392dbbab1d4b
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: 6e9ce2ff
-    digest: sha256:5a748fb6ddcf8949a36a888bec83fa5c5614b561d85d3c0345222f7b8483f58f
+    tag: a5b09e11
+    digest: sha256:217f4574648fbfe26c84de4c808f997ee6c67fe4db9aa05737c9d64d8dd08542
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun
@@ -85,8 +85,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: 6e9ce2ff
-    digest: sha256:758111f398a138cc5a5784c7bc26f32bbaf52c765fb08b6f517adff7e4165a75
+    tag: a5b09e11
+    digest: sha256:9c955378a1d05c4a6d9516be6b20f12acadb1aa5561b4426c6de3e21a00100fa
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `a5b09e11056bba541a2ab601420dfae6c4f2e4aa`
- Image tag: `a5b09e11`
- Agents build run: `26556219936`
- Promotion source: `workflow_run`