### PR TITLE
fix(torghut): allow reducing exits with broker symbol format

### DIFF
--- a/services/torghut/app/trading/execution_policy.py
+++ b/services/torghut/app/trading/execution_policy.py
@@ -1233,9 +1233,11 @@ def _resolve_price(
 
 
 def _position_summary(symbol: str, positions: Iterable[dict[str, Any]]) -> Decimal:
+    normalized_symbol = symbol.strip().upper()
     total_qty = Decimal("0")
     for position in positions:
-        if position.get("symbol") != symbol:
+        position_symbol = str(position.get("symbol") or "").strip().upper()
+        if position_symbol != normalized_symbol:
             continue
         qty = _optional_decimal(position.get("qty")) or _optional_decimal(
             position.get("quantity")

--- a/services/torghut/tests/test_execution_policy.py
+++ b/services/torghut/tests/test_execution_policy.py
@@ -138,6 +138,20 @@ class TestExecutionPolicy(TestCase):
         self.assertTrue(outcome.approved)
         self.assertNotIn("max_notional_exceeded", outcome.reasons)
 
+    def test_max_notional_does_not_block_position_reducing_sell_with_broker_symbol_format(
+        self,
+    ) -> None:
+        policy = ExecutionPolicy(config=_config(max_notional=Decimal("100")))
+        outcome = policy.evaluate(
+            _decision(action="sell", qty=Decimal("184"), price=Decimal("272.3")),
+            strategy=None,
+            positions=[{"symbol": " aapl ", "qty": "184", "side": "long"}],
+            market_snapshot=None,
+        )
+
+        self.assertTrue(outcome.approved)
+        self.assertNotIn("max_notional_exceeded", outcome.reasons)
+
     def test_max_notional_does_not_block_short_cover(self) -> None:
         policy = ExecutionPolicy(config=_config(max_notional=Decimal("100")))
         outcome = policy.evaluate(


### PR DESCRIPTION
## Summary

- Normalize execution-policy position symbols before deciding whether an order reduces exposure.
- Prevent broker-formatted position symbols from making reducing exits look position-increasing and tripping `max_notional_exceeded`.
- Add a regression test covering whitespace/lowercase broker symbol formatting for a large reducing sell.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_execution_policy.py -k 'max_notional_does_not_block_position_reducing_sell'`
- `uv run --frozen pytest tests/test_execution_policy.py`
- `uv run --frozen ruff format --check app/trading/execution_policy.py tests/test_execution_policy.py`
- `uv run --frozen ruff check app/trading/execution_policy.py tests/test_execution_policy.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
