### PR TITLE
test(synthesis): include route ts tests

### DIFF
--- a/apps/synthesis/vitest.config.ts
+++ b/apps/synthesis/vitest.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    include: ['src/{lib,server}/**/*.test.ts', 'src/routes/**/*.test.tsx'],
+    include: ['src/{lib,server}/**/*.test.ts', 'src/routes/**/*.test.{ts,tsx}'],
   },
 })


### PR DESCRIPTION
## Summary

- Include Synthesis route `.test.ts` files in the Vitest default include pattern.
- Ensures the autotrader runtime-alert test is exercised by `bun run --filter synthesis test`.
- Keeps existing `.test.tsx` route test coverage intact.

## Related Issues

None

## Testing

- `bun run --filter synthesis test -- ./src/routes/-autotrader-alerts.test.ts`
- `bun run --filter synthesis test -- src/server/__tests__/api.test.ts src/server/__tests__/mcp.test.ts`
- `bun run --filter synthesis test`
- `bun run --filter synthesis lint`
- `bunx oxfmt --check apps/synthesis/vitest.config.ts`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
