### PR TITLE
fix(torghut): keep paper exits closing positions

### DIFF
--- a/services/torghut/app/trading/execution_policy.py
+++ b/services/torghut/app/trading/execution_policy.py
@@ -203,6 +203,7 @@ class ExecutionPolicy:
         price = _resolve_price(decision, market_snapshot)
         position_qty = _position_summary(decision.symbol, positions)
         short_increasing = _is_short_increasing(decision, positions)
+        position_reducing = _is_position_reducing(decision, position_qty)
         qty, notional = self._resolve_qty_and_notional(
             decision=decision,
             position_qty=position_qty,
@@ -225,6 +226,7 @@ class ExecutionPolicy:
             max_notional is not None
             and notional is not None
             and notional > max_notional
+            and not position_reducing
         ):
             reasons.append("max_notional_exceeded")
 
@@ -1258,6 +1260,20 @@ def _is_short_increasing(
     if position_qty <= 0:
         return True
     return qty > position_qty
+
+
+def _is_position_reducing(
+    decision: StrategyDecision,
+    position_qty: Decimal,
+) -> bool:
+    qty = _optional_decimal(decision.qty)
+    if qty is None or qty <= 0:
+        return False
+    if decision.action == "sell" and position_qty > 0:
+        return qty <= position_qty
+    if decision.action == "buy" and position_qty < 0:
+        return qty <= abs(position_qty)
+    return False
 
 
 def _optional_decimal(value: Any) -> Optional[Decimal]:

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -1155,8 +1155,97 @@ class SimpleTradingPipeline(TradingPipeline):
             if str(metadata.get("exit_due_at") or "") != exit_due_at_text:
                 continue
             if row.status in {"planned", "submitted", "filled", "rejected"}:
+                if row.status == "rejected" and not self.executor.execution_exists(
+                    session, row
+                ):
+                    continue
                 return True
         return False
+
+    def _reopen_rejected_paper_route_probe_exit_decision(
+        self,
+        *,
+        session: Session,
+        decision: StrategyDecision,
+        decision_row: TradeDecision,
+    ) -> TradeDecision | None:
+        if decision_row.status != "rejected":
+            return None
+        exit_metadata = self._paper_route_probe_exit_metadata(decision)
+        if exit_metadata is None:
+            return None
+        if self.executor.execution_exists(session, decision_row):
+            return None
+        retry_limit = max(
+            _safe_int(settings.trading_simple_paper_route_probe_retry_attempt_limit),
+            0,
+        )
+        raw_decision_json: object = decision_row.decision_json
+        decision_json: dict[str, Any] = (
+            dict(cast(Mapping[str, Any], raw_decision_json))
+            if isinstance(raw_decision_json, Mapping)
+            else {}
+        )
+        retry_attempts = _safe_int(
+            decision_json.get("paper_route_probe_exit_retry_attempts")
+        )
+        if retry_limit > 0 and retry_attempts >= retry_limit:
+            return None
+        previous_stage = str(decision_json.get("submission_stage") or "rejected")
+        raw_previous_risk_reasons = decision_json.get("risk_reasons")
+        previous_risk_reason_items: Sequence[object] = []
+        if isinstance(raw_previous_risk_reasons, Sequence) and not isinstance(
+            raw_previous_risk_reasons,
+            (str, bytes, bytearray),
+        ):
+            previous_risk_reason_items = cast(
+                Sequence[object], raw_previous_risk_reasons
+            )
+        previous_risk_reasons = [
+            str(item)
+            for item in previous_risk_reason_items
+            if str(item).strip()
+        ]
+        self.executor.sync_decision_state(session, decision_row, decision)
+        raw_decision_json = decision_row.decision_json
+        decision_json = (
+            dict(cast(Mapping[str, Any], raw_decision_json))
+            if isinstance(raw_decision_json, Mapping)
+            else {}
+        )
+        decision_json["submission_stage"] = "paper_route_probe_exit_retry_pending"
+        decision_json["paper_route_probe_exit_retry_attempts"] = retry_attempts + 1
+        decision_json["paper_route_probe_exit_retry"] = {
+            "previous_decision_status": "rejected",
+            "previous_submission_stage": previous_stage,
+            "previous_risk_reasons": previous_risk_reasons,
+            "submission_stage": "paper_route_probe_exit_retry_pending",
+            "symbol": decision.symbol.strip().upper(),
+            "strategy_id": decision.strategy_id,
+            "exit_due_at": str(exit_metadata.get("exit_due_at") or ""),
+        }
+        for key in (
+            "risk_reasons",
+            "reject_reason_atomic",
+            "reject_class",
+            "reject_origin",
+            "broker_precheck",
+        ):
+            decision_json.pop(key, None)
+        decision_row.status = "planned"
+        decision_row.decision_json = decision_json
+        session.add(decision_row)
+        session.commit()
+        session.refresh(decision_row)
+        logger.warning(
+            "Reopening rejected paper route probe exit strategy_id=%s decision_id=%s symbol=%s previous_stage=%s reasons=%s",
+            decision.strategy_id,
+            decision_row.id,
+            decision.symbol,
+            previous_stage,
+            ",".join(previous_risk_reasons),
+        )
+        return decision_row
 
     @staticmethod
     def _restore_simulation_paper_route_probe_exit_position(
@@ -2496,6 +2585,13 @@ class SimpleTradingPipeline(TradingPipeline):
         if "paper_route_target_plan" in decision.params:
             self.executor.update_decision_params(session, decision_row, decision.params)
             self.executor.sync_decision_state(session, decision_row, decision)
+        reopened_exit = self._reopen_rejected_paper_route_probe_exit_decision(
+            session=session,
+            decision=decision,
+            decision_row=decision_row,
+        )
+        if reopened_exit is not None:
+            return reopened_exit
         if (
             decision_row.status == "planned"
             and self._paper_route_target_source_cap(decision.params) is not None

--- a/services/torghut/tests/test_execution_policy.py
+++ b/services/torghut/tests/test_execution_policy.py
@@ -126,6 +126,42 @@ class TestExecutionPolicy(TestCase):
         self.assertFalse(outcome.approved)
         self.assertIn("max_notional_exceeded", outcome.reasons)
 
+    def test_max_notional_does_not_block_position_reducing_sell(self) -> None:
+        policy = ExecutionPolicy(config=_config(max_notional=Decimal("100")))
+        outcome = policy.evaluate(
+            _decision(action="sell", qty=Decimal("184"), price=Decimal("272.3")),
+            strategy=None,
+            positions=[{"symbol": "AAPL", "qty": "184", "side": "long"}],
+            market_snapshot=None,
+        )
+
+        self.assertTrue(outcome.approved)
+        self.assertNotIn("max_notional_exceeded", outcome.reasons)
+
+    def test_max_notional_does_not_block_short_cover(self) -> None:
+        policy = ExecutionPolicy(config=_config(max_notional=Decimal("100")))
+        outcome = policy.evaluate(
+            _decision(action="buy", qty=Decimal("184"), price=Decimal("272.3")),
+            strategy=None,
+            positions=[{"symbol": "AAPL", "qty": "184", "side": "short"}],
+            market_snapshot=None,
+        )
+
+        self.assertTrue(outcome.approved)
+        self.assertNotIn("max_notional_exceeded", outcome.reasons)
+
+    def test_max_notional_still_blocks_position_increasing_sell(self) -> None:
+        policy = ExecutionPolicy(config=_config(max_notional=Decimal("100")))
+        outcome = policy.evaluate(
+            _decision(action="sell", qty=Decimal("185"), price=Decimal("272.3")),
+            strategy=None,
+            positions=[{"symbol": "AAPL", "qty": "184", "side": "long"}],
+            market_snapshot=None,
+        )
+
+        self.assertFalse(outcome.approved)
+        self.assertIn("max_notional_exceeded", outcome.reasons)
+
     def test_price_snapshot_drives_notional_when_signal_price_is_stale(self) -> None:
         policy = ExecutionPolicy(config=_config(max_notional=Decimal("1000")))
         decision = _decision(qty=Decimal("3"), price=Decimal("412.6704331378219"))

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -4102,6 +4102,138 @@ class TestTradingPipeline(TestCase):
                 1,
             )
 
+    def test_simple_pipeline_allows_large_position_reducing_probe_exit(
+        self,
+    ) -> None:
+        self._seed_filled_paper_route_probe_entry(qty=Decimal("20"))
+        alpaca_client = PositionedAlpacaClient(
+            [{"symbol": "AAPL", "qty": "20", "side": "long"}]
+        )
+
+        self._run_simple_paper_pipeline(
+            alpaca_client=alpaca_client,
+            now=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        self.assertEqual(alpaca_client.submitted[0]["side"], "sell")
+        self.assertEqual(alpaca_client.submitted[0]["qty"], "20.0")
+        with self.session_local() as session:
+            exit_row = (
+                session.execute(
+                    select(TradeDecision)
+                    .where(TradeDecision.symbol == "AAPL")
+                    .order_by(TradeDecision.created_at.desc())
+                )
+                .scalars()
+                .first()
+            )
+            assert exit_row is not None
+            self.assertEqual(exit_row.status, "submitted")
+            payload = cast(dict[str, Any], exit_row.decision_json)
+            self.assertNotIn("max_notional_exceeded", payload.get("risk_reasons", []))
+
+    def test_simple_pipeline_reopens_rejected_paper_route_probe_exit(
+        self,
+    ) -> None:
+        from app import config
+
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_simple_paper_route_probe_retry_attempt_limit = 2
+        self._seed_filled_paper_route_probe_entry()
+        now = datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc)
+        executor = OrderExecutor()
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=executor,
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+        with (
+            patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=now,
+            ),
+            self.session_local() as session,
+        ):
+            exit_decisions = pipeline._paper_route_probe_exit_decisions(
+                session=session
+            )
+            self.assertEqual(len(exit_decisions), 1)
+            exit_decision = exit_decisions[0]
+            strategy = (
+                session.execute(
+                    select(Strategy).where(Strategy.id == exit_decision.strategy_id)
+                )
+                .scalars()
+                .one()
+            )
+            exit_row = executor.ensure_decision(
+                session,
+                exit_decision,
+                strategy,
+                "paper",
+            )
+            exit_payload = dict(cast(Mapping[str, Any], exit_row.decision_json))
+            exit_payload["submission_stage"] = "rejected_pre_submit"
+            exit_payload["risk_reasons"] = ["max_notional_exceeded"]
+            exit_payload["reject_reason_atomic"] = ["max_notional_exceeded"]
+            exit_row.status = "rejected"
+            exit_row.decision_json = exit_payload
+            session.add(exit_row)
+            session.commit()
+
+        alpaca_client = PositionedAlpacaClient(
+            [{"symbol": "AAPL", "qty": "2", "side": "long"}]
+        )
+
+        self._run_simple_paper_pipeline(
+            alpaca_client=alpaca_client,
+            now=now,
+        )
+
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        self.assertEqual(alpaca_client.submitted[0]["side"], "sell")
+        with self.session_local() as session:
+            decisions = (
+                session.execute(
+                    select(TradeDecision).order_by(TradeDecision.created_at.asc())
+                )
+                .scalars()
+                .all()
+            )
+            self.assertEqual(len(decisions), 2)
+            exit_row = decisions[-1]
+            self.assertEqual(exit_row.status, "submitted")
+            exit_payload = cast(dict[str, Any], exit_row.decision_json)
+            self.assertEqual(
+                exit_payload.get("submission_stage"),
+                "submitted",
+            )
+            retry = cast(
+                dict[str, Any],
+                exit_payload.get("paper_route_probe_exit_retry"),
+            )
+            self.assertEqual(retry.get("previous_decision_status"), "rejected")
+            self.assertEqual(
+                retry.get("previous_submission_stage"), "rejected_pre_submit"
+            )
+            self.assertEqual(
+                exit_payload.get("paper_route_probe_exit_retry_attempts"), 1
+            )
+            self.assertNotIn("risk_reasons", exit_payload)
+            self.assertNotIn("reject_reason_atomic", exit_payload)
+
     def test_simple_pipeline_does_not_exit_without_broker_inventory(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Allows position-reducing sells and short-cover buys to pass execution-policy max-notional checks so exits are not blocked by entry caps.
- Reopens rejected paper-route probe exit decisions without creating duplicate decision rows, preserving retry metadata and keeping execution-backed rejected rows terminal.
- Adds regression coverage for large reducing exits, rejected exit retry, and max-notional behavior that still blocks risk-increasing orders.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/trading/execution_policy.py app/trading/scheduler/simple_pipeline.py tests/test_execution_policy.py tests/test_trading_pipeline.py`
- `uv run --frozen pytest tests/test_execution_policy.py tests/test_trading_pipeline.py -k 'max_notional or paper_route_probe_exit or large_position_reducing'`
- `uv run --frozen pytest tests/test_trading_pipeline.py`
- `uv run --frozen pytest tests/test_execution_policy.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
