### PR TITLE
chore(synthesis): promote image 0.580.6

### DIFF
--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: 0.580.5
+    newTag: 0.580.6
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promotes the Synthesis GitOps image tag from `0.580.5` to `0.580.6`.
- Rolls out the merged autotrader runtime tool-contract and analysis bootstrap hardening from `proompteng/lab#8641`.
- Leaves the rest of the Synthesis Argo application unchanged.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/synthesis >/tmp/synthesis-kustomize-0.580.6.yaml`
- `rg -n "image: registry.ide-newton.ts.net/lab/synthesis:0\\.580\\.6" /tmp/synthesis-kustomize-0.580.6.yaml`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
