### PR TITLE
fix(synthesis): start trader premarket bootstrap

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -77,7 +77,7 @@ spec:
     AGENTS_ARTIFACTS_SECURE: "false"
     ALPACA_PAPER_TRADE: "true"
     ANALYSIS_REPO_URL: https://github.com/gregkonush/analysis.git
-    ANALYSIS_REQUIRED_COMMIT: 4ce90bf7fc16f9bf90f7fe221f36db23c7ff44a5
+    ANALYSIS_REQUIRED_COMMIT: b4d7485e106dc1197d293683e3413fe74dacd698
     AUTONOMOUS_TRADER_ARTIFACT_DIR: /workspace/.agentrun/autonomous-trader
     CODEX_CONFIG: /root/.codex/config.toml
     CODEX_LOG_LEVEL: info
@@ -145,7 +145,7 @@ spec:
         artifact_dir="${AUTONOMOUS_TRADER_ARTIFACT_DIR:-/workspace/.agentrun/autonomous-trader}"
         analysis_dir="${ANALYSIS_REPO_DIR:-/workspace/analysis}"
         analysis_repo_url="${ANALYSIS_REPO_URL:-https://github.com/gregkonush/analysis.git}"
-        required_commit="${ANALYSIS_REQUIRED_COMMIT:-4ce90bf7fc16f9bf90f7fe221f36db23c7ff44a5}"
+        required_commit="${ANALYSIS_REQUIRED_COMMIT:-b4d7485e106dc1197d293683e3413fe74dacd698}"
         python_bin="${PYTHON_BIN:-python3}"
 
         mkdir -p "${artifact_dir}"

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -206,7 +206,9 @@ spec:
         analysis_python="${python_bin}"
         install_method="pythonpath"
         rm -rf "${artifact_dir}/analysis-venv"
-        if command -v uv >/dev/null 2>&1; then
+        if PYTHONPATH="${analysis_dir}/src" "${python_bin}" -m stock_analysis daytrading-import-smoke; then
+          install_method="preinstalled-pythonpath"
+        elif command -v uv >/dev/null 2>&1; then
           if uv venv --seed --python "${python_bin}" "${artifact_dir}/analysis-venv"; then
             uv pip install --python "${artifact_dir}/analysis-venv/bin/python" -e "${analysis_dir}[daytrading]"
             analysis_python="${artifact_dir}/analysis-venv/bin/python"

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml
@@ -35,6 +35,7 @@ spec:
     accountType: paper
     targetEquityUsd: "500000"
     marketOpenTimezone: America/New_York
+    premarketBootstrapMinutes: "15"
   secrets:
     - alpaca-mcp
     - agents-artifacts

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -42,7 +42,7 @@ spec:
     1. Bootstrap analysis before any market-open order:
        - Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`.
        - Read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`.
-       - Require analysis commit `4ce90bf7fc16f9bf90f7fe221f36db23c7ff44a5` or newer.
+       - Require analysis commit `b4d7485e106dc1197d293683e3413fe74dacd698` or newer.
        - Produce valid `/workspace/.agentrun/autonomous-trader/analysis-context.json` and `/workspace/.agentrun/autonomous-trader/analysis-bootstrap.json`.
        - Use the scheduled premarket window for this bootstrap, tool validation, scorecard readback, and context construction; do not submit orders until the regular session is open.
     2. Preflight:

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -20,6 +20,7 @@ spec:
     - Operate as a day-trading AgentRun for the Alpaca paper account only.
     - Verify Alpaca MCP account, clock, market data, order, and instrument tools before any order call.
     - Bootstrap and validate the private analysis repo before any market-open order.
+    - Start before the regular open so dependency/context validation is complete before execution hours.
     - Start a Synthesis autotrader session and use autotrader MCP/API tools as canonical runtime state.
     - Read Synthesis scorecards before grading new candidates and finalize every session with scorecard observations.
     - Use available Alpaca paper-account instruments and operations when justified by current account and market state.
