### PR TITLE
fix(synthesis): pass agent identity to trader mcp

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -37,6 +37,8 @@ spec:
             env:
               SYNTHESIS_API_TOKEN_FILE: /var/run/synthesis/SYNTHESIS_API_TOKEN
               SYNTHESIS_MCP_URL: http://synthesis.synthesis.svc.cluster.local:3000/mcp
+              AGENT_RUN_NAME: "{{ agentRun.name }}"
+              AGENT_RUN_NAMESPACE: "{{ agentRun.namespace }}"
         web_search: live
   argsTemplate: []
   secretEnv:
@@ -134,7 +136,7 @@ spec:
         [mcp_servers.synthesis]
         command = "node"
         args = ["/root/.codex/synthesis-mcp-proxy.mjs"]
-        env = { SYNTHESIS_API_TOKEN_FILE = "/var/run/synthesis/SYNTHESIS_API_TOKEN", SYNTHESIS_MCP_URL = "http://synthesis.synthesis.svc.cluster.local:3000/mcp" }
+        env = { SYNTHESIS_API_TOKEN_FILE = "/var/run/synthesis/SYNTHESIS_API_TOKEN", SYNTHESIS_MCP_URL = "http://synthesis.synthesis.svc.cluster.local:3000/mcp", AGENT_RUN_NAME = "{{ agentRun.name }}", AGENT_RUN_NAMESPACE = "{{ agentRun.namespace }}" }
     - path: /root/bootstrap-analysis-daytrading.sh
       content: |-
         #!/usr/bin/env bash

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -781,11 +781,15 @@ describe('synthesis autonomous trader provider', () => {
     expect(objectAt(objectAt(synthesis, 'env'), 'SYNTHESIS_MCP_URL')).toBe(
       'http://synthesis.synthesis.svc.cluster.local:3000/mcp',
     )
+    expect(objectAt(objectAt(synthesis, 'env'), 'AGENT_RUN_NAME')).toBe('{{ agentRun.name }}')
+    expect(objectAt(objectAt(synthesis, 'env'), 'AGENT_RUN_NAMESPACE')).toBe('{{ agentRun.namespace }}')
     expect(objectAt(envTemplate, 'SYNTHESIS_API_TOKEN_FILE')).toBe('/var/run/synthesis/SYNTHESIS_API_TOKEN')
     expect(objectAt(envTemplate, 'SYNTHESIS_MCP_URL')).toBe('http://synthesis.synthesis.svc.cluster.local:3000/mcp')
     expect((secretEnv ?? []).some((entry) => objectAt(entry, 'name') === 'SYNTHESIS_API_TOKEN')).toBe(true)
     expect(objectAt(codexConfig, 'content')).toContain('[mcp_servers.synthesis]')
     expect(objectAt(codexConfig, 'content')).toContain('SYNTHESIS_API_TOKEN_FILE')
+    expect(objectAt(codexConfig, 'content')).toContain('AGENT_RUN_NAME = "{{ agentRun.name }}"')
+    expect(objectAt(codexConfig, 'content')).toContain('AGENT_RUN_NAMESPACE = "{{ agentRun.namespace }}"')
     expect(objectAt(synthesisProxy, 'content')).toContain('Synthesis MCP HTTP')
     expect(objectAt(synthesisProxy, 'content')).toContain('Bearer')
     expect(objectAt(synthesisProxy, 'content')).toContain('const agentRunName = process.env.AGENT_RUN_NAME')


### PR DESCRIPTION
## Summary

- Pass the exact rendered `AGENT_RUN_NAME` and `AGENT_RUN_NAMESPACE` into the Synthesis MCP server environment.
- Keep the generated Codex `config.toml` fallback path aligned with the threadConfig MCP env.
- Extend the Synthesis autonomous-trader provider smoke test to cover both identity env paths.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "synthesis autonomous trader provider"`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
