### PR TITLE
fix(torghut): carry source account into runtime imports

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -123,6 +123,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--source-dsn-env", default="DB_DSN")
     parser.add_argument("--strategy-name", required=True)
     parser.add_argument("--account-label", required=True)
+    parser.add_argument("--source-account-label", default="")
     parser.add_argument("--window-start", required=True)
     parser.add_argument("--window-end", required=True)
     parser.add_argument("--bucket-minutes", type=int, default=30)
@@ -1544,6 +1545,13 @@ def _build_realized_strategy_pnl_rows(
         *(decision_lifecycle_rows or []),
         *(order_lifecycle_rows or []),
     ]
+    source_account_labels = sorted(
+        {
+            str(row.get("source_account_label") or "").strip()
+            for row in source_decision_rows
+            if str(row.get("source_account_label") or "").strip()
+        }
+    )
     source_decision_mode_counts = _source_decision_mode_counts(source_decision_rows)
     source_decision_profit_proof_eligible = _source_decision_rows_profit_proof_eligible(
         source_decision_rows
@@ -1561,6 +1569,14 @@ def _build_realized_strategy_pnl_rows(
             computed_at=unique_times[-1],
         )
         bucket_payload = row.get("runtime_ledger_bucket")
+        if source_account_labels and isinstance(bucket_payload, Mapping):
+            bucket_payload = {
+                **dict(bucket_payload),
+                "source_account_labels": source_account_labels,
+            }
+            if len(source_account_labels) == 1:
+                bucket_payload["source_account_label"] = source_account_labels[0]
+            row["runtime_ledger_bucket"] = bucket_payload
         if source_decision_mode_counts:
             row["source_decision_mode_counts"] = source_decision_mode_counts
             row["profit_proof_eligible"] = source_decision_profit_proof_eligible
@@ -2210,6 +2226,7 @@ def _runtime_ledger_tca_rows_from_source_dsn(
     observed_stage: str,
     strategy_names: list[str],
     account_label: str,
+    target_account_label: str | None = None,
     window_start: datetime,
     window_end: datetime,
 ) -> tuple[list[dict[str, object]], dict[str, Any]]:
@@ -2262,6 +2279,13 @@ def _runtime_ledger_tca_rows_from_source_dsn(
     tca_rows = [
         _runtime_ledger_tca_row_from_payload(payload=payload) for payload in payloads
     ]
+    materialized_account_label = str(target_account_label or "").strip()
+    if materialized_account_label and materialized_account_label != account_label:
+        tca_rows = _retarget_runtime_ledger_tca_rows(
+            tca_rows,
+            target_account_label=materialized_account_label,
+            source_account_label=account_label,
+        )
     return tca_rows, _runtime_ledger_bucket_metadata(
         prefix="source",
         payloads=payloads,
@@ -2269,11 +2293,65 @@ def _runtime_ledger_tca_rows_from_source_dsn(
     )
 
 
+def _retarget_source_rows_for_materialization(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    target_account_label: str,
+    source_account_label: str,
+) -> list[dict[str, object]]:
+    if not target_account_label or target_account_label == source_account_label:
+        return [dict(row) for row in rows]
+    retargeted: list[dict[str, object]] = []
+    for row in rows:
+        payload = dict(row)
+        payload.setdefault(
+            "source_account_label",
+            _first_text(payload, "account_label", "alpaca_account_label")
+            or source_account_label,
+        )
+        payload["account_label"] = target_account_label
+        retargeted.append(payload)
+    return retargeted
+
+
+def _retarget_runtime_ledger_tca_rows(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    target_account_label: str,
+    source_account_label: str,
+) -> list[dict[str, object]]:
+    if not target_account_label or target_account_label == source_account_label:
+        return [dict(row) for row in rows]
+    retargeted: list[dict[str, object]] = []
+    for row in rows:
+        payload = dict(row)
+        payload.setdefault(
+            "source_account_label",
+            _first_text(payload, "account_label", "alpaca_account_label")
+            or source_account_label,
+        )
+        if "account_label" in payload:
+            payload["account_label"] = target_account_label
+        bucket = _as_mapping(payload.get("runtime_ledger_bucket"))
+        if bucket:
+            source_bucket_label = (
+                _text_or_none(bucket.get("account_label")) or source_account_label
+            )
+            payload["runtime_ledger_bucket"] = {
+                **bucket,
+                "account_label": target_account_label,
+                "source_account_label": source_bucket_label,
+            }
+        retargeted.append(payload)
+    return retargeted
+
+
 def _query_timestamps(
     *,
     dsn: str,
     strategy_names: list[str],
     account_label: str,
+    target_account_label: str | None = None,
     window_start: datetime,
     window_end: datetime,
     symbols: Sequence[str] | None = None,
@@ -2285,6 +2363,10 @@ def _query_timestamps(
 ) -> tuple[list[datetime], list[datetime], list[dict[str, object]]]:
     if not strategy_names:
         raise RuntimeError("strategy_name_not_configured")
+    source_account_label = account_label
+    materialized_account_label = (
+        str(target_account_label or "").strip() or source_account_label
+    )
     decisions: list[datetime] = []
     executions: list[datetime] = []
     tca_rows: list[dict[str, object]] = []
@@ -2296,7 +2378,8 @@ def _query_timestamps(
         source_activity_diagnostics.update(
             {
                 "strategy_name_candidates": strategy_names,
-                "account_label": account_label,
+                "account_label": materialized_account_label,
+                "source_account_label": source_account_label,
                 "window_start": window_start.isoformat(),
                 "window_end": window_end.isoformat(),
                 "source_activity_symbol_filter": symbol_filter,
@@ -2676,6 +2759,26 @@ def _query_timestamps(
                 source_activity_diagnostics["order_feed_fill_lifecycle_blockers"] = (
                     lifecycle_blockers
                 )
+    decision_lifecycle_rows = _retarget_source_rows_for_materialization(
+        decision_lifecycle_rows,
+        target_account_label=materialized_account_label,
+        source_account_label=source_account_label,
+    )
+    execution_rows = _retarget_source_rows_for_materialization(
+        execution_rows,
+        target_account_label=materialized_account_label,
+        source_account_label=source_account_label,
+    )
+    order_lifecycle_rows = _retarget_source_rows_for_materialization(
+        order_lifecycle_rows,
+        target_account_label=materialized_account_label,
+        source_account_label=source_account_label,
+    )
+    tca_rows = _retarget_runtime_ledger_tca_rows(
+        tca_rows,
+        target_account_label=materialized_account_label,
+        source_account_label=source_account_label,
+    )
     tca_rows.extend(
         _build_realized_strategy_pnl_rows(
             execution_rows,
@@ -2698,6 +2801,7 @@ def _source_activity_missing_summary(
     strategy_name: str,
     strategy_names: list[str],
     account_label: str,
+    source_account_label: str | None = None,
     window_start: datetime,
     window_end: datetime,
     source_manifest_ref: str,
@@ -2719,6 +2823,7 @@ def _source_activity_missing_summary(
         "strategy_name": strategy_name,
         "strategy_name_candidates": strategy_names,
         "account_label": account_label,
+        "source_account_label": source_account_label or account_label,
         "source_activity_symbol_filter": symbol_filter,
         "diagnostic_blockers": diagnostic_blockers,
         "source_activity_diagnostics": diagnostics,
@@ -2789,6 +2894,7 @@ def _source_activity_missing_summary(
             "strategy_name": strategy_name,
             "strategy_name_candidates": strategy_names,
             "account_label": account_label,
+            "source_account_label": source_account_label or account_label,
             "source_activity_symbol_filter": symbol_filter,
             "window_start": window_start.isoformat(),
             "window_end": window_end.isoformat(),
@@ -2804,6 +2910,10 @@ def _source_activity_missing_summary(
 def main() -> int:
     args = _parse_args()
     source_dsn = args.source_dsn.strip() or os.getenv(args.source_dsn_env, "").strip()
+    source_account_label = (
+        str(getattr(args, "source_account_label", "") or "").strip()
+        or args.account_label
+    )
     artifact_refs = [
         str(item).strip()
         for item in getattr(args, "artifact_ref", [])
@@ -2838,6 +2948,7 @@ def main() -> int:
     source_activity_diagnostics: dict[str, Any] = {
         "strategy_name_candidates": strategy_names,
         "account_label": args.account_label,
+        "source_account_label": source_account_label,
         "window_start": window_start.isoformat(),
         "window_end": window_end.isoformat(),
         "source_activity_symbol_filter": source_activity_symbols,
@@ -2849,7 +2960,8 @@ def main() -> int:
         decisions, executions, tca_rows = _query_timestamps(
             dsn=source_dsn,
             strategy_names=strategy_names,
-            account_label=args.account_label,
+            account_label=source_account_label,
+            target_account_label=args.account_label,
             window_start=window_start,
             window_end=window_end,
             symbols=source_activity_symbols,
@@ -2891,7 +3003,8 @@ def main() -> int:
                 hypothesis_id=args.hypothesis_id,
                 observed_stage=args.observed_stage,
                 strategy_names=strategy_names,
-                account_label=args.account_label,
+                account_label=source_account_label,
+                target_account_label=args.account_label,
                 window_start=window_start,
                 window_end=window_end,
             )
@@ -2972,6 +3085,7 @@ def main() -> int:
             strategy_name=args.strategy_name,
             strategy_names=strategy_names,
             account_label=args.account_label,
+            source_account_label=source_account_label,
             window_start=window_start,
             window_end=window_end,
             source_manifest_ref=args.source_manifest_ref.strip(),
@@ -3048,6 +3162,7 @@ def main() -> int:
         "strategy_name": args.strategy_name,
         "strategy_name_candidates": strategy_names,
         "account_label": args.account_label,
+        "source_account_label": source_account_label,
         "source_activity_symbol_filter": source_activity_symbols,
         "source_activity_diagnostics": {
             **source_activity_diagnostics,

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -148,9 +148,17 @@ def _parse_args() -> argparse.Namespace:
         help=(
             "Repeatable comma-separated key=value runtime import target. "
             "Supported keys: hypothesis_id,candidate_id,strategy_family,"
-            "strategy_name,account_label,observed_stage,source_dsn_env,"
-            "dataset_snapshot_ref,source_manifest_ref,source_kind,"
+            "strategy_name,account_label,source_account_label,observed_stage,"
+            "source_dsn_env,dataset_snapshot_ref,source_manifest_ref,source_kind,"
             "delay_adjusted_depth_stress_report_ref."
+        ),
+    )
+    parser.add_argument(
+        "--runtime-window-source-account-label",
+        default="",
+        help=(
+            "Optional source account label used only for source DB activity queries. "
+            "The target account_label remains the materialized runtime-ledger label."
         ),
     )
     parser.add_argument(
@@ -392,6 +400,7 @@ class RuntimeWindowImportTarget:
     window_end: str = ""
     artifact_refs: tuple[str, ...] = ()
     target_metadata: Mapping[str, Any] | None = None
+    source_account_label: str = ""
 
 
 def _parse_runtime_window_target_spec(spec: str) -> dict[str, str]:
@@ -603,6 +612,9 @@ def _registry_runtime_window_targets(
                 ).strip(),
                 window_start="",
                 window_end="",
+                source_account_label=str(
+                    getattr(args, "runtime_window_source_account_label", "") or ""
+                ).strip(),
             )
         )
     return targets
@@ -724,6 +736,10 @@ def _runtime_window_targets_from_plan(
             window_end=str(payload.get("window_end") or "").strip(),
             artifact_refs=_runtime_window_target_artifact_refs(payload),
             target_metadata=_runtime_window_target_metadata(payload),
+            source_account_label=value(
+                "source_account_label",
+                "runtime_window_source_account_label",
+            ),
         )
         target_key = (
             target.hypothesis_id,
@@ -733,6 +749,7 @@ def _runtime_window_targets_from_plan(
             target.source_dsn_env,
             target.strategy_name,
             target.account_label,
+            target.source_account_label,
             target.dataset_snapshot_ref,
             target.source_manifest_ref,
             target.source_kind,
@@ -794,11 +811,12 @@ def _runtime_window_target_metadata(payload: Mapping[str, Any]) -> dict[str, Any
 
 def _runtime_window_target_identity(
     target: RuntimeWindowImportTarget,
-) -> tuple[str, str, str, str, str]:
+) -> tuple[str, str, str, str, str, str]:
     return (
         target.hypothesis_id,
         target.candidate_id,
         target.strategy_name,
+        target.source_account_label,
         target.window_start,
         target.window_end,
     )
@@ -939,6 +957,10 @@ def _runtime_window_targets(
                 ),
                 window_start=value("window_start", "runtime_window_start"),
                 window_end=value("window_end", "runtime_window_end"),
+                source_account_label=value(
+                    "source_account_label",
+                    "runtime_window_source_account_label",
+                ),
             )
         )
     explicit_hypothesis_ids = {target.hypothesis_id for target in targets}
@@ -1785,6 +1807,7 @@ def _run_runtime_window_import_target(
             "candidate_id": candidate_id,
             "strategy_name": target.strategy_name,
             "account_label": target.account_label,
+            "source_account_label": target.source_account_label or target.account_label,
             "source_kind": target.source_kind,
             "artifact_refs": [str(manifest_path), *target.artifact_refs],
             "target_metadata": dict(target.target_metadata or {}),
@@ -1843,6 +1866,8 @@ def _run_runtime_window_import_target(
         target.source_manifest_ref,
         "--source-kind",
         target.source_kind,
+        "--source-account-label",
+        target.source_account_label or target.account_label,
         "--artifact-ref",
         str(manifest_path),
         "--dependency-quorum-decision",
@@ -1909,6 +1934,7 @@ def _run_runtime_window_import_target(
         "candidate_id": candidate_id,
         "strategy_name": target.strategy_name,
         "account_label": target.account_label,
+        "source_account_label": target.source_account_label or target.account_label,
         "source_kind": target.source_kind,
         "artifact_refs": [str(manifest_path), *target.artifact_refs],
         "target_metadata": dict(target.target_metadata or {}),

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -2463,6 +2463,47 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(diagnostics["execution_rows_after_lineage_filter"], 1)
         self.assertEqual(diagnostics["order_lifecycle_rows_before_lineage_filter"], 1)
         self.assertEqual(diagnostics["tca_rows_before_lineage_filter"], 1)
+
+    def test_query_timestamps_uses_source_account_but_materializes_target_account(
+        self,
+    ) -> None:
+        cursor = _FakeCursor()
+        cursor._results = [
+            [
+                tuple(
+                    "TORGHUT_REPLAY" if item == "TORGHUT_SIM" else item for item in row
+                )
+                for row in rows
+            ]
+            for rows in cursor._results
+        ]
+        connection = _FakeConnection(cursor)
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+        diagnostics: dict[str, object] = {}
+
+        with patch(
+            "scripts.import_hypothesis_runtime_windows.psycopg.connect",
+            return_value=connection,
+        ):
+            _, _, tca_rows = _query_timestamps(
+                dsn="postgresql://example",
+                strategy_names=["intraday_tsmom_v1@paper"],
+                account_label="TORGHUT_REPLAY",
+                target_account_label="TORGHUT_SIM",
+                window_start=window_start,
+                window_end=window_end,
+                source_activity_diagnostics=diagnostics,
+            )
+
+        for _, params in cursor.executed:
+            self.assertIn("TORGHUT_REPLAY", params)
+            self.assertNotIn("TORGHUT_SIM", params)
+        self.assertEqual(diagnostics["account_label"], "TORGHUT_SIM")
+        self.assertEqual(diagnostics["source_account_label"], "TORGHUT_REPLAY")
+        runtime_bucket = tca_rows[1]["runtime_ledger_bucket"]
+        self.assertEqual(runtime_bucket["account_label"], "TORGHUT_SIM")
+        self.assertEqual(runtime_bucket["source_account_label"], "TORGHUT_REPLAY")
         self.assertEqual(
             diagnostics["order_feed_fill_lifecycle_blockers"],
             ["order_feed_fill_lifecycle_missing"],

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -3419,6 +3419,64 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             ("", "", ""),
         )
 
+    def test_runtime_window_import_target_passes_source_account_label(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-pairs-01.json"
+        hypothesis_path.write_text(
+            json.dumps({"candidate_id": "cand-paper-route"}),
+            encoding="utf-8",
+        )
+        target = renewal.RuntimeWindowImportTarget(
+            hypothesis_id="H-PAIRS-01",
+            candidate_id="cand-paper-route",
+            observed_stage="paper",
+            strategy_family="microbar_cross_sectional_pairs",
+            source_dsn_env="SIM_DB_DSN",
+            strategy_name="paper-route-candidate-v1",
+            account_label="TORGHUT_SIM",
+            dataset_snapshot_ref="",
+            source_manifest_ref=str(hypothesis_path),
+            source_kind="paper_route_probe_runtime_observed",
+            delay_adjusted_depth_stress_report_ref="",
+            source_account_label="TORGHUT_REPLAY",
+        )
+        args = SimpleNamespace(
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_target_plan_settlement_seconds=0,
+        )
+        completed = SimpleNamespace(
+            stdout=json.dumps({"status": "skipped", "proof_status": "blocked"})
+        )
+
+        with patch.object(
+            renewal.subprocess,
+            "run",
+            return_value=completed,
+        ) as run_mock:
+            payload = renewal._run_runtime_window_import_target(
+                args=args,
+                target=target,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+                window_end=datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc),
+                now=datetime(2026, 5, 26, 21, 23, tzinfo=timezone.utc),
+            )
+
+        command = run_mock.call_args.args[0]
+        self.assertIn("--source-account-label", command)
+        self.assertEqual(
+            command[command.index("--source-account-label") + 1],
+            "TORGHUT_REPLAY",
+        )
+        self.assertEqual(payload["account_label"], "TORGHUT_SIM")
+        self.assertEqual(payload["source_account_label"], "TORGHUT_REPLAY")
+
     def test_runtime_window_import_rejects_non_mapping_import_payload(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Propagates `source_account_label` from runtime-window target plans into the import command.
- Uses `source_account_label` only for source DB decisions/executions/order/TCA/runtime-ledger queries.
- Keeps the target `account_label` on materialized runtime-ledger buckets while recording source account provenance.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_run_empirical_promotion_jobs.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_import_hypothesis_runtime_windows.py tests/test_run_empirical_promotion_jobs.py`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_import_hypothesis_runtime_windows.py tests/test_run_empirical_promotion_jobs.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
