### PR TITLE
chore(agents): promote images 8cf843ec

### DIFF
--- a/argocd/applications/agents/values.yaml
+++ b/argocd/applications/agents/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 image:
   repository: registry.ide-newton.ts.net/lab/agents-controller
-  tag: 4e671a9e
-  digest: sha256:db6eceb83db832e31918622c24240424db51c9b307cbd27d74f90ac4c556a13d
+  tag: 8cf843ec
+  digest: sha256:90835edcfd69cd37d447d6ca07d1b96e076f06813ef6ebfdf67dcea39009a76b
   pullPolicy: IfNotPresent
 imagePolicy:
   requireDigest: true
@@ -11,26 +11,26 @@ nodeSelector:
 controlPlane:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-control-plane
-    tag: 4e671a9e
-    digest: sha256:e87b5d8e6a33ceb0e470462aad53de639d7533daa0c6d1d9aad7ab45b683dcc1
+    tag: 8cf843ec
+    digest: sha256:5a2c406d5e87a8736af574d2c1159839f1d7d6d36a01738549803096d4cf3005
   env:
     vars:
       AGENTS_CONTROL_PLANE_CACHE_ENABLED: "true"
       AGENTS_CONTROL_PLANE_CACHE_ALLOW_STALE: "false"
       AGENTS_CONTROL_PLANE_CACHE_RESYNC_SECONDS: "60"
       AGENTS_CONTROL_PLANE_CACHE_MAX_PENDING_WRITES: "5000"
-      AGENTS_SOURCE_HEAD_SHA: 4e671a9e0e768ee6863a321b7a4183332cefcae1
-      AGENTS_GITOPS_REVISION: 4e671a9e0e768ee6863a321b7a4183332cefcae1
-      AGENTS_SOURCE_CI_RUN_ID: "26563349266"
+      AGENTS_SOURCE_HEAD_SHA: 8cf843ecccb4da96c583cbb4d49c94be35992036
+      AGENTS_GITOPS_REVISION: 8cf843ecccb4da96c583cbb4d49c94be35992036
+      AGENTS_SOURCE_CI_RUN_ID: "26588039433"
       AGENTS_SOURCE_CI_CONCLUSION: success
-      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:e87b5d8e6a33ceb0e470462aad53de639d7533daa0c6d1d9aad7ab45b683dcc1
-      AGENTS_SERVING_BUILD_COMMIT: 4e671a9e0e768ee6863a321b7a4183332cefcae1
-      AGENTS_SERVING_IMAGE_DIGEST: sha256:e87b5d8e6a33ceb0e470462aad53de639d7533daa0c6d1d9aad7ab45b683dcc1
+      AGENTS_MANIFEST_IMAGE_DIGEST: sha256:5a2c406d5e87a8736af574d2c1159839f1d7d6d36a01738549803096d4cf3005
+      AGENTS_SERVING_BUILD_COMMIT: 8cf843ecccb4da96c583cbb4d49c94be35992036
+      AGENTS_SERVING_IMAGE_DIGEST: sha256:5a2c406d5e87a8736af574d2c1159839f1d7d6d36a01738549803096d4cf3005
 runner:
   image:
     repository: registry.ide-newton.ts.net/lab/agents-codex-runner
-    tag: 4e671a9e
-    digest: sha256:e2ef2b3a280b616fd2b622425871a1cb85438581ac484dea604a0ecc9ef64467
+    tag: 8cf843ec
+    digest: sha256:7ec40b630177ec8612576d2966e37eb65c0a260014b102ae0eb76b83ec34a10a
 agentRuntime:
   native:
     rerunOrchestration: codex-rerun
@@ -85,8 +85,8 @@ controllers:
   replicaCount: 2
   image:
     repository: registry.ide-newton.ts.net/lab/agents-controller
-    tag: 4e671a9e
-    digest: sha256:db6eceb83db832e31918622c24240424db51c9b307cbd27d74f90ac4c556a13d
+    tag: 8cf843ec
+    digest: sha256:90835edcfd69cd37d447d6ca07d1b96e076f06813ef6ebfdf67dcea39009a76b
   autoscaling:
     enabled: false
 swarm:


### PR DESCRIPTION
## Summary
Promote Agents controller and control-plane images into GitOps manifests.

- Source commit: `8cf843ecccb4da96c583cbb4d49c94be35992036`
- Image tag: `8cf843ec`
- Agents build run: `26588039433`
- Promotion source: `workflow_run`