### PR TITLE
fix(torghut): harden paper target plan timeouts

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -47,6 +47,9 @@ spec:
                     --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \
                     --runtime-window-import \
                     --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence \
+                    --runtime-window-target-plan-url-timeout-seconds 45 \
+                    --runtime-window-target-plan-url-attempts 3 \
+                    --runtime-window-target-plan-url-retry-backoff-seconds 5 \
                     --runtime-window-target-plan-exclusive \
                     --runtime-window-target-plan-required \
                     --runtime-window-target-plan-settlement-seconds 3600 \

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -113,7 +113,7 @@ spec:
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_URL
               value: http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS
-              value: "5"
+              value: "10"
             - name: TRADING_KILL_SWITCH_ENABLED
               value: "false"
             - name: TRADING_FEATURE_FLAGS_ENABLED

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import sys
+import time as wall_time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -197,6 +198,21 @@ def _parse_args() -> argparse.Namespace:
         default=5.0,
     )
     parser.add_argument(
+        "--runtime-window-target-plan-url-attempts",
+        type=int,
+        default=1,
+        help=(
+            "Bounded attempts for runtime-window target plan URL reads. Retries "
+            "transport failures and transient empty paper-route evidence while "
+            "preserving required/exclusive fail-closed semantics."
+        ),
+    )
+    parser.add_argument(
+        "--runtime-window-target-plan-url-retry-backoff-seconds",
+        type=float,
+        default=0.25,
+    )
+    parser.add_argument(
         "--runtime-window-target-plan-exclusive",
         action="store_true",
         help=(
@@ -289,6 +305,12 @@ def _as_dict(value: Any) -> dict[str, Any]:
         if isinstance(value, Mapping)
         else {}
     )
+
+
+def _as_sequence(value: Any) -> Sequence[Any]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return value
+    return ()
 
 
 def _as_text(value: Any) -> str | None:
@@ -490,11 +512,63 @@ def _runtime_window_target_plan_from_payload(
     return _as_dict(payload)
 
 
-def _read_runtime_window_target_plan_url(
+def _runtime_window_target_plan_has_targets(plan: Mapping[str, Any]) -> bool:
+    targets = plan.get("targets")
+    return (
+        isinstance(targets, Sequence)
+        and not isinstance(targets, (str, bytes, bytearray))
+        and len(targets) > 0
+    )
+
+
+def _runtime_window_target_plan_transient_empty_reason(
+    *,
+    payload: Mapping[str, Any],
+    plan: Mapping[str, Any],
+) -> str | None:
+    if _runtime_window_target_plan_has_targets(plan):
+        return None
+    reason_values: list[object] = []
+    summary = _as_dict(payload.get("summary"))
+    reason_values.extend(_as_sequence(summary.get("blockers")))
+    audit = _as_dict(payload.get("runtime_window_import_audit"))
+    reason_values.append(audit.get("state"))
+    reason_values.extend(_as_sequence(audit.get("blockers")))
+    gate = _as_dict(payload.get("live_submission_gate"))
+    reason_values.append(gate.get("paper_route_target_plan_error"))
+    gate_plan = _as_dict(gate.get("runtime_ledger_paper_probation_import_plan"))
+    for skipped in _as_sequence(gate_plan.get("skipped_targets")):
+        skipped_map = _as_dict(skipped)
+        reason_values.append(skipped_map.get("reason"))
+        reason_values.extend(
+            _as_sequence(skipped_map.get("missing_or_blocking_fields"))
+        )
+
+    transient_prefixes = (
+        "paper_route_target_plan_fetch_failed",
+        "paper_route_target_plan_http_status",
+        "paper_probation_import_plan_missing",
+        "external_paper_route_target_plan_unavailable",
+    )
+    for raw_reason in reason_values:
+        reason = str(raw_reason or "").strip()
+        if not reason:
+            continue
+        if reason.startswith(transient_prefixes) or "timed out" in reason.lower():
+            return reason
+    return None
+
+
+def _runtime_window_target_plan_url_error_retryable(error: RuntimeError) -> bool:
+    text = str(error)
+    return "runtime_window_target_plan_url_fetch_failed" in text
+
+
+def _read_runtime_window_target_plan_url_once(
     ref: str,
     *,
     timeout_seconds: float,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], dict[str, Any]]:
     url = ref.strip()
     if not url:
         raise RuntimeError("runtime_window_target_plan_url_empty")
@@ -517,7 +591,42 @@ def _read_runtime_window_target_plan_url(
     data = _as_dict(payload)
     if not data:
         raise RuntimeError(f"runtime_window_target_plan_url_invalid:{url}")
-    return _runtime_window_target_plan_from_payload(data)
+    return _runtime_window_target_plan_from_payload(data), data
+
+
+def _read_runtime_window_target_plan_url(
+    ref: str,
+    *,
+    timeout_seconds: float,
+    attempts: int = 1,
+    retry_backoff_seconds: float = 0.25,
+) -> dict[str, Any]:
+    max_attempts = max(int(attempts), 1)
+    last_plan: dict[str, Any] = {}
+    for attempt in range(1, max_attempts + 1):
+        try:
+            plan, payload = _read_runtime_window_target_plan_url_once(
+                ref,
+                timeout_seconds=timeout_seconds,
+            )
+            last_plan = plan
+            transient_empty_reason = _runtime_window_target_plan_transient_empty_reason(
+                payload=payload,
+                plan=plan,
+            )
+            if transient_empty_reason and attempt < max_attempts:
+                wall_time.sleep(max(float(retry_backoff_seconds), 0.0))
+                continue
+            return plan
+        except RuntimeError as exc:
+            if (
+                attempt < max_attempts
+                and _runtime_window_target_plan_url_error_retryable(exc)
+            ):
+                wall_time.sleep(max(float(retry_backoff_seconds), 0.0))
+                continue
+            raise
+    return last_plan
 
 
 def _runtime_family_harnesses(family_dir: str) -> dict[str, dict[str, str]]:
@@ -648,10 +757,21 @@ def _runtime_window_plan_targets(
     timeout_seconds = float(
         getattr(args, "runtime_window_target_plan_url_timeout_seconds", 5.0) or 5.0
     )
+    url_attempts = int(getattr(args, "runtime_window_target_plan_url_attempts", 1) or 1)
+    raw_retry_backoff_seconds = getattr(
+        args,
+        "runtime_window_target_plan_url_retry_backoff_seconds",
+        0.25,
+    )
+    retry_backoff_seconds = (
+        0.25 if raw_retry_backoff_seconds is None else float(raw_retry_backoff_seconds)
+    )
     for ref in url_refs:
         plan = _read_runtime_window_target_plan_url(
             ref,
             timeout_seconds=timeout_seconds,
+            attempts=url_attempts,
+            retry_backoff_seconds=retry_backoff_seconds,
         )
         targets.extend(_runtime_window_targets_from_plan(plan=plan, ref=ref, args=args))
     return targets

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -617,7 +617,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertEqual(
             sim_env.get("TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS"),
-            "5",
+            "10",
         )
         self.assertFalse(_manifest_bool(sim_env, "TRADING_SIMULATION_ENABLED"))
         self.assertEqual(sim_env.get("TRADING_UNIVERSE_SOURCE"), "static")
@@ -937,6 +937,12 @@ class TestLiveConfigManifestContract(TestCase):
             "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
+        self.assertIn("--runtime-window-target-plan-url-timeout-seconds 45", args)
+        self.assertIn("--runtime-window-target-plan-url-attempts 3", args)
+        self.assertIn(
+            "--runtime-window-target-plan-url-retry-backoff-seconds 5",
+            args,
+        )
         self.assertNotIn(
             "--runtime-window-target-plan-url "
             "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
@@ -1201,7 +1207,9 @@ class TestLiveConfigManifestContract(TestCase):
             _manifest_bool(env, "TRADING_ALPACA_QUOTE_FALLBACK_MARKET_SESSION_REQUIRED")
         )
         self.assertEqual(env.get("TRADING_ALPACA_QUOTE_FALLBACK_BACKOFF_SECONDS"), "60")
-        self.assertEqual(env.get("TRADING_OPTIONS_CATALOG_FRESHNESS_CACHE_SECONDS"), "30")
+        self.assertEqual(
+            env.get("TRADING_OPTIONS_CATALOG_FRESHNESS_CACHE_SECONDS"), "30"
+        )
         self.assertFalse(_manifest_bool(env, "TRADING_AUTONOMY_ENABLED"))
         self.assertFalse(_manifest_bool(env, "TRADING_AUTONOMY_ALLOW_LIVE_PROMOTION"))
         self.assertFalse(_manifest_bool(env, "TRADING_KILL_SWITCH_ENABLED"))

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -1059,6 +1059,177 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                 timeout_seconds=1.0,
             )
 
+    def test_runtime_window_target_plan_url_retries_transport_failure(self) -> None:
+        response = MagicMock()
+        response.__enter__.return_value.read.return_value = json.dumps(
+            {
+                "runtime_window_import_plan": {
+                    "targets": [
+                        {
+                            "candidate_id": "cand-retry",
+                            "hypothesis_id": "H-RETRY",
+                        }
+                    ]
+                }
+            }
+        ).encode("utf-8")
+
+        with (
+            patch.object(
+                renewal.urllib.request,
+                "urlopen",
+                side_effect=[
+                    renewal.urllib.error.URLError("connection refused"),
+                    response,
+                ],
+            ) as urlopen,
+            patch.object(renewal.wall_time, "sleep") as sleep,
+        ):
+            plan = renewal._read_runtime_window_target_plan_url(
+                "http://torghut.invalid/status",
+                timeout_seconds=1.0,
+                attempts=2,
+                retry_backoff_seconds=0.0,
+            )
+
+        self.assertEqual(urlopen.call_count, 2)
+        sleep.assert_called_once_with(0.0)
+        self.assertEqual(plan["targets"][0]["candidate_id"], "cand-retry")
+
+    def test_runtime_window_target_plan_url_retries_transient_empty_paper_route(
+        self,
+    ) -> None:
+        transient = MagicMock()
+        transient.__enter__.return_value.read.return_value = json.dumps(
+            {
+                "schema_version": "torghut.paper-route-evidence.v1",
+                "summary": {"blockers": ["paper_probation_import_plan_missing"]},
+                "runtime_window_import_audit": {
+                    "state": "paper_probation_import_plan_missing",
+                    "blockers": ["paper_probation_import_plan_missing"],
+                },
+                "live_submission_gate": {
+                    "paper_route_target_plan_error": (
+                        "paper_route_target_plan_fetch_failed:timed out"
+                    ),
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "targets": [],
+                        "skipped_targets": [
+                            {
+                                "reason": "external_paper_route_target_plan_unavailable",
+                                "missing_or_blocking_fields": [
+                                    "paper_route_target_plan_fetch_failed:timed out"
+                                ],
+                            }
+                        ],
+                    },
+                },
+                "next_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 0,
+                    "targets": [],
+                },
+            }
+        ).encode("utf-8")
+        success = MagicMock()
+        success.__enter__.return_value.read.return_value = json.dumps(
+            {
+                "schema_version": "torghut.paper-route-evidence.v1",
+                "next_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "candidate_id": "cand-paper-route",
+                            "hypothesis_id": "H-PAPER-ROUTE",
+                            "strategy_family": "microbar_pairs",
+                            "strategy_name": "paper-route-candidate-v1",
+                        }
+                    ],
+                },
+            }
+        ).encode("utf-8")
+
+        with (
+            patch.object(
+                renewal.urllib.request,
+                "urlopen",
+                side_effect=[transient, success],
+            ) as urlopen,
+            patch.object(renewal.wall_time, "sleep") as sleep,
+        ):
+            plan = renewal._read_runtime_window_target_plan_url(
+                "http://torghut.invalid/status",
+                timeout_seconds=1.0,
+                attempts=2,
+                retry_backoff_seconds=0.0,
+            )
+
+        self.assertEqual(urlopen.call_count, 2)
+        sleep.assert_called_once_with(0.0)
+        self.assertEqual(
+            plan["schema_version"],
+            "torghut.next-paper-route-runtime-window-targets.v1",
+        )
+        self.assertEqual(plan["targets"][0]["candidate_id"], "cand-paper-route")
+
+    def test_runtime_window_target_plan_required_stays_fail_closed_after_retries(
+        self,
+    ) -> None:
+        transient = MagicMock()
+        transient.__enter__.return_value.read.return_value = json.dumps(
+            {
+                "schema_version": "torghut.paper-route-evidence.v1",
+                "summary": {"blockers": ["paper_probation_import_plan_missing"]},
+                "live_submission_gate": {
+                    "paper_route_target_plan_error": (
+                        "paper_route_target_plan_fetch_failed:timed out"
+                    )
+                },
+                "next_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 0,
+                    "targets": [],
+                },
+            }
+        ).encode("utf-8")
+        args = SimpleNamespace(
+            runtime_window_target=[],
+            runtime_window_target_plan_ref=[],
+            runtime_window_target_plan_url=["http://torghut.invalid/status"],
+            runtime_window_target_plan_url_timeout_seconds=1.0,
+            runtime_window_target_plan_url_attempts=2,
+            runtime_window_target_plan_url_retry_backoff_seconds=0.0,
+            runtime_window_target_plan_required=True,
+            runtime_window_target_plan_exclusive=True,
+            runtime_window_targets_from_latest_autoresearch=True,
+            runtime_window_targets_from_registry=True,
+        )
+
+        with (
+            patch.object(
+                renewal.urllib.request,
+                "urlopen",
+                side_effect=[transient, transient],
+            ) as urlopen,
+            patch.object(renewal.wall_time, "sleep") as sleep,
+            patch.object(
+                renewal,
+                "_latest_autoresearch_runtime_window_targets",
+            ) as latest,
+            patch.object(renewal, "_registry_runtime_window_targets") as registry,
+            self.assertRaisesRegex(
+                RuntimeError,
+                "runtime_window_target_plan_required_but_empty",
+            ),
+        ):
+            renewal._runtime_window_targets(args)
+
+        self.assertEqual(urlopen.call_count, 2)
+        sleep.assert_called_once_with(0.0)
+        latest.assert_not_called()
+        registry.assert_not_called()
+
     def test_runtime_window_targets_from_candidate_board_plan_preserve_probation_handoff(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Increase the sim paper-route target-plan fetch timeout from 5s to 10s so transient slow `/trading/paper-route-evidence` responses do not drop the H-PAIRS import plan.
- Add bounded renewal-script retries for target-plan URL transport failures and transient empty paper-route evidence payloads, while preserving required/exclusive fail-closed behavior after retries exhaust.
- Configure the empirical promotion renewal CronJob for a 45s outer URL timeout, 3 attempts, and a 5s retry backoff, with manifest contract coverage.

## Related Issues

None

## Testing

- `uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff format --check scripts/renew_latest_empirical_promotion_jobs.py tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py -k 'runtime_window_target_plan_url or runtime_window_target_plan_required_stays_fail_closed_after_retries'`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py tests/test_live_config_manifest_contract.py`
- `bun run lint:argocd`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
