### PR TITLE
fix(torghut): persist paper-route ledgers to audited db

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -62,6 +62,7 @@ spec:
                     --runtime-window-account-label TORGHUT_SIM \
                     --runtime-window-observed-stage paper \
                     --runtime-window-source-dsn-env SIM_DB_DSN \
+                    --runtime-window-target-dsn-env SIM_DB_DSN \
                     --runtime-window-dataset-snapshot-ref portfolio-profit-autoresearch-500-v1 \
                     --runtime-window-source-manifest-ref config/trading/hypotheses/h-pairs-01.json \
                     --json \

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -768,6 +768,7 @@ def _target_identity(
         "account_label": _safe_text(target.get("account_label")),
         "source_kind": _safe_text(target.get("source_kind")),
         "source_dsn_env": _safe_text(target.get("source_dsn_env")),
+        "target_dsn_env": _safe_text(target.get("target_dsn_env")),
         "source_manifest_ref": _safe_text(target.get("source_manifest_ref")),
         "dataset_snapshot_ref": _safe_text(target.get("dataset_snapshot_ref")),
         "window_start": _safe_text(target.get("window_start")),
@@ -1053,6 +1054,7 @@ def _next_paper_route_runtime_window_targets(
         "target_plan_settlement_seconds": PAPER_ROUTE_RUNTIME_IMPORT_SETTLEMENT_SECONDS,
         "settlement_ready_at": session_readiness.get("settlement_ready_at"),
         "source_dsn_env": "SIM_DB_DSN",
+        "target_dsn_env": "SIM_DB_DSN",
         "account_label": PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
         "observed_stage": "paper",
         "import_ready": import_ready,
@@ -1219,6 +1221,7 @@ def _next_paper_route_runtime_window_targets(
             "account_label": PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
             "source_account_label": source_account_label or "",
             "source_dsn_env": "SIM_DB_DSN",
+            "target_dsn_env": "SIM_DB_DSN",
             "dataset_snapshot_ref": _safe_text(target.get("dataset_snapshot_ref"))
             or "",
             "source_manifest_ref": source_manifest_ref,

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -4,17 +4,18 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager
 import hashlib
 import json
 import os
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import ROUND_CEILING, Decimal
 from pathlib import Path
-from typing import Any, Mapping, Sequence, cast
+from typing import Any, Iterator, Mapping, Sequence, cast
 
 import psycopg
-from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
 
 from app.db import SessionLocal
 from app.models import StrategyRuntimeLedgerBucket
@@ -128,6 +129,15 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--strategy-family", default="")
     parser.add_argument("--source-dsn", default="")
     parser.add_argument("--source-dsn-env", default="DB_DSN")
+    parser.add_argument("--target-dsn", default="")
+    parser.add_argument(
+        "--target-dsn-env",
+        default="",
+        help=(
+            "Optional environment variable for the database where imported runtime "
+            "governance rows are persisted. Defaults to DB_DSN via SessionLocal."
+        ),
+    )
     parser.add_argument("--strategy-name", required=True)
     parser.add_argument("--account-label", required=True)
     parser.add_argument("--source-account-label", default="")
@@ -161,6 +171,56 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--json", action="store_true")
     return parser.parse_args()
+
+
+def _sqlalchemy_dsn(dsn: str) -> str:
+    text = dsn.strip()
+    if text.startswith("postgresql+psycopg://"):
+        return text
+    if text.startswith("postgres://"):
+        return text.replace("postgres://", "postgresql+psycopg://", 1)
+    if text.startswith("postgresql://"):
+        return text.replace("postgresql://", "postgresql+psycopg://", 1)
+    return text
+
+
+def _target_persistence_dsn(args: argparse.Namespace) -> str:
+    direct_dsn = str(getattr(args, "target_dsn", "") or "").strip()
+    if direct_dsn:
+        return direct_dsn
+    target_dsn_env = str(getattr(args, "target_dsn_env", "") or "").strip()
+    if not target_dsn_env:
+        return ""
+    dsn = os.getenv(target_dsn_env, "").strip()
+    if not dsn:
+        raise RuntimeError(f"target_dsn_not_configured:{target_dsn_env}")
+    return dsn
+
+
+@contextmanager
+def _persistence_session(args: argparse.Namespace) -> Iterator[Session]:
+    target_dsn = _target_persistence_dsn(args)
+    if not target_dsn:
+        with SessionLocal() as session:
+            yield session
+        return
+    engine = create_engine(
+        _sqlalchemy_dsn(target_dsn),
+        pool_pre_ping=True,
+        future=True,
+    )
+    TargetSessionLocal = sessionmaker(
+        bind=engine,
+        autocommit=False,
+        autoflush=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    try:
+        with TargetSessionLocal() as session:
+            yield session
+    finally:
+        engine.dispose()
 
 
 def _flag(value: str) -> bool:
@@ -3321,6 +3381,9 @@ def main() -> int:
         "strategy_name_candidates": strategy_names,
         "account_label": args.account_label,
         "source_account_label": source_account_label,
+        "source_dsn_env": str(getattr(args, "source_dsn_env", "") or "").strip(),
+        "target_dsn_env": str(getattr(args, "target_dsn_env", "") or "").strip(),
+        "target_dsn_configured": bool(_target_persistence_dsn(args)),
         "window_start": window_start.isoformat(),
         "window_end": window_end.isoformat(),
         "source_activity_symbol_filter": source_activity_symbols,
@@ -3406,7 +3469,7 @@ def main() -> int:
         not source_dsn
         and not runtime_ledger_artifact_metadata["runtime_ledger_artifact_refs"]
     ):
-        with SessionLocal() as session:
+        with _persistence_session(args) as session:
             durable_runtime_ledger_tca_rows, runtime_ledger_durable_metadata = (
                 _runtime_ledger_tca_rows_from_durable_buckets(
                     session=session,
@@ -3623,7 +3686,7 @@ def main() -> int:
         else:
             print(summary)
         return 0
-    with SessionLocal() as session:
+    with _persistence_session(args) as session:
         summary = persist_observed_runtime_windows(
             session=session,
             run_id=args.run_id,

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -158,8 +158,8 @@ def _parse_args() -> argparse.Namespace:
             "Repeatable comma-separated key=value runtime import target. "
             "Supported keys: hypothesis_id,candidate_id,strategy_family,"
             "strategy_name,account_label,source_account_label,observed_stage,"
-            "source_dsn_env,dataset_snapshot_ref,source_manifest_ref,source_kind,"
-            "delay_adjusted_depth_stress_report_ref."
+            "source_dsn_env,target_dsn_env,dataset_snapshot_ref,source_manifest_ref,"
+            "source_kind,delay_adjusted_depth_stress_report_ref."
         ),
     )
     parser.add_argument(
@@ -280,6 +280,7 @@ def _parse_args() -> argparse.Namespace:
         choices=("paper", "live"),
     )
     parser.add_argument("--runtime-window-source-dsn-env", default="DB_DSN")
+    parser.add_argument("--runtime-window-target-dsn-env", default="")
     parser.add_argument("--runtime-window-start", default="")
     parser.add_argument("--runtime-window-end", default="")
     parser.add_argument("--runtime-window-dataset-snapshot-ref", default="")
@@ -431,6 +432,7 @@ class RuntimeWindowImportTarget:
     artifact_refs: tuple[str, ...] = ()
     target_metadata: Mapping[str, Any] | None = None
     source_account_label: str = ""
+    target_dsn_env: str = ""
 
 
 def _parse_runtime_window_target_spec(spec: str) -> dict[str, str]:
@@ -704,6 +706,9 @@ def _registry_runtime_window_targets(
                     getattr(args, "runtime_window_source_dsn_env", "") or "DB_DSN"
                 ).strip()
                 or "DB_DSN",
+                target_dsn_env=str(
+                    getattr(args, "runtime_window_target_dsn_env", "") or ""
+                ).strip(),
                 strategy_name=strategy_name,
                 account_label=str(
                     getattr(args, "runtime_window_account_label", "") or "TORGHUT_SIM"
@@ -837,6 +842,7 @@ def _runtime_window_targets_from_plan(
             strategy_family=strategy_family,
             source_dsn_env=value("source_dsn_env", "runtime_window_source_dsn_env")
             or "DB_DSN",
+            target_dsn_env=value("target_dsn_env", "runtime_window_target_dsn_env"),
             strategy_name=strategy_name,
             account_label=value("account_label", "runtime_window_account_label")
             or "TORGHUT_SIM",
@@ -875,6 +881,7 @@ def _runtime_window_targets_from_plan(
             target.observed_stage,
             target.strategy_family,
             target.source_dsn_env,
+            target.target_dsn_env,
             target.strategy_name,
             target.account_label,
             target.source_account_label,
@@ -939,11 +946,12 @@ def _runtime_window_target_metadata(payload: Mapping[str, Any]) -> dict[str, Any
 
 def _runtime_window_target_identity(
     target: RuntimeWindowImportTarget,
-) -> tuple[str, str, str, str, str, str]:
+) -> tuple[str, str, str, str, str, str, str]:
     return (
         target.hypothesis_id,
         target.candidate_id,
         target.strategy_name,
+        target.target_dsn_env,
         target.source_account_label,
         target.window_start,
         target.window_end,
@@ -1066,6 +1074,7 @@ def _runtime_window_targets(
                 strategy_family=strategy_family,
                 source_dsn_env=value("source_dsn_env", "runtime_window_source_dsn_env")
                 or "DB_DSN",
+                target_dsn_env=value("target_dsn_env", "runtime_window_target_dsn_env"),
                 strategy_name=strategy_name,
                 account_label=value("account_label", "runtime_window_account_label")
                 or "TORGHUT_SIM",
@@ -2006,6 +2015,8 @@ def _run_runtime_window_import_target(
         drift_ok,
         "--json",
     ]
+    if target.target_dsn_env:
+        command.extend(["--target-dsn-env", target.target_dsn_env])
     audit_only = bool(getattr(args, "runtime_window_import_audit_only", False))
     if audit_only:
         command.append("--audit-only")
@@ -2082,6 +2093,8 @@ def _run_runtime_window_import_target(
         "strategy_name": target.strategy_name,
         "account_label": target.account_label,
         "source_account_label": target.source_account_label or target.account_label,
+        "source_dsn_env": target.source_dsn_env,
+        "target_dsn_env": target.target_dsn_env,
         "source_kind": target.source_kind,
         "artifact_refs": [str(manifest_path), *target.artifact_refs],
         "target_metadata": dict(target.target_metadata or {}),

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -51,12 +51,15 @@ from scripts.import_hypothesis_runtime_windows import (
     _source_kind_allows_runtime_ledger_materialization,
     _source_activity_diagnostics_blockers,
     _source_row_matches_lineage,
+    _persistence_session,
     _source_activity_missing_summary,
     _source_decision_mode,
     _source_decision_mode_counts,
     _source_decision_rows_profit_proof_eligible,
     _stable_payload_digest,
     _strategy_name_candidates,
+    _sqlalchemy_dsn,
+    _target_persistence_dsn,
     main,
 )
 
@@ -278,6 +281,73 @@ def _complete_runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
 
 
 class TestImportHypothesisRuntimeWindows(TestCase):
+    def test_sqlalchemy_dsn_normalizes_postgres_urls(self) -> None:
+        self.assertEqual(
+            _sqlalchemy_dsn("postgresql://user:pass@postgres:5432/torghut_sim_default"),
+            "postgresql+psycopg://user:pass@postgres:5432/torghut_sim_default",
+        )
+        self.assertEqual(
+            _sqlalchemy_dsn("postgres://user:pass@postgres:5432/torghut"),
+            "postgresql+psycopg://user:pass@postgres:5432/torghut",
+        )
+
+    def test_target_persistence_dsn_requires_configured_env(self) -> None:
+        args = SimpleNamespace(target_dsn="", target_dsn_env="SIM_DB_DSN")
+
+        with patch.dict("os.environ", {}, clear=True):
+            with self.assertRaisesRegex(RuntimeError, "target_dsn_not_configured:SIM_DB_DSN"):
+                _target_persistence_dsn(args)
+
+    def test_persistence_session_uses_target_dsn_env(self) -> None:
+        class _FakeEngine:
+            def __init__(self) -> None:
+                self.disposed = False
+
+            def dispose(self) -> None:
+                self.disposed = True
+
+        fake_engine = _FakeEngine()
+        fake_session = _FakeSession()
+        sessionmaker_calls: list[dict[str, object]] = []
+
+        def fake_sessionmaker(**kwargs: object):
+            sessionmaker_calls.append(dict(kwargs))
+
+            def factory() -> _FakeSession:
+                return fake_session
+
+            return factory
+
+        args = SimpleNamespace(target_dsn="", target_dsn_env="SIM_DB_DSN")
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "SIM_DB_DSN": "postgresql://user:pass@postgres:5432/torghut_sim_default"
+                },
+                clear=True,
+            ),
+            patch(
+                "scripts.import_hypothesis_runtime_windows.create_engine",
+                return_value=fake_engine,
+            ) as create_engine_mock,
+            patch(
+                "scripts.import_hypothesis_runtime_windows.sessionmaker",
+                side_effect=fake_sessionmaker,
+            ),
+        ):
+            with _persistence_session(args) as session:
+                self.assertIs(session, fake_session)
+
+        create_engine_mock.assert_called_once_with(
+            "postgresql+psycopg://user:pass@postgres:5432/torghut_sim_default",
+            pool_pre_ping=True,
+            future=True,
+        )
+        self.assertEqual(sessionmaker_calls[0]["bind"], fake_engine)
+        self.assertTrue(fake_engine.disposed)
+
     def test_runtime_observation_authority_requires_runtime_ledger_profit_proof(
         self,
     ) -> None:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -973,6 +973,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--runtime-window-account-label TORGHUT_SIM", args)
         self.assertIn("--runtime-window-observed-stage paper", args)
         self.assertIn("--runtime-window-source-dsn-env SIM_DB_DSN", args)
+        self.assertIn("--runtime-window-target-dsn-env SIM_DB_DSN", args)
         self.assertNotIn("--runtime-window-source-dsn-env DB_DSN", args)
         self.assertIn(
             "RENEWAL_OUTPUT=/tmp/torghut-empirical-renewal/runtime-window-renewal.json",

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -308,10 +308,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertFalse(handoff["promotion_allowed"])
         self.assertFalse(handoff["final_promotion_authorized"])
+        self.assertEqual(handoff["target_dsn_env"], "SIM_DB_DSN")
         target = plan["targets"][0]
         self.assertEqual(target["account_label"], "TORGHUT_SIM")
         self.assertEqual(target["source_account_label"], "TORGHUT_REPLAY")
         self.assertEqual(target["source_dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(target["target_dsn_env"], "SIM_DB_DSN")
         self.assertEqual(target["source_kind"], "paper_route_probe_runtime_observed")
         self.assertEqual(target["dependency_quorum_decision"], "allow")
         self.assertEqual(target["continuity_ok"], "true")

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -837,6 +837,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                             "strategy_family": "microbar_pairs",
                             "strategy_name": "paper-route-candidate-v1",
                             "source_dsn_env": "SIM_DB_DSN",
+                            "target_dsn_env": "SIM_DB_DSN",
                             "source_kind": "paper_route_probe_runtime_observed",
                             "source_manifest_ref": "config/trading/hypotheses/h-paper-route.json",
                             "dependency_quorum_decision": "missing",
@@ -882,6 +883,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                                     "--runtime-window-target-plan-settlement-seconds",
                                 ],
                                 "source_dsn_env": "SIM_DB_DSN",
+                                "target_dsn_env": "SIM_DB_DSN",
                                 "account_label": "TORGHUT_SIM",
                                 "import_ready": False,
                                 "import_blockers": [
@@ -901,6 +903,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                             "strategy_family": "microbar_pairs",
                             "strategy_name": "paper-route-candidate-v1",
                             "source_dsn_env": "SIM_DB_DSN",
+                            "target_dsn_env": "SIM_DB_DSN",
                             "source_kind": "paper_route_probe_runtime_observed",
                             "source_manifest_ref": "config/trading/hypotheses/h-paper-route.json",
                             "window_start": "2026-05-26T13:30:00+00:00",
@@ -929,6 +932,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             runtime_window_observed_stage="paper",
             runtime_window_strategy_family="",
             runtime_window_source_dsn_env="DB_DSN",
+            runtime_window_target_dsn_env="",
             runtime_window_strategy_name="",
             runtime_window_account_label="TORGHUT_SIM",
             runtime_window_dataset_snapshot_ref="",
@@ -945,6 +949,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual(len(targets), 1)
         self.assertEqual(targets[0].hypothesis_id, "H-PAPER-ROUTE")
         self.assertEqual(targets[0].source_dsn_env, "SIM_DB_DSN")
+        self.assertEqual(targets[0].target_dsn_env, "SIM_DB_DSN")
         self.assertEqual(targets[0].source_kind, "paper_route_probe_runtime_observed")
         self.assertEqual(targets[0].dependency_quorum_decision, "missing")
         self.assertEqual(targets[0].continuity_ok, "false")
@@ -1883,6 +1888,7 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             runtime_window_observed_stage="paper",
             runtime_window_strategy_family="intraday_tsmom_consistent",
             runtime_window_source_dsn_env="SIM_DB_DSN",
+            runtime_window_target_dsn_env="SIM_DB_DSN",
             runtime_window_strategy_name="intraday-tsmom-profit-v3",
             runtime_window_account_label="TORGHUT_SIM",
             runtime_window_start="2026-05-18T13:30:00Z",
@@ -1919,6 +1925,8 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertIn("spec-83161ae16d17828eabcc58cc", command)
         self.assertNotIn("stale-empirical-candidate", command)
         self.assertIn("--source-dsn-env", command)
+        self.assertIn("SIM_DB_DSN", command)
+        self.assertIn("--target-dsn-env", command)
         self.assertIn("SIM_DB_DSN", command)
         self.assertIn("--dataset-snapshot-ref", command)
         self.assertIn("portfolio-profit-autoresearch-500-v1", command)

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7270,6 +7270,7 @@ class TestTradingApi(TestCase):
             self.assertEqual(next_plan["target_count"], 1)
             next_target = next_plan["targets"][0]
             self.assertEqual(next_target["source_dsn_env"], "SIM_DB_DSN")
+            self.assertEqual(next_target["target_dsn_env"], "SIM_DB_DSN")
             self.assertEqual(
                 next_target["source_kind"], "paper_route_probe_runtime_observed"
             )
@@ -7400,6 +7401,7 @@ class TestTradingApi(TestCase):
             self.assertEqual(next_target["hypothesis_id"], "H-PAIRS-01")
             self.assertEqual(next_target["candidate_id"], "c88421d619759b2cfaa6f4d0")
             self.assertEqual(next_target["source_dsn_env"], "SIM_DB_DSN")
+            self.assertEqual(next_target["target_dsn_env"], "SIM_DB_DSN")
             self.assertEqual(
                 next_target["source_kind"], "paper_route_probe_runtime_observed"
             )


### PR DESCRIPTION
## Summary

- Adds an explicit target persistence DB for runtime-window imports, so paper-route runtime-ledger buckets can be written to the same `SIM_DB_DSN` database that `torghut-sim` audits.
- Carries `target_dsn_env=SIM_DB_DSN` through the paper-route evidence target plan and the empirical promotion renewal CronJob.
- Keeps promotion proof blocked by the existing runtime-ledger gates; this only fixes the importer/audit database mismatch.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_run_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_live_config_manifest_contract.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py scripts/renew_latest_empirical_promotion_jobs.py app/trading/paper_route_evidence.py tests/test_import_hypothesis_runtime_windows.py tests/test_run_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_live_config_manifest_contract.py`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
