### PR TITLE
feat(synthesis): add trader protective visibility contract

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agent.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agent.yaml
@@ -20,5 +20,6 @@ spec:
       - agents-artifacts
       - codex-auth
       - github-token
+      - synthesis-env
     allowedServiceAccounts:
       - agents-sa

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -30,6 +30,13 @@ spec:
               FASTMCP_SHOW_SERVER_BANNER: "false"
               FASTMCP_LOG_LEVEL: "ERROR"
             startup_timeout_sec: 60
+          synthesis:
+            command: node
+            args:
+              - /root/.codex/synthesis-mcp-proxy.mjs
+            env:
+              SYNTHESIS_API_TOKEN_FILE: /var/run/synthesis/SYNTHESIS_API_TOKEN
+              SYNTHESIS_MCP_URL: http://synthesis.synthesis.svc.cluster.local:3000/mcp
         web_search: live
   argsTemplate: []
   secretEnv:
@@ -57,6 +64,9 @@ spec:
     - name: AGENTS_ARTIFACTS_SECRET_ACCESS_KEY
       secretName: agents-artifacts
       key: AWS_SECRET_ACCESS_KEY
+    - name: SYNTHESIS_API_TOKEN
+      secretName: synthesis-env
+      key: SYNTHESIS_API_TOKEN
   envTemplate:
     AGENT_RUN_NAME: "{{agentRun.name}}"
     AGENT_RUN_NAMESPACE: "{{agentRun.namespace}}"
@@ -76,6 +86,8 @@ spec:
     FASTMCP_LOG_LEVEL: "ERROR"
     FASTMCP_SHOW_SERVER_BANNER: "false"
     HOME: /root
+    SYNTHESIS_API_TOKEN_FILE: /var/run/synthesis/SYNTHESIS_API_TOKEN
+    SYNTHESIS_MCP_URL: http://synthesis.synthesis.svc.cluster.local:3000/mcp
   inputFiles:
     - path: /root/.codex/config.toml
       content: |-
@@ -118,6 +130,11 @@ spec:
         args = ["-u", "/root/alpaca-mcp-stdio-bridge.py"]
         startup_timeout_sec = 60.0
         env = { FASTMCP_SHOW_SERVER_BANNER = "false", FASTMCP_LOG_LEVEL = "ERROR" }
+
+        [mcp_servers.synthesis]
+        command = "node"
+        args = ["/root/.codex/synthesis-mcp-proxy.mjs"]
+        env = { SYNTHESIS_API_TOKEN_FILE = "/var/run/synthesis/SYNTHESIS_API_TOKEN", SYNTHESIS_MCP_URL = "http://synthesis.synthesis.svc.cluster.local:3000/mcp" }
     - path: /root/bootstrap-analysis-daytrading.sh
       content: |-
         #!/usr/bin/env bash
@@ -267,6 +284,100 @@ spec:
 
         exit_code = child.wait()
         sys.exit(exit_code)
