### PR TITLE
fix(torghut): accept order-feed source proof

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 
 from ..models import (
     Execution,
+    ExecutionOrderEvent,
     ExecutionTCAMetric,
     RejectedSignalOutcomeEvent,
     Strategy,
@@ -322,6 +323,34 @@ def _execution_activity_at(row: Execution) -> datetime | None:
         or row.last_update_at
         or row.updated_at
         or row.created_at
+    )
+
+
+def _order_event_activity_timestamp() -> Any:
+    return func.coalesce(ExecutionOrderEvent.event_ts, ExecutionOrderEvent.created_at)
+
+
+def _order_event_activity_at(row: ExecutionOrderEvent) -> datetime | None:
+    return row.event_ts or row.created_at
+
+
+def _order_event_is_fill(row: ExecutionOrderEvent) -> bool:
+    event_type = str(row.event_type or "").strip().lower()
+    status = str(row.status or "").strip().lower()
+    return event_type in {"fill", "partial_fill"} or status in {
+        "filled",
+        "partially_filled",
+    }
+
+
+def _order_event_has_complete_fill_lifecycle(row: ExecutionOrderEvent) -> bool:
+    if not _order_event_is_fill(row):
+        return False
+    order_id = _safe_text(row.alpaca_order_id) or _safe_text(row.client_order_id)
+    return (
+        order_id is not None
+        and _safe_decimal(row.filled_qty) > 0
+        and _safe_decimal(row.avg_fill_price) > 0
     )
 
 
@@ -1377,9 +1406,13 @@ def _strategy_source_activity(
             "decision_count": 0,
             "execution_count": 0,
             "filled_execution_count": 0,
+            "order_event_count": 0,
+            "fill_order_event_count": 0,
+            "complete_fill_order_event_count": 0,
             "tca_sample_count": 0,
             "last_decision_at": None,
             "last_execution_at": None,
+            "last_order_event_at": None,
             "last_tca_at": None,
             "missing": True,
             "missing_reasons": ["strategy_name_missing"],
@@ -1448,6 +1481,28 @@ def _strategy_source_activity(
                 execution_stmt.order_by(execution_activity_ts.desc()).limit(500)
             ).scalars()
         )
