### PR TITLE
feat(torghut): require replay lineage for probation handoff

### DIFF
--- a/services/torghut/app/trading/discovery/replay_ledger_ranker.py
+++ b/services/torghut/app/trading/discovery/replay_ledger_ranker.py
@@ -53,6 +53,8 @@ class ReplayLedgerRankingPolicy:
 class ReplayLedgerCandidateRanking:
     artifact_ref: str
     candidate_id: str
+    candidate_identity_hash: str
+    cost_lineage_hash: str
     promotion_status: str
     promotion_blockers: tuple[str, ...]
     runtime_ledger_blockers: tuple[str, ...]
@@ -87,11 +89,19 @@ class ReplayLedgerCandidateRanking:
     source: str
     promotion_authority: str
     cost_basis_counts: Mapping[str, int]
+    candidate_identity: Mapping[str, object]
+    cost_lineage: Mapping[str, object]
+    fills_with_adv_notional: int
+    fills_with_participation_rate: int
+    fills_with_capacity_warning_contract: int
+    capacity_warning_counts: Mapping[str, int]
 
     def to_payload(self) -> dict[str, object]:
         return {
             "artifact_ref": self.artifact_ref,
             "candidate_id": self.candidate_id,
+            "candidate_identity_hash": self.candidate_identity_hash,
+            "cost_lineage_hash": self.cost_lineage_hash,
             "promotion_status": self.promotion_status,
             "promotion_blockers": list(self.promotion_blockers),
             "runtime_ledger_blockers": list(self.runtime_ledger_blockers),
@@ -139,6 +149,16 @@ class ReplayLedgerCandidateRanking:
             "source": self.source,
             "promotion_authority": self.promotion_authority,
             "cost_basis_counts": dict(sorted(self.cost_basis_counts.items())),
+            "candidate_identity": dict(sorted(self.candidate_identity.items())),
+            "cost_lineage": dict(sorted(self.cost_lineage.items())),
+            "fills_with_adv_notional": self.fills_with_adv_notional,
+            "fills_with_participation_rate": self.fills_with_participation_rate,
+            "fills_with_capacity_warning_contract": (
+                self.fills_with_capacity_warning_contract
+            ),
+            "capacity_warning_counts": dict(
+                sorted(self.capacity_warning_counts.items())
+            ),
         }
 
 
@@ -216,8 +236,13 @@ def rank_replay_ledger_payload(
         if policy.start_equity is not None and policy.start_equity > 0
         else None
     )
