### PR TITLE
fix(torghut): align paper-route execution activity time

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -306,6 +306,24 @@ def _isoformat(value: datetime | None) -> str | None:
     return value.astimezone(timezone.utc).isoformat()
 
 
+def _execution_activity_timestamp() -> Any:
+    return func.coalesce(
+        Execution.order_feed_last_event_ts,
+        Execution.last_update_at,
+        Execution.updated_at,
+        Execution.created_at,
+    )
+
+
+def _execution_activity_at(row: Execution) -> datetime | None:
+    return (
+        row.order_feed_last_event_ts
+        or row.last_update_at
+        or row.updated_at
+        or row.created_at
+    )
+
+
 def _parse_datetime(value: object) -> datetime | None:
     if isinstance(value, datetime):
         parsed = value
@@ -1409,11 +1427,12 @@ def _strategy_source_activity(
     decision_ids = [row.id for row in decision_rows]
     execution_rows: list[Execution] = []
     if decision_ids:
+        execution_activity_ts = _execution_activity_timestamp()
         execution_stmt = (
             select(Execution)
             .where(Execution.trade_decision_id.in_(decision_ids))
-            .where(Execution.created_at >= window_start)
-            .where(Execution.created_at <= window_end)
+            .where(execution_activity_ts >= window_start)
+            .where(execution_activity_ts < window_end)
         )
         if account_label:
             execution_stmt = execution_stmt.where(
@@ -1425,7 +1444,7 @@ def _strategy_source_activity(
             )
         execution_rows = list(
             session.execute(
-                execution_stmt.order_by(Execution.created_at.desc()).limit(500)
+                execution_stmt.order_by(execution_activity_ts.desc()).limit(500)
             ).scalars()
         )
     tca_rows: list[ExecutionTCAMetric] = []
@@ -1486,7 +1505,7 @@ def _strategy_source_activity(
             decision_rows[0].created_at if decision_rows else None
         ),
         "last_execution_at": _isoformat(
-            execution_rows[0].created_at if execution_rows else None
+            _execution_activity_at(execution_rows[0]) if execution_rows else None
         ),
         "last_tca_at": _isoformat(tca_rows[0].computed_at if tca_rows else None),
         "missing": bool(missing_reasons),

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1264,6 +1264,149 @@ class TestPaperRouteEvidenceAudit(TestCase):
             payload["targets"][0]["readiness"]["evidence_collection_blockers"],
         )
 
+    def test_source_activity_uses_order_feed_event_time_for_execution_window(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        event_at = window_start + timedelta(minutes=20)
+        strategy_name = "event-time-paper-route"
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="paper route source activity from order-feed event time",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "candidate_id": "candidate-event-time",
+                    "hypothesis_id": "H-EVENT-TIME",
+                },
+                rationale="event time fixture",
+                status="executed",
+                created_at=event_at - timedelta(minutes=1),
+                executed_at=event_at,
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="event-time-order-1",
+                client_order_id="event-time-client-1",
+                symbol="AAPL",
+                side="buy",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=window_end + timedelta(minutes=5),
+                updated_at=window_end + timedelta(minutes=5),
+                last_update_at=event_at,
+                order_feed_last_event_ts=event_at,
+            )
+            session.add(execution)
+            session.flush()
+            session.add(
+                ExecutionTCAMetric(
+                    execution_id=execution.id,
+                    trade_decision_id=decision.id,
+                    strategy_id=strategy.id,
+                    alpaca_account_label="TORGHUT_SIM",
+                    symbol="AAPL",
+                    side="buy",
+                    arrival_price=Decimal("99"),
+                    avg_fill_price=Decimal("100"),
+                    filled_qty=Decimal("1"),
+                    signed_qty=Decimal("1"),
+                    slippage_bps=Decimal("5"),
+                    shortfall_notional=Decimal("1"),
+                    realized_shortfall_bps=Decimal("5"),
+                    churn_qty=Decimal("0"),
+                    churn_ratio=Decimal("0"),
+                    computed_at=event_at + timedelta(minutes=1),
+                    created_at=event_at + timedelta(minutes=1),
+                    updated_at=event_at + timedelta(minutes=1),
+                )
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-EVENT-TIME",
+                                "candidate_id": "candidate-event-time",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": strategy_name,
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "account_label": "TORGHUT_SIM",
+                                "source_manifest_ref": "config/trading/hypotheses/h-event-time.json",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_route_probe_symbols": ["AAPL"],
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": ["AAPL"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "next_session_max_notional": "25",
+                        "eligible_symbol_count": 1,
+                    },
+                },
+                generated_at=window_start - timedelta(days=2),
+            )
+
+        source_activity = payload["targets"][0]["source_activity"]
+        self.assertFalse(source_activity["missing"])
+        self.assertEqual(source_activity["decision_count"], 1)
+        self.assertEqual(source_activity["execution_count"], 1)
+        self.assertEqual(source_activity["filled_execution_count"], 1)
+        self.assertEqual(source_activity["tca_sample_count"], 1)
+        self.assertEqual(source_activity["last_execution_at"], event_at.isoformat())
+        self.assertEqual(source_activity["missing_reasons"], [])
+        import_audit = payload["runtime_window_import_audit"]
+        self.assertEqual(import_audit["counts"]["targets_with_source_activity"], 1)
+        self.assertNotIn("source_executions_missing", import_audit["blockers"])
+
     def test_current_paper_route_probe_symbols_extend_next_window_target_scope(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Align paper-route source-activity execution filtering with the runtime-window importer by using order-feed event time, last update time, updated time, then created time.
- Report `last_execution_at` from the same activity timestamp so proof audits reflect the session event that made the fill importable.
- Add a regression covering a fill whose database row is created after the target window but whose order-feed event time lands inside the paper-route session.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_source_activity_uses_order_feed_event_time_for_execution_window -q`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -k 'source_activity or runtime_window_import' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
