### PR TITLE
chore(analysis): promote image 36c2e64f323c

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 702fa8f1d76c867c5b2100c3b691ad1d6b9c49ce
+    newTag: 36c2e64f323c37308486d99d226f2a3e65b8e22a


### PR DESCRIPTION
## Summary

- Promotes `argocd/applications/analysis` to `registry.ide-newton.ts.net/lab/analysis:36c2e64f323c37308486d99d226f2a3e65b8e22a`.
- Keeps rollout in lab GitOps by changing only the analysis kustomize image tag.
- Uses the self-hosted analysis image publish workflow output.

## Related Issues

None

## Testing

- `/Users/gregkonush/github.com/analysis/scripts/verify-analysis-image.sh 36c2e64f323c37308486d99d226f2a3e65b8e22a`
- `kubectl kustomize argocd/applications/analysis`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