+    candidate_id = _candidate_id(payload=payload, artifact_ref=artifact_ref)
+    candidate_identity = _mapping(payload.get("candidate_identity"))
+    cost_lineage = _mapping(payload.get("cost_lineage"))
+    capacity_summary = _capacity_lineage_summary(rows)
     blockers = _promotion_blockers(
         payload=payload,
+        rows=rows,
         full_bucket=full_bucket,
         total_net=total_net,
         daily_net=daily_net,
@@ -232,7 +257,14 @@ def rank_replay_ledger_payload(
 
     return ReplayLedgerCandidateRanking(
         artifact_ref=artifact_ref,
-        candidate_id=str(payload.get("candidate_id") or Path(artifact_ref).stem),
+        candidate_id=candidate_id,
+        candidate_identity_hash=_text(
+            payload.get("candidate_identity_hash")
+            or candidate_identity.get("candidate_identity_hash")
+        ),
+        cost_lineage_hash=_text(
+            payload.get("cost_lineage_hash") or cost_lineage.get("cost_lineage_hash")
+        ),
         promotion_status="blocked_pending_runtime_promotion_proof"
         if blockers
         else "candidate_replay_evidence_only",
@@ -281,6 +313,16 @@ def rank_replay_ledger_payload(
         source=str(payload.get("source") or ""),
         promotion_authority=str(payload.get("promotion_authority") or ""),
         cost_basis_counts=full_bucket.cost_basis_counts,
+        candidate_identity=candidate_identity,
+        cost_lineage=cost_lineage,
+        fills_with_adv_notional=capacity_summary["fills_with_adv_notional"],
+        fills_with_participation_rate=capacity_summary[
+            "fills_with_participation_rate"
+        ],
+        fills_with_capacity_warning_contract=capacity_summary[
+            "fills_with_capacity_warning_contract"
+        ],
+        capacity_warning_counts=capacity_summary["capacity_warning_counts"],
     )
 
 
@@ -374,6 +416,9 @@ def _runtime_rows_with_defaults(
             "source",
             "execution_policy_hash",
             "cost_model_hash",
+            "cost_lineage_hash",
+            "candidate_id",
+            "candidate_identity_hash",
             "lineage_hash",
             "replay_data_hash",
             "cost_basis",
@@ -410,6 +455,7 @@ def _full_window_bucket(
 def _promotion_blockers(
     *,
     payload: Mapping[str, Any],
+    rows: Sequence[Mapping[str, object]],
     full_bucket: RuntimeLedgerBucket,
     total_net: Decimal,
     daily_net: Mapping[str, Decimal],
@@ -419,6 +465,8 @@ def _promotion_blockers(
     policy: ReplayLedgerRankingPolicy,
 ) -> list[str]:
     blockers = list(full_bucket.blockers)
+    blockers.extend(_candidate_identity_blockers(payload))
+    blockers.extend(_cost_lineage_blockers(payload=payload, rows=rows))
     stage = str(payload.get("stage") or "").lower()
     promotion_authority = str(payload.get("promotion_authority") or "").lower()
     if (
@@ -442,6 +490,91 @@ def _promotion_blockers(
     elif max_single_fill_notional_pct_equity > policy.max_gross_exposure_pct_equity:
         blockers.append("max_single_fill_notional_pct_equity_above_max")
     return _dedupe(blockers)
+
+
+def _candidate_id(*, payload: Mapping[str, Any], artifact_ref: str) -> str:
+    return _text(payload.get("candidate_id")) or Path(artifact_ref).stem
+
+
+def _candidate_identity_blockers(payload: Mapping[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    candidate_id = _text(payload.get("candidate_id"))
+    identity = _mapping(payload.get("candidate_identity"))
+    identity_candidate_id = _text(identity.get("candidate_id"))
+    identity_hash = _text(
+        payload.get("candidate_identity_hash") or identity.get("candidate_identity_hash")
+    )
+    if not candidate_id:
+        blockers.append("candidate_id_missing")
+    if not identity:
+        blockers.append("candidate_identity_missing")
+    if not identity_hash:
+        blockers.append("candidate_identity_hash_missing")
+    if identity_candidate_id and candidate_id and identity_candidate_id != candidate_id:
+        blockers.append("candidate_identity_candidate_id_mismatch")
+    return blockers
+
+
+def _cost_lineage_blockers(
+    *,
+    payload: Mapping[str, Any],
+    rows: Sequence[Mapping[str, object]],
+) -> list[str]:
+    blockers: list[str] = []
+    cost_lineage = _mapping(payload.get("cost_lineage"))
+    cost_lineage_hash = _text(
+        payload.get("cost_lineage_hash") or cost_lineage.get("cost_lineage_hash")
+    )
+    warning_contract = _string_list(cost_lineage.get("warning_contract"))
+    capacity_summary = _capacity_lineage_summary(rows)
+    fill_count = capacity_summary["fill_count"]
+    if not cost_lineage:
+        blockers.append("exact_replay_cost_lineage_missing")
+    if not cost_lineage_hash:
+        blockers.append("exact_replay_cost_lineage_hash_missing")
+    if not _text(cost_lineage.get("adv_source")):
+        blockers.append("adv_capacity_lineage_missing")
+    if not warning_contract:
+        blockers.append("adv_capacity_warning_contract_missing")
+    if fill_count > 0:
+        if capacity_summary["fills_with_adv_notional"] < fill_count:
+            blockers.append("fill_adv_notional_missing")
+        if capacity_summary["fills_with_participation_rate"] < fill_count:
+            blockers.append("fill_capacity_participation_missing")
+        if capacity_summary["fills_with_capacity_warning_contract"] < fill_count:
+            blockers.append("fill_capacity_warning_contract_missing")
+    if capacity_summary["capacity_warning_counts"].get("participation_exceeds_max", 0):
+        blockers.append("adv_capacity_limit_breached")
+    return blockers
+
+
+def _capacity_lineage_summary(
+    rows: Sequence[Mapping[str, object]],
+) -> dict[str, Any]:
+    fill_rows = [row for row in rows if _event_type(row) == "fill"]
+    warning_counts: dict[str, int] = {}
+    fills_with_capacity_warning_contract = 0
+    for row in fill_rows:
+        warnings = row.get("capacity_warning_codes")
+        if isinstance(warnings, Sequence) and not isinstance(
+            warnings, (str, bytes, bytearray)
+        ):
+            fills_with_capacity_warning_contract += 1
+            for warning in cast(Sequence[object], warnings):
+                text = _text(warning)
+                if text:
+                    warning_counts[text] = warning_counts.get(text, 0) + 1
+    return {
+        "fill_count": len(fill_rows),
+        "fills_with_adv_notional": sum(
+            1 for row in fill_rows if _positive_decimal(row.get("adv_notional"))
+        ),
+        "fills_with_participation_rate": sum(
+            1 for row in fill_rows if _positive_decimal(row.get("participation_rate"))
+        ),
+        "fills_with_capacity_warning_contract": fills_with_capacity_warning_contract,
+        "capacity_warning_counts": warning_counts,
+    }
 
 
 def _daily_bucket_ranges(
@@ -483,6 +616,21 @@ def _parse_window_datetime(value: object, *, date_end: bool = False) -> datetime
 
 def _mapping(value: object) -> Mapping[str, Any]:
     return cast(Mapping[str, Any], value) if isinstance(value, Mapping) else {}
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    result: list[str] = []
+    for item in cast(Sequence[object], value):
+        text = _text(item)
+        if text:
+            result.append(text)
+    return result
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
 
 
 def _utc(value: datetime) -> datetime:

--- a/services/torghut/app/trading/discovery/replay_runtime_window_plan.py
+++ b/services/torghut/app/trading/discovery/replay_runtime_window_plan.py
@@ -307,9 +307,24 @@ def _target_replay_window_metadata(
             "replay_avg_filled_notional_per_window_weekday",
         ),
         ("best_day_share", "replay_best_day_share"),
+        ("candidate_identity_hash", "replay_candidate_identity_hash"),
+        ("cost_lineage_hash", "replay_cost_lineage_hash"),
+        ("fills_with_adv_notional", "replay_fills_with_adv_notional"),
+        ("fills_with_participation_rate", "replay_fills_with_participation_rate"),
+        (
+            "fills_with_capacity_warning_contract",
+            "replay_fills_with_capacity_warning_contract",
+        ),
     ):
         if (value := best_candidate.get(source_key)) is not None:
             metadata[target_key] = value
+    for source_key, target_key in (
+        ("candidate_identity", "replay_candidate_identity"),
+        ("cost_lineage", "replay_cost_lineage"),
+        ("capacity_warning_counts", "replay_capacity_warning_counts"),
+    ):
+        if isinstance(value := best_candidate.get(source_key), Mapping):
+            metadata[target_key] = dict(cast(Mapping[str, Any], value))
     for source_key, target_key in (
         ("min_window_weekday_count", "replay_min_window_weekday_count"),
         ("target_net_pnl_per_day", "replay_target_net_pnl_per_day"),

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -176,10 +176,37 @@ class PendingOrder:
 @dataclass(frozen=True)
 class ReplayLedgerContext:
     account_label: str
+    candidate_id: str
+    candidate_identity: dict[str, Any]
+    candidate_identity_hash: str
     execution_policy_hash: str
     cost_model_hash: str
+    cost_lineage: dict[str, Any]
+    cost_lineage_hash: str
     lineage_hash: str
     replay_data_hash: str | None
+
+
+@dataclass(frozen=True)
+class ReplayCostLineage:
+    total_cost: Decimal
+    notional: Decimal
+    adv_notional: Decimal | None
+    adv_source: str | None
+    participation_rate: Decimal | None
+    spread: Decimal | None
+    volatility: Decimal | None
+    spread_cost_bps: Decimal
+    volatility_cost_bps: Decimal
+    impact_cost_bps: Decimal
+    commission_cost: Decimal
+    commission_cost_bps: Decimal
+    total_cost_bps: Decimal
+    capacity_ok: bool
+    warnings: tuple[str, ...]
+    max_participation_rate: Decimal
+    impact_bps_at_full_participation: Decimal
+    impact_participation_exponent: Decimal
 
 
 @dataclass
@@ -259,6 +286,29 @@ def _build_replay_ledger_context(
             },
         }
     )
+    cost_lineage_payload = {
+        "cost_basis": _REPLAY_COST_BASIS,
+        "model": cost_model.__class__.__name__,
+        "module": cost_model.__class__.__module__,
+        "adv_source": _REPLAY_ADV_SOURCE,
+        "fill_adv_notional_required": True,
+        "fill_participation_rate_required": True,
+        "fill_capacity_warning_contract_required": True,
+        "warning_contract": ["missing_adv", "participation_exceeds_max"],
+        "config": {
+            "commission_bps": str(cost_model.config.commission_bps),
+            "commission_per_share": str(cost_model.config.commission_per_share),
+            "min_commission": str(cost_model.config.min_commission),
+            "max_participation_rate": str(cost_model.config.max_participation_rate),
+            "impact_bps_at_full_participation": str(
+                cost_model.config.impact_bps_at_full_participation
+            ),
+            "impact_participation_exponent": str(
+                cost_model.config.impact_participation_exponent
+            ),
+        },
+    }
+    cost_lineage_hash = _stable_json_hash(cost_lineage_payload)
     lineage_payload = {
         "source": _REPLAY_LEDGER_SOURCE,
         "strategy_configmap_sha256": config_hash,
@@ -280,10 +330,38 @@ def _build_replay_ledger_context(
             "replay_tape_manifest_sha256": replay_manifest_hash,
         }
     )
+    candidate_identity_seed = {
+        "source": _REPLAY_LEDGER_SOURCE,
+        "strategy_configmap_sha256": config_hash,
+        "start_date": config.start_date.isoformat(),
+        "end_date": config.end_date.isoformat(),
+        "symbols": list(config.symbols),
+        "execution_policy_hash": execution_policy_hash,
+        "cost_model_hash": cost_model_hash,
+        "cost_lineage_hash": cost_lineage_hash,
+        "lineage_hash": _stable_json_hash(lineage_payload),
+        "replay_data_hash": replay_data_hash,
+    }
+    candidate_identity_hash = _stable_json_hash(candidate_identity_seed)
+    candidate_id = f"exact-replay-{candidate_identity_hash[:24]}"
+    candidate_identity = {
+        **candidate_identity_seed,
+        "candidate_id": candidate_id,
+        "candidate_id_source": (
+            "sha256(strategy_config,replay_window,symbols,execution_policy,"
+            "cost_lineage,lineage,replay_data)"
+        ),
+        "candidate_identity_hash": candidate_identity_hash,
+    }
     return ReplayLedgerContext(
         account_label=_REPLAY_LEDGER_ACCOUNT_LABEL,
+        candidate_id=candidate_id,
+        candidate_identity=candidate_identity,
+        candidate_identity_hash=candidate_identity_hash,
         execution_policy_hash=execution_policy_hash,
         cost_model_hash=cost_model_hash,
+        cost_lineage=cost_lineage_payload,
+        cost_lineage_hash=cost_lineage_hash,
         lineage_hash=_stable_json_hash(lineage_payload),
         replay_data_hash=replay_data_hash,
     )
@@ -303,6 +381,8 @@ def _base_ledger_row(
         "event_type": event_type,
         "executed_at": _utc_text(executed_at),
         "account_label": context.account_label,
+        "candidate_id": context.candidate_id,
+        "candidate_identity_hash": context.candidate_identity_hash,
         "strategy_id": strategy_id,
         "symbol": decision.symbol.upper(),
         "side": decision.action,
@@ -311,6 +391,7 @@ def _base_ledger_row(
         "source": _REPLAY_LEDGER_SOURCE,
         "execution_policy_hash": context.execution_policy_hash,
         "cost_model_hash": context.cost_model_hash,
+        "cost_lineage_hash": context.cost_lineage_hash,
         "lineage_hash": context.lineage_hash,
         "replay_data_hash": context.replay_data_hash,
         "order_type": decision.order_type,
@@ -432,6 +513,7 @@ def _append_ledger_fill(
     filled_qty: Decimal,
     avg_fill_price: Decimal,
     cost_amount: Decimal,
+    cost_lineage: ReplayCostLineage | None = None,
 ) -> None:
     if rows is None or context is None:
         return
@@ -467,6 +549,39 @@ def _append_ledger_fill(
             "fill_price_basis": "local_replay_resolved_fill_price",
         }
     )
+    if cost_lineage is not None:
+        row.update(
+            {
+                "adv_source": cost_lineage.adv_source,
+                "adv_notional": _decimal_text_or_none(cost_lineage.adv_notional),
+                "participation_rate": _decimal_text_or_none(
+                    cost_lineage.participation_rate
+                ),
+                "capacity_ok": cost_lineage.capacity_ok,
+                "capacity_warning_codes": list(cost_lineage.warnings),
+                "spread": _decimal_text_or_none(cost_lineage.spread),
+                "volatility": _decimal_text_or_none(cost_lineage.volatility),
+                "spread_cost_bps": _decimal_text(cost_lineage.spread_cost_bps),
+                "volatility_cost_bps": _decimal_text(
+                    cost_lineage.volatility_cost_bps
+                ),
+                "impact_cost_bps": _decimal_text(cost_lineage.impact_cost_bps),
+                "commission_cost": _decimal_text(cost_lineage.commission_cost),
+                "commission_cost_bps": _decimal_text(
+                    cost_lineage.commission_cost_bps
+                ),
+                "total_cost_bps": _decimal_text(cost_lineage.total_cost_bps),
+                "max_participation_rate": _decimal_text(
+                    cost_lineage.max_participation_rate
+                ),
+                "impact_bps_at_full_participation": _decimal_text(
+                    cost_lineage.impact_bps_at_full_participation
+                ),
+                "impact_participation_exponent": _decimal_text(
+                    cost_lineage.impact_participation_exponent
+                ),
+            }
+        )
     rows.append(row)
 
 
@@ -479,16 +594,47 @@ def _exact_replay_ledger_payload(
     event_type_counts: defaultdict[str, int] = defaultdict(int)
     for row in rows:
         event_type_counts[str(row.get("event_type") or "diagnostic")] += 1
+    fill_rows = [row for row in rows if row.get("event_type") == "fill"]
+    capacity_warning_counts: defaultdict[str, int] = defaultdict(int)
+    fills_with_capacity_warning_contract = 0
+    for row in fill_rows:
+        warnings = row.get("capacity_warning_codes")
+        if isinstance(warnings, list):
+            fills_with_capacity_warning_contract += 1
+            for warning in warnings:
+                if isinstance(warning, str) and warning:
+                    capacity_warning_counts[warning] += 1
     return {
         "schema_version": _EXACT_REPLAY_LEDGER_ROWS_SCHEMA_VERSION,
         "source": _REPLAY_LEDGER_SOURCE,
         "account_label": context.account_label,
+        "candidate_id": context.candidate_id,
+        "candidate_identity": context.candidate_identity,
+        "candidate_identity_hash": context.candidate_identity_hash,
         "stage": "replay",
         "promotion_authority": "replay_artifact_only_not_live",
         "window_start": config.start_date.isoformat(),
         "window_end": config.end_date.isoformat(),
         "execution_policy_hash": context.execution_policy_hash,
         "cost_model_hash": context.cost_model_hash,
+        "cost_lineage": {
+            **context.cost_lineage,
+            "cost_lineage_hash": context.cost_lineage_hash,
+            "fill_count": len(fill_rows),
+            "fills_with_adv_notional": sum(
+                1 for row in fill_rows if row.get("adv_notional") not in (None, "")
+            ),
+            "fills_with_participation_rate": sum(
+                1
+                for row in fill_rows
+                if row.get("participation_rate") not in (None, "")
+            ),
+            "fills_with_capacity_warning_contract": (
+                fills_with_capacity_warning_contract
+            ),
+            "capacity_warning_counts": dict(sorted(capacity_warning_counts.items())),
+        },
+        "cost_lineage_hash": context.cost_lineage_hash,
         "lineage_hash": context.lineage_hash,
         "replay_data_hash": context.replay_data_hash,
         "cost_basis": _REPLAY_COST_BASIS,
@@ -1296,10 +1442,27 @@ def _estimate_trade_cost(
     day_bucket: Mapping[str, Any] | None = None,
     symbol_bucket: Mapping[str, Any] | None = None,
 ) -> Decimal:
+    return _estimate_trade_cost_lineage(
+        model=model,
+        decision=decision,
+        signal=signal,
+        day_bucket=day_bucket,
+        symbol_bucket=symbol_bucket,
+    ).total_cost
+
+
+def _estimate_trade_cost_lineage(
+    *,
+    model: TransactionCostModel,
+    decision: StrategyDecision,
+    signal: SignalEnvelope,
+    day_bucket: Mapping[str, Any] | None = None,
+    symbol_bucket: Mapping[str, Any] | None = None,
+) -> ReplayCostLineage:
     price = _extract_price(signal)
     spread = _extract_spread(signal)
     volatility = _extract_volatility(signal)
-    adv = _observed_adv_notional(
+    adv, adv_source = _observed_adv_notional_with_source(
         signal=signal,
         day_bucket=day_bucket,
         symbol_bucket=symbol_bucket,
@@ -1320,7 +1483,26 @@ def _estimate_trade_cost(
             adv=adv,
         ),
     )
-    return estimate.total_cost
+    return ReplayCostLineage(
+        total_cost=estimate.total_cost,
+        notional=estimate.notional,
+        adv_notional=adv,
+        adv_source=adv_source,
+        participation_rate=estimate.participation_rate,
+        spread=spread,
+        volatility=volatility,
+        spread_cost_bps=estimate.spread_cost_bps,
+        volatility_cost_bps=estimate.volatility_cost_bps,
+        impact_cost_bps=estimate.impact_cost_bps,
+        commission_cost=estimate.commission_cost,
+        commission_cost_bps=estimate.commission_cost_bps,
+        total_cost_bps=estimate.total_cost_bps,
+        capacity_ok=estimate.capacity_ok,
+        warnings=tuple(estimate.warnings),
+        max_participation_rate=model.config.max_participation_rate,
+        impact_bps_at_full_participation=model.config.impact_bps_at_full_participation,
+        impact_participation_exponent=model.config.impact_participation_exponent,
+    )
 
 
 def _positive_decimal_mapping_value(
@@ -1347,15 +1529,31 @@ def _observed_adv_notional(
     day_bucket: Mapping[str, Any] | None = None,
     symbol_bucket: Mapping[str, Any] | None = None,
 ) -> Decimal | None:
-    for bucket in (symbol_bucket, day_bucket):
+    return _observed_adv_notional_with_source(
+        signal=signal,
+        day_bucket=day_bucket,
+        symbol_bucket=symbol_bucket,
+    )[0]
+
+
+def _observed_adv_notional_with_source(
+    *,
+    signal: SignalEnvelope,
+    day_bucket: Mapping[str, Any] | None = None,
+    symbol_bucket: Mapping[str, Any] | None = None,
+) -> tuple[Decimal | None, str | None]:
+    for source, bucket in (
+        ("symbol_bucket.daily_adv_notional", symbol_bucket),
+        ("day_bucket.daily_adv_notional", day_bucket),
+    ):
         value = _positive_decimal_mapping_value(bucket, "daily_adv_notional")
         if value is not None:
-            return value
+            return value, source
     for key in ("daily_adv_notional", "adv_notional", "adv", "avg_dollar_volume"):
         value = _positive_decimal_mapping_value(signal.payload, key)
         if value is not None and value > 0:
-            return value
-    return None
+            return value, f"signal_payload.{key}"
+    return None, None
 
 
 def _record_decision(stats: dict[str, Any], decision: StrategyDecision) -> None:
@@ -2392,6 +2590,7 @@ def _apply_filled_decision(
         fill_qty: Decimal,
         fill_notional: Decimal,
         fill_cost: Decimal,
+        cost_lineage: ReplayCostLineage,
     ) -> None:
         day_bucket["cost_total"] += fill_cost
         day_bucket["filled_count"] += 1
@@ -2412,6 +2611,7 @@ def _apply_filled_decision(
             filled_qty=fill_qty,
             avg_fill_price=fill_price,
             cost_amount=fill_cost,
+            cost_lineage=cost_lineage,
         )
 
     owner_strategy_id = _decision_position_owner(
@@ -2420,19 +2620,23 @@ def _apply_filled_decision(
     )
     position_key = _position_key(decision.symbol, owner_strategy_id)
     existing = positions.get(position_key)
-    fill_cost = _estimate_trade_cost(
+    cost_lineage = _estimate_trade_cost_lineage(
         model=cost_model,
         decision=decision,
         signal=signal,
         day_bucket=day_bucket,
         symbol_bucket=symbol_bucket,
     )
+    fill_cost = cost_lineage.total_cost
     if decision.action == "buy":
         if existing is not None and existing.qty < 0:
             cover_qty = min(decision.qty, abs(existing.qty))
             fill_notional = fill_price * cover_qty
             _record_fill(
-                fill_qty=cover_qty, fill_notional=fill_notional, fill_cost=fill_cost
+                fill_qty=cover_qty,
+                fill_notional=fill_notional,
+                fill_cost=fill_cost,
+                cost_lineage=cost_lineage,
             )
             cash -= fill_notional + fill_cost
             entry_cost_allocated = existing.entry_cost_total * (
@@ -2469,7 +2673,10 @@ def _apply_filled_decision(
 
         fill_notional = fill_price * decision.qty
         _record_fill(
-            fill_qty=decision.qty, fill_notional=fill_notional, fill_cost=fill_cost
+            fill_qty=decision.qty,
+            fill_notional=fill_notional,
+            fill_cost=fill_cost,
+            cost_lineage=cost_lineage,
         )
         cash -= fill_notional + fill_cost
         if existing is None:
@@ -2501,7 +2708,10 @@ def _apply_filled_decision(
     if existing is None:
         fill_notional = fill_price * decision.qty
         _record_fill(
-            fill_qty=decision.qty, fill_notional=fill_notional, fill_cost=fill_cost
+            fill_qty=decision.qty,
+            fill_notional=fill_notional,
+            fill_cost=fill_cost,
+            cost_lineage=cost_lineage,
         )
         cash += fill_notional - fill_cost
         positions[position_key] = PositionState(
@@ -2518,7 +2728,10 @@ def _apply_filled_decision(
     if existing.qty < 0:
         fill_notional = fill_price * decision.qty
         _record_fill(
-            fill_qty=decision.qty, fill_notional=fill_notional, fill_cost=fill_cost
+            fill_qty=decision.qty,
+            fill_notional=fill_notional,
+            fill_cost=fill_cost,
+            cost_lineage=cost_lineage,
         )
         cash += fill_notional - fill_cost
         new_abs_qty = abs(existing.qty) + decision.qty
@@ -2538,7 +2751,12 @@ def _apply_filled_decision(
 
     sell_qty = min(decision.qty, existing.qty)
     fill_notional = fill_price * sell_qty
-    _record_fill(fill_qty=sell_qty, fill_notional=fill_notional, fill_cost=fill_cost)
+    _record_fill(
+        fill_qty=sell_qty,
+        fill_notional=fill_notional,
+        fill_cost=fill_cost,
+        cost_lineage=cost_lineage,
+    )
     cash += fill_notional - fill_cost
     entry_cost_allocated = existing.entry_cost_total * (sell_qty / existing.qty)
     remaining, trade = _close_position(
@@ -3513,13 +3731,14 @@ def _flatten_positions(
             time_in_force="day",
             params={},
         )
-        exit_cost = _estimate_trade_cost(
+        exit_cost_lineage = _estimate_trade_cost_lineage(
             model=cost_model,
             decision=synthetic_decision,
             signal=last_signal,
             day_bucket=stats,
             symbol_bucket=symbol_bucket,
         )
+        exit_cost = exit_cost_lineage.total_cost
         exit_notional = fill_price * exit_qty
         if position.qty < 0:
             current_cash -= exit_notional + exit_cost
@@ -3542,6 +3761,7 @@ def _flatten_positions(
             filled_qty=exit_qty,
             avg_fill_price=fill_price,
             cost_amount=exit_cost,
+            cost_lineage=exit_cost_lineage,
         )
         trade = ClosedTrade(
             symbol=symbol,

--- a/services/torghut/tests/test_local_intraday_tsmom_replay.py
+++ b/services/torghut/tests/test_local_intraday_tsmom_replay.py
@@ -37,6 +37,7 @@ from scripts.local_intraday_tsmom_replay import (
     _decision_position_owner,
     _decision_spread_bps,
     _estimate_trade_cost,
+    _estimate_trade_cost_lineage,
     _fetch_chunk,
     _flatten_positions,
     _http_query,
@@ -716,6 +717,41 @@ class TestLocalIntradayTsmomReplay(TestCase):
         )
 
         self.assertEqual(cost, Decimal("50"))
+
+    def test_estimate_trade_cost_lineage_exposes_adv_and_capacity_warnings(
+        self,
+    ) -> None:
+        signal = self._signal(bid="99.99", ask="100.01", price="100")
+        decision = StrategyDecision(
+            strategy_id="impact-aware",
+            symbol="META",
+            event_ts=signal.event_ts,
+            timeframe="1Sec",
+            action="buy",
+            qty=Decimal("100"),
+            order_type="limit",
+            time_in_force="day",
+            limit_price=Decimal("100"),
+            params={},
+        )
+
+        lineage = _estimate_trade_cost_lineage(
+            model=TransactionCostModel(
+                CostModelConfig(
+                    impact_bps_at_full_participation=Decimal("100"),
+                    max_participation_rate=Decimal("0.1"),
+                )
+            ),
+            decision=decision,
+            signal=signal,
+            symbol_bucket={"daily_adv_notional": Decimal("40000")},
+        )
+
+        self.assertEqual(lineage.adv_notional, Decimal("40000"))
+        self.assertEqual(lineage.adv_source, "symbol_bucket.daily_adv_notional")
+        self.assertEqual(lineage.participation_rate, Decimal("0.25"))
+        self.assertEqual(lineage.total_cost, Decimal("50"))
+        self.assertEqual(lineage.warnings, ("participation_exceeds_max",))
 
     def test_apply_filled_decision_prefers_symbol_adv_for_impact_cost(self) -> None:
         signal = self._signal(bid="9.99", ask="10.01", price="10")
@@ -2414,6 +2450,23 @@ class TestLocalIntradayTsmomReplay(TestCase):
         self.assertEqual(
             exact_ledger["promotion_authority"], "replay_artifact_only_not_live"
         )
+        self.assertTrue(str(exact_ledger["candidate_id"]).startswith("exact-replay-"))
+        self.assertEqual(
+            exact_ledger["candidate_identity"]["candidate_id"],
+            exact_ledger["candidate_id"],
+        )
+        self.assertEqual(
+            exact_ledger["candidate_identity"]["candidate_identity_hash"],
+            exact_ledger["candidate_identity_hash"],
+        )
+        self.assertEqual(
+            exact_ledger["cost_lineage"]["cost_lineage_hash"],
+            exact_ledger["cost_lineage_hash"],
+        )
+        self.assertEqual(
+            exact_ledger["cost_lineage"]["warning_contract"],
+            ["missing_adv", "participation_exceeds_max"],
+        )
         self.assertEqual(exact_ledger["decision_row_count"], 3)
         self.assertEqual(exact_ledger["submitted_order_row_count"], 3)
         self.assertEqual(exact_ledger["fill_row_count"], 2)
@@ -2431,6 +2484,23 @@ class TestLocalIntradayTsmomReplay(TestCase):
                 "order_submitted",
                 "fill",
             ],
+        )
+        fill_rows = [row for row in rows if row["event_type"] == "fill"]
+        self.assertEqual(
+            [row["candidate_identity_hash"] for row in fill_rows],
+            [exact_ledger["candidate_identity_hash"]] * 2,
+        )
+        self.assertEqual(
+            [row["cost_lineage_hash"] for row in fill_rows],
+            [exact_ledger["cost_lineage_hash"]] * 2,
+        )
+        self.assertEqual(
+            exact_ledger["cost_lineage"]["capacity_warning_counts"],
+            {"missing_adv": 2},
+        )
+        self.assertEqual(
+            [row["capacity_warning_codes"] for row in fill_rows],
+            [["missing_adv"], ["missing_adv"]],
         )
         ledger_bucket = build_runtime_ledger_buckets(
             rows,

--- a/services/torghut/tests/test_replay_ledger_ranker.py
+++ b/services/torghut/tests/test_replay_ledger_ranker.py
@@ -89,22 +89,52 @@ def _payload(
     rows: list[dict[str, object]],
     *,
     promotion_authority: str = "replay_artifact_only_not_live",
+    include_lineage: bool = True,
 ) -> dict[str, object]:
-    return {
+    if include_lineage:
+        for row in rows:
+            if row.get("event_type") == "fill":
+                row["adv_source"] = "observed_microbar_notional_by_symbol_day"
+                row["adv_notional"] = "10000000"
+                row["participation_rate"] = "0.0001"
+                row["capacity_warning_codes"] = []
+    payload: dict[str, object] = {
         "schema_version": "torghut.exact_replay_ledger.rows.v1",
         "candidate_id": candidate_id,
+        "candidate_identity": {
+            "candidate_id": candidate_id,
+            "candidate_identity_hash": f"identity-{candidate_id}",
+            "source_manifest_ref": f"manifests/{candidate_id}.json",
+        },
+        "candidate_identity_hash": f"identity-{candidate_id}",
         "window_start": "2026-05-18",
         "window_end": "2026-05-22",
         "account_label": "TORGHUT_REPLAY",
         "cost_basis": "local_replay_transaction_cost_model",
         "execution_policy_hash": "policy-sha",
         "cost_model_hash": "cost-sha",
+        "cost_lineage": {
+            "cost_lineage_hash": f"cost-lineage-{candidate_id}",
+            "adv_source": "observed_microbar_notional_by_symbol_day",
+            "warning_contract": ["missing_adv", "participation_exceeds_max"],
+        },
+        "cost_lineage_hash": f"cost-lineage-{candidate_id}",
         "lineage_hash": "lineage-sha",
         "promotion_authority": promotion_authority,
         "stage": "replay",
         "source": "local_intraday_tsmom_replay",
         "runtime_ledger_rows": rows,
     }
+    if not include_lineage:
+        for key in (
+            "candidate_id",
+            "candidate_identity",
+            "candidate_identity_hash",
+            "cost_lineage",
+            "cost_lineage_hash",
+        ):
+            payload.pop(key, None)
+    return payload
 
 
 def _policy() -> ReplayLedgerRankingPolicy:
@@ -199,6 +229,76 @@ def test_ranker_blocks_replay_only_and_over_equity_artifacts() -> None:
     assert "replay_artifact_only_not_live" in ranking.promotion_blockers
     assert "max_single_fill_notional_pct_equity_above_max" in ranking.promotion_blockers
     assert ranking.promotion_status == "blocked_pending_runtime_promotion_proof"
+
+
+def test_ranker_blocks_missing_candidate_identity_and_cost_lineage() -> None:
+    ranking = rank_replay_ledger_payload(
+        _payload(
+            "missing-lineage",
+            _round_trip(
+                day=18,
+                symbol="NVDA",
+                qty="20",
+                buy_price="100",
+                sell_price="160",
+                prefix="missing-lineage",
+            ),
+            promotion_authority="live_paper_runtime_ledger",
+            include_lineage=False,
+        ),
+        artifact_ref="/tmp/missing-lineage.json",
+        policy=ReplayLedgerRankingPolicy(
+            target_net_pnl_per_day=Decimal("1"),
+            min_window_weekday_count=1,
+            min_avg_filled_notional_per_day=Decimal("1"),
+            max_best_day_share=Decimal("1.0"),
+            max_gross_exposure_pct_equity=Decimal("10.0"),
+            start_equity=Decimal("100000"),
+        ),
+    )
+
+    assert ranking.candidate_id == "missing-lineage"
+    assert "candidate_id_missing" in ranking.promotion_blockers
+    assert "candidate_identity_missing" in ranking.promotion_blockers
+    assert "exact_replay_cost_lineage_missing" in ranking.promotion_blockers
+    assert "adv_capacity_lineage_missing" in ranking.promotion_blockers
+    assert "fill_adv_notional_missing" in ranking.promotion_blockers
+    assert ranking.promotion_status == "blocked_pending_runtime_promotion_proof"
+
+
+def test_ranker_exposes_candidate_and_cost_lineage_when_present() -> None:
+    ranking = rank_replay_ledger_payload(
+        _payload(
+            "lineaged-candidate",
+            _round_trip(
+                day=18,
+                symbol="NVDA",
+                qty="20",
+                buy_price="100",
+                sell_price="160",
+                prefix="lineaged",
+            ),
+            promotion_authority="live_paper_runtime_ledger",
+        ),
+        artifact_ref="/tmp/lineaged.json",
+        policy=ReplayLedgerRankingPolicy(
+            target_net_pnl_per_day=Decimal("1"),
+            min_window_weekday_count=1,
+            min_avg_filled_notional_per_day=Decimal("1"),
+            max_best_day_share=Decimal("1.0"),
+            max_gross_exposure_pct_equity=Decimal("10.0"),
+            start_equity=Decimal("100000"),
+        ),
+    )
+
+    payload = ranking.to_payload()
+    assert payload["candidate_identity_hash"] == "identity-lineaged-candidate"
+    assert payload["cost_lineage_hash"] == "cost-lineage-lineaged-candidate"
+    assert payload["fills_with_adv_notional"] == 2
+    assert payload["fills_with_participation_rate"] == 2
+    assert payload["fills_with_capacity_warning_contract"] == 2
+    assert "candidate_id_missing" not in ranking.promotion_blockers
+    assert "fill_adv_notional_missing" not in ranking.promotion_blockers
 
 
 def test_default_policy_tracks_oracle_promotion_gates() -> None:

--- a/services/torghut/tests/test_replay_runtime_window_plan.py
+++ b/services/torghut/tests/test_replay_runtime_window_plan.py
@@ -99,23 +99,56 @@ def _frontier_payload() -> dict[str, object]:
     }
 
 
-def _write_replay_ledger(path: Path, *, candidate_id: str) -> Path:
+def _write_replay_ledger(
+    path: Path,
+    *,
+    candidate_id: str,
+    include_lineage: bool = True,
+) -> Path:
+    rows = _round_trip(21)
+    if include_lineage:
+        for row in rows:
+            if row.get("event_type") == "fill":
+                row["adv_source"] = "observed_microbar_notional_by_symbol_day"
+                row["adv_notional"] = "10000000"
+                row["participation_rate"] = "0.001"
+                row["capacity_warning_codes"] = []
+    payload: dict[str, object] = {
+        "schema_version": "torghut.exact_replay_ledger.rows.v1",
+        "candidate_id": candidate_id,
+        "candidate_identity": {
+            "candidate_id": candidate_id,
+            "candidate_identity_hash": f"identity-{candidate_id}",
+            "source_manifest_ref": f"manifests/{candidate_id}.json",
+        },
+        "candidate_identity_hash": f"identity-{candidate_id}",
+        "window_start": "2026-05-18",
+        "window_end": "2026-05-22",
+        "account_label": "TORGHUT_REPLAY",
+        "execution_policy_hash": "policy-sha",
+        "cost_model_hash": "cost-sha",
+        "cost_lineage": {
+            "cost_lineage_hash": f"cost-lineage-{candidate_id}",
+            "adv_source": "observed_microbar_notional_by_symbol_day",
+            "warning_contract": ["missing_adv", "participation_exceeds_max"],
+        },
+        "cost_lineage_hash": f"cost-lineage-{candidate_id}",
+        "lineage_hash": "lineage-sha",
+        "promotion_authority": "replay_artifact_only_not_live",
+        "stage": "replay",
+        "runtime_ledger_rows": rows,
+    }
+    if not include_lineage:
+        for key in (
+            "candidate_id",
+            "candidate_identity",
+            "candidate_identity_hash",
+            "cost_lineage",
+            "cost_lineage_hash",
+        ):
+            payload.pop(key, None)
     path.write_text(
-        json.dumps(
-            {
-                "schema_version": "torghut.exact_replay_ledger.rows.v1",
-                "candidate_id": candidate_id,
-                "window_start": "2026-05-18",
-                "window_end": "2026-05-22",
-                "account_label": "TORGHUT_REPLAY",
-                "execution_policy_hash": "policy-sha",
-                "cost_model_hash": "cost-sha",
-                "lineage_hash": "lineage-sha",
-                "promotion_authority": "replay_artifact_only_not_live",
-                "stage": "replay",
-                "runtime_ledger_rows": _round_trip(21),
-            }
-        ),
+        json.dumps(payload),
         encoding="utf-8",
     )
     return path
@@ -144,6 +177,15 @@ def test_handoff_builds_non_promotional_runtime_window_target(
     assert len(plan["targets"]) == 1
     target = plan["targets"][0]
     assert target["candidate_id"] == "candidate-strong-one-day"
+    assert (
+        target["replay_candidate_identity_hash"]
+        == "identity-candidate-strong-one-day"
+    )
+    assert target["replay_cost_lineage_hash"] == "cost-lineage-candidate-strong-one-day"
+    assert target["replay_fills_with_adv_notional"] == 2
+    assert target["replay_fills_with_participation_rate"] == 2
+    assert target["replay_fills_with_capacity_warning_contract"] == 2
+    assert target["replay_capacity_warning_counts"] == {}
     assert target["hypothesis_id"] == "H-PAIRS-01"
     assert target["strategy_family"] == "microbar_cross_sectional_pairs"
     assert target["strategy_name"] == "microbar-cross-sectional-pairs-v1"
@@ -193,6 +235,43 @@ def test_handoff_blocks_target_when_runtime_metadata_is_missing(
         "strategy_family",
         "strategy_name",
     ]
+
+
+def test_handoff_blocks_probation_when_replay_lineage_is_missing(
+    tmp_path: Path,
+) -> None:
+    artifact_path = _write_replay_ledger(
+        tmp_path / "candidate-missing-lineage.json",
+        candidate_id="candidate-missing-lineage",
+        include_lineage=False,
+    )
+
+    handoff = build_replay_runtime_window_handoff(
+        ledger_paths=[artifact_path],
+        policy=ReplayLedgerRankingPolicy(
+            target_net_pnl_per_day=Decimal("1"),
+            min_window_weekday_count=1,
+            min_avg_filled_notional_per_day=Decimal("1"),
+            max_best_day_share=Decimal("1.0"),
+            max_gross_exposure_pct_equity=Decimal("10.0"),
+            start_equity=Decimal("100000"),
+        ),
+        hypothesis_id="H-PAIRS-01",
+        source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+        frontier_payload=_frontier_payload(),
+    )
+
+    plan = handoff["runtime_window_import_plan"]
+    target = plan["targets"][0]
+    assert target["paper_probation_authorized"] is False
+    assert target["probation_allowed"] is False
+    assert "candidate_id_missing" in target["final_promotion_blockers"]
+    assert "exact_replay_cost_lineage_missing" in target["final_promotion_blockers"]
+    assert any(
+        item["blocker"] == "exact_replay_search_blockers_remaining"
+        and "fill_adv_notional_missing" in item["blocking_reasons"]
+        for item in plan["blockers"]
+    )
 
 
 def test_handoff_blocks_target_when_no_ledger_candidate_exists() -> None:


### PR DESCRIPTION
## Summary

- Add deterministic exact-replay candidate identity fields and hashes to replay ledger output.
- Persist per-fill ADV, participation, capacity-warning, and detailed cost-lineage evidence in exact replay ledgers.
- Fail closed in replay ranking and runtime-window handoff when candidate identity, cost lineage, ADV, participation, or capacity-warning contracts are missing.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_local_intraday_tsmom_replay.py tests/test_replay_ledger_ranker.py tests/test_replay_runtime_window_plan.py -q`
- `uv run --frozen ruff check scripts/local_intraday_tsmom_replay.py app/trading/discovery/replay_ledger_ranker.py app/trading/discovery/replay_runtime_window_plan.py tests/test_local_intraday_tsmom_replay.py tests/test_replay_ledger_ranker.py tests/test_replay_runtime_window_plan.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
