### PR TITLE
fix(torghut): keep target source probes active

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -440,6 +440,13 @@ class SimpleTradingPipeline(TradingPipeline):
                 positions=positions,
                 allowed_symbols=allowed_symbols,
             )
+            self._process_paper_route_target_source_decisions(
+                session=session,
+                strategies=strategies,
+                account=account,
+                positions=positions,
+                allowed_symbols=allowed_symbols,
+            )
             self._process_paper_route_probe_retry_decisions(
                 session=session,
                 strategies=strategies,
@@ -1950,6 +1957,17 @@ class SimpleTradingPipeline(TradingPipeline):
             "final_promotion_allowed": False,
             **lineage,
         }
+        exit_minute = SimpleTradingPipeline._paper_route_probe_exit_minute_value(
+            target.get("exit_minute_after_open")
+            or target.get("paper_route_probe_exit_minute_after_open")
+        )
+        if exit_minute is not None:
+            effective_exit_minute = min(exit_minute, _REGULAR_SESSION_MINUTES - 1)
+            metadata["exit_minute_after_open"] = exit_minute
+            metadata["effective_exit_minute_after_open"] = effective_exit_minute
+            metadata["exit_due_at"] = (
+                window_start + timedelta(minutes=effective_exit_minute)
+            ).isoformat()
         for key in (
             "candidate_id",
             "hypothesis_id",
@@ -2057,6 +2075,10 @@ class SimpleTradingPipeline(TradingPipeline):
                     "final_promotion_allowed": False,
                     **_target_plan_lineage([dict(target)], symbol),
                 }
+                if "exit_minute_after_open" in metadata:
+                    params["exit_minute_after_open"] = metadata[
+                        "exit_minute_after_open"
+                    ]
                 timeframe = (
                     _safe_text(target.get("timeframe"))
                     or _safe_text(target.get("base_timeframe"))

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -4634,6 +4634,7 @@ class TestTradingPipeline(TestCase):
             "paper_route_probe_next_session_max_notional": "25",
             "paper_route_probe_window_start": window_start.isoformat(),
             "paper_route_probe_window_end": window_end.isoformat(),
+            "exit_minute_after_open": "120",
             "paper_probation_authorized": True,
             "promotion_allowed": False,
             "final_promotion_authorized": False,
@@ -4717,13 +4718,168 @@ class TestTradingPipeline(TestCase):
             )
             self.assertEqual(source_decision["candidate_id"], "cand-paper-route")
             self.assertEqual(source_decision["hypothesis_id"], "H-PAPER-ROUTE")
+            self.assertEqual(source_decision["exit_minute_after_open"], 120)
+            self.assertEqual(params["exit_minute_after_open"], 120)
             self.assertEqual(params["source_candidate_ids"], ["cand-paper-route"])
             self.assertEqual(params["source_hypothesis_ids"], ["H-PAPER-ROUTE"])
             self.assertFalse(params["promotion_allowed"])
             self.assertFalse(params["final_promotion_authorized"])
             self.assertEqual(paper_route_probe["max_notional"], "25")
             self.assertTrue(paper_route_probe["target_source_authorized"])
+            self.assertEqual(paper_route_probe["exit_minute_after_open"], 120)
+            self.assertEqual(
+                paper_route_probe["exit_due_at"],
+                "2026-05-26T15:30:00+00:00",
+            )
             self.assertEqual(paper_route_probe["capped_qty"], "0.2500")
