### PR TITLE
fix(torghut): harden paper proof blockers and metadata

### DIFF
--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -23,6 +23,7 @@ from ..models import (
     TradeDecision,
     coerce_json_payload,
 )
+from .tca import upsert_execution_tca_metric
 
 logger = logging.getLogger(__name__)
 
@@ -192,6 +193,7 @@ class OrderFeedIngestor:
         counters["apply_updates_total"] += 1
         if execution.trade_decision_id is not None:
             _update_trade_decision_from_execution(session, execution)
+        upsert_execution_tca_metric(session, execution)
         session.add(execution)
         return True
 
@@ -548,8 +550,46 @@ def apply_order_event_to_execution(
     if event.feed_seq is not None:
         execution.order_feed_last_seq = event.feed_seq
 
-    execution.raw_order = coerce_json_payload(event.raw_event)
+    execution.raw_order = merge_execution_raw_order_update(
+        execution.raw_order,
+        event.raw_event,
+        update_key="_order_feed_last_event",
+    )
     return updated, False
+
+
+def merge_execution_raw_order_update(
+    existing_raw_order: Any,
+    update_payload: Any,
+    *,
+    update_key: str,
+) -> dict[str, Any] | None:
+    """Preserve submit-time proof metadata while recording the latest update payload."""
+
+    coerced_existing = coerce_json_payload(existing_raw_order)
+    coerced_update = coerce_json_payload(update_payload)
+    existing: dict[str, Any] = {}
+    if isinstance(coerced_existing, Mapping):
+        existing = {
+            str(key): value
+            for key, value in cast(Mapping[object, Any], coerced_existing).items()
+        }
+    update: dict[str, Any] = {}
+    if isinstance(coerced_update, Mapping):
+        update = {
+            str(key): value
+            for key, value in cast(Mapping[object, Any], coerced_update).items()
+        }
+
+    if not existing and not update:
+        return None
+
+    merged = dict(existing)
+    for key, value in update.items():
+        merged.setdefault(key, value)
+    if update:
+        merged[update_key] = update
+    return coerce_json_payload(merged)
 
 
 def latest_order_event_for_execution(

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -2117,6 +2117,7 @@ def _runtime_window_import_audit(
         state = "runtime_ledger_ready_for_gate_review"
         next_action = "review_runtime_ledger_profit_gates"
         blockers = []
+    target_blockers = _runtime_window_target_blockers(next_target_audits)
     return {
         "schema_version": PAPER_ROUTE_RUNTIME_WINDOW_IMPORT_AUDIT_SCHEMA_VERSION,
         "state": state,
@@ -2132,7 +2133,9 @@ def _runtime_window_import_audit(
                 source_runtime_ledger_blockers
             ),
             "runtime_ledger_blockers": runtime_ledger_blockers,
+            "target_blockers_effective_when": "runtime_window_import_ready",
         },
+        "target_blockers": target_blockers,
         "counts": {
             "source_plan_target_count": source_plan_target_count,
             "selected_target_count": current_target_count,
@@ -2176,6 +2179,105 @@ def _runtime_window_import_audit(
             ],
         },
     }
+
+
+def _runtime_window_target_blockers(
+    target_audits: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    target_blockers: list[dict[str, object]] = []
+    for audit in target_audits:
+        target = _as_mapping(audit.get("target"))
+        source_activity = _as_mapping(audit.get("source_activity"))
+        rejected_signal_activity = _as_mapping(audit.get("rejected_signal_activity"))
+        runtime_ledger = _as_mapping(audit.get("runtime_ledger"))
+        promotion_decisions = _as_mapping(audit.get("promotion_decisions"))
+
+        blockers = _unique_text_items(
+            [
+                *(
+                    _unique_text_items(source_activity.get("missing_reasons"))
+                    if bool(source_activity.get("missing"))
+                    else []
+                ),
+                *_unique_text_items(rejected_signal_activity.get("blocking_reasons")),
+                *(
+                    ["runtime_ledger_bucket_missing"]
+                    if _safe_int(runtime_ledger.get("bucket_count")) <= 0
+                    else []
+                ),
+                *(
+                    ["runtime_ledger_evidence_grade_bucket_missing"]
+                    if _safe_int(runtime_ledger.get("evidence_grade_bucket_count")) <= 0
+                    else []
+                ),
+                *_unique_text_items(runtime_ledger.get("blockers")),
+                *(
+                    ["promotion_decision_missing"]
+                    if _safe_int(promotion_decisions.get("decision_count")) <= 0
+                    else []
+                ),
+            ]
+        )
+        if not blockers:
+            continue
+        target_blockers.append(
+            {
+                "hypothesis_id": _safe_text(target.get("hypothesis_id")),
+                "candidate_id": _safe_text(target.get("candidate_id")),
+                "strategy_name": _safe_text(target.get("strategy_name")),
+                "runtime_strategy_name": _safe_text(
+                    target.get("runtime_strategy_name")
+                ),
+                "account_label": _safe_text(target.get("account_label")),
+                "source_kind": _safe_text(target.get("source_kind")),
+                "window_start": _safe_text(target.get("window_start")),
+                "window_end": _safe_text(target.get("window_end")),
+                "paper_route_probe_symbols": [
+                    str(item).strip()
+                    for item in _as_sequence(target.get("paper_route_probe_symbols"))
+                    if str(item).strip()
+                ],
+                "source_activity": {
+                    "decision_count": _safe_int(source_activity.get("decision_count")),
+                    "execution_count": _safe_int(
+                        source_activity.get("execution_count")
+                    ),
+                    "filled_execution_count": _safe_int(
+                        source_activity.get("filled_execution_count")
+                    ),
+                    "tca_sample_count": _safe_int(
+                        source_activity.get("tca_sample_count")
+                    ),
+                    "last_decision_at": _safe_text(
+                        source_activity.get("last_decision_at")
+                    ),
+                    "last_execution_at": _safe_text(
+                        source_activity.get("last_execution_at")
+                    ),
+                    "last_tca_at": _safe_text(source_activity.get("last_tca_at")),
+                },
+                "runtime_ledger": {
+                    "bucket_count": _safe_int(runtime_ledger.get("bucket_count")),
+                    "evidence_grade_bucket_count": _safe_int(
+                        runtime_ledger.get("evidence_grade_bucket_count")
+                    ),
+                    "filled_notional": _safe_text(
+                        runtime_ledger.get("filled_notional")
+                    ),
+                    "closed_trade_count": _safe_int(
+                        runtime_ledger.get("closed_trade_count")
+                    ),
+                    "net_strategy_pnl_after_costs": _safe_text(
+                        runtime_ledger.get("net_strategy_pnl_after_costs")
+                    ),
+                },
+                "promotion_decision_count": _safe_int(
+                    promotion_decisions.get("decision_count")
+                ),
+                "blockers": blockers,
+            }
+        )
+    return target_blockers
 
 
 def _runtime_window_target_counts(

--- a/services/torghut/app/trading/reconcile.py
+++ b/services/torghut/app/trading/reconcile.py
@@ -9,9 +9,13 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from ..models import Execution, TradeDecision, coerce_json_payload
+from ..models import Execution, TradeDecision
 from ..snapshots import sync_order_to_db
-from .order_feed import apply_order_event_to_execution, latest_order_event_for_execution
+from .order_feed import (
+    apply_order_event_to_execution,
+    latest_order_event_for_execution,
+    merge_execution_raw_order_update,
+)
 from .route_metadata import coerce_route_text, resolve_order_route_metadata
 from .risk import FINAL_STATUSES
 from .tca import upsert_execution_tca_metric
@@ -61,10 +65,12 @@ class Reconciler:
                 continue
 
             expected_adapter = coerce_route_text(execution.execution_expected_adapter)
-            route_expected, route_actual, fallback_reason, fallback_count = resolve_order_route_metadata(
-                expected_adapter=expected_adapter,
-                execution_client=client,
-                order_response=order,
+            route_expected, route_actual, fallback_reason, fallback_count = (
+                resolve_order_route_metadata(
+                    expected_adapter=expected_adapter,
+                    execution_client=client,
+                    order_response=order,
+                )
             )
             updated = _apply_order_update(
                 execution,
@@ -83,7 +89,9 @@ class Reconciler:
     def _backfill_missing_executions(self, session: Session, client: Any) -> int:
         # Avoid scanning broker history unboundedly; reconcile only local decisions that are
         # missing an Execution and ask the broker for those specific client_order_ids.
-        cutoff = datetime.now(timezone.utc) - timedelta(days=BACKFILL_DECISION_LOOKBACK_DAYS)
+        cutoff = datetime.now(timezone.utc) - timedelta(
+            days=BACKFILL_DECISION_LOOKBACK_DAYS
+        )
         decision_stmt = (
             select(TradeDecision)
             .where(
@@ -108,17 +116,11 @@ class Reconciler:
             existing_stmt = select(Execution).where(
                 (
                     (Execution.trade_decision_id == decision.id)
-                    & (
-                        Execution.alpaca_account_label
-                        == decision.alpaca_account_label
-                    )
+                    & (Execution.alpaca_account_label == decision.alpaca_account_label)
                 )
                 | (
                     (Execution.client_order_id == decision.decision_hash)
-                    & (
-                        Execution.alpaca_account_label
-                        == decision.alpaca_account_label
-                    )
+                    & (Execution.alpaca_account_label == decision.alpaca_account_label)
                 )
             )
             existing = session.execute(existing_stmt).scalar_one_or_none()
@@ -141,10 +143,12 @@ class Reconciler:
             expected_route = coerce_route_text(order.get("_execution_route_expected"))
             if expected_route is None:
                 expected_route = coerce_route_text(order.get("_execution_route_actual"))
-            route_expected, route_actual, fallback_reason, fallback_count = resolve_order_route_metadata(
-                expected_adapter=expected_route,
-                execution_client=client,
-                order_response=order,
+            route_expected, route_actual, fallback_reason, fallback_count = (
+                resolve_order_route_metadata(
+                    expected_adapter=expected_route,
+                    execution_client=client,
+                    order_response=order,
+                )
             )
             execution = sync_order_to_db(
                 session,
@@ -157,7 +161,9 @@ class Reconciler:
             execution.execution_fallback_reason = fallback_reason
             execution.execution_fallback_count = fallback_count
             execution.execution_actual_adapter = route_actual
-            execution.execution_expected_adapter = route_expected or execution.execution_expected_adapter
+            execution.execution_expected_adapter = (
+                route_expected or execution.execution_expected_adapter
+            )
             upsert_execution_tca_metric(session, execution)
             _update_trade_decision(session, execution)
             updates += 1
@@ -189,10 +195,13 @@ def _apply_order_update(
     if execution_fallback_count is not None:
         execution.execution_fallback_count = execution_fallback_count
     execution.execution_fallback_reason = execution_fallback_reason
-    execution.raw_order = coerce_json_payload(order)
+    execution.raw_order = merge_execution_raw_order_update(
+        execution.raw_order,
+        order,
+        update_key="_broker_reconcile_last_order",
+    )
     execution.last_update_at = datetime.now(timezone.utc)
     return True
-
 
 
 def _update_trade_decision(session: Session, execution: Execution) -> None:

--- a/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
@@ -382,6 +382,61 @@ research_sources:
         asset_scope: us_equities_cross_section
         horizon_scope: statistical_arbitrage_validation
         expected_direction: neutral
+  - source_id: alphacrafter_factor_execution_loop_2026
+    title: 'AlphaCrafter: A Full-Stack Multi-Agent Framework for Cross-Sectional Quantitative Trading'
+    url: https://arxiv.org/abs/2605.05580
+    published_at: '2026-05-07'
+    claims:
+      - claim_id: adaptive_factor_to_execution_loop
+        summary: A profitable cross-sectional trading system should continuously couple factor discovery, regime-conditioned selection, and risk-constrained execution.
+        implication: 'Treat Torghut research candidates as a factor-to-execution loop: mine variants, screen by current regime, then route only bounded paper/live-paper probes with ledger proof.'
+      - claim_id: role_noise_less_useful_than_rational_pipeline
+        summary: The useful multi-agent split is systematic miner/screener/trader specialization, not noisy role-play committees.
+        implication: Keep AgentRuns focused on factor discovery, proof audit, and execution-readiness lanes with explicit artifacts rather than unbounded discussion swarms.
+  - source_id: financial_multi_agent_cost_awareness_2026
+    title: 'Toward Reliable Evaluation of LLM-Based Financial Multi-Agent Systems: Taxonomy, Coordination Primacy, and Cost Awareness'
+    url: https://arxiv.org/abs/2603.27539
+    published_at: '2026-03-29'
+    claims:
+      - claim_id: coordination_breakeven_spread
+        summary: Multi-agent coordination only adds value if it clears its own transaction-cost and coordination-overhead breakeven spread.
+        implication: Rank agent-discovered candidates by post-cost runtime-ledger edge after explicit route/TCA and coordination overhead, not by raw replay alpha.
+      - claim_id: evaluation_failures_reverse_returns
+        summary: Look-ahead bias, survivorship bias, overfitting, transaction-cost neglect, and regime-shift blindness can reverse apparent trading returns.
+        implication: Keep promotion blocked unless source data, replay split, transaction costs, regime stress, and runtime-ledger lineage are all present.
+  - source_id: live_market_agent_arena_2025
+    title: 'When Agents Trade: Live Multi-Market Trading Benchmark for LLM Agents'
+    url: https://arxiv.org/abs/2510.11695
+    published_at: '2025-10-13'
+    claims:
+      - claim_id: live_verified_agent_evaluation
+        summary: Live agent behavior differs materially across frameworks, and verified real-time data is needed to judge trading performance.
+        implication: Prefer live-paper route probes and runtime-ledger proof over static benchmark scores when deciding whether a candidate can advance.
+      - claim_id: framework_risk_style_matters
+        summary: Agent framework risk style can matter more than the model backbone for live trading behavior.
+        implication: Treat Torghut sleeves as risk-policy variants with separate drawdown, concentration, and order-lifecycle evidence rather than one generic model output.
+  - source_id: tradetrap_system_stress_2025
+    title: 'TradeTrap: Are LLM-based Trading Agents Truly Reliable and Faithful?'
+    url: https://arxiv.org/abs/2512.02261
+    published_at: '2025-12-01'
+    claims:
+      - claim_id: component_perturbations_cause_drawdown
+        summary: Small perturbations in market intelligence, strategy formulation, portfolio/ledger handling, or execution can cause concentration and runaway drawdowns.
+        implication: Keep source-activity, ledger, and execution-lifecycle blockers visible per target so a single weak component cannot pass as portfolio readiness.
+      - claim_id: ledger_handling_is_attack_surface
+        summary: Portfolio and ledger handling are first-class reliability surfaces for autonomous trading agents.
+        implication: Runtime-ledger materialization and post-cost proof must remain the promotion authority even for close paper-probation candidates.
+  - source_id: agentic_trading_evidence_ledger_2026
+    title: 'Agentic Trading: When LLM Agents Meet Financial Markets'
+    url: https://arxiv.org/abs/2605.19337
+    published_at: '2026-05-19'
+    claims:
+      - claim_id: evidence_ledger_required_for_reproducibility
+        summary: Current agentic-trading papers have weak reproducibility, sparse cost modeling, and inconsistent execution semantics.
+        implication: Require Torghut proof packets to preserve per-target source activity, runtime-ledger lineage, costs, and execution semantics before any promotion claim.
+      - claim_id: closed_loop_action_output_boundary
+        summary: Closed-loop action outputs and execution semantics are the minimum boundary for empirical trading-agent evidence.
+        implication: Research claims should become bounded executable sleeves and live-paper decisions before they can influence allocation.
   - source_id: asymmetric_ofi_hmm_regime_2025
     title: 'Asymmetric Hidden Markov Modeling of Order Flow Imbalances for Microstructure-Aware Market Regime Detection'
     url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5315733

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -511,6 +511,16 @@ def _paper_route_runtime_window_import_audit_blockers(
     return _text_list(audit.get("blockers"))
 
 
+def _paper_route_runtime_window_import_target_blockers(
+    audit: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    return [
+        {str(key): value for key, value in item.items()}
+        for item in (_mapping(raw) for raw in _sequence(audit.get("target_blockers")))
+        if item
+    ]
+
+
 def _paper_route_source_activity_blockers(
     audit_blockers: Sequence[str],
 ) -> list[str]:
@@ -1263,6 +1273,9 @@ def build_runtime_ledger_proof_packet(
     import_audit_blockers = _paper_route_runtime_window_import_audit_blockers(
         import_audit
     )
+    import_audit_target_blockers = _paper_route_runtime_window_import_target_blockers(
+        import_audit
+    )
     source_activity_blockers = _paper_route_source_activity_blockers(
         import_audit_blockers
     )
@@ -1356,6 +1369,7 @@ def build_runtime_ledger_proof_packet(
             "next_action": _text(import_audit.get("next_action")),
             "import_ready": import_audit.get("import_ready"),
             "blockers": import_audit_blockers,
+            "target_blockers": import_audit_target_blockers,
         },
         expected="paper-route evidence includes runtime_window_import_audit when import is due",
         blockers=[]
@@ -1822,6 +1836,7 @@ def build_runtime_ledger_proof_packet(
                 "next_action": import_audit.get("next_action"),
                 "import_ready": import_audit.get("import_ready"),
                 "blockers": import_audit_blockers,
+                "target_blockers": import_audit_target_blockers,
                 "counts": dict(import_audit_counts),
             },
             "runtime_window_import": {

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -2411,7 +2411,9 @@ def _query_timestamps(
                     oe.source_topic,
                     oe.source_partition,
                     oe.source_offset,
-                    oe.raw_event
+                    oe.raw_event,
+                    e.execution_audit_json,
+                    e.raw_order
                 from execution_order_events oe
                 left join executions e on e.id = oe.execution_id
                 join trade_decisions d
@@ -2451,6 +2453,8 @@ def _query_timestamps(
                     "source_partition": row[12],
                     "source_offset": row[13],
                     "raw_event": row[14],
+                    "execution_audit_json": row[15],
+                    "raw_order": row[16],
                 }
                 for row in cur.fetchall()
                 if row[0] is not None

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -1651,8 +1651,19 @@ def _runtime_window_import_payload_proof_blockers(
         )
 
     evidence_reasons = _as_text_list(payload.get("evidence_blocking_reasons"))
+    runtime_observation = _as_dict(payload.get("runtime_observation"))
+    source_activity_diagnostic_blockers = _as_text_list(
+        payload.get("source_activity_diagnostic_blockers")
+    )
+    if not source_activity_diagnostic_blockers and runtime_observation:
+        source_activity_diagnostic_blockers = _as_text_list(
+            runtime_observation.get("source_activity_diagnostic_blockers")
+        )
     if evidence_reasons:
         for reason in evidence_reasons:
+            add_blocker(reason)
+    elif source_activity_diagnostic_blockers:
+        for reason in source_activity_diagnostic_blockers:
             add_blocker(reason)
     elif payload.get("promotion_allowed") is False:
         if "evidence_blocking_reasons" not in payload:
@@ -1666,7 +1677,6 @@ def _runtime_window_import_payload_proof_blockers(
         else:
             add_blocker("runtime_window_import_promotion_allowed_missing")
 
-    runtime_observation = _as_dict(payload.get("runtime_observation"))
     if not runtime_observation:
         add_blocker("runtime_observation_missing")
     elif runtime_observation.get("authoritative") is not True:

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -802,6 +802,17 @@ class TestRuntimeLedgerProofPacket(TestCase):
                         "source_executions_missing",
                         "source_tca_missing",
                     ],
+                    "target_blockers": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "c88421d619759b2cfaa6f4d0",
+                            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                            "blockers": [
+                                "source_decisions_missing",
+                                "runtime_ledger_bucket_missing",
+                            ],
+                        }
+                    ],
                     "counts": {
                         "source_plan_target_count": 1,
                         "next_runtime_window_target_count": 1,
@@ -843,6 +854,18 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertEqual(
             result["evidence"]["paper_route_runtime_window_import_audit"]["state"],
             "import_due_source_activity_missing",
+        )
+        self.assertEqual(
+            result["evidence"]["paper_route_runtime_window_import_audit"][
+                "target_blockers"
+            ][0]["candidate_id"],
+            "c88421d619759b2cfaa6f4d0",
+        )
+        self.assertEqual(
+            result["checks"]["paper_route_runtime_window_import_audit"]["observed"][
+                "target_blockers"
+            ][0]["paper_route_probe_symbols"],
+            ["AAPL", "AMZN"],
         )
 
     def test_packet_requires_import_audit_when_paper_route_import_is_due(

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -33,6 +33,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _row_payloads,
     _runtime_ledger_bucket_profit_proof_present,
     _runtime_ledger_event_type,
+    _runtime_lifecycle_ledger_row,
     _runtime_ledger_profit_proof_present,
     _runtime_observation_authority_payload,
     _runtime_ledger_target_metadata_blockers,
@@ -110,6 +111,15 @@ class _FakeCursor:
                     {
                         "execution_policy": {"selected_order_type": "market"},
                         "cost_model": {"source": "broker_reported"},
+                    },
+                    {
+                        "cost_amount": "0.01",
+                        "cost_basis": "broker_reported_commission_and_fees",
+                    },
+                    {
+                        "execution_policy_hash": "policy-sha",
+                        "cost_model_hash": "cost-sha",
+                        "lineage_hash": "lineage-sha",
                     },
                 )
             ],
@@ -1656,6 +1666,55 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["blockers"], [])
         self.assertEqual(bucket["source_materialization"], "execution_order_events")
 
+    def test_order_event_lifecycle_uses_execution_raw_order_metadata(self) -> None:
+        row = {
+            "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+            "event_type": "filled",
+            "symbol": "AAPL",
+            "account_label": "TORGHUT_SIM",
+            "strategy_id": "microbar-cross-sectional-pairs-v1",
+            "decision_hash": "decision-buy",
+            "alpaca_order_id": "order-buy",
+            "raw_event": {
+                "event": "fill",
+                "order": {
+                    "id": "order-buy",
+                    "status": "filled",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100",
+                },
+            },
+            "execution_audit_json": {
+                "execution_policy_hash": "policy-sha",
+                "cost_model_hash": "cost-sha",
+                "lineage_hash": "lineage-sha",
+            },
+            "raw_order": {
+                "side": "buy",
+                "runtime_ledger_cost": {
+                    "cost_amount": "0.20",
+                    "cost_basis": "modeled_paper_cost_budget",
+                },
+            },
+        }
+
+        ledger_row = _runtime_lifecycle_ledger_row(
+            row,
+            event_type="filled",
+            require_complete_fill=True,
+        )
+
+        self.assertIsNotNone(ledger_row)
+        assert ledger_row is not None
+        self.assertEqual(ledger_row["side"], "buy")
+        self.assertEqual(ledger_row["filled_qty"], Decimal("1"))
+        self.assertEqual(ledger_row["avg_fill_price"], Decimal("100"))
+        self.assertEqual(ledger_row["cost_amount"], Decimal("0.20"))
+        self.assertEqual(ledger_row["cost_basis"], "modeled_paper_cost_budget")
+        self.assertEqual(ledger_row["execution_policy_hash"], "policy-sha")
+        self.assertEqual(ledger_row["cost_model_hash"], "cost-sha")
+        self.assertEqual(ledger_row["lineage_hash"], "lineage-sha")
+
     def test_runtime_ledger_tca_materialization_metadata_separates_authority(
         self,
     ) -> None:
@@ -2211,6 +2270,8 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertNotIn("and d.created_at < %s", execution_query)
         self.assertIn("from execution_order_events oe", order_event_query)
         self.assertIn("oe.alpaca_account_label = %s", order_event_query)
+        self.assertIn("e.execution_audit_json", order_event_query)
+        self.assertIn("e.raw_order", order_event_query)
         self.assertIn("coalesce(oe.event_ts, oe.created_at) >= %s", order_event_query)
         self.assertIn("coalesce(oe.event_ts, oe.created_at) < %s", order_event_query)
         self.assertNotIn("and d.created_at >= %s", order_event_query)
@@ -2398,6 +2459,15 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                         "execution_policy": {"selected_order_type": "market"},
                         "cost_model": {"source": "broker_reported"},
                     },
+                    {
+                        "execution_policy_hash": "policy-sha",
+                        "cost_model_hash": "cost-sha",
+                        "lineage_hash": "lineage-sha",
+                    },
+                    {
+                        "cost_amount": "0.01",
+                        "cost_basis": "broker_reported_commission_and_fees",
+                    },
                 ),
                 (
                     datetime(2026, 3, 6, 14, 36, 1, tzinfo=timezone.utc),
@@ -2414,6 +2484,8 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "alpaca-trade-updates",
                     0,
                     2,
+                    {},
+                    {},
                     {},
                 ),
             ],

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -26,6 +26,7 @@ from app.models import (
 from app.trading.order_feed import (
     OrderFeedIngestor,
     apply_order_event_to_execution,
+    merge_execution_raw_order_update,
     normalize_order_feed_record,
     persist_order_event,
 )
@@ -407,6 +408,113 @@ class TestOrderFeed(TestCase):
             self.assertTrue(out_of_order)
             self.assertEqual(execution.status, "filled")
             self.assertEqual(execution.filled_qty, Decimal("1"))
+
+    def test_order_feed_update_preserves_submit_audit_and_cost_metadata(self) -> None:
+        with Session(self.engine) as session:
+            execution = self._seed_execution(session)
+            execution.raw_order = {
+                "id": "order-1",
+                "status": "accepted",
+                "_execution_audit": {
+                    "execution_policy_hash": "policy-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                "runtime_ledger_cost": {
+                    "cost_amount": "0.20",
+                    "cost_basis": "modeled_paper_cost_budget",
+                },
+                "cost_amount": "0.20",
+                "cost_basis": "modeled_paper_cost_budget",
+                "execution_policy": {"max_order_notional": "1000"},
+            }
+            event = ExecutionOrderEvent(
+                event_fingerprint="fill-event",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=101,
+                alpaca_account_label="paper",
+                feed_seq=31,
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id="order-1",
+                client_order_id="client-1",
+                event_type="fill",
+                status="filled",
+                qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("190.2"),
+                raw_event={
+                    "event": "fill",
+                    "order": {
+                        "id": "order-1",
+                        "status": "filled",
+                        "filled_qty": "1",
+                        "filled_avg_price": "190.2",
+                    },
+                },
+                execution_id=execution.id,
+            )
+            session.add(event)
+            session.flush()
+
+            updated, out_of_order = apply_order_event_to_execution(execution, event)
+
+            self.assertTrue(updated)
+            self.assertFalse(out_of_order)
+            assert isinstance(execution.raw_order, dict)
+            self.assertEqual(
+                execution.raw_order["_execution_audit"]["execution_policy_hash"],
+                "policy-sha",
+            )
+            self.assertEqual(
+                execution.raw_order["runtime_ledger_cost"]["cost_basis"],
+                "modeled_paper_cost_budget",
+            )
+            self.assertEqual(execution.raw_order["cost_amount"], "0.20")
+            self.assertEqual(execution.raw_order["status"], "accepted")
+            self.assertEqual(
+                execution.raw_order["_order_feed_last_event"]["order"]["status"],
+                "filled",
+            )
+
+    def test_merge_execution_raw_order_update_preserves_existing_keys(self) -> None:
+        merged = merge_execution_raw_order_update(
+            {
+                "id": "order-1",
+                "status": "accepted",
+                "cost_amount": "0.20",
+            },
+            {"status": "filled", "filled_qty": "1"},
+            update_key="_broker_reconcile_last_order",
+        )
+
+        self.assertIsInstance(merged, dict)
+        assert isinstance(merged, dict)
+        self.assertEqual(merged["status"], "accepted")
+        self.assertEqual(merged["cost_amount"], "0.20")
+        self.assertEqual(merged["filled_qty"], "1")
+        self.assertEqual(merged["_broker_reconcile_last_order"]["status"], "filled")
+
+    def test_ingestor_refreshes_tca_after_order_feed_fill_update(self) -> None:
+        payload = (
+            b'{"channel":"trade_updates","payload":{"event":"fill","timestamp":"2026-02-01T10:00:00Z",'
+            b'"order":{"id":"order-1","client_order_id":"client-1","symbol":"AAPL","status":"filled",'
+            b'"qty":"1","filled_qty":"1","filled_avg_price":"190.2"}},"seq":31}'
+        )
+        consumer = FakeConsumer([FakeRecord(value=payload, offset=101)])
+        ingestor = OrderFeedIngestor(consumer_factory=lambda: consumer)
+
+        with Session(self.engine) as session:
+            execution = self._seed_execution(session)
+
+            with patch("app.trading.order_feed.upsert_execution_tca_metric") as upsert:
+                counters = ingestor.ingest_once(session)
+                session.refresh(execution)
+
+            self.assertEqual(counters["events_persisted_total"], 1)
+            self.assertEqual(counters["apply_updates_total"], 1)
+            self.assertEqual(execution.status, "filled")
+            upsert.assert_called_once()
 
     def test_ingestor_counts_out_of_order_updates(self) -> None:
         payload = (

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -365,6 +365,30 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(import_audit["counts"]["source_plan_target_count"], 2)
         self.assertEqual(import_audit["counts"]["selected_target_count"], 1)
         self.assertEqual(import_audit["counts"]["next_runtime_window_target_count"], 1)
+        self.assertEqual(
+            import_audit["diagnostics"]["target_blockers_effective_when"],
+            "runtime_window_import_ready",
+        )
+        self.assertEqual(len(import_audit["target_blockers"]), 1)
+        target_blocker = import_audit["target_blockers"][0]
+        self.assertEqual(target_blocker["candidate_id"], "candidate-paper-route")
+        self.assertEqual(target_blocker["hypothesis_id"], "H-PAPER-ROUTE")
+        self.assertEqual(target_blocker["paper_route_probe_symbols"], ["AAPL"])
+        self.assertEqual(
+            target_blocker["source_activity"],
+            {
+                "decision_count": 0,
+                "execution_count": 0,
+                "filled_execution_count": 0,
+                "tca_sample_count": 0,
+                "last_decision_at": None,
+                "last_execution_at": None,
+                "last_tca_at": None,
+            },
+        )
+        self.assertIn("source_decisions_missing", target_blocker["blockers"])
+        self.assertIn("runtime_ledger_bucket_missing", target_blocker["blockers"])
+        self.assertIn("promotion_decision_missing", target_blocker["blockers"])
         self.assertFalse(import_audit["promotion_authority"]["allowed"])
         proof_handoff = payload["runtime_ledger_proof_packet_handoff"]
         self.assertEqual(

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -3233,6 +3233,52 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             ],
         )
 
+    def test_runtime_window_import_payload_promotes_source_diagnostics_to_blockers(
+        self,
+    ) -> None:
+        target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="cand-paper-route",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            strategy_name="paper-route-candidate-v1",
+            account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="",
+            source_manifest_ref="manifest.json",
+            source_kind="paper_route_probe_runtime_observed",
+            delay_adjusted_depth_stress_report_ref="",
+        )
+
+        blockers = renewal._runtime_window_import_payload_proof_blockers(
+            payload={
+                "promotion_allowed": False,
+                "promotion_blocking_reasons": ["generic_not_allowed"],
+                "source_activity_diagnostic_blockers": [
+                    "source_lineage_filter_excluded_activity",
+                    "order_feed_fill_lifecycle_missing",
+                ],
+                "runtime_observation": {
+                    "authoritative": False,
+                    "authority_reason": "runtime_without_runtime_ledger_profit_proof",
+                },
+            },
+            target=target,
+            candidate_id="cand-paper-route",
+            window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+            window_end=datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(
+            [item["blocker"] for item in blockers],
+            [
+                "source_lineage_filter_excluded_activity",
+                "order_feed_fill_lifecycle_missing",
+                "runtime_without_runtime_ledger_profit_proof",
+            ],
+        )
+        self.assertNotIn("generic_not_allowed", [item["blocker"] for item in blockers])
+
     def test_runtime_window_import_payload_deduplicates_fallback_blockers(
         self,
     ) -> None:

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -5110,6 +5110,11 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertIn("idiosyncratic_trade_imbalance_2026", source_ids)
         self.assertIn("intraday_price_asymmetry_sp500_2026", source_ids)
         self.assertIn("market_depth_execution_delays_2026", source_ids)
+        self.assertIn("alphacrafter_factor_execution_loop_2026", source_ids)
+        self.assertIn("financial_multi_agent_cost_awareness_2026", source_ids)
+        self.assertIn("live_market_agent_arena_2025", source_ids)
+        self.assertIn("tradetrap_system_stress_2025", source_ids)
+        self.assertIn("agentic_trading_evidence_ledger_2026", source_ids)
 
         weighted_microprice = next(
             source
@@ -5156,6 +5161,19 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         book_claim_types = {str(claim["claim_type"]) for claim in book_source.claims}
         self.assertIn("feature_recipe", book_claim_types)
         self.assertIn("validation_requirement", book_claim_types)
+
+        agentic_ledger_source = next(
+            source
+            for source in sources
+            if source.run_id == "agentic_trading_evidence_ledger_2026"
+        )
+        self.assertEqual(
+            {claim["claim_id"] for claim in agentic_ledger_source.claims},
+            {
+                "evidence_ledger_required_for_reproducibility",
+                "closed_loop_action_output_boundary",
+            },
+        )
 
         depth_delay_source = next(
             source

--- a/services/torghut/tests/test_strategy_autoresearch.py
+++ b/services/torghut/tests/test_strategy_autoresearch.py
@@ -1983,6 +1983,11 @@ class TestStrategyAutoresearch(TestCase):
                 "idiosyncratic_trade_imbalance_2026",
                 "intraday_price_asymmetry_sp500_2026",
                 "market_depth_execution_delays_2026",
+                "alphacrafter_factor_execution_loop_2026",
+                "financial_multi_agent_cost_awareness_2026",
+                "live_market_agent_arena_2025",
+                "tradetrap_system_stress_2025",
+                "agentic_trading_evidence_ledger_2026",
             }.issubset(source_ids)
         )
         impact_source = next(


### PR DESCRIPTION
## Summary

- Adds per-target paper-route runtime-window blockers so selected targets expose missing source activity, runtime-ledger buckets, evidence-grade buckets, promotion decisions, filled notional, closed trades, and post-cost PnL fields.
- Carries target blockers into runtime-ledger proof packets and promotes source-activity diagnostics ahead of generic promotion fallback reasons.
- Preserves submit-time execution audit, cost, policy, and lineage metadata when order-feed or broker reconciliation updates arrive, while storing the latest update payload separately.
- Refreshes TCA after order-feed execution updates and lets runtime-window order-event imports inherit execution audit/raw-order context for lifecycle materialization.
- Refreshes the profit-autoresearch source list with recent 2025-2026 research entries.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen python -m pytest tests/test_order_feed.py tests/test_import_hypothesis_runtime_windows.py tests/test_paper_route_evidence.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_run_empirical_promotion_jobs.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_strategy_autoresearch.py -q`
- `uv run --frozen ruff check app/trading/order_feed.py app/trading/reconcile.py scripts/import_hypothesis_runtime_windows.py tests/test_order_feed.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff format --check app/trading/order_feed.py app/trading/reconcile.py scripts/import_hypothesis_runtime_windows.py tests/test_order_feed.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py scripts/assemble_runtime_ledger_proof_packet.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_strategy_autoresearch.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py scripts/assemble_runtime_ledger_proof_packet.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py tests/test_run_whitepaper_autoresearch_profit_target.py tests/test_strategy_autoresearch.py`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
