### PR TITLE
chore(synthesis): promote image 0.580.8

### DIFF
--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: 0.580.7
+    newTag: 0.580.8
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote the Synthesis GitOps image from `0.580.7` to `0.580.8`.
- Carries the merged autotrader schema hardening release into the live Synthesis deployment path.
- Leaves AgentRun schedules and prompts unchanged.

## Related Issues

None

## Testing

- `git diff --check`
- `kubectl kustomize argocd/applications/synthesis` confirmed the rendered Synthesis deployment image is `registry.ide-newton.ts.net/lab/synthesis:0.580.8`.
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A; GitOps image promotion only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