+
+    def test_simple_pipeline_signal_cycle_still_generates_target_plan_source_decision(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 5, 26, 14, 0, tzinfo=timezone.utc)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_pipeline_mode = "simple"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_fractional_equities_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_max_notional = 100.0
+        config.settings.trading_paper_route_target_plan_url = "http://torghut.test/plan"
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+        config.settings.trading_universe_static_fallback_enabled = True
+        config.settings.trading_universe_static_fallback_symbols_raw = "AAPL"
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="paper-route-candidate-v1",
+                description="paper route candidate",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+
+        target = {
+            "candidate_id": "cand-paper-route",
+            "hypothesis_id": "H-PAPER-ROUTE",
+            "observed_stage": "paper",
+            "strategy_family": "microbar_pairs",
+            "strategy_name": "paper-route-candidate-v1",
+            "runtime_strategy_name": "paper-route-runtime-name",
+            "strategy_lookup_names": [
+                "paper-route-runtime-name",
+                "paper-route-candidate-v1",
+            ],
+            "account_label": "paper",
+            "source_kind": "paper_route_probe_runtime_observed",
+            "source_manifest_ref": "config/trading/hypotheses/h-paper-route.json",
+            "paper_route_probe_symbols": ["AAPL"],
+            "paper_route_probe_next_session_max_notional": "25",
+            "paper_route_probe_window_start": window_start.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+            "exit_minute_after_open": "120",
+            "paper_probation_authorized": True,
+            "promotion_allowed": False,
+            "final_promotion_authorized": False,
+        }
+        proof_floor = {
+            "route_state": "repair_only",
+            "capital_state": "zero_notional",
+            "max_notional": "0",
+            "market_window": {"session_open": True},
+            "blocking_reasons": ["alpha_readiness_not_promotion_eligible"],
+        }
+        alpaca_client = FakeAlpacaClient()
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=FakeIngestor(
+                [
+                    SignalEnvelope(
+                        event_ts=now,
+                        symbol="AAPL",
+                        payload={
+                            "price": Decimal("100"),
+                            "imbalance_bid_px": Decimal("99.99"),
+                            "imbalance_ask_px": Decimal("100.01"),
+                            "spread": Decimal("0.02"),
+                        },
+                        timeframe="1Min",
+                    )
+                ]
+            ),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+            price_fetcher=FakePriceFetcher(Decimal("100")),
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+        with (
+            patch.object(
+                pipeline,
+                "_evaluate_signal_decisions",
+                return_value=[],
+            ) as evaluate_signals,
+            patch.object(
+                SimpleTradingPipeline,
+                "_external_paper_route_target_probe_symbols_cached",
+                return_value=({"AAPL"}, None, [target]),
+            ),
+            patch.object(
+                SimpleTradingPipeline,
+                "_external_paper_route_target_probe_symbols",
+                return_value=({"AAPL"}, None, [target]),
+            ),
+            patch.object(
+                SimpleTradingPipeline,
+                "_profitability_proof_floor",
+                return_value=proof_floor,
+            ),
+            patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=now,
+            ),
+            patch("app.trading.scheduler.pipeline.trading_now", return_value=now),
+            patch("app.trading.simulation.trading_now", return_value=now),
+        ):
+            pipeline.run_once()
+
+        evaluate_signals.assert_called_once()
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        self.assertEqual(alpaca_client.submitted[0]["side"], "buy")
+        self.assertEqual(alpaca_client.submitted[0]["qty"], "0.25")
+        with self.session_local() as session:
+            decision = session.execute(select(TradeDecision)).scalar_one()
+            decision_json = cast(dict[str, Any], decision.decision_json)
+            params = cast(dict[str, Any], decision_json.get("params"))
+            source_decision = cast(
+                dict[str, Any],
+                params.get("paper_route_target_plan_source_decision"),
+            )
+            paper_route_probe = cast(dict[str, Any], params.get("paper_route_probe"))
+
+            self.assertEqual(decision.status, "submitted")
+            self.assertEqual(source_decision["candidate_id"], "cand-paper-route")
+            self.assertEqual(source_decision["exit_minute_after_open"], 120)
+            self.assertEqual(params["source_hypothesis_ids"], ["H-PAPER-ROUTE"])
+            self.assertTrue(paper_route_probe["target_source_authorized"])
+            self.assertEqual(paper_route_probe["exit_minute_after_open"], 120)
 
     def test_simple_pipeline_target_plan_source_decision_requires_open_window(
         self,


### PR DESCRIPTION
## Summary

- Runs external target-plan paper source decisions on signal cycles as well as empty-signal cycles, so normal signal traffic cannot starve the proof lane.
- Carries target-plan exit timing into generated source-decision and paper-route probe metadata, allowing filled probes to feed the existing exit/closure path.
- Adds regression coverage for signal-cycle target source generation, exit-timing propagation, idempotent no-signal generation, and guard paths.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py --check`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q -k 'target_plan_source_decision or target_source_decision or signal_cycle_still_generates'`
- `uv run --frozen pytest tests/test_trading_pipeline.py tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q -k 'target_plan_source_decision or target_source_decision or signal_cycle_still_generates' --cov --cov-branch --cov-report=xml:coverage.xml --cov-fail-under=0 && GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
