### PR TITLE
fix(torghut): authenticate changed-file planner

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -66,6 +66,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BEFORE_SHA: ${{ github.event.before }}
           HEAD_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -78,14 +79,30 @@ jobs:
           fi
 
           changed_files="$(mktemp)"
+          github_api() {
+            local url="$1"
+            local attempt
+
+            for attempt in 1 2 3; do
+              if curl -fsSL \
+                -H "Authorization: Bearer ${GH_TOKEN}" \
+                -H 'Accept: application/vnd.github+json' \
+                -H 'X-GitHub-Api-Version: 2022-11-28' \
+                "${url}"; then
+                return 0
+              fi
+              sleep $((attempt * 2))
+            done
+
+            echo "Failed to fetch GitHub API URL after retries: ${url}" >&2
+            return 1
+          }
+
           if [ "${EVENT_NAME}" = "pull_request" ]; then
             page=1
             while true; do
               response="$(
-                curl -fsSL \
-                  -H 'Accept: application/vnd.github+json' \
-                  -H 'X-GitHub-Api-Version: 2022-11-28' \
-                  "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}/files?per_page=100&page=${page}"
+                github_api "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}/files?per_page=100&page=${page}"
               )"
               count="$(jq 'length' <<< "${response}")"
               if [ "${count}" -eq 0 ]; then
@@ -95,10 +112,7 @@ jobs:
               page=$((page + 1))
             done
           else
-            curl -fsSL \
-              -H 'Accept: application/vnd.github+json' \
-              -H 'X-GitHub-Api-Version: 2022-11-28' \
-              "https://api.github.com/repos/${GH_REPO}/compare/${BEFORE_SHA}...${HEAD_SHA}" \
+            github_api "https://api.github.com/repos/${GH_REPO}/compare/${BEFORE_SHA}...${HEAD_SHA}" \
               | jq -r '.files[].filename' > "${changed_files}"
           fi
 

--- a/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
+++ b/packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts
@@ -54,6 +54,20 @@ describe('torghut build-push workflow', () => {
     expect(installStep).toBeGreaterThan(cachePath)
   })
 
+  it('authenticates changed-file planner GitHub API calls', () => {
+    const changesJob = ciWorkflow.indexOf('changes:')
+    const tokenEnv = ciWorkflow.indexOf('GH_TOKEN: ${{ github.token }}', changesJob)
+    const authHeader = ciWorkflow.indexOf('-H "Authorization: Bearer ${GH_TOKEN}"', tokenEnv)
+    const prFilesCall = ciWorkflow.indexOf('/pulls/${PR_NUMBER}/files?per_page=100&page=${page}', authHeader)
+    const compareCall = ciWorkflow.indexOf('/compare/${BEFORE_SHA}...${HEAD_SHA}', authHeader)
+
+    expect(changesJob).toBeGreaterThan(-1)
+    expect(tokenEnv).toBeGreaterThan(changesJob)
+    expect(authHeader).toBeGreaterThan(tokenEnv)
+    expect(prFilesCall).toBeGreaterThan(authHeader)
+    expect(compareCall).toBeGreaterThan(authHeader)
+  })
+
   it('does not cancel main source CI that release promotion must verify', () => {
     expect(ciWorkflow).toContain(
       "group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}",


### PR DESCRIPTION
## Summary

- Authenticates `torghut-ci` changed-file planner GitHub API requests with the workflow token.
- Retries changed-file API calls before failing so transient API/rate-limit responses do not break release pushes immediately.
- Adds a workflow regression test that keeps authenticated PR-files and compare calls in place.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts`
- `bunx oxfmt --check packages/scripts/src/torghut/__tests__/build-push-workflow.test.ts`
- `actionlint .github/workflows/torghut-ci.yml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
