### PR TITLE
fix(synthesis): surface autotrader runtime alerts

### DIFF
--- a/apps/synthesis/src/routes/-autotrader-alerts.test.ts
+++ b/apps/synthesis/src/routes/-autotrader-alerts.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from 'vitest'
+
+import type { AutotraderSessionDetail } from '~/server/autotrader-schema'
+
+import { getAutotraderRuntimeAlerts } from './-autotrader-alerts'
+
+const now = new Date('2026-05-29T14:00:00Z')
+
+const detailFor = (overrides: Partial<AutotraderSessionDetail> = {}): AutotraderSessionDetail => ({
+  session: {
+    id: 'session-1',
+    agentRunName: 'autonomous-trader-market-open-test',
+    mode: 'market_open',
+    tradingDate: '2026-05-29',
+    accountId: 'paper',
+    goalEquity: '500000',
+    openingEquity: '38457.11',
+    closingEquity: null,
+    realizedPnl: null,
+    maxDrawdown: null,
+    marketOpenAt: '2026-05-29T13:30:00Z',
+    marketCloseAt: '2026-05-29T20:00:00Z',
+    analysisHead: 'abc123',
+    analysisContextHash: 'sha256:test',
+    startedAt: '2026-05-29T13:15:00Z',
+    finalizedAt: null,
+    terminalReason: null,
+    summary: {},
+  },
+  status: {
+    sessionId: 'session-1',
+    cycle: 1,
+    phase: 'scan',
+    equity: '38457.11',
+    buyingPower: '1000',
+    daytradeBuyingPower: '0',
+    grossExposure: '0',
+    netExposure: '0',
+    realizedPnl: '0',
+    unrealizedPnl: '0',
+    currentAction: 'scanning',
+    blocker: null,
+    payload: {},
+    updatedAt: '2026-05-29T13:59:30Z',
+  },
+  events: [],
+  tradeTickets: [],
+  riskChecks: [],
+  orders: [],
+  fills: [],
+  positionSnapshots: [],
+  scorecards: [],
+  setupExamples: [],
+  ...overrides,
+})
+
+describe('getAutotraderRuntimeAlerts', () => {
+  test('flags stale status heartbeat during market hours', () => {
+    const detail = detailFor({
+      status: {
+        ...detailFor().status!,
+        updatedAt: '2026-05-29T13:58:00Z',
+      },
+    })
+
+    expect(getAutotraderRuntimeAlerts(detail, now)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'stale-heartbeat', severity: 'critical' })]),
+    )
+  })
+
+  test('does not flag stale heartbeat before regular market hours', () => {
+    const detail = detailFor({
+      status: {
+        ...detailFor().status!,
+        updatedAt: '2026-05-29T13:00:00Z',
+      },
+    })
+
+    expect(getAutotraderRuntimeAlerts(detail, new Date('2026-05-29T13:10:00Z'))).toEqual([])
+  })
+
+  test('flags nonterminal orders older than 30 seconds', () => {
+    const detail = detailFor({
+      orders: [
+        {
+          sessionId: 'session-1',
+          ticketId: null,
+          clientOrderId: 'atr-20260529-test-1-NVDA-01',
+          brokerOrderId: null,
+          symbol: 'NVDA',
+          instrument: 'stock',
+          side: 'buy',
+          quantity: '1',
+          orderType: 'limit',
+          orderClass: null,
+          limitPrice: '100',
+          stopPrice: null,
+          takeProfitLimitPrice: null,
+          stopLossStopPrice: null,
+          stopLossLimitPrice: null,
+          status: 'submitted',
+          rejectReason: null,
+          brokerPayload: {},
+          updatedAt: '2026-05-29T13:59:20Z',
+        },
+      ],
+    })
+
+    expect(getAutotraderRuntimeAlerts(detail, now)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'unreconciled-order:atr-20260529-test-1-NVDA-01' })]),
+    )
+  })
+
+  test('flags positions with no confirmed protection or managed-loop fallback', () => {
+    const detail = detailFor({
+      positionSnapshots: [
+        {
+          id: 'pos-1',
+          sessionId: 'session-1',
+          symbol: 'SPY',
+          quantity: '1',
+          marketValue: '500',
+          averageEntryPrice: '500',
+          unrealizedPnl: '0',
+          capturedAt: '2026-05-29T13:59:30Z',
+          brokerPayload: {},
+        },
+      ],
+    })
+
+    expect(getAutotraderRuntimeAlerts(detail, now)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'unprotected-position:SPY' })]),
+    )
+  })
+
+  test('accepts broker-attached protection and active managed-loop fallbacks', () => {
+    const withBracket = detailFor({
+      orders: [
+        {
+          sessionId: 'session-1',
+          ticketId: null,
+          clientOrderId: 'atr-20260529-test-1-SPY-01',
+          brokerOrderId: 'alpaca-1',
+          symbol: 'SPY',
+          instrument: 'etf',
+          side: 'buy',
+          quantity: '1',
+          orderType: 'limit',
+          orderClass: 'bracket',
+          limitPrice: '500',
+          stopPrice: null,
+          takeProfitLimitPrice: '505',
+          stopLossStopPrice: '498',
+          stopLossLimitPrice: '497.95',
+          status: 'accepted',
+          rejectReason: null,
+          brokerPayload: {},
+          updatedAt: '2026-05-29T13:59:50Z',
+        },
+      ],
+      positionSnapshots: [
+        {
+          id: 'pos-1',
+          sessionId: 'session-1',
+          symbol: 'SPY',
+          quantity: '1',
+          marketValue: '500',
+          averageEntryPrice: '500',
+          unrealizedPnl: '0',
+          capturedAt: '2026-05-29T13:59:30Z',
+          brokerPayload: {},
+        },
+      ],
+    })
+    const withManagedLoop = detailFor({
+      status: {
+        ...detailFor().status!,
+        payload: { protection: { symbol: 'TSLA', managedLoopActive: true } },
+      },
+      positionSnapshots: [
+        {
+          id: 'pos-2',
+          sessionId: 'session-1',
+          symbol: 'TSLA',
+          quantity: '-1',
+          marketValue: '180',
+          averageEntryPrice: '180',
+          unrealizedPnl: '0',
+          capturedAt: '2026-05-29T13:59:30Z',
+          brokerPayload: {},
+        },
+      ],
+    })
+
+    expect(getAutotraderRuntimeAlerts(withBracket, now).map((alert) => alert.key)).not.toContain(
+      'unprotected-position:SPY',
+    )
+    expect(getAutotraderRuntimeAlerts(withManagedLoop, now).map((alert) => alert.key)).not.toContain(
+      'unprotected-position:TSLA',
+    )
+  })
+})

