### PR TITLE
fix(synthesis): persist autotrader stop loss limit

### DIFF
--- a/apps/synthesis/src/routes/autotrader.tsx
+++ b/apps/synthesis/src/routes/autotrader.tsx
@@ -317,6 +317,9 @@ function OrdersPanel({ orders, fills }: { orders: AutotraderOrder[]; fills: Auto
                 <span>{order.side}</span>
                 <span>qty {formatNumber(order.quantity)}</span>
                 <span>limit {formatMoney(order.limitPrice)}</span>
+                {order.takeProfitLimitPrice ? <span>target {formatMoney(order.takeProfitLimitPrice)}</span> : null}
+                {order.stopLossStopPrice ? <span>stop {formatMoney(order.stopLossStopPrice)}</span> : null}
+                {order.stopLossLimitPrice ? <span>stop limit {formatMoney(order.stopLossLimitPrice)}</span> : null}
               </div>
               {order.rejectReason ? <div className="mt-2 text-sm text-[#ff7a85]">{order.rejectReason}</div> : null}
             </div>

--- a/apps/synthesis/src/server/__tests__/mcp.test.ts
+++ b/apps/synthesis/src/server/__tests__/mcp.test.ts
@@ -435,6 +435,7 @@ describe('synthesis MCP', () => {
             limitPrice: '125.10',
             takeProfitLimitPrice: '128.50',
             stopLossStopPrice: '123.80',
+            stopLossLimitPrice: '123.70',
             status: 'filled',
             brokerPayload: { source: 'alpaca' },
           },
@@ -525,6 +526,7 @@ describe('synthesis MCP', () => {
 
     expect(finalizedPayload.detail.session.terminalReason).toBe('market_close')
     expect(finalizedPayload.detail.orders).toHaveLength(1)
+    expect(finalizedPayload.detail.orders[0].stopLossLimitPrice).toBe('123.70')
     expect(finalizedPayload.detail.positionSnapshots[0].symbol).toBe('NVDA')
     expect(scorecardPayload.scorecards[0]).toMatchObject({
       symbol: 'NVDA',

--- a/apps/synthesis/src/server/autotrader-schema.ts
+++ b/apps/synthesis/src/server/autotrader-schema.ts
@@ -154,6 +154,7 @@ export const AutotraderRecordOrderInputSchema = z
     stopPrice: OptionalNumericStringSchema,
     takeProfitLimitPrice: OptionalNumericStringSchema,
     stopLossStopPrice: OptionalNumericStringSchema,
+    stopLossLimitPrice: OptionalNumericStringSchema,
     status: AutotraderOrderStatusSchema,
     rejectReason: z.string().trim().min(1).max(1_000).nullable().optional(),
     brokerPayload: PayloadSchema,
@@ -347,6 +348,7 @@ export type AutotraderOrder = {
   stopPrice: string | null
   takeProfitLimitPrice: string | null
   stopLossStopPrice: string | null
+  stopLossLimitPrice: string | null
   status: z.infer<typeof AutotraderOrderStatusSchema>
   rejectReason: string | null
   brokerPayload: Record<string, unknown>

--- a/apps/synthesis/src/server/autotrader-store.ts
+++ b/apps/synthesis/src/server/autotrader-store.ts
@@ -323,6 +323,7 @@ class InMemoryAutotraderStore implements AutotraderStore {
       stopPrice: input.stopPrice ?? null,
       takeProfitLimitPrice: input.takeProfitLimitPrice ?? null,
       stopLossStopPrice: input.stopLossStopPrice ?? null,
+      stopLossLimitPrice: input.stopLossLimitPrice ?? null,
       status: input.status,
       rejectReason: input.rejectReason ?? null,
       brokerPayload: input.brokerPayload,
@@ -557,6 +558,7 @@ type OrderRow = {
   stop_price: string | null
   take_profit_limit_price: string | null
   stop_loss_stop_price: string | null
+  stop_loss_limit_price: string | null
   status: AutotraderOrder['status']
   reject_reason: string | null
   broker_payload: unknown
@@ -732,6 +734,7 @@ const mapOrder = (row: OrderRow): AutotraderOrder => ({
   stopPrice: row.stop_price == null ? null : String(row.stop_price),
   takeProfitLimitPrice: row.take_profit_limit_price == null ? null : String(row.take_profit_limit_price),
   stopLossStopPrice: row.stop_loss_stop_price == null ? null : String(row.stop_loss_stop_price),
+  stopLossLimitPrice: row.stop_loss_limit_price == null ? null : String(row.stop_loss_limit_price),
   status: row.status,
   rejectReason: row.reject_reason,
   brokerPayload: toPayload(row.broker_payload),
@@ -1020,10 +1023,10 @@ class PostgresAutotraderStore implements AutotraderStore {
     const result = await this.pool.query<OrderRow>(
       `INSERT INTO autotrader.orders (
         session_id, ticket_id, client_order_id, broker_order_id, symbol, instrument, side, quantity, order_type,
-        order_class, limit_price, stop_price, take_profit_limit_price, stop_loss_stop_price, status, reject_reason,
-        broker_payload
+        order_class, limit_price, stop_price, take_profit_limit_price, stop_loss_stop_price, stop_loss_limit_price,
+        status, reject_reason, broker_payload
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17::jsonb)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18::jsonb)
       ON CONFLICT (client_order_id) DO UPDATE SET
         session_id = EXCLUDED.session_id,
         ticket_id = EXCLUDED.ticket_id,
@@ -1038,6 +1041,7 @@ class PostgresAutotraderStore implements AutotraderStore {
         stop_price = EXCLUDED.stop_price,
         take_profit_limit_price = EXCLUDED.take_profit_limit_price,
         stop_loss_stop_price = EXCLUDED.stop_loss_stop_price,
+        stop_loss_limit_price = EXCLUDED.stop_loss_limit_price,
         status = EXCLUDED.status,
         reject_reason = EXCLUDED.reject_reason,
         broker_payload = EXCLUDED.broker_payload,
@@ -1058,6 +1062,7 @@ class PostgresAutotraderStore implements AutotraderStore {
         numericOrNull(input.stopPrice),
         numericOrNull(input.takeProfitLimitPrice),
         numericOrNull(input.stopLossStopPrice),
+        numericOrNull(input.stopLossLimitPrice),
         input.status,
         input.rejectReason ?? null,
         toJson(input.brokerPayload),
@@ -1480,11 +1485,15 @@ class PostgresAutotraderStore implements AutotraderStore {
         stop_price numeric,
         take_profit_limit_price numeric,
         stop_loss_stop_price numeric,
+        stop_loss_limit_price numeric,
         status text NOT NULL,
         reject_reason text,
         broker_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
         updated_at timestamptz NOT NULL DEFAULT now()
       );
+
+      ALTER TABLE autotrader.orders
+        ADD COLUMN IF NOT EXISTS stop_loss_limit_price numeric;
 
       CREATE TABLE IF NOT EXISTS autotrader.fills (
         broker_fill_id text PRIMARY KEY,

--- a/apps/synthesis/src/server/mcp.ts
+++ b/apps/synthesis/src/server/mcp.ts
@@ -458,6 +458,7 @@ const toolsListResult = {
           stopPrice: numericStringSchema,
           takeProfitLimitPrice: numericStringSchema,
           stopLossStopPrice: numericStringSchema,
+          stopLossLimitPrice: numericStringSchema,
           status: {
             type: 'string',
             enum: [


### PR DESCRIPTION
## Summary

- Persist `stopLossLimitPrice` through the Synthesis autotrader order schema, MCP contract, in-memory store, and Postgres store.
- Add an idempotent Postgres column migration for existing `autotrader.orders` tables.
- Show target, stop, and stop-limit values in the Autotrader orders panel for operator visibility.

## Related Issues

None

## Testing

- `bun test apps/synthesis/src/server/__tests__/mcp.test.ts -t 'records an autotrader session'`
- `bun test apps/synthesis/src/server/__tests__/api.test.ts -t 'serves canonical autotrader state'`
- `bun run lint:synthesis`
- `bun run build:synthesis`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
