### PR TITLE
chore(analysis): promote image 9bef93fd1723

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 706e16a7e17073d7ce465caecc46e7ed812b32dd
+    newTag: 9bef93fd1723309aaa326fe9548563b0a9ea753c


### PR DESCRIPTION
## Summary

- Promotes `argocd/applications/analysis` to `registry.ide-newton.ts.net/lab/analysis:9bef93fd1723309aaa326fe9548563b0a9ea753c`.
- Keeps rollout in lab GitOps by changing only the analysis kustomize image tag.
- Uses the self-hosted analysis image publish workflow output.

## Related Issues

None

## Testing

- `/Users/gregkonush/github.com/analysis/scripts/verify-analysis-image.sh 9bef93fd1723309aaa326fe9548563b0a9ea753c`
- `kubectl kustomize argocd/applications/analysis`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
