### PR TITLE
fix(synthesis): harden autotrader runtime tool contract

### DIFF
--- a/apps/synthesis/src/server/__tests__/mcp.test.ts
+++ b/apps/synthesis/src/server/__tests__/mcp.test.ts
@@ -308,10 +308,20 @@ describe('synthesis MCP', () => {
     }>
     const toolNames = tools.map((tool) => tool.name)
     const startSessionTool = tools.find((tool) => tool.name === 'autotrader_start_session')
+    const finalizeSessionTool = tools.find((tool) => tool.name === 'autotrader_finalize_session')
 
     expect(toolNames).toEqual(expect.arrayContaining(['autotrader_start_session', 'autotrader_get_scorecard']))
     expect(startSessionTool?.inputSchema?.properties?.mode?.enum).toEqual(
       expect.arrayContaining(['market_session', 'market_open', 'dry_run', 'paper_smoke', 'scorecard_readback']),
+    )
+    expect(startSessionTool?.inputSchema?.properties?.openingEquity).toBeDefined()
+    expect(finalizeSessionTool?.inputSchema?.properties).toEqual(
+      expect.objectContaining({
+        openingEquity: expect.any(Object),
+        closingEquity: expect.any(Object),
+        realizedPnl: expect.any(Object),
+        maxDrawdown: expect.any(Object),
+      }),
     )
 
     const sessionPayload = await parseToolJson(
@@ -324,6 +334,7 @@ describe('synthesis MCP', () => {
             tradingDate: '2026-05-29',
             accountId: 'paper-account',
             goalEquity: '500000',
+            openingEquity: '38400',
             marketOpenAt: '2026-05-29T13:30:00Z',
             marketCloseAt: '2026-05-29T20:00:00Z',
             analysisHead: 'b187dcf',

--- a/apps/synthesis/src/server/mcp.ts
+++ b/apps/synthesis/src/server/mcp.ts
@@ -307,6 +307,7 @@ const toolsListResult = {
           tradingDate: { type: 'string' },
           accountId: { type: 'string' },
           goalEquity: numericStringSchema,
+          openingEquity: numericStringSchema,
           marketOpenAt: { type: 'string' },
           marketCloseAt: { type: 'string' },
           analysisHead: { type: 'string' },
@@ -531,6 +532,10 @@ const toolsListResult = {
         properties: {
           sessionId: { type: 'string' },
           terminalReason: { type: 'string' },
+          openingEquity: numericStringSchema,
+          closingEquity: numericStringSchema,
+          realizedPnl: numericStringSchema,
+          maxDrawdown: numericStringSchema,
           summary: payloadSchema,
           scorecardObservations: {
             type: 'array',

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -78,7 +78,6 @@ spec:
     ALPACA_PAPER_TRADE: "true"
     ANALYSIS_REPO_URL: https://github.com/gregkonush/analysis.git
     ANALYSIS_REQUIRED_COMMIT: b4d7485e106dc1197d293683e3413fe74dacd698
-    ANALYSIS_FETCH_DEPTH: "64"
     AUTONOMOUS_TRADER_ARTIFACT_DIR: /workspace/.agentrun/autonomous-trader
     CODEX_CONFIG: /root/.codex/config.toml
     CODEX_LOG_LEVEL: info
@@ -147,7 +146,6 @@ spec:
         analysis_dir="${ANALYSIS_REPO_DIR:-/workspace/analysis}"
         analysis_repo_url="${ANALYSIS_REPO_URL:-https://github.com/gregkonush/analysis.git}"
         required_commit="${ANALYSIS_REQUIRED_COMMIT:-b4d7485e106dc1197d293683e3413fe74dacd698}"
-        fetch_depth="${ANALYSIS_FETCH_DEPTH:-64}"
         python_bin="${PYTHON_BIN:-python3}"
 
         mkdir -p "${artifact_dir}"
@@ -189,17 +187,7 @@ spec:
         }
 
         fetch_analysis_main() {
-          local depth="$1"
-          if ! git_with_auth -C "${analysis_dir}" fetch --filter=blob:none --prune --depth="${depth}" origin main:refs/remotes/origin/main; then
-            git_with_auth -C "${analysis_dir}" fetch --prune --depth="${depth}" origin main:refs/remotes/origin/main
-          fi
-        }
-
-        deepen_analysis_history() {
-          local deepen_by="$1"
-          if ! git_with_auth -C "${analysis_dir}" fetch --filter=blob:none --deepen="${deepen_by}" origin main:refs/remotes/origin/main; then
-            git_with_auth -C "${analysis_dir}" fetch --deepen="${deepen_by}" origin main:refs/remotes/origin/main || true
-          fi
+          git_with_auth -C "${analysis_dir}" fetch --prune origin main:refs/remotes/origin/main
         }
 
         if [ ! -d "${analysis_dir}/.git" ]; then
@@ -211,18 +199,12 @@ spec:
 
         git -C "${analysis_dir}" remote set-url origin "${analysis_repo_url}"
         git -C "${analysis_dir}" config gc.auto 0
-        fetch_analysis_main "${fetch_depth}"
+        fetch_analysis_main
         git -C "${analysis_dir}" checkout --force --detach origin/main
         git -C "${analysis_dir}" reset --hard origin/main
         git -C "${analysis_dir}" clean -ffd
 
         analysis_head="$(git -C "${analysis_dir}" rev-parse HEAD)"
-        if ! git -C "${analysis_dir}" merge-base --is-ancestor "${required_commit}" HEAD; then
-          deepen_analysis_history 256
-        fi
-        if ! git -C "${analysis_dir}" merge-base --is-ancestor "${required_commit}" HEAD; then
-          deepen_analysis_history 1024
-        fi
         if ! git -C "${analysis_dir}" merge-base --is-ancestor "${required_commit}" HEAD; then
           printf '{"ok":false,"reason":"analysis_repo_stale","analysis_head":"%s","required_commit":"%s"}\n' \
             "${analysis_head}" "${required_commit}" > "${artifact_dir}/analysis-bootstrap.json"
@@ -260,19 +242,27 @@ spec:
           fi
         fi
 
+        analysis_cli="${artifact_dir}/stock_analysis"
+        {
+          printf '#!/usr/bin/env bash\n'
+          printf 'set -euo pipefail\n'
+          printf 'PYTHONPATH=%q %q -m stock_analysis "$@"\n' "${analysis_dir}/src" "${analysis_python}"
+        } > "${analysis_cli}"
+        chmod +x "${analysis_cli}"
+
         (
           cd "${analysis_dir}"
-          PYTHONPATH=src "${analysis_python}" -m stock_analysis audit
+          "${analysis_cli}" audit
         )
-        PYTHONPATH="${analysis_dir}/src" "${analysis_python}" -m stock_analysis daytrading-import-smoke
-        PYTHONPATH="${analysis_dir}/src" "${analysis_python}" -m stock_analysis daytrading-context \
+        "${analysis_cli}" daytrading-import-smoke
+        "${analysis_cli}" daytrading-context \
           --repo-root "${analysis_dir}" \
           --output "${artifact_dir}/analysis-context.json"
-        PYTHONPATH="${analysis_dir}/src" "${analysis_python}" -m stock_analysis daytrading-validate-context \
+        "${analysis_cli}" daytrading-validate-context \
           "${artifact_dir}/analysis-context.json"
 
-        printf '{"ok":true,"analysis_head":"%s","required_commit":"%s","context_path":"%s","install_method":"%s","fetch_depth":"%s","partial_clone":true,"started_at":"%s","finished_at":"%s"}\n' \
-          "${analysis_head}" "${required_commit}" "${artifact_dir}/analysis-context.json" "${install_method}" "${fetch_depth}" "${bootstrap_started_at}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        printf '{"ok":true,"analysis_head":"%s","required_commit":"%s","context_path":"%s","analysis_cli":"%s","install_method":"%s","fetch_mode":"full","partial_clone":false,"started_at":"%s","finished_at":"%s"}\n' \
+          "${analysis_head}" "${required_commit}" "${artifact_dir}/analysis-context.json" "${analysis_cli}" "${install_method}" "${bootstrap_started_at}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
           > "${artifact_dir}/analysis-bootstrap.json"
     - path: /root/alpaca-mcp-stdio-bridge.py
       content: |-

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -75,7 +75,7 @@ spec:
        - Reconcile open orders and absorb any account/position changes as current state.
        - Call `autotrader_get_scorecard` before ranking candidates and include the scorecard summary in scanner input.
        - Build a ranked action list from analysis context, live snapshots/quotes/bars, option-chain data when relevant, technicals, catalysts, liquidity, account constraints, and web research when fresh information can change the trade.
-       - Before each non-smoke order, run `stock_analysis daytrading-scan` and validate `/workspace/.agentrun/autonomous-trader/trade-ticket.json` with `stock_analysis daytrading-validate-ticket`.
+       - Before each non-smoke order, run `/workspace/.agentrun/autonomous-trader/stock_analysis daytrading-scan` and validate `/workspace/.agentrun/autonomous-trader/trade-ticket.json` with `/workspace/.agentrun/autonomous-trader/stock_analysis daytrading-validate-ticket`.
        - Submit an order only after the trade ticket records setup type, setup grade, expected R, fat-pitch flag, thesis, entry, invalidation, exit logic, sizing, max loss, liquidity, and reconciliation plan.
        - Block C setups and record the no-trade reason with `autotrader_create_trade_ticket`, `autotrader_record_risk_check`, and `autotrader_append_event`.
        - For new stock or ETF entries, use Alpaca MCP bracket or OTO orders when feasible with `order_class`, `take_profit_limit_price`, `stop_loss_stop_price`, optional `stop_loss_limit_price`, and unique `client_order_id`.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -48,7 +48,7 @@ data:
     - If Alpaca rejects or blocks the smoke, record the exact request, rejection/blocker, and reconciliation attempt in Synthesis with `autotrader_record_order` status `rejected` or an `autotrader_append_event` `paper_order_smoke_blocked`; do not retry more than once and do not leave unmanaged exposure.
     - Each cycle re-reads account and market state, reconciles orders, absorbs account changes, evaluates actions, updates artifacts, and waits with heartbeat output at least every 60 seconds.
     - Call `autotrader_get_scorecard` before ranking candidates and include the scorecard summary in scanner input.
-    - Before each non-smoke order, run `stock_analysis daytrading-scan` and validate `trade-ticket.json` with `stock_analysis daytrading-validate-ticket`.
+    - Before each non-smoke order, run `/workspace/.agentrun/autonomous-trader/stock_analysis daytrading-scan` and validate `trade-ticket.json` with `/workspace/.agentrun/autonomous-trader/stock_analysis daytrading-validate-ticket`.
     - Block C or blocked setups and record the no-trade reason with `autotrader_create_trade_ticket`, `autotrader_record_risk_check`, and `autotrader_append_event`.
     - Submit only orders with a recorded thesis, entry, invalidation, exit logic, sizing, max loss, liquidity, and reconciliation plan.
     - For new stock or ETF entries, use Alpaca MCP bracket or OTO orders when feasible, including `order_class`, `take_profit_limit_price`, `stop_loss_stop_price`, optional `stop_loss_limit_price`, and unique `client_order_id`.


### PR DESCRIPTION
## Summary

- Exposes autotrader equity/session metric fields in the MCP `tools/list` schemas so agents can discover and write first-class session metrics.
- Replaces the partial/shallow analysis checkout bootstrap with a normal full `main` fetch for simpler, more reliable day-trading startup.
- Writes and documents a bootstrapped `/workspace/.agentrun/autonomous-trader/stock_analysis` CLI wrapper so market-open cycles use the same validated analysis environment.

## Related Issues

None

## Testing

- `bun run --filter synthesis test -- src/server/__tests__/mcp.test.ts`
- `bun run --filter synthesis test`
- `bun run --filter synthesis lint`
- `bun run --filter synthesis build`
- `bunx oxfmt --check apps/synthesis/src/server/mcp.ts apps/synthesis/src/server/__tests__/mcp.test.ts`
- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/synthesis >/tmp/synthesis-kustomize-autotrader-bootstrap.yaml`
- `bash -n /tmp/bootstrap-analysis-daytrading-check.sh`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
