### PR TITLE
fix(torghut): materialize paper-route proof inputs

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -2672,7 +2672,8 @@ class SimpleTradingPipeline(TradingPipeline):
         )
         if capped_qty <= 0:
             return False
-        if decision.qty > 0:
+        target_source_authorized = bool(context.get("target_source_authorized"))
+        if decision.qty > 0 and not target_source_authorized:
             capped_qty = min(decision.qty, capped_qty)
 
         capped_notional = capped_qty * price
@@ -2681,6 +2682,8 @@ class SimpleTradingPipeline(TradingPipeline):
         simple_lane["final_qty"] = str(capped_qty)
         simple_lane["notional"] = str(capped_notional)
         simple_lane["paper_route_probe_cap_applied"] = True
+        if target_source_authorized:
+            simple_lane["target_source_notional_sized"] = True
         params["simple_lane"] = simple_lane
         params["paper_route_probe"] = {
             **dict(context),
@@ -2688,6 +2691,7 @@ class SimpleTradingPipeline(TradingPipeline):
             "capped_qty": str(capped_qty),
             "capped_notional": str(capped_notional),
             "capital_stage": str(proof_floor.get("capital_state") or "zero_notional"),
+            "target_source_notional_sized": target_source_authorized,
         }
         decision.qty = capped_qty
         decision.params = params

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -3145,7 +3145,13 @@ def _query_timestamps(
             cur.execute(
                 f"""
                 select
-                    t.computed_at,
+                    coalesce(
+                        e.order_feed_last_event_ts,
+                        e.last_update_at,
+                        e.updated_at,
+                        e.created_at
+                    ) as execution_event_at,
+                    t.computed_at as tca_computed_at,
                     abs(coalesce(t.realized_shortfall_bps, t.slippage_bps)) as abs_slippage_bps,
                     (-coalesce(t.realized_shortfall_bps, t.slippage_bps)) as post_cost_expectancy_bps,
                     d.decision_hash,
@@ -3157,10 +3163,25 @@ def _query_timestamps(
                 where s.name = any(%s)
                   and d.alpaca_account_label = %s
                   and coalesce(t.alpaca_account_label, e.alpaca_account_label, d.alpaca_account_label) = %s
-                  and t.computed_at >= %s
-                  and t.computed_at < %s
+                  and coalesce(
+                        e.order_feed_last_event_ts,
+                        e.last_update_at,
+                        e.updated_at,
+                        e.created_at
+                      ) >= %s
+                  and coalesce(
+                        e.order_feed_last_event_ts,
+                        e.last_update_at,
+                        e.updated_at,
+                        e.created_at
+                      ) < %s
                   {execution_symbol_clause}
-                order by t.computed_at
+                order by coalesce(
+                    e.order_feed_last_event_ts,
+                    e.last_update_at,
+                    e.updated_at,
+                    e.created_at
+                )
                 """,
                 (
                     strategy_names,
@@ -3174,10 +3195,11 @@ def _query_timestamps(
             tca_rows = [
                 {
                     "computed_at": row[0],
-                    "abs_slippage_bps": row[1] or Decimal("0"),
-                    "post_cost_expectancy_bps": row[2] or Decimal("0"),
-                    "decision_hash": row[3],
-                    "decision_json": row[4],
+                    "tca_computed_at": row[1],
+                    "abs_slippage_bps": row[2] or Decimal("0"),
+                    "post_cost_expectancy_bps": row[3] or Decimal("0"),
+                    "decision_hash": row[4],
+                    "decision_json": row[5],
                     "post_cost_expectancy_basis": POST_COST_BASIS_TCA_PROXY,
                     "post_cost_promotion_eligible": False,
                 }

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -136,6 +136,7 @@ class _FakeCursor:
             [
                 (
                     datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 5, tzinfo=timezone.utc),
                     Decimal("1.25"),
                     Decimal("0.50"),
                     "decision-sha",
@@ -2765,6 +2766,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(tca_rows[0]["abs_slippage_bps"], Decimal("1.25"))
         self.assertEqual(tca_rows[0]["post_cost_expectancy_bps"], Decimal("0.50"))
         self.assertEqual(
+            tca_rows[0]["computed_at"],
+            datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            tca_rows[0]["tca_computed_at"],
+            datetime(2026, 3, 6, 15, 5, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
             tca_rows[0]["post_cost_expectancy_basis"], POST_COST_BASIS_TCA_PROXY
         )
         self.assertEqual(tca_rows[0]["post_cost_promotion_eligible"], False)
@@ -2801,13 +2810,18 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIn("coalesce(oe.event_ts, oe.created_at) < %s", order_event_query)
         self.assertNotIn("and d.created_at >= %s", order_event_query)
         self.assertNotIn("and d.created_at < %s", order_event_query)
-        self.assertIn("select\n                    t.computed_at", tca_query)
+        self.assertIn("as execution_event_at", tca_query)
+        self.assertIn("t.computed_at as tca_computed_at", tca_query)
         self.assertIn(
             "coalesce(t.alpaca_account_label, e.alpaca_account_label, d.alpaca_account_label) = %s",
             tca_query,
         )
-        self.assertIn("t.computed_at >= %s", tca_query)
-        self.assertIn("t.computed_at < %s", tca_query)
+        self.assertIn("e.order_feed_last_event_ts", tca_query)
+        self.assertIn("e.last_update_at", tca_query)
+        self.assertIn("e.updated_at", tca_query)
+        self.assertIn("e.created_at", tca_query)
+        self.assertNotIn("t.computed_at >= %s", tca_query)
+        self.assertNotIn("t.computed_at < %s", tca_query)
         self.assertNotIn("and d.created_at >= %s", tca_query)
         self.assertNotIn("and d.created_at < %s", tca_query)
         self.assertEqual(diagnostics["decision_rows_before_lineage_filter"], 1)
@@ -3079,6 +3093,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             [
                 (
                     datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 5, tzinfo=timezone.utc),
                     Decimal("1.25"),
                     Decimal("0.50"),
                     "decision-matched",
@@ -3086,6 +3101,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 ),
                 (
                     datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 15, 6, tzinfo=timezone.utc),
                     Decimal("9.99"),
                     Decimal("-9.99"),
                     "decision-unscoped",

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -4729,7 +4729,7 @@ class TestTradingPipeline(TestCase):
         config.settings.trading_simple_submit_enabled = True
         config.settings.trading_fractional_equities_enabled = True
         config.settings.trading_simple_paper_route_probe_enabled = True
-        config.settings.trading_simple_paper_route_probe_max_notional = 100.0
+        config.settings.trading_simple_paper_route_probe_max_notional = 1000.0
         config.settings.trading_paper_route_target_plan_url = "http://torghut.test/plan"
         config.settings.trading_universe_source = "static"
         config.settings.trading_static_symbols_raw = "AAPL"
@@ -4764,7 +4764,7 @@ class TestTradingPipeline(TestCase):
             "source_kind": "paper_route_probe_runtime_observed",
             "source_manifest_ref": "config/trading/hypotheses/h-paper-route.json",
             "paper_route_probe_symbols": ["AAPL"],
-            "paper_route_probe_next_session_max_notional": "25",
+            "paper_route_probe_next_session_max_notional": "250",
             "paper_route_probe_window_start": window_start.isoformat(),
             "paper_route_probe_window_end": window_end.isoformat(),
             "exit_minute_after_open": "120",
@@ -4825,7 +4825,7 @@ class TestTradingPipeline(TestCase):
 
         self.assertEqual(len(alpaca_client.submitted), 1)
         self.assertEqual(alpaca_client.submitted[0]["side"], "buy")
-        self.assertEqual(alpaca_client.submitted[0]["qty"], "0.25")
+        self.assertEqual(alpaca_client.submitted[0]["qty"], "2.5")
         with self.session_local() as session:
             decisions = list(session.execute(select(TradeDecision)).scalars())
             executions = list(session.execute(select(Execution)).scalars())
@@ -4863,7 +4863,7 @@ class TestTradingPipeline(TestCase):
             self.assertFalse(params["profit_proof_eligible"])
             self.assertFalse(params["promotion_allowed"])
             self.assertFalse(params["final_promotion_authorized"])
-            self.assertEqual(paper_route_probe["max_notional"], "25")
+            self.assertEqual(paper_route_probe["max_notional"], "250")
             self.assertTrue(paper_route_probe["target_source_authorized"])
             self.assertEqual(
                 paper_route_probe["source_decision_mode"], "route_acquisition_probe"
@@ -4874,7 +4874,9 @@ class TestTradingPipeline(TestCase):
                 paper_route_probe["exit_due_at"],
                 "2026-05-26T15:30:00+00:00",
             )
-            self.assertEqual(paper_route_probe["capped_qty"], "0.2500")
+            self.assertEqual(paper_route_probe["capped_qty"], "2.5000")
+            self.assertEqual(paper_route_probe["capped_notional"], "250.000000")
+            self.assertTrue(paper_route_probe["target_source_notional_sized"])
 
     def test_simple_pipeline_signal_cycle_still_generates_target_plan_source_decision(
         self,


### PR DESCRIPTION
## Summary

- Scale external target-plan paper probes to the configured target notional cap when the target plan explicitly authorizes the probe.
- Keep target-plan route acquisition marked as non-profit-proof while surfacing `target_source_notional_sized` in the paper-route probe diagnostics.
- Select TCA rows for runtime-window imports by execution event time instead of TCA refresh time, while preserving the metric computation timestamp for diagnostics.
- Add regression coverage for target-plan notional sizing and post-session TCA refresh selection.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k "target_plan_source_decision"`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k "query_timestamps"`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py scripts/import_hypothesis_runtime_windows.py tests/test_trading_pipeline.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
