### PR TITLE
fix(synthesis): reduce trader dry-run runtime overhead

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -94,7 +94,7 @@ spec:
     - path: /root/.codex/config.toml
       content: |-
         model = "gpt-5.5"
-        model_reasoning_summary = "detailed"
+        model_reasoning_summary = "none"
         model_reasoning_effort = "xhigh"
         model_verbosity = "medium"
         approval_policy = "never"
@@ -149,6 +149,23 @@ spec:
         python_bin="${PYTHON_BIN:-python3}"
 
         mkdir -p "${artifact_dir}"
+
+        ensure_artifact_file() {
+          local name="$1"
+          local content="${2:-}"
+          if [ ! -e "${artifact_dir}/${name}" ]; then
+            printf '%s' "${content}" > "${artifact_dir}/${name}"
+          fi
+        }
+
+        ensure_artifact_file "decision-ledger.jsonl" ""
+        ensure_artifact_file "visibility-events.jsonl" ""
+        ensure_artifact_file "synthesis-posts.jsonl" ""
+        ensure_artifact_file "protective-orders.jsonl" ""
+        ensure_artifact_file "preflight.json" $'{}\n'
+        ensure_artifact_file "current-status.json" $'{}\n'
+        ensure_artifact_file "trade-ticket.json" $'{}\n'
+        ensure_artifact_file "report.md" $'# Autonomous Trader Report\n\nstatus: bootstrapping\n'
 
         git_auth=()
         git_token="${GITHUB_TOKEN:-}"

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -53,9 +53,10 @@ spec:
        - Write `/workspace/.agentrun/autonomous-trader/preflight.json` with redacted evidence.
        - Call `autotrader_start_session` before scanning and persist its returned `sessionId`.
     3. Mode handling:
-       - `dry-run`: perform bootstrap, read-only Alpaca preflight, Synthesis scorecard read, one scanner/ticket validation pass, blocked/no-trade decision recording, risk recording, status/event writes, and `autotrader_finalize_session`; do not call Alpaca order submission, cancel, replace, or close-position tools; finish with terminal_reason `dry_run_complete`.
-       - In `dry-run`, finalize the autotrader session immediately after ticket/risk/status writes; write only the required output files and exit the AgentRun.
-       - After `autotrader_finalize_session` succeeds in `dry-run`, write the final `report.md`, mark the AgentRun-local goal complete, and stop. Do not run completion audits, inspect PR/CI state, re-read scorecards, retry visibility, optimize wording, wait for market state, or perform any further analysis.
+       - `dry-run`: perform bootstrap, read-only Alpaca preflight, Synthesis scorecard read, one scanner/ticket validation pass, blocked/no-trade decision recording, risk recording, status/event writes, and `autotrader_finalize_session`; do not call Alpaca order submission, cancel, replace, close-position tools, or `synthesis_submit_item`; finish with terminal_reason `dry_run_complete`.
+       - In `dry-run`, structured Synthesis autotrader state is the visibility path; feed milestone posts are disabled.
+       - In `dry-run`, finalize the autotrader session immediately after ticket/risk/status writes; update only the minimal output placeholders created by bootstrap and exit the AgentRun.
+       - After `autotrader_finalize_session` succeeds in `dry-run`, write the final `report.md`, mark the AgentRun-local goal complete, and stop. Do not run completion audits, inspect PR/CI state, re-read scorecards, retry visibility, optimize wording, wait for market state, backfill JSONL exports, or perform any further analysis.
        - `preflight`: perform readiness checks and, only if safe, one tiny non-marketable paper bracket or OTO stock order proof that is verified by id/client id and canceled; if Alpaca rejects or blocks it, record the exact request and reason.
        - `market-open`: wait for the market to open, then run an intraday loop until market close, equity is at least 500000 USD, or account/order state becomes unrecoverable.
     4. Each market-open cycle:
@@ -73,6 +74,7 @@ spec:
        - Reconcile each submitted order by order id or client order id before the next action.
        - Write each cycle through Synthesis autotrader MCP: `autotrader_upsert_status` for current state, `autotrader_append_event` for decisions/no-trade/order lifecycle, `autotrader_create_trade_ticket` for every candidate selected or blocked, `autotrader_record_risk_check` for risk gates, `autotrader_record_order` and `autotrader_record_fill` for Alpaca reconciliation, and `autotrader_record_position_snapshot` after broker position reads.
        - Append local JSONL artifacts only as export/debug copies; Synthesis Postgres is primary runtime state.
