### PR TITLE
fix(synthesis): lower trader storage request

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml
@@ -52,7 +52,7 @@ spec:
       requests:
         cpu: "2"
         memory: 4Gi
-        ephemeral-storage: 8Gi
+        ephemeral-storage: 2Gi
       limits:
         memory: 16Gi
         ephemeral-storage: 16Gi

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -786,6 +786,9 @@ describe('synthesis autonomous trader provider', () => {
       (inputFile) => objectAt(inputFile, 'path') === '/root/.codex/synthesis-mcp-proxy.mjs',
     )
     const workload = objectAt(objectAt(template, 'spec'), 'workload')
+    const resources = objectAt(workload, 'resources')
+    const requests = objectAt(resources, 'requests')
+    const limits = objectAt(resources, 'limits')
     const volumes = objectAt(workload, 'volumes') as Record<string, unknown>[] | undefined
     const synthesisVolume = (volumes ?? []).find((volume) => objectAt(volume, 'name') === 'synthesis-env')
 
@@ -814,6 +817,8 @@ describe('synthesis autonomous trader provider', () => {
     expect(objectAt(synthesisProxy, 'content')).toContain('normalizeAutotraderArguments')
     expect(objectAt(synthesisProxy, 'content')).toContain("toolName !== 'autotrader_start_session'")
     expect(objectAt(synthesisProxy, 'content')).toContain('nextArgs.agentRunName = agentRunName')
+    expect(objectAt(requests, 'ephemeral-storage')).toBe('2Gi')
+    expect(objectAt(limits, 'ephemeral-storage')).toBe('16Gi')
     expect(objectAt(synthesisVolume, 'mountPath')).toBe('/var/run/synthesis')
     expect(objectAt(synthesisVolume, 'readOnly')).toBe(true)
     expect(objectAt(objectAt(objectAt(agent, 'spec'), 'security'), 'allowedSecrets')).toContain('synthesis-env')


### PR DESCRIPTION
## Summary

- Lower the autonomous-trader market-open AgentRun ephemeral-storage request from 8Gi to 2Gi while keeping the 16Gi limit.
- Add a manifest smoke assertion so the Synthesis trader template keeps the lower scheduling request.
- Addresses the live scheduling blocker observed when the arm64 node had only enough free requested storage for one 8Gi trader run.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "synthesis autonomous trader provider"`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
