### PR TITLE
feat(torghut): mark qualified paper signal decisions

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -29,7 +29,10 @@ from ..paper_route_target_plan import (
 )
 from ..prices import MarketSnapshot
 from ..proof_floor import build_profitability_proof_floor_receipt
-from ..runtime_decision_authority import ROUTE_ACQUISITION_SOURCE_DECISION_MODE
+from ..runtime_decision_authority import (
+    ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+    STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+)
 from ..session_context import REGULAR_OPEN_UTC
 from ..simple_risk import (
     position_qty_for_symbol,
@@ -204,6 +207,14 @@ def _target_probe_action(target: Mapping[str, Any]) -> Literal["buy", "sell"]:
         if normalized in {"sell", "short"}:
             return "sell"
     return "buy"
+
+
+def _target_truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float | Decimal):
+        return bool(value)
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _lineage_text_values(value: object) -> list[str]:
@@ -2140,9 +2151,147 @@ class SimpleTradingPipeline(TradingPipeline):
             **lineage,
         }
 
+    @staticmethod
+    def _target_matches_decision_strategy(
+        target: Mapping[str, Any],
+        decision: StrategyDecision,
+        strategy: Strategy | None,
+    ) -> bool:
+        lookup_names = {value.lower() for value in _target_lookup_names(target)}
+        if not lookup_names:
+            return False
+        candidate_names = {
+            str(decision.strategy_id).strip(),
+        }
+        if strategy is not None:
+            candidate_names.add(str(strategy.id))
+            candidate_names.add(str(strategy.name))
+        return any(
+            candidate.strip().lower() in lookup_names
+            for candidate in candidate_names
+            if candidate.strip()
+        )
+
+    @staticmethod
+    def _decision_event_in_target_window(
+        decision: StrategyDecision,
+        target: Mapping[str, Any],
+    ) -> bool:
+        window = _target_probe_window(target)
+        if window is None:
+            return False
+        window_start, window_end = window
+        event_ts = decision.event_ts
+        if event_ts.tzinfo is None:
+            event_ts = event_ts.replace(tzinfo=timezone.utc)
+        event_ts = event_ts.astimezone(timezone.utc)
+        return window_start <= event_ts < window_end
+
+    def _strategy_signal_paper_target_for_decision(
+        self,
+        decision: StrategyDecision,
+        strategy: Strategy | None,
+    ) -> Mapping[str, Any] | None:
+        if settings.trading_mode != "paper":
+            return None
+        if not settings.trading_simple_paper_route_probe_enabled:
+            return None
+        if self._paper_route_target_source_cap(decision.params) is not None:
+            return None
+        if isinstance(
+            decision.params.get("paper_route_target_plan_source_decision"), Mapping
+        ):
+            return None
+        existing_mode = (
+            str(decision.params.get("source_decision_mode") or "")
+            .strip()
+            .lower()
+            .replace("-", "_")
+        )
+        if existing_mode == ROUTE_ACQUISITION_SOURCE_DECISION_MODE:
+            return None
+        symbol = decision.symbol.strip().upper()
+        if not symbol:
+            return None
+        target_plan_symbols, target_plan_error, target_plan_targets = (
+            self._external_paper_route_target_probe_symbols_cached()
+        )
+        if target_plan_error or symbol not in target_plan_symbols:
+            return None
+        for target in target_plan_targets:
+            target_symbols = _target_symbols(target)
+            if target_symbols and symbol not in target_symbols:
+                continue
+            if not self._decision_event_in_target_window(decision, target):
+                continue
+            if not self._target_matches_decision_strategy(target, decision, strategy):
+                continue
+            if _safe_text(target.get("candidate_id")) is None:
+                continue
+            if _safe_text(target.get("hypothesis_id")) is None:
+                continue
+            if str(target.get("observed_stage") or "").strip().lower() != "paper":
+                continue
+            if (
+                _safe_text(target.get("source_kind"))
+                != "paper_route_probe_runtime_observed"
+            ):
+                continue
+            if not _target_truthy(target.get("paper_probation_authorized")):
+                continue
+            return target
+        return None
+
+    @staticmethod
+    def _strategy_signal_paper_metadata(
+        *,
+        decision: StrategyDecision,
+        target: Mapping[str, Any],
+        strategy: Strategy | None,
+    ) -> dict[str, Any]:
+        lineage = _target_plan_lineage([dict(target)], decision.symbol)
+        window = _target_probe_window(target)
+        metadata: dict[str, Any] = {
+            "mode": STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+            "source": "external_target_plan_url",
+            "symbol": decision.symbol.strip().upper(),
+            "source_decision_mode": STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+            "profit_proof_eligible": True,
+            "paper_route_target_plan_source": "external_target_plan_url",
+            "paper_route_probe_scope_authority": "external_target_plan",
+            "paper_probation_authorized": True,
+            "promotion_allowed": False,
+            "final_promotion_authorized": False,
+            "final_promotion_allowed": False,
+            **lineage,
+        }
+        if strategy is not None:
+            metadata["strategy_name"] = strategy.name
+            metadata["strategy_id"] = str(strategy.id)
+        for key in (
+            "candidate_id",
+            "hypothesis_id",
+            "observed_stage",
+            "strategy_family",
+            "runtime_strategy_name",
+            "source_kind",
+            "source_manifest_ref",
+            "dataset_snapshot_ref",
+        ):
+            value = _safe_text(target.get(key))
+            if value is not None:
+                metadata[key] = value
+        if window is not None:
+            window_start, window_end = window
+            metadata["paper_route_probe_window_start"] = window_start.isoformat()
+            metadata["paper_route_probe_window_end"] = window_end.isoformat()
+        return metadata
+
     def _with_paper_route_target_lineage(
         self,
         decision: StrategyDecision,
+        *,
+        strategy: Strategy | None = None,
     ) -> StrategyDecision:
         lineage = self._paper_route_target_lineage_for_decision(decision)
         if not lineage:
@@ -2158,6 +2307,27 @@ class SimpleTradingPipeline(TradingPipeline):
         else:
             params["paper_route_target_plan"] = lineage
         _merge_paper_route_probe_lineage(params, lineage)
+        strategy_signal_target = self._strategy_signal_paper_target_for_decision(
+            decision, strategy
+        )
+        if strategy_signal_target is not None:
+            metadata = self._strategy_signal_paper_metadata(
+                decision=decision,
+                target=strategy_signal_target,
+                strategy=strategy,
+            )
+            params["strategy_signal_paper"] = metadata
+            params["source_decision_mode"] = STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE
+            params["profit_proof_eligible"] = True
+            params.setdefault("promotion_allowed", False)
+            params.setdefault("final_promotion_authorized", False)
+            params.setdefault("final_promotion_allowed", False)
+            target_plan = params.get("paper_route_target_plan")
+            if isinstance(target_plan, Mapping):
+                merged_target_plan = dict(cast(Mapping[str, Any], target_plan))
+                for key, value in metadata.items():
+                    merged_target_plan.setdefault(key, value)
+                params["paper_route_target_plan"] = merged_target_plan
         return decision.model_copy(update={"params": params})
 
     def _paper_route_probe_context(
@@ -2319,7 +2489,7 @@ class SimpleTradingPipeline(TradingPipeline):
         decision: StrategyDecision,
         strategy: Strategy,
     ) -> TradeDecision | None:
-        decision = self._with_paper_route_target_lineage(decision)
+        decision = self._with_paper_route_target_lineage(decision, strategy=strategy)
         decision_row = self.executor.ensure_decision(
             session, decision, strategy, self.account_label
         )

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -59,6 +59,7 @@ from app.trading.scheduler.simple_pipeline import (
     _safe_int,
     _target_probe_action,
     _target_probe_window,
+    _target_truthy,
 )
 from app.trading.scheduler.pipeline_helpers import (
     _apply_projected_position_decision,
@@ -5981,6 +5982,288 @@ class TestTradingPipeline(TestCase):
             ],
         )
         self.assertNotIn("paper_route_probe", params)
