### PR TITLE
fix(torghut): keep order feed lifecycle as promotion blocker

### DIFF
--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -51,6 +51,7 @@ CAPITAL_PROMOTION_STATUS_BLOCKERS = frozenset(
         "runtime_ledger_stage_not_live",
         "sample_count_below_canary_minimum",
         "simple_submit_disabled",
+        "order_feed_lifecycle_disabled",
     }
 )
 CAPITAL_PROMOTION_STATUS_BLOCKER_PREFIXES = (

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -403,6 +403,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
             _status(
                 blockers=[
                     "simple_submit_disabled",
+                    "order_feed_lifecycle_disabled",
                     "promotion_decision_not_allowed",
                     "promotion_certificate_shadow_only",
                 ]
@@ -428,6 +429,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result["capital_promotion_authority"]["blocking_reasons"],
             [
                 "simple_submit_disabled",
+                "order_feed_lifecycle_disabled",
                 "promotion_decision_not_allowed",
                 "promotion_certificate_shadow_only",
             ],
@@ -447,6 +449,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
             ],
             [
                 "simple_submit_disabled",
+                "order_feed_lifecycle_disabled",
                 "promotion_decision_not_allowed",
                 "promotion_certificate_shadow_only",
             ],


### PR DESCRIPTION
## Summary

- Keeps `order_feed_lifecycle_disabled` out of the post-cost proof blocker set in runtime-ledger proof packets.
- Preserves it as a capital-promotion blocker so live submit/capital authority still stays blocked until live order-feed lifecycle is enabled.
- Updates the proof-packet regression test covering split post-cost proof authority versus capital-promotion authority.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff format --check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen ruff check scripts/assemble_runtime_ledger_proof_packet.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv run --frozen python -m pytest tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Live preflight captured current `/trading/status`, `/trading/paper-route-evidence`, and `/trading/completion/doc29`, then assembled a proof packet locally. The packet now reports `verdict=waiting_for_runtime_window`, post-cost proof blocked only by `paper_route_session_window_not_open`, and `order_feed_lifecycle_disabled` retained under capital-promotion blockers.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
