### PR TITLE
fix(torghut): add runtime import source audit dry run

### DIFF
--- a/docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
+++ b/docs/torghut/design-system/v1/operations-ta-replay-and-recovery.md
@@ -252,6 +252,11 @@ If the packet reports `paper_route_source_activity_missing`, `source_decisions_m
 activity is present but runtime ledger counts are missing, then inspect `renew_latest_empirical_promotion_jobs.py`
 runtime-window import output and the DB-backed runtime-ledger buckets. Neither case authorizes promotion by itself.
 
+Before a settled live-paper import, use the renewal runner's `--runtime-window-import-audit-only` option when you need a
+read-only diagnosis of source decisions, executions, TCA rows, and runtime-ledger materialization. Audit-only output is
+explicitly non-authoritative because it does not persist runtime/governance rows; promotion still requires the normal
+runtime-window import and the post-cost runtime-ledger proof packet.
+
 Execute the planned sequence with explicit human confirmation:
 
 ```bash

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4612,52 +4612,85 @@ def _fetch_paper_route_target_plan_url(
     url: str,
     *,
     timeout_seconds: float,
+    attempts: int = 1,
+    retry_backoff_seconds: float = 0.25,
 ) -> dict[str, Any]:
-    parsed = urlsplit(url)
-    scheme = parsed.scheme.lower()
-    if scheme not in {"http", "https"}:
-        return {
-            "load_error": f"paper_route_target_plan_invalid_scheme:{scheme or 'missing'}"
-        }
-    if not parsed.hostname:
-        return {"load_error": "paper_route_target_plan_invalid_host"}
-
-    path = parsed.path or "/"
-    if parsed.query:
-        path = f"{path}?{parsed.query}"
-    connection_class = HTTPSConnection if scheme == "https" else HTTPConnection
-    connection = connection_class(
-        parsed.hostname,
-        parsed.port,
-        timeout=max(float(timeout_seconds), 0.1),
-    )
-    try:
-        connection.request("GET", path, headers={"Accept": "application/json"})
-        response = connection.getresponse()
-        if response.status < 200 or response.status >= 300:
+    max_attempts = max(int(attempts), 1)
+    result: dict[str, Any] = {}
+    for attempt in range(1, max_attempts + 1):
+        parsed = urlsplit(url)
+        scheme = parsed.scheme.lower()
+        if scheme not in {"http", "https"}:
             return {
-                "load_error": f"paper_route_target_plan_http_status:{response.status}"
+                "load_error": f"paper_route_target_plan_invalid_scheme:{scheme or 'missing'}"
             }
-        raw = response.read(5_000_001)
-    except Exception as exc:  # pragma: no cover - depends on network
-        return {"load_error": f"paper_route_target_plan_fetch_failed:{exc}"}
-    finally:
-        connection.close()
+        if not parsed.hostname:
+            return {"load_error": "paper_route_target_plan_invalid_host"}
 
-    if len(raw) > 5_000_000:
-        return {"load_error": "paper_route_target_plan_response_too_large"}
-    try:
-        payload = json.loads(raw.decode("utf-8"))
-    except Exception as exc:
-        return {"load_error": f"paper_route_target_plan_invalid_json:{exc}"}
-    if not isinstance(payload, Mapping):
-        return {"load_error": "paper_route_target_plan_invalid_payload"}
-    plan = _paper_route_target_plan_from_payload(cast(Mapping[str, Any], payload))
-    if not plan:
-        return {"load_error": "paper_route_target_plan_missing"}
-    plan = dict(plan)
-    plan.setdefault("source", "external_paper_route_target_plan")
-    return plan
+        path = parsed.path or "/"
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        connection_class = HTTPSConnection if scheme == "https" else HTTPConnection
+        connection = connection_class(
+            parsed.hostname,
+            parsed.port,
+            timeout=max(float(timeout_seconds), 0.1),
+        )
+        try:
+            connection.request("GET", path, headers={"Accept": "application/json"})
+            response = connection.getresponse()
+            if response.status < 200 or response.status >= 300:
+                result = {
+                    "load_error": f"paper_route_target_plan_http_status:{response.status}"
+                }
+            else:
+                raw = response.read(5_000_001)
+                if len(raw) > 5_000_000:
+                    result = {
+                        "load_error": "paper_route_target_plan_response_too_large"
+                    }
+                else:
+                    try:
+                        payload = json.loads(raw.decode("utf-8"))
+                    except Exception as exc:
+                        result = {
+                            "load_error": f"paper_route_target_plan_invalid_json:{exc}"
+                        }
+                    else:
+                        if not isinstance(payload, Mapping):
+                            result = {
+                                "load_error": "paper_route_target_plan_invalid_payload"
+                            }
+                        else:
+                            plan = _paper_route_target_plan_from_payload(
+                                cast(Mapping[str, Any], payload)
+                            )
+                            if not plan:
+                                result = {
+                                    "load_error": "paper_route_target_plan_missing"
+                                }
+                            else:
+                                result = dict(plan)
+                                result.setdefault(
+                                    "source", "external_paper_route_target_plan"
+                                )
+        except Exception as exc:  # pragma: no cover - depends on network
+            result = {"load_error": f"paper_route_target_plan_fetch_failed:{exc}"}
+        finally:
+            connection.close()
+
+        if not str(result.get("load_error") or "").strip():
+            if attempt > 1:
+                result = dict(result)
+                result["fetch_attempts"] = attempt
+            return result
+        if attempt < max_attempts:
+            time.sleep(max(float(retry_backoff_seconds), 0.0))
+
+    if max_attempts > 1:
+        result = dict(result)
+        result["fetch_attempts"] = max_attempts
+    return result
 
 
 def _load_external_paper_route_target_plan() -> dict[str, Any]:
@@ -4667,6 +4700,8 @@ def _load_external_paper_route_target_plan() -> dict[str, Any]:
     return _fetch_paper_route_target_plan_url(
         url,
         timeout_seconds=settings.trading_paper_route_target_plan_timeout_seconds,
+        attempts=3,
+        retry_backoff_seconds=0.25,
     )
 
 

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1845,6 +1845,18 @@ def _source_runtime_ledger_materialization_blockers(
     return sorted(blockers)
 
 
+def _rejected_signal_reasons_actionable(
+    source_activity: Mapping[str, object],
+) -> bool:
+    if bool(source_activity.get("missing")):
+        return True
+    return (
+        _safe_int(source_activity.get("filled_execution_count")) <= 0
+        and _safe_int(source_activity.get("tca_sample_count")) <= 0
+        and _safe_int(source_activity.get("complete_fill_order_event_count")) <= 0
+    )
+
+
 def _hypothesis_window_summary(
     session: Session,
     *,
@@ -2111,17 +2123,25 @@ def _runtime_window_import_audit(
         {
             str(reason).strip()
             for audit in next_target_audits
-            for reason in (
-                *_as_sequence(
-                    _as_mapping(audit.get("source_activity")).get("missing_reasons")
-                ),
-                *_as_sequence(
-                    _as_mapping(audit.get("rejected_signal_activity")).get(
-                        "blocking_reasons"
-                    )
-                ),
+            for reason in _as_sequence(
+                _as_mapping(audit.get("source_activity")).get("missing_reasons")
             )
             if str(reason).strip()
+        }
+    )
+    rejected_signal_reasons = sorted(
+        {
+            str(reason).strip()
+            for audit in next_target_audits
+            for reason in _as_sequence(
+                _as_mapping(audit.get("rejected_signal_activity")).get(
+                    "blocking_reasons"
+                )
+            )
+            if str(reason).strip()
+            and _rejected_signal_reasons_actionable(
+                _as_mapping(audit.get("source_activity"))
+            )
         }
     )
     runtime_ledger_blockers = sorted(
@@ -2173,7 +2193,11 @@ def _runtime_window_import_audit(
     elif targets_with_source_activity < current_target_count:
         state = "import_due_source_activity_missing"
         next_action = "inspect_paper_route_source_activity_before_import"
-        blockers = ["paper_route_source_activity_missing", *source_missing_reasons]
+        blockers = [
+            "paper_route_source_activity_missing",
+            *source_missing_reasons,
+            *rejected_signal_reasons,
+        ]
     elif targets_with_runtime_ledger < current_target_count:
         state = "import_due_runtime_ledger_missing"
         next_action = "run_runtime_window_import_or_repair_source_materialization"
@@ -2204,6 +2228,7 @@ def _runtime_window_import_audit(
         "blockers": sorted(dict.fromkeys(blockers)),
         "diagnostics": {
             "source_activity_missing_reasons": source_missing_reasons,
+            "rejected_signal_diagnostic_reasons": rejected_signal_reasons,
             "source_activity_to_runtime_ledger_blockers": (
                 source_runtime_ledger_blockers
             ),
@@ -2274,7 +2299,11 @@ def _runtime_window_target_blockers(
                     if bool(source_activity.get("missing"))
                     else []
                 ),
-                *_unique_text_items(rejected_signal_activity.get("blocking_reasons")),
+                *(
+                    _unique_text_items(rejected_signal_activity.get("blocking_reasons"))
+                    if _rejected_signal_reasons_actionable(source_activity)
+                    else []
+                ),
                 *(
                     ["runtime_ledger_bucket_missing"]
                     if _safe_int(runtime_ledger.get("bucket_count")) <= 0

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -146,6 +146,14 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--dependency-quorum-decision", default="")
     parser.add_argument("--continuity-ok", default="")
     parser.add_argument("--drift-ok", default="")
+    parser.add_argument(
+        "--audit-only",
+        action="store_true",
+        help=(
+            "Run source, execution, TCA, and runtime-ledger proof diagnostics "
+            "without writing imported governance rows."
+        ),
+    )
     parser.add_argument("--json", action="store_true")
     return parser.parse_args()
 
@@ -991,6 +999,116 @@ def _runtime_ledger_tca_materialization_metadata(
         "runtime_ledger_materialization_blockers": sorted(dict.fromkeys(blockers)),
         "runtime_ledger_profit_proof_blockers": sorted(
             dict.fromkeys(profit_proof_blockers)
+        ),
+    }
+
+
+def _runtime_window_import_audit_summary(
+    *,
+    run_id: str,
+    candidate_id: str | None,
+    hypothesis_id: str,
+    observed_stage: str,
+    strategy_name: str,
+    strategy_names: Sequence[str],
+    account_label: str,
+    source_account_label: str,
+    window_start: datetime,
+    window_end: datetime,
+    source_kind: str,
+    source_manifest_ref: str | None,
+    dataset_snapshot_ref: str | None,
+    decisions: Sequence[datetime],
+    executions: Sequence[datetime],
+    tca_rows: Sequence[Mapping[str, object]],
+    buckets: Sequence[object],
+    runtime_observation_payload: Mapping[str, Any],
+    runtime_ledger_target_metadata_blockers: Sequence[str],
+) -> dict[str, Any]:
+    ledger_payloads = [
+        payload
+        for row in tca_rows
+        if (payload := _as_mapping(row.get("runtime_ledger_bucket")))
+    ]
+    ledger_profit_proof_blockers = sorted(
+        {
+            blocker
+            for payload in ledger_payloads
+            for blocker in _runtime_ledger_bucket_profit_proof_blockers(payload)
+        }
+    )
+    observed_bucket_payloads = [
+        _as_mapping(getattr(bucket, "payload_json", {})) for bucket in buckets
+    ]
+    observed_bucket_blockers = sorted(
+        {
+            blocker
+            for payload in observed_bucket_payloads
+            for blocker in _metadata_text_list(
+                payload.get("runtime_ledger_profit_proof_blockers")
+                or payload.get("promotion_blocking_reasons")
+                or payload.get("blockers")
+            )
+        }
+    )
+    source_activity_diagnostics = _as_mapping(
+        runtime_observation_payload.get("source_activity_diagnostics")
+    )
+    return {
+        "schema_version": "torghut.runtime-window-import-source-audit.v1",
+        "audit_only": True,
+        "would_persist": False,
+        "verdict": (
+            "profit_proof_present"
+            if _runtime_ledger_profit_proof_present(tca_rows)
+            else "blocked"
+        ),
+        "run_id": run_id,
+        "candidate_id": candidate_id,
+        "hypothesis_id": hypothesis_id,
+        "observed_stage": observed_stage,
+        "strategy_name": strategy_name,
+        "strategy_name_candidates": list(strategy_names),
+        "account_label": account_label,
+        "source_account_label": source_account_label,
+        "window_start": window_start.isoformat(),
+        "window_end": window_end.isoformat(),
+        "source_kind": source_kind,
+        "source_manifest_ref": source_manifest_ref,
+        "dataset_snapshot_ref": dataset_snapshot_ref,
+        "decision_count": len(decisions),
+        "execution_count": len(executions),
+        "tca_row_count": len(tca_rows),
+        "runtime_ledger_bucket_row_count": len(ledger_payloads),
+        "observed_runtime_bucket_count": len(buckets),
+        "observed_runtime_bucket_blockers": observed_bucket_blockers,
+        "runtime_ledger_profit_proof_present": _runtime_ledger_profit_proof_present(
+            tca_rows
+        ),
+        "runtime_ledger_profit_proof_blockers": ledger_profit_proof_blockers,
+        "runtime_ledger_target_metadata_blockers": list(
+            dict.fromkeys(runtime_ledger_target_metadata_blockers)
+        ),
+        "source_activity_diagnostics": source_activity_diagnostics,
+        "source_activity_diagnostic_blockers": _metadata_text_list(
+            runtime_observation_payload.get("source_activity_diagnostic_blockers")
+        ),
+        "promotion_authority": runtime_observation_payload.get("promotion_authority"),
+        "authority_reason": runtime_observation_payload.get("authority_reason"),
+        "runtime_observation": {
+            "runtime_ledger_profit_proof_present": runtime_observation_payload.get(
+                "runtime_ledger_profit_proof_present"
+            ),
+            "evidence_provenance": runtime_observation_payload.get(
+                "evidence_provenance"
+            ),
+            "source_kind": runtime_observation_payload.get("source_kind"),
+            "source_activity_symbol_filter": runtime_observation_payload.get(
+                "source_activity_symbol_filter"
+            ),
+        },
+        "runtime_ledger_materialization": _runtime_ledger_tca_materialization_metadata(
+            tca_rows
         ),
     }
 
@@ -3169,6 +3287,8 @@ def main() -> int:
                 **runtime_ledger_source_metadata,
             },
         )
+        if getattr(args, "audit_only", False):
+            summary = {**summary, "audit_only": True, "would_persist": False}
         if args.json:
             print(json.dumps(summary, indent=2))
         else:
@@ -3290,6 +3410,33 @@ def main() -> int:
                 else None,
             }
         )
+    if getattr(args, "audit_only", False):
+        summary = _runtime_window_import_audit_summary(
+            run_id=args.run_id,
+            candidate_id=args.candidate_id.strip() or None,
+            hypothesis_id=args.hypothesis_id,
+            observed_stage=args.observed_stage,
+            strategy_name=args.strategy_name,
+            strategy_names=strategy_names,
+            account_label=args.account_label,
+            source_account_label=source_account_label,
+            window_start=window_start,
+            window_end=window_end,
+            source_kind=source_kind,
+            source_manifest_ref=args.source_manifest_ref.strip() or None,
+            dataset_snapshot_ref=dataset_snapshot_ref,
+            decisions=decisions,
+            executions=executions,
+            tca_rows=tca_rows,
+            buckets=buckets,
+            runtime_observation_payload=runtime_observation_payload,
+            runtime_ledger_target_metadata_blockers=runtime_ledger_target_metadata_blockers,
+        )
+        if args.json:
+            print(json.dumps(summary, indent=2))
+        else:
+            print(summary)
+        return 0
     with SessionLocal() as session:
         summary = persist_observed_runtime_windows(
             session=session,

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -124,6 +124,14 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--runtime-window-import", action="store_true")
     parser.add_argument(
+        "--runtime-window-import-audit-only",
+        action="store_true",
+        help=(
+            "Run planned runtime-window imports in read-only audit mode. "
+            "This never authorizes promotion because no governance/runtime rows are persisted."
+        ),
+    )
+    parser.add_argument(
         "--runtime-window-targets-from-registry",
         action="store_true",
         help=(
@@ -1878,6 +1886,9 @@ def _run_runtime_window_import_target(
         drift_ok,
         "--json",
     ]
+    audit_only = bool(getattr(args, "runtime_window_import_audit_only", False))
+    if audit_only:
+        command.append("--audit-only")
     for artifact_ref in target.artifact_refs:
         command.extend(["--artifact-ref", artifact_ref])
     if target.target_metadata:
@@ -1924,8 +1935,24 @@ def _run_runtime_window_import_target(
         window_end=window_end,
     )
     proof_blockers.extend(payload_proof_blockers)
+    if audit_only:
+        proof_blockers.append(
+            {
+                "blocker": "runtime_window_import_audit_only_no_persistence",
+                "hypothesis_id": target.hypothesis_id,
+                "candidate_id": candidate_id,
+                "observed_stage": target.observed_stage,
+                "window_start": _utc_iso(window_start),
+                "window_end": _utc_iso(window_end),
+                "remediation": (
+                    "Use the audit counts to repair source, execution, TCA, or "
+                    "runtime-ledger materialization, then rerun the normal "
+                    "runtime-window import before promotion."
+                ),
+            }
+        )
     return {
-        "status": "ok",
+        "status": "audit_only" if audit_only else "ok",
         "command": " ".join(command[:2] + ["..."]),
         "window_start": _utc_iso(window_start),
         "window_end": _utc_iso(window_end),

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -3367,6 +3367,129 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ],
         )
 
+    def test_main_audit_only_reports_source_to_ledger_path_without_persisting(
+        self,
+    ) -> None:
+        args = SimpleNamespace(
+            run_id="run-audit",
+            candidate_id="cand-audit",
+            hypothesis_id="H-CONT-01",
+            observed_stage="paper",
+            strategy_family="",
+            source_dsn="postgresql://example",
+            source_dsn_env="DB_DSN",
+            strategy_name="intraday-tsmom-profit-v2",
+            account_label="TORGHUT_SIM",
+            source_account_label="TORGHUT_SIM",
+            window_start="2026-03-06T14:30:00Z",
+            window_end="2026-03-06T15:00:00Z",
+            bucket_minutes=30,
+            sample_minutes=5,
+            source_manifest_ref="",
+            source_kind="paper_runtime_observed",
+            artifact_ref=[],
+            delay_adjusted_depth_stress_report_ref="",
+            dataset_snapshot_ref="runtime-audit-snapshot",
+            target_metadata_json="",
+            dependency_quorum_decision="allow",
+            continuity_ok="true",
+            drift_ok="true",
+            audit_only=True,
+            json=True,
+        )
+        manifest = SimpleNamespace(
+            strategy_family="intraday_continuation",
+            strategy_id="intraday_tsmom_v1@paper",
+            max_allowed_slippage_bps=Decimal("12"),
+        )
+        runtime_bucket = _complete_runtime_ledger_bucket()
+        tca_row = {
+            "computed_at": datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+            "abs_slippage_bps": Decimal("1"),
+            "post_cost_expectancy_bps": Decimal("40"),
+            "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+            "post_cost_promotion_eligible": True,
+            "source_decision_mode": "strategy_signal_paper",
+            "runtime_ledger_bucket": runtime_bucket,
+        }
+
+        with (
+            patch(
+                "scripts.import_hypothesis_runtime_windows._parse_args",
+                return_value=args,
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.resolve_hypothesis_manifest",
+                return_value=(
+                    SimpleNamespace(path="config/trading/hypotheses/h-cont-01.json"),
+                    manifest,
+                ),
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows._query_timestamps",
+                return_value=(
+                    [datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+                    [datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+                    [tca_row],
+                ),
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows._runtime_ledger_tca_rows_from_source_dsn",
+                return_value=(
+                    [],
+                    {
+                        "runtime_ledger_source_bucket_count": 0,
+                        "runtime_ledger_source_bucket_run_ids": [],
+                        "runtime_ledger_source_bucket_fill_count": 0,
+                        "runtime_ledger_source_bucket_tca_row_count": 0,
+                        "runtime_ledger_source_bucket_profit_proof_count": 0,
+                    },
+                ),
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.build_regular_session_buckets",
+                return_value=[
+                    (
+                        datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                        datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                        6,
+                    )
+                ],
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.build_observed_runtime_buckets",
+                return_value=[
+                    SimpleNamespace(
+                        payload_json={
+                            "runtime_ledger_profit_proof_present": True,
+                            "runtime_ledger_profit_proof_blockers": [],
+                        }
+                    )
+                ],
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.persist_observed_runtime_windows",
+                return_value={"run_id": "run-audit"},
+            ) as persist_windows,
+            patch("builtins.print") as print_result,
+        ):
+            exit_code = main()
+
+        self.assertEqual(exit_code, 0)
+        persist_windows.assert_not_called()
+        summary = json.loads(print_result.call_args.args[0])
+        self.assertEqual(
+            summary["schema_version"],
+            "torghut.runtime-window-import-source-audit.v1",
+        )
+        self.assertEqual(summary["verdict"], "profit_proof_present")
+        self.assertEqual(summary["decision_count"], 1)
+        self.assertEqual(summary["execution_count"], 1)
+        self.assertEqual(summary["tca_row_count"], 1)
+        self.assertEqual(summary["runtime_ledger_bucket_row_count"], 1)
+        self.assertTrue(summary["runtime_ledger_profit_proof_present"])
+        self.assertFalse(summary["would_persist"])
+
     def test_main_attaches_target_metadata_to_runtime_payload(self) -> None:
         args = SimpleNamespace(
             run_id="run-probation",

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -3490,6 +3490,76 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertTrue(summary["runtime_ledger_profit_proof_present"])
         self.assertFalse(summary["would_persist"])
 
+        args_plain = SimpleNamespace(**vars(args))
+        args_plain.json = False
+        with (
+            patch(
+                "scripts.import_hypothesis_runtime_windows._parse_args",
+                return_value=args_plain,
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.resolve_hypothesis_manifest",
+                return_value=(
+                    SimpleNamespace(path="config/trading/hypotheses/h-cont-01.json"),
+                    manifest,
+                ),
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows._query_timestamps",
+                return_value=(
+                    [datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+                    [datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+                    [tca_row],
+                ),
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows._runtime_ledger_tca_rows_from_source_dsn",
+                return_value=(
+                    [],
+                    {
+                        "runtime_ledger_source_bucket_count": 0,
+                        "runtime_ledger_source_bucket_run_ids": [],
+                        "runtime_ledger_source_bucket_fill_count": 0,
+                        "runtime_ledger_source_bucket_tca_row_count": 0,
+                        "runtime_ledger_source_bucket_profit_proof_count": 0,
+                    },
+                ),
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.build_regular_session_buckets",
+                return_value=[
+                    (
+                        datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                        datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                        6,
+                    )
+                ],
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.build_observed_runtime_buckets",
+                return_value=[
+                    SimpleNamespace(
+                        payload_json={
+                            "runtime_ledger_profit_proof_present": True,
+                            "runtime_ledger_profit_proof_blockers": [],
+                        }
+                    )
+                ],
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.persist_observed_runtime_windows",
+                return_value={"run_id": "run-audit"},
+            ) as plain_persist_windows,
+            patch("builtins.print") as print_plain,
+        ):
+            plain_exit_code = main()
+        self.assertEqual(plain_exit_code, 0)
+        plain_persist_windows.assert_not_called()
+        self.assertEqual(
+            print_plain.call_args.args[0]["schema_version"],
+            "torghut.runtime-window-import-source-audit.v1",
+        )
+
     def test_main_attaches_target_metadata_to_runtime_payload(self) -> None:
         args = SimpleNamespace(
             run_id="run-probation",
@@ -3610,6 +3680,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             dependency_quorum_decision="allow",
             continuity_ok="true",
             drift_ok="true",
+            audit_only=True,
             json=False,
         )
         manifest = SimpleNamespace(
@@ -3655,6 +3726,8 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(summary["status"], "skipped")
         self.assertEqual(summary["proof_status"], "blocked")
         self.assertEqual(summary["decision_count"], 0)
+        self.assertTrue(summary["audit_only"])
+        self.assertFalse(summary["would_persist"])
         self.assertEqual(
             summary["proof_blockers"][0]["blocker"],
             "runtime_window_source_activity_missing",

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -2297,6 +2297,29 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         created_at=now,
                         updated_at=now,
                     ),
+                    RejectedSignalOutcomeEvent(
+                        event_id="paper-route-reject-filled-aapl",
+                        source="quote_quality_gate",
+                        paper_source="paper-arxiv-2605.12151",
+                        paper_claim_id="rejection-event-outcome-labels",
+                        account_label="TORGHUT_SIM",
+                        symbol="AAPL",
+                        event_ts=window_start + timedelta(minutes=14),
+                        timeframe="1Sec",
+                        seq="reject-after-fill",
+                        reject_reason="missing_executable_quote",
+                        outcome_label_status="pending",
+                        counterfactual_required=True,
+                        required_outcome_fields_json=[
+                            "counterfactual_return",
+                            "route_tca",
+                            "post_cost_net_pnl",
+                            "executable_quote",
+                        ],
+                        event_payload_json={
+                            "event_id": "paper-route-reject-filled-aapl"
+                        },
+                    ),
                 ]
             )
             session.commit()
@@ -2365,6 +2388,14 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(audit["source_activity"]["execution_count"], 1)
         self.assertEqual(audit["source_activity"]["filled_execution_count"], 1)
         self.assertEqual(audit["source_activity"]["tca_sample_count"], 1)
+        self.assertEqual(audit["rejected_signal_activity"]["event_count"], 1)
+        self.assertEqual(
+            audit["rejected_signal_activity"]["blocking_reasons"],
+            [
+                "source_signal_rejected_by_quote_quality",
+                "source_reject_missing_executable_quote",
+            ],
+        )
         self.assertEqual(audit["runtime_ledger"]["bucket_count"], 2)
         self.assertEqual(audit["runtime_ledger"]["evidence_grade_bucket_count"], 1)
         self.assertEqual(audit["runtime_ledger"]["non_evidence_grade_bucket_count"], 1)
@@ -2427,6 +2458,14 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertTrue(import_audit["import_ready"])
         self.assertEqual(import_audit["blockers"], [])
+        self.assertEqual(
+            import_audit["diagnostics"]["rejected_signal_diagnostic_reasons"], []
+        )
+        self.assertEqual(len(import_audit["target_blockers"]), 1)
+        self.assertEqual(
+            import_audit["target_blockers"][0]["blockers"],
+            ["open_position_count_nonzero"],
+        )
         self.assertEqual(import_audit["counts"]["source_plan_target_count"], 1)
         self.assertEqual(import_audit["counts"]["selected_target_count"], 1)
         self.assertEqual(import_audit["counts"]["targets_with_source_activity"], 1)

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -324,6 +324,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                 "--run-id-prefix",
                 "renew-prefix",
                 "--runtime-window-import",
+                "--runtime-window-import-audit-only",
                 "--runtime-window-hypothesis-id",
                 "H-TSMOM-01",
                 "--runtime-window-candidate-id",
@@ -351,6 +352,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual(args.strategy_spec_ref, "strategy@paper")
         self.assertEqual(args.run_id_prefix, "renew-prefix")
         self.assertTrue(args.runtime_window_import)
+        self.assertTrue(args.runtime_window_import_audit_only)
         self.assertEqual(args.runtime_window_hypothesis_id, "H-TSMOM-01")
         self.assertEqual(
             args.runtime_window_candidate_id, "spec-83161ae16d17828eabcc58cc"
@@ -1750,6 +1752,80 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertIn("--dataset-snapshot-ref", command)
         self.assertIn("portfolio-profit-autoresearch-500-v1", command)
         self.assertNotIn("stale-empirical-dataset", command)
+
+    def test_runtime_window_import_audit_only_never_counts_as_promotion_proof(
+        self,
+    ) -> None:
+        manifest_path = self.tmp_dir / "empirical-promotion-manifest.yaml"
+        manifest_path.write_text("run_id: renew-1\n", encoding="utf-8")
+        hypothesis_path = self.tmp_dir / "h-tsmom-01.json"
+        hypothesis_path.write_text(
+            json.dumps(
+                {
+                    "candidate_id": "spec-83161ae16d17828eabcc58cc",
+                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                }
+            ),
+            encoding="utf-8",
+        )
+        completed = SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "schema_version": "torghut.runtime-window-import-source-audit.v1",
+                    "audit_only": True,
+                    "would_persist": False,
+                    "verdict": "profit_proof_present",
+                    "runtime_observation": {
+                        "authoritative": True,
+                        "promotion_authority": "runtime_ledger_profit_proof",
+                    },
+                    "promotion_allowed": True,
+                }
+            )
+        )
+        args = SimpleNamespace(
+            runtime_window_import=True,
+            runtime_window_import_audit_only=True,
+            runtime_window_hypothesis_id="H-TSMOM-01",
+            runtime_window_candidate_id="",
+            runtime_window_observed_stage="paper",
+            runtime_window_strategy_family="intraday_tsmom_consistent",
+            runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_strategy_name="intraday-tsmom-profit-v3",
+            runtime_window_account_label="TORGHUT_SIM",
+            runtime_window_start="2026-05-18T13:30:00Z",
+            runtime_window_end="2026-05-18T20:00:00Z",
+            runtime_window_dataset_snapshot_ref="",
+            runtime_window_bucket_minutes=30,
+            runtime_window_sample_minutes=5,
+            runtime_window_source_manifest_ref=str(hypothesis_path),
+            runtime_window_source_kind="paper_runtime_observed",
+        )
+
+        with patch.object(
+            renewal.subprocess, "run", return_value=completed
+        ) as run_mock:
+            payload = renewal._run_runtime_window_import(
+                args=args,
+                manifest={},
+                run_id="renew-1",
+                manifest_path=manifest_path,
+                now=datetime(2026, 5, 18, 21, 23, tzinfo=timezone.utc),
+            )
+
+        self.assertIsNotNone(payload)
+        assert payload is not None
+        self.assertEqual(payload["status"], "audit_only")
+        self.assertEqual(payload["proof_status"], "blocked")
+        command = run_mock.call_args.args[0]
+        self.assertIn("--audit-only", command)
+        blocker_codes = [item["blocker"] for item in payload["proof_blockers"]]
+        self.assertEqual(
+            blocker_codes,
+            ["runtime_window_import_audit_only_no_persistence"],
+        )
+        self.assertTrue(payload["summary"]["audit_only"])
+        self.assertFalse(payload["summary"]["would_persist"])
 
     def test_runtime_window_import_passes_probation_metadata_and_artifacts(
         self,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7831,6 +7831,8 @@ class TestTradingApi(TestCase):
             fetch.assert_called_once_with(
                 "http://torghut.example/plan",
                 timeout_seconds=7,
+                attempts=3,
+                retry_backoff_seconds=0.25,
             )
         finally:
             settings.trading_paper_route_target_plan_url = original_target_plan_url

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7542,6 +7542,27 @@ class TestTradingApi(TestCase):
         self.assertEqual(http_error_connection.instances[0].timeout, 0.1)
         self.assertTrue(http_error_connection.instances[0].closed)
 
+        retried_error_connection = connection_class(503, b"{}")
+        with (
+            patch("app.main.HTTPConnection", retried_error_connection),
+            patch("app.main.time.sleep") as sleep,
+        ):
+            failed_retry = _fetch_paper_route_target_plan_url(
+                "http://torghut.example",
+                timeout_seconds=1,
+                attempts=2,
+                retry_backoff_seconds=0,
+            )
+        self.assertEqual(
+            failed_retry,
+            {
+                "load_error": "paper_route_target_plan_http_status:503",
+                "fetch_attempts": 2,
+            },
+        )
+        sleep.assert_called_once_with(0.0)
+        self.assertEqual(len(retried_error_connection.instances), 2)
+
         class FlakyConnection:
             instances: list["FlakyConnection"] = []
             responses = [
@@ -7593,6 +7614,21 @@ class TestTradingApi(TestCase):
             def close(self) -> None:
                 self.closed = True
 
+        FlakyConnection.instances = []
+        with patch("app.main.HTTPConnection", FlakyConnection):
+            app_retried_plan = _fetch_paper_route_target_plan_url(
+                "http://torghut.example",
+                timeout_seconds=1,
+                attempts=2,
+                retry_backoff_seconds=0,
+            )
+        self.assertEqual(app_retried_plan["fetch_attempts"], 2)
+        self.assertEqual(
+            app_retried_plan["targets"][0]["candidate_id"], "retry-candidate"
+        )
+        self.assertEqual(len(FlakyConnection.instances), 2)
+
+        FlakyConnection.instances = []
         with patch(
             "app.trading.paper_route_target_plan.HTTPConnection",
             FlakyConnection,


### PR DESCRIPTION
## Summary

- Adds a read-only `--audit-only` runtime-window importer mode that reports source decisions, executions, TCA rows, runtime-ledger rows, blockers, and proof authority without persisting governance rows.
- Adds `renew_latest_empirical_promotion_jobs.py --runtime-window-import-audit-only` and keeps audit-only renewal output fail-closed with `runtime_window_import_audit_only_no_persistence`.
- Retries external paper-route target-plan fetches from the API path so transient live-service timeouts do not erase the current paper-route import target.
- Keeps quote-quality rejected signals diagnostic-only once a target has filled source activity/TCA, so stale reject rows do not mask real route evidence while runtime-ledger and post-cost gates stay strict.
- Documents the audit-only proof workflow in the Torghut TA replay/recovery runbook.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py tests/test_import_hypothesis_runtime_windows.py tests/test_trading_api.py tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_import_hypothesis_runtime_windows.py --cov --cov-branch --cov-report=xml:coverage.xml --cov-fail-under=0 -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen ruff check app/main.py app/trading/paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py scripts/import_hypothesis_runtime_windows.py tests/test_run_empirical_promotion_jobs.py tests/test_import_hypothesis_runtime_windows.py tests/test_trading_api.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/main.py app/trading/paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py scripts/import_hypothesis_runtime_windows.py tests/test_run_empirical_promotion_jobs.py tests/test_import_hypothesis_runtime_windows.py tests/test_trading_api.py tests/test_paper_route_evidence.py`
- `git diff --check`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Read-only live check in `torghut-sim` showed current H-PAIRS paper route source activity before close: 8 decisions, 8 executions, 8 TCA rows, 0 source runtime-ledger bucket rows.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
