### PR TITLE
fix(torghut): surface next paper route proof targets

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -2513,6 +2513,43 @@ def _runtime_window_target_counts(
     }
 
 
+def _next_paper_route_target_summaries(
+    targets: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    summaries: list[dict[str, object]] = []
+    for target in targets:
+        strategy_name = _safe_text(target.get("strategy_name"))
+        runtime_strategy_name = _safe_text(target.get("runtime_strategy_name"))
+        summaries.append(
+            {
+                "hypothesis_id": _safe_text(target.get("hypothesis_id")),
+                "candidate_id": _safe_text(target.get("candidate_id")),
+                "strategy_family": _safe_text(target.get("strategy_family")),
+                "strategy_name": strategy_name,
+                "runtime_strategy_name": runtime_strategy_name,
+                "runtime_strategy_id": runtime_strategy_name or strategy_name,
+                "account_label": _safe_text(target.get("account_label")),
+                "source_kind": _safe_text(target.get("source_kind")),
+                "symbols": _unique_text_items(target.get("paper_route_probe_symbols")),
+                "session_start": _safe_text(target.get("window_start")),
+                "session_end": _safe_text(target.get("window_end")),
+                "next_session_max_notional": _safe_text(
+                    target.get("paper_route_probe_next_session_max_notional")
+                )
+                or "0",
+                "import_ready": bool(target.get("paper_route_session_import_ready")),
+                "import_blockers": _unique_text_items(
+                    target.get("paper_route_session_import_blockers")
+                ),
+                "promotion_allowed": bool(target.get("promotion_allowed")),
+                "final_promotion_allowed": bool(target.get("final_promotion_allowed")),
+                "promotion_blocked": not bool(target.get("final_promotion_allowed")),
+                "promotion_gate": _safe_text(target.get("promotion_gate")),
+            }
+        )
+    return summaries
+
+
 def _runtime_ledger_proof_packet_handoff(
     *,
     next_targets: Mapping[str, object],
@@ -2712,6 +2749,7 @@ def build_paper_route_evidence_audit(
         target_audits=target_audits,
         next_target_audits=next_target_audits,
     )
+    next_target_counts = _runtime_window_target_counts(next_target_audits)
     proof_packet_handoff = _runtime_ledger_proof_packet_handoff(
         next_targets=next_targets,
         runtime_window_import_audit=runtime_window_import_audit,
@@ -2856,6 +2894,31 @@ def build_paper_route_evidence_audit(
                     )
                 )
                 for audit in target_audits
+            ),
+            "next_runtime_window_target_count": _safe_int(
+                next_targets.get("target_count")
+            ),
+            "next_runtime_window_selected_target_count": len(next_target_audits),
+            "next_runtime_window_target_with_source_activity_count": (
+                next_target_counts["source_activity"]
+            ),
+            "next_runtime_window_target_with_rejected_signal_activity_count": (
+                next_target_counts["rejected_signal_activity"]
+            ),
+            "next_runtime_window_target_with_runtime_ledger_count": (
+                next_target_counts["runtime_ledger"]
+            ),
+            "next_runtime_window_target_with_evidence_grade_runtime_ledger_count": (
+                next_target_counts["evidence_grade_runtime_ledger"]
+            ),
+            "next_runtime_window_target_with_promotion_decision_count": (
+                next_target_counts["promotion_decision"]
+            ),
+            "next_runtime_window_import_next_action": runtime_window_import_audit[
+                "next_action"
+            ],
+            "next_paper_route_targets": _next_paper_route_target_summaries(
+                _as_mapping_items(next_targets.get("targets"))
             ),
             "promotion_authority": {
                 "allowed": False,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -436,6 +436,45 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(import_audit["counts"]["source_plan_target_count"], 2)
         self.assertEqual(import_audit["counts"]["selected_target_count"], 1)
         self.assertEqual(import_audit["counts"]["next_runtime_window_target_count"], 1)
+        summary = payload["summary"]
+        self.assertEqual(summary["next_runtime_window_target_count"], 1)
+        self.assertEqual(summary["next_runtime_window_selected_target_count"], 1)
+        self.assertEqual(
+            summary["next_runtime_window_target_with_source_activity_count"],
+            0,
+        )
+        self.assertEqual(
+            summary["next_runtime_window_target_with_runtime_ledger_count"],
+            0,
+        )
+        self.assertEqual(
+            summary["next_runtime_window_import_next_action"],
+            "wait_for_regular_session_open",
+        )
+        self.assertEqual(len(summary["next_paper_route_targets"]), 1)
+        summary_target = summary["next_paper_route_targets"][0]
+        self.assertEqual(summary_target["candidate_id"], "candidate-paper-route")
+        self.assertEqual(summary_target["hypothesis_id"], "H-PAPER-ROUTE")
+        self.assertEqual(
+            summary_target["runtime_strategy_id"],
+            "paper-route-candidate-v1",
+        )
+        self.assertEqual(summary_target["symbols"], ["AAPL"])
+        self.assertEqual(
+            summary_target["session_start"],
+            "2026-05-26T13:30:00+00:00",
+        )
+        self.assertEqual(
+            summary_target["session_end"],
+            "2026-05-26T20:00:00+00:00",
+        )
+        self.assertFalse(summary_target["import_ready"])
+        self.assertEqual(
+            summary_target["import_blockers"],
+            ["paper_route_session_window_not_open"],
+        )
+        self.assertFalse(summary_target["promotion_allowed"])
+        self.assertTrue(summary_target["promotion_blocked"])
         self.assertEqual(
             import_audit["diagnostics"]["target_blockers_effective_when"],
             "runtime_window_import_ready",


### PR DESCRIPTION
## Summary

- Adds selected next-session paper-route target identities to `/trading/paper-route-evidence` summary output.
- Surfaces selected next-runtime-window source/runtime-ledger/evidence-grade counts and import next action in the summary.
- Preserves fail-closed promotion semantics; the new fields are observability-only and do not authorize promotion.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_builder_exports_next_paper_route_runtime_window_targets -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
