### PR TITLE
feat(synthesis): add autotrader runtime state

### DIFF
--- a/apps/synthesis/src/lib/synthesis-ui-contract.test.ts
+++ b/apps/synthesis/src/lib/synthesis-ui-contract.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe('synthesis shell polish contract', () => {
   test('removes legacy navigation/actions and makes search full width', () => {
-    expect(synthesisSidebarItems).toEqual(['Feed'])
+    expect(synthesisSidebarItems).toEqual(['Feed', 'Autotrader'])
     expect(synthesisSidebarItems).not.toContain('Search')
     expect(synthesisHasCurateAction).toBe(false)
     expect(synthesisHasBottomLeftCounter).toBe(false)

--- a/apps/synthesis/src/lib/synthesis-ui-contract.ts
+++ b/apps/synthesis/src/lib/synthesis-ui-contract.ts
@@ -1,4 +1,4 @@
-export const synthesisSidebarItems = ['Feed'] as const
+export const synthesisSidebarItems = ['Feed', 'Autotrader'] as const
 export const synthesisHasCurateAction = false
 export const synthesisHasBottomLeftCounter = false
 export const synthesisSearchInputClassName =

--- a/apps/synthesis/src/routeTree.gen.ts
+++ b/apps/synthesis/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as McpRouteImport } from './routes/mcp'
+import { Route as AutotraderRouteImport } from './routes/autotrader'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as CompaniesSymbolRouteImport } from './routes/companies/$symbol'
 import { Route as ApiRunsRouteImport } from './routes/api/runs'
@@ -18,12 +19,28 @@ import { Route as ApiFeedRouteImport } from './routes/api/feed'
 import { Route as ApiItemsBatchRouteImport } from './routes/api/items/batch'
 import { Route as ApiItemsIdRouteImport } from './routes/api/items/$id'
 import { Route as ApiCompaniesSymbolRouteImport } from './routes/api/companies/$symbol'
+import { Route as ApiAutotraderTradeTicketsRouteImport } from './routes/api/autotrader/trade-tickets'
+import { Route as ApiAutotraderStatusRouteImport } from './routes/api/autotrader/status'
+import { Route as ApiAutotraderSessionsRouteImport } from './routes/api/autotrader/sessions'
+import { Route as ApiAutotraderScorecardsRouteImport } from './routes/api/autotrader/scorecards'
+import { Route as ApiAutotraderRiskChecksRouteImport } from './routes/api/autotrader/risk-checks'
+import { Route as ApiAutotraderPositionSnapshotsRouteImport } from './routes/api/autotrader/position-snapshots'
+import { Route as ApiAutotraderOrdersRouteImport } from './routes/api/autotrader/orders'
+import { Route as ApiAutotraderFinalizeRouteImport } from './routes/api/autotrader/finalize'
+import { Route as ApiAutotraderFillsRouteImport } from './routes/api/autotrader/fills'
+import { Route as ApiAutotraderEventsRouteImport } from './routes/api/autotrader/events'
 import { Route as ApiAssetsIdRouteImport } from './routes/api/assets/$id'
 import { Route as ApiItemsIdFeedbackRouteImport } from './routes/api/items/$id/feedback'
+import { Route as ApiAutotraderSessionsIdRouteImport } from './routes/api/autotrader/sessions/$id'
 
 const McpRoute = McpRouteImport.update({
   id: '/mcp',
   path: '/mcp',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AutotraderRoute = AutotraderRouteImport.update({
+  id: '/autotrader',
+  path: '/autotrader',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -66,6 +83,58 @@ const ApiCompaniesSymbolRoute = ApiCompaniesSymbolRouteImport.update({
   path: '/api/companies/$symbol',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiAutotraderTradeTicketsRoute =
+  ApiAutotraderTradeTicketsRouteImport.update({
+    id: '/api/autotrader/trade-tickets',
+    path: '/api/autotrader/trade-tickets',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiAutotraderStatusRoute = ApiAutotraderStatusRouteImport.update({
+  id: '/api/autotrader/status',
+  path: '/api/autotrader/status',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAutotraderSessionsRoute = ApiAutotraderSessionsRouteImport.update({
+  id: '/api/autotrader/sessions',
+  path: '/api/autotrader/sessions',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAutotraderScorecardsRoute = ApiAutotraderScorecardsRouteImport.update({
+  id: '/api/autotrader/scorecards',
+  path: '/api/autotrader/scorecards',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAutotraderRiskChecksRoute = ApiAutotraderRiskChecksRouteImport.update({
+  id: '/api/autotrader/risk-checks',
+  path: '/api/autotrader/risk-checks',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAutotraderPositionSnapshotsRoute =
+  ApiAutotraderPositionSnapshotsRouteImport.update({
+    id: '/api/autotrader/position-snapshots',
+    path: '/api/autotrader/position-snapshots',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiAutotraderOrdersRoute = ApiAutotraderOrdersRouteImport.update({
+  id: '/api/autotrader/orders',
+  path: '/api/autotrader/orders',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAutotraderFinalizeRoute = ApiAutotraderFinalizeRouteImport.update({
+  id: '/api/autotrader/finalize',
+  path: '/api/autotrader/finalize',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAutotraderFillsRoute = ApiAutotraderFillsRouteImport.update({
+  id: '/api/autotrader/fills',
+  path: '/api/autotrader/fills',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAutotraderEventsRoute = ApiAutotraderEventsRouteImport.update({
+  id: '/api/autotrader/events',
+  path: '/api/autotrader/events',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiAssetsIdRoute = ApiAssetsIdRouteImport.update({
   id: '/api/assets/$id',
   path: '/api/assets/$id',
@@ -76,97 +145,185 @@ const ApiItemsIdFeedbackRoute = ApiItemsIdFeedbackRouteImport.update({
   path: '/feedback',
   getParentRoute: () => ApiItemsIdRoute,
 } as any)
+const ApiAutotraderSessionsIdRoute = ApiAutotraderSessionsIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => ApiAutotraderSessionsRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/autotrader': typeof AutotraderRoute
   '/mcp': typeof McpRoute
   '/api/feed': typeof ApiFeedRoute
   '/api/items': typeof ApiItemsRouteWithChildren
   '/api/runs': typeof ApiRunsRoute
   '/companies/$symbol': typeof CompaniesSymbolRoute
   '/api/assets/$id': typeof ApiAssetsIdRoute
+  '/api/autotrader/events': typeof ApiAutotraderEventsRoute
+  '/api/autotrader/fills': typeof ApiAutotraderFillsRoute
+  '/api/autotrader/finalize': typeof ApiAutotraderFinalizeRoute
+  '/api/autotrader/orders': typeof ApiAutotraderOrdersRoute
+  '/api/autotrader/position-snapshots': typeof ApiAutotraderPositionSnapshotsRoute
+  '/api/autotrader/risk-checks': typeof ApiAutotraderRiskChecksRoute
+  '/api/autotrader/scorecards': typeof ApiAutotraderScorecardsRoute
+  '/api/autotrader/sessions': typeof ApiAutotraderSessionsRouteWithChildren
+  '/api/autotrader/status': typeof ApiAutotraderStatusRoute
+  '/api/autotrader/trade-tickets': typeof ApiAutotraderTradeTicketsRoute
   '/api/companies/$symbol': typeof ApiCompaniesSymbolRoute
   '/api/items/$id': typeof ApiItemsIdRouteWithChildren
   '/api/items/batch': typeof ApiItemsBatchRoute
+  '/api/autotrader/sessions/$id': typeof ApiAutotraderSessionsIdRoute
   '/api/items/$id/feedback': typeof ApiItemsIdFeedbackRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/autotrader': typeof AutotraderRoute
   '/mcp': typeof McpRoute
   '/api/feed': typeof ApiFeedRoute
   '/api/items': typeof ApiItemsRouteWithChildren
   '/api/runs': typeof ApiRunsRoute
   '/companies/$symbol': typeof CompaniesSymbolRoute
   '/api/assets/$id': typeof ApiAssetsIdRoute
+  '/api/autotrader/events': typeof ApiAutotraderEventsRoute
+  '/api/autotrader/fills': typeof ApiAutotraderFillsRoute
+  '/api/autotrader/finalize': typeof ApiAutotraderFinalizeRoute
+  '/api/autotrader/orders': typeof ApiAutotraderOrdersRoute
+  '/api/autotrader/position-snapshots': typeof ApiAutotraderPositionSnapshotsRoute
+  '/api/autotrader/risk-checks': typeof ApiAutotraderRiskChecksRoute
+  '/api/autotrader/scorecards': typeof ApiAutotraderScorecardsRoute
+  '/api/autotrader/sessions': typeof ApiAutotraderSessionsRouteWithChildren
+  '/api/autotrader/status': typeof ApiAutotraderStatusRoute
+  '/api/autotrader/trade-tickets': typeof ApiAutotraderTradeTicketsRoute
   '/api/companies/$symbol': typeof ApiCompaniesSymbolRoute
   '/api/items/$id': typeof ApiItemsIdRouteWithChildren
   '/api/items/batch': typeof ApiItemsBatchRoute
+  '/api/autotrader/sessions/$id': typeof ApiAutotraderSessionsIdRoute
   '/api/items/$id/feedback': typeof ApiItemsIdFeedbackRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/autotrader': typeof AutotraderRoute
   '/mcp': typeof McpRoute
   '/api/feed': typeof ApiFeedRoute
   '/api/items': typeof ApiItemsRouteWithChildren
   '/api/runs': typeof ApiRunsRoute
   '/companies/$symbol': typeof CompaniesSymbolRoute
   '/api/assets/$id': typeof ApiAssetsIdRoute
+  '/api/autotrader/events': typeof ApiAutotraderEventsRoute
+  '/api/autotrader/fills': typeof ApiAutotraderFillsRoute
+  '/api/autotrader/finalize': typeof ApiAutotraderFinalizeRoute
+  '/api/autotrader/orders': typeof ApiAutotraderOrdersRoute
+  '/api/autotrader/position-snapshots': typeof ApiAutotraderPositionSnapshotsRoute
+  '/api/autotrader/risk-checks': typeof ApiAutotraderRiskChecksRoute
+  '/api/autotrader/scorecards': typeof ApiAutotraderScorecardsRoute
+  '/api/autotrader/sessions': typeof ApiAutotraderSessionsRouteWithChildren
+  '/api/autotrader/status': typeof ApiAutotraderStatusRoute
+  '/api/autotrader/trade-tickets': typeof ApiAutotraderTradeTicketsRoute
   '/api/companies/$symbol': typeof ApiCompaniesSymbolRoute
   '/api/items/$id': typeof ApiItemsIdRouteWithChildren
   '/api/items/batch': typeof ApiItemsBatchRoute
+  '/api/autotrader/sessions/$id': typeof ApiAutotraderSessionsIdRoute
   '/api/items/$id/feedback': typeof ApiItemsIdFeedbackRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/autotrader'
     | '/mcp'
     | '/api/feed'
     | '/api/items'
     | '/api/runs'
     | '/companies/$symbol'
     | '/api/assets/$id'
+    | '/api/autotrader/events'
+    | '/api/autotrader/fills'
+    | '/api/autotrader/finalize'
+    | '/api/autotrader/orders'
+    | '/api/autotrader/position-snapshots'
+    | '/api/autotrader/risk-checks'
+    | '/api/autotrader/scorecards'
+    | '/api/autotrader/sessions'
+    | '/api/autotrader/status'
+    | '/api/autotrader/trade-tickets'
     | '/api/companies/$symbol'
     | '/api/items/$id'
     | '/api/items/batch'
+    | '/api/autotrader/sessions/$id'
     | '/api/items/$id/feedback'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/autotrader'
     | '/mcp'
     | '/api/feed'
     | '/api/items'
     | '/api/runs'
     | '/companies/$symbol'
     | '/api/assets/$id'
+    | '/api/autotrader/events'
+    | '/api/autotrader/fills'
+    | '/api/autotrader/finalize'
+    | '/api/autotrader/orders'
+    | '/api/autotrader/position-snapshots'
+    | '/api/autotrader/risk-checks'
+    | '/api/autotrader/scorecards'
+    | '/api/autotrader/sessions'
+    | '/api/autotrader/status'
+    | '/api/autotrader/trade-tickets'
     | '/api/companies/$symbol'
     | '/api/items/$id'
     | '/api/items/batch'
+    | '/api/autotrader/sessions/$id'
     | '/api/items/$id/feedback'
   id:
     | '__root__'
     | '/'
+    | '/autotrader'
     | '/mcp'
     | '/api/feed'
     | '/api/items'
     | '/api/runs'
     | '/companies/$symbol'
     | '/api/assets/$id'
+    | '/api/autotrader/events'
+    | '/api/autotrader/fills'
+    | '/api/autotrader/finalize'
+    | '/api/autotrader/orders'
+    | '/api/autotrader/position-snapshots'
+    | '/api/autotrader/risk-checks'
+    | '/api/autotrader/scorecards'
+    | '/api/autotrader/sessions'
+    | '/api/autotrader/status'
+    | '/api/autotrader/trade-tickets'
     | '/api/companies/$symbol'
     | '/api/items/$id'
     | '/api/items/batch'
+    | '/api/autotrader/sessions/$id'
     | '/api/items/$id/feedback'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AutotraderRoute: typeof AutotraderRoute
   McpRoute: typeof McpRoute
   ApiFeedRoute: typeof ApiFeedRoute
   ApiItemsRoute: typeof ApiItemsRouteWithChildren
   ApiRunsRoute: typeof ApiRunsRoute
   CompaniesSymbolRoute: typeof CompaniesSymbolRoute
   ApiAssetsIdRoute: typeof ApiAssetsIdRoute
+  ApiAutotraderEventsRoute: typeof ApiAutotraderEventsRoute
+  ApiAutotraderFillsRoute: typeof ApiAutotraderFillsRoute
+  ApiAutotraderFinalizeRoute: typeof ApiAutotraderFinalizeRoute
+  ApiAutotraderOrdersRoute: typeof ApiAutotraderOrdersRoute
+  ApiAutotraderPositionSnapshotsRoute: typeof ApiAutotraderPositionSnapshotsRoute
+  ApiAutotraderRiskChecksRoute: typeof ApiAutotraderRiskChecksRoute
+  ApiAutotraderScorecardsRoute: typeof ApiAutotraderScorecardsRoute
+  ApiAutotraderSessionsRoute: typeof ApiAutotraderSessionsRouteWithChildren
+  ApiAutotraderStatusRoute: typeof ApiAutotraderStatusRoute
+  ApiAutotraderTradeTicketsRoute: typeof ApiAutotraderTradeTicketsRoute
   ApiCompaniesSymbolRoute: typeof ApiCompaniesSymbolRoute
 }
 
@@ -177,6 +334,13 @@ declare module '@tanstack/react-router' {
       path: '/mcp'
       fullPath: '/mcp'
       preLoaderRoute: typeof McpRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/autotrader': {
+      id: '/autotrader'
+      path: '/autotrader'
+      fullPath: '/autotrader'
+      preLoaderRoute: typeof AutotraderRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -235,6 +399,76 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiCompaniesSymbolRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/autotrader/trade-tickets': {
+      id: '/api/autotrader/trade-tickets'
+      path: '/api/autotrader/trade-tickets'
+      fullPath: '/api/autotrader/trade-tickets'
+      preLoaderRoute: typeof ApiAutotraderTradeTicketsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/autotrader/status': {
+      id: '/api/autotrader/status'
+      path: '/api/autotrader/status'
+      fullPath: '/api/autotrader/status'
+      preLoaderRoute: typeof ApiAutotraderStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/autotrader/sessions': {
+      id: '/api/autotrader/sessions'
+      path: '/api/autotrader/sessions'
+      fullPath: '/api/autotrader/sessions'
+      preLoaderRoute: typeof ApiAutotraderSessionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/autotrader/scorecards': {
+      id: '/api/autotrader/scorecards'
+      path: '/api/autotrader/scorecards'
+      fullPath: '/api/autotrader/scorecards'
+      preLoaderRoute: typeof ApiAutotraderScorecardsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/autotrader/risk-checks': {
+      id: '/api/autotrader/risk-checks'
+      path: '/api/autotrader/risk-checks'
+      fullPath: '/api/autotrader/risk-checks'
+      preLoaderRoute: typeof ApiAutotraderRiskChecksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/autotrader/position-snapshots': {
+      id: '/api/autotrader/position-snapshots'
+      path: '/api/autotrader/position-snapshots'
+      fullPath: '/api/autotrader/position-snapshots'
+      preLoaderRoute: typeof ApiAutotraderPositionSnapshotsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/autotrader/orders': {
+      id: '/api/autotrader/orders'
+      path: '/api/autotrader/orders'
+      fullPath: '/api/autotrader/orders'
+      preLoaderRoute: typeof ApiAutotraderOrdersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/autotrader/finalize': {
+      id: '/api/autotrader/finalize'
+      path: '/api/autotrader/finalize'
+      fullPath: '/api/autotrader/finalize'
+      preLoaderRoute: typeof ApiAutotraderFinalizeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/autotrader/fills': {
+      id: '/api/autotrader/fills'
+      path: '/api/autotrader/fills'
+      fullPath: '/api/autotrader/fills'
+      preLoaderRoute: typeof ApiAutotraderFillsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/autotrader/events': {
+      id: '/api/autotrader/events'
+      path: '/api/autotrader/events'
+      fullPath: '/api/autotrader/events'
+      preLoaderRoute: typeof ApiAutotraderEventsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/assets/$id': {
       id: '/api/assets/$id'
       path: '/api/assets/$id'
@@ -248,6 +482,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/items/$id/feedback'
       preLoaderRoute: typeof ApiItemsIdFeedbackRouteImport
       parentRoute: typeof ApiItemsIdRoute
+    }
+    '/api/autotrader/sessions/$id': {
+      id: '/api/autotrader/sessions/$id'
+      path: '/$id'
+      fullPath: '/api/autotrader/sessions/$id'
+      preLoaderRoute: typeof ApiAutotraderSessionsIdRouteImport
+      parentRoute: typeof ApiAutotraderSessionsRoute
     }
   }
 }
@@ -278,14 +519,38 @@ const ApiItemsRouteWithChildren = ApiItemsRoute._addFileChildren(
   ApiItemsRouteChildren,
 )
 
+interface ApiAutotraderSessionsRouteChildren {
+  ApiAutotraderSessionsIdRoute: typeof ApiAutotraderSessionsIdRoute
+}
+
+const ApiAutotraderSessionsRouteChildren: ApiAutotraderSessionsRouteChildren = {
+  ApiAutotraderSessionsIdRoute: ApiAutotraderSessionsIdRoute,
+}
+
+const ApiAutotraderSessionsRouteWithChildren =
+  ApiAutotraderSessionsRoute._addFileChildren(
+    ApiAutotraderSessionsRouteChildren,
+  )
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AutotraderRoute: AutotraderRoute,
   McpRoute: McpRoute,
   ApiFeedRoute: ApiFeedRoute,
   ApiItemsRoute: ApiItemsRouteWithChildren,
   ApiRunsRoute: ApiRunsRoute,
   CompaniesSymbolRoute: CompaniesSymbolRoute,
   ApiAssetsIdRoute: ApiAssetsIdRoute,
+  ApiAutotraderEventsRoute: ApiAutotraderEventsRoute,
+  ApiAutotraderFillsRoute: ApiAutotraderFillsRoute,
+  ApiAutotraderFinalizeRoute: ApiAutotraderFinalizeRoute,
+  ApiAutotraderOrdersRoute: ApiAutotraderOrdersRoute,
+  ApiAutotraderPositionSnapshotsRoute: ApiAutotraderPositionSnapshotsRoute,
+  ApiAutotraderRiskChecksRoute: ApiAutotraderRiskChecksRoute,
+  ApiAutotraderScorecardsRoute: ApiAutotraderScorecardsRoute,
+  ApiAutotraderSessionsRoute: ApiAutotraderSessionsRouteWithChildren,
+  ApiAutotraderStatusRoute: ApiAutotraderStatusRoute,
+  ApiAutotraderTradeTicketsRoute: ApiAutotraderTradeTicketsRoute,
   ApiCompaniesSymbolRoute: ApiCompaniesSymbolRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/synthesis/src/routes/api/autotrader/events.ts
+++ b/apps/synthesis/src/routes/api/autotrader/events.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/autotrader/events')({
+  server: {
+    handlers: {
+      POST: async ({ request }: { request: Request }) => {
+        const { handleAutotraderAppendEvent } = await import('~/server/autotrader-api')
+        return handleAutotraderAppendEvent(request)
+      },
+    },
+  },
+})

--- a/apps/synthesis/src/routes/api/autotrader/fills.ts
+++ b/apps/synthesis/src/routes/api/autotrader/fills.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/autotrader/fills')({
+  server: {
+    handlers: {
+      POST: async ({ request }: { request: Request }) => {
+        const { handleAutotraderRecordFill } = await import('~/server/autotrader-api')
+        return handleAutotraderRecordFill(request)
+      },
+    },
+  },
+})

--- a/apps/synthesis/src/routes/api/autotrader/finalize.ts
+++ b/apps/synthesis/src/routes/api/autotrader/finalize.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/autotrader/finalize')({
+  server: {
+    handlers: {
+      POST: async ({ request }: { request: Request }) => {
+        const { handleAutotraderFinalizeSession } = await import('~/server/autotrader-api')
+        return handleAutotraderFinalizeSession(request)
+      },
+    },
+  },
+})

--- a/apps/synthesis/src/routes/api/autotrader/orders.ts
+++ b/apps/synthesis/src/routes/api/autotrader/orders.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/autotrader/orders')({
+  server: {
+    handlers: {
+      POST: async ({ request }: { request: Request }) => {
+        const { handleAutotraderRecordOrder } = await import('~/server/autotrader-api')
+        return handleAutotraderRecordOrder(request)
+      },
+    },
+  },
+})

--- a/apps/synthesis/src/routes/api/autotrader/position-snapshots.ts
+++ b/apps/synthesis/src/routes/api/autotrader/position-snapshots.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/autotrader/position-snapshots')({
+  server: {
+    handlers: {
+      POST: async ({ request }: { request: Request }) => {
+        const { handleAutotraderRecordPositionSnapshot } = await import('~/server/autotrader-api')
+        return handleAutotraderRecordPositionSnapshot(request)
+      },
+    },
+  },
+})

--- a/apps/synthesis/src/routes/api/autotrader/risk-checks.ts
+++ b/apps/synthesis/src/routes/api/autotrader/risk-checks.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/autotrader/risk-checks')({
+  server: {
+    handlers: {
+      POST: async ({ request }: { request: Request }) => {
+        const { handleAutotraderRecordRiskCheck } = await import('~/server/autotrader-api')
+        return handleAutotraderRecordRiskCheck(request)
+      },
+    },
+  },
+})

--- a/apps/synthesis/src/routes/api/autotrader/scorecards.ts
+++ b/apps/synthesis/src/routes/api/autotrader/scorecards.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/autotrader/scorecards')({
+  server: {
+    handlers: {
+      GET: async ({ request }: { request: Request }) => {
+        const { handleAutotraderGetScorecard } = await import('~/server/autotrader-api')
+        return handleAutotraderGetScorecard(request)
+      },
+    },
+  },
+})

--- a/apps/synthesis/src/routes/api/autotrader/sessions.ts
+++ b/apps/synthesis/src/routes/api/autotrader/sessions.ts
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/autotrader/sessions')({
+  server: {
+    handlers: {
+      GET: async ({ request }: { request: Request }) => {
+        const { handleAutotraderListSessions } = await import('~/server/autotrader-api')
+        return handleAutotraderListSessions(request)
+      },
+      POST: async ({ request }: { request: Request }) => {
+        const { handleAutotraderStartSession } = await import('~/server/autotrader-api')
+        return handleAutotraderStartSession(request)
+      },
+    },
+  },
+})

--- a/apps/synthesis/src/routes/api/autotrader/sessions/$id.ts
+++ b/apps/synthesis/src/routes/api/autotrader/sessions/$id.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/autotrader/sessions/$id')({
+  server: {
+    handlers: {
+      GET: async ({ params, request }: { params: { id: string }; request: Request }) => {
+        const { handleAutotraderGetSession } = await import('~/server/autotrader-api')
+        return handleAutotraderGetSession(request, params.id)
+      },
+    },
+  },
+})

--- a/apps/synthesis/src/routes/api/autotrader/status.ts
+++ b/apps/synthesis/src/routes/api/autotrader/status.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/autotrader/status')({
+  server: {
+    handlers: {
+      POST: async ({ request }: { request: Request }) => {
+        const { handleAutotraderUpsertStatus } = await import('~/server/autotrader-api')
+        return handleAutotraderUpsertStatus(request)
+      },
+    },
+  },
+})

--- a/apps/synthesis/src/routes/api/autotrader/trade-tickets.ts
+++ b/apps/synthesis/src/routes/api/autotrader/trade-tickets.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/api/autotrader/trade-tickets')({
+  server: {
+    handlers: {
+      POST: async ({ request }: { request: Request }) => {
+        const { handleAutotraderCreateTradeTicket } = await import('~/server/autotrader-api')
+        return handleAutotraderCreateTradeTicket(request)
+      },
+    },
+  },
+})

--- a/apps/synthesis/src/routes/autotrader.tsx
+++ b/apps/synthesis/src/routes/autotrader.tsx
@@ -1,0 +1,504 @@
+import { useQuery } from '@tanstack/react-query'
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  Activity,
+  AlertTriangle,
+  BarChart3,
+  CheckCircle2,
+  CircleDollarSign,
+  Clock,
+  Crosshair,
+  ListChecks,
+  Newspaper,
+  ShieldCheck,
+  TrendingUp,
+  Wallet,
+} from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+
+import type {
+  AutotraderEvent,
+  AutotraderOrder,
+  AutotraderRiskCheck,
+  AutotraderSession,
+  AutotraderSessionDetail,
+  AutotraderTradeTicket,
+} from '~/server/autotrader-schema'
+
+export const Route = createFileRoute('/autotrader')({
+  component: AutotraderPage,
+})
+
+const cx = (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(' ')
+
+type SessionsResponse = {
+  sessions: AutotraderSession[]
+}
+
+async function fetchSessions(): Promise<SessionsResponse> {
+  const response = await fetch('/api/autotrader/sessions?limit=30')
+  if (!response.ok) throw new Error(`autotrader sessions request failed: ${response.status}`)
+  return (await response.json()) as SessionsResponse
+}
+
+async function fetchSessionDetail(sessionId: string): Promise<AutotraderSessionDetail> {
+  const response = await fetch(`/api/autotrader/sessions/${sessionId}`)
+  if (!response.ok) throw new Error(`autotrader session request failed: ${response.status}`)
+  return (await response.json()) as AutotraderSessionDetail
+}
+
+const formatDate = (value: string | null) => {
+  if (!value) return 'open'
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(parsed)
+}
+
+const formatNumber = (value: string | null | undefined) => {
+  if (value == null) return 'n/a'
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return value
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(parsed)
+}
+
+const formatMoney = (value: string | null | undefined) => {
+  if (value == null) return 'n/a'
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return value
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 2 }).format(
+    parsed,
+  )
+}
+
+function AutotraderPage() {
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null)
+  const sessions = useQuery({
+    queryKey: ['autotrader-sessions'],
+    queryFn: fetchSessions,
+    refetchInterval: 20_000,
+  })
+  const activeSessionId = selectedSessionId ?? sessions.data?.sessions[0]?.id ?? null
+  const detail = useQuery({
+    queryKey: ['autotrader-session', activeSessionId],
+    queryFn: () => fetchSessionDetail(activeSessionId ?? ''),
+    enabled: Boolean(activeSessionId),
+    refetchInterval: 10_000,
+  })
+
+  useEffect(() => {
+    if (selectedSessionId || !sessions.data?.sessions[0]) return
+    setSelectedSessionId(sessions.data.sessions[0].id)
+  }, [selectedSessionId, sessions.data?.sessions])
+
+  const selectedSession = useMemo(
+    () => sessions.data?.sessions.find((session) => session.id === activeSessionId) ?? null,
+    [activeSessionId, sessions.data?.sessions],
+  )
+
+  return (
+    <main className="grid h-dvh w-full grid-cols-1 overflow-hidden bg-black text-[#e7e9ea] xl:grid-cols-[220px_minmax(0,1fr)]">
+      <aside className="hidden min-h-0 justify-end border-r border-[#2f3336] bg-black xl:flex">
+        <div className="flex w-[220px] flex-col px-2 py-3">
+          <nav className="grid gap-1" aria-label="Synthesis navigation">
+            <RailLink href="/" icon={<Newspaper />}>
+              Feed
+            </RailLink>
+            <RailLink href="/autotrader" active icon={<Activity />}>
+              Autotrader
+            </RailLink>
+          </nav>
+          <div className="mt-auto px-3 py-4 font-mono text-xs leading-6 text-[#71767b]">synthesis runtime state</div>
+        </div>
+      </aside>
+
+      <section className="flex min-h-0 min-w-0 flex-col bg-black">
+        <header className="shrink-0 border-b border-[#2f3336] bg-black/90 px-4 py-3 backdrop-blur sm:px-5">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="min-w-0">
+              <h1 className="text-xl font-semibold tracking-normal">Autotrader</h1>
+              <p className="mt-0.5 text-xs text-[#71767b]">
+                {selectedSession
+                  ? `${selectedSession.tradingDate} / ${selectedSession.agentRunName}`
+                  : 'market-session runtime'}
+              </p>
+            </div>
+            <div className="flex items-center gap-2 font-mono text-xs text-[#71767b]">
+              <Clock className="size-4" />
+              <span>{detail.data?.status?.updatedAt ? formatDate(detail.data.status.updatedAt) : 'waiting'}</span>
+            </div>
+          </div>
+        </header>
+
+        <div className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden xl:grid-cols-[340px_minmax(0,1fr)]">
+          <section className="min-h-0 border-b border-[#2f3336] xl:border-b-0 xl:border-r">
+            <div className="border-b border-[#2f3336] px-4 py-3 text-sm font-semibold">Sessions</div>
+            <div className="max-h-56 overflow-y-auto xl:max-h-none xl:h-[calc(100dvh-106px)]">
+              {sessions.isLoading ? (
+                <LoadingRows count={6} />
+              ) : sessions.error ? (
+                <ErrorLine
+                  message={sessions.error instanceof Error ? sessions.error.message : 'sessions unavailable'}
+                />
+              ) : sessions.data?.sessions.length ? (
+                sessions.data.sessions.map((session) => (
+                  <button
+                    key={session.id}
+                    type="button"
+                    className={cx(
+                      'block w-full border-b border-[#2f3336] px-4 py-3 text-left transition-colors hover:bg-[#080808]',
+                      activeSessionId === session.id && 'bg-[#0b141a]',
+                    )}
+                    onClick={() => setSelectedSessionId(session.id)}
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="truncate text-sm font-semibold">{session.agentRunName}</span>
+                      <span className="shrink-0 rounded-full border border-[#2f3336] px-2 py-0.5 text-[0.625rem] text-[#71767b]">
+                        {session.mode}
+                      </span>
+                    </div>
+                    <div className="mt-1 flex items-center justify-between gap-3 font-mono text-xs text-[#71767b]">
+                      <span>{session.tradingDate}</span>
+                      <span>{formatDate(session.finalizedAt)}</span>
+                    </div>
+                  </button>
+                ))
+              ) : (
+                <div className="px-4 py-8 text-sm text-[#71767b]">No autotrader sessions recorded.</div>
+              )}
+            </div>
+          </section>
+
+          <section className="min-h-0 overflow-y-auto">
+            {detail.isLoading ? (
+              <div className="p-4">
+                <LoadingRows count={10} />
+              </div>
+            ) : detail.error ? (
+              <ErrorLine message={detail.error instanceof Error ? detail.error.message : 'session unavailable'} />
+            ) : detail.data ? (
+              <SessionDashboard detail={detail.data} />
+            ) : (
+              <div className="px-6 py-16 text-sm text-[#71767b]">Select a session.</div>
+            )}
+          </section>
+        </div>
+      </section>
+    </main>
+  )
+}
+
+function RailLink({
+  href,
+  active = false,
+  icon,
+  children,
+}: {
+  href: string
+  active?: boolean
+  icon: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <a
+      href={href}
+      className={cx(
+        'flex w-fit items-center gap-4 rounded-full px-4 py-3 text-xl tracking-normal transition-colors hover:bg-[#181818]',
+        active ? 'font-bold text-[#e7e9ea]' : 'font-normal text-[#e7e9ea]',
+      )}
+    >
+      <span className="[&>svg]:size-6">{icon}</span>
+      <span>{children}</span>
+    </a>
+  )
+}
+
+function SessionDashboard({ detail }: { detail: AutotraderSessionDetail }) {
+  return (
+    <div className="grid gap-0 xl:grid-cols-[minmax(0,1fr)_380px]">
+      <div className="min-w-0">
+        <StatusPanel detail={detail} />
+        <TicketsPanel tickets={detail.tradeTickets} />
+        <OrdersPanel orders={detail.orders} fills={detail.fills} />
+        <EventsPanel events={detail.events} />
+      </div>
+      <div className="min-w-0 border-t border-[#2f3336] xl:border-l xl:border-t-0">
+        <RiskPanel riskChecks={detail.riskChecks} />
+        <PositionsPanel detail={detail} />
+        <ScorecardsPanel detail={detail} />
+        <SummaryPanel detail={detail} />
+      </div>
+    </div>
+  )
+}
+
+function Panel({ title, icon, children }: { title: string; icon: ReactNode; children: ReactNode }) {
+  return (
+    <section className="border-b border-[#2f3336]">
+      <div className="flex items-center gap-2 border-b border-[#2f3336] px-4 py-3 text-sm font-semibold">
+        <span className="[&>svg]:size-4">{icon}</span>
+        <span>{title}</span>
+      </div>
+      <div>{children}</div>
+    </section>
+  )
+}
+
+function StatusPanel({ detail }: { detail: AutotraderSessionDetail }) {
+  const status = detail.status
+  return (
+    <Panel title="Live Status" icon={<Activity />}>
+      <div className="grid gap-px bg-[#2f3336] sm:grid-cols-2 2xl:grid-cols-4">
+        <Metric label="phase" value={status?.phase ?? 'waiting'} />
+        <Metric label="cycle" value={status?.cycle == null ? 'n/a' : String(status.cycle)} />
+        <Metric label="equity" value={formatMoney(status?.equity)} />
+        <Metric label="goal" value={formatMoney(detail.session.goalEquity)} />
+        <Metric label="buying power" value={formatMoney(status?.buyingPower)} />
+        <Metric label="daytrade bp" value={formatMoney(status?.daytradeBuyingPower)} />
+        <Metric label="realized p/l" value={formatMoney(status?.realizedPnl)} />
+        <Metric label="unrealized p/l" value={formatMoney(status?.unrealizedPnl)} />
+      </div>
+      <div className="px-4 py-3">
+        <div className="text-xs font-medium uppercase tracking-normal text-[#71767b]">current action</div>
+        <div className="mt-1 text-sm leading-6">{status?.currentAction ?? 'No status written yet.'}</div>
+        {status?.blocker ? <div className="mt-2 text-sm leading-6 text-[#ffb86b]">{status.blocker}</div> : null}
+      </div>
+    </Panel>
+  )
+}
+
+function TicketsPanel({ tickets }: { tickets: AutotraderTradeTicket[] }) {
+  return (
+    <Panel title="Trade Tickets" icon={<Crosshair />}>
+      {tickets.length ? (
+        tickets.map((ticket) => (
+          <div key={ticket.id} className="border-b border-[#2f3336] px-4 py-3 last:border-b-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-semibold">{ticket.symbol}</span>
+              <Pill>{ticket.setupGrade}</Pill>
+              <Pill>{ticket.status}</Pill>
+              <Pill>{ticket.protectionType}</Pill>
+            </div>
+            <div className="mt-2 grid gap-2 text-xs text-[#71767b] 2xl:grid-cols-3">
+              <span>{ticket.setupType}</span>
+              <span>R {formatNumber(ticket.expectedR)}</span>
+              <span>risk {formatMoney(ticket.riskDollars ?? ticket.maxLossAmount)}</span>
+            </div>
+            <div className="mt-2 text-sm leading-6 text-[#cfd3d6]">{ticket.thesis}</div>
+            {ticket.noTradeReason ? <div className="mt-2 text-sm text-[#ffb86b]">{ticket.noTradeReason}</div> : null}
+          </div>
+        ))
+      ) : (
+        <EmptyLine text="No trade tickets recorded." />
+      )}
+    </Panel>
+  )
+}
+
+function OrdersPanel({ orders, fills }: { orders: AutotraderOrder[]; fills: AutotraderSessionDetail['fills'] }) {
+  return (
+    <Panel title="Orders And Fills" icon={<CircleDollarSign />}>
+      {orders.length || fills.length ? (
+        <>
+          {orders.map((order) => (
+            <div key={order.clientOrderId} className="border-b border-[#2f3336] px-4 py-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-mono text-sm">{order.clientOrderId}</span>
+                <Pill>{order.status}</Pill>
+                {order.orderClass ? <Pill>{order.orderClass}</Pill> : null}
+              </div>
+              <div className="mt-2 grid gap-2 text-xs text-[#71767b] 2xl:grid-cols-4">
+                <span>{order.symbol}</span>
+                <span>{order.side}</span>
+                <span>qty {formatNumber(order.quantity)}</span>
+                <span>limit {formatMoney(order.limitPrice)}</span>
+              </div>
+              {order.rejectReason ? <div className="mt-2 text-sm text-[#ff7a85]">{order.rejectReason}</div> : null}
+            </div>
+          ))}
+          {fills.map((fill) => (
+            <div key={fill.brokerFillId} className="border-b border-[#2f3336] px-4 py-3 last:border-b-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <CheckCircle2 className="size-4 text-[#3fb950]" />
+                <span className="text-sm font-semibold">{fill.symbol}</span>
+                <span className="font-mono text-xs text-[#71767b]">{fill.brokerFillId}</span>
+              </div>
+              <div className="mt-2 grid gap-2 text-xs text-[#71767b] 2xl:grid-cols-4">
+                <span>{fill.side}</span>
+                <span>qty {formatNumber(fill.quantity)}</span>
+                <span>@ {formatMoney(fill.price)}</span>
+                <span>{formatDate(fill.filledAt)}</span>
+              </div>
+            </div>
+          ))}
+        </>
+      ) : (
+        <EmptyLine text="No orders or fills recorded." />
+      )}
+    </Panel>
+  )
+}
+
+function EventsPanel({ events }: { events: AutotraderEvent[] }) {
+  return (
+    <Panel title="Event Stream" icon={<ListChecks />}>
+      {events.length ? (
+        events.map((event) => (
+          <div key={`${event.sessionId}:${event.seq}`} className="border-b border-[#2f3336] px-4 py-3 last:border-b-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-mono text-xs text-[#71767b]">#{event.seq}</span>
+              <span className="text-sm font-semibold">{event.eventType}</span>
+              <Pill>{event.severity}</Pill>
+              {event.symbol ? <Pill>{event.symbol}</Pill> : null}
+            </div>
+            <div className="mt-1 text-xs text-[#71767b]">{formatDate(event.occurredAt)}</div>
+          </div>
+        ))
+      ) : (
+        <EmptyLine text="No events recorded." />
+      )}
+    </Panel>
+  )
+}
+
+function RiskPanel({ riskChecks }: { riskChecks: AutotraderRiskCheck[] }) {
+  return (
+    <Panel title="Risk Checks" icon={<ShieldCheck />}>
+      {riskChecks.length ? (
+        riskChecks.map((riskCheck) => (
+          <div key={riskCheck.id} className="border-b border-[#2f3336] px-4 py-3 last:border-b-0">
+            <div className="flex flex-wrap items-center gap-2">
+              {riskCheck.passed ? (
+                <CheckCircle2 className="size-4 text-[#3fb950]" />
+              ) : (
+                <AlertTriangle className="size-4 text-[#ffb86b]" />
+              )}
+              <span className="text-sm font-semibold">{riskCheck.checkType}</span>
+              <Pill>{riskCheck.passed ? 'passed' : 'blocked'}</Pill>
+            </div>
+            {riskCheck.reason ? <div className="mt-2 text-sm leading-6 text-[#cfd3d6]">{riskCheck.reason}</div> : null}
+          </div>
+        ))
+      ) : (
+        <EmptyLine text="No risk checks recorded." />
+      )}
+    </Panel>
+  )
+}
+
+function PositionsPanel({ detail }: { detail: AutotraderSessionDetail }) {
+  const latestBySymbol = new Map<string, AutotraderSessionDetail['positionSnapshots'][number]>()
+  for (const snapshot of detail.positionSnapshots) {
+    if (!latestBySymbol.has(snapshot.symbol)) latestBySymbol.set(snapshot.symbol, snapshot)
+  }
+  const snapshots = [...latestBySymbol.values()]
+
+  return (
+    <Panel title="Positions" icon={<Wallet />}>
+      {snapshots.length ? (
+        snapshots.map((snapshot) => (
+          <div key={snapshot.id} className="border-b border-[#2f3336] px-4 py-3 last:border-b-0">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-sm font-semibold">{snapshot.symbol}</span>
+              <span className="font-mono text-xs text-[#71767b]">{formatDate(snapshot.capturedAt)}</span>
+            </div>
+            <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-[#71767b]">
+              <span>qty {formatNumber(snapshot.quantity)}</span>
+              <span>value {formatMoney(snapshot.marketValue)}</span>
+              <span>avg {formatMoney(snapshot.averageEntryPrice)}</span>
+              <span>p/l {formatMoney(snapshot.unrealizedPnl)}</span>
+            </div>
+          </div>
+        ))
+      ) : (
+        <EmptyLine text="No position snapshots recorded." />
+      )}
+    </Panel>
+  )
+}
+
+function ScorecardsPanel({ detail }: { detail: AutotraderSessionDetail }) {
+  return (
+    <Panel title="Scorecards" icon={<BarChart3 />}>
+      {detail.scorecards.length ? (
+        detail.scorecards.map((scorecard) => (
+          <div key={scorecard.key} className="border-b border-[#2f3336] px-4 py-3 last:border-b-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <TrendingUp className="size-4 text-[#1d9bf0]" />
+              <span className="text-sm font-semibold">{scorecard.symbol ?? 'ALL'}</span>
+              <Pill>{scorecard.setupGrade}</Pill>
+              <Pill>{scorecard.timeBucket}</Pill>
+            </div>
+            <div className="mt-2 text-xs text-[#71767b]">{scorecard.setupType}</div>
+            <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-[#71767b]">
+              <span>n {scorecard.sampleSize}</span>
+              <span>avg R {formatNumber(scorecard.avgRealizedR)}</span>
+              <span>wins {scorecard.wins}</span>
+              <span>losses {scorecard.losses}</span>
+            </div>
+          </div>
+        ))
+      ) : (
+        <EmptyLine text="No scorecards linked to this session." />
+      )}
+    </Panel>
+  )
+}
+
+function SummaryPanel({ detail }: { detail: AutotraderSessionDetail }) {
+  return (
+    <Panel title="Session Summary" icon={<Activity />}>
+      <div className="grid gap-px bg-[#2f3336]">
+        <Metric label="started" value={formatDate(detail.session.startedAt)} />
+        <Metric label="finalized" value={formatDate(detail.session.finalizedAt)} />
+        <Metric label="terminal" value={detail.session.terminalReason ?? 'running'} />
+      </div>
+      <pre className="max-h-72 overflow-auto px-4 py-3 font-mono text-xs leading-5 text-[#cfd3d6]">
+        {JSON.stringify(detail.session.summary, null, 2)}
+      </pre>
+    </Panel>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-black px-4 py-3">
+      <div className="text-[0.625rem] font-medium uppercase tracking-normal text-[#71767b]">{label}</div>
+      <div className="mt-1 truncate font-mono text-sm text-[#e7e9ea]">{value}</div>
+    </div>
+  )
+}
+
+function Pill({ children }: { children: ReactNode }) {
+  return (
+    <span className="inline-flex h-5 items-center rounded-full border border-[#2f3336] px-2 text-[0.625rem] font-medium text-[#cfd3d6]">
+      {children}
+    </span>
+  )
+}
+
+function EmptyLine({ text }: { text: string }) {
+  return <div className="px-4 py-5 text-sm text-[#71767b]">{text}</div>
+}
+
+function ErrorLine({ message }: { message: string }) {
+  return <div className="border-b border-[#2f3336] px-4 py-5 text-sm text-[#ff7a85]">{message}</div>
+}
+
+function LoadingRows({ count }: { count: number }) {
+  return (
+    <div>
+      {Array.from({ length: count }, (_, index) => (
+        <div key={index} className="border-b border-[#2f3336] px-4 py-4">
+          <div className="h-3 w-2/3 rounded bg-[#202327]" />
+          <div className="mt-3 h-3 w-1/3 rounded bg-[#16181c]" />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/synthesis/src/routes/index.tsx
+++ b/apps/synthesis/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { ArrowUpRight, ExternalLink, ImageIcon, Newspaper, Search, X } from 'lucide-react'
+import { Activity, ArrowUpRight, ExternalLink, ImageIcon, Newspaper, Search, X } from 'lucide-react'
 import { useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import type {
   ButtonHTMLAttributes,
@@ -247,9 +247,14 @@ function App() {
         <div className="flex w-[220px] flex-col px-2 py-3">
           <nav className="grid gap-1" aria-label="Synthesis navigation">
             {synthesisSidebarItems.map((item) => (
-              <RailButton key={item} active={item === 'Feed'} icon={<Newspaper />}>
+              <RailLink
+                key={item}
+                active={item === 'Feed'}
+                href={item === 'Autotrader' ? '/autotrader' : '/'}
+                icon={item === 'Autotrader' ? <Activity /> : <Newspaper />}
+              >
                 {item}
-              </RailButton>
+              </RailLink>
             ))}
           </nav>
           <div className="mt-auto px-3 py-4 font-mono text-xs leading-6 text-[#71767b]">private reading output</div>
@@ -332,10 +337,20 @@ function App() {
   )
 }
 
-function RailButton({ active, icon, children }: { active?: boolean; icon: ReactNode; children: ReactNode }) {
+function RailLink({
+  href,
+  active,
+  icon,
+  children,
+}: {
+  href: string
+  active?: boolean
+  icon: ReactNode
+  children: ReactNode
+}) {
   return (
-    <button
-      type="button"
+    <a
+      href={href}
       className={cx(
         'flex w-fit items-center gap-4 rounded-full px-4 py-3 text-xl tracking-normal transition-colors hover:bg-[#181818]',
         active ? 'font-bold text-[#e7e9ea]' : 'font-normal text-[#e7e9ea]',
@@ -343,7 +358,7 @@ function RailButton({ active, icon, children }: { active?: boolean; icon: ReactN
     >
       <span className="[&>svg]:size-6">{icon}</span>
       <span>{children}</span>
-    </button>
+    </a>
   )
 }
 

--- a/apps/synthesis/src/server/__tests__/api.test.ts
+++ b/apps/synthesis/src/server/__tests__/api.test.ts
@@ -1,5 +1,16 @@
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
+import {
+  handleAutotraderAppendEvent,
+  handleAutotraderCreateTradeTicket,
+  handleAutotraderFinalizeSession,
+  handleAutotraderGetScorecard,
+  handleAutotraderGetSession,
+  handleAutotraderListSessions,
+  handleAutotraderStartSession,
+  handleAutotraderUpsertStatus,
+} from '../autotrader-api'
+import { createInMemoryAutotraderStore, setAutotraderStoreForTests } from '../autotrader-store'
 import { handleCreateRun, handleGetAsset, handleListFeed, handleSubmitItem } from '../api'
 import { setSynthesisEmbeddingProviderForTests } from '../embeddings'
 import { createInMemorySynthesisStore, setSynthesisStoreForTests } from '../store'
@@ -67,6 +78,7 @@ describe('synthesis REST auth', () => {
       return { embedding: [0, 0, 1], model: config.model, dimension: config.dimension }
     })
     setSynthesisStoreForTests(createInMemorySynthesisStore())
+    setAutotraderStoreForTests(createInMemoryAutotraderStore())
   })
 
   afterEach(() => {
@@ -75,6 +87,7 @@ describe('synthesis REST auth', () => {
     delete process.env.SYNTHESIS_EMBEDDING_MODEL
     setSynthesisEmbeddingProviderForTests(null)
     setSynthesisStoreForTests(null)
+    setAutotraderStoreForTests(null)
   })
 
   test('rejects missing bearer token for mutating routes', async () => {
@@ -355,5 +368,131 @@ describe('synthesis REST auth', () => {
     expect(payload.items).toHaveLength(1)
     expect(payload.items[0].dedupeKey).toBe('theme:hbm-memory-capacity')
     expect(payload.nextCursor).toBeNull()
+  })
+
+  test('serves canonical autotrader state and scorecards through REST handlers', async () => {
+    const authedHeaders = {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    }
+    const startResponse = await handleAutotraderStartSession(
+      new Request('http://synthesis.test/api/autotrader/sessions', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          agentRunName: 'autonomous-trader-market-open-api-test',
+          mode: 'dry_run',
+          tradingDate: '2026-05-29',
+          accountId: 'paper-account',
+          goalEquity: '500000',
+          marketOpenAt: '2026-05-29T13:30:00Z',
+          marketCloseAt: '2026-05-29T20:00:00Z',
+        }),
+      }),
+    )
+    const startPayload = await startResponse.json()
+    const sessionId = startPayload.session.id
+
+    await handleAutotraderUpsertStatus(
+      new Request('http://synthesis.test/api/autotrader/status', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          sessionId,
+          cycle: 3,
+          phase: 'scan',
+          currentAction: 'standing down on weak candidates',
+          blocker: null,
+          payload: { noTradeReason: 'no A setup' },
+        }),
+      }),
+    )
+    await handleAutotraderAppendEvent(
+      new Request('http://synthesis.test/api/autotrader/events', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          sessionId,
+          seq: 3,
+          eventType: 'no_trade_decision',
+          symbol: 'AMD',
+          setupType: 'vwap_reclaim',
+          setupGrade: 'C',
+          payload: { reason: 'wide spread' },
+        }),
+      }),
+    )
+    const ticketResponse = await handleAutotraderCreateTradeTicket(
+      new Request('http://synthesis.test/api/autotrader/trade-tickets', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          sessionId,
+          idempotencyKey: 'amd-c-setup',
+          symbol: 'AMD',
+          instrument: 'stock',
+          side: 'buy',
+          setupType: 'vwap_reclaim',
+          setupGrade: 'C',
+          regime: 'range_bound',
+          timeBucket: 'midday',
+          thesis: 'Rejected because setup grade was too weak.',
+          entryTrigger: 'Not applicable.',
+          invalidation: 'Not applicable.',
+          protectionType: 'none',
+          status: 'blocked',
+          noTradeReason: 'C setup blocked',
+        }),
+      }),
+    )
+    const ticketPayload = await ticketResponse.json()
+    await handleAutotraderFinalizeSession(
+      new Request('http://synthesis.test/api/autotrader/finalize', {
+        method: 'POST',
+        headers: authedHeaders,
+        body: JSON.stringify({
+          sessionId,
+          terminalReason: 'dry_run_complete',
+          summary: { noTrade: true },
+          scorecardObservations: [
+            {
+              ticketId: ticketPayload.ticket.id,
+              symbol: 'AMD',
+              setupType: 'vwap_reclaim',
+              setupGrade: 'C',
+              regime: 'range_bound',
+              timeBucket: 'midday',
+              outcome: 'rejected_invalid',
+              realizedR: '0',
+              notes: 'C setup correctly blocked',
+            },
+          ],
+        }),
+      }),
+    )
+
+    const listResponse = await handleAutotraderListSessions(
+      new Request('http://synthesis.test/api/autotrader/sessions?limit=5'),
+    )
+    const detailResponse = await handleAutotraderGetSession(
+      new Request(`http://synthesis.test/api/autotrader/sessions/${sessionId}`),
+      sessionId,
+    )
+    const scorecardResponse = await handleAutotraderGetScorecard(
+      new Request('http://synthesis.test/api/autotrader/scorecards?symbol=AMD&setupType=vwap_reclaim&limit=5'),
+    )
+    const listPayload = await listResponse.json()
+    const detailPayload = await detailResponse.json()
+    const scorecardPayload = await scorecardResponse.json()
+
+    expect(listPayload.sessions[0].agentRunName).toBe('autonomous-trader-market-open-api-test')
+    expect(detailPayload.status.currentAction).toContain('standing down')
+    expect(detailPayload.events[0].eventType).toBe('no_trade_decision')
+    expect(detailPayload.tradeTickets[0].noTradeReason).toBe('C setup blocked')
+    expect(scorecardPayload.scorecards[0]).toMatchObject({
+      symbol: 'AMD',
+      setupType: 'vwap_reclaim',
+      rejectedInvalid: 1,
+    })
   })
 })

--- a/apps/synthesis/src/server/__tests__/mcp.test.ts
+++ b/apps/synthesis/src/server/__tests__/mcp.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { setSynthesisEmbeddingProviderForTests } from '../embeddings'
 import { handleMcpRequest } from '../mcp'
 import { createInMemorySynthesisStore, setSynthesisStoreForTests } from '../store'
+import { createInMemoryAutotraderStore, setAutotraderStoreForTests } from '../autotrader-store'
 
 const token = 'test-synthesis-token'
 
@@ -41,6 +42,7 @@ describe('synthesis MCP', () => {
       return { embedding: [0, 0, 1], model: config.model, dimension: config.dimension }
     })
     setSynthesisStoreForTests(createInMemorySynthesisStore())
+    setAutotraderStoreForTests(createInMemoryAutotraderStore())
   })
 
   afterEach(() => {
@@ -49,6 +51,7 @@ describe('synthesis MCP', () => {
     delete process.env.SYNTHESIS_EMBEDDING_MODEL
     setSynthesisEmbeddingProviderForTests(null)
     setSynthesisStoreForTests(null)
+    setAutotraderStoreForTests(null)
   })
 
   test('initializes with synthesis-control-plane server info', async () => {
@@ -293,5 +296,243 @@ describe('synthesis MCP', () => {
 
     expect(feedPayload.items).toHaveLength(1)
     expect(feedPayload.items[0].dedupeKey).toBe('theme:browser-agents')
+  })
+
+  test('records an autotrader session and returns compounded scorecards through MCP', async () => {
+    const headers = { authorization: `Bearer ${token}` }
+    const toolsResponse = await handleMcpRequest(rpc('tools/list'))
+    const toolsPayload = await toolsResponse.json()
+    const toolNames = toolsPayload.result.tools.map((tool: { name: string }) => tool.name)
+
+    expect(toolNames).toEqual(expect.arrayContaining(['autotrader_start_session', 'autotrader_get_scorecard']))
+
+    const sessionPayload = await parseToolJson(
+      await handleMcpRequest(
+        callTool(
+          'autotrader_start_session',
+          {
+            agentRunName: 'autonomous-trader-market-open-20260529-0930',
+            mode: 'market_open',
+            tradingDate: '2026-05-29',
+            accountId: 'paper-account',
+            goalEquity: '500000',
+            marketOpenAt: '2026-05-29T13:30:00Z',
+            marketCloseAt: '2026-05-29T20:00:00Z',
+            analysisHead: 'b187dcf',
+            analysisContextHash: 'sha256:test',
+          },
+          headers,
+        ),
+      ),
+    )
+    const sessionId = sessionPayload.session.id
+
+    await parseToolJson(
+      await handleMcpRequest(
+        callTool(
+          'autotrader_upsert_status',
+          {
+            sessionId,
+            cycle: 1,
+            phase: 'scan',
+            equity: '38763.11',
+            buyingPower: '51235.31',
+            daytradeBuyingPower: '51235.31',
+            grossExposure: '0',
+            netExposure: '0',
+            realizedPnl: '0',
+            unrealizedPnl: '0',
+            currentAction: 'ranking candidates',
+            payload: { topCandidates: ['NVDA'] },
+          },
+          headers,
+        ),
+      ),
+    )
+    await parseToolJson(
+      await handleMcpRequest(
+        callTool(
+          'autotrader_append_event',
+          {
+            sessionId,
+            seq: 1,
+            eventType: 'candidate_ranked',
+            symbol: 'nvda',
+            setupType: 'opening_range_breakout',
+            setupGrade: 'A',
+            payload: { relativeVolume: 4.2 },
+          },
+          headers,
+        ),
+      ),
+    )
+    const ticketPayload = await parseToolJson(
+      await handleMcpRequest(
+        callTool(
+          'autotrader_create_trade_ticket',
+          {
+            sessionId,
+            idempotencyKey: 'cycle-1-nvda',
+            symbol: 'NVDA',
+            instrument: 'stock',
+            side: 'buy',
+            setupType: 'opening_range_breakout',
+            setupGrade: 'A',
+            fatPitch: true,
+            regime: 'news_driven',
+            timeBucket: 'open_30m',
+            thesis: 'Relative strength and clean opening range break.',
+            entryTrigger: 'Break and hold above opening range high.',
+            invalidation: 'Loss of VWAP.',
+            entryLimitPrice: '125.10',
+            stopPrice: '123.80',
+            targetPrice: '128.50',
+            expectedR: '2.61',
+            maxLossAmount: '260',
+            riskDollars: '260',
+            plannedQuantity: '200',
+            protectionType: 'bracket',
+            brokerOrderPlan: { orderClass: 'bracket' },
+            status: 'validated',
+          },
+          headers,
+        ),
+      ),
+    )
+
+    await parseToolJson(
+      await handleMcpRequest(
+        callTool(
+          'autotrader_record_risk_check',
+          {
+            sessionId,
+            ticketId: ticketPayload.ticket.id,
+            idempotencyKey: 'cycle-1-nvda-risk',
+            checkType: 'expected_r',
+            passed: true,
+            reason: 'expected R above threshold',
+            payload: { expectedR: '2.61' },
+          },
+          headers,
+        ),
+      ),
+    )
+    await parseToolJson(
+      await handleMcpRequest(
+        callTool(
+          'autotrader_record_order',
+          {
+            sessionId,
+            ticketId: ticketPayload.ticket.id,
+            clientOrderId: 'atr-test-nvda-1',
+            brokerOrderId: 'alpaca-order-1',
+            symbol: 'NVDA',
+            instrument: 'stock',
+            side: 'buy',
+            quantity: '200',
+            orderType: 'limit',
+            orderClass: 'bracket',
+            limitPrice: '125.10',
+            takeProfitLimitPrice: '128.50',
+            stopLossStopPrice: '123.80',
+            status: 'filled',
+            brokerPayload: { source: 'alpaca' },
+          },
+          headers,
+        ),
+      ),
+    )
+    await parseToolJson(
+      await handleMcpRequest(
+        callTool(
+          'autotrader_record_fill',
+          {
+            sessionId,
+            clientOrderId: 'atr-test-nvda-1',
+            brokerFillId: 'fill-1',
+            symbol: 'NVDA',
+            side: 'buy',
+            quantity: '200',
+            price: '125.04',
+            filledAt: '2026-05-29T13:42:00Z',
+            brokerPayload: { source: 'alpaca' },
+          },
+          headers,
+        ),
+      ),
+    )
+    await parseToolJson(
+      await handleMcpRequest(
+        callTool(
+          'autotrader_record_position_snapshot',
+          {
+            sessionId,
+            symbol: 'NVDA',
+            quantity: '200',
+            marketValue: '25100',
+            averageEntryPrice: '125.04',
+            unrealizedPnl: '92',
+            capturedAt: '2026-05-29T13:43:00Z',
+            brokerPayload: { source: 'alpaca' },
+          },
+          headers,
+        ),
+      ),
+    )
+
+    const finalizedPayload = await parseToolJson(
+      await handleMcpRequest(
+        callTool(
+          'autotrader_finalize_session',
+          {
+            sessionId,
+            terminalReason: 'market_close',
+            summary: { realizedPnl: '350' },
+            scorecardObservations: [
+              {
+                ticketId: ticketPayload.ticket.id,
+                symbol: 'NVDA',
+                setupType: 'opening_range_breakout',
+                setupGrade: 'A',
+                regime: 'news_driven',
+                timeBucket: 'open_30m',
+                outcome: 'win',
+                realizedR: '1.35',
+                holdSeconds: '930',
+                mfeR: '1.8',
+                maeR: '-0.2',
+                mistakeTags: [],
+                notes: 'clean break and target management',
+                payload: { targetHit: true },
+              },
+            ],
+          },
+          headers,
+        ),
+      ),
+    )
+    const scorecardPayload = await parseToolJson(
+      await handleMcpRequest(
+        callTool('autotrader_get_scorecard', {
+          symbol: 'NVDA',
+          setupType: 'opening_range_breakout',
+          setupGrade: 'A',
+          regime: 'news_driven',
+          timeBucket: 'open_30m',
+        }),
+      ),
+    )
+
+    expect(finalizedPayload.detail.session.terminalReason).toBe('market_close')
+    expect(finalizedPayload.detail.orders).toHaveLength(1)
+    expect(finalizedPayload.detail.positionSnapshots[0].symbol).toBe('NVDA')
+    expect(scorecardPayload.scorecards[0]).toMatchObject({
+      symbol: 'NVDA',
+      setupType: 'opening_range_breakout',
+      sampleSize: 1,
+      wins: 1,
+      avgRealizedR: '1.35',
+    })
+    expect(scorecardPayload.setupExamples[0].notes).toContain('clean break')
   })
 })

--- a/apps/synthesis/src/server/autotrader-api.ts
+++ b/apps/synthesis/src/server/autotrader-api.ts
@@ -1,0 +1,185 @@
+import {
+  AutotraderAppendEventInputSchema,
+  AutotraderCreateTradeTicketInputSchema,
+  AutotraderFinalizeSessionInputSchema,
+  AutotraderGetScorecardInputSchema,
+  AutotraderListSessionsInputSchema,
+  AutotraderRecordFillInputSchema,
+  AutotraderRecordOrderInputSchema,
+  AutotraderRecordPositionSnapshotInputSchema,
+  AutotraderRecordRiskCheckInputSchema,
+  AutotraderStartSessionInputSchema,
+  AutotraderUpsertStatusInputSchema,
+} from './autotrader-schema'
+import { getAutotraderStore } from './autotrader-store'
+import { requireAuthorized } from './auth'
+import { badRequest, jsonResponse, notFound, readJson } from './http'
+
+const internalError = (error: unknown) =>
+  jsonResponse({ error: error instanceof Error ? error.message : 'internal server error' }, { status: 500 })
+
+const parseQuery = (request: Request) => {
+  const url = new URL(request.url)
+  return Object.fromEntries(url.searchParams.entries())
+}
+
+export const handleAutotraderListSessions = async (request: Request) => {
+  const parsed = AutotraderListSessionsInputSchema.safeParse(parseQuery(request))
+  if (!parsed.success) return badRequest('invalid autotrader sessions query')
+
+  try {
+    return jsonResponse({ sessions: await getAutotraderStore().listSessions(parsed.data.limit) })
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+export const handleAutotraderGetSession = async (_request: Request, sessionId: string) => {
+  try {
+    const detail = await getAutotraderStore().getSessionDetail(sessionId)
+    if (!detail) return notFound('autotrader session not found')
+    return jsonResponse(detail)
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+export const handleAutotraderGetScorecard = async (request: Request) => {
+  const parsed = AutotraderGetScorecardInputSchema.safeParse(parseQuery(request))
+  if (!parsed.success) return badRequest('invalid autotrader scorecard query')
+
+  try {
+    return jsonResponse(await getAutotraderStore().getScorecard(parsed.data))
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+export const handleAutotraderStartSession = async (request: Request) => {
+  const unauthorized = requireAuthorized(request)
+  if (unauthorized) return unauthorized
+
+  const parsed = await readJson(request, AutotraderStartSessionInputSchema)
+  if (parsed instanceof Response) return parsed
+
+  try {
+    return jsonResponse({ session: await getAutotraderStore().startSession(parsed.value) }, { status: 201 })
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+export const handleAutotraderUpsertStatus = async (request: Request) => {
+  const unauthorized = requireAuthorized(request)
+  if (unauthorized) return unauthorized
+
+  const parsed = await readJson(request, AutotraderUpsertStatusInputSchema)
+  if (parsed instanceof Response) return parsed
+
+  try {
+    return jsonResponse({ status: await getAutotraderStore().upsertStatus(parsed.value) }, { status: 201 })
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+export const handleAutotraderAppendEvent = async (request: Request) => {
+  const unauthorized = requireAuthorized(request)
+  if (unauthorized) return unauthorized
+
+  const parsed = await readJson(request, AutotraderAppendEventInputSchema)
+  if (parsed instanceof Response) return parsed
+
+  try {
+    return jsonResponse({ event: await getAutotraderStore().appendEvent(parsed.value) }, { status: 201 })
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+export const handleAutotraderCreateTradeTicket = async (request: Request) => {
+  const unauthorized = requireAuthorized(request)
+  if (unauthorized) return unauthorized
+
+  const parsed = await readJson(request, AutotraderCreateTradeTicketInputSchema)
+  if (parsed instanceof Response) return parsed
+
+  try {
+    return jsonResponse({ ticket: await getAutotraderStore().createTradeTicket(parsed.value) }, { status: 201 })
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+export const handleAutotraderRecordRiskCheck = async (request: Request) => {
+  const unauthorized = requireAuthorized(request)
+  if (unauthorized) return unauthorized
+
+  const parsed = await readJson(request, AutotraderRecordRiskCheckInputSchema)
+  if (parsed instanceof Response) return parsed
+
+  try {
+    return jsonResponse({ riskCheck: await getAutotraderStore().recordRiskCheck(parsed.value) }, { status: 201 })
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+export const handleAutotraderRecordOrder = async (request: Request) => {
+  const unauthorized = requireAuthorized(request)
+  if (unauthorized) return unauthorized
+
+  const parsed = await readJson(request, AutotraderRecordOrderInputSchema)
+  if (parsed instanceof Response) return parsed
+
+  try {
+    return jsonResponse({ order: await getAutotraderStore().recordOrder(parsed.value) }, { status: 201 })
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+export const handleAutotraderRecordFill = async (request: Request) => {
+  const unauthorized = requireAuthorized(request)
+  if (unauthorized) return unauthorized
+
+  const parsed = await readJson(request, AutotraderRecordFillInputSchema)
+  if (parsed instanceof Response) return parsed
+
+  try {
+    return jsonResponse({ fill: await getAutotraderStore().recordFill(parsed.value) }, { status: 201 })
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+export const handleAutotraderRecordPositionSnapshot = async (request: Request) => {
+  const unauthorized = requireAuthorized(request)
+  if (unauthorized) return unauthorized
+
+  const parsed = await readJson(request, AutotraderRecordPositionSnapshotInputSchema)
+  if (parsed instanceof Response) return parsed
+
+  try {
+    return jsonResponse(
+      { positionSnapshot: await getAutotraderStore().recordPositionSnapshot(parsed.value) },
+      { status: 201 },
+    )
+  } catch (error) {
+    return internalError(error)
+  }
+}
+
+export const handleAutotraderFinalizeSession = async (request: Request) => {
+  const unauthorized = requireAuthorized(request)
+  if (unauthorized) return unauthorized
+
+  const parsed = await readJson(request, AutotraderFinalizeSessionInputSchema)
+  if (parsed instanceof Response) return parsed
+
+  try {
+    return jsonResponse(await getAutotraderStore().finalizeSession(parsed.value), { status: 201 })
+  } catch (error) {
+    return internalError(error)
+  }
+}

--- a/apps/synthesis/src/server/autotrader-schema.ts
+++ b/apps/synthesis/src/server/autotrader-schema.ts
@@ -1,0 +1,433 @@
+import { z } from 'zod'
+
+const NumericStringSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(80)
+  .refine((value) => Number.isFinite(Number(value)), 'must be numeric')
+
+const OptionalNumericStringSchema = NumericStringSchema.optional()
+const PayloadSchema = z.record(z.string(), z.unknown()).default({})
+const TagsSchema = z.array(z.string().trim().min(1).max(80)).max(32).default([])
+
+export const AutotraderSessionModeSchema = z.enum(['market_session', 'market_open', 'dry_run', 'paper_smoke'])
+export const AutotraderPhaseSchema = z.enum([
+  'preflight',
+  'scan',
+  'ticket',
+  'risk_check',
+  'order',
+  'manage',
+  'reconcile',
+  'finalize',
+  'blocked',
+  'idle',
+])
+export const AutotraderInstrumentSchema = z.enum(['stock', 'etf', 'option', 'crypto', 'other'])
+export const AutotraderSideSchema = z.enum([
+  'buy',
+  'sell',
+  'sell_short',
+  'buy_to_cover',
+  'buy_to_open',
+  'buy_to_close',
+  'sell_to_open',
+  'sell_to_close',
+])
+export const AutotraderSetupGradeSchema = z.enum(['A+', 'A', 'B', 'C', 'blocked'])
+export const AutotraderSeveritySchema = z.enum(['debug', 'info', 'warn', 'error'])
+export const AutotraderTicketStatusSchema = z.enum(['candidate', 'validated', 'blocked', 'ordered', 'filled', 'closed'])
+export const AutotraderOrderStatusSchema = z.enum([
+  'planned',
+  'submitted',
+  'accepted',
+  'partially_filled',
+  'filled',
+  'canceled',
+  'rejected',
+  'expired',
+  'reconciled',
+])
+export const AutotraderOutcomeSchema = z.enum(['win', 'loss', 'scratch', 'rejected_valid', 'rejected_invalid'])
+
+export const AutotraderStartSessionInputSchema = z
+  .object({
+    agentRunName: z.string().trim().min(1).max(180),
+    mode: AutotraderSessionModeSchema.default('market_session'),
+    tradingDate: z.string().trim().min(1).max(40),
+    accountId: z.string().trim().min(1).max(180).optional(),
+    goalEquity: NumericStringSchema.default('500000'),
+    marketOpenAt: z.string().trim().min(1).max(80),
+    marketCloseAt: z.string().trim().min(1).max(80),
+    analysisHead: z.string().trim().min(1).max(120).optional(),
+    analysisContextHash: z.string().trim().min(1).max(160).optional(),
+  })
+  .strict()
+
+export const AutotraderUpsertStatusInputSchema = z
+  .object({
+    sessionId: z.string().trim().min(1),
+    cycle: z.coerce.number().int().min(0),
+    phase: AutotraderPhaseSchema,
+    equity: OptionalNumericStringSchema,
+    buyingPower: OptionalNumericStringSchema,
+    daytradeBuyingPower: OptionalNumericStringSchema,
+    grossExposure: OptionalNumericStringSchema,
+    netExposure: OptionalNumericStringSchema,
+    realizedPnl: OptionalNumericStringSchema,
+    unrealizedPnl: OptionalNumericStringSchema,
+    currentAction: z.string().trim().min(1).max(500),
+    blocker: z.string().trim().min(1).max(1_000).nullable().optional(),
+    payload: PayloadSchema,
+  })
+  .strict()
+
+export const AutotraderAppendEventInputSchema = z
+  .object({
+    sessionId: z.string().trim().min(1),
+    seq: z.coerce.number().int().min(0),
+    occurredAt: z.string().trim().min(1).max(80).optional(),
+    eventType: z.string().trim().min(1).max(120),
+    symbol: z.string().trim().min(1).max(32).optional(),
+    setupType: z.string().trim().min(1).max(120).optional(),
+    setupGrade: AutotraderSetupGradeSchema.optional(),
+    severity: AutotraderSeveritySchema.default('info'),
+    payload: PayloadSchema,
+  })
+  .strict()
+
+export const AutotraderCreateTradeTicketInputSchema = z
+  .object({
+    sessionId: z.string().trim().min(1),
+    idempotencyKey: z.string().trim().min(1).max(240),
+    symbol: z.string().trim().min(1).max(32),
+    instrument: AutotraderInstrumentSchema,
+    side: AutotraderSideSchema,
+    setupType: z.string().trim().min(1).max(120),
+    setupGrade: AutotraderSetupGradeSchema,
+    fatPitch: z.boolean().default(false),
+    regime: z.string().trim().min(1).max(120),
+    timeBucket: z.string().trim().min(1).max(80).optional(),
+    thesis: z.string().trim().min(1).max(2_000),
+    entryTrigger: z.string().trim().min(1).max(1_200),
+    invalidation: z.string().trim().min(1).max(1_200),
+    entryLimitPrice: OptionalNumericStringSchema,
+    stopPrice: OptionalNumericStringSchema,
+    targetPrice: OptionalNumericStringSchema,
+    expectedR: OptionalNumericStringSchema,
+    maxLossAmount: OptionalNumericStringSchema,
+    riskDollars: OptionalNumericStringSchema,
+    plannedQuantity: OptionalNumericStringSchema,
+    protectionType: z.string().trim().min(1).max(80),
+    brokerOrderPlan: PayloadSchema,
+    status: AutotraderTicketStatusSchema.default('candidate'),
+    noTradeReason: z.string().trim().min(1).max(1_000).nullable().optional(),
+  })
+  .strict()
+
+export const AutotraderRecordRiskCheckInputSchema = z
+  .object({
+    sessionId: z.string().trim().min(1),
+    ticketId: z.string().trim().min(1).optional(),
+    idempotencyKey: z.string().trim().min(1).max(240),
+    checkType: z.string().trim().min(1).max(120),
+    passed: z.boolean(),
+    reason: z.string().trim().min(1).max(1_200).optional(),
+    payload: PayloadSchema,
+  })
+  .strict()
+
+export const AutotraderRecordOrderInputSchema = z
+  .object({
+    sessionId: z.string().trim().min(1),
+    ticketId: z.string().trim().min(1).optional(),
+    clientOrderId: z.string().trim().min(1).max(240),
+    brokerOrderId: z.string().trim().min(1).max(240).nullable().optional(),
+    symbol: z.string().trim().min(1).max(32),
+    instrument: AutotraderInstrumentSchema,
+    side: AutotraderSideSchema,
+    quantity: NumericStringSchema,
+    orderType: z.string().trim().min(1).max(80),
+    orderClass: z.string().trim().min(1).max(80).optional(),
+    limitPrice: OptionalNumericStringSchema,
+    stopPrice: OptionalNumericStringSchema,
+    takeProfitLimitPrice: OptionalNumericStringSchema,
+    stopLossStopPrice: OptionalNumericStringSchema,
+    status: AutotraderOrderStatusSchema,
+    rejectReason: z.string().trim().min(1).max(1_000).nullable().optional(),
+    brokerPayload: PayloadSchema,
+  })
+  .strict()
+
+export const AutotraderRecordFillInputSchema = z
+  .object({
+    sessionId: z.string().trim().min(1),
+    clientOrderId: z.string().trim().min(1).max(240),
+    brokerFillId: z.string().trim().min(1).max(240),
+    symbol: z.string().trim().min(1).max(32),
+    side: AutotraderSideSchema,
+    quantity: NumericStringSchema,
+    price: NumericStringSchema,
+    filledAt: z.string().trim().min(1).max(80),
+    brokerPayload: PayloadSchema,
+  })
+  .strict()
+
+export const AutotraderRecordPositionSnapshotInputSchema = z
+  .object({
+    sessionId: z.string().trim().min(1),
+    symbol: z.string().trim().min(1).max(32),
+    quantity: NumericStringSchema,
+    marketValue: OptionalNumericStringSchema,
+    averageEntryPrice: OptionalNumericStringSchema,
+    unrealizedPnl: OptionalNumericStringSchema,
+    capturedAt: z.string().trim().min(1).max(80).optional(),
+    brokerPayload: PayloadSchema,
+  })
+  .strict()
+
+export const AutotraderScorecardObservationSchema = z
+  .object({
+    ticketId: z.string().trim().min(1).optional(),
+    symbol: z.string().trim().min(1).max(32).optional(),
+    setupType: z.string().trim().min(1).max(120),
+    setupGrade: AutotraderSetupGradeSchema,
+    regime: z.string().trim().min(1).max(120),
+    timeBucket: z.string().trim().min(1).max(80),
+    outcome: AutotraderOutcomeSchema,
+    realizedR: OptionalNumericStringSchema,
+    holdSeconds: OptionalNumericStringSchema,
+    mfeR: OptionalNumericStringSchema,
+    maeR: OptionalNumericStringSchema,
+    mistakeTags: TagsSchema,
+    notes: z.string().trim().min(1).max(1_200).optional(),
+    payload: PayloadSchema,
+  })
+  .strict()
+
+export const AutotraderFinalizeSessionInputSchema = z
+  .object({
+    sessionId: z.string().trim().min(1),
+    terminalReason: z.string().trim().min(1).max(240),
+    summary: PayloadSchema,
+    scorecardObservations: z.array(AutotraderScorecardObservationSchema).max(200).default([]),
+  })
+  .strict()
+
+export const AutotraderGetScorecardInputSchema = z
+  .object({
+    symbol: z.string().trim().min(1).max(32).optional(),
+    setupType: z.string().trim().min(1).max(120).optional(),
+    setupGrade: AutotraderSetupGradeSchema.optional(),
+    regime: z.string().trim().min(1).max(120).optional(),
+    timeBucket: z.string().trim().min(1).max(80).optional(),
+    limit: z.coerce.number().int().min(1).max(100).default(20),
+  })
+  .strict()
+
+export const AutotraderListSessionsInputSchema = z
+  .object({
+    limit: z.coerce.number().int().min(1).max(100).default(20),
+  })
+  .strict()
+
+export type AutotraderStartSessionInput = z.infer<typeof AutotraderStartSessionInputSchema>
+export type AutotraderUpsertStatusInput = z.infer<typeof AutotraderUpsertStatusInputSchema>
+export type AutotraderAppendEventInput = z.infer<typeof AutotraderAppendEventInputSchema>
+export type AutotraderCreateTradeTicketInput = z.infer<typeof AutotraderCreateTradeTicketInputSchema>
+export type AutotraderRecordRiskCheckInput = z.infer<typeof AutotraderRecordRiskCheckInputSchema>
+export type AutotraderRecordOrderInput = z.infer<typeof AutotraderRecordOrderInputSchema>
+export type AutotraderRecordFillInput = z.infer<typeof AutotraderRecordFillInputSchema>
+export type AutotraderRecordPositionSnapshotInput = z.infer<typeof AutotraderRecordPositionSnapshotInputSchema>
+export type AutotraderFinalizeSessionInput = z.infer<typeof AutotraderFinalizeSessionInputSchema>
+export type AutotraderGetScorecardInput = z.infer<typeof AutotraderGetScorecardInputSchema>
+export type AutotraderScorecardObservation = z.infer<typeof AutotraderScorecardObservationSchema>
+
+export type AutotraderSession = {
+  id: string
+  agentRunName: string
+  mode: z.infer<typeof AutotraderSessionModeSchema>
+  tradingDate: string
+  accountId: string | null
+  goalEquity: string
+  marketOpenAt: string
+  marketCloseAt: string
+  analysisHead: string | null
+  analysisContextHash: string | null
+  startedAt: string
+  finalizedAt: string | null
+  terminalReason: string | null
+  summary: Record<string, unknown>
+}
+
+export type AutotraderStatus = {
+  sessionId: string
+  cycle: number
+  phase: z.infer<typeof AutotraderPhaseSchema>
+  equity: string | null
+  buyingPower: string | null
+  daytradeBuyingPower: string | null
+  grossExposure: string | null
+  netExposure: string | null
+  realizedPnl: string | null
+  unrealizedPnl: string | null
+  currentAction: string
+  blocker: string | null
+  payload: Record<string, unknown>
+  updatedAt: string
+}
+
+export type AutotraderEvent = {
+  sessionId: string
+  seq: number
+  occurredAt: string
+  eventType: string
+  symbol: string | null
+  setupType: string | null
+  setupGrade: z.infer<typeof AutotraderSetupGradeSchema> | null
+  severity: z.infer<typeof AutotraderSeveritySchema>
+  payload: Record<string, unknown>
+}
+
+export type AutotraderTradeTicket = {
+  id: string
+  sessionId: string
+  idempotencyKey: string
+  symbol: string
+  instrument: z.infer<typeof AutotraderInstrumentSchema>
+  side: z.infer<typeof AutotraderSideSchema>
+  setupType: string
+  setupGrade: z.infer<typeof AutotraderSetupGradeSchema>
+  fatPitch: boolean
+  regime: string
+  timeBucket: string | null
+  thesis: string
+  entryTrigger: string
+  invalidation: string
+  entryLimitPrice: string | null
+  stopPrice: string | null
+  targetPrice: string | null
+  expectedR: string | null
+  maxLossAmount: string | null
+  riskDollars: string | null
+  plannedQuantity: string | null
+  protectionType: string
+  brokerOrderPlan: Record<string, unknown>
+  status: z.infer<typeof AutotraderTicketStatusSchema>
+  noTradeReason: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type AutotraderRiskCheck = {
+  id: string
+  sessionId: string
+  ticketId: string | null
+  idempotencyKey: string
+  checkType: string
+  passed: boolean
+  reason: string | null
+  payload: Record<string, unknown>
+  createdAt: string
+}
+
+export type AutotraderOrder = {
+  sessionId: string
+  ticketId: string | null
+  clientOrderId: string
+  brokerOrderId: string | null
+  symbol: string
+  instrument: z.infer<typeof AutotraderInstrumentSchema>
+  side: z.infer<typeof AutotraderSideSchema>
+  quantity: string
+  orderType: string
+  orderClass: string | null
+  limitPrice: string | null
+  stopPrice: string | null
+  takeProfitLimitPrice: string | null
+  stopLossStopPrice: string | null
+  status: z.infer<typeof AutotraderOrderStatusSchema>
+  rejectReason: string | null
+  brokerPayload: Record<string, unknown>
+  updatedAt: string
+}
+
+export type AutotraderFill = {
+  sessionId: string
+  clientOrderId: string
+  brokerFillId: string
+  symbol: string
+  side: z.infer<typeof AutotraderSideSchema>
+  quantity: string
+  price: string
+  filledAt: string
+  brokerPayload: Record<string, unknown>
+}
+
+export type AutotraderPositionSnapshot = {
+  id: string
+  sessionId: string
+  symbol: string
+  quantity: string
+  marketValue: string | null
+  averageEntryPrice: string | null
+  unrealizedPnl: string | null
+  capturedAt: string
+  brokerPayload: Record<string, unknown>
+}
+
+export type AutotraderScorecard = {
+  key: string
+  symbol: string | null
+  setupType: string
+  setupGrade: z.infer<typeof AutotraderSetupGradeSchema>
+  regime: string
+  timeBucket: string
+  sampleSize: number
+  wins: number
+  losses: number
+  scratches: number
+  rejectedValid: number
+  rejectedInvalid: number
+  totalRealizedR: string
+  avgRealizedR: string
+  avgHoldSeconds: string | null
+  avgMfeR: string | null
+  avgMaeR: string | null
+  lastOutcome: z.infer<typeof AutotraderOutcomeSchema> | null
+  confidence: string
+  updatedAt: string
+  lastSessionId: string | null
+}
+
+export type AutotraderSetupExample = {
+  id: string
+  scorecardKey: string
+  sessionId: string
+  ticketId: string | null
+  symbol: string | null
+  setupType: string
+  setupGrade: z.infer<typeof AutotraderSetupGradeSchema>
+  regime: string
+  timeBucket: string
+  outcome: z.infer<typeof AutotraderOutcomeSchema>
+  realizedR: string | null
+  notes: string | null
+  mistakeTags: string[]
+  payload: Record<string, unknown>
+  createdAt: string
+}
+
+export type AutotraderSessionDetail = {
+  session: AutotraderSession
+  status: AutotraderStatus | null
+  events: AutotraderEvent[]
+  tradeTickets: AutotraderTradeTicket[]
+  riskChecks: AutotraderRiskCheck[]
+  orders: AutotraderOrder[]
+  fills: AutotraderFill[]
+  positionSnapshots: AutotraderPositionSnapshot[]
+  scorecards: AutotraderScorecard[]
+  setupExamples: AutotraderSetupExample[]
+}

--- a/apps/synthesis/src/server/autotrader-store.ts
+++ b/apps/synthesis/src/server/autotrader-store.ts
@@ -1,0 +1,1590 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { Pool, type PoolClient } from 'pg'
+
+import type {
+  AutotraderAppendEventInput,
+  AutotraderCreateTradeTicketInput,
+  AutotraderEvent,
+  AutotraderFill,
+  AutotraderFinalizeSessionInput,
+  AutotraderGetScorecardInput,
+  AutotraderOrder,
+  AutotraderPositionSnapshot,
+  AutotraderRecordFillInput,
+  AutotraderRecordOrderInput,
+  AutotraderRecordPositionSnapshotInput,
+  AutotraderRecordRiskCheckInput,
+  AutotraderRiskCheck,
+  AutotraderScorecard,
+  AutotraderScorecardObservation,
+  AutotraderSession,
+  AutotraderSessionDetail,
+  AutotraderSetupExample,
+  AutotraderStartSessionInput,
+  AutotraderStatus,
+  AutotraderTradeTicket,
+  AutotraderUpsertStatusInput,
+} from './autotrader-schema'
+
+export type AutotraderStore = {
+  startSession(input: AutotraderStartSessionInput): Promise<AutotraderSession>
+  upsertStatus(input: AutotraderUpsertStatusInput): Promise<AutotraderStatus>
+  appendEvent(input: AutotraderAppendEventInput): Promise<AutotraderEvent>
+  createTradeTicket(input: AutotraderCreateTradeTicketInput): Promise<AutotraderTradeTicket>
+  recordRiskCheck(input: AutotraderRecordRiskCheckInput): Promise<AutotraderRiskCheck>
+  recordOrder(input: AutotraderRecordOrderInput): Promise<AutotraderOrder>
+  recordFill(input: AutotraderRecordFillInput): Promise<AutotraderFill>
+  recordPositionSnapshot(input: AutotraderRecordPositionSnapshotInput): Promise<AutotraderPositionSnapshot>
+  finalizeSession(input: AutotraderFinalizeSessionInput): Promise<AutotraderSessionDetail>
+  getScorecard(input: AutotraderGetScorecardInput): Promise<{
+    scorecards: AutotraderScorecard[]
+    setupExamples: AutotraderSetupExample[]
+  }>
+  listSessions(limit: number): Promise<AutotraderSession[]>
+  getSessionDetail(sessionId: string): Promise<AutotraderSessionDetail | null>
+}
+
+const nowIso = () => new Date().toISOString()
+
+const toIso = (value: Date | string | null | undefined) => {
+  if (!value) return null
+  if (value instanceof Date) return value.toISOString()
+  const parsed = new Date(value)
+  if (!Number.isNaN(parsed.getTime())) return parsed.toISOString()
+  return value
+}
+
+const toPayload = (value: unknown): Record<string, unknown> => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as Record<string, unknown>
+}
+
+const toJson = (value: Record<string, unknown>) => JSON.stringify(value)
+const numericOrNull = (value: string | null | undefined) => value ?? null
+const normalizedSymbol = (value: string | null | undefined) => value?.trim().toUpperCase() || null
+const scorecardSymbol = (value: string | null | undefined) => normalizedSymbol(value) ?? '*'
+
+const scorecardKeyFor = (value: {
+  symbol?: string | null
+  setupType: string
+  setupGrade: string
+  regime: string
+  timeBucket: string
+}) =>
+  createHash('sha256')
+    .update(
+      [
+        scorecardSymbol(value.symbol),
+        value.setupType.trim(),
+        value.setupGrade,
+        value.regime.trim(),
+        value.timeBucket.trim(),
+      ]
+        .join('|')
+        .toLowerCase(),
+    )
+    .digest('base64url')
+    .slice(0, 32)
+
+const asNumber = (value: string | number | null | undefined) => {
+  if (value == null) return 0
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+const averageWithObservation = (currentAverage: string | null, sampleSize: number, next: string | null | undefined) => {
+  if (next == null) return currentAverage
+  const divisor = sampleSize + 1
+  return String((asNumber(currentAverage) * sampleSize + asNumber(next)) / divisor)
+}
+
+const confidenceForSampleSize = (sampleSize: number) => String(Number((sampleSize / (sampleSize + 10)).toFixed(4)))
+
+const updateScorecardWithObservation = (
+  existing: AutotraderScorecard | null,
+  sessionId: string,
+  observation: AutotraderScorecardObservation,
+): AutotraderScorecard => {
+  const key = scorecardKeyFor(observation)
+  const sampleSize = (existing?.sampleSize ?? 0) + 1
+  const realizedR = observation.realizedR ?? '0'
+  const totalRealizedR = asNumber(existing?.totalRealizedR) + asNumber(realizedR)
+  const wins = (existing?.wins ?? 0) + (observation.outcome === 'win' ? 1 : 0)
+  const losses = (existing?.losses ?? 0) + (observation.outcome === 'loss' ? 1 : 0)
+  const scratches = (existing?.scratches ?? 0) + (observation.outcome === 'scratch' ? 1 : 0)
+  const rejectedValid = (existing?.rejectedValid ?? 0) + (observation.outcome === 'rejected_valid' ? 1 : 0)
+  const rejectedInvalid = (existing?.rejectedInvalid ?? 0) + (observation.outcome === 'rejected_invalid' ? 1 : 0)
+
+  return {
+    key,
+    symbol: normalizedSymbol(observation.symbol),
+    setupType: observation.setupType,
+    setupGrade: observation.setupGrade,
+    regime: observation.regime,
+    timeBucket: observation.timeBucket,
+    sampleSize,
+    wins,
+    losses,
+    scratches,
+    rejectedValid,
+    rejectedInvalid,
+    totalRealizedR: String(totalRealizedR),
+    avgRealizedR: String(totalRealizedR / sampleSize),
+    avgHoldSeconds: averageWithObservation(
+      existing?.avgHoldSeconds ?? null,
+      existing?.sampleSize ?? 0,
+      observation.holdSeconds,
+    ),
+    avgMfeR: averageWithObservation(existing?.avgMfeR ?? null, existing?.sampleSize ?? 0, observation.mfeR),
+    avgMaeR: averageWithObservation(existing?.avgMaeR ?? null, existing?.sampleSize ?? 0, observation.maeR),
+    lastOutcome: observation.outcome,
+    confidence: confidenceForSampleSize(sampleSize),
+    updatedAt: nowIso(),
+    lastSessionId: sessionId,
+  }
+}
+
+const exampleFromObservation = (
+  sessionId: string,
+  observation: AutotraderScorecardObservation,
+): AutotraderSetupExample => ({
+  id: randomUUID(),
+  scorecardKey: scorecardKeyFor(observation),
+  sessionId,
+  ticketId: observation.ticketId ?? null,
+  symbol: normalizedSymbol(observation.symbol),
+  setupType: observation.setupType,
+  setupGrade: observation.setupGrade,
+  regime: observation.regime,
+  timeBucket: observation.timeBucket,
+  outcome: observation.outcome,
+  realizedR: observation.realizedR ?? null,
+  notes: observation.notes ?? null,
+  mistakeTags: observation.mistakeTags,
+  payload: observation.payload,
+  createdAt: nowIso(),
+})
+
+class InMemoryAutotraderStore implements AutotraderStore {
+  private sessions = new Map<string, AutotraderSession>()
+  private sessionByAgentRunName = new Map<string, string>()
+  private statuses = new Map<string, AutotraderStatus>()
+  private events = new Map<string, AutotraderEvent>()
+  private tickets = new Map<string, AutotraderTradeTicket>()
+  private ticketByIdempotency = new Map<string, string>()
+  private riskChecks = new Map<string, AutotraderRiskCheck>()
+  private riskByIdempotency = new Map<string, string>()
+  private orders = new Map<string, AutotraderOrder>()
+  private fills = new Map<string, AutotraderFill>()
+  private positions = new Map<string, AutotraderPositionSnapshot>()
+  private scorecards = new Map<string, AutotraderScorecard>()
+  private examples = new Map<string, AutotraderSetupExample>()
+
+  async startSession(input: AutotraderStartSessionInput): Promise<AutotraderSession> {
+    const existingId = this.sessionByAgentRunName.get(input.agentRunName)
+    const existing = existingId ? this.sessions.get(existingId) : null
+    if (existing) return existing
+
+    const session: AutotraderSession = {
+      id: randomUUID(),
+      agentRunName: input.agentRunName,
+      mode: input.mode,
+      tradingDate: input.tradingDate,
+      accountId: input.accountId ?? null,
+      goalEquity: input.goalEquity,
+      marketOpenAt: input.marketOpenAt,
+      marketCloseAt: input.marketCloseAt,
+      analysisHead: input.analysisHead ?? null,
+      analysisContextHash: input.analysisContextHash ?? null,
+      startedAt: nowIso(),
+      finalizedAt: null,
+      terminalReason: null,
+      summary: {},
+    }
+    this.sessions.set(session.id, session)
+    this.sessionByAgentRunName.set(session.agentRunName, session.id)
+    return session
+  }
+
+  async upsertStatus(input: AutotraderUpsertStatusInput): Promise<AutotraderStatus> {
+    this.requireSession(input.sessionId)
+    const status: AutotraderStatus = {
+      sessionId: input.sessionId,
+      cycle: input.cycle,
+      phase: input.phase,
+      equity: input.equity ?? null,
+      buyingPower: input.buyingPower ?? null,
+      daytradeBuyingPower: input.daytradeBuyingPower ?? null,
+      grossExposure: input.grossExposure ?? null,
+      netExposure: input.netExposure ?? null,
+      realizedPnl: input.realizedPnl ?? null,
+      unrealizedPnl: input.unrealizedPnl ?? null,
+      currentAction: input.currentAction,
+      blocker: input.blocker ?? null,
+      payload: input.payload,
+      updatedAt: nowIso(),
+    }
+    this.statuses.set(input.sessionId, status)
+    return status
+  }
+
+  async appendEvent(input: AutotraderAppendEventInput): Promise<AutotraderEvent> {
+    this.requireSession(input.sessionId)
+    const event: AutotraderEvent = {
+      sessionId: input.sessionId,
+      seq: input.seq,
+      occurredAt: toIso(input.occurredAt) ?? nowIso(),
+      eventType: input.eventType,
+      symbol: normalizedSymbol(input.symbol),
+      setupType: input.setupType ?? null,
+      setupGrade: input.setupGrade ?? null,
+      severity: input.severity,
+      payload: input.payload,
+    }
+    this.events.set(`${input.sessionId}:${input.seq}`, event)
+    return event
+  }
+
+  async createTradeTicket(input: AutotraderCreateTradeTicketInput): Promise<AutotraderTradeTicket> {
+    this.requireSession(input.sessionId)
+    const idempotencyKey = `${input.sessionId}:${input.idempotencyKey}`
+    const existingId = this.ticketByIdempotency.get(idempotencyKey)
+    const existing = existingId ? this.tickets.get(existingId) : null
+    const timestamp = nowIso()
+    const ticket: AutotraderTradeTicket = {
+      id: existing?.id ?? randomUUID(),
+      sessionId: input.sessionId,
+      idempotencyKey: input.idempotencyKey,
+      symbol: normalizedSymbol(input.symbol) ?? input.symbol,
+      instrument: input.instrument,
+      side: input.side,
+      setupType: input.setupType,
+      setupGrade: input.setupGrade,
+      fatPitch: input.fatPitch,
+      regime: input.regime,
+      timeBucket: input.timeBucket ?? null,
+      thesis: input.thesis,
+      entryTrigger: input.entryTrigger,
+      invalidation: input.invalidation,
+      entryLimitPrice: input.entryLimitPrice ?? null,
+      stopPrice: input.stopPrice ?? null,
+      targetPrice: input.targetPrice ?? null,
+      expectedR: input.expectedR ?? null,
+      maxLossAmount: input.maxLossAmount ?? null,
+      riskDollars: input.riskDollars ?? null,
+      plannedQuantity: input.plannedQuantity ?? null,
+      protectionType: input.protectionType,
+      brokerOrderPlan: input.brokerOrderPlan,
+      status: input.status,
+      noTradeReason: input.noTradeReason ?? null,
+      createdAt: existing?.createdAt ?? timestamp,
+      updatedAt: timestamp,
+    }
+    this.ticketByIdempotency.set(idempotencyKey, ticket.id)
+    this.tickets.set(ticket.id, ticket)
+    return ticket
+  }
+
+  async recordRiskCheck(input: AutotraderRecordRiskCheckInput): Promise<AutotraderRiskCheck> {
+    this.requireSession(input.sessionId)
+    const key = `${input.sessionId}:${input.idempotencyKey}`
+    const existingId = this.riskByIdempotency.get(key)
+    const existing = existingId ? this.riskChecks.get(existingId) : null
+    const riskCheck: AutotraderRiskCheck = {
+      id: existing?.id ?? randomUUID(),
+      sessionId: input.sessionId,
+      ticketId: input.ticketId ?? null,
+      idempotencyKey: input.idempotencyKey,
+      checkType: input.checkType,
+      passed: input.passed,
+      reason: input.reason ?? null,
+      payload: input.payload,
+      createdAt: existing?.createdAt ?? nowIso(),
+    }
+    this.riskByIdempotency.set(key, riskCheck.id)
+    this.riskChecks.set(riskCheck.id, riskCheck)
+    return riskCheck
+  }
+
+  async recordOrder(input: AutotraderRecordOrderInput): Promise<AutotraderOrder> {
+    this.requireSession(input.sessionId)
+    const order: AutotraderOrder = {
+      sessionId: input.sessionId,
+      ticketId: input.ticketId ?? null,
+      clientOrderId: input.clientOrderId,
+      brokerOrderId: input.brokerOrderId ?? null,
+      symbol: normalizedSymbol(input.symbol) ?? input.symbol,
+      instrument: input.instrument,
+      side: input.side,
+      quantity: input.quantity,
+      orderType: input.orderType,
+      orderClass: input.orderClass ?? null,
+      limitPrice: input.limitPrice ?? null,
+      stopPrice: input.stopPrice ?? null,
+      takeProfitLimitPrice: input.takeProfitLimitPrice ?? null,
+      stopLossStopPrice: input.stopLossStopPrice ?? null,
+      status: input.status,
+      rejectReason: input.rejectReason ?? null,
+      brokerPayload: input.brokerPayload,
+      updatedAt: nowIso(),
+    }
+    this.orders.set(order.clientOrderId, order)
+    return order
+  }
+
+  async recordFill(input: AutotraderRecordFillInput): Promise<AutotraderFill> {
+    this.requireSession(input.sessionId)
+    const fill: AutotraderFill = {
+      sessionId: input.sessionId,
+      clientOrderId: input.clientOrderId,
+      brokerFillId: input.brokerFillId,
+      symbol: normalizedSymbol(input.symbol) ?? input.symbol,
+      side: input.side,
+      quantity: input.quantity,
+      price: input.price,
+      filledAt: toIso(input.filledAt) ?? input.filledAt,
+      brokerPayload: input.brokerPayload,
+    }
+    this.fills.set(fill.brokerFillId, fill)
+    return fill
+  }
+
+  async recordPositionSnapshot(input: AutotraderRecordPositionSnapshotInput): Promise<AutotraderPositionSnapshot> {
+    this.requireSession(input.sessionId)
+    const capturedAt = toIso(input.capturedAt) ?? nowIso()
+    const id = `${input.sessionId}:${normalizedSymbol(input.symbol) ?? input.symbol}:${capturedAt}`
+    const snapshot: AutotraderPositionSnapshot = {
+      id,
+      sessionId: input.sessionId,
+      symbol: normalizedSymbol(input.symbol) ?? input.symbol,
+      quantity: input.quantity,
+      marketValue: input.marketValue ?? null,
+      averageEntryPrice: input.averageEntryPrice ?? null,
+      unrealizedPnl: input.unrealizedPnl ?? null,
+      capturedAt,
+      brokerPayload: input.brokerPayload,
+    }
+    this.positions.set(snapshot.id, snapshot)
+    return snapshot
+  }
+
+  async finalizeSession(input: AutotraderFinalizeSessionInput): Promise<AutotraderSessionDetail> {
+    const session = this.requireSession(input.sessionId)
+    const updatedSession: AutotraderSession = {
+      ...session,
+      finalizedAt: nowIso(),
+      terminalReason: input.terminalReason,
+      summary: input.summary,
+    }
+    this.sessions.set(updatedSession.id, updatedSession)
+    for (const observation of input.scorecardObservations) {
+      const key = scorecardKeyFor(observation)
+      this.scorecards.set(
+        key,
+        updateScorecardWithObservation(this.scorecards.get(key) ?? null, input.sessionId, observation),
+      )
+      const example = exampleFromObservation(input.sessionId, observation)
+      this.examples.set(example.id, example)
+    }
+    const detail = await this.getSessionDetail(input.sessionId)
+    if (!detail) throw new Error(`Unknown autotrader session: ${input.sessionId}`)
+    return detail
+  }
+
+  async getScorecard(input: AutotraderGetScorecardInput) {
+    const scorecards = [...this.scorecards.values()]
+      .filter((scorecard) => (input.symbol ? scorecard.symbol === normalizedSymbol(input.symbol) : true))
+      .filter((scorecard) => (input.setupType ? scorecard.setupType === input.setupType : true))
+      .filter((scorecard) => (input.setupGrade ? scorecard.setupGrade === input.setupGrade : true))
+      .filter((scorecard) => (input.regime ? scorecard.regime === input.regime : true))
+      .filter((scorecard) => (input.timeBucket ? scorecard.timeBucket === input.timeBucket : true))
+      .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))
+      .slice(0, input.limit)
+    const keys = new Set(scorecards.map((scorecard) => scorecard.key))
+    const setupExamples = [...this.examples.values()]
+      .filter((example) => keys.has(example.scorecardKey))
+      .sort((left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt))
+      .slice(0, input.limit * 3)
+    return { scorecards, setupExamples }
+  }
+
+  async listSessions(limit: number): Promise<AutotraderSession[]> {
+    return [...this.sessions.values()]
+      .sort((left, right) => Date.parse(right.startedAt) - Date.parse(left.startedAt))
+      .slice(0, limit)
+  }
+
+  async getSessionDetail(sessionId: string): Promise<AutotraderSessionDetail | null> {
+    const session = this.sessions.get(sessionId)
+    if (!session) return null
+    const sessionTickets = [...this.tickets.values()].filter((ticket) => ticket.sessionId === sessionId)
+    const ticketScorecardKeys = new Set(
+      sessionTickets.map((ticket) =>
+        scorecardKeyFor({
+          symbol: ticket.symbol,
+          setupType: ticket.setupType,
+          setupGrade: ticket.setupGrade,
+          regime: ticket.regime,
+          timeBucket: ticket.timeBucket ?? 'unknown',
+        }),
+      ),
+    )
+    return {
+      session,
+      status: this.statuses.get(sessionId) ?? null,
+      events: [...this.events.values()]
+        .filter((event) => event.sessionId === sessionId)
+        .sort((left, right) => left.seq - right.seq),
+      tradeTickets: sessionTickets,
+      riskChecks: [...this.riskChecks.values()].filter((riskCheck) => riskCheck.sessionId === sessionId),
+      orders: [...this.orders.values()].filter((order) => order.sessionId === sessionId),
+      fills: [...this.fills.values()].filter((fill) => fill.sessionId === sessionId),
+      positionSnapshots: [...this.positions.values()]
+        .filter((snapshot) => snapshot.sessionId === sessionId)
+        .sort((left, right) => Date.parse(right.capturedAt) - Date.parse(left.capturedAt)),
+      scorecards: [...this.scorecards.values()].filter((scorecard) => ticketScorecardKeys.has(scorecard.key)),
+      setupExamples: [...this.examples.values()].filter((example) => example.sessionId === sessionId),
+    }
+  }
+
+  private requireSession(sessionId: string) {
+    const session = this.sessions.get(sessionId)
+    if (!session) throw new Error(`Unknown autotrader session: ${sessionId}`)
+    return session
+  }
+}
+
+type SessionRow = {
+  id: string
+  agent_run_name: string
+  mode: AutotraderSession['mode']
+  trading_date: string
+  account_id: string | null
+  goal_equity: string
+  market_open_at: Date | string
+  market_close_at: Date | string
+  analysis_head: string | null
+  analysis_context_hash: string | null
+  started_at: Date | string
+  finalized_at: Date | string | null
+  terminal_reason: string | null
+  summary: unknown
+}
+
+type StatusRow = {
+  session_id: string
+  cycle: number
+  phase: AutotraderStatus['phase']
+  equity: string | null
+  buying_power: string | null
+  daytrade_buying_power: string | null
+  gross_exposure: string | null
+  net_exposure: string | null
+  realized_pnl: string | null
+  unrealized_pnl: string | null
+  current_action: string
+  blocker: string | null
+  payload: unknown
+  updated_at: Date | string
+}
+
+type EventRow = {
+  session_id: string
+  seq: number
+  occurred_at: Date | string
+  event_type: string
+  symbol: string | null
+  setup_type: string | null
+  setup_grade: AutotraderEvent['setupGrade']
+  severity: AutotraderEvent['severity']
+  payload: unknown
+}
+
+type TicketRow = {
+  id: string
+  session_id: string
+  idempotency_key: string
+  symbol: string
+  instrument: AutotraderTradeTicket['instrument']
+  side: AutotraderTradeTicket['side']
+  setup_type: string
+  setup_grade: AutotraderTradeTicket['setupGrade']
+  fat_pitch: boolean
+  regime: string
+  time_bucket: string | null
+  thesis: string
+  entry_trigger: string
+  invalidation: string
+  entry_limit_price: string | null
+  stop_price: string | null
+  target_price: string | null
+  expected_r: string | null
+  max_loss_amount: string | null
+  risk_dollars: string | null
+  planned_quantity: string | null
+  protection_type: string
+  broker_order_plan: unknown
+  status: AutotraderTradeTicket['status']
+  no_trade_reason: string | null
+  created_at: Date | string
+  updated_at: Date | string
+}
+
+type RiskCheckRow = {
+  id: string
+  session_id: string
+  ticket_id: string | null
+  idempotency_key: string
+  check_type: string
+  passed: boolean
+  reason: string | null
+  payload: unknown
+  created_at: Date | string
+}
+
+type OrderRow = {
+  session_id: string
+  ticket_id: string | null
+  client_order_id: string
+  broker_order_id: string | null
+  symbol: string
+  instrument: AutotraderOrder['instrument']
+  side: AutotraderOrder['side']
+  quantity: string
+  order_type: string
+  order_class: string | null
+  limit_price: string | null
+  stop_price: string | null
+  take_profit_limit_price: string | null
+  stop_loss_stop_price: string | null
+  status: AutotraderOrder['status']
+  reject_reason: string | null
+  broker_payload: unknown
+  updated_at: Date | string
+}
+
+type FillRow = {
+  session_id: string
+  client_order_id: string
+  broker_fill_id: string
+  symbol: string
+  side: AutotraderFill['side']
+  quantity: string
+  price: string
+  filled_at: Date | string
+  broker_payload: unknown
+}
+
+type PositionSnapshotRow = {
+  id: string
+  session_id: string
+  symbol: string
+  quantity: string
+  market_value: string | null
+  average_entry_price: string | null
+  unrealized_pnl: string | null
+  captured_at: Date | string
+  broker_payload: unknown
+}
+
+type ScorecardRow = {
+  key: string
+  symbol: string | null
+  setup_type: string
+  setup_grade: AutotraderScorecard['setupGrade']
+  regime: string
+  time_bucket: string
+  sample_size: number
+  wins: number
+  losses: number
+  scratches: number
+  rejected_valid: number
+  rejected_invalid: number
+  total_realized_r: string
+  avg_realized_r: string
+  avg_hold_seconds: string | null
+  avg_mfe_r: string | null
+  avg_mae_r: string | null
+  last_outcome: AutotraderScorecard['lastOutcome']
+  confidence: string
+  updated_at: Date | string
+  last_session_id: string | null
+}
+
+type SetupExampleRow = {
+  id: string
+  scorecard_key: string
+  session_id: string
+  ticket_id: string | null
+  symbol: string | null
+  setup_type: string
+  setup_grade: AutotraderSetupExample['setupGrade']
+  regime: string
+  time_bucket: string
+  outcome: AutotraderSetupExample['outcome']
+  realized_r: string | null
+  notes: string | null
+  mistake_tags: unknown
+  payload: unknown
+  created_at: Date | string
+}
+
+const mapSession = (row: SessionRow): AutotraderSession => ({
+  id: row.id,
+  agentRunName: row.agent_run_name,
+  mode: row.mode,
+  tradingDate: row.trading_date,
+  accountId: row.account_id,
+  goalEquity: String(row.goal_equity),
+  marketOpenAt: toIso(row.market_open_at) ?? String(row.market_open_at),
+  marketCloseAt: toIso(row.market_close_at) ?? String(row.market_close_at),
+  analysisHead: row.analysis_head,
+  analysisContextHash: row.analysis_context_hash,
+  startedAt: toIso(row.started_at) ?? nowIso(),
+  finalizedAt: toIso(row.finalized_at),
+  terminalReason: row.terminal_reason,
+  summary: toPayload(row.summary),
+})
+
+const mapStatus = (row: StatusRow): AutotraderStatus => ({
+  sessionId: row.session_id,
+  cycle: Number(row.cycle),
+  phase: row.phase,
+  equity: row.equity == null ? null : String(row.equity),
+  buyingPower: row.buying_power == null ? null : String(row.buying_power),
+  daytradeBuyingPower: row.daytrade_buying_power == null ? null : String(row.daytrade_buying_power),
+  grossExposure: row.gross_exposure == null ? null : String(row.gross_exposure),
+  netExposure: row.net_exposure == null ? null : String(row.net_exposure),
+  realizedPnl: row.realized_pnl == null ? null : String(row.realized_pnl),
+  unrealizedPnl: row.unrealized_pnl == null ? null : String(row.unrealized_pnl),
+  currentAction: row.current_action,
+  blocker: row.blocker,
+  payload: toPayload(row.payload),
+  updatedAt: toIso(row.updated_at) ?? nowIso(),
+})
+
+const mapEvent = (row: EventRow): AutotraderEvent => ({
+  sessionId: row.session_id,
+  seq: Number(row.seq),
+  occurredAt: toIso(row.occurred_at) ?? nowIso(),
+  eventType: row.event_type,
+  symbol: row.symbol,
+  setupType: row.setup_type,
+  setupGrade: row.setup_grade,
+  severity: row.severity,
+  payload: toPayload(row.payload),
+})
+
+const mapTicket = (row: TicketRow): AutotraderTradeTicket => ({
+  id: row.id,
+  sessionId: row.session_id,
+  idempotencyKey: row.idempotency_key,
+  symbol: row.symbol,
+  instrument: row.instrument,
+  side: row.side,
+  setupType: row.setup_type,
+  setupGrade: row.setup_grade,
+  fatPitch: row.fat_pitch,
+  regime: row.regime,
+  timeBucket: row.time_bucket,
+  thesis: row.thesis,
+  entryTrigger: row.entry_trigger,
+  invalidation: row.invalidation,
+  entryLimitPrice: row.entry_limit_price == null ? null : String(row.entry_limit_price),
+  stopPrice: row.stop_price == null ? null : String(row.stop_price),
+  targetPrice: row.target_price == null ? null : String(row.target_price),
+  expectedR: row.expected_r == null ? null : String(row.expected_r),
+  maxLossAmount: row.max_loss_amount == null ? null : String(row.max_loss_amount),
+  riskDollars: row.risk_dollars == null ? null : String(row.risk_dollars),
+  plannedQuantity: row.planned_quantity == null ? null : String(row.planned_quantity),
+  protectionType: row.protection_type,
+  brokerOrderPlan: toPayload(row.broker_order_plan),
+  status: row.status,
+  noTradeReason: row.no_trade_reason,
+  createdAt: toIso(row.created_at) ?? nowIso(),
+  updatedAt: toIso(row.updated_at) ?? nowIso(),
+})
+
+const mapRiskCheck = (row: RiskCheckRow): AutotraderRiskCheck => ({
+  id: row.id,
+  sessionId: row.session_id,
+  ticketId: row.ticket_id,
+  idempotencyKey: row.idempotency_key,
+  checkType: row.check_type,
+  passed: row.passed,
+  reason: row.reason,
+  payload: toPayload(row.payload),
+  createdAt: toIso(row.created_at) ?? nowIso(),
+})
+
+const mapOrder = (row: OrderRow): AutotraderOrder => ({
+  sessionId: row.session_id,
+  ticketId: row.ticket_id,
+  clientOrderId: row.client_order_id,
+  brokerOrderId: row.broker_order_id,
+  symbol: row.symbol,
+  instrument: row.instrument,
+  side: row.side,
+  quantity: String(row.quantity),
+  orderType: row.order_type,
+  orderClass: row.order_class,
+  limitPrice: row.limit_price == null ? null : String(row.limit_price),
+  stopPrice: row.stop_price == null ? null : String(row.stop_price),
+  takeProfitLimitPrice: row.take_profit_limit_price == null ? null : String(row.take_profit_limit_price),
+  stopLossStopPrice: row.stop_loss_stop_price == null ? null : String(row.stop_loss_stop_price),
+  status: row.status,
+  rejectReason: row.reject_reason,
+  brokerPayload: toPayload(row.broker_payload),
+  updatedAt: toIso(row.updated_at) ?? nowIso(),
+})
+
+const mapFill = (row: FillRow): AutotraderFill => ({
+  sessionId: row.session_id,
+  clientOrderId: row.client_order_id,
+  brokerFillId: row.broker_fill_id,
+  symbol: row.symbol,
+  side: row.side,
+  quantity: String(row.quantity),
+  price: String(row.price),
+  filledAt: toIso(row.filled_at) ?? nowIso(),
+  brokerPayload: toPayload(row.broker_payload),
+})
+
+const mapPositionSnapshot = (row: PositionSnapshotRow): AutotraderPositionSnapshot => ({
+  id: row.id,
+  sessionId: row.session_id,
+  symbol: row.symbol,
+  quantity: String(row.quantity),
+  marketValue: row.market_value == null ? null : String(row.market_value),
+  averageEntryPrice: row.average_entry_price == null ? null : String(row.average_entry_price),
+  unrealizedPnl: row.unrealized_pnl == null ? null : String(row.unrealized_pnl),
+  capturedAt: toIso(row.captured_at) ?? nowIso(),
+  brokerPayload: toPayload(row.broker_payload),
+})
+
+const mapScorecard = (row: ScorecardRow): AutotraderScorecard => ({
+  key: row.key,
+  symbol: row.symbol,
+  setupType: row.setup_type,
+  setupGrade: row.setup_grade,
+  regime: row.regime,
+  timeBucket: row.time_bucket,
+  sampleSize: Number(row.sample_size),
+  wins: Number(row.wins),
+  losses: Number(row.losses),
+  scratches: Number(row.scratches),
+  rejectedValid: Number(row.rejected_valid),
+  rejectedInvalid: Number(row.rejected_invalid),
+  totalRealizedR: String(row.total_realized_r),
+  avgRealizedR: String(row.avg_realized_r),
+  avgHoldSeconds: row.avg_hold_seconds == null ? null : String(row.avg_hold_seconds),
+  avgMfeR: row.avg_mfe_r == null ? null : String(row.avg_mfe_r),
+  avgMaeR: row.avg_mae_r == null ? null : String(row.avg_mae_r),
+  lastOutcome: row.last_outcome,
+  confidence: String(row.confidence),
+  updatedAt: toIso(row.updated_at) ?? nowIso(),
+  lastSessionId: row.last_session_id,
+})
+
+const mapSetupExample = (row: SetupExampleRow): AutotraderSetupExample => ({
+  id: row.id,
+  scorecardKey: row.scorecard_key,
+  sessionId: row.session_id,
+  ticketId: row.ticket_id,
+  symbol: row.symbol,
+  setupType: row.setup_type,
+  setupGrade: row.setup_grade,
+  regime: row.regime,
+  timeBucket: row.time_bucket,
+  outcome: row.outcome,
+  realizedR: row.realized_r == null ? null : String(row.realized_r),
+  notes: row.notes,
+  mistakeTags: Array.isArray(row.mistake_tags) ? row.mistake_tags.map(String) : [],
+  payload: toPayload(row.payload),
+  createdAt: toIso(row.created_at) ?? nowIso(),
+})
+
+class PostgresAutotraderStore implements AutotraderStore {
+  private readonly pool: Pool
+  private schemaPromise: Promise<void> | null = null
+
+  constructor(databaseUrl: string) {
+    this.pool = new Pool({ connectionString: databaseUrl, max: 5 })
+  }
+
+  async startSession(input: AutotraderStartSessionInput): Promise<AutotraderSession> {
+    await this.ensureSchema()
+    const result = await this.pool.query<SessionRow>(
+      `INSERT INTO autotrader.sessions (
+        id, agent_run_name, mode, trading_date, account_id, goal_equity, market_open_at, market_close_at,
+        analysis_head, analysis_context_hash
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7::timestamptz, $8::timestamptz, $9, $10)
+      ON CONFLICT (agent_run_name) DO UPDATE SET
+        mode = EXCLUDED.mode,
+        account_id = COALESCE(EXCLUDED.account_id, autotrader.sessions.account_id),
+        goal_equity = EXCLUDED.goal_equity,
+        market_open_at = EXCLUDED.market_open_at,
+        market_close_at = EXCLUDED.market_close_at,
+        analysis_head = COALESCE(EXCLUDED.analysis_head, autotrader.sessions.analysis_head),
+        analysis_context_hash = COALESCE(EXCLUDED.analysis_context_hash, autotrader.sessions.analysis_context_hash)
+      RETURNING *`,
+      [
+        randomUUID(),
+        input.agentRunName,
+        input.mode,
+        input.tradingDate,
+        input.accountId ?? null,
+        input.goalEquity,
+        input.marketOpenAt,
+        input.marketCloseAt,
+        input.analysisHead ?? null,
+        input.analysisContextHash ?? null,
+      ],
+    )
+    return mapSession(result.rows[0])
+  }
+
+  async upsertStatus(input: AutotraderUpsertStatusInput): Promise<AutotraderStatus> {
+    await this.ensureSchema()
+    const result = await this.pool.query<StatusRow>(
+      `INSERT INTO autotrader.status (
+        session_id, cycle, phase, equity, buying_power, daytrade_buying_power, gross_exposure, net_exposure,
+        realized_pnl, unrealized_pnl, current_action, blocker, payload
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb)
+      ON CONFLICT (session_id) DO UPDATE SET
+        cycle = EXCLUDED.cycle,
+        phase = EXCLUDED.phase,
+        equity = EXCLUDED.equity,
+        buying_power = EXCLUDED.buying_power,
+        daytrade_buying_power = EXCLUDED.daytrade_buying_power,
+        gross_exposure = EXCLUDED.gross_exposure,
+        net_exposure = EXCLUDED.net_exposure,
+        realized_pnl = EXCLUDED.realized_pnl,
+        unrealized_pnl = EXCLUDED.unrealized_pnl,
+        current_action = EXCLUDED.current_action,
+        blocker = EXCLUDED.blocker,
+        payload = EXCLUDED.payload,
+        updated_at = now()
+      RETURNING *`,
+      [
+        input.sessionId,
+        input.cycle,
+        input.phase,
+        numericOrNull(input.equity),
+        numericOrNull(input.buyingPower),
+        numericOrNull(input.daytradeBuyingPower),
+        numericOrNull(input.grossExposure),
+        numericOrNull(input.netExposure),
+        numericOrNull(input.realizedPnl),
+        numericOrNull(input.unrealizedPnl),
+        input.currentAction,
+        input.blocker ?? null,
+        toJson(input.payload),
+      ],
+    )
+    return mapStatus(result.rows[0])
+  }
+
+  async appendEvent(input: AutotraderAppendEventInput): Promise<AutotraderEvent> {
+    await this.ensureSchema()
+    const result = await this.pool.query<EventRow>(
+      `INSERT INTO autotrader.events (
+        session_id, seq, occurred_at, event_type, symbol, setup_type, setup_grade, severity, payload
+      )
+      VALUES ($1, $2, COALESCE($3::timestamptz, now()), $4, $5, $6, $7, $8, $9::jsonb)
+      ON CONFLICT (session_id, seq) DO UPDATE SET
+        occurred_at = EXCLUDED.occurred_at,
+        event_type = EXCLUDED.event_type,
+        symbol = EXCLUDED.symbol,
+        setup_type = EXCLUDED.setup_type,
+        setup_grade = EXCLUDED.setup_grade,
+        severity = EXCLUDED.severity,
+        payload = EXCLUDED.payload
+      RETURNING *`,
+      [
+        input.sessionId,
+        input.seq,
+        input.occurredAt ?? null,
+        input.eventType,
+        normalizedSymbol(input.symbol),
+        input.setupType ?? null,
+        input.setupGrade ?? null,
+        input.severity,
+        toJson(input.payload),
+      ],
+    )
+    return mapEvent(result.rows[0])
+  }
+
+  async createTradeTicket(input: AutotraderCreateTradeTicketInput): Promise<AutotraderTradeTicket> {
+    await this.ensureSchema()
+    const result = await this.pool.query<TicketRow>(
+      `INSERT INTO autotrader.trade_tickets (
+        id, session_id, idempotency_key, symbol, instrument, side, setup_type, setup_grade, fat_pitch, regime,
+        time_bucket, thesis, entry_trigger, invalidation, entry_limit_price, stop_price, target_price, expected_r,
+        max_loss_amount, risk_dollars, planned_quantity, protection_type, broker_order_plan, status, no_trade_reason
+      )
+      VALUES (
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+        $11, $12, $13, $14, $15, $16, $17, $18,
+        $19, $20, $21, $22, $23::jsonb, $24, $25
+      )
+      ON CONFLICT (session_id, idempotency_key) DO UPDATE SET
+        symbol = EXCLUDED.symbol,
+        instrument = EXCLUDED.instrument,
+        side = EXCLUDED.side,
+        setup_type = EXCLUDED.setup_type,
+        setup_grade = EXCLUDED.setup_grade,
+        fat_pitch = EXCLUDED.fat_pitch,
+        regime = EXCLUDED.regime,
+        time_bucket = EXCLUDED.time_bucket,
+        thesis = EXCLUDED.thesis,
+        entry_trigger = EXCLUDED.entry_trigger,
+        invalidation = EXCLUDED.invalidation,
+        entry_limit_price = EXCLUDED.entry_limit_price,
+        stop_price = EXCLUDED.stop_price,
+        target_price = EXCLUDED.target_price,
+        expected_r = EXCLUDED.expected_r,
+        max_loss_amount = EXCLUDED.max_loss_amount,
+        risk_dollars = EXCLUDED.risk_dollars,
+        planned_quantity = EXCLUDED.planned_quantity,
+        protection_type = EXCLUDED.protection_type,
+        broker_order_plan = EXCLUDED.broker_order_plan,
+        status = EXCLUDED.status,
+        no_trade_reason = EXCLUDED.no_trade_reason,
+        updated_at = now()
+      RETURNING *`,
+      [
+        randomUUID(),
+        input.sessionId,
+        input.idempotencyKey,
+        normalizedSymbol(input.symbol) ?? input.symbol,
+        input.instrument,
+        input.side,
+        input.setupType,
+        input.setupGrade,
+        input.fatPitch,
+        input.regime,
+        input.timeBucket ?? null,
+        input.thesis,
+        input.entryTrigger,
+        input.invalidation,
+        numericOrNull(input.entryLimitPrice),
+        numericOrNull(input.stopPrice),
+        numericOrNull(input.targetPrice),
+        numericOrNull(input.expectedR),
+        numericOrNull(input.maxLossAmount),
+        numericOrNull(input.riskDollars),
+        numericOrNull(input.plannedQuantity),
+        input.protectionType,
+        toJson(input.brokerOrderPlan),
+        input.status,
+        input.noTradeReason ?? null,
+      ],
+    )
+    return mapTicket(result.rows[0])
+  }
+
+  async recordRiskCheck(input: AutotraderRecordRiskCheckInput): Promise<AutotraderRiskCheck> {
+    await this.ensureSchema()
+    const result = await this.pool.query<RiskCheckRow>(
+      `INSERT INTO autotrader.risk_checks (
+        id, session_id, ticket_id, idempotency_key, check_type, passed, reason, payload
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+      ON CONFLICT (session_id, idempotency_key) DO UPDATE SET
+        ticket_id = EXCLUDED.ticket_id,
+        check_type = EXCLUDED.check_type,
+        passed = EXCLUDED.passed,
+        reason = EXCLUDED.reason,
+        payload = EXCLUDED.payload
+      RETURNING *`,
+      [
+        randomUUID(),
+        input.sessionId,
+        input.ticketId ?? null,
+        input.idempotencyKey,
+        input.checkType,
+        input.passed,
+        input.reason ?? null,
+        toJson(input.payload),
+      ],
+    )
+    return mapRiskCheck(result.rows[0])
+  }
+
+  async recordOrder(input: AutotraderRecordOrderInput): Promise<AutotraderOrder> {
+    await this.ensureSchema()
+    const result = await this.pool.query<OrderRow>(
+      `INSERT INTO autotrader.orders (
+        session_id, ticket_id, client_order_id, broker_order_id, symbol, instrument, side, quantity, order_type,
+        order_class, limit_price, stop_price, take_profit_limit_price, stop_loss_stop_price, status, reject_reason,
+        broker_payload
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17::jsonb)
+      ON CONFLICT (client_order_id) DO UPDATE SET
+        session_id = EXCLUDED.session_id,
+        ticket_id = EXCLUDED.ticket_id,
+        broker_order_id = COALESCE(EXCLUDED.broker_order_id, autotrader.orders.broker_order_id),
+        symbol = EXCLUDED.symbol,
+        instrument = EXCLUDED.instrument,
+        side = EXCLUDED.side,
+        quantity = EXCLUDED.quantity,
+        order_type = EXCLUDED.order_type,
+        order_class = EXCLUDED.order_class,
+        limit_price = EXCLUDED.limit_price,
+        stop_price = EXCLUDED.stop_price,
+        take_profit_limit_price = EXCLUDED.take_profit_limit_price,
+        stop_loss_stop_price = EXCLUDED.stop_loss_stop_price,
+        status = EXCLUDED.status,
+        reject_reason = EXCLUDED.reject_reason,
+        broker_payload = EXCLUDED.broker_payload,
+        updated_at = now()
+      RETURNING *`,
+      [
+        input.sessionId,
+        input.ticketId ?? null,
+        input.clientOrderId,
+        input.brokerOrderId ?? null,
+        normalizedSymbol(input.symbol) ?? input.symbol,
+        input.instrument,
+        input.side,
+        input.quantity,
+        input.orderType,
+        input.orderClass ?? null,
+        numericOrNull(input.limitPrice),
+        numericOrNull(input.stopPrice),
+        numericOrNull(input.takeProfitLimitPrice),
+        numericOrNull(input.stopLossStopPrice),
+        input.status,
+        input.rejectReason ?? null,
+        toJson(input.brokerPayload),
+      ],
+    )
+    return mapOrder(result.rows[0])
+  }
+
+  async recordFill(input: AutotraderRecordFillInput): Promise<AutotraderFill> {
+    await this.ensureSchema()
+    const result = await this.pool.query<FillRow>(
+      `INSERT INTO autotrader.fills (
+        session_id, client_order_id, broker_fill_id, symbol, side, quantity, price, filled_at, broker_payload
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8::timestamptz, $9::jsonb)
+      ON CONFLICT (broker_fill_id) DO UPDATE SET
+        session_id = EXCLUDED.session_id,
+        client_order_id = EXCLUDED.client_order_id,
+        symbol = EXCLUDED.symbol,
+        side = EXCLUDED.side,
+        quantity = EXCLUDED.quantity,
+        price = EXCLUDED.price,
+        filled_at = EXCLUDED.filled_at,
+        broker_payload = EXCLUDED.broker_payload
+      RETURNING *`,
+      [
+        input.sessionId,
+        input.clientOrderId,
+        input.brokerFillId,
+        normalizedSymbol(input.symbol) ?? input.symbol,
+        input.side,
+        input.quantity,
+        input.price,
+        input.filledAt,
+        toJson(input.brokerPayload),
+      ],
+    )
+    return mapFill(result.rows[0])
+  }
+
+  async recordPositionSnapshot(input: AutotraderRecordPositionSnapshotInput): Promise<AutotraderPositionSnapshot> {
+    await this.ensureSchema()
+    const capturedAt = toIso(input.capturedAt) ?? nowIso()
+    const result = await this.pool.query<PositionSnapshotRow>(
+      `INSERT INTO autotrader.position_snapshots (
+        id, session_id, symbol, quantity, market_value, average_entry_price, unrealized_pnl, captured_at, broker_payload
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8::timestamptz, $9::jsonb)
+      ON CONFLICT (session_id, symbol, captured_at) DO UPDATE SET
+        quantity = EXCLUDED.quantity,
+        market_value = EXCLUDED.market_value,
+        average_entry_price = EXCLUDED.average_entry_price,
+        unrealized_pnl = EXCLUDED.unrealized_pnl,
+        broker_payload = EXCLUDED.broker_payload
+      RETURNING *`,
+      [
+        randomUUID(),
+        input.sessionId,
+        normalizedSymbol(input.symbol) ?? input.symbol,
+        input.quantity,
+        numericOrNull(input.marketValue),
+        numericOrNull(input.averageEntryPrice),
+        numericOrNull(input.unrealizedPnl),
+        capturedAt,
+        toJson(input.brokerPayload),
+      ],
+    )
+    return mapPositionSnapshot(result.rows[0])
+  }
+
+  async finalizeSession(input: AutotraderFinalizeSessionInput): Promise<AutotraderSessionDetail> {
+    await this.ensureSchema()
+    const client = await this.pool.connect()
+    try {
+      await client.query('BEGIN')
+      await client.query(
+        `UPDATE autotrader.sessions
+         SET finalized_at = now(), terminal_reason = $2, summary = $3::jsonb
+         WHERE id = $1`,
+        [input.sessionId, input.terminalReason, toJson(input.summary)],
+      )
+      for (const observation of input.scorecardObservations) {
+        await this.recordScorecardObservation(client, input.sessionId, observation)
+      }
+      await client.query('COMMIT')
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+
+    const detail = await this.getSessionDetail(input.sessionId)
+    if (!detail) throw new Error(`Unknown autotrader session: ${input.sessionId}`)
+    return detail
+  }
+
+  async getScorecard(input: AutotraderGetScorecardInput) {
+    await this.ensureSchema()
+    const where: string[] = []
+    const values: unknown[] = []
+    if (input.symbol) {
+      values.push(normalizedSymbol(input.symbol))
+      where.push(`symbol = $${values.length}`)
+    }
+    if (input.setupType) {
+      values.push(input.setupType)
+      where.push(`setup_type = $${values.length}`)
+    }
+    if (input.setupGrade) {
+      values.push(input.setupGrade)
+      where.push(`setup_grade = $${values.length}`)
+    }
+    if (input.regime) {
+      values.push(input.regime)
+      where.push(`regime = $${values.length}`)
+    }
+    if (input.timeBucket) {
+      values.push(input.timeBucket)
+      where.push(`time_bucket = $${values.length}`)
+    }
+    values.push(input.limit)
+    const scorecards = (
+      await this.pool.query<ScorecardRow>(
+        `SELECT * FROM autotrader.scorecards
+         ${where.length ? `WHERE ${where.join(' AND ')}` : ''}
+         ORDER BY updated_at DESC
+         LIMIT $${values.length}`,
+        values,
+      )
+    ).rows.map(mapScorecard)
+    const keys = scorecards.map((scorecard) => scorecard.key)
+    if (!keys.length) return { scorecards, setupExamples: [] }
+    const setupExamples = (
+      await this.pool.query<SetupExampleRow>(
+        `SELECT * FROM autotrader.setup_examples
+         WHERE scorecard_key = ANY($1)
+         ORDER BY created_at DESC
+         LIMIT $2`,
+        [keys, input.limit * 3],
+      )
+    ).rows.map(mapSetupExample)
+    return { scorecards, setupExamples }
+  }
+
+  async listSessions(limit: number): Promise<AutotraderSession[]> {
+    await this.ensureSchema()
+    const result = await this.pool.query<SessionRow>(
+      `SELECT * FROM autotrader.sessions ORDER BY started_at DESC LIMIT $1`,
+      [limit],
+    )
+    return result.rows.map(mapSession)
+  }
+
+  async getSessionDetail(sessionId: string): Promise<AutotraderSessionDetail | null> {
+    await this.ensureSchema()
+    const sessionResult = await this.pool.query<SessionRow>(`SELECT * FROM autotrader.sessions WHERE id = $1`, [
+      sessionId,
+    ])
+    const session = sessionResult.rows[0] ? mapSession(sessionResult.rows[0]) : null
+    if (!session) return null
+    const [
+      statusResult,
+      eventResult,
+      ticketResult,
+      riskResult,
+      orderResult,
+      fillResult,
+      positionResult,
+      scorecardResult,
+      exampleResult,
+    ] = await Promise.all([
+      this.pool.query<StatusRow>(`SELECT * FROM autotrader.status WHERE session_id = $1`, [sessionId]),
+      this.pool.query<EventRow>(`SELECT * FROM autotrader.events WHERE session_id = $1 ORDER BY seq ASC`, [sessionId]),
+      this.pool.query<TicketRow>(
+        `SELECT * FROM autotrader.trade_tickets WHERE session_id = $1 ORDER BY created_at ASC`,
+        [sessionId],
+      ),
+      this.pool.query<RiskCheckRow>(
+        `SELECT * FROM autotrader.risk_checks WHERE session_id = $1 ORDER BY created_at ASC`,
+        [sessionId],
+      ),
+      this.pool.query<OrderRow>(`SELECT * FROM autotrader.orders WHERE session_id = $1 ORDER BY updated_at ASC`, [
+        sessionId,
+      ]),
+      this.pool.query<FillRow>(`SELECT * FROM autotrader.fills WHERE session_id = $1 ORDER BY filled_at ASC`, [
+        sessionId,
+      ]),
+      this.pool.query<PositionSnapshotRow>(
+        `SELECT * FROM autotrader.position_snapshots WHERE session_id = $1 ORDER BY captured_at DESC`,
+        [sessionId],
+      ),
+      this.pool.query<ScorecardRow>(
+        `SELECT DISTINCT s.*
+         FROM autotrader.scorecards s
+         JOIN autotrader.setup_examples e ON e.scorecard_key = s.key
+         WHERE e.session_id = $1
+         ORDER BY s.updated_at DESC`,
+        [sessionId],
+      ),
+      this.pool.query<SetupExampleRow>(
+        `SELECT * FROM autotrader.setup_examples WHERE session_id = $1 ORDER BY created_at DESC`,
+        [sessionId],
+      ),
+    ])
+    return {
+      session,
+      status: statusResult.rows[0] ? mapStatus(statusResult.rows[0]) : null,
+      events: eventResult.rows.map(mapEvent),
+      tradeTickets: ticketResult.rows.map(mapTicket),
+      riskChecks: riskResult.rows.map(mapRiskCheck),
+      orders: orderResult.rows.map(mapOrder),
+      fills: fillResult.rows.map(mapFill),
+      positionSnapshots: positionResult.rows.map(mapPositionSnapshot),
+      scorecards: scorecardResult.rows.map(mapScorecard),
+      setupExamples: exampleResult.rows.map(mapSetupExample),
+    }
+  }
+
+  private async recordScorecardObservation(
+    client: PoolClient,
+    sessionId: string,
+    observation: AutotraderScorecardObservation,
+  ) {
+    const key = scorecardKeyFor(observation)
+    const existingResult = await client.query<ScorecardRow>(`SELECT * FROM autotrader.scorecards WHERE key = $1`, [key])
+    const updated = updateScorecardWithObservation(
+      existingResult.rows[0] ? mapScorecard(existingResult.rows[0]) : null,
+      sessionId,
+      observation,
+    )
+    await client.query(
+      `INSERT INTO autotrader.scorecards (
+        key, symbol, setup_type, setup_grade, regime, time_bucket, sample_size, wins, losses, scratches,
+        rejected_valid, rejected_invalid, total_realized_r, avg_realized_r, avg_hold_seconds, avg_mfe_r, avg_mae_r,
+        last_outcome, confidence, updated_at, last_session_id
+      )
+      VALUES (
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+        $11, $12, $13, $14, $15, $16, $17, $18, $19, $20::timestamptz, $21
+      )
+      ON CONFLICT (key) DO UPDATE SET
+        sample_size = EXCLUDED.sample_size,
+        wins = EXCLUDED.wins,
+        losses = EXCLUDED.losses,
+        scratches = EXCLUDED.scratches,
+        rejected_valid = EXCLUDED.rejected_valid,
+        rejected_invalid = EXCLUDED.rejected_invalid,
+        total_realized_r = EXCLUDED.total_realized_r,
+        avg_realized_r = EXCLUDED.avg_realized_r,
+        avg_hold_seconds = EXCLUDED.avg_hold_seconds,
+        avg_mfe_r = EXCLUDED.avg_mfe_r,
+        avg_mae_r = EXCLUDED.avg_mae_r,
+        last_outcome = EXCLUDED.last_outcome,
+        confidence = EXCLUDED.confidence,
+        updated_at = EXCLUDED.updated_at,
+        last_session_id = EXCLUDED.last_session_id`,
+      [
+        updated.key,
+        updated.symbol,
+        updated.setupType,
+        updated.setupGrade,
+        updated.regime,
+        updated.timeBucket,
+        updated.sampleSize,
+        updated.wins,
+        updated.losses,
+        updated.scratches,
+        updated.rejectedValid,
+        updated.rejectedInvalid,
+        updated.totalRealizedR,
+        updated.avgRealizedR,
+        updated.avgHoldSeconds,
+        updated.avgMfeR,
+        updated.avgMaeR,
+        updated.lastOutcome,
+        updated.confidence,
+        updated.updatedAt,
+        sessionId,
+      ],
+    )
+    const example = exampleFromObservation(sessionId, observation)
+    await client.query(
+      `INSERT INTO autotrader.setup_examples (
+        id, scorecard_key, session_id, ticket_id, symbol, setup_type, setup_grade, regime, time_bucket, outcome,
+        realized_r, notes, mistake_tags, payload
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14::jsonb)`,
+      [
+        example.id,
+        example.scorecardKey,
+        example.sessionId,
+        example.ticketId,
+        example.symbol,
+        example.setupType,
+        example.setupGrade,
+        example.regime,
+        example.timeBucket,
+        example.outcome,
+        example.realizedR,
+        example.notes,
+        JSON.stringify(example.mistakeTags),
+        toJson(example.payload),
+      ],
+    )
+  }
+
+  private ensureSchema() {
+    this.schemaPromise ??= this.createSchema()
+    return this.schemaPromise
+  }
+
+  private async createSchema() {
+    await this.pool.query(`
+      CREATE SCHEMA IF NOT EXISTS autotrader;
+
+      CREATE TABLE IF NOT EXISTS autotrader.sessions (
+        id text PRIMARY KEY,
+        agent_run_name text NOT NULL UNIQUE,
+        mode text NOT NULL,
+        trading_date text NOT NULL,
+        account_id text,
+        goal_equity numeric NOT NULL,
+        market_open_at timestamptz NOT NULL,
+        market_close_at timestamptz NOT NULL,
+        analysis_head text,
+        analysis_context_hash text,
+        started_at timestamptz NOT NULL DEFAULT now(),
+        finalized_at timestamptz,
+        terminal_reason text,
+        summary jsonb NOT NULL DEFAULT '{}'::jsonb
+      );
+
+      CREATE TABLE IF NOT EXISTS autotrader.status (
+        session_id text PRIMARY KEY REFERENCES autotrader.sessions(id) ON DELETE CASCADE,
+        cycle integer NOT NULL,
+        phase text NOT NULL,
+        equity numeric,
+        buying_power numeric,
+        daytrade_buying_power numeric,
+        gross_exposure numeric,
+        net_exposure numeric,
+        realized_pnl numeric,
+        unrealized_pnl numeric,
+        current_action text NOT NULL,
+        blocker text,
+        payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+        updated_at timestamptz NOT NULL DEFAULT now()
+      );
+
+      CREATE TABLE IF NOT EXISTS autotrader.events (
+        session_id text NOT NULL REFERENCES autotrader.sessions(id) ON DELETE CASCADE,
+        seq integer NOT NULL,
+        occurred_at timestamptz NOT NULL DEFAULT now(),
+        event_type text NOT NULL,
+        symbol text,
+        setup_type text,
+        setup_grade text,
+        severity text NOT NULL DEFAULT 'info',
+        payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+        PRIMARY KEY (session_id, seq)
+      );
+
+      CREATE TABLE IF NOT EXISTS autotrader.trade_tickets (
+        id text PRIMARY KEY,
+        session_id text NOT NULL REFERENCES autotrader.sessions(id) ON DELETE CASCADE,
+        idempotency_key text NOT NULL,
+        symbol text NOT NULL,
+        instrument text NOT NULL,
+        side text NOT NULL,
+        setup_type text NOT NULL,
+        setup_grade text NOT NULL,
+        fat_pitch boolean NOT NULL DEFAULT false,
+        regime text NOT NULL,
+        time_bucket text,
+        thesis text NOT NULL,
+        entry_trigger text NOT NULL,
+        invalidation text NOT NULL,
+        entry_limit_price numeric,
+        stop_price numeric,
+        target_price numeric,
+        expected_r numeric,
+        max_loss_amount numeric,
+        risk_dollars numeric,
+        planned_quantity numeric,
+        protection_type text NOT NULL,
+        broker_order_plan jsonb NOT NULL DEFAULT '{}'::jsonb,
+        status text NOT NULL,
+        no_trade_reason text,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now(),
+        UNIQUE (session_id, idempotency_key)
+      );
+
+      CREATE TABLE IF NOT EXISTS autotrader.risk_checks (
+        id text PRIMARY KEY,
+        session_id text NOT NULL REFERENCES autotrader.sessions(id) ON DELETE CASCADE,
+        ticket_id text REFERENCES autotrader.trade_tickets(id) ON DELETE SET NULL,
+        idempotency_key text NOT NULL,
+        check_type text NOT NULL,
+        passed boolean NOT NULL,
+        reason text,
+        payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        UNIQUE (session_id, idempotency_key)
+      );
+
+      CREATE TABLE IF NOT EXISTS autotrader.orders (
+        client_order_id text PRIMARY KEY,
+        session_id text NOT NULL REFERENCES autotrader.sessions(id) ON DELETE CASCADE,
+        ticket_id text REFERENCES autotrader.trade_tickets(id) ON DELETE SET NULL,
+        broker_order_id text,
+        symbol text NOT NULL,
+        instrument text NOT NULL,
+        side text NOT NULL,
+        quantity numeric NOT NULL,
+        order_type text NOT NULL,
+        order_class text,
+        limit_price numeric,
+        stop_price numeric,
+        take_profit_limit_price numeric,
+        stop_loss_stop_price numeric,
+        status text NOT NULL,
+        reject_reason text,
+        broker_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+        updated_at timestamptz NOT NULL DEFAULT now()
+      );
+
+      CREATE TABLE IF NOT EXISTS autotrader.fills (
+        broker_fill_id text PRIMARY KEY,
+        session_id text NOT NULL REFERENCES autotrader.sessions(id) ON DELETE CASCADE,
+        client_order_id text NOT NULL REFERENCES autotrader.orders(client_order_id) ON DELETE CASCADE,
+        symbol text NOT NULL,
+        side text NOT NULL,
+        quantity numeric NOT NULL,
+        price numeric NOT NULL,
+        filled_at timestamptz NOT NULL,
+        broker_payload jsonb NOT NULL DEFAULT '{}'::jsonb
+      );
+
+      CREATE TABLE IF NOT EXISTS autotrader.position_snapshots (
+        id text PRIMARY KEY,
+        session_id text NOT NULL REFERENCES autotrader.sessions(id) ON DELETE CASCADE,
+        symbol text NOT NULL,
+        quantity numeric NOT NULL,
+        market_value numeric,
+        average_entry_price numeric,
+        unrealized_pnl numeric,
+        captured_at timestamptz NOT NULL DEFAULT now(),
+        broker_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+        UNIQUE (session_id, symbol, captured_at)
+      );
+
+      CREATE TABLE IF NOT EXISTS autotrader.scorecards (
+        key text PRIMARY KEY,
+        symbol text,
+        setup_type text NOT NULL,
+        setup_grade text NOT NULL,
+        regime text NOT NULL,
+        time_bucket text NOT NULL,
+        sample_size integer NOT NULL DEFAULT 0,
+        wins integer NOT NULL DEFAULT 0,
+        losses integer NOT NULL DEFAULT 0,
+        scratches integer NOT NULL DEFAULT 0,
+        rejected_valid integer NOT NULL DEFAULT 0,
+        rejected_invalid integer NOT NULL DEFAULT 0,
+        total_realized_r numeric NOT NULL DEFAULT 0,
+        avg_realized_r numeric NOT NULL DEFAULT 0,
+        avg_hold_seconds numeric,
+        avg_mfe_r numeric,
+        avg_mae_r numeric,
+        last_outcome text,
+        confidence numeric NOT NULL DEFAULT 0,
+        updated_at timestamptz NOT NULL DEFAULT now(),
+        last_session_id text REFERENCES autotrader.sessions(id) ON DELETE SET NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS autotrader.setup_examples (
+        id text PRIMARY KEY,
+        scorecard_key text NOT NULL REFERENCES autotrader.scorecards(key) ON DELETE CASCADE,
+        session_id text NOT NULL REFERENCES autotrader.sessions(id) ON DELETE CASCADE,
+        ticket_id text REFERENCES autotrader.trade_tickets(id) ON DELETE SET NULL,
+        symbol text,
+        setup_type text NOT NULL,
+        setup_grade text NOT NULL,
+        regime text NOT NULL,
+        time_bucket text NOT NULL,
+        outcome text NOT NULL,
+        realized_r numeric,
+        notes text,
+        mistake_tags jsonb NOT NULL DEFAULT '[]'::jsonb,
+        payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+        created_at timestamptz NOT NULL DEFAULT now()
+      );
+
+      CREATE INDEX IF NOT EXISTS autotrader_sessions_started_at_idx ON autotrader.sessions (started_at DESC);
+      CREATE INDEX IF NOT EXISTS autotrader_status_phase_idx ON autotrader.status (phase, updated_at DESC);
+      CREATE INDEX IF NOT EXISTS autotrader_events_session_seq_idx ON autotrader.events (session_id, seq);
+      CREATE INDEX IF NOT EXISTS autotrader_trade_tickets_session_idx ON autotrader.trade_tickets (session_id, created_at);
+      CREATE INDEX IF NOT EXISTS autotrader_orders_session_idx ON autotrader.orders (session_id, updated_at);
+      CREATE INDEX IF NOT EXISTS autotrader_fills_session_idx ON autotrader.fills (session_id, filled_at);
+      CREATE INDEX IF NOT EXISTS autotrader_positions_session_idx ON autotrader.position_snapshots (session_id, captured_at DESC);
+      CREATE INDEX IF NOT EXISTS autotrader_scorecards_lookup_idx
+        ON autotrader.scorecards (setup_type, setup_grade, regime, time_bucket, updated_at DESC);
+      CREATE INDEX IF NOT EXISTS autotrader_setup_examples_scorecard_idx
+        ON autotrader.setup_examples (scorecard_key, created_at DESC);
+    `)
+  }
+}
+
+let autotraderStoreSingleton: AutotraderStore | null = null
+
+export const createInMemoryAutotraderStore = (): AutotraderStore => new InMemoryAutotraderStore()
+
+export const getAutotraderStore = () => {
+  if (autotraderStoreSingleton) return autotraderStoreSingleton
+
+  const databaseUrl = process.env.DATABASE_URL?.trim()
+  if (!databaseUrl || process.env.SYNTHESIS_STORAGE === 'memory') {
+    autotraderStoreSingleton = createInMemoryAutotraderStore()
+    return autotraderStoreSingleton
+  }
+
+  autotraderStoreSingleton = new PostgresAutotraderStore(databaseUrl)
+  return autotraderStoreSingleton
+}
+
+export const setAutotraderStoreForTests = (store: AutotraderStore | null) => {
+  autotraderStoreSingleton = store
+}

--- a/apps/synthesis/src/server/mcp.ts
+++ b/apps/synthesis/src/server/mcp.ts
@@ -2,6 +2,19 @@ import { isAuthorized } from './auth'
 import { CompanyProfileHintSchema } from './company'
 import { jsonResponse } from './http'
 import {
+  AutotraderAppendEventInputSchema,
+  AutotraderCreateTradeTicketInputSchema,
+  AutotraderFinalizeSessionInputSchema,
+  AutotraderGetScorecardInputSchema,
+  AutotraderRecordFillInputSchema,
+  AutotraderRecordOrderInputSchema,
+  AutotraderRecordPositionSnapshotInputSchema,
+  AutotraderRecordRiskCheckInputSchema,
+  AutotraderStartSessionInputSchema,
+  AutotraderUpsertStatusInputSchema,
+} from './autotrader-schema'
+import { getAutotraderStore } from './autotrader-store'
+import {
   ListFeedInputSchema,
   RecordFeedbackInputSchema,
   StartRunInputSchema,
@@ -43,7 +56,26 @@ const mutatingTools = new Set([
   'synthesis_submit_batch',
   'synthesis_prefill_company',
   'synthesis_record_feedback',
+  'autotrader_start_session',
+  'autotrader_upsert_status',
+  'autotrader_append_event',
+  'autotrader_create_trade_ticket',
+  'autotrader_record_risk_check',
+  'autotrader_record_order',
+  'autotrader_record_fill',
+  'autotrader_record_position_snapshot',
+  'autotrader_finalize_session',
 ])
+
+const numericStringSchema = { type: 'string', description: 'Decimal value encoded as a string.' } as const
+const payloadSchema = { type: 'object', additionalProperties: true } as const
+const optionalStringArraySchema = { type: 'array', items: { type: 'string' } } as const
+const setupGradeSchema = { type: 'string', enum: ['A+', 'A', 'B', 'C', 'blocked'] } as const
+const sideSchema = {
+  type: 'string',
+  enum: ['buy', 'sell', 'sell_short', 'buy_to_cover', 'buy_to_open', 'buy_to_close', 'sell_to_open', 'sell_to_close'],
+} as const
+const instrumentSchema = { type: 'string', enum: ['stock', 'etf', 'option', 'crypto', 'other'] } as const
 
 const toolsListResult = {
   tools: [
@@ -260,6 +292,288 @@ const toolsListResult = {
         additionalProperties: false,
       },
     },
+    {
+      name: 'autotrader_start_session',
+      description:
+        'Start or idempotently reopen a Synthesis-owned autonomous-trader market session. This creates durable canonical state before the AgentRun scans or trades.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          agentRunName: { type: 'string' },
+          mode: { type: 'string', enum: ['market_session', 'market_open', 'dry_run', 'paper_smoke'] },
+          tradingDate: { type: 'string' },
+          accountId: { type: 'string' },
+          goalEquity: numericStringSchema,
+          marketOpenAt: { type: 'string' },
+          marketCloseAt: { type: 'string' },
+          analysisHead: { type: 'string' },
+          analysisContextHash: { type: 'string' },
+        },
+        required: ['agentRunName', 'tradingDate', 'marketOpenAt', 'marketCloseAt'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'autotrader_upsert_status',
+      description: 'Write the latest live trading loop status for operator visibility and recovery.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+          cycle: { type: 'integer', minimum: 0 },
+          phase: {
+            type: 'string',
+            enum: [
+              'preflight',
+              'scan',
+              'ticket',
+              'risk_check',
+              'order',
+              'manage',
+              'reconcile',
+              'finalize',
+              'blocked',
+              'idle',
+            ],
+          },
+          equity: numericStringSchema,
+          buyingPower: numericStringSchema,
+          daytradeBuyingPower: numericStringSchema,
+          grossExposure: numericStringSchema,
+          netExposure: numericStringSchema,
+          realizedPnl: numericStringSchema,
+          unrealizedPnl: numericStringSchema,
+          currentAction: { type: 'string' },
+          blocker: { type: ['string', 'null'] },
+          payload: payloadSchema,
+        },
+        required: ['sessionId', 'cycle', 'phase', 'currentAction'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'autotrader_append_event',
+      description: 'Append or idempotently replace a sequenced autotrader session event.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+          seq: { type: 'integer', minimum: 0 },
+          occurredAt: { type: 'string' },
+          eventType: { type: 'string' },
+          symbol: { type: 'string' },
+          setupType: { type: 'string' },
+          setupGrade: setupGradeSchema,
+          severity: { type: 'string', enum: ['debug', 'info', 'warn', 'error'] },
+          payload: payloadSchema,
+        },
+        required: ['sessionId', 'seq', 'eventType'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'autotrader_create_trade_ticket',
+      description:
+        'Create or update the validated trade ticket that must exist before any non-smoke order. C setups should be recorded as blocked/no-trade tickets.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+          idempotencyKey: { type: 'string' },
+          symbol: { type: 'string' },
+          instrument: instrumentSchema,
+          side: sideSchema,
+          setupType: { type: 'string' },
+          setupGrade: setupGradeSchema,
+          fatPitch: { type: 'boolean' },
+          regime: { type: 'string' },
+          timeBucket: { type: 'string' },
+          thesis: { type: 'string' },
+          entryTrigger: { type: 'string' },
+          invalidation: { type: 'string' },
+          entryLimitPrice: numericStringSchema,
+          stopPrice: numericStringSchema,
+          targetPrice: numericStringSchema,
+          expectedR: numericStringSchema,
+          maxLossAmount: numericStringSchema,
+          riskDollars: numericStringSchema,
+          plannedQuantity: numericStringSchema,
+          protectionType: { type: 'string' },
+          brokerOrderPlan: payloadSchema,
+          status: { type: 'string', enum: ['candidate', 'validated', 'blocked', 'ordered', 'filled', 'closed'] },
+          noTradeReason: { type: ['string', 'null'] },
+        },
+        required: [
+          'sessionId',
+          'idempotencyKey',
+          'symbol',
+          'instrument',
+          'side',
+          'setupType',
+          'setupGrade',
+          'regime',
+          'thesis',
+          'entryTrigger',
+          'invalidation',
+          'protectionType',
+        ],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'autotrader_record_risk_check',
+      description: 'Record the ticket risk gate, including blocked/no-trade rationale.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+          ticketId: { type: 'string' },
+          idempotencyKey: { type: 'string' },
+          checkType: { type: 'string' },
+          passed: { type: 'boolean' },
+          reason: { type: 'string' },
+          payload: payloadSchema,
+        },
+        required: ['sessionId', 'idempotencyKey', 'checkType', 'passed'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'autotrader_record_order',
+      description: 'Record or reconcile an Alpaca order by client order id.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+          ticketId: { type: 'string' },
+          clientOrderId: { type: 'string' },
+          brokerOrderId: { type: ['string', 'null'] },
+          symbol: { type: 'string' },
+          instrument: instrumentSchema,
+          side: sideSchema,
+          quantity: numericStringSchema,
+          orderType: { type: 'string' },
+          orderClass: { type: 'string' },
+          limitPrice: numericStringSchema,
+          stopPrice: numericStringSchema,
+          takeProfitLimitPrice: numericStringSchema,
+          stopLossStopPrice: numericStringSchema,
+          status: {
+            type: 'string',
+            enum: [
+              'planned',
+              'submitted',
+              'accepted',
+              'partially_filled',
+              'filled',
+              'canceled',
+              'rejected',
+              'expired',
+              'reconciled',
+            ],
+          },
+          rejectReason: { type: ['string', 'null'] },
+          brokerPayload: payloadSchema,
+        },
+        required: ['sessionId', 'clientOrderId', 'symbol', 'instrument', 'side', 'quantity', 'orderType', 'status'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'autotrader_record_fill',
+      description: 'Record or reconcile an Alpaca fill by broker fill id.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+          clientOrderId: { type: 'string' },
+          brokerFillId: { type: 'string' },
+          symbol: { type: 'string' },
+          side: sideSchema,
+          quantity: numericStringSchema,
+          price: numericStringSchema,
+          filledAt: { type: 'string' },
+          brokerPayload: payloadSchema,
+        },
+        required: ['sessionId', 'clientOrderId', 'brokerFillId', 'symbol', 'side', 'quantity', 'price', 'filledAt'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'autotrader_record_position_snapshot',
+      description: 'Record broker position state for reconciliation and UI visibility.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+          symbol: { type: 'string' },
+          quantity: numericStringSchema,
+          marketValue: numericStringSchema,
+          averageEntryPrice: numericStringSchema,
+          unrealizedPnl: numericStringSchema,
+          capturedAt: { type: 'string' },
+          brokerPayload: payloadSchema,
+        },
+        required: ['sessionId', 'symbol', 'quantity'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'autotrader_finalize_session',
+      description:
+        'Finalize the market session and update setup scorecards/examples from realized outcomes so the next run can compound evidence.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+          terminalReason: { type: 'string' },
+          summary: payloadSchema,
+          scorecardObservations: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                ticketId: { type: 'string' },
+                symbol: { type: 'string' },
+                setupType: { type: 'string' },
+                setupGrade: setupGradeSchema,
+                regime: { type: 'string' },
+                timeBucket: { type: 'string' },
+                outcome: { type: 'string', enum: ['win', 'loss', 'scratch', 'rejected_valid', 'rejected_invalid'] },
+                realizedR: numericStringSchema,
+                holdSeconds: numericStringSchema,
+                mfeR: numericStringSchema,
+                maeR: numericStringSchema,
+                mistakeTags: optionalStringArraySchema,
+                notes: { type: 'string' },
+                payload: payloadSchema,
+              },
+              required: ['setupType', 'setupGrade', 'regime', 'timeBucket', 'outcome'],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ['sessionId', 'terminalReason'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'autotrader_get_scorecard',
+      description:
+        'Read prior setup scorecards and examples before grading new candidates. Scorecards inform filtering/sizing but do not replace live confirmation.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          symbol: { type: 'string' },
+          setupType: { type: 'string' },
+          setupGrade: setupGradeSchema,
+          regime: { type: 'string' },
+          timeBucket: { type: 'string' },
+          limit: { type: 'integer', minimum: 1, maximum: 100 },
+        },
+        additionalProperties: false,
+      },
+    },
   ],
 } as const
 
@@ -348,6 +662,13 @@ const buildConfigResource = (request: Request) => ({
           primaryProfileSource: 'Webull when configured; local official-source fixtures/manual hints otherwise',
           quoteContext: 'optional Alpaca market-data read only; never required for static prefill',
         },
+        autotrader: {
+          appOwnedState: true,
+          brokerTruth: 'Alpaca MCP',
+          durableState: 'Postgres autotrader schema',
+          feedItems: 'milestone summaries only; never primary trade state',
+          learning: 'scorecards/examples must be read before grading new candidates',
+        },
       },
       tools: toolsListResult.tools,
     },
@@ -409,6 +730,89 @@ const handleToolCall = async (
       const parsed = RecordFeedbackInputSchema.safeParse(args)
       if (!parsed.success) return invalidParams(id, 'Invalid synthesis_record_feedback input')
       return asJsonRpcResponse(id, toTextToolResult({ ok: true, feedback: await store.recordFeedback(parsed.data) }))
+    }
+    if (name === 'autotrader_start_session') {
+      const parsed = AutotraderStartSessionInputSchema.safeParse(args)
+      if (!parsed.success) return invalidParams(id, 'Invalid autotrader_start_session input')
+      return asJsonRpcResponse(
+        id,
+        toTextToolResult({ ok: true, session: await getAutotraderStore().startSession(parsed.data) }),
+      )
+    }
+    if (name === 'autotrader_upsert_status') {
+      const parsed = AutotraderUpsertStatusInputSchema.safeParse(args)
+      if (!parsed.success) return invalidParams(id, 'Invalid autotrader_upsert_status input')
+      return asJsonRpcResponse(
+        id,
+        toTextToolResult({ ok: true, status: await getAutotraderStore().upsertStatus(parsed.data) }),
+      )
+    }
+    if (name === 'autotrader_append_event') {
+      const parsed = AutotraderAppendEventInputSchema.safeParse(args)
+      if (!parsed.success) return invalidParams(id, 'Invalid autotrader_append_event input')
+      return asJsonRpcResponse(
+        id,
+        toTextToolResult({ ok: true, event: await getAutotraderStore().appendEvent(parsed.data) }),
+      )
+    }
+    if (name === 'autotrader_create_trade_ticket') {
+      const parsed = AutotraderCreateTradeTicketInputSchema.safeParse(args)
+      if (!parsed.success) return invalidParams(id, 'Invalid autotrader_create_trade_ticket input')
+      return asJsonRpcResponse(
+        id,
+        toTextToolResult({ ok: true, ticket: await getAutotraderStore().createTradeTicket(parsed.data) }),
+      )
+    }
+    if (name === 'autotrader_record_risk_check') {
+      const parsed = AutotraderRecordRiskCheckInputSchema.safeParse(args)
+      if (!parsed.success) return invalidParams(id, 'Invalid autotrader_record_risk_check input')
+      return asJsonRpcResponse(
+        id,
+        toTextToolResult({ ok: true, riskCheck: await getAutotraderStore().recordRiskCheck(parsed.data) }),
+      )
+    }
+    if (name === 'autotrader_record_order') {
+      const parsed = AutotraderRecordOrderInputSchema.safeParse(args)
+      if (!parsed.success) return invalidParams(id, 'Invalid autotrader_record_order input')
+      return asJsonRpcResponse(
+        id,
+        toTextToolResult({ ok: true, order: await getAutotraderStore().recordOrder(parsed.data) }),
+      )
+    }
+    if (name === 'autotrader_record_fill') {
+      const parsed = AutotraderRecordFillInputSchema.safeParse(args)
+      if (!parsed.success) return invalidParams(id, 'Invalid autotrader_record_fill input')
+      return asJsonRpcResponse(
+        id,
+        toTextToolResult({ ok: true, fill: await getAutotraderStore().recordFill(parsed.data) }),
+      )
+    }
+    if (name === 'autotrader_record_position_snapshot') {
+      const parsed = AutotraderRecordPositionSnapshotInputSchema.safeParse(args)
+      if (!parsed.success) return invalidParams(id, 'Invalid autotrader_record_position_snapshot input')
+      return asJsonRpcResponse(
+        id,
+        toTextToolResult({
+          ok: true,
+          positionSnapshot: await getAutotraderStore().recordPositionSnapshot(parsed.data),
+        }),
+      )
+    }
+    if (name === 'autotrader_finalize_session') {
+      const parsed = AutotraderFinalizeSessionInputSchema.safeParse(args)
+      if (!parsed.success) return invalidParams(id, 'Invalid autotrader_finalize_session input')
+      return asJsonRpcResponse(
+        id,
+        toTextToolResult({ ok: true, detail: await getAutotraderStore().finalizeSession(parsed.data) }),
+      )
+    }
+    if (name === 'autotrader_get_scorecard') {
+      const parsed = AutotraderGetScorecardInputSchema.safeParse(args)
+      if (!parsed.success) return invalidParams(id, 'Invalid autotrader_get_scorecard input')
+      return asJsonRpcResponse(
+        id,
+        toTextToolResult({ ok: true, ...(await getAutotraderStore().getScorecard(parsed.data)) }),
+      )
     }
 
     return asJsonRpcError(id, { code: -32601, message: `Unknown tool: ${name}` })

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -75,7 +75,7 @@ spec:
     AGENTS_ARTIFACTS_SECURE: "false"
     ALPACA_PAPER_TRADE: "true"
     ANALYSIS_REPO_URL: https://github.com/gregkonush/analysis.git
-    ANALYSIS_REQUIRED_COMMIT: b187dcf3e71999c04c3a019ec5861413551ceda1
+    ANALYSIS_REQUIRED_COMMIT: 4ce90bf7fc16f9bf90f7fe221f36db23c7ff44a5
     AUTONOMOUS_TRADER_ARTIFACT_DIR: /workspace/.agentrun/autonomous-trader
     CODEX_CONFIG: /root/.codex/config.toml
     CODEX_LOG_LEVEL: info
@@ -143,7 +143,7 @@ spec:
         artifact_dir="${AUTONOMOUS_TRADER_ARTIFACT_DIR:-/workspace/.agentrun/autonomous-trader}"
         analysis_dir="${ANALYSIS_REPO_DIR:-/workspace/analysis}"
         analysis_repo_url="${ANALYSIS_REPO_URL:-https://github.com/gregkonush/analysis.git}"
-        required_commit="${ANALYSIS_REQUIRED_COMMIT:-b187dcf3e71999c04c3a019ec5861413551ceda1}"
+        required_commit="${ANALYSIS_REQUIRED_COMMIT:-4ce90bf7fc16f9bf90f7fe221f36db23c7ff44a5}"
         python_bin="${PYTHON_BIN:-python3}"
 
         mkdir -p "${artifact_dir}"

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -20,9 +20,11 @@ spec:
     - Operate as a day-trading AgentRun for the Alpaca paper account only.
     - Verify Alpaca MCP account, clock, market data, order, and instrument tools before any order call.
     - Bootstrap and validate the private analysis repo before any market-open order.
+    - Start a Synthesis autotrader session and use autotrader MCP/API tools as canonical runtime state.
+    - Read Synthesis scorecards before grading new candidates and finalize every session with scorecard observations.
     - Use available Alpaca paper-account instruments and operations when justified by current account and market state.
     - Use stock/ETF bracket, OTO, or OCO protective order classes when feasible; otherwise record the exact managed-exit fallback.
-    - Publish operator-visible status through Synthesis MCP and durable status/event artifacts.
+    - Publish operator-visible status through Synthesis MCP autotrader tables; feed items are milestone summaries only.
     - Keep market-open runs active until market close, 500000 USD equity, or an unrecoverable blocker.
     - Reconcile every order by id or client order id and write preflight, ledger, and report artifacts.
   text: |-
@@ -38,41 +40,47 @@ spec:
     1. Bootstrap analysis before any market-open order:
        - Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`.
        - Read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`.
-       - Require analysis commit `b187dcf3e71999c04c3a019ec5861413551ceda1` or newer.
+       - Require analysis commit `4ce90bf7fc16f9bf90f7fe221f36db23c7ff44a5` or newer.
        - Produce valid `/workspace/.agentrun/autonomous-trader/analysis-context.json` and `/workspace/.agentrun/autonomous-trader/analysis-bootstrap.json`.
     2. Preflight:
        - Use Alpaca MCP to read account, account config, clock, calendar, open orders, positions, recent portfolio state, and available tools.
        - Confirm stock order tooling exposes `order_class`, `take_profit_limit_price`, `stop_loss_stop_price`, and `stop_loss_limit_price`.
-       - Confirm Synthesis MCP exposes `synthesis_start_run` and `synthesis_submit_item`.
+       - Confirm Synthesis MCP exposes `autotrader_start_session`, `autotrader_upsert_status`, `autotrader_append_event`, `autotrader_create_trade_ticket`, `autotrader_record_risk_check`, `autotrader_record_order`, `autotrader_record_fill`, `autotrader_record_position_snapshot`, `autotrader_finalize_session`, `autotrader_get_scorecard`, and `synthesis_submit_item`.
        - Confirm paper account routing before any order call.
        - Write `/workspace/.agentrun/autonomous-trader/preflight.json` with redacted evidence.
+       - Call `autotrader_start_session` before scanning and persist its returned `sessionId`.
     3. Mode handling:
        - `preflight`: perform readiness checks and, only if safe, one tiny non-marketable paper bracket or OTO stock order proof that is verified by id/client id and canceled; if Alpaca rejects or blocks it, record the exact request and reason.
        - `market-open`: wait for the market to open, then run an intraday loop until market close, equity is at least 500000 USD, or account/order state becomes unrecoverable.
     4. Each market-open cycle:
        - Re-read clock, account, orders, positions, portfolio state, and relevant market data.
        - Reconcile open orders and absorb any account/position changes as current state.
+       - Call `autotrader_get_scorecard` before ranking candidates and include the scorecard summary in scanner input.
        - Build a ranked action list from analysis context, live snapshots/quotes/bars, option-chain data when relevant, technicals, catalysts, liquidity, account constraints, and web research when fresh information can change the trade.
        - Before each non-smoke order, run `stock_analysis daytrading-scan` and validate `/workspace/.agentrun/autonomous-trader/trade-ticket.json` with `stock_analysis daytrading-validate-ticket`.
-       - Submit an order only after the trade ticket records thesis, entry, invalidation, exit logic, sizing, max loss, liquidity, and reconciliation plan.
+       - Submit an order only after the trade ticket records setup type, setup grade, expected R, fat-pitch flag, thesis, entry, invalidation, exit logic, sizing, max loss, liquidity, and reconciliation plan.
+       - Block C setups and record the no-trade reason with `autotrader_create_trade_ticket`, `autotrader_record_risk_check`, and `autotrader_append_event`.
        - For new stock or ETF entries, use Alpaca MCP bracket or OTO orders when feasible with `order_class`, `take_profit_limit_price`, `stop_loss_stop_price`, optional `stop_loss_limit_price`, and unique `client_order_id`.
        - For existing stock or ETF positions, prefer OCO exits when feasible.
        - For options, manage exits explicitly in the loop with max loss, target, invalidation, and near-close liquidation or hold decision because the current option MCP tool does not expose bracket/stop/take-profit fields.
        - Do not create a new unmanaged position unless broker-attached protection is unavailable and the active fallback monitor is recorded in `/workspace/.agentrun/autonomous-trader/protective-orders.jsonl`.
        - Reconcile each submitted order by order id or client order id before the next action.
-       - Append cycle state and decisions to `/workspace/.agentrun/autonomous-trader/decision-ledger.jsonl`; update `/workspace/.agentrun/autonomous-trader/report.md`; emit heartbeat output at least every 60 seconds while waiting.
-       - Update `/workspace/.agentrun/autonomous-trader/current-status.json` and append `/workspace/.agentrun/autonomous-trader/visibility-events.jsonl` with cycle number, account equity, buying power, P/L, positions, open orders, candidate actions, selected action, order parameters, protective exit state, reconciliation state, blockers, and next action.
+       - Write each cycle through Synthesis autotrader MCP: `autotrader_upsert_status` for current state, `autotrader_append_event` for decisions/no-trade/order lifecycle, `autotrader_create_trade_ticket` for every candidate selected or blocked, `autotrader_record_risk_check` for risk gates, `autotrader_record_order` and `autotrader_record_fill` for Alpaca reconciliation, and `autotrader_record_position_snapshot` after broker position reads.
+       - Append local JSONL artifacts only as export/debug copies; Synthesis Postgres is primary runtime state.
+       - Update `/workspace/.agentrun/autonomous-trader/report.md`; emit heartbeat output at least every 60 seconds while waiting.
     5. Synthesis visibility:
-       - Use Synthesis MCP to call `synthesis_start_run` once per AgentRun.
-       - Use `synthesis_submit_item` for high-signal updates: session start, preflight complete, material action or stand-down, order submitted, fill/reject/cancel, protective exit change, risk blocker, and terminal summary.
+       - Use Synthesis MCP to call `autotrader_start_session` once per AgentRun and use its `sessionId` for all structured state.
+       - Use `synthesis_submit_item` only for high-signal milestone updates: session start, preflight complete, material action or stand-down, order submitted, fill/reject/cancel, protective exit change, risk blocker, and terminal summary.
        - Use strict payloads with `title`, `synthesis`, `takeaways`, `whyValuable`, `sourcePosts`, `dedupeKey`, `score`, and `confidence`; use `https://synthesis.proompteng.ai/agentruns/${AGENT_RUN_NAME}#cycle-N` for the synthetic source URL and record each payload/result in `/workspace/.agentrun/autonomous-trader/synthesis-posts.jsonl`.
+       - Link milestone feed items to the Synthesis autotrader session id and AgentRun name.
 
     Recovery and stop conditions:
     - Retry transient Alpaca MCP read failures up to 3 times with backoff and record `mcp_retry`.
     - After an order submission attempt, resolve the order by id/client id before submitting anything else.
     - Stand down, reduce, close, or monitor when buying power, permissions, liquidity, rejected orders, or market state block a good trade.
     - Finish with terminal_reason `target_reached`, `market_closed`, or `hard_stop`.
+    - Before finishing, call `autotrader_finalize_session` with realized scorecard observations for terminal tickets, rejected valid setups, rejected invalid setups, slippage, hold time, MFE/MAE, and mistake tags.
 
     Output contract:
     - Always write `preflight.json`, `decision-ledger.jsonl`, `report.md`, `analysis-bootstrap.json`, `analysis-context.json`, `current-status.json`, `visibility-events.jsonl`, `synthesis-posts.jsonl`, `trade-ticket.json`, and `protective-orders.jsonl`.
-    - In `report.md`, include mode, terminal_reason, account equity, cash, buying power, margin fields, exposure, positions, open orders, submitted/canceled/filled orders, analysis repo head, scanner/ticket status, protective-order status, Synthesis visibility status, distance to 500000 USD, and next action.
+    - In `report.md`, include mode, terminal_reason, Synthesis autotrader session id, account equity, cash, buying power, margin fields, exposure, positions, open orders, submitted/canceled/filled orders, analysis repo head, scanner/ticket status, scorecard read/write status, protective-order status, Synthesis visibility status, distance to 500000 USD, and next action.


### PR DESCRIPTION
## Summary

- Adds production Synthesis autotrader runtime state with typed REST/MCP tools for sessions, status, events, tickets, risk checks, orders, fills, position snapshots, finalization, and scorecards.
- Adds the Synthesis `/autotrader` operator dashboard and sidebar entry for live sessions, status, events, tickets, risk, broker reconciliation, positions, and compounding scorecards.
- Updates the autonomous-trader AgentRun implementation spec to use Synthesis autotrader state as canonical runtime memory, Alpaca MCP as broker truth, and milestone Synthesis feed posts only for human summaries.
- Pins the autonomous-trader provider/bootstrap contract to analysis commit `4ce90bf7fc16f9bf90f7fe221f36db23c7ff44a5`, which contains the scanner/ticket/scorecard contract updates.

## Related Issues

None

## Testing

- `bun run --filter synthesis test`
- `bun run --filter synthesis lint`
- `bun run --filter synthesis build`
- `bun run lint:argocd`
- Seeded local Synthesis with `SYNTHESIS_API_TOKEN=local-autotrader-proof`, wrote autotrader session/status/events/ticket/risk/order/fill/position/finalize data through REST, and verified `/autotrader` by Playwright screenshot at `http://localhost:5179/autotrader`.
- Analysis repo: `uv run --python 3.11 --extra dev ruff check src tests`
- Analysis repo: `uv run --python 3.11 --extra dev mypy src`
- Analysis repo: `PYTHONPATH=src uv run --python 3.11 --extra dev pytest`

## Screenshots (if applicable)

N/A. Local Playwright visual verification was performed; live rollout screenshots/readback will be captured after the GitOps deployment lands.

## Breaking Changes

None. The Synthesis autotrader store creates additive `autotrader` schema tables lazily and does not migrate or delete existing Synthesis data.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
