### PR TITLE
fix(torghut): block modeled cost promotion proof

### DIFF
--- a/services/torghut/app/snapshots.py
+++ b/services/torghut/app/snapshots.py
@@ -45,6 +45,15 @@ _RUNTIME_COST_MODEL_PAYLOAD_FIELDS = (
     "fee_model",
     "market_impact_cost_model",
 )
+_AUTHORITATIVE_EXISTING_COST_SOURCES = frozenset(
+    {
+        "broker_order_response",
+        "broker_reported_order_response",
+        "alpaca_broker_order_response",
+        "runtime_order_feed",
+        "broker_reconciliation",
+    }
+)
 _BROKER_COST_BASIS_BY_FIELD = {
     "commission": "broker_reported_commission",
     "fees": "broker_reported_fees",
@@ -109,6 +118,10 @@ def sync_order_to_db(
         alpaca_account_label=alpaca_account_label,
         order_response=order_response,
     )
+    account_label_explicit = _account_label_explicit(
+        alpaca_account_label=alpaca_account_label,
+        order_response=order_response,
+    )
     client_order_id = order_response.get("client_order_id")
     existing = _find_existing_execution(
         session=session,
@@ -122,6 +135,7 @@ def sync_order_to_db(
         order_response=order_response,
         trade_decision_id=trade_decision_id,
         account_label=account_label,
+        account_label_explicit=account_label_explicit,
         alpaca_order_id=alpaca_order_id,
         resolved_expected_adapter=resolved_expected_adapter,
         resolved_actual_adapter=resolved_actual_adapter,
@@ -201,10 +215,29 @@ def _resolve_account_label(
     alpaca_account_label: str | None,
     order_response: dict[str, Any],
 ) -> str:
-    account_label = alpaca_account_label or order_response.get("alpaca_account_label")
+    account_label = (
+        alpaca_account_label
+        or order_response.get("alpaca_account_label")
+        or order_response.get("account_label")
+    )
     if not account_label:
         return "paper"
     return str(account_label)
+
+
+def _account_label_explicit(
+    *,
+    alpaca_account_label: str | None,
+    order_response: Mapping[str, Any],
+) -> bool:
+    return any(
+        _coerce_text(value) is not None
+        for value in (
+            alpaca_account_label,
+            order_response.get("alpaca_account_label"),
+            order_response.get("account_label"),
+        )
+    )
 
 
 def _find_existing_execution(
@@ -242,6 +275,7 @@ def _build_execution_payload(
     order_response: dict[str, Any],
     trade_decision_id: str | None,
     account_label: str,
+    account_label_explicit: bool,
     alpaca_order_id: Any,
     resolved_expected_adapter: str,
     resolved_actual_adapter: str,
@@ -279,6 +313,8 @@ def _build_execution_payload(
         raw_order_payload["simulation_context"] = simulation_context
     _attach_runtime_ledger_cost_payload(
         order_response=order_response,
+        account_label=account_label,
+        account_label_explicit=account_label_explicit,
         audit_payload=audit_payload,
         raw_order_payload=raw_order_payload,
     )
@@ -330,6 +366,8 @@ def _persist_existing_execution(
 def _attach_runtime_ledger_cost_payload(
     *,
     order_response: Mapping[str, Any],
+    account_label: str,
+    account_label_explicit: bool,
     audit_payload: dict[str, Any],
     raw_order_payload: dict[str, Any],
 ) -> None:
@@ -341,21 +379,39 @@ def _attach_runtime_ledger_cost_payload(
         )
     if cost_payload is None and _modeled_paper_cost_allowed(
         order_response=order_response,
+        account_label=account_label,
+        account_label_explicit=account_label_explicit,
         audit_payload=audit_payload,
     ):
-        cost_payload = _runtime_ledger_cost_payload_from_cost_model(
+        modeled_cost_payload = _runtime_ledger_cost_payload_from_cost_model(
             order_response=order_response,
             audit_payload=audit_payload,
         )
+        if modeled_cost_payload is not None:
+            audit_payload.setdefault(
+                "modeled_paper_cost_estimate", modeled_cost_payload
+            )
+            raw_order_payload.setdefault(
+                "modeled_paper_cost_estimate", modeled_cost_payload
+            )
+        return
     if cost_payload is None:
         return
 
-    audit_payload.setdefault("runtime_ledger_cost", cost_payload)
-    raw_order_payload.setdefault("runtime_ledger_cost", cost_payload)
-    audit_payload.setdefault("cost_amount", cost_payload["cost_amount"])
-    audit_payload.setdefault("cost_basis", cost_payload["cost_basis"])
-    raw_order_payload.setdefault("cost_amount", cost_payload["cost_amount"])
-    raw_order_payload.setdefault("cost_basis", cost_payload["cost_basis"])
+    if cost_payload.get("source") == "broker_order_response":
+        audit_payload["runtime_ledger_cost"] = cost_payload
+        raw_order_payload["runtime_ledger_cost"] = cost_payload
+        audit_payload["cost_amount"] = cost_payload["cost_amount"]
+        audit_payload["cost_basis"] = cost_payload["cost_basis"]
+        raw_order_payload["cost_amount"] = cost_payload["cost_amount"]
+        raw_order_payload["cost_basis"] = cost_payload["cost_basis"]
+    else:
+        audit_payload.setdefault("runtime_ledger_cost", cost_payload)
+        raw_order_payload.setdefault("runtime_ledger_cost", cost_payload)
+        audit_payload.setdefault("cost_amount", cost_payload["cost_amount"])
+        audit_payload.setdefault("cost_basis", cost_payload["cost_basis"])
+        raw_order_payload.setdefault("cost_amount", cost_payload["cost_amount"])
+        raw_order_payload.setdefault("cost_basis", cost_payload["cost_basis"])
 
     fee_model = {
         "source": cost_payload.get("source", "broker_order_response"),
@@ -379,7 +435,7 @@ def _runtime_ledger_cost_payload_from_order(
 def _runtime_ledger_cost_payload_from_existing_metadata(
     *payloads: Mapping[str, Any],
 ) -> dict[str, str] | None:
-    for payload in _iter_nested_mappings(*payloads):
+    for payload in payloads:
         for key in ("runtime_ledger_cost", "execution_cost", "explicit_execution_cost"):
             nested = payload.get(key)
             if not isinstance(nested, Mapping):
@@ -390,10 +446,13 @@ def _runtime_ledger_cost_payload_from_existing_metadata(
             }
             cost_payload = _runtime_cost_payload_from_mapping(
                 nested_payload,
-                source="execution_audit_cost_payload",
+                source=str(nested_payload.get("source") or ""),
                 source_field_prefix=f"{key}.",
             )
-            if cost_payload is not None:
+            if (
+                cost_payload is not None
+                and cost_payload["source"] in _AUTHORITATIVE_EXISTING_COST_SOURCES
+            ):
                 return cost_payload
     return None
 
@@ -470,8 +529,20 @@ def _runtime_cost_payload_from_mapping(
 def _modeled_paper_cost_allowed(
     *,
     order_response: Mapping[str, Any],
+    account_label: str,
+    account_label_explicit: bool,
     audit_payload: Mapping[str, Any],
 ) -> bool:
+    resolved_label = account_label.strip().lower()
+    if not account_label_explicit:
+        return False
+    if "live" in resolved_label:
+        return False
+    if resolved_label == "paper":
+        return False
+    if not any(token in resolved_label for token in ("paper", "sim", "simulation")):
+        return False
+
     markers: list[str] = []
     for payload in _iter_nested_mappings(order_response, audit_payload, max_depth=2):
         for key in (

--- a/services/torghut/app/snapshots.py
+++ b/services/torghut/app/snapshots.py
@@ -38,6 +38,13 @@ _RUNTIME_COST_BASIS_FIELDS = (
     "commission_basis",
     "broker_fee_basis",
 )
+_RUNTIME_COST_MODEL_PAYLOAD_FIELDS = (
+    "cost_model",
+    "cost_model_config",
+    "transaction_cost_model",
+    "fee_model",
+    "market_impact_cost_model",
+)
 _BROKER_COST_BASIS_BY_FIELD = {
     "commission": "broker_reported_commission",
     "fees": "broker_reported_fees",
@@ -328,6 +335,19 @@ def _attach_runtime_ledger_cost_payload(
 ) -> None:
     cost_payload = _runtime_ledger_cost_payload_from_order(order_response)
     if cost_payload is None:
+        cost_payload = _runtime_ledger_cost_payload_from_existing_metadata(
+            audit_payload,
+            raw_order_payload,
+        )
+    if cost_payload is None and _modeled_paper_cost_allowed(
+        order_response=order_response,
+        audit_payload=audit_payload,
+    ):
+        cost_payload = _runtime_ledger_cost_payload_from_cost_model(
+            order_response=order_response,
+            audit_payload=audit_payload,
+        )
+    if cost_payload is None:
         return
 
     audit_payload.setdefault("runtime_ledger_cost", cost_payload)
@@ -338,7 +358,7 @@ def _attach_runtime_ledger_cost_payload(
     raw_order_payload.setdefault("cost_basis", cost_payload["cost_basis"])
 
     fee_model = {
-        "source": "broker_order_response",
+        "source": cost_payload.get("source", "broker_order_response"),
         "source_field": cost_payload["source_field"],
         "cost_basis": cost_payload["cost_basis"],
     }
@@ -349,9 +369,90 @@ def _attach_runtime_ledger_cost_payload(
 def _runtime_ledger_cost_payload_from_order(
     order_response: Mapping[str, Any],
 ) -> dict[str, str] | None:
-    basis = _first_text(order_response, *_RUNTIME_COST_BASIS_FIELDS)
+    return _runtime_cost_payload_from_mapping(
+        order_response,
+        source="broker_order_response",
+        source_field_prefix="",
+    )
+
+
+def _runtime_ledger_cost_payload_from_existing_metadata(
+    *payloads: Mapping[str, Any],
+) -> dict[str, str] | None:
+    for payload in _iter_nested_mappings(*payloads):
+        for key in ("runtime_ledger_cost", "execution_cost", "explicit_execution_cost"):
+            nested = payload.get(key)
+            if not isinstance(nested, Mapping):
+                continue
+            nested_payload = {
+                str(item_key): item
+                for item_key, item in cast(Mapping[object, Any], nested).items()
+            }
+            cost_payload = _runtime_cost_payload_from_mapping(
+                nested_payload,
+                source="execution_audit_cost_payload",
+                source_field_prefix=f"{key}.",
+            )
+            if cost_payload is not None:
+                return cost_payload
+    return None
+
+
+def _runtime_ledger_cost_payload_from_cost_model(
+    *,
+    order_response: Mapping[str, Any],
+    audit_payload: Mapping[str, Any],
+) -> dict[str, str] | None:
+    for model_key, payload in _iter_cost_model_payloads(audit_payload, order_response):
+        estimate = payload.get("estimate")
+        if not isinstance(estimate, Mapping):
+            continue
+        estimate_payload = {
+            str(key): value
+            for key, value in cast(Mapping[object, Any], estimate).items()
+        }
+        total_cost = _optional_decimal(
+            estimate_payload.get("total_cost")
+            or estimate_payload.get("estimated_total_cost")
+            or estimate_payload.get("modeled_total_cost")
+        )
+        source_field = f"{model_key}.estimate.total_cost"
+        if total_cost is None:
+            total_cost_bps = _optional_decimal(
+                estimate_payload.get("total_cost_bps")
+                or estimate_payload.get("estimated_total_cost_bps")
+            )
+            notional = _optional_decimal(
+                estimate_payload.get("notional") or payload.get("notional")
+            )
+            if (
+                total_cost_bps is not None
+                and total_cost_bps >= 0
+                and notional is not None
+                and notional > 0
+            ):
+                total_cost = notional * total_cost_bps / Decimal("10000")
+                source_field = f"{model_key}.estimate.total_cost_bps"
+        if total_cost is None or total_cost < 0:
+            continue
+        return {
+            "cost_amount": str(total_cost),
+            "cost_basis": "modeled_paper_cost_budget",
+            "source_field": source_field,
+            "source": "paper_cost_model_estimate",
+        }
+    return None
+
+
+def _runtime_cost_payload_from_mapping(
+    payload: Mapping[str, Any],
+    *,
+    source: str,
+    source_field_prefix: str,
+) -> dict[str, str] | None:
+    basis = _first_text(payload, *_RUNTIME_COST_BASIS_FIELDS)
     for amount_key in _RUNTIME_COST_AMOUNT_FIELDS:
-        amount = _optional_decimal(order_response.get(amount_key))
+        amount = _optional_decimal(payload.get(amount_key))
         if amount is None or amount < 0:
             continue
         resolved_basis = basis or _BROKER_COST_BASIS_BY_FIELD.get(amount_key)
@@ -360,9 +461,86 @@ def _runtime_ledger_cost_payload_from_order(
         return {
             "cost_amount": str(amount),
             "cost_basis": resolved_basis,
-            "source_field": amount_key,
+            "source_field": f"{source_field_prefix}{amount_key}",
+            "source": source,
         }
     return None
+
+
+def _modeled_paper_cost_allowed(
+    *,
+    order_response: Mapping[str, Any],
+    audit_payload: Mapping[str, Any],
+) -> bool:
+    markers: list[str] = []
+    for payload in _iter_nested_mappings(order_response, audit_payload, max_depth=2):
+        for key in (
+            "alpaca_account_label",
+            "account_label",
+            "execution_lane",
+            "submit_path",
+            "adapter",
+            "execution_adapter",
+            "_execution_adapter",
+            "_execution_route_actual",
+        ):
+            text = _coerce_text(payload.get(key))
+            if text is not None:
+                markers.append(text.lower())
+
+    if any("live" in marker and "paper" not in marker for marker in markers):
+        return False
+    if any(
+        token in marker
+        for marker in markers
+        for token in ("paper", "sim", "simulation", "route_probe", "dry_run", "shadow")
+    ):
+        return True
+    return False
+
+
+def _iter_cost_model_payloads(
+    *values: object,
+) -> list[tuple[str, dict[str, Any]]]:
+    payloads: list[tuple[str, dict[str, Any]]] = []
+    for payload in _iter_nested_mappings(*values, max_depth=3):
+        for key in _RUNTIME_COST_MODEL_PAYLOAD_FIELDS:
+            nested = payload.get(key)
+            if not isinstance(nested, Mapping):
+                continue
+            payloads.append(
+                (
+                    key,
+                    {
+                        str(item_key): item
+                        for item_key, item in cast(Mapping[object, Any], nested).items()
+                    },
+                )
+            )
+    return payloads
+
+
+def _iter_nested_mappings(
+    *values: object,
+    max_depth: int = 4,
+) -> list[dict[str, Any]]:
+    mappings: list[dict[str, Any]] = []
+
+    def append(value: object, *, depth: int) -> None:
+        if not isinstance(value, Mapping):
+            return
+        payload = {
+            str(key): item for key, item in cast(Mapping[object, Any], value).items()
+        }
+        mappings.append(payload)
+        if depth <= 0:
+            return
+        for child in payload.values():
+            append(child, depth=depth - 1)
+
+    for value in values:
+        append(value, depth=max_depth)
+    return mappings
 
 
 def _preserve_existing_execution_audit(

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -36,6 +36,13 @@ PROMOTION_GRADE_POST_COST_BASES = frozenset(
         "realized_strategy_pnl_after_explicit_costs",
     }
 )
+NON_PROMOTION_GRADE_RUNTIME_COST_BASES = frozenset(
+    {
+        "modeled_paper_cost_budget",
+        "paper_cost_model_estimate",
+        "decision_impact_assumptions_total_cost_bps",
+    }
+)
 _RUNTIME_LEDGER_PROOF_SATISFIED_METADATA_BLOCKERS = frozenset(
     {
         "paper_route_runtime_ledger_import_pending",
@@ -250,6 +257,16 @@ def _hash_count(value: Any) -> int:
     return sum(1 for key in mapping.keys() if str(key).strip())
 
 
+def _cost_basis_counts_have_non_promotion_grade_costs(value: Any) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    return any(
+        str(key).strip() in NON_PROMOTION_GRADE_RUNTIME_COST_BASES
+        and _observation_int(count) > 0
+        for key, count in cast(Mapping[object, object], value).items()
+    )
+
+
 def _persisted_runtime_ledger_bucket_evidence_grade(
     row: StrategyRuntimeLedgerBucket,
 ) -> bool:
@@ -265,6 +282,9 @@ def _persisted_runtime_ledger_bucket_evidence_grade(
         and _hash_count(row.execution_policy_hash_counts) > 0
         and _hash_count(row.cost_model_hash_counts) > 0
         and _hash_count(row.lineage_hash_counts) > 0
+        and not _cost_basis_counts_have_non_promotion_grade_costs(
+            _mapping(row.payload_json).get("cost_basis_counts")
+        )
         and not blockers
     )
 
@@ -301,6 +321,14 @@ def _runtime_ledger_bucket_blockers(bucket: Mapping[str, Any]) -> list[str]:
         blockers.append("filled_notional_missing")
     if cost_amount is None or cost_amount < 0:
         blockers.append("explicit_cost_missing")
+    non_promotion_grade_cost_basis = (
+        str(bucket.get("cost_basis") or "").strip()
+        in NON_PROMOTION_GRADE_RUNTIME_COST_BASES
+    ) or _cost_basis_counts_have_non_promotion_grade_costs(
+        bucket.get("cost_basis_counts")
+    )
+    if non_promotion_grade_cost_basis:
+        blockers.append("runtime_ledger_cost_basis_non_promotion_grade")
     if post_cost_expectancy is None:
         blockers.append("runtime_ledger_expectancy_missing")
     if _hash_count(bucket.get("execution_policy_hash_counts")) <= 0:

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -55,6 +55,13 @@ RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
         "torghut.runtime-ledger-bucket.v1",
     }
 )
+NON_PROMOTION_GRADE_RUNTIME_COST_BASES = frozenset(
+    {
+        "modeled_paper_cost_budget",
+        "paper_cost_model_estimate",
+        "decision_impact_assumptions_total_cost_bps",
+    }
+)
 EXACT_REPLAY_ARTIFACT_AUTHORITY_CLASS = "exact_replay_artifact_only_not_live"
 EXACT_REPLAY_ARTIFACT_AUTHORITY_BLOCKERS = (
     "exact_replay_artifact_not_runtime_proof",
@@ -396,6 +403,16 @@ def _mapping_hash_count(value: object) -> int:
     return sum(1 for key in value.keys() if str(key).strip())
 
 
+def _cost_basis_counts_have_non_promotion_grade_costs(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    return any(
+        str(key).strip() in NON_PROMOTION_GRADE_RUNTIME_COST_BASES
+        and _nonnegative_int(count) > 0
+        for key, count in cast(Mapping[object, object], value).items()
+    )
+
+
 def _runtime_ledger_bucket_profit_proof_present(
     bucket: Mapping[str, object],
 ) -> bool:
@@ -423,6 +440,15 @@ def _runtime_ledger_bucket_profit_proof_present(
     if filled_notional is None or filled_notional <= 0:
         return False
     if cost_amount is None or cost_amount < 0:
+        return False
+    if (
+        str(bucket.get("cost_basis") or "").strip()
+        in NON_PROMOTION_GRADE_RUNTIME_COST_BASES
+    ):
+        return False
+    if _cost_basis_counts_have_non_promotion_grade_costs(
+        bucket.get("cost_basis_counts")
+    ):
         return False
     if post_cost_expectancy is None:
         return False

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -495,6 +495,21 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     )
                 )
 
+    def test_runtime_ledger_profit_proof_rejects_modeled_cost_basis(
+        self,
+    ) -> None:
+        for overrides in (
+            {"cost_basis": "modeled_paper_cost_budget"},
+            {"cost_basis_counts": {"modeled_paper_cost_budget": 1}},
+            {"cost_basis_counts": {"decision_impact_assumptions_total_cost_bps": 2}},
+        ):
+            with self.subTest(overrides=overrides):
+                self.assertFalse(
+                    _runtime_ledger_bucket_profit_proof_present(
+                        _complete_runtime_ledger_bucket(**overrides)
+                    )
+                )
+
     def test_runtime_ledger_tca_rows_from_durable_buckets_queries_matching_proof(
         self,
     ) -> None:

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -24,6 +24,7 @@ from app.trading.runtime_window_import import (
     _observation_decimal,
     _observation_int,
     _parse_observation_datetime,
+    _persisted_runtime_ledger_bucket_evidence_grade,
     _runtime_ledger_bucket_blockers,
     _runtime_ledger_bucket_payloads,
     _runtime_ledger_daily_summary_from_observed_buckets,
@@ -358,6 +359,63 @@ class TestRuntimeWindowImport(TestCase):
         self.assertIn("runtime_ledger_execution_policy_hash_missing", invalid_blockers)
         self.assertIn("runtime_ledger_cost_model_hash_missing", invalid_blockers)
         self.assertIn("runtime_ledger_lineage_hash_missing", invalid_blockers)
+
+    def test_runtime_ledger_bucket_blockers_reject_non_promotion_grade_cost_basis(
+        self,
+    ) -> None:
+        blockers = _runtime_ledger_bucket_blockers(
+            {
+                "ledger_schema_version": "torghut.runtime-ledger-bucket.v1",
+                "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
+                "fill_count": 2,
+                "decision_count": 2,
+                "submitted_order_count": 2,
+                "closed_trade_count": 1,
+                "open_position_count": 0,
+                "filled_notional": "200",
+                "cost_amount": "0.20",
+                "cost_basis_counts": {"modeled_paper_cost_budget": 2},
+                "post_cost_expectancy_bps": "40",
+                "execution_policy_hash_counts": {"policy-sha": 2},
+                "cost_model_hash_counts": {"cost-sha": 2},
+                "lineage_hash_counts": {"lineage-sha": 2},
+            }
+        )
+
+        self.assertEqual(blockers, ["runtime_ledger_cost_basis_non_promotion_grade"])
+
+    def test_persisted_runtime_ledger_bucket_evidence_grade_rejects_modeled_cost_basis(
+        self,
+    ) -> None:
+        row = StrategyRuntimeLedgerBucket(
+            run_id="run-modeled-cost",
+            candidate_id="cand",
+            hypothesis_id="hyp",
+            observed_stage="paper",
+            bucket_started_at=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+            bucket_ended_at=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+            account_label="TORGHUT_SIM",
+            runtime_strategy_name="strategy",
+            fill_count=2,
+            decision_count=2,
+            submitted_order_count=2,
+            closed_trade_count=1,
+            open_position_count=0,
+            filled_notional=Decimal("200"),
+            gross_strategy_pnl=Decimal("1"),
+            cost_amount=Decimal("0.20"),
+            net_strategy_pnl_after_costs=Decimal("0.80"),
+            post_cost_expectancy_bps=Decimal("40"),
+            pnl_basis="realized_strategy_pnl_after_explicit_costs",
+            ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+            execution_policy_hash_counts={"policy-sha": 2},
+            cost_model_hash_counts={"cost-sha": 2},
+            lineage_hash_counts={"lineage-sha": 2},
+            blockers_json=[],
+            payload_json={"cost_basis_counts": {"modeled_paper_cost_budget": 2}},
+        )
+
+        self.assertFalse(_persisted_runtime_ledger_bucket_evidence_grade(row))
 
     def test_runtime_ledger_bucket_payloads_accept_single_bucket_payload(
         self,

--- a/services/torghut/tests/test_snapshot_runtime_cost_coverage.py
+++ b/services/torghut/tests/test_snapshot_runtime_cost_coverage.py
@@ -37,6 +37,7 @@ class TestSnapshotRuntimeCostCoverage(TestCase):
                 "cost_amount": "0.25",
                 "cost_basis": "broker_reported_fees",
                 "source_field": "cost_amount",
+                "source": "broker_order_response",
             },
         )
 
@@ -54,6 +55,7 @@ class TestSnapshotRuntimeCostCoverage(TestCase):
                 "cost_amount": "0",
                 "cost_basis": "broker_reported_commission",
                 "source_field": "commission",
+                "source": "broker_order_response",
             },
         )
 

--- a/services/torghut/tests/test_snapshots.py
+++ b/services/torghut/tests/test_snapshots.py
@@ -349,6 +349,7 @@ class TestSnapshots(TestCase):
                         "runtime_ledger_cost": {
                             "fee_amount": "0.07",
                             "fee_basis": "broker_reported_fees",
+                            "source": "broker_reconciliation",
                         },
                     },
                 },
@@ -367,7 +368,7 @@ class TestSnapshots(TestCase):
             fee_model = audit.get("fee_model")
             self.assertIsInstance(fee_model, dict)
             assert isinstance(fee_model, dict)
-            self.assertEqual(fee_model.get("source"), "execution_audit_cost_payload")
+            self.assertEqual(fee_model.get("source"), "broker_reconciliation")
 
     def test_sync_order_to_db_models_paper_cost_when_broker_omits_fees(self) -> None:
         with Session(self.engine) as session:
@@ -403,7 +404,7 @@ class TestSnapshots(TestCase):
             self.assertIsInstance(raw_order, dict)
             assert isinstance(audit, dict)
             assert isinstance(raw_order, dict)
-            cost = audit.get("runtime_ledger_cost")
+            cost = audit.get("modeled_paper_cost_estimate")
             self.assertIsInstance(cost, dict)
             assert isinstance(cost, dict)
             self.assertEqual(cost.get("cost_amount"), "0.15")
@@ -412,12 +413,11 @@ class TestSnapshots(TestCase):
             self.assertEqual(
                 cost.get("source_field"), "cost_model.estimate.total_cost_bps"
             )
-            self.assertEqual(audit.get("cost_amount"), "0.15")
-            self.assertEqual(raw_order.get("cost_amount"), "0.15")
-            fee_model = audit.get("fee_model")
-            self.assertIsInstance(fee_model, dict)
-            assert isinstance(fee_model, dict)
-            self.assertEqual(fee_model.get("source"), "paper_cost_model_estimate")
+            self.assertEqual(raw_order.get("modeled_paper_cost_estimate"), cost)
+            self.assertNotIn("runtime_ledger_cost", audit)
+            self.assertNotIn("cost_amount", audit)
+            self.assertNotIn("cost_amount", raw_order)
+            self.assertNotIn("fee_model", audit)
 
     def test_sync_order_to_db_does_not_model_live_cost_when_broker_omits_fees(
         self,
@@ -457,6 +457,171 @@ class TestSnapshots(TestCase):
             self.assertNotIn("runtime_ledger_cost", audit)
             self.assertNotIn("cost_amount", audit)
             self.assertNotIn("cost_amount", raw_order)
+
+    def test_sync_order_to_db_does_not_trust_payload_paper_marker_for_live_label(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = sync_order_to_db(
+                session,
+                {
+                    "id": "order-live-arg-no-modeled-cost",
+                    "alpaca_account_label": "TORGHUT_PAPER",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "2",
+                    "filled_qty": "2",
+                    "filled_avg_price": "100",
+                    "status": "filled",
+                    "_execution_audit": {
+                        "execution_lane": "paper_route_probe",
+                        "cost_model": {
+                            "estimate": {
+                                "notional": "200",
+                                "total_cost_bps": "7.5",
+                            },
+                        },
+                    },
+                },
+                alpaca_account_label="TORGHUT_LIVE",
+            )
+
+            audit = execution.execution_audit_json
+            raw_order = execution.raw_order
+            self.assertIsInstance(audit, dict)
+            self.assertIsInstance(raw_order, dict)
+            assert isinstance(audit, dict)
+            assert isinstance(raw_order, dict)
+            self.assertEqual(execution.alpaca_account_label, "TORGHUT_LIVE")
+            self.assertNotIn("modeled_paper_cost_estimate", audit)
+            self.assertNotIn("runtime_ledger_cost", audit)
+            self.assertNotIn("cost_amount", audit)
+            self.assertNotIn("cost_amount", raw_order)
+
+    def test_sync_order_to_db_does_not_model_cost_when_label_has_live_marker(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = sync_order_to_db(
+                session,
+                {
+                    "id": "order-live-paper-label-no-modeled-cost",
+                    "alpaca_account_label": "TORGHUT_LIVE_PAPER",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "2",
+                    "filled_qty": "2",
+                    "filled_avg_price": "100",
+                    "status": "filled",
+                    "_execution_audit": {
+                        "execution_lane": "paper_route_probe",
+                        "cost_model": {
+                            "estimate": {
+                                "notional": "200",
+                                "total_cost_bps": "7.5",
+                            },
+                        },
+                    },
+                },
+            )
+
+            audit = execution.execution_audit_json
+            raw_order = execution.raw_order
+            self.assertIsInstance(audit, dict)
+            self.assertIsInstance(raw_order, dict)
+            assert isinstance(audit, dict)
+            assert isinstance(raw_order, dict)
+            self.assertNotIn("modeled_paper_cost_estimate", audit)
+            self.assertNotIn("runtime_ledger_cost", audit)
+            self.assertNotIn("cost_amount", audit)
+            self.assertNotIn("cost_amount", raw_order)
+
+    def test_sync_order_to_db_ignores_nested_spoofed_runtime_cost_metadata(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = sync_order_to_db(
+                session,
+                {
+                    "id": "order-nested-runtime-cost-spoof",
+                    "alpaca_account_label": "TORGHUT_PAPER",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "1",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100",
+                    "status": "filled",
+                    "_execution_audit": {
+                        "analytics": {
+                            "runtime_ledger_cost": {
+                                "cost_amount": "0.01",
+                                "cost_basis": "broker_reported_commission",
+                                "source": "broker_reconciliation",
+                            }
+                        }
+                    },
+                },
+            )
+
+            audit = execution.execution_audit_json
+            raw_order = execution.raw_order
+            self.assertIsInstance(audit, dict)
+            self.assertIsInstance(raw_order, dict)
+            assert isinstance(audit, dict)
+            assert isinstance(raw_order, dict)
+            self.assertNotIn("runtime_ledger_cost", audit)
+            self.assertNotIn("cost_amount", audit)
+            self.assertNotIn("cost_amount", raw_order)
+
+    def test_sync_order_to_db_prefers_broker_response_cost_over_audit_cost(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = sync_order_to_db(
+                session,
+                {
+                    "id": "order-broker-cost-wins",
+                    "alpaca_account_label": "TORGHUT_PAPER",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "1",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100",
+                    "status": "filled",
+                    "commission": "0.25",
+                    "_execution_audit": {
+                        "cost_amount": "0",
+                        "cost_basis": "broker_reported_commission",
+                        "runtime_ledger_cost": {
+                            "cost_amount": "0",
+                            "cost_basis": "broker_reported_commission",
+                            "source": "broker_reconciliation",
+                        },
+                    },
+                },
+            )
+
+            audit = execution.execution_audit_json
+            raw_order = execution.raw_order
+            self.assertIsInstance(audit, dict)
+            self.assertIsInstance(raw_order, dict)
+            assert isinstance(audit, dict)
+            assert isinstance(raw_order, dict)
+            cost = audit.get("runtime_ledger_cost")
+            self.assertIsInstance(cost, dict)
+            assert isinstance(cost, dict)
+            self.assertEqual(cost.get("cost_amount"), "0.25")
+            self.assertEqual(cost.get("source"), "broker_order_response")
+            self.assertEqual(audit.get("cost_amount"), "0.25")
+            self.assertEqual(raw_order.get("cost_amount"), "0.25")
 
     def test_sync_order_to_db_requires_paper_marker_before_modeling_costs(self) -> None:
         with Session(self.engine) as session:

--- a/services/torghut/tests/test_snapshots.py
+++ b/services/torghut/tests/test_snapshots.py
@@ -131,7 +131,9 @@ class TestSnapshots(TestCase):
                 },
             )
 
-            self.assertEqual(execution.raw_order["meta"]["strategy_run_id"], str(sample_id))
+            self.assertEqual(
+                execution.raw_order["meta"]["strategy_run_id"], str(sample_id)
+            )
 
     def test_sync_order_to_db_normalizes_fallback_route_marker(self) -> None:
         with Session(self.engine) as session:
@@ -152,8 +154,8 @@ class TestSnapshots(TestCase):
                 },
             )
 
-            self.assertEqual(execution.execution_expected_adapter, 'lean')
-            self.assertEqual(execution.execution_actual_adapter, 'alpaca')
+            self.assertEqual(execution.execution_expected_adapter, "lean")
+            self.assertEqual(execution.execution_actual_adapter, "alpaca")
 
     def test_sync_order_to_db_resolves_expected_from_actual_marker(self) -> None:
         with Session(self.engine) as session:
@@ -172,58 +174,60 @@ class TestSnapshots(TestCase):
                 },
             )
 
-            self.assertEqual(execution.execution_expected_adapter, 'lean')
-            self.assertEqual(execution.execution_actual_adapter, 'lean')
+            self.assertEqual(execution.execution_expected_adapter, "lean")
+            self.assertEqual(execution.execution_actual_adapter, "lean")
 
     def test_sync_order_to_db_persists_execution_correlation_fields(self) -> None:
         with Session(self.engine) as session:
             execution = sync_order_to_db(
                 session,
                 {
-                    'id': 'order-correlation',
-                    'symbol': 'AAPL',
-                    'side': 'buy',
-                    'type': 'market',
-                    'time_in_force': 'day',
-                    'qty': '1',
-                    'filled_qty': '0',
-                    'status': 'accepted',
-                    '_execution_correlation_id': 'corr-123',
-                    '_execution_idempotency_key': 'idem-123',
+                    "id": "order-correlation",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "1",
+                    "filled_qty": "0",
+                    "status": "accepted",
+                    "_execution_correlation_id": "corr-123",
+                    "_execution_idempotency_key": "idem-123",
                 },
             )
-            self.assertEqual(execution.execution_correlation_id, 'corr-123')
-            self.assertEqual(execution.execution_idempotency_key, 'idem-123')
+            self.assertEqual(execution.execution_correlation_id, "corr-123")
+            self.assertEqual(execution.execution_idempotency_key, "idem-123")
 
-    def test_sync_order_to_db_persists_simulation_context_in_audit_and_raw_order(self) -> None:
+    def test_sync_order_to_db_persists_simulation_context_in_audit_and_raw_order(
+        self,
+    ) -> None:
         with Session(self.engine) as session:
             execution = sync_order_to_db(
                 session,
                 {
-                    'id': 'sim-order-1',
-                    'client_order_id': 'decision-hash-1',
-                    'symbol': 'AAPL',
-                    'side': 'buy',
-                    'type': 'market',
-                    'time_in_force': 'day',
-                    'qty': '1',
-                    'filled_qty': '1',
-                    'filled_avg_price': '100.5',
-                    'status': 'filled',
-                    '_execution_adapter': 'simulation',
-                    '_execution_audit': {
-                        'adapter': 'simulation',
-                        'simulation_context': {
-                            'simulation_run_id': 'sim-2026-02-27-01',
-                            'dataset_id': 'dataset-a',
-                            'dataset_event_id': 'evt-1',
-                            'source_topic': 'torghut.trades.v1',
-                            'source_partition': 3,
-                            'source_offset': 9001,
+                    "id": "sim-order-1",
+                    "client_order_id": "decision-hash-1",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "1",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100.5",
+                    "status": "filled",
+                    "_execution_adapter": "simulation",
+                    "_execution_audit": {
+                        "adapter": "simulation",
+                        "simulation_context": {
+                            "simulation_run_id": "sim-2026-02-27-01",
+                            "dataset_id": "dataset-a",
+                            "dataset_event_id": "evt-1",
+                            "source_topic": "torghut.trades.v1",
+                            "source_partition": 3,
+                            "source_offset": 9001,
                         },
                     },
                 },
-                trade_decision_id='123e4567-e89b-12d3-a456-426614174000',
+                trade_decision_id="123e4567-e89b-12d3-a456-426614174000",
             )
             audit = execution.execution_audit_json
             raw_order = execution.raw_order
@@ -231,33 +235,37 @@ class TestSnapshots(TestCase):
             self.assertIsInstance(raw_order, dict)
             assert isinstance(audit, dict)
             assert isinstance(raw_order, dict)
-            simulation_context = audit.get('simulation_context')
+            simulation_context = audit.get("simulation_context")
             self.assertIsInstance(simulation_context, dict)
             assert isinstance(simulation_context, dict)
-            self.assertEqual(simulation_context.get('simulation_run_id'), 'sim-2026-02-27-01')
-            self.assertEqual(simulation_context.get('dataset_event_id'), 'evt-1')
-            self.assertEqual(raw_order.get('simulation_context'), simulation_context)
+            self.assertEqual(
+                simulation_context.get("simulation_run_id"), "sim-2026-02-27-01"
+            )
+            self.assertEqual(simulation_context.get("dataset_event_id"), "evt-1")
+            self.assertEqual(raw_order.get("simulation_context"), simulation_context)
 
-    def test_sync_order_to_db_preserves_execution_audit_metadata_on_update(self) -> None:
+    def test_sync_order_to_db_preserves_execution_audit_metadata_on_update(
+        self,
+    ) -> None:
         with Session(self.engine) as session:
             execution = sync_order_to_db(
                 session,
                 {
-                    'id': 'order-runtime-audit',
-                    'symbol': 'AAPL',
-                    'side': 'buy',
-                    'type': 'market',
-                    'time_in_force': 'day',
-                    'qty': '1',
-                    'filled_qty': '0',
-                    'status': 'accepted',
-                    '_execution_audit': {
-                        'execution_policy_hash': 'policy-sha',
-                        'cost_model_hash': 'cost-sha',
-                        'lineage_hash': 'lineage-sha',
-                        'runtime_ledger_cost': {
-                            'cost_amount': '0',
-                            'cost_basis': 'broker_reported_commission',
+                    "id": "order-runtime-audit",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "1",
+                    "filled_qty": "0",
+                    "status": "accepted",
+                    "_execution_audit": {
+                        "execution_policy_hash": "policy-sha",
+                        "cost_model_hash": "cost-sha",
+                        "lineage_hash": "lineage-sha",
+                        "runtime_ledger_cost": {
+                            "cost_amount": "0",
+                            "cost_basis": "broker_reported_commission",
                         },
                     },
                 },
@@ -266,15 +274,15 @@ class TestSnapshots(TestCase):
             updated = sync_order_to_db(
                 session,
                 {
-                    'id': 'order-runtime-audit',
-                    'symbol': 'AAPL',
-                    'side': 'buy',
-                    'type': 'market',
-                    'time_in_force': 'day',
-                    'qty': '1',
-                    'filled_qty': '1',
-                    'filled_avg_price': '100',
-                    'status': 'filled',
+                    "id": "order-runtime-audit",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "1",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100",
+                    "status": "filled",
                 },
             )
 
@@ -282,41 +290,244 @@ class TestSnapshots(TestCase):
             audit = updated.execution_audit_json
             self.assertIsInstance(audit, dict)
             assert isinstance(audit, dict)
-            self.assertEqual(audit.get('execution_policy_hash'), 'policy-sha')
-            self.assertEqual(audit.get('cost_model_hash'), 'cost-sha')
-            self.assertEqual(audit.get('lineage_hash'), 'lineage-sha')
-            cost = audit.get('runtime_ledger_cost')
+            self.assertEqual(audit.get("execution_policy_hash"), "policy-sha")
+            self.assertEqual(audit.get("cost_model_hash"), "cost-sha")
+            self.assertEqual(audit.get("lineage_hash"), "lineage-sha")
+            cost = audit.get("runtime_ledger_cost")
             self.assertIsInstance(cost, dict)
             assert isinstance(cost, dict)
-            self.assertEqual(cost.get('cost_amount'), '0')
-            self.assertEqual(cost.get('cost_basis'), 'broker_reported_commission')
+            self.assertEqual(cost.get("cost_amount"), "0")
+            self.assertEqual(cost.get("cost_basis"), "broker_reported_commission")
 
     def test_sync_order_to_db_normalizes_explicit_broker_cost_metadata(self) -> None:
         with Session(self.engine) as session:
             execution = sync_order_to_db(
                 session,
                 {
-                    'id': 'order-runtime-cost',
-                    'symbol': 'AAPL',
-                    'side': 'buy',
-                    'type': 'market',
-                    'time_in_force': 'day',
-                    'qty': '1',
-                    'filled_qty': '1',
-                    'filled_avg_price': '100',
-                    'status': 'filled',
-                    'commission': '0',
+                    "id": "order-runtime-cost",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "1",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100",
+                    "status": "filled",
+                    "commission": "0",
                 },
             )
 
             audit = execution.execution_audit_json
             self.assertIsInstance(audit, dict)
             assert isinstance(audit, dict)
-            cost = audit.get('runtime_ledger_cost')
+            cost = audit.get("runtime_ledger_cost")
             self.assertIsInstance(cost, dict)
             assert isinstance(cost, dict)
-            self.assertEqual(cost.get('cost_amount'), '0')
-            self.assertEqual(cost.get('cost_basis'), 'broker_reported_commission')
-            self.assertEqual(audit.get('cost_amount'), '0')
-            self.assertEqual(audit.get('cost_basis'), 'broker_reported_commission')
-            self.assertIn('fee_model', audit)
+            self.assertEqual(cost.get("cost_amount"), "0")
+            self.assertEqual(cost.get("cost_basis"), "broker_reported_commission")
+            self.assertEqual(audit.get("cost_amount"), "0")
+            self.assertEqual(audit.get("cost_basis"), "broker_reported_commission")
+            self.assertIn("fee_model", audit)
+
+    def test_sync_order_to_db_promotes_existing_audit_runtime_cost_metadata(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = sync_order_to_db(
+                session,
+                {
+                    "id": "order-audit-runtime-cost",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "1",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100",
+                    "status": "filled",
+                    "_execution_audit": {
+                        "runtime_ledger_cost": {
+                            "fee_amount": "0.07",
+                            "fee_basis": "broker_reported_fees",
+                        },
+                    },
+                },
+            )
+
+            audit = execution.execution_audit_json
+            raw_order = execution.raw_order
+            self.assertIsInstance(audit, dict)
+            self.assertIsInstance(raw_order, dict)
+            assert isinstance(audit, dict)
+            assert isinstance(raw_order, dict)
+            self.assertEqual(audit.get("cost_amount"), "0.07")
+            self.assertEqual(audit.get("cost_basis"), "broker_reported_fees")
+            self.assertEqual(raw_order.get("cost_amount"), "0.07")
+            self.assertEqual(raw_order.get("cost_basis"), "broker_reported_fees")
+            fee_model = audit.get("fee_model")
+            self.assertIsInstance(fee_model, dict)
+            assert isinstance(fee_model, dict)
+            self.assertEqual(fee_model.get("source"), "execution_audit_cost_payload")
+
+    def test_sync_order_to_db_models_paper_cost_when_broker_omits_fees(self) -> None:
+        with Session(self.engine) as session:
+            execution = sync_order_to_db(
+                session,
+                {
+                    "id": "order-modeled-paper-cost",
+                    "alpaca_account_label": "TORGHUT_PAPER",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "2",
+                    "filled_qty": "2",
+                    "filled_avg_price": "100",
+                    "status": "filled",
+                    "_execution_audit": {
+                        "execution_lane": "paper_route_probe",
+                        "cost_model": {
+                            "model": {"commission_bps": "0"},
+                            "estimate": {
+                                "notional": "200",
+                                "total_cost_bps": "7.5",
+                            },
+                        },
+                    },
+                },
+            )
+
+            audit = execution.execution_audit_json
+            raw_order = execution.raw_order
+            self.assertIsInstance(audit, dict)
+            self.assertIsInstance(raw_order, dict)
+            assert isinstance(audit, dict)
+            assert isinstance(raw_order, dict)
+            cost = audit.get("runtime_ledger_cost")
+            self.assertIsInstance(cost, dict)
+            assert isinstance(cost, dict)
+            self.assertEqual(cost.get("cost_amount"), "0.15")
+            self.assertEqual(cost.get("cost_basis"), "modeled_paper_cost_budget")
+            self.assertEqual(cost.get("source"), "paper_cost_model_estimate")
+            self.assertEqual(
+                cost.get("source_field"), "cost_model.estimate.total_cost_bps"
+            )
+            self.assertEqual(audit.get("cost_amount"), "0.15")
+            self.assertEqual(raw_order.get("cost_amount"), "0.15")
+            fee_model = audit.get("fee_model")
+            self.assertIsInstance(fee_model, dict)
+            assert isinstance(fee_model, dict)
+            self.assertEqual(fee_model.get("source"), "paper_cost_model_estimate")
+
+    def test_sync_order_to_db_does_not_model_live_cost_when_broker_omits_fees(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = sync_order_to_db(
+                session,
+                {
+                    "id": "order-live-no-modeled-cost",
+                    "alpaca_account_label": "TORGHUT_LIVE",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "2",
+                    "filled_qty": "2",
+                    "filled_avg_price": "100",
+                    "status": "filled",
+                    "_execution_audit": {
+                        "execution_lane": "live",
+                        "cost_model": {
+                            "estimate": {
+                                "notional": "200",
+                                "total_cost_bps": "7.5",
+                            },
+                        },
+                    },
+                },
+            )
+
+            audit = execution.execution_audit_json
+            raw_order = execution.raw_order
+            self.assertIsInstance(audit, dict)
+            self.assertIsInstance(raw_order, dict)
+            assert isinstance(audit, dict)
+            assert isinstance(raw_order, dict)
+            self.assertNotIn("runtime_ledger_cost", audit)
+            self.assertNotIn("cost_amount", audit)
+            self.assertNotIn("cost_amount", raw_order)
+
+    def test_sync_order_to_db_requires_paper_marker_before_modeling_costs(self) -> None:
+        with Session(self.engine) as session:
+            execution = sync_order_to_db(
+                session,
+                {
+                    "id": "order-unlabeled-no-modeled-cost",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "2",
+                    "filled_qty": "2",
+                    "filled_avg_price": "100",
+                    "status": "filled",
+                    "_execution_audit": {
+                        "cost_model": {
+                            "estimate": {
+                                "notional": "200",
+                                "total_cost_bps": "7.5",
+                            },
+                        },
+                    },
+                },
+            )
+
+            audit = execution.execution_audit_json
+            raw_order = execution.raw_order
+            self.assertIsInstance(audit, dict)
+            self.assertIsInstance(raw_order, dict)
+            assert isinstance(audit, dict)
+            assert isinstance(raw_order, dict)
+            self.assertNotIn("runtime_ledger_cost", audit)
+            self.assertNotIn("cost_amount", audit)
+            self.assertNotIn("cost_amount", raw_order)
+
+    def test_sync_order_to_db_ignores_unrelated_estimate_payload_for_costs(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = sync_order_to_db(
+                session,
+                {
+                    "id": "order-unrelated-estimate-no-cost",
+                    "alpaca_account_label": "TORGHUT_PAPER",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "2",
+                    "filled_qty": "2",
+                    "filled_avg_price": "100",
+                    "status": "filled",
+                    "_execution_audit": {
+                        "execution_lane": "paper_route_probe",
+                        "analytics": {
+                            "estimate": {
+                                "notional": "200",
+                                "total_cost_bps": "7.5",
+                            },
+                        },
+                    },
+                },
+            )
+
+            audit = execution.execution_audit_json
+            raw_order = execution.raw_order
+            self.assertIsInstance(audit, dict)
+            self.assertIsInstance(raw_order, dict)
+            assert isinstance(audit, dict)
+            assert isinstance(raw_order, dict)
+            self.assertNotIn("runtime_ledger_cost", audit)
+            self.assertNotIn("cost_amount", audit)
+            self.assertNotIn("cost_amount", raw_order)


### PR DESCRIPTION
## Summary

- Tightens Torghut order snapshot cost handling so modeled paper estimates stay non-authoritative and are not written as runtime-ledger cost proof.
- Requires explicit paper/sim account labels before modeled paper costs are retained, with live markers failing closed.
- Blocks modeled or assumption-derived cost bases from promotion-grade runtime-ledger proof paths.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_snapshots.py tests/test_snapshot_runtime_cost_coverage.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py -q`
- `uv run --frozen ruff check app/snapshots.py scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py tests/test_snapshots.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- `uv run --frozen ruff format --check app/snapshots.py scripts/import_hypothesis_runtime_windows.py app/trading/runtime_window_import.py tests/test_snapshots.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- `git diff --check origin/main...HEAD`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
