### PR TITLE
fix(torghut): fail closed on runtime proof authority

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -131,6 +131,9 @@ from .trading.paper_route_target_plan import (
     paper_route_target_plan_from_payload as _shared_paper_route_target_plan_from_payload,
 )
 from .trading.paper_route_evidence import build_paper_route_evidence_audit
+from .trading.runtime_cost_authority import (
+    cost_basis_counts_have_non_promotion_grade_costs,
+)
 from .trading.proof_floor import build_profitability_proof_floor_receipt
 from .trading.quality_adjusted_profit_frontier import (
     build_quality_adjusted_profit_frontier,
@@ -3872,6 +3875,15 @@ def trading_autonomy() -> dict[str, object]:
 def _runtime_ledger_bucket_evidence_grade(row: StrategyRuntimeLedgerBucket) -> bool:
     raw_blockers = cast(Sequence[object], row.blockers_json or [])
     blockers = [str(item).strip() for item in raw_blockers if str(item).strip()]
+    raw_payload_json = cast(object, row.payload_json)
+    payload_json = (
+        {
+            str(key): item
+            for key, item in cast(Mapping[object, object], raw_payload_json).items()
+        }
+        if isinstance(raw_payload_json, Mapping)
+        else {}
+    )
     return (
         row.pnl_basis == "realized_strategy_pnl_after_explicit_costs"
         and int(row.fill_count or 0) > 0
@@ -3882,6 +3894,9 @@ def _runtime_ledger_bucket_evidence_grade(row: StrategyRuntimeLedgerBucket) -> b
         and bool(row.execution_policy_hash_counts)
         and bool(row.cost_model_hash_counts)
         and bool(row.lineage_hash_counts)
+        and not cost_basis_counts_have_non_promotion_grade_costs(
+            payload_json.get("cost_basis_counts")
+        )
         and not blockers
     )
 

--- a/services/torghut/app/snapshots.py
+++ b/services/torghut/app/snapshots.py
@@ -19,6 +19,7 @@ from .trading.route_metadata import (
     coerce_route_int,
     normalize_route_provenance,
 )
+from .trading.runtime_cost_authority import is_non_promotion_grade_runtime_cost_basis
 from .trading.simulation import resolve_simulation_context
 
 logger = logging.getLogger(__name__)
@@ -516,6 +517,8 @@ def _runtime_cost_payload_from_mapping(
             continue
         resolved_basis = basis or _BROKER_COST_BASIS_BY_FIELD.get(amount_key)
         if resolved_basis is None:
+            continue
+        if is_non_promotion_grade_runtime_cost_basis(resolved_basis):
             continue
         return {
             "cost_amount": str(amount),

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -26,6 +26,7 @@ from ..models import (
     StrategyRuntimeLedgerBucket,
     TradeDecision,
 )
+from .runtime_cost_authority import cost_basis_counts_have_non_promotion_grade_costs
 from .runtime_ledger import POST_COST_PNL_BASIS
 
 
@@ -1632,6 +1633,9 @@ def _runtime_ledger_bucket_evidence_grade(row: StrategyRuntimeLedgerBucket) -> b
         and _positive_hash_count(row.execution_policy_hash_counts)
         and _positive_hash_count(row.cost_model_hash_counts)
         and _positive_hash_count(row.lineage_hash_counts)
+        and not cost_basis_counts_have_non_promotion_grade_costs(
+            _as_mapping(row.payload_json).get("cost_basis_counts")
+        )
         and not blockers
     )
 

--- a/services/torghut/app/trading/runtime_cost_authority.py
+++ b/services/torghut/app/trading/runtime_cost_authority.py
@@ -1,0 +1,39 @@
+"""Shared runtime cost authority checks for promotion-grade ledger proof."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+NON_PROMOTION_GRADE_RUNTIME_COST_BASES = frozenset(
+    {
+        "modeled_paper_cost_budget",
+        "paper_cost_model_estimate",
+        "decision_impact_assumptions_total_cost_bps",
+    }
+)
+
+
+def is_non_promotion_grade_runtime_cost_basis(value: object) -> bool:
+    return str(value or "").strip() in NON_PROMOTION_GRADE_RUNTIME_COST_BASES
+
+
+def cost_basis_counts_have_non_promotion_grade_costs(value: Any) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    for key, count in cast(Mapping[object, object], value).items():
+        if not is_non_promotion_grade_runtime_cost_basis(key):
+            continue
+        try:
+            if int(str(count or "0")) > 0:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
+__all__ = [
+    "NON_PROMOTION_GRADE_RUNTIME_COST_BASES",
+    "cost_basis_counts_have_non_promotion_grade_costs",
+    "is_non_promotion_grade_runtime_cost_basis",
+]

--- a/services/torghut/app/trading/runtime_decision_authority.py
+++ b/services/torghut/app/trading/runtime_decision_authority.py
@@ -1,0 +1,66 @@
+"""Source-decision authority labels for runtime-ledger proof."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+ROUTE_ACQUISITION_SOURCE_DECISION_MODE = "route_acquisition_probe"
+STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE = "strategy_signal_paper"
+LIVE_STRATEGY_SIGNAL_SOURCE_DECISION_MODE = "live_strategy_signal"
+SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER = (
+    "source_decision_mode_not_profit_proof_eligible"
+)
+
+_ROUTE_ACQUISITION_ALIASES = frozenset(
+    {
+        "paper_route_acquisition",
+        "paper_route_target_plan_source_decision",
+        ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+    }
+)
+PROFIT_PROOF_ELIGIBLE_SOURCE_DECISION_MODES = frozenset(
+    {
+        STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+        LIVE_STRATEGY_SIGNAL_SOURCE_DECISION_MODE,
+    }
+)
+
+
+def normalize_source_decision_mode(value: object) -> str | None:
+    text = str(value or "").strip().lower().replace("-", "_")
+    if not text:
+        return None
+    if text in _ROUTE_ACQUISITION_ALIASES:
+        return ROUTE_ACQUISITION_SOURCE_DECISION_MODE
+    return text
+
+
+def source_decision_mode_is_profit_proof_eligible(value: object) -> bool:
+    mode = normalize_source_decision_mode(value)
+    return mode in PROFIT_PROOF_ELIGIBLE_SOURCE_DECISION_MODES
+
+
+def source_decision_mode_counts_have_non_profit_proof_modes(value: Any) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    for key, count in cast(Mapping[object, object], value).items():
+        try:
+            positive = int(str(count or "0")) > 0
+        except (TypeError, ValueError):
+            positive = False
+        if positive and not source_decision_mode_is_profit_proof_eligible(key):
+            return True
+    return False
+
+
+__all__ = [
+    "LIVE_STRATEGY_SIGNAL_SOURCE_DECISION_MODE",
+    "PROFIT_PROOF_ELIGIBLE_SOURCE_DECISION_MODES",
+    "ROUTE_ACQUISITION_SOURCE_DECISION_MODE",
+    "SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER",
+    "STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE",
+    "normalize_source_decision_mode",
+    "source_decision_mode_counts_have_non_profit_proof_modes",
+    "source_decision_mode_is_profit_proof_eligible",
+]

--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 
+from .runtime_cost_authority import is_non_promotion_grade_runtime_cost_basis
+
 POST_COST_PNL_BASIS = "realized_strategy_pnl_after_explicit_costs"
 EXACT_REPLAY_LEDGER_SCHEMA_VERSION = "torghut.exact_replay_ledger.v1"
 
@@ -19,9 +21,13 @@ _SUBMITTED_ORDER_EVENTS = frozenset(
     {"order_submitted", "submitted_order", "submitted", "accepted", "new"}
 )
 _FILL_EVENTS = frozenset({"fill", "filled", "partial_fill", "partially_filled"})
-_CANCELLED_ORDER_EVENTS = frozenset({"order_cancelled", "order_canceled", "cancelled", "canceled"})
+_CANCELLED_ORDER_EVENTS = frozenset(
+    {"order_cancelled", "order_canceled", "cancelled", "canceled"}
+)
 _REJECTED_ORDER_EVENTS = frozenset({"order_rejected", "rejected"})
-_UNFILLED_ORDER_EVENTS = frozenset({"order_unfilled", "unfilled", "expired", "order_expired"})
+_UNFILLED_ORDER_EVENTS = frozenset(
+    {"order_unfilled", "unfilled", "expired", "order_expired"}
+)
 _LIFECYCLE_EVENTS = (
     _DECISION_EVENTS
     | _SUBMITTED_ORDER_EVENTS
@@ -281,6 +287,8 @@ def _build_bucket(
         assert fill.cost_basis is not None
 
         cost_basis_counter[fill.cost_basis] += 1
+        if is_non_promotion_grade_runtime_cost_basis(fill.cost_basis):
+            blockers.append("runtime_ledger_cost_basis_non_promotion_grade")
         position_key = (fill.account_label, fill.strategy_id, fill.symbol)
         state = positions.setdefault(position_key, _PositionState())
         _apply_fill_to_position(state=state, fill=fill, accumulator=accumulator)
@@ -336,7 +344,9 @@ def _build_bucket(
         net_strategy_pnl_after_costs=accumulator.net_strategy_pnl_after_costs,
         post_cost_expectancy_bps=post_cost_expectancy_bps,
         cost_basis_counts=dict(sorted(cost_basis_counter.items())),
-        execution_policy_hash_counts=dict(sorted(execution_policy_hash_counter.items())),
+        execution_policy_hash_counts=dict(
+            sorted(execution_policy_hash_counter.items())
+        ),
         cost_model_hash_counts=dict(sorted(cost_model_hash_counter.items())),
         lineage_hash_counts=dict(sorted(lineage_hash_counter.items())),
         blockers=unique_blockers,
@@ -378,9 +388,7 @@ def _order_lifecycle_blockers(
     if submitted_without_decision:
         blockers.append("order_decision_linkage_missing")
 
-    fill_order_ids = {
-        row.order_id for row in usable_fills if row.order_id is not None
-    }
+    fill_order_ids = {row.order_id for row in usable_fills if row.order_id is not None}
     if usable_fills and len(fill_order_ids) < len(usable_fills):
         blockers.append("fill_order_linkage_missing")
     if fill_order_ids - submitted_order_ids:
@@ -396,7 +404,10 @@ def _order_lifecycle_blockers(
         blockers.append("execution_policy_hash_missing")
     if any(row.cost_model_hash is None for row in lifecycle_rows):
         blockers.append("cost_model_hash_missing")
-    if any(row.lineage_hash is None and row.replay_data_hash is None for row in lifecycle_rows):
+    if any(
+        row.lineage_hash is None and row.replay_data_hash is None
+        for row in lifecycle_rows
+    ):
         blockers.append("proof_lineage_hash_missing")
     if len(execution_policy_hash_counter) > 1:
         blockers.append("execution_policy_hash_ambiguous")
@@ -603,6 +614,8 @@ def _normalize_fill_row(
             blockers.append("explicit_cost_missing")
         if cost_basis is None:
             blockers.append("cost_basis_missing")
+        elif is_non_promotion_grade_runtime_cost_basis(cost_basis):
+            blockers.append("runtime_ledger_cost_basis_non_promotion_grade")
 
     return _NormalizedFill(
         row_index=row_index,
@@ -661,7 +674,10 @@ def _coerce_event_type(row: RuntimeLedgerFill | Mapping[str, object]) -> str:
         if candidate in _LIFECYCLE_EVENTS:
             return candidate
 
-    if _row_value(row, "filled_qty", "qty", "quantity", "avg_fill_price", "fill_price") is not None:
+    if (
+        _row_value(row, "filled_qty", "qty", "quantity", "avg_fill_price", "fill_price")
+        is not None
+    ):
         return "fill"
     if _row_value(row, "alpaca_order_id", "client_order_id", "order_id") is not None:
         return "order_submitted"

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -27,6 +27,16 @@ from .hypotheses import (
     load_hypothesis_registry,
 )
 from .runtime_ledger import EXACT_REPLAY_LEDGER_SCHEMA_VERSION, POST_COST_PNL_BASIS
+from .runtime_cost_authority import (
+    cost_basis_counts_have_non_promotion_grade_costs,
+    is_non_promotion_grade_runtime_cost_basis,
+)
+from .runtime_decision_authority import (
+    SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER,
+    normalize_source_decision_mode,
+    source_decision_mode_counts_have_non_profit_proof_modes,
+    source_decision_mode_is_profit_proof_eligible,
+)
 
 US_EQUITIES_REGULAR_TIMEZONE = "America/New_York"
 US_EQUITIES_REGULAR_OPEN = time(hour=9, minute=30)
@@ -34,13 +44,6 @@ US_EQUITIES_REGULAR_CLOSE = time(hour=16, minute=0)
 PROMOTION_GRADE_POST_COST_BASES = frozenset(
     {
         "realized_strategy_pnl_after_explicit_costs",
-    }
-)
-NON_PROMOTION_GRADE_RUNTIME_COST_BASES = frozenset(
-    {
-        "modeled_paper_cost_budget",
-        "paper_cost_model_estimate",
-        "decision_impact_assumptions_total_cost_bps",
     }
 )
 _RUNTIME_LEDGER_PROOF_SATISFIED_METADATA_BLOCKERS = frozenset(
@@ -115,6 +118,7 @@ class _NormalizedTcaRow:
     post_cost_expectancy_basis: str
     post_cost_promotion_eligible: bool
     runtime_ledger_bucket: dict[str, Any]
+    source_decision_mode: str | None = None
 
 
 def _utc(dt: datetime) -> datetime:
@@ -257,16 +261,6 @@ def _hash_count(value: Any) -> int:
     return sum(1 for key in mapping.keys() if str(key).strip())
 
 
-def _cost_basis_counts_have_non_promotion_grade_costs(value: Any) -> bool:
-    if not isinstance(value, Mapping):
-        return False
-    return any(
-        str(key).strip() in NON_PROMOTION_GRADE_RUNTIME_COST_BASES
-        and _observation_int(count) > 0
-        for key, count in cast(Mapping[object, object], value).items()
-    )
-
-
 def _persisted_runtime_ledger_bucket_evidence_grade(
     row: StrategyRuntimeLedgerBucket,
 ) -> bool:
@@ -282,7 +276,7 @@ def _persisted_runtime_ledger_bucket_evidence_grade(
         and _hash_count(row.execution_policy_hash_counts) > 0
         and _hash_count(row.cost_model_hash_counts) > 0
         and _hash_count(row.lineage_hash_counts) > 0
-        and not _cost_basis_counts_have_non_promotion_grade_costs(
+        and not cost_basis_counts_have_non_promotion_grade_costs(
             _mapping(row.payload_json).get("cost_basis_counts")
         )
         and not blockers
@@ -321,14 +315,26 @@ def _runtime_ledger_bucket_blockers(bucket: Mapping[str, Any]) -> list[str]:
         blockers.append("filled_notional_missing")
     if cost_amount is None or cost_amount < 0:
         blockers.append("explicit_cost_missing")
-    non_promotion_grade_cost_basis = (
-        str(bucket.get("cost_basis") or "").strip()
-        in NON_PROMOTION_GRADE_RUNTIME_COST_BASES
-    ) or _cost_basis_counts_have_non_promotion_grade_costs(
+    non_promotion_grade_cost_basis = is_non_promotion_grade_runtime_cost_basis(
+        bucket.get("cost_basis")
+    ) or cost_basis_counts_have_non_promotion_grade_costs(
         bucket.get("cost_basis_counts")
     )
     if non_promotion_grade_cost_basis:
         blockers.append("runtime_ledger_cost_basis_non_promotion_grade")
+    source_decision_mode = normalize_source_decision_mode(
+        bucket.get("source_decision_mode")
+    )
+    if source_decision_mode and not source_decision_mode_is_profit_proof_eligible(
+        source_decision_mode
+    ):
+        blockers.append(SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER)
+    if source_decision_mode_counts_have_non_profit_proof_modes(
+        bucket.get("source_decision_mode_counts")
+    ):
+        blockers.append(SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER)
+    if _observation_bool(bucket.get("profit_proof_eligible")) is False:
+        blockers.append(SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER)
     if post_cost_expectancy is None:
         blockers.append("runtime_ledger_expectancy_missing")
     if _hash_count(bucket.get("execution_policy_hash_counts")) <= 0:
@@ -351,6 +357,10 @@ def _runtime_ledger_row_is_promotion_grade(row: _NormalizedTcaRow) -> bool:
     return (
         row.post_cost_expectancy_bps is not None
         and row.post_cost_promotion_eligible
+        and (
+            row.source_decision_mode is None
+            or source_decision_mode_is_profit_proof_eligible(row.source_decision_mode)
+        )
         and row.post_cost_expectancy_basis == POST_COST_PNL_BASIS
         and bool(row.runtime_ledger_bucket)
         and not _runtime_ledger_bucket_blockers(row.runtime_ledger_bucket)
@@ -1000,6 +1010,17 @@ def build_observed_runtime_buckets(
         basis = _post_cost_expectancy_basis(
             row.get("post_cost_expectancy_basis") or row.get("post_cost_basis")
         )
+        runtime_ledger_bucket = _runtime_ledger_bucket_payload(
+            row.get("runtime_ledger_bucket")
+        )
+        source_decision_mode = normalize_source_decision_mode(
+            row.get("source_decision_mode")
+            or runtime_ledger_bucket.get("source_decision_mode")
+        )
+        source_decision_mode_eligible = (
+            source_decision_mode is None
+            or source_decision_mode_is_profit_proof_eligible(source_decision_mode)
+        )
         normalized_tca_rows.append(
             _NormalizedTcaRow(
                 computed_at=_utc(computed_at_raw),
@@ -1011,10 +1032,10 @@ def build_observed_runtime_buckets(
                 post_cost_promotion_eligible=_post_cost_basis_is_promotion_grade(
                     basis=basis,
                     explicit_value=row.get("post_cost_promotion_eligible"),
-                ),
-                runtime_ledger_bucket=_runtime_ledger_bucket_payload(
-                    row.get("runtime_ledger_bucket")
-                ),
+                )
+                and source_decision_mode_eligible,
+                runtime_ledger_bucket=runtime_ledger_bucket,
+                source_decision_mode=source_decision_mode,
             )
         )
 

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -29,6 +29,7 @@ from ..paper_route_target_plan import (
 )
 from ..prices import MarketSnapshot
 from ..proof_floor import build_profitability_proof_floor_receipt
+from ..runtime_decision_authority import ROUTE_ACQUISITION_SOURCE_DECISION_MODE
 from ..session_context import REGULAR_OPEN_UTC
 from ..simple_risk import (
     position_qty_for_symbol,
@@ -1947,6 +1948,8 @@ class SimpleTradingPipeline(TradingPipeline):
             "paper_route_probe_next_session_max_notional": str(max_notional),
             "paper_route_target_plan_source": "external_target_plan_url",
             "paper_route_probe_scope_authority": "external_target_plan",
+            "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+            "profit_proof_eligible": False,
             "source_kind": _safe_text(target.get("source_kind")),
             "source_manifest_ref": _safe_text(target.get("source_manifest_ref")),
             "paper_probation_authorized": bool(
@@ -2070,6 +2073,8 @@ class SimpleTradingPipeline(TradingPipeline):
                     "paper_route_target_plan": metadata,
                     "paper_route_target_plan_source_decision": metadata,
                     "simple_lane": simple_lane,
+                    "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+                    "profit_proof_eligible": False,
                     "promotion_allowed": False,
                     "final_promotion_authorized": False,
                     "final_promotion_allowed": False,
@@ -2250,6 +2255,8 @@ class SimpleTradingPipeline(TradingPipeline):
         return {
             "enabled": True,
             "mode": "paper_route_acquisition",
+            "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+            "profit_proof_eligible": False,
             "max_notional": str(cap),
             "symbol": symbol,
             "side": decision.action,

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -25,6 +25,16 @@ from app.trading.runtime_ledger import (
     RuntimeLedgerBucket,
     build_runtime_ledger_buckets,
 )
+from app.trading.runtime_cost_authority import (
+    cost_basis_counts_have_non_promotion_grade_costs,
+    is_non_promotion_grade_runtime_cost_basis,
+)
+from app.trading.runtime_decision_authority import (
+    SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER,
+    normalize_source_decision_mode,
+    source_decision_mode_counts_have_non_profit_proof_modes,
+    source_decision_mode_is_profit_proof_eligible,
+)
 from app.trading.runtime_window_import import (
     build_observed_runtime_buckets,
     build_regular_session_buckets,
@@ -53,13 +63,6 @@ RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
     {
         EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
         "torghut.runtime-ledger-bucket.v1",
-    }
-)
-NON_PROMOTION_GRADE_RUNTIME_COST_BASES = frozenset(
-    {
-        "modeled_paper_cost_budget",
-        "paper_cost_model_estimate",
-        "decision_impact_assumptions_total_cost_bps",
     }
 )
 EXACT_REPLAY_ARTIFACT_AUTHORITY_CLASS = "exact_replay_artifact_only_not_live"
@@ -264,6 +267,61 @@ def _text_values(row: Mapping[str, object], *keys: str) -> set[str]:
     return values
 
 
+def _first_bool(row: Mapping[str, object], *keys: str) -> bool | None:
+    for payload in _row_payloads(row):
+        for key in keys:
+            value = payload.get(key)
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, int | float | Decimal):
+                return bool(value)
+            text = str(value or "").strip().lower()
+            if text in {"1", "true", "yes", "on", "pass", "passed", "ok"}:
+                return True
+            if text in {"0", "false", "no", "off", "fail", "failed", "blocked"}:
+                return False
+    return None
+
+
+def _source_decision_mode(row: Mapping[str, object]) -> str | None:
+    explicit = normalize_source_decision_mode(_first_text(row, "source_decision_mode"))
+    if explicit is not None:
+        return explicit
+    return normalize_source_decision_mode(_first_text(row, "mode"))
+
+
+def _source_decision_mode_counts(
+    rows: Sequence[Mapping[str, object]],
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        mode = _source_decision_mode(row)
+        if mode is None:
+            continue
+        counts[mode] = counts.get(mode, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _source_decision_rows_profit_proof_eligible(
+    rows: Sequence[Mapping[str, object]],
+) -> bool:
+    modes = _source_decision_mode_counts(rows)
+    if source_decision_mode_counts_have_non_profit_proof_modes(modes):
+        return False
+    explicit: list[bool] = []
+    for row in rows:
+        value = _first_bool(
+            row,
+            "profit_proof_eligible",
+            "post_cost_promotion_eligible",
+        )
+        if value is not None:
+            explicit.append(value)
+    if any(value is False for value in explicit):
+        return False
+    return True
+
+
 def _source_row_matches_lineage(
     row: Mapping[str, object],
     *,
@@ -403,16 +461,6 @@ def _mapping_hash_count(value: object) -> int:
     return sum(1 for key in value.keys() if str(key).strip())
 
 
-def _cost_basis_counts_have_non_promotion_grade_costs(value: object) -> bool:
-    if not isinstance(value, Mapping):
-        return False
-    return any(
-        str(key).strip() in NON_PROMOTION_GRADE_RUNTIME_COST_BASES
-        and _nonnegative_int(count) > 0
-        for key, count in cast(Mapping[object, object], value).items()
-    )
-
-
 def _runtime_ledger_bucket_profit_proof_present(
     bucket: Mapping[str, object],
 ) -> bool:
@@ -441,14 +489,24 @@ def _runtime_ledger_bucket_profit_proof_present(
         return False
     if cost_amount is None or cost_amount < 0:
         return False
-    if (
-        str(bucket.get("cost_basis") or "").strip()
-        in NON_PROMOTION_GRADE_RUNTIME_COST_BASES
-    ):
+    if is_non_promotion_grade_runtime_cost_basis(bucket.get("cost_basis")):
         return False
-    if _cost_basis_counts_have_non_promotion_grade_costs(
+    if cost_basis_counts_have_non_promotion_grade_costs(
         bucket.get("cost_basis_counts")
     ):
+        return False
+    source_decision_mode = normalize_source_decision_mode(
+        bucket.get("source_decision_mode")
+    )
+    if source_decision_mode and not source_decision_mode_is_profit_proof_eligible(
+        source_decision_mode
+    ):
+        return False
+    if source_decision_mode_counts_have_non_profit_proof_modes(
+        bucket.get("source_decision_mode_counts")
+    ):
+        return False
+    if _first_bool(bucket, "profit_proof_eligible") is False:
         return False
     if post_cost_expectancy is None:
         return False
@@ -1481,6 +1539,15 @@ def _build_realized_strategy_pnl_rows(
             *(order_lifecycle_rows or []),
         ]
     )
+    source_decision_rows = [
+        *execution_rows,
+        *(decision_lifecycle_rows or []),
+        *(order_lifecycle_rows or []),
+    ]
+    source_decision_mode_counts = _source_decision_mode_counts(source_decision_rows)
+    source_decision_profit_proof_eligible = _source_decision_rows_profit_proof_eligible(
+        source_decision_rows
+    )
     realized_rows: list[dict[str, object]] = []
     for bucket in build_runtime_ledger_buckets(
         ledger_rows,
@@ -1494,6 +1561,31 @@ def _build_realized_strategy_pnl_rows(
             computed_at=unique_times[-1],
         )
         bucket_payload = row.get("runtime_ledger_bucket")
+        if source_decision_mode_counts:
+            row["source_decision_mode_counts"] = source_decision_mode_counts
+            row["profit_proof_eligible"] = source_decision_profit_proof_eligible
+            if isinstance(bucket_payload, Mapping):
+                bucket_payload = {
+                    **dict(bucket_payload),
+                    "source_decision_mode_counts": source_decision_mode_counts,
+                    "profit_proof_eligible": source_decision_profit_proof_eligible,
+                }
+                if not source_decision_profit_proof_eligible:
+                    blockers = list(bucket_payload.get("blockers") or [])
+                    if (
+                        SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER
+                        not in blockers
+                    ):
+                        blockers.append(
+                            SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER
+                        )
+                    bucket_payload["blockers"] = blockers
+                    row["runtime_ledger_blockers"] = blockers
+                    row["post_cost_promotion_eligible"] = False
+                    row["promotion_blocker"] = (
+                        SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER
+                    )
+                row["runtime_ledger_bucket"] = bucket_payload
         event_sourced_runtime_ledger = (
             allow_authoritative_runtime_ledger_materialization
             and event_sourced_lifecycle_rows > 0

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -22,6 +22,7 @@ from scripts.import_hypothesis_runtime_windows import (
     POST_COST_BASIS_SIMULATION_REPORT,
     POST_COST_BASIS_TCA_PROXY,
     _build_realized_strategy_pnl_rows,
+    _first_bool,
     _first_lineage_digest,
     _load_json_artifact,
     _load_report_post_cost_expectancy_bps,
@@ -48,6 +49,9 @@ from scripts.import_hypothesis_runtime_windows import (
     _source_activity_diagnostics_blockers,
     _source_row_matches_lineage,
     _source_activity_missing_summary,
+    _source_decision_mode,
+    _source_decision_mode_counts,
+    _source_decision_rows_profit_proof_eligible,
     _stable_payload_digest,
     _strategy_name_candidates,
     main,
@@ -509,6 +513,91 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                         _complete_runtime_ledger_bucket(**overrides)
                     )
                 )
+
+    def test_runtime_ledger_profit_proof_rejects_route_acquisition_source_mode(
+        self,
+    ) -> None:
+        self.assertFalse(
+            _runtime_ledger_bucket_profit_proof_present(
+                _complete_runtime_ledger_bucket(
+                    source_decision_mode_counts={"route_acquisition_probe": 2}
+                )
+            )
+        )
+        self.assertFalse(
+            _runtime_ledger_bucket_profit_proof_present(
+                _complete_runtime_ledger_bucket(
+                    source_decision_mode="route_acquisition_probe"
+                )
+            )
+        )
+        self.assertFalse(
+            _runtime_ledger_bucket_profit_proof_present(
+                _complete_runtime_ledger_bucket(profit_proof_eligible=False)
+            )
+        )
+        self.assertTrue(
+            _runtime_ledger_bucket_profit_proof_present(
+                _complete_runtime_ledger_bucket(
+                    source_decision_mode_counts={"strategy_signal_paper": 2}
+                )
+            )
+        )
+
+    def test_source_decision_helpers_normalize_counts_and_profit_proof_flags(
+        self,
+    ) -> None:
+        self.assertTrue(
+            _first_bool(
+                {"profit_proof_eligible": Decimal("1")}, "profit_proof_eligible"
+            )
+        )
+        self.assertTrue(
+            _first_bool({"profit_proof_eligible": "yes"}, "profit_proof_eligible")
+        )
+        self.assertFalse(
+            _first_bool({"profit_proof_eligible": "blocked"}, "profit_proof_eligible")
+        )
+        self.assertEqual(
+            _source_decision_mode(
+                {"source_decision_mode": "paper-route-target-plan-source-decision"}
+            ),
+            "route_acquisition_probe",
+        )
+        self.assertEqual(
+            _source_decision_mode({"mode": "strategy_signal_paper"}),
+            "strategy_signal_paper",
+        )
+        self.assertEqual(
+            _source_decision_mode_counts(
+                [
+                    {"source_decision_mode": "route_acquisition_probe"},
+                    {"mode": "strategy_signal_paper"},
+                    {"source_decision_mode": ""},
+                ]
+            ),
+            {"route_acquisition_probe": 1, "strategy_signal_paper": 1},
+        )
+        self.assertFalse(
+            _source_decision_rows_profit_proof_eligible(
+                [{"source_decision_mode": "route_acquisition_probe"}]
+            )
+        )
+        self.assertFalse(
+            _source_decision_rows_profit_proof_eligible(
+                [{"profit_proof_eligible": "failed"}]
+            )
+        )
+        self.assertTrue(
+            _source_decision_rows_profit_proof_eligible(
+                [
+                    {
+                        "source_decision_mode": "strategy_signal_paper",
+                        "profit_proof_eligible": True,
+                    }
+                ]
+            )
+        )
 
     def test_runtime_ledger_tca_rows_from_durable_buckets_queries_matching_proof(
         self,
@@ -2121,19 +2210,87 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         bucket = rows[0]["runtime_ledger_bucket"]
         self.assertIsInstance(bucket, dict)
         assert isinstance(bucket, dict)
+        self.assertIn(
+            "runtime_ledger_cost_basis_non_promotion_grade", bucket["blockers"]
+        )
+        self.assertIn("runtime_fills_missing", bucket["blockers"])
         self.assertIn("runtime_decision_lifecycle_missing", bucket["blockers"])
         self.assertIn("submitted_order_lifecycle_missing", bucket["blockers"])
-        self.assertIn("fill_order_submission_missing", bucket["blockers"])
         self.assertIn(
             "execution_reconstruction_not_runtime_ledger_proof",
             bucket["blockers"],
         )
         self.assertEqual(
             bucket["cost_basis_counts"],
-            {"decision_impact_assumptions_total_cost_bps": 2},
+            {},
         )
-        self.assertEqual(bucket["cost_amount"], "0.201")
-        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.799"))
+        self.assertEqual(bucket["cost_amount"], "0")
+        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0"))
+
+    def test_build_realized_strategy_pnl_rows_marks_route_acquisition_not_profit_proof(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "route_acquisition_probe",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "route_acquisition_probe",
+                },
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(
+            row["source_decision_mode_counts"], {"route_acquisition_probe": 2}
+        )
+        self.assertFalse(row["profit_proof_eligible"])
+        self.assertFalse(row["post_cost_promotion_eligible"])
+        self.assertIn(
+            "source_decision_mode_not_profit_proof_eligible",
+            row["runtime_ledger_blockers"],
+        )
+        self.assertEqual(
+            row["promotion_blocker"],
+            "execution_reconstruction_not_runtime_ledger_proof",
+        )
+        bucket = row["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(
+            bucket["source_decision_mode_counts"], {"route_acquisition_probe": 2}
+        )
+        self.assertFalse(bucket["profit_proof_eligible"])
+        self.assertIn(
+            "source_decision_mode_not_profit_proof_eligible", bucket["blockers"]
+        )
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
 
     def test_runtime_ledger_tca_row_separates_explicit_cost_from_slippage(

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -8,6 +8,8 @@ import pytest
 from app.trading.runtime_ledger import (
     EXACT_REPLAY_LEDGER_SCHEMA_VERSION,
     RuntimeLedgerFill,
+    _build_bucket,
+    _NormalizedFill,
     build_runtime_ledger_buckets,
 )
 
@@ -579,6 +581,133 @@ def test_exact_replay_ledger_requires_order_lifecycle_and_hash_lineage() -> None
     assert bucket.cost_model_hash_counts == {"cost-sha": 6}
     assert bucket.lineage_hash_counts == {"lineage-sha": 6}
     assert bucket.post_cost_expectancy_bps is not None
+
+
+def test_runtime_ledger_blocks_non_promotion_grade_cost_basis_at_builder() -> None:
+    common = {
+        "account_label": "paper",
+        "strategy_id": "strategy-1",
+        "symbol": "NVDA",
+        "execution_policy_hash": "policy-sha",
+        "cost_model_hash": "cost-sha",
+        "lineage_hash": "lineage-sha",
+    }
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                **common,
+                "event_type": "decision",
+                "executed_at": _ts(1),
+                "decision_id": "decision-buy",
+            },
+            {
+                **common,
+                "event_type": "order_submitted",
+                "executed_at": _ts(2),
+                "decision_id": "decision-buy",
+                "order_id": "order-buy",
+            },
+            {
+                **common,
+                "event_type": "fill",
+                "executed_at": _ts(3),
+                "order_id": "order-buy",
+                "side": "buy",
+                "filled_qty": "10",
+                "avg_fill_price": "100",
+                "cost_amount": "1",
+                "cost_basis": "modeled_paper_cost_budget",
+            },
+            {
+                **common,
+                "event_type": "decision",
+                "executed_at": _ts(10),
+                "decision_id": "decision-sell",
+            },
+            {
+                **common,
+                "event_type": "order_submitted",
+                "executed_at": _ts(11),
+                "decision_id": "decision-sell",
+                "order_id": "order-sell",
+            },
+            {
+                **common,
+                "event_type": "fill",
+                "executed_at": _ts(12),
+                "order_id": "order-sell",
+                "side": "sell",
+                "filled_qty": "10",
+                "avg_fill_price": "110",
+                "cost_amount": "2",
+                "cost_basis": "modeled_paper_cost_budget",
+            },
+        ],
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.fill_count == 0
+    assert bucket.net_strategy_pnl_after_costs == Decimal("0")
+    assert bucket.cost_basis_counts == {}
+    assert "runtime_ledger_cost_basis_non_promotion_grade" in bucket.blockers
+    assert bucket.post_cost_expectancy_bps is None
+
+
+def test_runtime_ledger_defensively_blocks_usable_non_promotion_grade_cost_basis() -> (
+    None
+):
+    rows = [
+        _NormalizedFill(
+            row_index=0,
+            executed_at=_ts(1),
+            account_label="paper",
+            strategy_id="strategy-1",
+            symbol="NVDA",
+            side="buy",
+            filled_qty=Decimal("10"),
+            avg_fill_price=Decimal("100"),
+            filled_notional=Decimal("1000"),
+            cost_amount=Decimal("1"),
+            cost_basis="modeled_paper_cost_budget",
+            event_type="fill",
+            decision_id="decision-buy",
+            order_id="order-buy",
+            execution_policy_hash="policy-sha",
+            cost_model_hash="cost-sha",
+            lineage_hash="lineage-sha",
+            replay_data_hash=None,
+            blockers=(),
+        ),
+        _NormalizedFill(
+            row_index=1,
+            executed_at=_ts(12),
+            account_label="paper",
+            strategy_id="strategy-1",
+            symbol="NVDA",
+            side="sell",
+            filled_qty=Decimal("10"),
+            avg_fill_price=Decimal("110"),
+            filled_notional=Decimal("1100"),
+            cost_amount=Decimal("2"),
+            cost_basis="modeled_paper_cost_budget",
+            event_type="fill",
+            decision_id="decision-sell",
+            order_id="order-sell",
+            execution_policy_hash="policy-sha",
+            cost_model_hash="cost-sha",
+            lineage_hash="lineage-sha",
+            replay_data_hash=None,
+            blockers=(),
+        ),
+    ]
+
+    bucket = _build_bucket(bucket_start=_ts(), bucket_end=_ts(60), rows=rows)
+
+    assert bucket.fill_count == 2
+    assert bucket.cost_basis_counts == {"modeled_paper_cost_budget": 2}
+    assert "runtime_ledger_cost_basis_non_promotion_grade" in bucket.blockers
+    assert bucket.post_cost_expectancy_bps is None
 
 
 def test_exact_replay_ledger_blocks_fill_only_profit_proof() -> None:

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -18,6 +18,12 @@ from app.models import (
     StrategyRuntimeLedgerBucket,
     VNextDatasetSnapshot,
 )
+from app.trading.runtime_cost_authority import (
+    cost_basis_counts_have_non_promotion_grade_costs,
+)
+from app.trading.runtime_decision_authority import (
+    source_decision_mode_counts_have_non_profit_proof_modes,
+)
 from app.trading.runtime_window_import import (
     _delay_adjusted_depth_stress_blocking_reasons,
     _observation_bool,
@@ -363,6 +369,44 @@ class TestRuntimeWindowImport(TestCase):
     def test_runtime_ledger_bucket_blockers_reject_non_promotion_grade_cost_basis(
         self,
     ) -> None:
+        for basis in (
+            "modeled_paper_cost_budget",
+            "paper_cost_model_estimate",
+            "decision_impact_assumptions_total_cost_bps",
+        ):
+            with self.subTest(basis=basis):
+                blockers = _runtime_ledger_bucket_blockers(
+                    {
+                        "ledger_schema_version": "torghut.runtime-ledger-bucket.v1",
+                        "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
+                        "fill_count": 2,
+                        "decision_count": 2,
+                        "submitted_order_count": 2,
+                        "closed_trade_count": 1,
+                        "open_position_count": 0,
+                        "filled_notional": "200",
+                        "cost_amount": "0.20",
+                        "cost_basis_counts": {basis: 2},
+                        "post_cost_expectancy_bps": "40",
+                        "execution_policy_hash_counts": {"policy-sha": 2},
+                        "cost_model_hash_counts": {"cost-sha": 2},
+                        "lineage_hash_counts": {"lineage-sha": 2},
+                    }
+                )
+
+                self.assertEqual(
+                    blockers, ["runtime_ledger_cost_basis_non_promotion_grade"]
+                )
+
+        self.assertFalse(
+            cost_basis_counts_have_non_promotion_grade_costs(
+                {"modeled_paper_cost_budget": object()}
+            )
+        )
+
+    def test_runtime_ledger_bucket_blockers_reject_route_acquisition_profit_proof(
+        self,
+    ) -> None:
         blockers = _runtime_ledger_bucket_blockers(
             {
                 "ledger_schema_version": "torghut.runtime-ledger-bucket.v1",
@@ -374,7 +418,8 @@ class TestRuntimeWindowImport(TestCase):
                 "open_position_count": 0,
                 "filled_notional": "200",
                 "cost_amount": "0.20",
-                "cost_basis_counts": {"modeled_paper_cost_budget": 2},
+                "cost_basis_counts": {"broker_reported_commission_and_fees": 2},
+                "source_decision_mode_counts": {"route_acquisition_probe": 2},
                 "post_cost_expectancy_bps": "40",
                 "execution_policy_hash_counts": {"policy-sha": 2},
                 "cost_model_hash_counts": {"cost-sha": 2},
@@ -382,7 +427,31 @@ class TestRuntimeWindowImport(TestCase):
             }
         )
 
-        self.assertEqual(blockers, ["runtime_ledger_cost_basis_non_promotion_grade"])
+        self.assertEqual(blockers, ["source_decision_mode_not_profit_proof_eligible"])
+
+        self.assertFalse(
+            source_decision_mode_counts_have_non_profit_proof_modes(
+                {"route_acquisition_probe": object()}
+            )
+        )
+
+    def test_runtime_ledger_bucket_blockers_reject_direct_route_acquisition_mode(
+        self,
+    ) -> None:
+        blockers = _runtime_ledger_bucket_blockers(
+            _runtime_ledger_bucket(source_decision_mode="route-acquisition-probe")
+        )
+
+        self.assertEqual(blockers, ["source_decision_mode_not_profit_proof_eligible"])
+
+    def test_runtime_ledger_bucket_blockers_reject_false_profit_proof_flag(
+        self,
+    ) -> None:
+        blockers = _runtime_ledger_bucket_blockers(
+            _runtime_ledger_bucket(profit_proof_eligible="false")
+        )
+
+        self.assertEqual(blockers, ["source_decision_mode_not_profit_proof_eligible"])
 
     def test_persisted_runtime_ledger_bucket_evidence_grade_rejects_modeled_cost_basis(
         self,

--- a/services/torghut/tests/test_snapshots.py
+++ b/services/torghut/tests/test_snapshots.py
@@ -9,7 +9,11 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
 from app.models import Base
-from app.snapshots import snapshot_account_and_positions, sync_order_to_db
+from app.snapshots import (
+    _runtime_cost_payload_from_mapping,
+    snapshot_account_and_positions,
+    sync_order_to_db,
+)
 
 
 class DummyAlpacaClient:
@@ -48,6 +52,19 @@ class TestSnapshots(TestCase):
             self.assertEqual(snapshot.cash, Decimal("5000"))
             self.assertEqual(snapshot.buying_power, Decimal("20000"))
             self.assertEqual(len(snapshot.positions), 1)
+
+    def test_runtime_cost_payload_skips_non_promotion_grade_cost_basis(self) -> None:
+        self.assertIsNone(
+            _runtime_cost_payload_from_mapping(
+                {
+                    "cost_amount": "1.23",
+                    "cost_basis": "modeled_paper_cost_budget",
+                    "commission": "0.25",
+                },
+                source="audit",
+                source_field_prefix="audit.",
+            )
+        )
 
     def test_snapshot_account_and_positions_serializes_uuid_payloads(self) -> None:
         client = DummyAlpacaClient()

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -4718,14 +4718,24 @@ class TestTradingPipeline(TestCase):
             )
             self.assertEqual(source_decision["candidate_id"], "cand-paper-route")
             self.assertEqual(source_decision["hypothesis_id"], "H-PAPER-ROUTE")
+            self.assertEqual(
+                source_decision["source_decision_mode"], "route_acquisition_probe"
+            )
+            self.assertFalse(source_decision["profit_proof_eligible"])
             self.assertEqual(source_decision["exit_minute_after_open"], 120)
             self.assertEqual(params["exit_minute_after_open"], 120)
             self.assertEqual(params["source_candidate_ids"], ["cand-paper-route"])
             self.assertEqual(params["source_hypothesis_ids"], ["H-PAPER-ROUTE"])
+            self.assertEqual(params["source_decision_mode"], "route_acquisition_probe")
+            self.assertFalse(params["profit_proof_eligible"])
             self.assertFalse(params["promotion_allowed"])
             self.assertFalse(params["final_promotion_authorized"])
             self.assertEqual(paper_route_probe["max_notional"], "25")
             self.assertTrue(paper_route_probe["target_source_authorized"])
+            self.assertEqual(
+                paper_route_probe["source_decision_mode"], "route_acquisition_probe"
+            )
+            self.assertFalse(paper_route_probe["profit_proof_eligible"])
             self.assertEqual(paper_route_probe["exit_minute_after_open"], 120)
             self.assertEqual(
                 paper_route_probe["exit_due_at"],
@@ -4876,9 +4886,19 @@ class TestTradingPipeline(TestCase):
 
             self.assertEqual(decision.status, "submitted")
             self.assertEqual(source_decision["candidate_id"], "cand-paper-route")
+            self.assertEqual(
+                source_decision["source_decision_mode"], "route_acquisition_probe"
+            )
+            self.assertFalse(source_decision["profit_proof_eligible"])
             self.assertEqual(source_decision["exit_minute_after_open"], 120)
             self.assertEqual(params["source_hypothesis_ids"], ["H-PAPER-ROUTE"])
+            self.assertEqual(params["source_decision_mode"], "route_acquisition_probe")
+            self.assertFalse(params["profit_proof_eligible"])
             self.assertTrue(paper_route_probe["target_source_authorized"])
+            self.assertEqual(
+                paper_route_probe["source_decision_mode"], "route_acquisition_probe"
+            )
+            self.assertFalse(paper_route_probe["profit_proof_eligible"])
             self.assertEqual(paper_route_probe["exit_minute_after_open"], 120)
 
     def test_simple_pipeline_target_plan_source_decision_requires_open_window(


### PR DESCRIPTION
## Summary

- Adds shared runtime cost and source-decision authority helpers for promotion-grade runtime-ledger proof.
- Marks target-plan and paper-route acquisition decisions as `route_acquisition_probe` with `profit_proof_eligible=false`.
- Blocks modeled/non-authoritative cost bases and route-acquisition source modes from counting as post-cost profitability proof.
- Extends ledger, runtime-window import, hypothesis import, paper-route evidence, snapshots, and trading pipeline tests for the stricter gates.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_trading_pipeline.py tests/test_paper_route_evidence.py tests/test_snapshots.py -q`
- `uv run --frozen pytest tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_snapshots.py tests/test_paper_route_evidence.py tests/test_trading_pipeline.py --cov --cov-branch --cov-report=xml:coverage.xml --cov-fail-under=0 -q`
- `GITHUB_BASE_REF=main GITHUB_EVENT_NAME=pull_request uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen ruff check app/main.py app/snapshots.py app/trading/paper_route_evidence.py app/trading/runtime_cost_authority.py app/trading/runtime_decision_authority.py app/trading/runtime_ledger.py app/trading/runtime_window_import.py app/trading/scheduler/simple_pipeline.py scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/main.py app/snapshots.py app/trading/paper_route_evidence.py app/trading/runtime_cost_authority.py app/trading/runtime_decision_authority.py app/trading/runtime_ledger.py app/trading/runtime_window_import.py app/trading/scheduler/simple_pipeline.py scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_runtime_window_import.py tests/test_trading_pipeline.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

No API break. Promotion/proof evidence is intentionally stricter: modeled paper costs and route-acquisition probes no longer qualify as post-cost profitability proof.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
