### PR TITLE
fix(torghut): emit paper target source decisions

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -148,6 +148,63 @@ def _target_plan_lineage(
     }
 
 
+def _target_lookup_names(target: Mapping[str, Any]) -> list[str]:
+    names: list[str] = []
+    for value in (
+        target.get("strategy_id"),
+        target.get("runtime_strategy_name"),
+        target.get("strategy_name"),
+        target.get("strategy_lookup_names"),
+    ):
+        _merge_unique_texts(names, _lineage_text_values(value))
+    return names
+
+
+def _parse_target_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        raw_text = _safe_text(value)
+        if raw_text is None:
+            return None
+        try:
+            parsed = datetime.fromisoformat(raw_text.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _target_probe_window(target: Mapping[str, Any]) -> tuple[datetime, datetime] | None:
+    window_start = _parse_target_datetime(
+        target.get("paper_route_probe_window_start") or target.get("window_start")
+    )
+    window_end = _parse_target_datetime(
+        target.get("paper_route_probe_window_end") or target.get("window_end")
+    )
+    if window_start is None or window_end is None or window_end <= window_start:
+        return None
+    return window_start, window_end
+
+
+def _target_probe_action(target: Mapping[str, Any]) -> Literal["buy", "sell"]:
+    for key in (
+        "paper_route_probe_action",
+        "paper_route_probe_side",
+        "probe_action",
+        "probe_side",
+        "action",
+        "side",
+    ):
+        normalized = str(target.get(key) or "").strip().lower()
+        if normalized in {"buy", "long"}:
+            return "buy"
+        if normalized in {"sell", "short"}:
+            return "sell"
+    return "buy"
+
+
 def _lineage_text_values(value: object) -> list[str]:
     raw_items: Sequence[object]
     if isinstance(value, str):
@@ -337,6 +394,13 @@ class SimpleTradingPipeline(TradingPipeline):
                     allowed_symbols=allowed_symbols,
                 )
                 self._process_paper_route_probe_retry_decisions(
+                    session=session,
+                    strategies=strategies,
+                    account=account,
+                    positions=positions,
+                    allowed_symbols=allowed_symbols,
+                )
+                self._process_paper_route_target_source_decisions(
                     session=session,
                     strategies=strategies,
                     account=account,
@@ -1275,6 +1339,49 @@ class SimpleTradingPipeline(TradingPipeline):
                     ["broker_submit_failed"]
                 )
 
+    def _process_paper_route_target_source_decisions(
+        self,
+        *,
+        session: Session,
+        strategies: list[Strategy],
+        account: dict[str, str],
+        positions: list[dict[str, Any]],
+        allowed_symbols: set[str],
+    ) -> None:
+        decisions = self._paper_route_target_source_decisions(
+            strategies=strategies,
+            allowed_symbols=allowed_symbols,
+        )
+        for decision in decisions:
+            self.state.metrics.decisions_total += 1
+            try:
+                submitted = self._handle_decision(
+                    session,
+                    decision,
+                    strategies,
+                    account,
+                    positions,
+                    allowed_symbols,
+                )
+                if submitted is not None:
+                    self._apply_simple_projected_buying_power(
+                        account,
+                        positions,
+                        submitted,
+                    )
+                    self._apply_simple_projected_position(positions, submitted)
+            except Exception:
+                logger.exception(
+                    "Paper-route target source decision handling failed strategy_id=%s symbol=%s timeframe=%s",
+                    decision.strategy_id,
+                    decision.symbol,
+                    decision.timeframe,
+                )
+                self.state.metrics.orders_rejected_total += 1
+                self.state.metrics.record_decision_rejection_reasons(
+                    ["broker_submit_failed"]
+                )
+
     def _submission_control_plane_snapshot(
         self,
         *,
@@ -1783,6 +1890,195 @@ class SimpleTradingPipeline(TradingPipeline):
         )
         return symbols, load_error, targets
 
