### PR TITLE
fix(synthesis): keep full analysis repo for autotrader

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml
@@ -76,6 +76,7 @@ spec:
     AGENTS_ARTIFACTS_ENDPOINT: http://rook-ceph-rgw-objectstore.rook-ceph.svc:80
     AGENTS_ARTIFACTS_SECURE: "false"
     ALPACA_PAPER_TRADE: "true"
+    ANALYSIS_REPO_DIR: /workspace/analysis
     ANALYSIS_REPO_URL: https://github.com/gregkonush/analysis.git
     ANALYSIS_REQUIRED_COMMIT: b4d7485e106dc1197d293683e3413fe74dacd698
     AUTONOMOUS_TRADER_ARTIFACT_DIR: /workspace/.agentrun/autonomous-trader

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -19,7 +19,7 @@ spec:
   acceptanceCriteria:
     - Operate as a day-trading AgentRun for the Alpaca paper account only.
     - Verify Alpaca MCP account, clock, market data, order, and instrument tools before any order call.
-    - Bootstrap and validate the private analysis repo before any market-open order.
+    - Bootstrap and validate the full private analysis repo before any market-open order.
     - Start before the regular open so dependency/context validation is complete before execution hours.
     - Start a Synthesis autotrader session and use autotrader MCP/API tools as canonical runtime state.
     - Read Synthesis scorecards before grading new candidates and finalize every session with scorecard observations.
@@ -43,6 +43,8 @@ spec:
     Execution contract:
     1. Bootstrap analysis before any market-open order:
        - Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh`.
+       - Treat `/workspace/analysis` as the full analysis repo checkout and primary local knowledge base. Use its docs, data, source, examples, and tools directly when useful.
+       - Do not spend market-session time copying, pruning, reshaping, summarizing, or rebuilding a separate subset of the analysis repo. Keep the repo whole; use the `stock_analysis` wrapper only as a convenience for the packaged day-trading commands.
        - Read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`.
        - Require analysis commit `b4d7485e106dc1197d293683e3413fe74dacd698` or newer.
        - Produce valid `/workspace/.agentrun/autonomous-trader/analysis-context.json` and `/workspace/.agentrun/autonomous-trader/analysis-bootstrap.json`.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -23,6 +23,8 @@ data:
     - Read the exact Kubernetes AgentRun name from `AGENT_RUN_NAME` and use that value unchanged for Synthesis session identity, artifacts, milestone URLs, dedupe keys, and report fields.
     - Do not invent, normalize, shorten, timestamp, or replace the `AGENT_RUN_NAME` value.
     - Run `/usr/bin/env bash /root/bootstrap-analysis-daytrading.sh` before any market-open order, then read `/workspace/analysis/docs/daytrading-agent-bootstrap.md`.
+    - Treat `/workspace/analysis` as the full analysis repo checkout and primary local knowledge base. Use its docs, data, source, examples, and tools directly when useful.
+    - Do not copy, prune, reshape, summarize, or rebuild a separate subset of the analysis repo during market hours. Keep the repo whole; use the `stock_analysis` wrapper only as a convenience for packaged day-trading commands.
     - Build and validate `/workspace/.agentrun/autonomous-trader/analysis-context.json` before trading.
     - Use the scheduled premarket window for bootstrap, tool validation, scorecard readback, and context construction; do not submit orders until the regular session is open.
     - Use local Python, the analysis repo, and web research when they can change the trade decision.


### PR DESCRIPTION
## Summary

- Make the autonomous trader contract explicitly treat `/workspace/analysis` as the full private analysis repo checkout and primary local knowledge base.
- Clarify that the day-trading wrapper is only a convenience and the agent should not spend market-session time building a separate repo subset.
- Set `ANALYSIS_REPO_DIR=/workspace/analysis` explicitly in the AgentProvider runtime environment.

## Related Issues

None

## Testing

- `git diff --check`
- `kubectl kustomize argocd/applications/synthesis`
- `kubectl apply --dry-run=server -f /tmp/synthesis-render.yaml -o name`
- Generated live `autonomous-trader-market-open-template` AgentRun with placeholder delivery id replaced and validated it using `kubectl -n synthesis create --dry-run=server -f <tmp-run.json> -o name`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
