### PR TITLE
fix(torghut): price replay impact from observed adv

### DIFF
--- a/services/torghut/app/trading/evaluation_trace.py
+++ b/services/torghut/app/trading/evaluation_trace.py
@@ -207,6 +207,9 @@ class ReplayFunnelBucket:
     gross_pnl: Decimal
     net_pnl: Decimal
     cost_total: Decimal
+    daily_adv_notional: Decimal = Decimal("0")
+    depth_notional: Decimal | None = None
+    liquidity_observation_count: int = 0
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -234,6 +237,11 @@ class ReplayFunnelBucket:
             "gross_pnl": str(self.gross_pnl),
             "net_pnl": str(self.net_pnl),
             "cost_total": str(self.cost_total),
+            "daily_adv_notional": str(self.daily_adv_notional),
+            "depth_notional": str(self.depth_notional)
+            if self.depth_notional is not None
+            else None,
+            "liquidity_observation_count": self.liquidity_observation_count,
         }
 
 

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -77,6 +77,7 @@ _FILL_LATENCY_THRESHOLDS_MS = (50, 150, 250)
 _EXACT_REPLAY_LEDGER_ROWS_SCHEMA_VERSION = "torghut.exact_replay_ledger.rows.v1"
 _REPLAY_LEDGER_ACCOUNT_LABEL = "TORGHUT_REPLAY"
 _REPLAY_COST_BASIS = "local_replay_transaction_cost_model"
+_REPLAY_ADV_SOURCE = "observed_microbar_notional_by_symbol_day"
 _REPLAY_LEDGER_SOURCE = "local_intraday_tsmom_replay"
 
 