+    - path: /root/.codex/synthesis-mcp-proxy.mjs
+      content: |-
+        #!/usr/bin/env node
+
+        import { readFileSync } from 'node:fs'
+        import readline from 'node:readline'
+
+        const readFirstTokenFile = (paths) => {
+          for (const path of paths) {
+            if (!path) continue
+            try {
+              const token = readFileSync(path, 'utf8').trim()
+              if (token) return token
+            } catch {}
+          }
+          return ''
+        }
+
+        const endpoint = process.env.SYNTHESIS_MCP_URL || 'http://synthesis.synthesis.svc.cluster.local:3000/mcp'
+        const token =
+          process.env.SYNTHESIS_API_TOKEN ||
+          process.env.SYNTHESIS_MCP_TOKEN ||
+          readFirstTokenFile([process.env.SYNTHESIS_API_TOKEN_FILE, '/var/run/synthesis/SYNTHESIS_API_TOKEN'])
+
+        const buildError = (id, code, message, data) => ({
+          jsonrpc: '2.0',
+          id,
+          error: {
+            code,
+            message,
+            ...(data == null ? {} : { data }),
+          },
+        })
+
+        const getId = (message) => {
+          if (!message || typeof message !== 'object') return null
+          const id = message.id
+          return typeof id === 'string' || typeof id === 'number' || id === null ? id : null
+        }
+
+        const writeJson = (message) => {
+          process.stdout.write(`${JSON.stringify(message)}\n`)
+        }
+
+        const forward = async (line) => {
+          if (!line.trim()) return
+
+          let message
+          try {
+            message = JSON.parse(line)
+          } catch {
+            writeJson(buildError(null, -32700, 'Parse error'))
+            return
+          }
+
+          const id = getId(message)
+          const headers = {
+            accept: 'application/json, text/event-stream',
+            'content-type': 'application/json',
+          }
+          if (token) headers.authorization = `Bearer ${token}`
+
+          try {
+            const response = await fetch(endpoint, {
+              method: 'POST',
+              headers,
+              body: JSON.stringify(message),
+            })
+            const body = await response.text()
+
+            if (!body.trim()) return
+            if (!response.ok) {
+              writeJson(buildError(id, -32000, `Synthesis MCP HTTP ${response.status}`, body.slice(0, 1000)))
+              return
+            }
+
+            for (const event of body.split(/\n\n+/)) {
+              const dataLine = event.split(/\r?\n/).find((eventLine) => eventLine.startsWith('data:'))
+              if (dataLine) {
+                process.stdout.write(`${dataLine.slice(5).trim()}\n`)
+                continue
+              }
+              process.stdout.write(`${body.trim()}\n`)
+              break
+            }
+          } catch (error) {
+            writeJson(buildError(id, -32000, 'Synthesis MCP proxy failed', error instanceof Error ? error.message : error))
+          }
+        }
+
+        const input = readline.createInterface({ input: process.stdin, crlfDelay: Infinity })
+        input.on('line', (line) => {
+          void forward(line)
+        })
   outputArtifacts:
     - name: autonomous-trader-report
       path: /workspace/.agentrun/autonomous-trader/report.md
@@ -283,6 +394,21 @@ spec:
     - name: autonomous-trader-analysis-context
       path: /workspace/.agentrun/autonomous-trader/analysis-context.json
       key: synthesis/autonomous-trader/{{ agentRun.name }}/analysis-context.json
+    - name: autonomous-trader-current-status
+      path: /workspace/.agentrun/autonomous-trader/current-status.json
+      key: synthesis/autonomous-trader/{{ agentRun.name }}/current-status.json
+    - name: autonomous-trader-visibility-events
+      path: /workspace/.agentrun/autonomous-trader/visibility-events.jsonl
+      key: synthesis/autonomous-trader/{{ agentRun.name }}/visibility-events.jsonl
+    - name: autonomous-trader-synthesis-posts
+      path: /workspace/.agentrun/autonomous-trader/synthesis-posts.jsonl
+      key: synthesis/autonomous-trader/{{ agentRun.name }}/synthesis-posts.jsonl
+    - name: autonomous-trader-trade-ticket
+      path: /workspace/.agentrun/autonomous-trader/trade-ticket.json
+      key: synthesis/autonomous-trader/{{ agentRun.name }}/trade-ticket.json
+    - name: autonomous-trader-protective-orders
+      path: /workspace/.agentrun/autonomous-trader/protective-orders.jsonl
+      key: synthesis/autonomous-trader/{{ agentRun.name }}/protective-orders.jsonl
     - name: runner-log
       path: /workspace/.agent/runner.log
     - name: runner-status

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml
@@ -40,7 +40,14 @@ spec:
     - agents-artifacts
     - codex-auth
     - github-token
+    - synthesis-env
   workload:
+    volumes:
+      - type: secret
+        name: synthesis-env
+        secretName: synthesis-env
+        mountPath: /var/run/synthesis
+        readOnly: true
     resources:
       requests:
         cpu: "2"

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -21,6 +21,8 @@ spec:
     - Verify Alpaca MCP account, clock, market data, order, and instrument tools before any order call.
     - Bootstrap and validate the private analysis repo before any market-open order.
     - Use available Alpaca paper-account instruments and operations when justified by current account and market state.
+    - Use stock/ETF bracket, OTO, or OCO protective order classes when feasible; otherwise record the exact managed-exit fallback.
+    - Publish operator-visible status through Synthesis MCP and durable status/event artifacts.
     - Keep market-open runs active until market close, 500000 USD equity, or an unrecoverable blocker.
     - Reconcile every order by id or client order id and write preflight, ledger, and report artifacts.
   text: |-