@@ -43,6 +44,7 @@ spec:
        - Read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`.
        - Require analysis commit `4ce90bf7fc16f9bf90f7fe221f36db23c7ff44a5` or newer.
        - Produce valid `/workspace/.agentrun/autonomous-trader/analysis-context.json` and `/workspace/.agentrun/autonomous-trader/analysis-bootstrap.json`.
+       - Use the scheduled premarket window for this bootstrap, tool validation, scorecard readback, and context construction; do not submit orders until the regular session is open.
     2. Preflight:
        - Read the exact Kubernetes AgentRun name from the `AGENT_RUN_NAME` environment variable and store it in `preflight.json`.
        - Use that exact `AGENT_RUN_NAME` unchanged for `autotrader_start_session`, local artifacts, milestone URLs, and dedupe keys; do not invent, normalize, shorten, timestamp, or replace it.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-schedule.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-schedule.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: synthesis
     app.kubernetes.io/component: autonomous-trader
 spec:
-  cron: "30 9 * * 1-5"
+  cron: "15 9 * * 1-5"
   timezone: America/New_York
   targetRef:
     apiVersion: agents.proompteng.ai/v1alpha1

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -24,6 +24,7 @@ data:
     - Do not invent, normalize, shorten, timestamp, or replace the `AGENT_RUN_NAME` value.
     - Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh` before any market-open order, then read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`.
     - Build and validate `/workspace/.agentrun/autonomous-trader/analysis-context.json` before trading.
+    - Use the scheduled premarket window for bootstrap, tool validation, scorecard readback, and context construction; do not submit orders until the regular session is open.
     - Use local Python, the analysis repo, and web research when they can change the trade decision.
 
     Execution discipline:

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -595,6 +595,31 @@ describe('scheduled AgentRun templates', () => {
 })
 
 describe('synthesis autonomous trader provider', () => {
+  it('starts the single market session run before the bell for bootstrap', () => {
+    const schedule = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-schedule.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'Schedule')
+    const template = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'AgentRun')
+    const spec = objectAt(schedule, 'spec')
+    const parameters = objectAt(objectAt(template, 'spec'), 'parameters')
+
+    expect(objectAt(spec, 'cron')).toBe('15 9 * * 1-5')
+    expect(objectAt(spec, 'timezone')).toBe('America/New_York')
+    expect(objectAt(parameters, 'mode')).toBe('market-open')
+    expect(objectAt(parameters, 'premarketBootstrapMinutes')).toBe('15')
+  })
+
+  it('preinstalls day-trading Python dependencies in the Codex runner image', () => {
+    const dockerfile = readFileSync(resolve(process.cwd(), 'services/agents/Dockerfile.codex-runner'), 'utf8')
+
+    expect(dockerfile).toContain('"alpaca-py>=0.43"')
+    expect(dockerfile).toContain('"pandas>=2.2"')
+    expect(dockerfile).toContain('"pydantic>=2.8"')
+    expect(dockerfile).toContain('"pyarrow>=16.0"')
+  })
+
   it('sets the trader goal to reach 500000 without a token budget', () => {
     const template = readYamlObjects(
       'argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml',
@@ -647,6 +672,7 @@ describe('synthesis autonomous trader provider', () => {
       'terminal_reason `target_reached`, `market_closed`, `dry_run_complete`, or `hard_stop`',
     )
     expect(taskPrompt).toContain('/root/bootstrap-analysis-daytrading.sh')
+    expect(taskPrompt).toContain('Use the scheduled premarket window')
     expect(taskPrompt).toContain('4ce90bf7fc16f9bf90f7fe221f36db23c7ff44a5')
     expect(taskPrompt).toContain('daytrading-scan')
     expect(taskPrompt).toContain('daytrading-validate-ticket')
@@ -659,6 +685,7 @@ describe('synthesis autonomous trader provider', () => {
     expect(prompt).toContain('Retry transient Alpaca MCP read failures up to 3 times')
     expect(prompt).toContain('record `mcp_retry`')
     expect(prompt).toContain('/root/bootstrap-analysis-daytrading.sh')
+    expect(prompt).toContain('Use the scheduled premarket window')
     expect(prompt).toContain('analysis-context.json')
     expect(prompt).toContain('daytrading-validate-ticket')
     expect(prompt).toContain('terminal_reason as `target_reached`, `market_closed`, `dry_run_complete`, or `hard_stop`')
@@ -750,6 +777,7 @@ describe('synthesis autonomous trader provider', () => {
     expect(objectAt(bootstrap, 'content')).toContain('decision-ledger.jsonl')
     expect(objectAt(bootstrap, 'content')).toContain('protective-orders.jsonl')
     expect(objectAt(bootstrap, 'content')).toContain('uv venv --seed')
+    expect(objectAt(bootstrap, 'content')).toContain('preinstalled-pythonpath')
     expect(objectAt(bootstrap, 'content')).toContain('--break-system-packages')
     expect(objectAt(bootstrap, 'content')).toContain('install_method')
     expect(objectAt(bootstrap, 'content')).toContain('daytrading-context')

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -673,7 +673,7 @@ describe('synthesis autonomous trader provider', () => {
     )
     expect(taskPrompt).toContain('/root/bootstrap-analysis-daytrading.sh')
     expect(taskPrompt).toContain('Use the scheduled premarket window')
-    expect(taskPrompt).toContain('4ce90bf7fc16f9bf90f7fe221f36db23c7ff44a5')
+    expect(taskPrompt).toContain('b4d7485e106dc1197d293683e3413fe74dacd698')
     expect(taskPrompt).toContain('daytrading-scan')
     expect(taskPrompt).toContain('daytrading-validate-ticket')
     expect(prompt).toContain('loop until market close, 500000 USD equity, or unrecoverable account/order state')
@@ -767,7 +767,7 @@ describe('synthesis autonomous trader provider', () => {
     const artifactNames = (outputArtifacts ?? []).map((artifact) => objectAt(artifact, 'name'))
 
     expect(objectAt(envTemplate, 'ANALYSIS_REPO_URL')).toBe('https://github.com/gregkonush/analysis.git')
-    expect(objectAt(envTemplate, 'ANALYSIS_REQUIRED_COMMIT')).toBe('4ce90bf7fc16f9bf90f7fe221f36db23c7ff44a5')
+    expect(objectAt(envTemplate, 'ANALYSIS_REQUIRED_COMMIT')).toBe('b4d7485e106dc1197d293683e3413fe74dacd698')
     expect(objectAt(codexConfig, 'content')).toContain('[projects."/workspace/analysis"]')
     expect(objectAt(codexConfig, 'content')).toContain('model_reasoning_summary = "none"')
     expect(objectAt(bootstrap, 'content')).toContain('x-access-token:%s')

--- a/services/agents/Dockerfile.codex-runner
+++ b/services/agents/Dockerfile.codex-runner
@@ -97,6 +97,19 @@ RUN set -eux; \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install --break-system-packages --no-cache-dir "uv==${UV_VERSION}" \
+    && python3 -m pip install --break-system-packages --no-cache-dir \
+      "alpaca-py>=0.43" \
+      "duckdb>=1.3" \
+      "exchange-calendars>=4.10" \
+      "httpx>=0.28" \
+      "numpy>=2.0" \
+      "orjson>=3.10" \
+      "pandas>=2.2" \
+      "pandas-ta-classic>=0.3.54" \
+      "polars>=1.0" \
+      "pyarrow>=16.0" \
+      "pydantic>=2.8" \
+      "tenacity>=9.0" \
     && uv tool install "alpaca-mcp-server==${ALPACA_MCP_SERVER_VERSION}" \
     && ln -sf /root/.local/bin/alpaca-mcp-server /usr/local/bin/alpaca-mcp-server \
     && test -x /usr/local/bin/alpaca-mcp-server


### PR DESCRIPTION
## Summary

- Starts the single Synthesis autonomous-trader schedule at 09:15 America/New_York so bootstrap, tool validation, scorecard readback, and context construction happen before regular-session execution.
- Keeps order submission blocked until the regular market is open while preserving the one market-session AgentRun/template.
- Preinstalls day-trading Python dependencies in the Codex runner image and makes the bootstrap script prefer the preinstalled source path before falling back to venv installs.
- Pins the trader bootstrap to the current `gregkonush/analysis` `main` commit `b4d7485e106dc1197d293683e3413fe74dacd698`, which contains the day-trading scanner/context contract.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t "synthesis autonomous trader provider"`
- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `bun run lint:argocd`
- `kubectl kustomize argocd/applications/synthesis/agents-domain >/tmp/synthesis-agents-domain-render.yaml`
- `uv sync --locked --extra daytrading --extra dev` in `/Users/gregkonush/github.com/analysis`
- `PYTHONPATH=src .venv/bin/python -m stock_analysis audit` in `/Users/gregkonush/github.com/analysis`
- `PYTHONPATH=src .venv/bin/python -m stock_analysis daytrading-import-smoke` in `/Users/gregkonush/github.com/analysis`
- `PYTHONPATH=src .venv/bin/python -m stock_analysis daytrading-context --repo-root . --output /tmp/analysis-main-context.json` in `/Users/gregkonush/github.com/analysis`
- `PYTHONPATH=src .venv/bin/python -m stock_analysis daytrading-validate-context /tmp/analysis-main-context.json` in `/Users/gregkonush/github.com/analysis`
- `PYTHONPATH=src .venv/bin/python -m stock_analysis.site --output /tmp/analysis-main-site` in `/Users/gregkonush/github.com/analysis`
- Extracted `/root/bootstrap-analysis-daytrading.sh` from the AgentProvider and ran it against a temp clone of `/Users/gregkonush/github.com/analysis`; it completed with `install_method:"preinstalled-pythonpath"` and generated `analysis-context.json`.
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
