### PR TITLE
fix(torghut): surface non-evidence ledger diagnostics

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -7,6 +7,7 @@ of mutating any live submission gate.
 
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Mapping, Sequence
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal, InvalidOperation
@@ -1711,6 +1712,75 @@ def _runtime_ledger_bucket_evidence_grade(row: StrategyRuntimeLedgerBucket) -> b
     )
 
 
+def _runtime_ledger_row_diagnostic_expectancy_bps(
+    row: StrategyRuntimeLedgerBucket,
+) -> Decimal | None:
+    payload = _as_mapping(row.payload_json)
+    if diagnostic := payload.get("diagnostic_closed_trade_expectancy_bps"):
+        return _safe_decimal(diagnostic)
+    if row.post_cost_expectancy_bps is not None:
+        return _safe_decimal(row.post_cost_expectancy_bps)
+    filled_notional = _safe_decimal(row.filled_notional)
+    if _safe_int(row.closed_trade_count) <= 0 or filled_notional <= 0:
+        return None
+    return (
+        _safe_decimal(row.net_strategy_pnl_after_costs)
+        / filled_notional
+        * Decimal("10000")
+    )
+
+
+def _runtime_ledger_non_evidence_diagnostic_summary(
+    rows: Sequence[StrategyRuntimeLedgerBucket],
+) -> dict[str, object]:
+    diagnostic_rows = [
+        row
+        for row in rows
+        if _runtime_ledger_row_diagnostic_expectancy_bps(row) is not None
+    ]
+    filled_notional = sum(
+        (_safe_decimal(row.filled_notional) for row in diagnostic_rows), Decimal("0")
+    )
+    net_pnl = sum(
+        (_safe_decimal(row.net_strategy_pnl_after_costs) for row in diagnostic_rows),
+        Decimal("0"),
+    )
+    blocker_counts: Counter[str] = Counter(
+        str(item).strip()
+        for row in rows
+        for item in _as_sequence(row.blockers_json)
+        if str(item).strip()
+    )
+    return {
+        "scope": (
+            "non_evidence_grade_runtime_ledger_buckets_diagnostic_only_not_promotion_proof"
+        ),
+        "bucket_count": len(rows),
+        "diagnostic_bucket_count": len(diagnostic_rows),
+        "fill_count": sum(max(0, _safe_int(row.fill_count)) for row in rows),
+        "decision_count": sum(max(0, _safe_int(row.decision_count)) for row in rows),
+        "submitted_order_count": sum(
+            max(0, _safe_int(row.submitted_order_count)) for row in rows
+        ),
+        "closed_trade_count": sum(
+            max(0, _safe_int(row.closed_trade_count)) for row in rows
+        ),
+        "open_position_count": sum(
+            max(0, _safe_int(row.open_position_count)) for row in rows
+        ),
+        "filled_notional": _decimal_text(filled_notional),
+        "net_strategy_pnl_after_costs": _decimal_text(net_pnl),
+        "diagnostic_closed_trade_expectancy_bps": _decimal_text(
+            (net_pnl / filled_notional * Decimal("10000"))
+            if filled_notional > 0
+            else Decimal("0")
+        ),
+        "blocker_counts": dict(sorted(blocker_counts.items())),
+        "latest_bucket_ended_at": _isoformat(rows[0].bucket_ended_at if rows else None),
+        "db_row_refs": [str(row.id) for row in rows],
+    }
+
+
 def _runtime_ledger_summary(
     session: Session,
     *,
@@ -1757,6 +1827,10 @@ def _runtime_ledger_summary(
     evidence_grade_rows = [
         row for row in rows if _runtime_ledger_bucket_evidence_grade(row)
     ]
+    evidence_grade_row_ids = {id(row) for row in evidence_grade_rows}
+    non_evidence_grade_rows = [
+        row for row in rows if id(row) not in evidence_grade_row_ids
+    ]
     filled_notional = sum(
         (row.filled_notional for row in evidence_grade_rows), Decimal("0")
     )
@@ -1767,7 +1841,7 @@ def _runtime_ledger_summary(
     return {
         "bucket_count": len(rows),
         "evidence_grade_bucket_count": len(evidence_grade_rows),
-        "non_evidence_grade_bucket_count": len(rows) - len(evidence_grade_rows),
+        "non_evidence_grade_bucket_count": len(non_evidence_grade_rows),
         "returned_bucket_count": len(rows),
         "query_limit": RUNTIME_LEDGER_SUMMARY_ROW_LIMIT,
         "truncated": truncated,
@@ -1812,6 +1886,9 @@ def _runtime_ledger_summary(
                 for item in _as_sequence(row.blockers_json)
                 if str(item).strip()
             }
+        ),
+        "non_evidence_grade_diagnostic": (
+            _runtime_ledger_non_evidence_diagnostic_summary(non_evidence_grade_rows)
         ),
     }
 

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -24,6 +24,7 @@ from app.trading.paper_route_evidence import (
     RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION,
     _next_regular_equities_session_window,
     _paper_route_probe_summary,
+    _runtime_ledger_row_diagnostic_expectancy_bps,
     build_paper_route_evidence_audit,
 )
 
@@ -37,6 +38,73 @@ class TestPaperRouteEvidenceAudit(TestCase):
             poolclass=StaticPool,
         )
         Base.metadata.create_all(self.engine)
+
+    def test_runtime_ledger_diagnostic_expectancy_prefers_payload_value(self) -> None:
+        row = StrategyRuntimeLedgerBucket(
+            run_id="diagnostic-runtime-ledger-run",
+            candidate_id="candidate-diagnostic",
+            hypothesis_id="H-DIAGNOSTIC",
+            observed_stage="paper",
+            bucket_started_at=datetime(2026, 5, 28, 14, 30, tzinfo=timezone.utc),
+            bucket_ended_at=datetime(2026, 5, 28, 15, 30, tzinfo=timezone.utc),
+            account_label="TORGHUT_SIM",
+            runtime_strategy_name="diagnostic-strategy",
+            strategy_family="microbar_pairs",
+            fill_count=2,
+            decision_count=1,
+            submitted_order_count=1,
+            closed_trade_count=0,
+            open_position_count=1,
+            filled_notional=Decimal("1000"),
+            gross_strategy_pnl=Decimal("20"),
+            cost_amount=Decimal("1"),
+            net_strategy_pnl_after_costs=Decimal("19"),
+            post_cost_expectancy_bps=None,
+            ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+            pnl_basis="realized_strategy_pnl_after_explicit_costs",
+            execution_policy_hash_counts={"policy-a": 1},
+            cost_model_hash_counts={"cost-a": 1},
+            lineage_hash_counts={"lineage-a": 1},
+            blockers_json=["unclosed_position"],
+            payload_json={"diagnostic_closed_trade_expectancy_bps": "12.5"},
+        )
+
+        self.assertEqual(
+            _runtime_ledger_row_diagnostic_expectancy_bps(row),
+            Decimal("12.5"),
+        )
+
+    def test_runtime_ledger_diagnostic_expectancy_requires_closed_trade(self) -> None:
+        row = StrategyRuntimeLedgerBucket(
+            run_id="diagnostic-runtime-ledger-run",
+            candidate_id="candidate-diagnostic",
+            hypothesis_id="H-DIAGNOSTIC",
+            observed_stage="paper",
+            bucket_started_at=datetime(2026, 5, 28, 14, 30, tzinfo=timezone.utc),
+            bucket_ended_at=datetime(2026, 5, 28, 15, 30, tzinfo=timezone.utc),
+            account_label="TORGHUT_SIM",
+            runtime_strategy_name="diagnostic-strategy",
+            strategy_family="microbar_pairs",
+            fill_count=1,
+            decision_count=1,
+            submitted_order_count=1,
+            closed_trade_count=0,
+            open_position_count=1,
+            filled_notional=Decimal("1000"),
+            gross_strategy_pnl=Decimal("20"),
+            cost_amount=Decimal("1"),
+            net_strategy_pnl_after_costs=Decimal("19"),
+            post_cost_expectancy_bps=None,
+            ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+            pnl_basis="realized_strategy_pnl_after_explicit_costs",
+            execution_policy_hash_counts={"policy-a": 1},
+            cost_model_hash_counts={"cost-a": 1},
+            lineage_hash_counts={"lineage-a": 1},
+            blockers_json=["closed_round_trip_missing"],
+            payload_json={},
+        )
+
+        self.assertIsNone(_runtime_ledger_row_diagnostic_expectancy_bps(row))
 
     def test_next_paper_route_window_stays_on_current_session_for_import(
         self,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -2260,13 +2260,13 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         fill_count=50,
                         decision_count=25,
                         submitted_order_count=25,
-                        closed_trade_count=0,
+                        closed_trade_count=1,
                         open_position_count=1,
                         filled_notional=Decimal("1000000"),
                         gross_strategy_pnl=Decimal("110000"),
                         cost_amount=Decimal("10000"),
                         net_strategy_pnl_after_costs=Decimal("100000"),
-                        post_cost_expectancy_bps=Decimal("1000"),
+                        post_cost_expectancy_bps=None,
                         ledger_schema_version="torghut.runtime-ledger-bucket.v1",
                         pnl_basis="realized_strategy_pnl_after_explicit_costs",
                         execution_policy_hash_counts={"policy-a": 25},
@@ -2401,6 +2401,32 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(audit["runtime_ledger"]["bucket_count"], 2)
         self.assertEqual(audit["runtime_ledger"]["evidence_grade_bucket_count"], 1)
         self.assertEqual(audit["runtime_ledger"]["non_evidence_grade_bucket_count"], 1)
+        self.assertEqual(
+            audit["runtime_ledger"]["non_evidence_grade_diagnostic"]["scope"],
+            "non_evidence_grade_runtime_ledger_buckets_diagnostic_only_not_promotion_proof",
+        )
+        self.assertEqual(
+            audit["runtime_ledger"]["non_evidence_grade_diagnostic"][
+                "diagnostic_bucket_count"
+            ],
+            1,
+        )
+        self.assertEqual(
+            audit["runtime_ledger"]["non_evidence_grade_diagnostic"][
+                "net_strategy_pnl_after_costs"
+            ],
+            "100000",
+        )
+        self.assertEqual(
+            audit["runtime_ledger"]["non_evidence_grade_diagnostic"][
+                "diagnostic_closed_trade_expectancy_bps"
+            ],
+            "1000",
+        )
+        self.assertEqual(
+            audit["runtime_ledger"]["non_evidence_grade_diagnostic"]["blocker_counts"],
+            {"open_position_count_nonzero": 1},
+        )
         self.assertEqual(
             audit["runtime_ledger"]["proof_scope"],
             "evidence_grade_runtime_ledger_buckets_only",


### PR DESCRIPTION
## Summary

- Adds a diagnostic-only summary for non-evidence-grade runtime ledger buckets in paper-route evidence audits.
- Computes diagnostic closed-trade expectancy from persisted net PnL and filled notional when promotion-grade expectancy is absent.
- Keeps evidence-grade proof fields and promotion authority unchanged, with explicit diagnostic scope text.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'paper_route_evidence or runtime_ledger_summary'`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