@@ -40,10 +42,12 @@ spec:
        - Produce valid `/workspace/.agentrun/autonomous-trader/analysis-context.json` and `/workspace/.agentrun/autonomous-trader/analysis-bootstrap.json`.
     2. Preflight:
        - Use Alpaca MCP to read account, account config, clock, calendar, open orders, positions, recent portfolio state, and available tools.
+       - Confirm stock order tooling exposes `order_class`, `take_profit_limit_price`, `stop_loss_stop_price`, and `stop_loss_limit_price`.
+       - Confirm Synthesis MCP exposes `synthesis_start_run` and `synthesis_submit_item`.
        - Confirm paper account routing before any order call.
        - Write `/workspace/.agentrun/autonomous-trader/preflight.json` with redacted evidence.
     3. Mode handling:
-       - `preflight`: perform readiness checks and, only if safe, one tiny paper order smoke test that is immediately reconciled or canceled.
+       - `preflight`: perform readiness checks and, only if safe, one tiny non-marketable paper bracket or OTO stock order proof that is verified by id/client id and canceled; if Alpaca rejects or blocks it, record the exact request and reason.
        - `market-open`: wait for the market to open, then run an intraday loop until market close, equity is at least 500000 USD, or account/order state becomes unrecoverable.
     4. Each market-open cycle:
        - Re-read clock, account, orders, positions, portfolio state, and relevant market data.
@@ -51,8 +55,17 @@ spec:
        - Build a ranked action list from analysis context, live snapshots/quotes/bars, option-chain data when relevant, technicals, catalysts, liquidity, account constraints, and web research when fresh information can change the trade.
        - Before each non-smoke order, run `stock_analysis daytrading-scan` and validate `/workspace/.agentrun/autonomous-trader/trade-ticket.json` with `stock_analysis daytrading-validate-ticket`.
        - Submit an order only after the trade ticket records thesis, entry, invalidation, exit logic, sizing, max loss, liquidity, and reconciliation plan.
+       - For new stock or ETF entries, use Alpaca MCP bracket or OTO orders when feasible with `order_class`, `take_profit_limit_price`, `stop_loss_stop_price`, optional `stop_loss_limit_price`, and unique `client_order_id`.
+       - For existing stock or ETF positions, prefer OCO exits when feasible.
+       - For options, manage exits explicitly in the loop with max loss, target, invalidation, and near-close liquidation or hold decision because the current option MCP tool does not expose bracket/stop/take-profit fields.
+       - Do not create a new unmanaged position unless broker-attached protection is unavailable and the active fallback monitor is recorded in `/workspace/.agentrun/autonomous-trader/protective-orders.jsonl`.
        - Reconcile each submitted order by order id or client order id before the next action.
        - Append cycle state and decisions to `/workspace/.agentrun/autonomous-trader/decision-ledger.jsonl`; update `/workspace/.agentrun/autonomous-trader/report.md`; emit heartbeat output at least every 60 seconds while waiting.
+       - Update `/workspace/.agentrun/autonomous-trader/current-status.json` and append `/workspace/.agentrun/autonomous-trader/visibility-events.jsonl` with cycle number, account equity, buying power, P/L, positions, open orders, candidate actions, selected action, order parameters, protective exit state, reconciliation state, blockers, and next action.
+    5. Synthesis visibility:
+       - Use Synthesis MCP to call `synthesis_start_run` once per AgentRun.
+       - Use `synthesis_submit_item` for high-signal updates: session start, preflight complete, material action or stand-down, order submitted, fill/reject/cancel, protective exit change, risk blocker, and terminal summary.
+       - Use strict payloads with `title`, `synthesis`, `takeaways`, `whyValuable`, `sourcePosts`, `dedupeKey`, `score`, and `confidence`; use `https://synthesis.proompteng.ai/agentruns/${AGENT_RUN_NAME}#cycle-N` for the synthetic source URL and record each payload/result in `/workspace/.agentrun/autonomous-trader/synthesis-posts.jsonl`.
 
     Recovery and stop conditions:
     - Retry transient Alpaca MCP read failures up to 3 times with backoff and record `mcp_retry`.
@@ -61,5 +74,5 @@ spec:
     - Finish with terminal_reason `target_reached`, `market_closed`, or `hard_stop`.
 
     Output contract:
