### PR TITLE
fix(torghut): retain paper route target plans across transient fetch failures

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -210,6 +210,9 @@ _OPTIONS_CATALOG_FRESHNESS_CACHE: dict[
 ] = {}
 _ALPACA_HEALTH_CACHE_LOCK = Lock()
 _ALPACA_HEALTH_STATE: dict[str, object] = {}
+_PAPER_ROUTE_TARGET_PLAN_STALE_SUCCESS_SECONDS = 600
+_PAPER_ROUTE_TARGET_PLAN_SUCCESS_CACHE_LOCK = Lock()
+_paper_route_target_plan_success_cache: tuple[dict[str, Any], float] | None = None
 
 
 def _extract_bearer_token(authorization_header: str | None) -> str | None:
@@ -4697,12 +4700,55 @@ def _load_external_paper_route_target_plan() -> dict[str, Any]:
     url = str(settings.trading_paper_route_target_plan_url or "").strip()
     if not url:
         return {}
-    return _fetch_paper_route_target_plan_url(
+    plan = _fetch_paper_route_target_plan_url(
         url,
         timeout_seconds=settings.trading_paper_route_target_plan_timeout_seconds,
         attempts=3,
         retry_backoff_seconds=0.25,
     )
+    load_error = str(plan.get("load_error") or "").strip()
+    if load_error:
+        cached_plan = _cached_external_paper_route_target_plan_success(load_error)
+        if cached_plan:
+            logger.warning(
+                "Using stale successful paper-route target plan after fetch failure url=%s error=%s",
+                url,
+                load_error,
+            )
+            return cached_plan
+        return plan
+    if _paper_route_target_plan_targets(plan):
+        _remember_external_paper_route_target_plan_success(plan)
+    return plan
+
+
+def _remember_external_paper_route_target_plan_success(
+    plan: Mapping[str, Any],
+) -> None:
+    global _paper_route_target_plan_success_cache
+
+    if not _paper_route_target_plan_targets(plan):
+        return
+    with _PAPER_ROUTE_TARGET_PLAN_SUCCESS_CACHE_LOCK:
+        _paper_route_target_plan_success_cache = (deepcopy(dict(plan)), time.time())
+
+
+def _cached_external_paper_route_target_plan_success(
+    load_error: str,
+) -> dict[str, Any]:
+    with _PAPER_ROUTE_TARGET_PLAN_SUCCESS_CACHE_LOCK:
+        cached = _paper_route_target_plan_success_cache
+    if cached is None:
+        return {}
+    plan, cached_at = cached
+    age_seconds = max(time.time() - cached_at, 0.0)
+    if age_seconds > _PAPER_ROUTE_TARGET_PLAN_STALE_SUCCESS_SECONDS:
+        return {}
+    cached_plan = deepcopy(plan)
+    cached_plan["paper_route_target_plan_cache_status"] = "stale_success"
+    cached_plan["paper_route_target_plan_last_load_error"] = load_error
+    cached_plan["paper_route_target_plan_stale_success_age_seconds"] = int(age_seconds)
+    return cached_plan
 
 
 def _merge_external_paper_route_target_plan(
@@ -4754,6 +4800,12 @@ def _merge_external_paper_route_target_plan(
 
     if _paper_route_target_plan_targets(external_plan):
         merged_plan = dict(external_plan)
+        cache_status = str(
+            merged_plan.get("paper_route_target_plan_cache_status") or ""
+        ).strip()
+        last_load_error = str(
+            merged_plan.get("paper_route_target_plan_last_load_error") or ""
+        ).strip()
         merged_targets: list[dict[str, Any]] = []
         for raw_target in _paper_route_target_plan_targets(external_plan):
             target = dict(raw_target)
@@ -4771,6 +4823,10 @@ def _merge_external_paper_route_target_plan(
         merged_plan["final_promotion_authorized"] = False
         gate["runtime_ledger_paper_probation_import_plan"] = merged_plan
         gate["paper_route_target_plan_source"] = "external_target_plan_url"
+        if cache_status:
+            gate["paper_route_target_plan_cache_status"] = cache_status
+        if last_load_error:
+            gate["paper_route_target_plan_error"] = last_load_error
         return gate
 
     return gate

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -74,6 +74,7 @@ _SIMPLE_MARKET_CONTEXT_RETRY_INTERVAL = timedelta(seconds=30)
 _PAPER_ROUTE_PROBE_QTY_STEP = Decimal("0.0001")
 _REGULAR_SESSION_MINUTES = 390
 _PAPER_ROUTE_TARGET_PLAN_CACHE_SECONDS = 60
+_PAPER_ROUTE_TARGET_PLAN_STALE_SUCCESS_SECONDS = 600
 
 
 def _safe_int(value: object) -> int:
@@ -371,6 +372,14 @@ class SimpleTradingPipeline(TradingPipeline):
         tuple[
             set[str],
             str | None,
+            list[dict[str, Any]],
+            datetime,
+        ]
+        | None
+    ) = None
+    _paper_route_target_plan_success_cache: (
+        tuple[
+            set[str],
             list[dict[str, Any]],
             datetime,
         ]
@@ -1990,6 +1999,41 @@ class SimpleTradingPipeline(TradingPipeline):
             ).total_seconds() < _PAPER_ROUTE_TARGET_PLAN_CACHE_SECONDS:
                 return set(symbols), load_error, [dict(target) for target in targets]
         symbols, load_error, targets = self._external_paper_route_target_probe_symbols()
+        used_stale_success = False
+        if load_error:
+            success_cached = self._paper_route_target_plan_success_cache
+            if success_cached is not None:
+                cached_symbols, cached_targets, success_cached_at = success_cached
+                success_age_seconds = max(
+                    (now - success_cached_at.astimezone(timezone.utc)).total_seconds(),
+                    0.0,
+                )
+                if success_age_seconds < _PAPER_ROUTE_TARGET_PLAN_STALE_SUCCESS_SECONDS:
+                    logger.warning(
+                        "Using stale successful paper-route target plan for bounded probe error=%s age_seconds=%.1f",
+                        load_error,
+                        success_age_seconds,
+                    )
+                    targets = [
+                        {
+                            **dict(target),
+                            "paper_route_target_plan_cache_status": "stale_success",
+                            "paper_route_target_plan_last_load_error": load_error,
+                            "paper_route_target_plan_stale_success_age_seconds": int(
+                                max(success_age_seconds, 0.0)
+                            ),
+                        }
+                        for target in cached_targets
+                    ]
+                    symbols = set(cached_symbols)
+                    load_error = None
+                    used_stale_success = True
+        if load_error is None and symbols and targets and not used_stale_success:
+            self._paper_route_target_plan_success_cache = (
+                set(symbols),
+                [dict(target) for target in targets],
+                now,
+            )
         self._paper_route_target_plan_cache = (
             set(symbols),
             load_error,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -18,6 +18,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import Session, sessionmaker
 
+import app.main as main_module
 from app.db import get_session
 from app.main import (
     _ALPACA_HEALTH_STATE,
@@ -7876,6 +7877,117 @@ class TestTradingApi(TestCase):
             settings.trading_paper_route_target_plan_url = original_target_plan_url
             settings.trading_paper_route_target_plan_timeout_seconds = original_timeout
 
+    def test_load_external_paper_route_target_plan_uses_recent_success_after_timeout(
+        self,
+    ) -> None:
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        original_timeout = settings.trading_paper_route_target_plan_timeout_seconds
+        original_cache = main_module._paper_route_target_plan_success_cache
+        settings.trading_paper_route_target_plan_url = "http://torghut.example/plan"
+        settings.trading_paper_route_target_plan_timeout_seconds = 7
+        main_module._paper_route_target_plan_success_cache = None
+        success_plan = {
+            "source": "external_paper_route_target_plan",
+            "targets": [
+                {
+                    "candidate_id": "candidate-stale-safe",
+                    "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                }
+            ],
+        }
+        try:
+            with (
+                patch(
+                    "app.main._fetch_paper_route_target_plan_url",
+                    side_effect=[
+                        success_plan,
+                        {
+                            "load_error": (
+                                "paper_route_target_plan_fetch_failed:timed out"
+                            )
+                        },
+                    ],
+                ),
+                patch(
+                    "app.main.time.time",
+                    side_effect=[1000.0, 1005.0, 1005.0, 1005.0],
+                ),
+            ):
+                first_plan = _load_external_paper_route_target_plan()
+                second_plan = _load_external_paper_route_target_plan()
+        finally:
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+            settings.trading_paper_route_target_plan_timeout_seconds = original_timeout
+            main_module._paper_route_target_plan_success_cache = original_cache
+
+        self.assertEqual(
+            first_plan["targets"][0]["candidate_id"],
+            "candidate-stale-safe",
+        )
+        self.assertEqual(
+            second_plan["paper_route_target_plan_cache_status"], "stale_success"
+        )
+        self.assertEqual(
+            second_plan["paper_route_target_plan_last_load_error"],
+            "paper_route_target_plan_fetch_failed:timed out",
+        )
+        self.assertEqual(
+            second_plan["targets"][0]["candidate_id"],
+            "candidate-stale-safe",
+        )
+
+    def test_external_paper_route_target_plan_cache_fails_closed_when_unusable(
+        self,
+    ) -> None:
+        original_target_plan_url = settings.trading_paper_route_target_plan_url
+        original_cache = main_module._paper_route_target_plan_success_cache
+        settings.trading_paper_route_target_plan_url = "http://torghut.example/plan"
+        main_module._paper_route_target_plan_success_cache = None
+        try:
+            with patch(
+                "app.main._fetch_paper_route_target_plan_url",
+                return_value={
+                    "load_error": "paper_route_target_plan_fetch_failed:timed out"
+                },
+            ):
+                plan = _load_external_paper_route_target_plan()
+            self.assertEqual(
+                plan["load_error"],
+                "paper_route_target_plan_fetch_failed:timed out",
+            )
+
+            main_module._paper_route_target_plan_success_cache = ("sentinel", 1000.0)
+            main_module._remember_external_paper_route_target_plan_success(
+                {"targets": []}
+            )
+            self.assertEqual(
+                main_module._paper_route_target_plan_success_cache,
+                ("sentinel", 1000.0),
+            )
+
+            main_module._paper_route_target_plan_success_cache = None
+            self.assertEqual(
+                main_module._cached_external_paper_route_target_plan_success(
+                    "paper_route_target_plan_fetch_failed:missing"
+                ),
+                {},
+            )
+
+            main_module._paper_route_target_plan_success_cache = (
+                {"targets": [{"candidate_id": "expired"}]},
+                1000.0,
+            )
+            with patch("app.main.time.time", return_value=2000.0):
+                self.assertEqual(
+                    main_module._cached_external_paper_route_target_plan_success(
+                        "paper_route_target_plan_fetch_failed:expired"
+                    ),
+                    {},
+                )
+        finally:
+            settings.trading_paper_route_target_plan_url = original_target_plan_url
+            main_module._paper_route_target_plan_success_cache = original_cache
+
     def test_merge_external_paper_route_target_plan_fails_closed(self) -> None:
         local_gate = {
             "runtime_ledger_paper_probation_import_plan": {
@@ -7991,6 +8103,8 @@ class TestTradingApi(TestCase):
         with patch(
             "app.main._load_external_paper_route_target_plan",
             return_value={
+                "paper_route_target_plan_cache_status": "stale_success",
+                "paper_route_target_plan_last_load_error": "paper_route_timeout",
                 "promotion_allowed": True,
                 "final_promotion_allowed": True,
                 "final_promotion_authorized": True,
@@ -8007,6 +8121,8 @@ class TestTradingApi(TestCase):
         self.assertEqual(
             gate["paper_route_target_plan_source"], "external_target_plan_url"
         )
+        self.assertEqual(gate["paper_route_target_plan_cache_status"], "stale_success")
+        self.assertEqual(gate["paper_route_target_plan_error"], "paper_route_timeout")
         self.assertFalse(plan["promotion_allowed"])
         self.assertFalse(plan["final_promotion_allowed"])
         self.assertFalse(plan["final_promotion_authorized"])

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -6195,6 +6195,91 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(third_targets[0]["candidate_id"], "candidate-pairs-a")
         self.assertEqual(fetch_plan.call_count, 2)
 
+    def test_external_paper_route_target_plan_cache_uses_recent_success_after_timeout(
+        self,
+    ) -> None:
+        from app import config
+
+        original_target_plan_url = config.settings.trading_paper_route_target_plan_url
+        original_target_plan_timeout = (
+            config.settings.trading_paper_route_target_plan_timeout_seconds
+        )
+        config.settings.trading_paper_route_target_plan_url = (
+            "http://torghut.local/trading/paper-route-evidence"
+        )
+        config.settings.trading_paper_route_target_plan_timeout_seconds = 1.0
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        pipeline._paper_route_target_plan_cache = None
+        pipeline._paper_route_target_plan_success_cache = None
+        now = datetime(2026, 3, 26, 14, 30, tzinfo=timezone.utc)
+        try:
+            with (
+                patch(
+                    "app.trading.scheduler.simple_pipeline.trading_now",
+                    side_effect=[now, now + timedelta(seconds=120)],
+                ),
+                patch(
+                    "app.trading.scheduler.simple_pipeline.fetch_paper_route_target_plan_url",
+                    side_effect=[
+                        {
+                            "targets": [
+                                {
+                                    "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                                    "candidate_id": "candidate-pairs-a",
+                                }
+                            ]
+                        },
+                        {
+                            "load_error": (
+                                "paper_route_target_plan_fetch_failed:timed out"
+                            ),
+                        },
+                    ],
+                ) as fetch_plan,
+            ):
+                first_symbols, first_error, first_targets = (
+                    pipeline._external_paper_route_target_probe_symbols_cached()
+                )
+                second_symbols, second_error, second_targets = (
+                    pipeline._external_paper_route_target_probe_symbols_cached()
+                )
+        finally:
+            config.settings.trading_paper_route_target_plan_url = (
+                original_target_plan_url
+            )
+            config.settings.trading_paper_route_target_plan_timeout_seconds = (
+                original_target_plan_timeout
+            )
+
+        self.assertEqual(first_symbols, {"AAPL", "AMZN"})
+        self.assertIsNone(first_error)
+        self.assertEqual(first_targets[0]["candidate_id"], "candidate-pairs-a")
+        self.assertEqual(second_symbols, {"AAPL", "AMZN"})
+        self.assertIsNone(second_error)
+        self.assertEqual(second_targets[0]["candidate_id"], "candidate-pairs-a")
+        self.assertEqual(
+            second_targets[0]["paper_route_target_plan_cache_status"],
+            "stale_success",
+        )
+        self.assertEqual(
+            second_targets[0]["paper_route_target_plan_last_load_error"],
+            "paper_route_target_plan_fetch_failed:timed out",
+        )
+        self.assertEqual(fetch_plan.call_count, 2)
+
     def test_matching_paper_target_signal_gets_strategy_signal_paper_authority(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Retains the most recent successful external paper-route target plan for a bounded window when a later fetch times out.
- Applies the same stale-success behavior to the simple scheduler target-plan cache so transient target-plan fetch failures do not erase source-decision routing.
- Marks stale-success use with explicit cache/error metadata while keeping promotion and final authorization forced false.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check app/main.py app/trading/scheduler/simple_pipeline.py tests/test_trading_api.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -q -k 'paper_route_target_plan and (load_external or merge_external or external_paper_route_target)'`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -q -k 'external_paper_route_target_plan_cache or matching_paper_target_signal_gets_strategy_signal_paper_authority'`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