+    @staticmethod
+    def _paper_route_target_strategy(
+        target: Mapping[str, Any],
+        strategies: Sequence[Strategy],
+    ) -> Strategy | None:
+        lookup_names = set(_target_lookup_names(target))
+        if not lookup_names:
+            return None
+        for strategy in strategies:
+            if str(strategy.id) in lookup_names or strategy.name in lookup_names:
+                return strategy
+        return None
+
+    @staticmethod
+    def _paper_route_target_strategy_symbols(strategy: Strategy) -> set[str]:
+        raw_symbols = strategy.universe_symbols
+        if isinstance(raw_symbols, str):
+            values: Sequence[object] = raw_symbols.split(",")
+        elif isinstance(raw_symbols, Sequence) and not isinstance(
+            raw_symbols, (bytes, bytearray)
+        ):
+            values = cast(Sequence[object], raw_symbols)
+        else:
+            values = ()
+        return {symbol for raw in values if (symbol := str(raw).strip().upper())}
+
+    @staticmethod
+    def _paper_route_target_source_decision_metadata(
+        *,
+        target: Mapping[str, Any],
+        strategy: Strategy,
+        symbol: str,
+        window_start: datetime,
+        window_end: datetime,
+        max_notional: Decimal,
+    ) -> dict[str, Any]:
+        lineage = _target_plan_lineage([dict(target)], symbol)
+        metadata: dict[str, Any] = {
+            "mode": "paper_route_target_plan_source_decision",
+            "source": "external_target_plan_url",
+            "symbol": symbol,
+            "strategy_name": strategy.name,
+            "runtime_strategy_name": _safe_text(target.get("runtime_strategy_name")),
+            "strategy_lookup_names": _target_lookup_names(target),
+            "paper_route_probe_symbols": sorted(_target_symbols(target)),
+            "paper_route_probe_window_start": window_start.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+            "paper_route_probe_next_session_max_notional": str(max_notional),
+            "paper_route_target_plan_source": "external_target_plan_url",
+            "paper_route_probe_scope_authority": "external_target_plan",
+            "source_kind": _safe_text(target.get("source_kind")),
+            "source_manifest_ref": _safe_text(target.get("source_manifest_ref")),
+            "paper_probation_authorized": bool(
+                target.get("paper_probation_authorized")
+            ),
+            "promotion_allowed": False,
+            "final_promotion_authorized": False,
+            "final_promotion_allowed": False,
+            **lineage,
+        }
+        for key in (
+            "candidate_id",
+            "hypothesis_id",
+            "observed_stage",
+            "strategy_family",
+        ):
+            value = _safe_text(target.get(key))
+            if value is not None:
+                metadata[key] = value
+        return metadata
+
+    @staticmethod
+    def _paper_route_target_source_cap(
+        params: Mapping[str, Any],
+    ) -> Decimal | None:
+        metadata = params.get("paper_route_target_plan_source_decision")
+        if not isinstance(metadata, Mapping):
+            metadata = params.get("paper_route_target_plan")
+        if not isinstance(metadata, Mapping):
+            return None
+        mode = str(cast(Mapping[str, Any], metadata).get("mode") or "").strip()
+        if mode != "paper_route_target_plan_source_decision":
+            return None
+        cap = _optional_decimal(
+            cast(Mapping[str, Any], metadata).get(
+                "paper_route_probe_next_session_max_notional"
+            )
+        )
+        return cap if cap is not None and cap > 0 else None
+
+    def _paper_route_target_source_decisions(
+        self,
+        *,
+        strategies: Sequence[Strategy],
+        allowed_symbols: set[str],
+    ) -> list[StrategyDecision]:
+        if settings.trading_mode != "paper":
+            return []
+        if not settings.trading_simple_paper_route_probe_enabled:
+            return []
+        now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
+        if not self._is_market_session_open(now):
+            return []
+        target_symbols, target_plan_error, target_plan_targets = (
+            self._external_paper_route_target_probe_symbols_cached()
+        )
+        if target_plan_error or not target_symbols:
+            return []
+
+        normalized_allowed = {
+            symbol.strip().upper() for symbol in allowed_symbols if symbol.strip()
+        }
+        decisions: list[StrategyDecision] = []
+        seen: set[tuple[str, str, str, str]] = set()
+        for target in target_plan_targets:
+            window = _target_probe_window(target)
+            if window is None:
+                continue
+            window_start, window_end = window
+            if now < window_start or now >= window_end:
+                continue
+            target_cap = _optional_decimal(
+                target.get("paper_route_probe_next_session_max_notional")
+            )
+            if target_cap is None or target_cap <= 0:
+                continue
+            strategy = self._paper_route_target_strategy(target, strategies)
+            if strategy is None:
+                continue
+            strategy_symbols = self._paper_route_target_strategy_symbols(strategy)
+            symbols = sorted(_target_symbols(target) & target_symbols)
+            if normalized_allowed:
+                symbols = [symbol for symbol in symbols if symbol in normalized_allowed]
+            if strategy_symbols:
+                symbols = [symbol for symbol in symbols if symbol in strategy_symbols]
+            action = _target_probe_action(target)
+            if action == "sell" and not settings.trading_allow_shorts:
+                continue
+            for symbol in symbols:
+                key = (str(strategy.id), symbol, window_start.isoformat(), action)
+                if key in seen:
+                    continue
+                seen.add(key)
+                metadata = self._paper_route_target_source_decision_metadata(
+                    target=target,
+                    strategy=strategy,
+                    symbol=symbol,
+                    window_start=window_start,
+                    window_end=window_end,
+                    max_notional=target_cap,
+                )
+                simple_lane = {
+                    "source": "external_target_plan_url",
+                    "target_plan_source_decision": True,
+                    "paper_route_probe_max_notional": str(target_cap),
+                    "paper_route_probe_window_start": window_start.isoformat(),
+                    "paper_route_probe_window_end": window_end.isoformat(),
+                }
+                params: dict[str, Any] = {
+                    "paper_route_target_plan": metadata,
+                    "paper_route_target_plan_source_decision": metadata,
+                    "simple_lane": simple_lane,
+                    "promotion_allowed": False,
+                    "final_promotion_authorized": False,
+                    "final_promotion_allowed": False,
+                    **_target_plan_lineage([dict(target)], symbol),
+                }
+                timeframe = (
+                    _safe_text(target.get("timeframe"))
+                    or _safe_text(target.get("base_timeframe"))
+                    or _safe_text(strategy.base_timeframe)
+                    or "1Min"
+                )
+                decisions.append(
+                    StrategyDecision(
+                        strategy_id=str(strategy.id),
+                        symbol=symbol,
+                        event_ts=window_start,
+                        timeframe=timeframe,
+                        action=action,
+                        qty=Decimal("1"),
+                        order_type="market",
+                        time_in_force="day",
+                        rationale="external paper-route target plan source decision",
+                        params=params,
+                    )
+                )
+        return decisions
+
     def _paper_route_target_lineage_for_decision(
         self,
         decision: StrategyDecision,
@@ -1856,7 +2152,10 @@ class SimpleTradingPipeline(TradingPipeline):
             return None
         if decision.action not in {"buy", "sell"}:
             return None
-        cap = _optional_decimal(settings.trading_simple_paper_route_probe_max_notional)
+        cap = _min_optional_decimal(
+            _optional_decimal(settings.trading_simple_paper_route_probe_max_notional),
+            self._paper_route_target_source_cap(decision.params),
+        )
         if cap is None or cap <= 0:
             return None
         if not self._proof_floor_market_session_open(proof_floor):
@@ -1897,6 +2196,11 @@ class SimpleTradingPipeline(TradingPipeline):
             return None
         if target_plan_symbols and symbol not in target_plan_symbols:
             return None
+        target_source_authorized = (
+            self._paper_route_target_source_cap(decision.params) is not None
+            and bool(target_plan_symbols)
+            and symbol in target_plan_symbols
+        )
         symbol_route_probe_reasons = self._proof_floor_symbol_route_probe_reasons(
             proof_floor,
             symbol,
@@ -1909,6 +2213,7 @@ class SimpleTradingPipeline(TradingPipeline):
             (blocking_reasons & _PAPER_ROUTE_PROBE_REASONS)
             or symbol_route_probe_reasons
             or symbol_paper_route_probe_eligible
+            or target_source_authorized
         ):
             return None
 
@@ -1927,6 +2232,7 @@ class SimpleTradingPipeline(TradingPipeline):
             "symbol": symbol,
             "side": decision.action,
             "blocking_reasons": sorted(blocking_reasons | symbol_route_probe_reasons),
+            "target_source_authorized": target_source_authorized,
             "route_repair_symbols": sorted(repair_symbols),
             "paper_route_probe_symbols": sorted(paper_route_probe_symbols),
             "paper_route_target_plan_symbols": sorted(target_plan_symbols),
@@ -1991,6 +2297,14 @@ class SimpleTradingPipeline(TradingPipeline):
         if "paper_route_target_plan" in decision.params:
             self.executor.update_decision_params(session, decision_row, decision.params)
             self.executor.sync_decision_state(session, decision_row, decision)
+        if (
+            decision_row.status == "planned"
+            and self._paper_route_target_source_cap(decision.params) is not None
+        ):
+            decision_row.created_at = trading_now(account_label=self.account_label)
+            session.add(decision_row)
+            session.commit()
+            session.refresh(decision_row)
         retry_metadata = self._paper_route_probe_retry_metadata(decision_row)
         if retry_metadata is None:
             return super()._ensure_pending_decision_row(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -53,7 +53,13 @@ from app.trading.ingest import SignalBatch
 from app.trading.reconcile import Reconciler
 from app.trading.risk import RiskEngine
 from app.trading.scheduler.pipeline import TradingPipeline
-from app.trading.scheduler.simple_pipeline import SimpleTradingPipeline, _safe_int
+from app.trading.scheduler.simple_pipeline import (
+    SimpleTradingPipeline,
+    _parse_target_datetime,
+    _safe_int,
+    _target_probe_action,
+    _target_probe_window,
+)
 from app.trading.scheduler.pipeline_helpers import (
     _apply_projected_position_decision,
     _build_dspy_lineage,
@@ -4574,6 +4580,491 @@ class TestTradingPipeline(TestCase):
             self.assertEqual(paper_route_probe.get("max_notional"), "25.0")
             self.assertEqual(paper_route_probe.get("capped_qty"), "0.2500")
             self.assertEqual(simple_lane.get("paper_route_probe_cap_applied"), True)
+
+    def test_simple_pipeline_no_signal_cycle_generates_target_plan_source_decision(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 5, 26, 14, 0, tzinfo=timezone.utc)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_pipeline_mode = "simple"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_max_notional = 100.0
+        config.settings.trading_paper_route_target_plan_url = "http://torghut.test/plan"
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+        config.settings.trading_universe_static_fallback_enabled = True
+        config.settings.trading_universe_static_fallback_symbols_raw = "AAPL"
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="paper-route-candidate-v1",
+                description="paper route candidate",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+
+        target = {
+            "candidate_id": "cand-paper-route",
+            "hypothesis_id": "H-PAPER-ROUTE",
+            "observed_stage": "paper",
+            "strategy_family": "microbar_pairs",
+            "strategy_name": "paper-route-candidate-v1",
+            "runtime_strategy_name": "paper-route-runtime-name",
+            "strategy_lookup_names": [
+                "paper-route-runtime-name",
+                "paper-route-candidate-v1",
+            ],
+            "account_label": "paper",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "source_manifest_ref": "config/trading/hypotheses/h-paper-route.json",
+            "paper_route_probe_symbols": ["AAPL"],
+            "paper_route_probe_next_session_max_notional": "25",
+            "paper_route_probe_window_start": window_start.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+            "paper_probation_authorized": True,
+            "promotion_allowed": False,
+            "final_promotion_authorized": False,
+        }
+        proof_floor = {
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "market_window": {"session_open": True},
+            "blocking_reasons": ["alpha_readiness_not_promotion_eligible"],
+        }
+        alpaca_client = FakeAlpacaClient()
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+            price_fetcher=FakePriceFetcher(Decimal("100")),
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+        with (
+            patch.object(
+                SimpleTradingPipeline,
+                "_external_paper_route_target_probe_symbols_cached",
+                return_value=({"AAPL"}, None, [target]),
+            ),
+            patch.object(
+                SimpleTradingPipeline,
+                "_external_paper_route_target_probe_symbols",
+                return_value=({"AAPL"}, None, [target]),
+            ),
+            patch.object(
+                SimpleTradingPipeline,
+                "_profitability_proof_floor",
+                return_value=proof_floor,
+            ),
+            patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=now,
+            ),
+            patch("app.trading.scheduler.pipeline.trading_now", return_value=now),
+            patch("app.trading.simulation.trading_now", return_value=now),
+        ):
+            pipeline.run_once()
+            pipeline.run_once()
+
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        self.assertEqual(alpaca_client.submitted[0]["side"], "buy")
+        self.assertEqual(alpaca_client.submitted[0]["qty"], "0.25")
+        with self.session_local() as session:
+            decisions = list(session.execute(select(TradeDecision)).scalars())
+            executions = list(session.execute(select(Execution)).scalars())
+            self.assertEqual(len(decisions), 1)
+            self.assertEqual(len(executions), 1)
+            decision = decisions[0]
+            decision_json = cast(dict[str, Any], decision.decision_json)
+            params = cast(dict[str, Any], decision_json.get("params"))
+            target_plan = cast(dict[str, Any], params.get("paper_route_target_plan"))
+            source_decision = cast(
+                dict[str, Any],
+                params.get("paper_route_target_plan_source_decision"),
+            )
+            paper_route_probe = cast(dict[str, Any], params.get("paper_route_probe"))
+
+            self.assertEqual(decision.status, "submitted")
+            created_at = decision.created_at
+            if created_at.tzinfo is None:
+                created_at = created_at.replace(tzinfo=timezone.utc)
+            self.assertEqual(created_at, now)
+            self.assertEqual(
+                target_plan["mode"], "paper_route_target_plan_source_decision"
+            )
+            self.assertEqual(source_decision["candidate_id"], "cand-paper-route")
+            self.assertEqual(source_decision["hypothesis_id"], "H-PAPER-ROUTE")
+            self.assertEqual(params["source_candidate_ids"], ["cand-paper-route"])
+            self.assertEqual(params["source_hypothesis_ids"], ["H-PAPER-ROUTE"])
+            self.assertFalse(params["promotion_allowed"])
+            self.assertFalse(params["final_promotion_authorized"])
+            self.assertEqual(paper_route_probe["max_notional"], "25")
+            self.assertTrue(paper_route_probe["target_source_authorized"])
+            self.assertEqual(paper_route_probe["capped_qty"], "0.2500")
+
+    def test_simple_pipeline_target_plan_source_decision_requires_open_window(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 5, 26, 12, 0, tzinfo=timezone.utc)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_pipeline_mode = "simple"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_max_notional = 25.0
+        config.settings.trading_paper_route_target_plan_url = "http://torghut.test/plan"
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="paper-route-candidate-v1",
+                description="paper route candidate",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+
+        target = {
+            "candidate_id": "cand-paper-route",
+            "hypothesis_id": "H-PAPER-ROUTE",
+            "strategy_name": "paper-route-candidate-v1",
+            "paper_route_probe_symbols": ["AAPL"],
+            "paper_route_probe_next_session_max_notional": "25",
+            "paper_route_probe_window_start": window_start.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+        }
+        alpaca_client = FakeAlpacaClient()
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+            price_fetcher=FakePriceFetcher(Decimal("100")),
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+        with (
+            patch.object(
+                SimpleTradingPipeline,
+                "_external_paper_route_target_probe_symbols_cached",
+                return_value=({"AAPL"}, None, [target]),
+            ),
+            patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=now,
+            ),
+        ):
+            pipeline.run_once()
+
+        self.assertEqual(alpaca_client.submitted, [])
+        with self.session_local() as session:
+            self.assertEqual(list(session.execute(select(TradeDecision)).scalars()), [])
+
+    def test_paper_route_target_source_decision_helpers_cover_rejection_edges(
+        self,
+    ) -> None:
+        aware = datetime(2026, 5, 26, 14, 0, tzinfo=timezone.utc)
+
+        self.assertEqual(_parse_target_datetime(aware), aware)
+        self.assertEqual(
+            _parse_target_datetime("2026-05-26T14:00:00"),
+            aware,
+        )
+        self.assertIsNone(_parse_target_datetime(None))
+        self.assertIsNone(_parse_target_datetime("not-a-date"))
+        self.assertIsNone(
+            _target_probe_window(
+                {
+                    "paper_route_probe_window_start": aware.isoformat(),
+                    "paper_route_probe_window_end": aware.isoformat(),
+                }
+            )
+        )
+        self.assertEqual(
+            _target_probe_action({"paper_route_probe_action": "long"}), "buy"
+        )
+        self.assertEqual(
+            _target_probe_action({"paper_route_probe_side": "short"}), "sell"
+        )
+
+        strategy = Strategy(
+            name="paper-route-candidate-v1",
+            description="paper route candidate",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_target_strategy({}, [strategy])
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_target_strategy(
+                {"strategy_name": "missing-strategy"},
+                [strategy],
+            )
+        )
+        self.assertIs(
+            SimpleTradingPipeline._paper_route_target_strategy(
+                {"strategy_name": "paper-route-candidate-v1"},
+                [strategy],
+            ),
+            strategy,
+        )
+        self.assertEqual(
+            SimpleTradingPipeline._paper_route_target_strategy_symbols(
+                Strategy(
+                    name="string-universe",
+                    description="string universe",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=cast(Any, "AAPL, MSFT"),
+                )
+            ),
+            {"AAPL", "MSFT"},
+        )
+        self.assertEqual(
+            SimpleTradingPipeline._paper_route_target_strategy_symbols(
+                Strategy(
+                    name="invalid-universe",
+                    description="invalid universe",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=cast(Any, object()),
+                )
+            ),
+            set(),
+        )
+
+    def test_paper_route_target_source_decisions_guard_paths_and_dedupes(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 5, 26, 14, 0, tzinfo=timezone.utc)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_pipeline_mode = "simple"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_allow_shorts = False
+
+        strategy = Strategy(
+            name="paper-route-candidate-v1",
+            description="paper route candidate",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        target = {
+            "strategy_name": "paper-route-candidate-v1",
+            "paper_route_probe_symbols": ["AAPL"],
+            "paper_route_probe_next_session_max_notional": "25",
+            "paper_route_probe_window_start": window_start.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+        }
+        alpaca_client = FakeAlpacaClient()
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+        with patch(
+            "app.trading.scheduler.simple_pipeline.trading_now",
+            return_value=now,
+        ):
+            config.settings.trading_mode = "live"
+            self.assertEqual(
+                pipeline._paper_route_target_source_decisions(
+                    strategies=[strategy],
+                    allowed_symbols={"AAPL"},
+                ),
+                [],
+            )
+
+            config.settings.trading_mode = "paper"
+            config.settings.trading_simple_paper_route_probe_enabled = False
+            self.assertEqual(
+                pipeline._paper_route_target_source_decisions(
+                    strategies=[strategy],
+                    allowed_symbols={"AAPL"},
+                ),
+                [],
+            )
+
+            config.settings.trading_simple_paper_route_probe_enabled = True
+            pipeline._is_market_session_open = lambda _now=None: False  # type: ignore[method-assign]
+            self.assertEqual(
+                pipeline._paper_route_target_source_decisions(
+                    strategies=[strategy],
+                    allowed_symbols={"AAPL"},
+                ),
+                [],
+            )
+
+            pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+            for skipped_target in (
+                {
+                    **target,
+                    "paper_route_probe_window_start": window_start.isoformat(),
+                    "paper_route_probe_window_end": window_start.isoformat(),
+                },
+                {**target, "paper_route_probe_next_session_max_notional": "0"},
+                {**target, "strategy_name": "missing-strategy"},
+                {**target, "paper_route_probe_action": "sell"},
+            ):
+                with patch.object(
+                    SimpleTradingPipeline,
+                    "_external_paper_route_target_probe_symbols_cached",
+                    return_value=({"AAPL"}, None, [skipped_target]),
+                ):
+                    self.assertEqual(
+                        pipeline._paper_route_target_source_decisions(
+                            strategies=[strategy],
+                            allowed_symbols={"AAPL"},
+                        ),
+                        [],
+                    )
+
+            with patch.object(
+                SimpleTradingPipeline,
+                "_external_paper_route_target_probe_symbols_cached",
+                return_value=({"AAPL"}, None, [target, dict(target)]),
+            ):
+                decisions = pipeline._paper_route_target_source_decisions(
+                    strategies=[strategy],
+                    allowed_symbols={"AAPL"},
+                )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].symbol, "AAPL")
+        self.assertEqual(decisions[0].action, "buy")
+
+    def test_process_paper_route_target_source_decisions_records_submit_failure(
+        self,
+    ) -> None:
+        alpaca_client = FakeAlpacaClient()
+        state = TradingState()
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=state,
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        strategy = Strategy(
+            name="paper-route-candidate-v1",
+            description="paper route candidate",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        decision = StrategyDecision(
+            strategy_id="strategy-1",
+            symbol="AAPL",
+            event_ts=datetime(2026, 5, 26, 14, 0, tzinfo=timezone.utc),
+            timeframe="1Min",
+            action="buy",
+            qty=Decimal("1"),
+            rationale="target-plan-source-decision",
+            params={"price": "100"},
+        )
+
+        with (
+            patch.object(
+                pipeline,
+                "_paper_route_target_source_decisions",
+                return_value=[decision],
+            ),
+            patch.object(
+                pipeline,
+                "_handle_decision",
+                side_effect=RuntimeError("submit failed"),
+            ),
+            self.session_local() as session,
+        ):
+            pipeline._process_paper_route_target_source_decisions(
+                session=session,
+                strategies=[strategy],
+                account={"equity": "10000", "cash": "10000", "buying_power": "10000"},
+                positions=[],
+                allowed_symbols={"AAPL"},
+            )
+
+        self.assertEqual(state.metrics.decisions_total, 1)
+        self.assertEqual(state.metrics.orders_rejected_total, 1)
+        self.assertEqual(
+            state.metrics.decision_reject_reason_total.get("broker_submit_failed"),
+            1,
+        )
 
     def test_simple_pipeline_paper_route_probe_can_repair_symbol_outside_candidates(
         self,


### PR DESCRIPTION
## Summary

- Emit bounded paper-route source decisions from explicit external target plans during no-signal simple-pipeline cycles.
- Require paper mode, probe enablement, an open market/session window, a matching strategy name/id, scoped symbols, and positive target notional before creating any source decision.
- Preserve promotion honesty by labeling generated decisions as evidence collection only and keeping promotion/final-promotion flags false.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py -q -k 'target_plan_source_decision or bounded_paper_route_probe_for_tca_repair'`
- `uv run --frozen pytest tests/test_trading_pipeline.py tests/test_paper_route_evidence.py -q`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `git diff --check HEAD~1..HEAD`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