+    order_event_rows: list[ExecutionOrderEvent] = []
+    if decision_ids:
+        order_event_activity_ts = _order_event_activity_timestamp()
+        order_event_stmt = (
+            select(ExecutionOrderEvent)
+            .where(ExecutionOrderEvent.trade_decision_id.in_(decision_ids))
+            .where(order_event_activity_ts >= window_start)
+            .where(order_event_activity_ts < window_end)
+        )
+        if account_label:
+            order_event_stmt = order_event_stmt.where(
+                ExecutionOrderEvent.alpaca_account_label == account_label
+            )
+        if symbol_filters:
+            order_event_stmt = order_event_stmt.where(
+                func.upper(ExecutionOrderEvent.symbol).in_(symbol_filters)
+            )
+        order_event_rows = list(
+            session.execute(
+                order_event_stmt.order_by(order_event_activity_ts.desc()).limit(500)
+            ).scalars()
+        )
     tca_rows: list[ExecutionTCAMetric] = []
     if decision_ids:
         tca_stmt = (
@@ -1479,12 +1534,19 @@ def _strategy_source_activity(
     filled_execution_count = sum(
         int(_safe_decimal(row.filled_qty) > 0) for row in execution_rows
     )
+    order_event_count = len(order_event_rows)
+    fill_order_event_count = sum(
+        int(_order_event_is_fill(row)) for row in order_event_rows
+    )
+    complete_fill_order_event_count = sum(
+        int(_order_event_has_complete_fill_lifecycle(row)) for row in order_event_rows
+    )
     missing_reasons: list[str] = []
     if decision_count <= 0:
         missing_reasons.append("source_decisions_missing")
     if execution_count <= 0:
         missing_reasons.append("source_executions_missing")
-    if tca_sample_count <= 0:
+    if tca_sample_count <= 0 and complete_fill_order_event_count <= 0:
         missing_reasons.append("source_tca_missing")
     missing_reasons.extend(lineage_blockers)
     return {
@@ -1501,12 +1563,18 @@ def _strategy_source_activity(
         "decision_count": decision_count,
         "execution_count": execution_count,
         "filled_execution_count": filled_execution_count,
+        "order_event_count": order_event_count,
+        "fill_order_event_count": fill_order_event_count,
+        "complete_fill_order_event_count": complete_fill_order_event_count,
         "tca_sample_count": tca_sample_count,
         "last_decision_at": _isoformat(
             decision_rows[0].created_at if decision_rows else None
         ),
         "last_execution_at": _isoformat(
             _execution_activity_at(execution_rows[0]) if execution_rows else None
+        ),
+        "last_order_event_at": _isoformat(
+            _order_event_activity_at(order_event_rows[0]) if order_event_rows else None
         ),
         "last_tca_at": _isoformat(tca_rows[0].computed_at if tca_rows else None),
         "missing": bool(missing_reasons),
@@ -1764,7 +1832,10 @@ def _source_runtime_ledger_materialization_blockers(
             blockers.add("source_executions_missing")
         if _safe_int(source_activity.get("filled_execution_count")) <= 0:
             blockers.add("source_filled_executions_missing")
-        if _safe_int(source_activity.get("tca_sample_count")) <= 0:
+        if (
+            _safe_int(source_activity.get("tca_sample_count")) <= 0
+            and _safe_int(source_activity.get("complete_fill_order_event_count")) <= 0
+        ):
             blockers.add("source_tca_missing")
         blockers.update(
             str(item).strip()

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -11,6 +11,7 @@ from sqlalchemy.pool import StaticPool
 from app.models import (
     Base,
     Execution,
+    ExecutionOrderEvent,
     ExecutionTCAMetric,
     RejectedSignalOutcomeEvent,
     Strategy,
@@ -1444,6 +1445,168 @@ class TestPaperRouteEvidenceAudit(TestCase):
         import_audit = payload["runtime_window_import_audit"]
         self.assertEqual(import_audit["counts"]["targets_with_source_activity"], 1)
         self.assertNotIn("source_executions_missing", import_audit["blockers"])
+
+    def test_source_activity_accepts_order_feed_fill_lifecycle_without_tca(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        event_at = window_start + timedelta(minutes=20)
+        strategy_name = "order-feed-source-activity"
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name=strategy_name,
+                description="paper route source activity from order-feed lifecycle",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "action": "buy",
+                    "qty": "1",
+                    "candidate_id": "candidate-order-feed",
+                    "hypothesis_id": "H-ORDER-FEED",
+                },
+                rationale="order-feed lifecycle fixture",
+                status="executed",
+                created_at=event_at - timedelta(minutes=1),
+                executed_at=event_at,
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="order-feed-order-1",
+                client_order_id="order-feed-client-1",
+                symbol="AAPL",
+                side="buy",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=event_at,
+                updated_at=event_at,
+                last_update_at=event_at,
+                order_feed_last_event_ts=event_at,
+            )
+            session.add(execution)
+            session.flush()
+            session.add(
+                ExecutionOrderEvent(
+                    event_fingerprint="order-feed-fill-event",
+                    source_topic="trade_updates",
+                    source_partition=0,
+                    source_offset=1,
+                    alpaca_account_label="TORGHUT_SIM",
+                    feed_seq=10,
+                    event_ts=event_at,
+                    symbol="AAPL",
+                    alpaca_order_id="order-feed-order-1",
+                    client_order_id="order-feed-client-1",
+                    event_type="fill",
+                    status="filled",
+                    qty=Decimal("1"),
+                    filled_qty=Decimal("1"),
+                    avg_fill_price=Decimal("100"),
+                    raw_event={
+                        "event": "fill",
+                        "order": {
+                            "id": "order-feed-order-1",
+                            "client_order_id": "order-feed-client-1",
+                            "symbol": "AAPL",
+                            "status": "filled",
+                            "qty": "1",
+                            "filled_qty": "1",
+                            "filled_avg_price": "100",
+                        },
+                    },
+                    execution_id=execution.id,
+                    trade_decision_id=decision.id,
+                    created_at=event_at,
+                )
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-ORDER-FEED",
+                                "candidate_id": "candidate-order-feed",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": strategy_name,
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "account_label": "TORGHUT_SIM",
+                                "source_manifest_ref": "config/trading/hypotheses/h-order-feed.json",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_route_probe_symbols": ["AAPL"],
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": ["AAPL"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "next_session_max_notional": "25",
+                        "eligible_symbol_count": 1,
+                    },
+                },
+                generated_at=window_end + timedelta(hours=2),
+            )
+
+        source_activity = payload["targets"][0]["source_activity"]
+        self.assertFalse(source_activity["missing"])
+        self.assertEqual(source_activity["decision_count"], 1)
+        self.assertEqual(source_activity["execution_count"], 1)
+        self.assertEqual(source_activity["filled_execution_count"], 1)
+        self.assertEqual(source_activity["tca_sample_count"], 0)
+        self.assertEqual(source_activity["order_event_count"], 1)
+        self.assertEqual(source_activity["fill_order_event_count"], 1)
+        self.assertEqual(source_activity["complete_fill_order_event_count"], 1)
+        self.assertEqual(source_activity["last_order_event_at"], event_at.isoformat())
+        self.assertEqual(source_activity["missing_reasons"], [])
+        import_audit = payload["runtime_window_import_audit"]
+        self.assertEqual(import_audit["state"], "import_due_runtime_ledger_missing")
+        self.assertEqual(import_audit["counts"]["targets_with_source_activity"], 1)
+        self.assertNotIn(
+            "paper_route_source_activity_missing", import_audit["blockers"]
+        )
+        self.assertNotIn("source_tca_missing", import_audit["blockers"])
 
     def test_current_paper_route_probe_symbols_extend_next_window_target_scope(
         self,


### PR DESCRIPTION
## Summary

- Treat complete Alpaca order-feed fill lifecycle events as valid paper-route source activity when no TCA metric has been materialized yet.
- Expose order-feed source activity counts and latest event timestamps in the paper-route evidence audit.
- Keep promotion blocked on missing runtime-ledger buckets; this only moves real filled order-feed activity past the source-activity audit.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