--- a/apps/synthesis/src/routes/-autotrader-alerts.ts
+++ b/apps/synthesis/src/routes/-autotrader-alerts.ts
@@ -1,0 +1,180 @@
+import type { AutotraderOrder, AutotraderSessionDetail, AutotraderTradeTicket } from '~/server/autotrader-schema'
+
+export type AutotraderRuntimeAlert = {
+  key: string
+  severity: 'warning' | 'critical'
+  title: string
+  message: string
+}
+
+const staleHeartbeatMs = 90_000
+const unreconciledOrderMs = 30_000
+
+const terminalOrderStatuses = new Set<AutotraderOrder['status']>([
+  'filled',
+  'canceled',
+  'rejected',
+  'expired',
+  'reconciled',
+])
+
+const protectiveOrderClasses = new Set(['bracket', 'oco', 'oto'])
+
+const ageMs = (value: string | null | undefined, now: Date) => {
+  if (!value) return null
+  const parsed = Date.parse(value)
+  if (!Number.isFinite(parsed)) return null
+  return now.getTime() - parsed
+}
+
+const isNonZeroQuantity = (value: string) => {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && Math.abs(parsed) > 0
+}
+
+const normalizeSymbol = (value: string | null | undefined) => value?.trim().toUpperCase() ?? ''
+
+const stringify = (value: unknown) => (typeof value === 'string' ? value.trim().toLowerCase() : '')
+
+const truthyRuntimeFlag = (value: unknown) => {
+  if (value === true) return true
+  const normalized = stringify(value)
+  return normalized === 'true' || normalized === 'active' || normalized === 'managed_loop'
+}
+
+const payloadHasManagedLoop = (payload: Record<string, unknown>, symbol: string): boolean => {
+  const normalizedSymbol = normalizeSymbol(symbol)
+  const stack: unknown[] = [payload]
+
+  while (stack.length) {
+    const current = stack.pop()
+    if (!current || typeof current !== 'object') continue
+    if (Array.isArray(current)) {
+      stack.push(...current)
+      continue
+    }
+
+    const record = current as Record<string, unknown>
+    let recordSymbolValue: string | undefined
+    if (typeof record.symbol === 'string') {
+      recordSymbolValue = record.symbol
+    } else if (typeof record.ticker === 'string') {
+      recordSymbolValue = record.ticker
+    }
+    const recordSymbol = normalizeSymbol(recordSymbolValue)
+    const symbolMatches = !recordSymbol || recordSymbol === normalizedSymbol
+    if (!symbolMatches) continue
+
+    if (
+      truthyRuntimeFlag(record.managedLoopActive) ||
+      truthyRuntimeFlag(record.managed_loop_active) ||
+      truthyRuntimeFlag(record.activeManagedLoop) ||
+      truthyRuntimeFlag(record.protectiveManagedLoop) ||
+      stringify(record.protectionType) === 'managed_loop' ||
+      stringify(record.protection_type) === 'managed_loop'
+    ) {
+      return true
+    }
+
+    stack.push(...Object.values(record).filter((value) => value && typeof value === 'object'))
+  }
+
+  return false
+}
+
+export const isMarketSessionActive = (detail: AutotraderSessionDetail, now = new Date()) => {
+  if (detail.session.finalizedAt) return false
+  const marketOpen = Date.parse(detail.session.marketOpenAt)
+  const marketClose = Date.parse(detail.session.marketCloseAt)
+  if (!Number.isFinite(marketOpen) || !Number.isFinite(marketClose)) return false
+  const current = now.getTime()
+  return current >= marketOpen && current <= marketClose
+}
+
+export const isAutotraderOrderUnreconciled = (order: AutotraderOrder, now = new Date()) => {
+  if (terminalOrderStatuses.has(order.status)) return false
+  const orderAgeMs = ageMs(order.updatedAt, now)
+  return orderAgeMs == null || orderAgeMs > unreconciledOrderMs
+}
+
+export const hasBrokerAttachedProtection = (order: AutotraderOrder) => {
+  if (order.status === 'rejected' || order.status === 'canceled' || order.status === 'expired') return false
+  if (order.orderClass && protectiveOrderClasses.has(order.orderClass.toLowerCase())) return true
+  return Boolean(order.stopPrice || order.takeProfitLimitPrice || order.stopLossStopPrice || order.stopLossLimitPrice)
+}
+
+const ticketHasManagedLoopFallback = (ticket: AutotraderTradeTicket) =>
+  ticket.protectionType.toLowerCase() === 'managed_loop' && ticket.status !== 'blocked' && ticket.status !== 'candidate'
+
+const hasManagedLoopFallback = (detail: AutotraderSessionDetail, symbol: string) => {
+  const normalizedSymbol = normalizeSymbol(symbol)
+  if (detail.status?.payload && payloadHasManagedLoop(detail.status.payload, normalizedSymbol)) return true
+
+  return detail.tradeTickets.some(
+    (ticket) => normalizeSymbol(ticket.symbol) === normalizedSymbol && ticketHasManagedLoopFallback(ticket),
+  )
+}
+
+const latestPositionSnapshots = (detail: AutotraderSessionDetail) => {
+  const snapshotsBySymbol = new Map<string, AutotraderSessionDetail['positionSnapshots'][number]>()
+
+  for (const snapshot of detail.positionSnapshots) {
+    const symbol = normalizeSymbol(snapshot.symbol)
+    const existing = snapshotsBySymbol.get(symbol)
+    if (!existing || Date.parse(snapshot.capturedAt) > Date.parse(existing.capturedAt)) {
+      snapshotsBySymbol.set(symbol, snapshot)
+    }
+  }
+
+  return [...snapshotsBySymbol.values()]
+}
+
+const positionHasProtection = (
+  detail: AutotraderSessionDetail,
+  snapshot: AutotraderSessionDetail['positionSnapshots'][number],
+) => {
+  const symbol = normalizeSymbol(snapshot.symbol)
+  if (!isNonZeroQuantity(snapshot.quantity)) return true
+  if (payloadHasManagedLoop(snapshot.brokerPayload, symbol)) return true
+  if (hasManagedLoopFallback(detail, symbol)) return true
+
+  return detail.orders.some((order) => normalizeSymbol(order.symbol) === symbol && hasBrokerAttachedProtection(order))
+}
+
+export const getAutotraderRuntimeAlerts = (detail: AutotraderSessionDetail, now = new Date()) => {
+  const alerts: AutotraderRuntimeAlert[] = []
+
+  if (isMarketSessionActive(detail, now)) {
+    const heartbeatAgeMs = ageMs(detail.status?.updatedAt, now)
+    if (heartbeatAgeMs == null || heartbeatAgeMs > staleHeartbeatMs) {
+      alerts.push({
+        key: 'stale-heartbeat',
+        severity: 'critical',
+        title: 'Stale heartbeat',
+        message: 'No fresh status heartbeat has been written in the last 90 seconds during market hours.',
+      })
+    }
+  }
+
+  for (const order of detail.orders) {
+    if (!isAutotraderOrderUnreconciled(order, now)) continue
+    alerts.push({
+      key: `unreconciled-order:${order.clientOrderId}`,
+      severity: 'critical',
+      title: 'Unreconciled order',
+      message: `${order.symbol} order ${order.clientOrderId} is still ${order.status} after 30 seconds.`,
+    })
+  }
+
+  for (const snapshot of latestPositionSnapshots(detail)) {
+    if (positionHasProtection(detail, snapshot)) continue
+    alerts.push({
+      key: `unprotected-position:${snapshot.symbol}`,
+      severity: 'warning',
+      title: 'Position protection missing',
+      message: `${snapshot.symbol} has a non-zero position without broker-attached protection or an active managed-loop fallback.`,
+    })
+  }
+
+  return alerts
+}

