### PR TITLE
fix(torghut): expose diagnostic ledger expectancy

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -45,6 +45,21 @@ _TCA_PNL_BASES = frozenset(
         "execution_tca_shortfall_cost",
     }
 )
+_DIAGNOSTIC_EXPECTANCY_SUPPRESSING_BLOCKERS = frozenset(
+    {
+        "runtime_fills_missing",
+        "zero_fill_runtime_ledger",
+        "closed_round_trip_missing",
+        "filled_notional_missing",
+        "filled_qty_missing_or_non_positive",
+        "fill_price_missing",
+        "side_missing_or_invalid",
+        "explicit_cost_missing",
+        "cost_basis_missing",
+        "tca_shortfall_not_runtime_pnl",
+        "runtime_ledger_cost_basis_non_promotion_grade",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -98,6 +113,7 @@ class RuntimeLedgerBucket:
     cost_model_hash_counts: dict[str, int]
     lineage_hash_counts: dict[str, int]
     blockers: list[str]
+    diagnostic_closed_trade_expectancy_bps: Decimal | None = None
     ledger_schema_version: str = EXACT_REPLAY_LEDGER_SCHEMA_VERSION
     pnl_basis: str = POST_COST_PNL_BASIS
 
@@ -317,12 +333,19 @@ def _build_bucket(
 
     unique_blockers = _dedupe(blockers)
     post_cost_expectancy_bps: Decimal | None = None
-    if not unique_blockers and accumulator.filled_notional > 0:
-        post_cost_expectancy_bps = (
+    diagnostic_closed_trade_expectancy_bps: Decimal | None = None
+    if (
+        accumulator.filled_notional > 0
+        and accumulator.closed_trade_count > 0
+        and not (_DIAGNOSTIC_EXPECTANCY_SUPPRESSING_BLOCKERS & set(unique_blockers))
+    ):
+        diagnostic_closed_trade_expectancy_bps = (
             accumulator.net_strategy_pnl_after_costs
             / accumulator.filled_notional
             * _BPS_MULTIPLIER
         )
+    if not unique_blockers and accumulator.filled_notional > 0:
+        post_cost_expectancy_bps = diagnostic_closed_trade_expectancy_bps
 
     return RuntimeLedgerBucket(
         bucket_started_at=bucket_start,
@@ -350,6 +373,7 @@ def _build_bucket(
         cost_model_hash_counts=dict(sorted(cost_model_hash_counter.items())),
         lineage_hash_counts=dict(sorted(lineage_hash_counter.items())),
         blockers=unique_blockers,
+        diagnostic_closed_trade_expectancy_bps=diagnostic_closed_trade_expectancy_bps,
     )
 
 

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -292,6 +292,9 @@ def _runtime_ledger_bucket_blockers(bucket: Mapping[str, Any]) -> list[str]:
     filled_notional = _optional_decimal(bucket.get("filled_notional"))
     cost_amount = _optional_decimal(bucket.get("cost_amount"))
     post_cost_expectancy = _optional_decimal(bucket.get("post_cost_expectancy_bps"))
+    diagnostic_closed_trade_expectancy = _optional_decimal(
+        bucket.get("diagnostic_closed_trade_expectancy_bps")
+    )
 
     if ledger_schema_version is None:
         blockers.append("runtime_ledger_schema_version_missing")
@@ -351,7 +354,11 @@ def _runtime_ledger_bucket_blockers(bucket: Mapping[str, Any]) -> list[str]:
     if profit_proof_eligible is False:
         blockers.append(SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER)
     if post_cost_expectancy is None:
-        blockers.append("runtime_ledger_expectancy_missing")
+        blockers.append(
+            "runtime_ledger_expectancy_not_promotion_grade"
+            if diagnostic_closed_trade_expectancy is not None
+            else "runtime_ledger_expectancy_missing"
+        )
     if _hash_count(bucket.get("execution_policy_hash_counts")) <= 0:
         blockers.append("runtime_ledger_execution_policy_hash_missing")
     if _hash_count(bucket.get("cost_model_hash_counts")) <= 0:

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -643,6 +643,16 @@ def _runtime_ledger_bucket_payload(bucket: RuntimeLedgerBucket) -> dict[str, obj
             if bucket.post_cost_expectancy_bps is not None
             else None
         ),
+        "diagnostic_closed_trade_expectancy_bps": (
+            str(bucket.diagnostic_closed_trade_expectancy_bps)
+            if bucket.diagnostic_closed_trade_expectancy_bps is not None
+            else None
+        ),
+        "diagnostic_closed_trade_expectancy_basis": (
+            "realized_closed_trips_after_explicit_costs_not_promotion_grade"
+            if bucket.diagnostic_closed_trade_expectancy_bps is not None
+            else None
+        ),
         "cost_basis_counts": bucket.cost_basis_counts,
         "execution_policy_hash_counts": bucket.execution_policy_hash_counts,
         "cost_model_hash_counts": bucket.cost_model_hash_counts,
@@ -671,6 +681,9 @@ def _runtime_ledger_bucket_profit_proof_blockers(
     filled_notional = _decimal_or_none(bucket.get("filled_notional"))
     cost_amount = _decimal_or_none(bucket.get("cost_amount"))
     post_cost_expectancy = _decimal_or_none(bucket.get("post_cost_expectancy_bps"))
+    diagnostic_closed_trade_expectancy = _decimal_or_none(
+        bucket.get("diagnostic_closed_trade_expectancy_bps")
+    )
     if bucket.get("pnl_basis") != POST_COST_BASIS_RUNTIME_LEDGER:
         add("runtime_ledger_pnl_basis_not_runtime_ledger")
     if bucket.get("ledger_schema_version") not in RUNTIME_LEDGER_BUCKET_SCHEMAS:
@@ -730,7 +743,11 @@ def _runtime_ledger_bucket_profit_proof_blockers(
     if profit_proof_eligible is False:
         add(SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER)
     if post_cost_expectancy is None:
-        add("runtime_ledger_post_cost_expectancy_missing")
+        add(
+            "runtime_ledger_post_cost_expectancy_not_promotion_grade"
+            if diagnostic_closed_trade_expectancy is not None
+            else "runtime_ledger_post_cost_expectancy_missing"
+        )
     if _mapping_hash_count(bucket.get("execution_policy_hash_counts")) <= 0:
         add("runtime_ledger_execution_policy_hash_missing")
     if _mapping_hash_count(bucket.get("cost_model_hash_counts")) <= 0:
@@ -768,6 +785,14 @@ def _runtime_ledger_tca_row_from_bucket(
         "post_cost_expectancy_bps": bucket.post_cost_expectancy_bps,
         "post_cost_expectancy_basis": POST_COST_BASIS_RUNTIME_LEDGER,
         "post_cost_promotion_eligible": promotion_eligible,
+        "diagnostic_closed_trade_expectancy_bps": (
+            bucket.diagnostic_closed_trade_expectancy_bps
+        ),
+        "diagnostic_closed_trade_expectancy_basis": (
+            "realized_closed_trips_after_explicit_costs_not_promotion_grade"
+            if bucket.diagnostic_closed_trade_expectancy_bps is not None
+            else None
+        ),
         "realized_gross_pnl": bucket.gross_strategy_pnl,
         "realized_net_pnl": bucket.net_strategy_pnl_after_costs,
         "turnover_notional": bucket.filled_notional,

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -295,7 +295,9 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         args = SimpleNamespace(target_dsn="", target_dsn_env="SIM_DB_DSN")
 
         with patch.dict("os.environ", {}, clear=True):
-            with self.assertRaisesRegex(RuntimeError, "target_dsn_not_configured:SIM_DB_DSN"):
+            with self.assertRaisesRegex(
+                RuntimeError, "target_dsn_not_configured:SIM_DB_DSN"
+            ):
                 _target_persistence_dsn(args)
 
     def test_persistence_session_uses_target_dsn_env(self) -> None:
@@ -603,6 +605,35 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIn("runtime_ledger_cost_model_hash_missing", blockers)
         self.assertIn("runtime_ledger_lineage_hash_missing", blockers)
         self.assertIn("source_decision_mode_not_profit_proof_eligible", blockers)
+
+    def test_runtime_ledger_profit_proof_distinguishes_diagnostic_expectancy(
+        self,
+    ) -> None:
+        blockers = _runtime_ledger_bucket_profit_proof_blockers(
+            _complete_runtime_ledger_bucket(
+                open_position_count=1,
+                post_cost_expectancy_bps=None,
+                diagnostic_closed_trade_expectancy_bps="282.5",
+                diagnostic_closed_trade_expectancy_basis=(
+                    "realized_closed_trips_after_explicit_costs_not_promotion_grade"
+                ),
+            )
+        )
+
+        self.assertIn("unclosed_position", blockers)
+        self.assertIn(
+            "runtime_ledger_post_cost_expectancy_not_promotion_grade", blockers
+        )
+        self.assertNotIn("runtime_ledger_post_cost_expectancy_missing", blockers)
+        self.assertFalse(
+            _runtime_ledger_bucket_profit_proof_present(
+                _complete_runtime_ledger_bucket(
+                    open_position_count=1,
+                    post_cost_expectancy_bps=None,
+                    diagnostic_closed_trade_expectancy_bps="282.5",
+                )
+            )
+        )
 
     def test_runtime_ledger_profit_proof_rejects_missing_source_decision_evidence(
         self,

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -107,6 +107,10 @@ def test_partial_unclosed_positions_report_realized_pnl_but_block_expectancy() -
     assert bucket.gross_strategy_pnl == Decimal("40")
     assert bucket.net_strategy_pnl_after_costs == Decimal("38.60")
     assert bucket.post_cost_expectancy_bps is None
+    _assert_decimal_close(
+        bucket.diagnostic_closed_trade_expectancy_bps,
+        (Decimal("38.60") / Decimal("840")) * Decimal("10000"),
+    )
 
 
 def test_missing_price_notional_and_cost_basis_are_blockers() -> None:
@@ -708,6 +712,7 @@ def test_runtime_ledger_defensively_blocks_usable_non_promotion_grade_cost_basis
     assert bucket.cost_basis_counts == {"modeled_paper_cost_budget": 2}
     assert "runtime_ledger_cost_basis_non_promotion_grade" in bucket.blockers
     assert bucket.post_cost_expectancy_bps is None
+    assert bucket.diagnostic_closed_trade_expectancy_bps is None
 
 
 def test_exact_replay_ledger_blocks_fill_only_profit_proof() -> None:
@@ -742,6 +747,10 @@ def test_exact_replay_ledger_blocks_fill_only_profit_proof() -> None:
 
     assert bucket.net_strategy_pnl_after_costs == Decimal("97")
     assert bucket.post_cost_expectancy_bps is None
+    _assert_decimal_close(
+        bucket.diagnostic_closed_trade_expectancy_bps,
+        (Decimal("97") / Decimal("2100")) * Decimal("10000"),
+    )
     assert "runtime_decision_lifecycle_missing" in bucket.blockers
     assert "submitted_order_lifecycle_missing" in bucket.blockers
     assert "fill_order_linkage_missing" in bucket.blockers

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -369,6 +369,24 @@ class TestRuntimeWindowImport(TestCase):
         self.assertIn("runtime_ledger_lineage_hash_missing", invalid_blockers)
         self.assertIn("source_decision_mode_profit_proof_missing", invalid_blockers)
 
+    def test_runtime_ledger_bucket_blockers_preserve_diagnostic_expectancy(
+        self,
+    ) -> None:
+        blockers = _runtime_ledger_bucket_blockers(
+            _runtime_ledger_bucket(
+                open_position_count=1,
+                post_cost_expectancy_bps=None,
+                diagnostic_closed_trade_expectancy_bps="282.5",
+                diagnostic_closed_trade_expectancy_basis=(
+                    "realized_closed_trips_after_explicit_costs_not_promotion_grade"
+                ),
+            )
+        )
+
+        self.assertIn("unclosed_position", blockers)
+        self.assertIn("runtime_ledger_expectancy_not_promotion_grade", blockers)
+        self.assertNotIn("runtime_ledger_expectancy_missing", blockers)
+
     def test_runtime_ledger_bucket_blockers_reject_non_promotion_grade_cost_basis(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds `diagnostic_closed_trade_expectancy_bps` to runtime-ledger buckets so near-miss buckets can expose realized closed-trip economics without becoming promotion-grade.
- Keeps `post_cost_expectancy_bps` reserved for blocker-free evidence-grade buckets, preserving fail-closed promotion behavior.
- Updates runtime-window import blocker wording to distinguish missing expectancy from diagnostic-only expectancy that is not promotion-grade.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_runtime_ledger.py`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'runtime_ledger_profit_proof or runtime_ledger_tca_row_from_bucket'`
- `uv run --frozen pytest tests/test_runtime_window_import.py -k 'runtime_ledger_bucket_blockers or persisted_runtime_ledger_bucket_evidence_grade'`
- `uv run --frozen ruff check app/trading/runtime_ledger.py app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- `uv run --frozen ruff format --check app/trading/runtime_ledger.py app/trading/runtime_window_import.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