+       - The bootstrap script pre-creates output placeholders; do not spend runtime reconstructing export files that already exist.
        - Update `/workspace/.agentrun/autonomous-trader/report.md`; emit heartbeat output at least every 60 seconds while waiting.
     5. Synthesis visibility:
        - Use Synthesis MCP to call `autotrader_start_session` once per AgentRun and use its `sessionId` for all structured state.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -31,9 +31,10 @@ data:
     - Confirm Alpaca MCP exposes stock protective-order fields: `order_class`, `take_profit_limit_price`, `stop_loss_stop_price`, and `stop_loss_limit_price`.
     - Confirm Synthesis MCP exposes `autotrader_start_session`, `autotrader_upsert_status`, `autotrader_append_event`, `autotrader_create_trade_ticket`, `autotrader_record_risk_check`, `autotrader_record_order`, `autotrader_record_fill`, `autotrader_record_position_snapshot`, `autotrader_finalize_session`, `autotrader_get_scorecard`, and `synthesis_submit_item`.
     - Call `autotrader_start_session` before scanning and persist its returned `sessionId`.
-    - In dry-run mode, perform bootstrap, read-only Alpaca preflight, Synthesis scorecard read, one scanner/ticket validation pass, blocked/no-trade decision recording, risk recording, status/event writes, and `autotrader_finalize_session`; do not call Alpaca order submission, cancel, replace, or close-position tools.
-    - In dry-run mode, finalize the autotrader session immediately after ticket/risk/status writes; write only the required output files and exit the AgentRun.
-    - After `autotrader_finalize_session` succeeds in dry-run mode, write the final `report.md`, mark the AgentRun-local goal complete, and stop. Do not run completion audits, inspect PR/CI state, re-read scorecards, retry visibility, optimize wording, wait for market state, or perform any further analysis.
+    - In dry-run mode, perform bootstrap, read-only Alpaca preflight, Synthesis scorecard read, one scanner/ticket validation pass, blocked/no-trade decision recording, risk recording, status/event writes, and `autotrader_finalize_session`; do not call Alpaca order submission, cancel, replace, close-position tools, or `synthesis_submit_item`.
+    - In dry-run mode, structured Synthesis autotrader state is the visibility path; feed milestone posts are disabled.
+    - In dry-run mode, finalize the autotrader session immediately after ticket/risk/status writes; update only the minimal output placeholders created by bootstrap and exit the AgentRun.
+    - After `autotrader_finalize_session` succeeds in dry-run mode, write the final `report.md`, mark the AgentRun-local goal complete, and stop. Do not run completion audits, inspect PR/CI state, re-read scorecards, retry visibility, optimize wording, wait for market state, backfill JSONL exports, or perform any further analysis.
     - In preflight mode, prove the stock protective-order path with one tiny non-marketable paper bracket or OTO order when safe; verify by id/client id and cancel it, or record the exact Alpaca rejection/blocker.
     - In market-open mode, loop until market close, 500000 USD equity, or unrecoverable account/order state.
     - Each cycle re-reads account and market state, reconciles orders, absorbs account changes, evaluates actions, updates artifacts, and waits with heartbeat output at least every 60 seconds.
@@ -48,6 +49,7 @@ data:
     - Reconcile every submitted order by order id or client order id before the next action.
     - Write each cycle through Synthesis autotrader MCP: `autotrader_upsert_status` for current state, `autotrader_append_event` for decisions/no-trade/order lifecycle, `autotrader_create_trade_ticket` for every candidate selected or blocked, `autotrader_record_risk_check` for risk gates, `autotrader_record_order` and `autotrader_record_fill` for Alpaca reconciliation, and `autotrader_record_position_snapshot` after broker position reads.
     - Append local JSONL artifacts only as export/debug copies; Synthesis Postgres is primary runtime state.