+
+    def test_matching_paper_target_signal_gets_strategy_signal_paper_authority(
+        self,
+    ) -> None:
+        from app import config
+
+        window_start = datetime(2026, 5, 28, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 28, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = (
+            "http://torghut.local/trading/paper-route-evidence"
+        )
+        config.settings.trading_paper_route_target_plan_timeout_seconds = 1.0
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 5, 28, 15, 30, tzinfo=timezone.utc),
+                timeframe="1Sec",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": "100"},
+            )
+            with patch(
+                "app.trading.scheduler.simple_pipeline.fetch_paper_route_target_plan_url",
+                return_value={
+                    "targets": [
+                        {
+                            "paper_route_probe_symbols": ["AAPL"],
+                            "paper_route_probe_window_start": window_start.isoformat(),
+                            "paper_route_probe_window_end": window_end.isoformat(),
+                            "candidate_id": "candidate-pairs-a",
+                            "hypothesis_id": "H-PAIRS-01",
+                            "observed_stage": "paper",
+                            "strategy_family": "microbar_cross_sectional_pairs",
+                            "strategy_name": "microbar-cross-sectional-pairs-v1",
+                            "strategy_lookup_names": [
+                                str(strategy.id),
+                                "microbar-cross-sectional-pairs-v1",
+                            ],
+                            "source_kind": "paper_route_probe_runtime_observed",
+                            "source_manifest_ref": (
+                                "config/trading/hypotheses/h-pairs-01.json"
+                            ),
+                            "dataset_snapshot_ref": (
+                                "portfolio-profit-autoresearch-500-v1"
+                            ),
+                            "paper_probation_authorized": True,
+                        }
+                    ]
+                },
+            ):
+                row = pipeline._ensure_pending_decision_row(
+                    session=session,
+                    decision=decision,
+                    strategy=strategy,
+                )
+
+            self.assertIsNotNone(row)
+            assert row is not None
+            payload = cast(dict[str, Any], row.decision_json)
+            params = cast(dict[str, Any], payload.get("params"))
+            target_plan = cast(dict[str, Any], params.get("paper_route_target_plan"))
+            authority = cast(dict[str, Any], params.get("strategy_signal_paper"))
+
+        self.assertEqual(params.get("source_candidate_ids"), ["candidate-pairs-a"])
+        self.assertEqual(params.get("source_hypothesis_ids"), ["H-PAIRS-01"])
+        self.assertEqual(params.get("source_decision_mode"), "strategy_signal_paper")
+        self.assertTrue(params.get("profit_proof_eligible"))
+        self.assertFalse(params.get("promotion_allowed"))
+        self.assertEqual(authority.get("mode"), "strategy_signal_paper")
+        self.assertEqual(authority.get("candidate_id"), "candidate-pairs-a")
+        self.assertEqual(authority.get("hypothesis_id"), "H-PAIRS-01")
+        self.assertEqual(
+            authority.get("source_kind"), "paper_route_probe_runtime_observed"
+        )
+        self.assertEqual(
+            authority.get("paper_route_probe_window_start"), window_start.isoformat()
+        )
+        self.assertEqual(
+            target_plan.get("source_decision_mode"), "strategy_signal_paper"
+        )
+        self.assertTrue(target_plan.get("profit_proof_eligible"))
+        self.assertNotIn("paper_route_probe", params)
+        self.assertNotIn("paper_route_target_plan_source_decision", params)
+
+    def test_strategy_signal_paper_target_rejects_unqualified_targets(
+        self,
+    ) -> None:
+        from app import config
+
+        window_start = datetime(2026, 5, 28, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 28, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = (
+            "http://torghut.local/trading/paper-route-evidence"
+        )
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        strategy = Strategy(
+            id=uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+        )
+
+        def make_decision(
+            *,
+            symbol: str = "AAPL",
+            event_ts: datetime = datetime(2026, 5, 28, 15, 30),
+            params: Mapping[str, Any] | None = None,
+        ) -> StrategyDecision:
+            return StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol=symbol,
+                event_ts=event_ts,
+                timeframe="1Sec",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": "100", **dict(params or {})},
+            )
+
+        def make_target(**overrides: object) -> dict[str, object]:
+            target: dict[str, object] = {
+                "paper_route_probe_symbols": ["AAPL"],
+                "paper_route_probe_window_start": window_start.isoformat(),
+                "paper_route_probe_window_end": window_end.isoformat(),
+                "candidate_id": "candidate-pairs-a",
+                "hypothesis_id": "H-PAIRS-01",
+                "observed_stage": "paper",
+                "strategy_lookup_names": [str(strategy.id), strategy.name],
+                "source_kind": "paper_route_probe_runtime_observed",
+                "paper_probation_authorized": "yes",
+            }
+            target.update(overrides)
+            return target
+
+        good_decision = make_decision()
+        good_target = make_target()
+
+        self.assertFalse(_target_truthy(Decimal("0")))
+        self.assertTrue(_target_truthy("yes"))
+
+        config.settings.trading_mode = "live"
+        self.assertIsNone(
+            pipeline._strategy_signal_paper_target_for_decision(
+                good_decision,
+                strategy,
+            )
+        )
+
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = False
+        self.assertIsNone(
+            pipeline._strategy_signal_paper_target_for_decision(
+                good_decision,
+                strategy,
+            )
+        )
+        config.settings.trading_simple_paper_route_probe_enabled = True
+
+        guarded_cases: list[tuple[str, StrategyDecision, list[Mapping[str, Any]]]] = [
+            (
+                "source decision payload",
+                make_decision(
+                    params={"paper_route_target_plan_source_decision": {"mode": "x"}}
+                ),
+                [good_target],
+            ),
+            (
+                "route acquisition mode",
+                make_decision(
+                    params={"source_decision_mode": "route_acquisition_probe"}
+                ),
+                [good_target],
+            ),
+            ("blank symbol", make_decision(symbol=" "), [good_target]),
+            (
+                "empty strategy lookup names",
+                good_decision,
+                [
+                    make_target(
+                        strategy_lookup_names=[],
+                        strategy_name=None,
+                        strategy_id=None,
+                        runtime_strategy_name=None,
+                    )
+                ],
+            ),
+            (
+                "strategy mismatch",
+                good_decision,
+                [make_target(strategy_lookup_names=["other-strategy"])],
+            ),
+            ("missing candidate", good_decision, [make_target(candidate_id=None)]),
+            ("missing hypothesis", good_decision, [make_target(hypothesis_id=None)]),
+            ("wrong stage", good_decision, [make_target(observed_stage="backtest")]),
+            ("wrong source kind", good_decision, [make_target(source_kind="manual")]),
+            (
+                "probation unauthorized",
+                good_decision,
+                [make_target(paper_probation_authorized=0)],
+            ),
+        ]
+        for name, decision, targets in guarded_cases:
+            with self.subTest(name=name):
+                with patch.object(
+                    pipeline,
+                    "_external_paper_route_target_probe_symbols_cached",
+                    return_value=({"AAPL"}, None, targets),
+                ):
+                    self.assertIsNone(
+                        pipeline._strategy_signal_paper_target_for_decision(
+                            decision,
+                            strategy,
+                        )
+                    )
+
+        with patch.object(
+            pipeline,
+            "_external_paper_route_target_probe_symbols_cached",
+            return_value=({"AAPL"}, "fetch failed", [good_target]),
+        ):
+            self.assertIsNone(
+                pipeline._strategy_signal_paper_target_for_decision(
+                    good_decision,
+                    strategy,
+                )
+            )
+
+        with patch.object(
+            pipeline,
+            "_external_paper_route_target_probe_symbols_cached",
+            return_value=({"AAPL"}, None, [good_target]),
+        ):
+            self.assertEqual(
+                pipeline._strategy_signal_paper_target_for_decision(
+                    good_decision,
+                    strategy,
+                ),
+                good_target,
+            )
 
     def test_paper_decision_persists_external_target_lineage_existing_row(
         self,


### PR DESCRIPTION
## Summary

- Mark real paper-mode strategy signal decisions as `strategy_signal_paper` only when they match an external paper target by symbol, strategy lookup, runtime window, candidate, hypothesis, stage, source kind, and probation authorization.
- Keep external target-plan source decisions and route-acquisition probes explicitly non-profit-proof so they cannot satisfy runtime-ledger promotion gates.
- Persist the strategy-signal authority metadata into decision params and `paper_route_target_plan` for runtime-window import source-mode accounting.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_decision_persists_external_target_lineage_without_gate_bypass or matching_paper_target_signal_gets_strategy_signal_paper_authority or paper_decision_persists_external_target_lineage_existing_row or paper_route_target_lineage_cache_and_existing_plan_merge or simple_pipeline_no_signal_cycle_generates_target_plan_source_decision or simple_pipeline_signal_cycle_still_generates_target_plan_source_decision'`
- `uv run --frozen pytest tests/test_trading_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