@@ -243,6 +244,19 @@ def _build_replay_ledger_context(
             "model": cost_model.__class__.__name__,
             "module": cost_model.__class__.__module__,
             "cost_basis": _REPLAY_COST_BASIS,
+            "adv_source": _REPLAY_ADV_SOURCE,
+            "config": {
+                "commission_bps": str(cost_model.config.commission_bps),
+                "commission_per_share": str(cost_model.config.commission_per_share),
+                "min_commission": str(cost_model.config.min_commission),
+                "max_participation_rate": str(cost_model.config.max_participation_rate),
+                "impact_bps_at_full_participation": str(
+                    cost_model.config.impact_bps_at_full_participation
+                ),
+                "impact_participation_exponent": str(
+                    cost_model.config.impact_participation_exponent
+                ),
+            },
         }
     )
     lineage_payload = {
@@ -1279,10 +1293,17 @@ def _estimate_trade_cost(
     model: TransactionCostModel,
     decision: StrategyDecision,
     signal: SignalEnvelope,
+    day_bucket: Mapping[str, Any] | None = None,
+    symbol_bucket: Mapping[str, Any] | None = None,
 ) -> Decimal:
     price = _extract_price(signal)
     spread = _extract_spread(signal)
     volatility = _extract_volatility(signal)
+    adv = _observed_adv_notional(
+        signal=signal,
+        day_bucket=day_bucket,
+        symbol_bucket=symbol_bucket,
+    )
     estimate = model.estimate_costs(
         order=OrderIntent(
             symbol=decision.symbol,
@@ -1296,9 +1317,45 @@ def _estimate_trade_cost(
             price=price,
             spread=spread,
             volatility=volatility,
+            adv=adv,
         ),
     )
     return estimate.total_cost
+
+
+def _positive_decimal_mapping_value(
+    bucket: Mapping[str, Any] | None, key: str
+) -> Decimal | None:
+    if bucket is None:
+        return None
+    raw = bucket.get(key)
+    if isinstance(raw, Decimal):
+        value = raw
+    elif raw is None:
+        return None
+    else:
+        try:
+            value = Decimal(str(raw))
+        except (ArithmeticError, ValueError):
+            return None
+    return value if value > 0 else None
+
+
+def _observed_adv_notional(
+    *,
+    signal: SignalEnvelope,
+    day_bucket: Mapping[str, Any] | None = None,
+    symbol_bucket: Mapping[str, Any] | None = None,
+) -> Decimal | None:
+    for bucket in (symbol_bucket, day_bucket):
+        value = _positive_decimal_mapping_value(bucket, "daily_adv_notional")
+        if value is not None:
+            return value
+    for key in ("daily_adv_notional", "adv_notional", "adv", "avg_dollar_volume"):
+        value = _positive_decimal_mapping_value(signal.payload, key)
+        if value is not None and value > 0:
+            return value
+    return None
 
 
 def _record_decision(stats: dict[str, Any], decision: StrategyDecision) -> None:
@@ -2363,7 +2420,13 @@ def _apply_filled_decision(
     )
     position_key = _position_key(decision.symbol, owner_strategy_id)
     existing = positions.get(position_key)
-    fill_cost = _estimate_trade_cost(model=cost_model, decision=decision, signal=signal)
+    fill_cost = _estimate_trade_cost(
+        model=cost_model,
+        decision=decision,
+        signal=signal,
+        day_bucket=day_bucket,
+        symbol_bucket=symbol_bucket,
+    )
     if decision.action == "buy":
         if existing is not None and existing.qty < 0:
             cover_qty = min(decision.qty, abs(existing.qty))
@@ -2722,6 +2785,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
             last_prices[signal.symbol] = price
             last_signals[signal.symbol] = signal
             _record_liquidity_observation(bucket=day_bucket, signal=signal)
+            _record_liquidity_observation(bucket=symbol_bucket, signal=signal)
             equity = _record_capital_snapshot(
                 bucket=day_bucket,
                 cash=cash,
@@ -3205,6 +3269,13 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                 gross_pnl=bucket["gross_pnl"],
                 net_pnl=bucket["net_pnl"],
                 cost_total=bucket["cost_total"],
+                daily_adv_notional=bucket.get("daily_adv_notional", Decimal("0")),
+                depth_notional=bucket.get("depth_notional")
+                if isinstance(bucket.get("depth_notional"), Decimal)
+                else None,
+                liquidity_observation_count=int(
+                    bucket.get("liquidity_observation_count") or 0
+                ),
             )
             for (trading_day, symbol), bucket in sorted(funnel_stats.items())
         ),
@@ -3424,6 +3495,9 @@ def _flatten_positions(
         last_signal = last_signals.get(symbol)
         if last_signal is None:
             continue
+        symbol_bucket = funnel_stats.setdefault(
+            (day.isoformat(), symbol), _init_funnel_stats()
+        )
         fill_price = last_prices.get(symbol, position.avg_entry_price)
         exit_action = "buy" if position.qty < 0 else "sell"
         exit_qty = abs(position.qty)
@@ -3443,6 +3517,8 @@ def _flatten_positions(
             model=cost_model,
             decision=synthetic_decision,
             signal=last_signal,
+            day_bucket=stats,
+            symbol_bucket=symbol_bucket,
         )
         exit_notional = fill_price * exit_qty
         if position.qty < 0:
@@ -3498,9 +3574,6 @@ def _flatten_positions(
         stats["filled_count"] += 1
         _record_fill_order_type(stats, "market")
         stats["filled_notional"] += exit_notional
-        symbol_bucket = funnel_stats.setdefault(
-            (day.isoformat(), symbol), _init_funnel_stats()
-        )
         symbol_bucket["gross_pnl"] += trade.gross_pnl
         symbol_bucket["net_pnl"] += trade.net_pnl
         symbol_bucket["cost_total"] += exit_cost

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -4,15 +4,16 @@ import json
 import os
 import subprocess
 import sys
+from argparse import Namespace
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from argparse import Namespace
+from typing import Any
 from unittest import TestCase
 from unittest.mock import patch
 
-from app.trading.costs import TransactionCostModel
+from app.trading.costs import CostModelConfig, TransactionCostModel
 from app.trading.evaluation_trace import (
     GateTrace,
     NearMissRecord,
@@ -35,6 +36,7 @@ from scripts.local_intraday_tsmom_replay import (
     _decision_market_order_spread_bps_max,
     _decision_position_owner,
     _decision_spread_bps,
+    _estimate_trade_cost,
     _fetch_chunk,
     _flatten_positions,
     _http_query,
@@ -646,6 +648,119 @@ class TestLocalIntradayTsmomReplay(TestCase):
         self.assertEqual(day_bucket["filled_count"], 1)
         self.assertEqual(day_bucket["filled_notional"], Decimal("5232.80"))
         self.assertLess(cash, Decimal("10000"))
+
+    def test_estimate_trade_cost_uses_observed_adv_for_square_root_impact(
+        self,
+    ) -> None:
+        signal = self._signal(bid="99.99", ask="100.01", price="100")
+        decision = StrategyDecision(
+            strategy_id="impact-aware",
+            symbol="META",
+            event_ts=signal.event_ts,
+            timeframe="1Sec",
+            action="buy",
+            qty=Decimal("100"),
+            order_type="limit",
+            time_in_force="day",
+            limit_price=Decimal("100"),
+            params={},
+        )
+        cost_model = TransactionCostModel(
+            CostModelConfig(
+                impact_bps_at_full_participation=Decimal("100"),
+                max_participation_rate=Decimal("1"),
+            )
+        )
+
+        cost_without_adv = _estimate_trade_cost(
+            model=cost_model,
+            decision=decision,
+            signal=signal,
+        )
+        cost_with_adv = _estimate_trade_cost(
+            model=cost_model,
+            decision=decision,
+            signal=signal,
+            symbol_bucket={"daily_adv_notional": Decimal("40000")},
+        )
+
+        self.assertEqual(cost_without_adv, Decimal("0"))
+        self.assertEqual(cost_with_adv, Decimal("50"))
+
+    def test_estimate_trade_cost_falls_back_to_signal_payload_adv(self) -> None:
+        signal = self._signal(bid="99.99", ask="100.01", price="100")
+        signal.payload["adv"] = "40000"
+        decision = StrategyDecision(
+            strategy_id="impact-aware",
+            symbol="META",
+            event_ts=signal.event_ts,
+            timeframe="1Sec",
+            action="buy",
+            qty=Decimal("100"),
+            order_type="limit",
+            time_in_force="day",
+            limit_price=Decimal("100"),
+            params={},
+        )
+
+        cost = _estimate_trade_cost(
+            model=TransactionCostModel(
+                CostModelConfig(
+                    impact_bps_at_full_participation=Decimal("100"),
+                    max_participation_rate=Decimal("1"),
+                )
+            ),
+            decision=decision,
+            signal=signal,
+            symbol_bucket={"daily_adv_notional": "not-a-number"},
+        )
+
+        self.assertEqual(cost, Decimal("50"))
+
+    def test_apply_filled_decision_prefers_symbol_adv_for_impact_cost(self) -> None:
+        signal = self._signal(bid="9.99", ask="10.01", price="10")
+        decision = StrategyDecision(
+            strategy_id="impact-aware",
+            symbol="META",
+            event_ts=signal.event_ts,
+            timeframe="1Sec",
+            action="buy",
+            qty=Decimal("100"),
+            order_type="limit",
+            time_in_force="day",
+            limit_price=Decimal("10"),
+            params={},
+        )
+        positions: dict[tuple[str, str], PositionState] = {}
+        day_bucket: dict[str, Any] = {
+            "daily_adv_notional": Decimal("1000000"),
+        }
+        symbol_bucket: dict[str, Any] = {
+            "daily_adv_notional": Decimal("4000"),
+        }
+
+        cash = _apply_filled_decision(
+            decision=decision,
+            signal=signal,
+            fill_price=Decimal("10"),
+            filled_at=signal.event_ts,
+            created_at=signal.event_ts,
+            positions=positions,
+            day_bucket=day_bucket,
+            symbol_bucket=symbol_bucket,
+            cost_model=TransactionCostModel(
+                CostModelConfig(
+                    impact_bps_at_full_participation=Decimal("100"),
+                    max_participation_rate=Decimal("1"),
+                )
+            ),
+            cash=Decimal("10000"),
+            all_closed_trades=[],
+        )
+
+        self.assertEqual(day_bucket["cost_total"], Decimal("5"))
+        self.assertEqual(symbol_bucket["cost_total"], Decimal("5"))
+        self.assertEqual(cash, Decimal("8995"))
 
     def test_apply_filled_decision_opens_short_position_on_sell_entry(self) -> None:
         signal = self._signal(bid="523.22", ask="523.28", price="523.25")


### PR DESCRIPTION
## Summary

- Feeds observed symbol/day microbar notional into local replay transaction cost estimates so square-root market-impact costs are active in fills and EOD flattening.
- Records per-symbol liquidity evidence in replay funnel payloads alongside existing daily liquidity evidence.
- Expands exact replay ledger cost-model lineage to include impact configuration and the observed ADV source.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_local_intraday_tsmom_replay.py -k 'impact_cost or liquidity_evidence' -q`
- `uv run --frozen pytest tests/test_evaluation_trace.py -q`
- `uv run --frozen ruff check app/trading/evaluation_trace.py scripts/local_intraday_tsmom_replay.py tests/test_local_intraday_tsmom_replay.py tests/test_evaluation_trace.py`
- `uv run --frozen ruff format --check app/trading/evaluation_trace.py scripts/local_intraday_tsmom_replay.py tests/test_local_intraday_tsmom_replay.py tests/test_evaluation_trace.py`
- `uv run --frozen pytest tests/test_local_intraday_tsmom_replay.py tests/test_evaluation_trace.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