+    - The bootstrap script pre-creates output placeholders; do not spend runtime reconstructing export files that already exist.
     - Retry transient Alpaca MCP read failures up to 3 times with backoff and record `mcp_retry`.
     - When a good trade is blocked by buying power, permissions, liquidity, rejected orders, or market state, stand down, reduce, close, or monitor.
     - Before finishing, call `autotrader_finalize_session` with realized scorecard observations for terminal tickets, rejected valid setups, rejected invalid setups, slippage, hold time, MFE/MAE, and mistake tags.

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -670,12 +670,19 @@ describe('synthesis autonomous trader provider', () => {
     expect(prompt).toContain('/milestones/${dedupeKey}')
     expect(prompt).not.toContain('synthesis_start_run')
     expect(prompt).toContain('synthesis_submit_item')
+    expect(prompt).toContain(
+      'do not call Alpaca order submission, cancel, replace, close-position tools, or `synthesis_submit_item`',
+    )
+    expect(prompt).toContain('feed milestone posts are disabled')
+    expect(prompt).toContain('The bootstrap script pre-creates output placeholders')
     expect(prompt).toContain('current-status.json')
     expect(prompt).toContain('visibility-events.jsonl')
     expect(prompt).toContain('synthesis-posts.jsonl')
-    expect(prompt).toContain('write only the required output files and exit the AgentRun')
+    expect(prompt).toContain('update only the minimal output placeholders created by bootstrap and exit the AgentRun')
     expect(prompt).toContain('Do not run completion audits')
-    expect(taskPrompt).toContain('write only the required output files and exit the AgentRun')
+    expect(taskPrompt).toContain(
+      'update only the minimal output placeholders created by bootstrap and exit the AgentRun',
+    )
     expect(taskPrompt).toContain('Do not run completion audits')
     expect(taskPrompt).toContain('order_class')
     expect(taskPrompt).toContain('take_profit_limit_price')
@@ -695,6 +702,11 @@ describe('synthesis autonomous trader provider', () => {
     expect(taskPrompt).toContain('/milestones/${dedupeKey}')
     expect(taskPrompt).not.toContain('synthesis_start_run')
     expect(taskPrompt).toContain('synthesis_submit_item')
+    expect(taskPrompt).toContain(
+      'do not call Alpaca order submission, cancel, replace, close-position tools, or `synthesis_submit_item`',
+    )
+    expect(taskPrompt).toContain('feed milestone posts are disabled')
+    expect(taskPrompt).toContain('The bootstrap script pre-creates output placeholders')
     expect(taskPrompt).toContain('current-status.json')
     expect(taskPrompt).toContain('visibility-events.jsonl')
     expect(taskPrompt).toContain('synthesis-posts.jsonl')
@@ -722,9 +734,13 @@ describe('synthesis autonomous trader provider', () => {
     expect(objectAt(envTemplate, 'ANALYSIS_REPO_URL')).toBe('https://github.com/gregkonush/analysis.git')
     expect(objectAt(envTemplate, 'ANALYSIS_REQUIRED_COMMIT')).toBe('4ce90bf7fc16f9bf90f7fe221f36db23c7ff44a5')
     expect(objectAt(codexConfig, 'content')).toContain('[projects."/workspace/analysis"]')
+    expect(objectAt(codexConfig, 'content')).toContain('model_reasoning_summary = "none"')
     expect(objectAt(bootstrap, 'content')).toContain('x-access-token:%s')
     expect(objectAt(bootstrap, 'content')).toContain('Authorization: Basic')
     expect(objectAt(bootstrap, 'content')).not.toContain('Authorization: Bearer')
+    expect(objectAt(bootstrap, 'content')).toContain('ensure_artifact_file')
+    expect(objectAt(bootstrap, 'content')).toContain('decision-ledger.jsonl')
+    expect(objectAt(bootstrap, 'content')).toContain('protective-orders.jsonl')
     expect(objectAt(bootstrap, 'content')).toContain('uv venv --seed')
     expect(objectAt(bootstrap, 'content')).toContain('--break-system-packages')
     expect(objectAt(bootstrap, 'content')).toContain('install_method')


### PR DESCRIPTION
## Summary

- Disable detailed Codex reasoning summaries for the long-running Synthesis trader while keeping gpt-5.5 xhigh reasoning.
- Pre-create autotrader export artifact placeholders during analysis bootstrap so dry and preflight runs do not spend runtime reconstructing debug files.
- Tighten dry-run instructions to use Synthesis autotrader structured state only, skip feed milestone posts, and stop after finalization.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "synthesis autonomous trader provider"`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `git diff --check`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
