### PR TITLE
fix(torghut): stop hashing per-event ids as ledger policy

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -595,7 +595,6 @@ def _normalize_fill_row(
             "execution_policy_hash",
             "execution_policy_sha256",
             "policy_hash",
-            "execution_idempotency_key",
         )
     )
     cost_model_hash = _coerce_text(

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -1470,7 +1470,6 @@ def _runtime_lifecycle_ledger_row(
             "execution_policy_hash",
             "execution_policy_sha256",
             "policy_hash",
-            "execution_idempotency_key",
         )
         or _first_payload_digest(
             row,
@@ -1478,8 +1477,6 @@ def _runtime_lifecycle_ledger_row(
             "execution_policy_context",
             "execution_advisor",
             "_execution_advice_provenance",
-            "decision_json",
-            "raw_event",
         ),
         "cost_model_hash": _first_text(
             row,
@@ -1494,9 +1491,6 @@ def _runtime_lifecycle_ledger_row(
             "transaction_cost_model",
             "fee_model",
             "fees_model",
-            "model",
-            "decision_json",
-            "raw_event",
         ),
         "lineage_hash": _first_text(
             row,
@@ -1871,7 +1865,6 @@ def _build_realized_strategy_pnl_rows(
                 "execution_policy_hash",
                 "execution_policy_sha256",
                 "policy_hash",
-                "execution_idempotency_key",
             )
             or _first_payload_digest(
                 row,

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -2004,6 +2004,56 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(ledger_row["cost_model_hash"], "cost-sha")
         self.assertEqual(ledger_row["lineage_hash"], "lineage-sha")
 
+    def test_order_event_lifecycle_does_not_hash_raw_event_as_policy_or_cost(
+        self,
+    ) -> None:
+        row = {
+            "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+            "event_type": "filled",
+            "symbol": "AAPL",
+            "account_label": "TORGHUT_SIM",
+            "strategy_id": "microbar-cross-sectional-pairs-v1",
+            "decision_hash": "decision-buy",
+            "alpaca_order_id": "order-buy",
+            "execution_idempotency_key": "order-specific-idempotency-key",
+            "decision_json": {
+                "candidate_id": "candidate-1",
+                "decision_nonce": "changes-every-order",
+            },
+            "raw_event": {
+                "event": "fill",
+                "sequence": 25,
+                "order": {
+                    "id": "order-buy",
+                    "status": "filled",
+                    "filled_qty": "1",
+                    "filled_avg_price": "100",
+                },
+            },
+            "lineage_hash": "lineage-sha",
+            "raw_order": {
+                "side": "buy",
+                "runtime_ledger_cost": {
+                    "cost_amount": "0.20",
+                    "cost_basis": "broker_reported_commission_and_fees",
+                },
+            },
+        }
+
+        ledger_row = _runtime_lifecycle_ledger_row(
+            row,
+            event_type="filled",
+            require_complete_fill=True,
+        )
+
+        self.assertIsNotNone(ledger_row)
+        assert ledger_row is not None
+        self.assertIsNone(ledger_row["execution_policy_hash"])
+        self.assertIsNone(ledger_row["cost_model_hash"])
+        self.assertEqual(ledger_row["lineage_hash"], "lineage-sha")
+        self.assertEqual(ledger_row["filled_qty"], Decimal("1"))
+        self.assertEqual(ledger_row["cost_amount"], Decimal("0.20"))
+
     def test_order_event_lifecycle_materializes_alpaca_fee_schedule_costs(self) -> None:
         row = {
             "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
@@ -2059,6 +2109,52 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ledger_row["cost_model_hash"],
             _alpaca_2026_equity_fee_schedule_hash(),
         )
+
+    def test_build_realized_strategy_pnl_rows_does_not_use_idempotency_key_as_policy_hash(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_idempotency_key": "buy-order-key",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_idempotency_key": "sell-order-key",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["execution_policy_hash_counts"], {})
+        self.assertIn("execution_policy_hash_missing", bucket["blockers"])
+        self.assertNotIn("execution_policy_hash_ambiguous", bucket["blockers"])
+        self.assertEqual(bucket["cost_model_hash_counts"], {"cost-sha": 2})
 
     def test_runtime_ledger_tca_materialization_metadata_separates_authority(
         self,

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -587,6 +587,82 @@ def test_exact_replay_ledger_requires_order_lifecycle_and_hash_lineage() -> None
     assert bucket.post_cost_expectancy_bps is not None
 
 
+def test_exact_replay_ledger_does_not_use_idempotency_key_as_policy_hash() -> None:
+    common = {
+        "account_label": "paper",
+        "strategy_id": "strategy-1",
+        "symbol": "NVDA",
+        "cost_model_hash": "cost-sha",
+        "lineage_hash": "lineage-sha",
+    }
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                **common,
+                "event_type": "decision",
+                "executed_at": _ts(1),
+                "decision_id": "decision-buy",
+                "execution_idempotency_key": "buy-decision-key",
+            },
+            {
+                **common,
+                "event_type": "order_submitted",
+                "executed_at": _ts(2),
+                "decision_id": "decision-buy",
+                "order_id": "order-buy",
+                "execution_idempotency_key": "buy-order-key",
+            },
+            {
+                **common,
+                "event_type": "fill",
+                "executed_at": _ts(3),
+                "order_id": "order-buy",
+                "side": "buy",
+                "filled_qty": "10",
+                "avg_fill_price": "100",
+                "cost_amount": "1",
+                "cost_basis": "broker_reported_commission_and_fees",
+                "execution_idempotency_key": "buy-fill-key",
+            },
+            {
+                **common,
+                "event_type": "decision",
+                "executed_at": _ts(10),
+                "decision_id": "decision-sell",
+                "execution_idempotency_key": "sell-decision-key",
+            },
+            {
+                **common,
+                "event_type": "order_submitted",
+                "executed_at": _ts(11),
+                "decision_id": "decision-sell",
+                "order_id": "order-sell",
+                "execution_idempotency_key": "sell-order-key",
+            },
+            {
+                **common,
+                "event_type": "fill",
+                "executed_at": _ts(12),
+                "order_id": "order-sell",
+                "side": "sell",
+                "filled_qty": "10",
+                "avg_fill_price": "110",
+                "cost_amount": "2",
+                "cost_basis": "broker_reported_commission_and_fees",
+                "execution_idempotency_key": "sell-fill-key",
+            },
+        ],
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.execution_policy_hash_counts == {}
+    assert "execution_policy_hash_missing" in bucket.blockers
+    assert "execution_policy_hash_ambiguous" not in bucket.blockers
+    assert bucket.cost_model_hash_counts == {"cost-sha": 6}
+    assert bucket.lineage_hash_counts == {"lineage-sha": 6}
+
+
 def test_runtime_ledger_blocks_non_promotion_grade_cost_basis_at_builder() -> None:
     common = {
         "account_label": "paper",


### PR DESCRIPTION
## Summary

- Stop treating per-order `execution_idempotency_key` values as stable runtime-ledger execution policy hashes.
- Stop hashing whole `decision_json` / `raw_event` payloads, or generic `model` fields, as policy or cost-model identity.
- Add regression coverage proving missing ledger authority metadata fails closed as missing instead of becoming false hash ambiguity.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_runtime_ledger.py -k 'idempotency_key or hash_lineage or unhashed_order_lifecycle'`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'idempotency_key_as_policy_hash or raw_event_as_policy_or_cost or raw_order_metadata or alpaca_fee_schedule_costs'`
- `uv run --frozen pytest tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py -k 'idempotency_key or raw_event_as_policy_or_cost or raw_order_metadata or alpaca_fee_schedule_costs or hash_lineage or unhashed_order_lifecycle' --cov=app.trading.runtime_ledger --cov=scripts.import_hypothesis_runtime_windows --cov-report=xml --cov-fail-under=0 -q`
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `git diff --check`
- `uv run --frozen ruff check app/trading/runtime_ledger.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff format --check app/trading/runtime_ledger.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