-    - Always write `preflight.json`, `decision-ledger.jsonl`, `report.md`, `analysis-bootstrap.json`, and `analysis-context.json`.
-    - In `report.md`, include mode, terminal_reason, account equity, cash, buying power, margin fields, exposure, positions, open orders, submitted/canceled/filled orders, analysis repo head, scanner/ticket status, distance to 500000 USD, and next action.
+    - Always write `preflight.json`, `decision-ledger.jsonl`, `report.md`, `analysis-bootstrap.json`, `analysis-context.json`, `current-status.json`, `visibility-events.jsonl`, `synthesis-posts.jsonl`, `trade-ticket.json`, and `protective-orders.jsonl`.
+    - In `report.md`, include mode, terminal_reason, account equity, cash, buying power, margin fields, exposure, positions, open orders, submitted/canceled/filled orders, analysis repo head, scanner/ticket status, protective-order status, Synthesis visibility status, distance to 500000 USD, and next action.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-secretbinding.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-secretbinding.yaml
@@ -15,3 +15,4 @@ spec:
     - agents-artifacts
     - codex-auth
     - github-token
+    - synthesis-env

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -25,14 +25,26 @@ data:
 
     Execution discipline:
     - Start with preflight: account/config, clock/calendar, positions, open orders, portfolio state, and tool inventory.
+    - Confirm Alpaca MCP exposes stock protective-order fields: `order_class`, `take_profit_limit_price`, `stop_loss_stop_price`, and `stop_loss_limit_price`.
+    - In preflight mode, prove the stock protective-order path with one tiny non-marketable paper bracket or OTO order when safe; verify by id/client id and cancel it, or record the exact Alpaca rejection/blocker.
     - In market-open mode, loop until market close, 500000 USD equity, or unrecoverable account/order state.
     - Each cycle re-reads account and market state, reconciles orders, absorbs account changes, evaluates actions, updates artifacts, and waits with heartbeat output at least every 60 seconds.
     - Before each non-smoke order, run `stock_analysis daytrading-scan` and validate `trade-ticket.json` with `stock_analysis daytrading-validate-ticket`.
     - Submit only orders with a recorded thesis, entry, invalidation, exit logic, sizing, max loss, liquidity, and reconciliation plan.
+    - For new stock or ETF entries, use Alpaca MCP bracket or OTO orders when feasible, including `order_class`, `take_profit_limit_price`, `stop_loss_stop_price`, optional `stop_loss_limit_price`, and unique `client_order_id`.
+    - For existing stock or ETF positions, prefer OCO exits when feasible.
+    - For options, explicitly manage exits in the loop with max loss, target, invalidation, and near-close liquidation or hold decision; the current option MCP tool does not expose bracket/stop/take-profit fields.
+    - Do not create a new unmanaged position unless broker-attached protection is unavailable and the active fallback monitor is recorded in `protective-orders.jsonl`.
     - Reconcile every submitted order by order id or client order id before the next action.
     - Retry transient Alpaca MCP read failures up to 3 times with backoff and record `mcp_retry`.
     - When a good trade is blocked by buying power, permissions, liquidity, rejected orders, or market state, stand down, reduce, close, or monitor.
 
+    Visibility:
+    - Use Synthesis MCP for operator-visible status posts: call `synthesis_start_run` once per AgentRun, then `synthesis_submit_item` for session start, preflight complete, material decision or stand-down, order submitted, fill/reject/cancel, protective exit update, risk blocker, and terminal summary.
+    - Use strict Synthesis item payloads with `title`, `synthesis`, `takeaways`, `whyValuable`, `sourcePosts`, `dedupeKey`, `score`, and `confidence`; use an AgentRun URL such as `https://synthesis.proompteng.ai/agentruns/${AGENT_RUN_NAME}#cycle-N` as `sourcePosts[0].originalUrl`.
+    - Append each submitted Synthesis visibility payload/result to `/workspace/.agentrun/autonomous-trader/synthesis-posts.jsonl`.
+    - Maintain `/workspace/.agentrun/autonomous-trader/current-status.json` and `/workspace/.agentrun/autonomous-trader/visibility-events.jsonl` with cycle, equity, buying power, P/L, positions, open orders, candidate actions, selected action, order parameters, protective exit state, reconciliation state, blockers, and next action.
+
     Outputs:
