### PR TITLE
chore(analysis): promote image 7ea9d6381e6e

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: d84dccf34ec6a1520948768a24370af5986e7c9c
+    newTag: 7ea9d6381e6e8aa714bf0ada7cb2315320b157df


### PR DESCRIPTION
## Summary

- Promotes `argocd/applications/analysis` to `registry.ide-newton.ts.net/lab/analysis:7ea9d6381e6e8aa714bf0ada7cb2315320b157df`.
- Keeps rollout in lab GitOps by changing only the analysis kustomize image tag.
- Uses the self-hosted analysis image publish workflow output.

## Related Issues

None

## Testing

- `/Users/gregkonush/github.com/analysis/scripts/verify-analysis-image.sh 7ea9d6381e6e8aa714bf0ada7cb2315320b157df`
- `kubectl kustomize argocd/applications/analysis`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