--- a/apps/synthesis/src/routes/autotrader.tsx
+++ b/apps/synthesis/src/routes/autotrader.tsx
@@ -26,6 +26,9 @@ import type {
   AutotraderTradeTicket,
 } from '~/server/autotrader-schema'
 
+import { getAutotraderRuntimeAlerts } from './-autotrader-alerts'
+import type { AutotraderRuntimeAlert } from './-autotrader-alerts'
+
 export const Route = createFileRoute('/autotrader')({
   component: AutotraderPage,
 })
@@ -219,10 +222,13 @@ function RailLink({
 }
 
 function SessionDashboard({ detail }: { detail: AutotraderSessionDetail }) {
+  const alerts = getAutotraderRuntimeAlerts(detail)
+
   return (
     <div className="grid gap-0 xl:grid-cols-[minmax(0,1fr)_380px]">
       <div className="min-w-0">
         <StatusPanel detail={detail} />
+        <RuntimeAlertsPanel alerts={alerts} />
         <TicketsPanel tickets={detail.tradeTickets} />
         <OrdersPanel orders={detail.orders} fills={detail.fills} />
         <EventsPanel events={detail.events} />
@@ -234,6 +240,38 @@ function SessionDashboard({ detail }: { detail: AutotraderSessionDetail }) {
         <SummaryPanel detail={detail} />
       </div>
     </div>
+  )
+}
+
+function RuntimeAlertsPanel({ alerts }: { alerts: AutotraderRuntimeAlert[] }) {
+  return (
+    <Panel title="Runtime Alerts" icon={<AlertTriangle />}>
+      {alerts.length ? (
+        alerts.map((alert) => (
+          <div
+            key={alert.key}
+            className={cx(
+              'border-b border-[#2f3336] px-4 py-3 last:border-b-0',
+              alert.severity === 'critical' ? 'bg-[#19090d]' : 'bg-[#151109]',
+            )}
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <AlertTriangle
+                className={cx('size-4', alert.severity === 'critical' ? 'text-[#ff7a85]' : 'text-[#ffb86b]')}
+              />
+              <span className="text-sm font-semibold">{alert.title}</span>
+              <Pill>{alert.severity}</Pill>
+            </div>
+            <div className="mt-2 text-sm leading-6 text-[#cfd3d6]">{alert.message}</div>
+          </div>
+        ))
+      ) : (
+        <div className="flex items-center gap-2 px-4 py-4 text-sm text-[#71767b]">
+          <CheckCircle2 className="size-4 text-[#3fb950]" />
+          <span>No runtime alerts for the selected session.</span>
+        </div>
+      )}
+    </Panel>
   )
 }
 


### PR DESCRIPTION
## Summary

- Adds a runtime alert model for autotrader sessions covering stale market-hours heartbeats, unreconciled orders, and unprotected positions.
- Shows those alerts in the `/autotrader` operator dashboard directly below live status.
- Adds focused tests for the alert rules, including broker-attached protection and managed-loop fallback cases.

## Related Issues

None

## Testing

- `bun test apps/synthesis/src/routes/-autotrader-alerts.test.ts`
- `bun run --filter synthesis test`
- `bun run --filter synthesis lint`
- `bun run --filter synthesis build`
- Local Playwright CLI screenshot of `http://127.0.0.1:5175/autotrader` with seeded in-memory Synthesis data showing stale heartbeat and missing protection alerts.

## Screenshots (if applicable)

Local screenshot verification completed with Playwright CLI; no repository artifact attached.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