-    - Write `/workspace/.agentrun/autonomous-trader/report.md`, `/workspace/.agentrun/autonomous-trader/decision-ledger.jsonl`, `/workspace/.agentrun/autonomous-trader/preflight.json`, `/workspace/.agentrun/autonomous-trader/analysis-bootstrap.json`, and `/workspace/.agentrun/autonomous-trader/analysis-context.json` before exiting.
+    - Write `/workspace/.agentrun/autonomous-trader/report.md`, `/workspace/.agentrun/autonomous-trader/decision-ledger.jsonl`, `/workspace/.agentrun/autonomous-trader/preflight.json`, `/workspace/.agentrun/autonomous-trader/analysis-bootstrap.json`, `/workspace/.agentrun/autonomous-trader/analysis-context.json`, `/workspace/.agentrun/autonomous-trader/current-status.json`, `/workspace/.agentrun/autonomous-trader/visibility-events.jsonl`, `/workspace/.agentrun/autonomous-trader/synthesis-posts.jsonl`, `/workspace/.agentrun/autonomous-trader/trade-ticket.json`, and `/workspace/.agentrun/autonomous-trader/protective-orders.jsonl` before exiting.
     - Final `report.md` must include terminal_reason as `target_reached`, `market_closed`, or `hard_stop`.

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -652,6 +652,32 @@ describe('synthesis autonomous trader provider', () => {
     expect(prompt).toContain('analysis-context.json')
     expect(prompt).toContain('daytrading-validate-ticket')
     expect(prompt).toContain('terminal_reason as `target_reached`, `market_closed`, or `hard_stop`')
+    expect(prompt).toContain('order_class')
+    expect(prompt).toContain('take_profit_limit_price')
+    expect(prompt).toContain('stop_loss_stop_price')
+    expect(prompt).toContain('stock protective-order path')
+    expect(prompt).toContain('bracket or OTO orders')
+    expect(prompt).toContain('prefer OCO exits')
+    expect(prompt).toContain('protective-orders.jsonl')
+    expect(prompt).toContain('Use Synthesis MCP for operator-visible status posts')
+    expect(prompt).toContain('synthesis_start_run')
+    expect(prompt).toContain('synthesis_submit_item')
+    expect(prompt).toContain('current-status.json')
+    expect(prompt).toContain('visibility-events.jsonl')
+    expect(prompt).toContain('synthesis-posts.jsonl')
+    expect(taskPrompt).toContain('order_class')
+    expect(taskPrompt).toContain('take_profit_limit_price')
+    expect(taskPrompt).toContain('stop_loss_stop_price')
+    expect(taskPrompt).toContain('non-marketable paper bracket or OTO stock order proof')
+    expect(taskPrompt).toContain('bracket or OTO orders')
+    expect(taskPrompt).toContain('prefer OCO exits')
+    expect(taskPrompt).toContain('protective-orders.jsonl')
+    expect(taskPrompt).toContain('Synthesis visibility')
+    expect(taskPrompt).toContain('synthesis_start_run')
+    expect(taskPrompt).toContain('synthesis_submit_item')
+    expect(taskPrompt).toContain('current-status.json')
+    expect(taskPrompt).toContain('visibility-events.jsonl')
+    expect(taskPrompt).toContain('synthesis-posts.jsonl')
   })
 
   it('wires the analysis daytrading bootstrap into the trader provider', () => {
@@ -684,9 +710,66 @@ describe('synthesis autonomous trader provider', () => {
     expect(objectAt(bootstrap, 'content')).toContain('analysis-bootstrap.json')
     expect(artifactNames).toContain('autonomous-trader-analysis-bootstrap')
     expect(artifactNames).toContain('autonomous-trader-analysis-context')
+    expect(artifactNames).toContain('autonomous-trader-current-status')
+    expect(artifactNames).toContain('autonomous-trader-visibility-events')
+    expect(artifactNames).toContain('autonomous-trader-synthesis-posts')
+    expect(artifactNames).toContain('autonomous-trader-trade-ticket')
+    expect(artifactNames).toContain('autonomous-trader-protective-orders')
     expect(objectAt(objectAt(objectAt(vcsProvider, 'spec'), 'repositoryPolicy'), 'allow')).toContain(
       'gregkonush/analysis',
     )
+  })
+
+  it('wires Synthesis MCP visibility into the trader provider', () => {
+    const provider = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'AgentProvider')
+    const agent = readYamlObjects('argocd/applications/synthesis/agents-domain/autonomous-trader-agent.yaml').find(
+      (manifest) => objectAt(manifest, 'kind') === 'Agent',
+    )
+    const template = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'AgentRun')
+    const secretBinding = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-secretbinding.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'SecretBinding')
+    const spec = objectAt(provider, 'spec')
+    const codex = objectAt(objectAt(spec, 'adapter'), 'codex')
+    const threadConfig = objectAt(codex, 'threadConfig')
+    const synthesis = objectAt(objectAt(threadConfig, 'mcp_servers'), 'synthesis')
+    const envTemplate = objectAt(spec, 'envTemplate')
+    const secretEnv = objectAt(spec, 'secretEnv') as Record<string, unknown>[] | undefined
+    const inputFiles = objectAt(spec, 'inputFiles') as Record<string, unknown>[] | undefined
+    const codexConfig = (inputFiles ?? []).find(
+      (inputFile) => objectAt(inputFile, 'path') === '/root/.codex/config.toml',
+    )
+    const synthesisProxy = (inputFiles ?? []).find(
+      (inputFile) => objectAt(inputFile, 'path') === '/root/.codex/synthesis-mcp-proxy.mjs',
+    )
+    const workload = objectAt(objectAt(template, 'spec'), 'workload')
+    const volumes = objectAt(workload, 'volumes') as Record<string, unknown>[] | undefined
+    const synthesisVolume = (volumes ?? []).find((volume) => objectAt(volume, 'name') === 'synthesis-env')
+
+    expect(objectAt(synthesis, 'command')).toBe('node')
+    expect(objectAt(synthesis, 'args')).toEqual(['/root/.codex/synthesis-mcp-proxy.mjs'])
+    expect(objectAt(objectAt(synthesis, 'env'), 'SYNTHESIS_API_TOKEN_FILE')).toBe(
+      '/var/run/synthesis/SYNTHESIS_API_TOKEN',
+    )
+    expect(objectAt(objectAt(synthesis, 'env'), 'SYNTHESIS_MCP_URL')).toBe(
+      'http://synthesis.synthesis.svc.cluster.local:3000/mcp',
+    )
+    expect(objectAt(envTemplate, 'SYNTHESIS_API_TOKEN_FILE')).toBe('/var/run/synthesis/SYNTHESIS_API_TOKEN')
+    expect(objectAt(envTemplate, 'SYNTHESIS_MCP_URL')).toBe('http://synthesis.synthesis.svc.cluster.local:3000/mcp')
+    expect((secretEnv ?? []).some((entry) => objectAt(entry, 'name') === 'SYNTHESIS_API_TOKEN')).toBe(true)
+    expect(objectAt(codexConfig, 'content')).toContain('[mcp_servers.synthesis]')
+    expect(objectAt(codexConfig, 'content')).toContain('SYNTHESIS_API_TOKEN_FILE')
+    expect(objectAt(synthesisProxy, 'content')).toContain('Synthesis MCP HTTP')
+    expect(objectAt(synthesisProxy, 'content')).toContain('Bearer')
+    expect(objectAt(synthesisVolume, 'mountPath')).toBe('/var/run/synthesis')
+    expect(objectAt(synthesisVolume, 'readOnly')).toBe(true)
+    expect(objectAt(objectAt(objectAt(agent, 'spec'), 'security'), 'allowedSecrets')).toContain('synthesis-env')
+    expect(objectAt(objectAt(secretBinding, 'spec'), 'allowedSecrets')).toContain('synthesis-env')
+    expect(objectAt(objectAt(template, 'spec'), 'secrets')).toContain('synthesis-env')
   })
 
   it('bridges Codex framed MCP stdio to Alpaca newline stdio', () => {


### PR DESCRIPTION
## Summary

- Adds Alpaca protective-order requirements for Synthesis autonomous trader stock/ETF entries, existing-position OCO exits, and managed option exits.
- Wires Synthesis MCP into the trader provider so the AgentRun can publish operator-visible status updates.
- Adds durable visibility artifacts for current status, event ledger, Synthesis posts, trade tickets, and protective-order state.
- Extends smoke tests to enforce the no-token-budget goal, protective-order contract, Synthesis MCP wiring, and artifact uploads.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "synthesis autonomous trader provider"`
- `bunx oxfmt --check argocd/applications/synthesis/agents-domain/autonomous-trader-agent.yaml argocd/applications/synthesis/agents-domain/autonomous-trader-secretbinding.yaml argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/synthesis >/tmp/synthesis-trader-protective-visibility-render.yaml`
- `kubectl apply --dry-run=server -f /tmp/synthesis-trader-protective-visibility-render.yaml`
- `git diff --check`
- `scripts/agents/validate-agents.sh`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
