### PR TITLE
fix(torghut): materialize runtime ledger fills

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -389,7 +389,7 @@ def _order_lifecycle_blockers(
         blockers.append("order_decision_linkage_missing")
 
     fill_order_ids = {row.order_id for row in usable_fills if row.order_id is not None}
-    if usable_fills and len(fill_order_ids) < len(usable_fills):
+    if any(row.order_id is None for row in usable_fills):
         blockers.append("fill_order_linkage_missing")
     if fill_order_ids - submitted_order_ids:
         blockers.append("fill_order_submission_missing")

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -8,7 +8,7 @@ import hashlib
 import json
 import os
 from datetime import date, datetime, time, timedelta, timezone
-from decimal import Decimal
+from decimal import ROUND_CEILING, Decimal
 from pathlib import Path
 from typing import Any, Mapping, Sequence, cast
 
@@ -84,6 +84,11 @@ ORDER_FEED_FILL_LIFECYCLE_INCOMPLETE_BLOCKER = "order_feed_fill_lifecycle_incomp
 ORDER_FEED_FILL_LIFECYCLE_ORDER_ID_MISSING_BLOCKER = (
     "order_feed_fill_lifecycle_order_id_missing"
 )
+ALPACA_2026_EQUITY_SEC_FEE_RATE = Decimal("20.60") / Decimal("1000000")
+ALPACA_2026_EQUITY_TAF_RATE_PER_SHARE = Decimal("0.000195")
+ALPACA_2026_EQUITY_TAF_CAP = Decimal("9.79")
+ALPACA_2026_FEE_SCHEDULE_REVISED_ON = "2026-04-01"
+_CENT = Decimal("0.01")
 _RUNTIME_LEDGER_EQUITY_DENOMINATOR_KEYS = (
     "account_equity",
     "portfolio_equity",
@@ -298,7 +303,7 @@ def _source_decision_mode(row: Mapping[str, object]) -> str | None:
     explicit = normalize_source_decision_mode(_first_text(row, "source_decision_mode"))
     if explicit is not None:
         return explicit
-    return normalize_source_decision_mode(_first_text(row, "mode"))
+    return normalize_source_decision_mode(row.get("mode"))
 
 
 def _source_decision_mode_counts(
@@ -391,6 +396,126 @@ def _stable_payload_digest(value: object) -> str | None:
         default=_json_default,
     ).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _runtime_source_lineage_hash(
+    *,
+    candidate_id: str | None,
+    hypothesis_id: str | None,
+) -> str | None:
+    payload = {
+        key: value
+        for key, value in {
+            "candidate_id": candidate_id,
+            "hypothesis_id": hypothesis_id,
+            "source": "runtime_window_lineage_filter",
+        }.items()
+        if value
+    }
+    return _stable_payload_digest(payload)
+
+
+def _attach_source_lineage_context(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    candidate_id: str | None,
+    hypothesis_id: str | None,
+) -> list[dict[str, object]]:
+    lineage_hash = _runtime_source_lineage_hash(
+        candidate_id=candidate_id,
+        hypothesis_id=hypothesis_id,
+    )
+    contextualized: list[dict[str, object]] = []
+    for row in rows:
+        payload = dict(row)
+        if candidate_id:
+            payload.setdefault("source_candidate_id", candidate_id)
+        if hypothesis_id:
+            payload.setdefault("source_hypothesis_id", hypothesis_id)
+        if lineage_hash:
+            payload["lineage_hash"] = lineage_hash
+        contextualized.append(payload)
+    return contextualized
+
+
+def _decimal_ceil_cent(value: Decimal) -> Decimal:
+    if value <= 0:
+        return Decimal("0")
+    return value.quantize(_CENT, rounding=ROUND_CEILING)
+
+
+def _row_has_alpaca_us_equity_order_source(row: Mapping[str, object]) -> bool:
+    alpaca_markers = {
+        str(item or "").strip().lower()
+        for item in (
+            *_text_values(row, "feed", "source_topic", "channel", "submit_path"),
+            *_text_values(row, "source"),
+        )
+    }
+    if not any(
+        "alpaca" in marker or marker == "trade_updates" for marker in alpaca_markers
+    ):
+        return False
+    asset_classes = {
+        value.strip().lower().replace("-", "_")
+        for value in _text_values(row, "asset_class")
+    }
+    return not asset_classes or any(
+        item in {"us_equity", "us_equities", "equity", "equities"}
+        for item in asset_classes
+    )
+
+
+def _alpaca_2026_equity_fee_schedule_cost(
+    row: Mapping[str, object],
+    *,
+    side: Any,
+    filled_qty: Decimal | None,
+    filled_notional: Decimal,
+) -> tuple[Decimal, str] | None:
+    if (
+        filled_qty is None
+        or filled_qty <= 0
+        or filled_notional <= 0
+        or not _row_has_alpaca_us_equity_order_source(row)
+    ):
+        return None
+    normalized_side = str(side or "").strip().lower().replace("-", "_")
+    if normalized_side in {"buy", "buy_to_cover", "cover"}:
+        return Decimal("0"), "alpaca_2026_equity_zero_commission_and_cat_fee_schedule"
+    if normalized_side not in {"sell", "sell_short", "short"}:
+        return None
+    sec_fee = _decimal_ceil_cent(filled_notional * ALPACA_2026_EQUITY_SEC_FEE_RATE)
+    taf_fee = min(
+        _decimal_ceil_cent(filled_qty * ALPACA_2026_EQUITY_TAF_RATE_PER_SHARE),
+        ALPACA_2026_EQUITY_TAF_CAP,
+    )
+    return (
+        sec_fee + taf_fee,
+        "alpaca_2026_equity_sec_taf_cat_fee_schedule",
+    )
+
+
+def _alpaca_2026_equity_fee_schedule_hash() -> str:
+    digest = _stable_payload_digest(
+        {
+            "broker": "alpaca",
+            "asset_class": "us_equity",
+            "schedule": "alpaca_brokerage_fee_schedule",
+            "revised_on": ALPACA_2026_FEE_SCHEDULE_REVISED_ON,
+            "sec_fee_rate_per_notional": str(ALPACA_2026_EQUITY_SEC_FEE_RATE),
+            "taf_rate_per_share": str(ALPACA_2026_EQUITY_TAF_RATE_PER_SHARE),
+            "taf_cap": str(ALPACA_2026_EQUITY_TAF_CAP),
+            "cat_fee_equities": "0",
+            "commission": "0",
+        }
+    )
+    assert digest is not None
+    return digest
+
+
+def _cost_basis_is_alpaca_fee_schedule(value: object) -> bool:
+    return str(value or "").strip().startswith("alpaca_2026_equity_")
 
 
 def _first_payload_digest(row: Mapping[str, object], *keys: str) -> str | None:
@@ -1148,6 +1273,8 @@ def _runtime_execution_cost_amount(
     row: Mapping[str, object],
     *,
     filled_notional: Decimal,
+    side: Any = None,
+    filled_qty: Decimal | None = None,
 ) -> Decimal | None:
     explicit_cost = _first_decimal(
         row,
@@ -1160,6 +1287,14 @@ def _runtime_execution_cost_amount(
     )
     if explicit_cost is not None:
         return explicit_cost
+    fee_schedule_cost = _alpaca_2026_equity_fee_schedule_cost(
+        row,
+        side=side,
+        filled_qty=filled_qty,
+        filled_notional=filled_notional,
+    )
+    if fee_schedule_cost is not None:
+        return fee_schedule_cost[0]
     total_cost_bps = _first_decimal(
         row,
         "total_cost_bps",
@@ -1176,6 +1311,9 @@ def _runtime_execution_cost_basis(
     row: Mapping[str, object],
     *,
     cost_amount: Decimal | None,
+    side: Any = None,
+    filled_qty: Decimal | None = None,
+    filled_notional: Decimal | None = None,
 ) -> str | None:
     cost_basis = _first_text(
         row,
@@ -1187,6 +1325,15 @@ def _runtime_execution_cost_basis(
     )
     if cost_basis is not None:
         return cost_basis
+    if filled_notional is not None:
+        fee_schedule_cost = _alpaca_2026_equity_fee_schedule_cost(
+            row,
+            side=side,
+            filled_qty=filled_qty,
+            filled_notional=filled_notional,
+        )
+        if fee_schedule_cost is not None and cost_amount == fee_schedule_cost[0]:
+            return fee_schedule_cost[1]
     if (
         cost_amount is not None
         and _first_decimal(
@@ -1316,11 +1463,22 @@ def _runtime_lifecycle_ledger_row(
         ):
             filled_notional = filled_qty * avg_fill_price
         cost_amount = (
-            _runtime_execution_cost_amount(row, filled_notional=filled_notional)
+            _runtime_execution_cost_amount(
+                row,
+                filled_notional=filled_notional,
+                side=side,
+                filled_qty=filled_qty,
+            )
             if filled_notional is not None
             else None
         )
-        cost_basis = _runtime_execution_cost_basis(row, cost_amount=cost_amount)
+        cost_basis = _runtime_execution_cost_basis(
+            row,
+            cost_amount=cost_amount,
+            side=side,
+            filled_qty=filled_qty,
+            filled_notional=filled_notional,
+        )
         if require_complete_fill and (
             side is None
             or filled_qty is None
@@ -1346,6 +1504,8 @@ def _runtime_lifecycle_ledger_row(
             ledger_row["cost_amount"] = cost_amount
         if cost_basis is not None:
             ledger_row["cost_basis"] = cost_basis
+        if _cost_basis_is_alpaca_fee_schedule(cost_basis):
+            ledger_row["cost_model_hash"] = _alpaca_2026_equity_fee_schedule_hash()
         ledger_row["source"] = "execution_order_event"
     return ledger_row
 
@@ -1585,8 +1745,9 @@ def _build_realized_strategy_pnl_rows(
             "fill_price",
             "filled_price",
         )
+        side = _first_text(row, "side", "order_side") or ""
         signed_qty = _execution_signed_qty(
-            side=_first_text(row, "side", "order_side"),
+            side=side,
             qty=_first_decimal(
                 row,
                 "filled_qty",
@@ -1669,11 +1830,20 @@ def _build_realized_strategy_pnl_rows(
         cost_amount = _runtime_execution_cost_amount(
             row,
             filled_notional=filled_notional,
+            side=side,
+            filled_qty=filled_qty,
         )
         cost_basis = _runtime_execution_cost_basis(
             row,
             cost_amount=cost_amount,
+            side=side,
+            filled_qty=filled_qty,
+            filled_notional=filled_notional,
         )
+        if _cost_basis_is_alpaca_fee_schedule(cost_basis):
+            common_ledger_fields["cost_model_hash"] = (
+                _alpaca_2026_equity_fee_schedule_hash()
+            )
         ledger_rows.append(
             RuntimeLedgerFill(
                 executed_at=(
@@ -1688,7 +1858,7 @@ def _build_realized_strategy_pnl_rows(
                 cost_model_hash=common_ledger_fields["cost_model_hash"],
                 lineage_hash=common_ledger_fields["lineage_hash"],
                 replay_data_hash=common_ledger_fields["replay_data_hash"],
-                side=_first_text(row, "side", "order_side") or "",
+                side=side,
                 filled_qty=filled_qty,
                 avg_fill_price=price,
                 filled_notional=filled_notional,
@@ -1730,6 +1900,7 @@ def _build_realized_strategy_pnl_rows(
     for bucket in build_runtime_ledger_buckets(
         ledger_rows,
         bucket_ranges=bucket_ranges,
+        group_by=("symbol",),
         require_order_lifecycle=True,
     ):
         if bucket.closed_trade_count <= 0 and not bucket.blockers:
@@ -2662,6 +2833,11 @@ def _query_timestamps(
                 source_activity_diagnostics["decision_rows_after_lineage_filter"] = len(
                     decision_lifecycle_rows
                 )
+            decision_lifecycle_rows = _attach_source_lineage_context(
+                decision_lifecycle_rows,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+            )
             decisions = []
             for row in decision_lifecycle_rows:
                 computed_at = row.get("computed_at")
@@ -2776,6 +2952,11 @@ def _query_timestamps(
                 source_activity_diagnostics[
                     "fill_execution_rows_after_lineage_filter"
                 ] = sum(1 for row in execution_rows if _execution_row_has_fill(row))
+            execution_rows = _attach_source_lineage_context(
+                execution_rows,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+            )
             executions = []
             for row in execution_rows:
                 execution_event_at = row.get("execution_event_at")
@@ -2878,6 +3059,11 @@ def _query_timestamps(
                     for row in order_lifecycle_rows
                     if _runtime_ledger_event_type(row) in _RUNTIME_LEDGER_FILL_EVENTS
                 )
+            order_lifecycle_rows = _attach_source_lineage_context(
+                order_lifecycle_rows,
+                candidate_id=candidate_id,
+                hypothesis_id=hypothesis_id,
+            )
             cur.execute(
                 f"""
                 select

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -22,6 +22,7 @@ from scripts.import_hypothesis_runtime_windows import (
     POST_COST_BASIS_RUNTIME_LEDGER,
     POST_COST_BASIS_SIMULATION_REPORT,
     POST_COST_BASIS_TCA_PROXY,
+    _alpaca_2026_equity_fee_schedule_hash,
     _build_realized_strategy_pnl_rows,
     _first_bool,
     _first_lineage_digest,
@@ -615,6 +616,15 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(
             _source_decision_mode({"mode": "strategy_signal_paper"}),
             "strategy_signal_paper",
+        )
+        self.assertIsNone(
+            _source_decision_mode(
+                {
+                    "decision_json": {
+                        "params": {"strategy_runtime": {"mode": "scheduler_v3"}}
+                    }
+                }
+            )
         )
         self.assertEqual(
             _source_decision_mode_counts(
@@ -1892,6 +1902,62 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(ledger_row["execution_policy_hash"], "policy-sha")
         self.assertEqual(ledger_row["cost_model_hash"], "cost-sha")
         self.assertEqual(ledger_row["lineage_hash"], "lineage-sha")
+
+    def test_order_event_lifecycle_materializes_alpaca_fee_schedule_costs(self) -> None:
+        row = {
+            "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+            "event_type": "filled",
+            "symbol": "AAPL",
+            "account_label": "TORGHUT_SIM",
+            "strategy_id": "microbar-cross-sectional-pairs-v1",
+            "decision_hash": "decision-sell",
+            "alpaca_order_id": "order-sell",
+            "source_topic": "alpaca-trade-updates",
+            "raw_event": {
+                "event": "fill",
+                "feed": "alpaca",
+                "channel": "trade_updates",
+                "payload": {
+                    "qty": "10",
+                    "price": "100",
+                    "order": {
+                        "id": "order-sell",
+                        "asset_class": "us_equity",
+                        "side": "sell",
+                        "symbol": "AAPL",
+                        "status": "filled",
+                        "filled_qty": "10",
+                        "filled_avg_price": "100",
+                    },
+                },
+            },
+            "execution_audit_json": {
+                "execution_policy_hash": "policy-sha",
+                "lineage_hash": "lineage-sha",
+            },
+        }
+
+        ledger_row = _runtime_lifecycle_ledger_row(
+            row,
+            event_type="filled",
+            require_complete_fill=True,
+        )
+
+        self.assertIsNotNone(ledger_row)
+        assert ledger_row is not None
+        self.assertEqual(ledger_row["side"], "sell")
+        self.assertEqual(ledger_row["filled_qty"], Decimal("10"))
+        self.assertEqual(ledger_row["avg_fill_price"], Decimal("100"))
+        self.assertEqual(ledger_row["filled_notional"], Decimal("1000"))
+        self.assertEqual(ledger_row["cost_amount"], Decimal("0.04"))
+        self.assertEqual(
+            ledger_row["cost_basis"],
+            "alpaca_2026_equity_sec_taf_cat_fee_schedule",
+        )
+        self.assertEqual(
+            ledger_row["cost_model_hash"],
+            _alpaca_2026_equity_fee_schedule_hash(),
+        )
 
     def test_runtime_ledger_tca_materialization_metadata_separates_authority(
         self,

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -747,6 +747,121 @@ def test_exact_replay_ledger_blocks_fill_only_profit_proof() -> None:
     assert "fill_order_linkage_missing" in bucket.blockers
 
 
+def test_exact_replay_ledger_accepts_multiple_partial_fills_for_one_order() -> None:
+    rows: list[dict[str, object]] = [
+        {
+            "event_type": "decision",
+            "executed_at": _ts(1),
+            "decision_id": "decision-buy",
+            "account_label": "paper",
+            "strategy_id": "strategy-1",
+            "symbol": "NVDA",
+            "execution_policy_hash": "policy-sha",
+            "cost_model_hash": "cost-sha",
+            "lineage_hash": "lineage-sha",
+        },
+        {
+            "event_type": "order_submitted",
+            "executed_at": _ts(2),
+            "decision_id": "decision-buy",
+            "order_id": "order-buy",
+            "account_label": "paper",
+            "strategy_id": "strategy-1",
+            "symbol": "NVDA",
+            "execution_policy_hash": "policy-sha",
+            "cost_model_hash": "cost-sha",
+            "lineage_hash": "lineage-sha",
+        },
+        {
+            "event_type": "partial_fill",
+            "executed_at": _ts(3),
+            "decision_id": "decision-buy",
+            "order_id": "order-buy",
+            "account_label": "paper",
+            "strategy_id": "strategy-1",
+            "symbol": "NVDA",
+            "side": "buy",
+            "filled_qty": Decimal("0.4"),
+            "avg_fill_price": Decimal("100"),
+            "cost_amount": Decimal("0.01"),
+            "cost_basis": "broker_reported_commission_and_fees",
+            "execution_policy_hash": "policy-sha",
+            "cost_model_hash": "cost-sha",
+            "lineage_hash": "lineage-sha",
+        },
+        {
+            "event_type": "fill",
+            "executed_at": _ts(4),
+            "decision_id": "decision-buy",
+            "order_id": "order-buy",
+            "account_label": "paper",
+            "strategy_id": "strategy-1",
+            "symbol": "NVDA",
+            "side": "buy",
+            "filled_qty": Decimal("0.6"),
+            "avg_fill_price": Decimal("100"),
+            "cost_amount": Decimal("0.01"),
+            "cost_basis": "broker_reported_commission_and_fees",
+            "execution_policy_hash": "policy-sha",
+            "cost_model_hash": "cost-sha",
+            "lineage_hash": "lineage-sha",
+        },
+        {
+            "event_type": "decision",
+            "executed_at": _ts(10),
+            "decision_id": "decision-sell",
+            "account_label": "paper",
+            "strategy_id": "strategy-1",
+            "symbol": "NVDA",
+            "execution_policy_hash": "policy-sha",
+            "cost_model_hash": "cost-sha",
+            "lineage_hash": "lineage-sha",
+        },
+        {
+            "event_type": "order_submitted",
+            "executed_at": _ts(11),
+            "decision_id": "decision-sell",
+            "order_id": "order-sell",
+            "account_label": "paper",
+            "strategy_id": "strategy-1",
+            "symbol": "NVDA",
+            "execution_policy_hash": "policy-sha",
+            "cost_model_hash": "cost-sha",
+            "lineage_hash": "lineage-sha",
+        },
+        {
+            "event_type": "fill",
+            "executed_at": _ts(12),
+            "decision_id": "decision-sell",
+            "order_id": "order-sell",
+            "account_label": "paper",
+            "strategy_id": "strategy-1",
+            "symbol": "NVDA",
+            "side": "sell",
+            "filled_qty": Decimal("1"),
+            "avg_fill_price": Decimal("101"),
+            "cost_amount": Decimal("0.02"),
+            "cost_basis": "broker_reported_commission_and_fees",
+            "execution_policy_hash": "policy-sha",
+            "cost_model_hash": "cost-sha",
+            "lineage_hash": "lineage-sha",
+        },
+    ]
+
+    bucket = build_runtime_ledger_buckets(
+        rows,
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.blockers == []
+    assert bucket.fill_count == 3
+    assert bucket.submitted_order_count == 2
+    assert bucket.closed_trade_count == 1
+    assert bucket.open_position_count == 0
+    assert bucket.net_strategy_pnl_after_costs == Decimal("0.96")
+
+
 def test_exact_replay_ledger_blocks_unfilled_or_unhashed_order_lifecycle() -> None:
     bucket = build_runtime_ledger_buckets(
         [


### PR DESCRIPTION
## Summary

- Materializes Alpaca US-equity order-feed fills into runtime-ledger rows with explicit 2026 SEC/TAF fee-schedule cost basis.
- Attaches stable candidate/hypothesis source lineage after source filtering so event fingerprints and offsets do not create false proof-lineage ambiguity.
- Keeps source-decision proof mode extraction scoped to explicit fields, and allows multiple partial fills on one order ID without treating them as missing linkage.

## Related Issues

None

## Testing

- `uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py app/trading/runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py app/trading/runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py -k 'source_decision_helpers or alpaca_fee_schedule or partial_fills or materializes_order_feed_fills_once or authorizes_event_sourced_lifecycle or order_event_lifecycle_uses_execution_raw_order_metadata'`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
