### PR TITLE
fix(synthesis): harden autotrader analysis bootstrap

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -184,21 +184,31 @@ spec:
           exit 42
         fi
 
-        "${python_bin}" -m venv "${artifact_dir}/analysis-venv"
-        # shellcheck disable=SC1091
-        source "${artifact_dir}/analysis-venv/bin/activate"
-        python -m pip install --upgrade pip
-        python -m pip install -e "${analysis_dir}[daytrading]"
+        analysis_python="${python_bin}"
+        rm -rf "${artifact_dir}/analysis-venv"
+        if "${python_bin}" -m venv "${artifact_dir}/analysis-venv"; then
+          # shellcheck disable=SC1091
+          source "${artifact_dir}/analysis-venv/bin/activate"
+          python -m pip install --upgrade pip
+          python -m pip install -e "${analysis_dir}[daytrading]"
+          analysis_python="python"
+        else
+          printf 'analysis bootstrap warning: venv unavailable, continuing with PYTHONPATH source checkout\n' >&2
+          if "${python_bin}" -m pip --version >/dev/null 2>&1; then
+            "${python_bin}" -m pip install --user -e "${analysis_dir}[daytrading]" || \
+              printf 'analysis bootstrap warning: user install failed, continuing with PYTHONPATH\n' >&2
+          fi
+        fi
 
         (
           cd "${analysis_dir}"
-          PYTHONPATH=src python -m stock_analysis audit
+          PYTHONPATH=src "${analysis_python}" -m stock_analysis audit
         )
-        PYTHONPATH="${analysis_dir}/src" python -m stock_analysis daytrading-import-smoke
-        PYTHONPATH="${analysis_dir}/src" python -m stock_analysis daytrading-context \
+        PYTHONPATH="${analysis_dir}/src" "${analysis_python}" -m stock_analysis daytrading-import-smoke
+        PYTHONPATH="${analysis_dir}/src" "${analysis_python}" -m stock_analysis daytrading-context \
           --repo-root "${analysis_dir}" \
           --output "${artifact_dir}/analysis-context.json"
-        PYTHONPATH="${analysis_dir}/src" python -m stock_analysis daytrading-validate-context \
+        PYTHONPATH="${analysis_dir}/src" "${analysis_python}" -m stock_analysis daytrading-validate-context \
           "${artifact_dir}/analysis-context.json"
 
         printf '{"ok":true,"analysis_head":"%s","required_commit":"%s","context_path":"%s"}\n' \


### PR DESCRIPTION
## Summary

- Hardens the autonomous-trader analysis bootstrap script for runner images that lack `python3-venv`.
- Falls back to the source checkout with `PYTHONPATH` and attempts a user-level install only when pip is available.
- Removes partial venv state before retrying bootstrap so a failed venv creation does not poison the next run.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- Live dry AgentRun `autonomous-trader-dry-proof-20260529024315` exposed the missing `python3.13-venv` failure this patch addresses.

## Screenshots (if applicable)

N/A. AgentProvider bootstrap script change.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
