### PR TITLE
fix(torghut): roll back options freshness fallback

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -5745,6 +5745,12 @@ WHERE status = 'active'
             zero_open_interest_count = int(row["zero_open_interest_count"] or 0)
     except SQLAlchemyError as exc:
         logger.warning("Options catalog freshness summary unavailable: %s", exc)
+        rollback = getattr(session, "rollback", None)
+        if callable(rollback):
+            try:
+                rollback()
+            except SQLAlchemyError:
+                logger.warning("Failed to roll back options catalog freshness session")
         bounded_payload = _load_bounded_options_catalog_freshness_summary(
             session,
             scoped_symbols,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -287,6 +287,50 @@ class _FallbackOptionsFreshnessSession:
         return _ExecuteResult([])
 
 
+class _FallbackOptionsFreshnessRequiresRollbackSession:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object | None]] = []
+        self.rollback_count = 0
+        self._transaction_failed = False
+
+    def rollback(self) -> None:
+        self.rollback_count += 1
+        self._transaction_failed = False
+
+    def execute(
+        self, statement: object, params: object | None = None
+    ) -> _ExecuteResult:
+        statement_text = str(statement)
+        self.calls.append((statement_text, params))
+        if statement_text.startswith("SET LOCAL"):
+            return _ExecuteResult([])
+        if "GROUP BY underlying_symbol" in statement_text:
+            self._transaction_failed = True
+            raise SQLAlchemyError("statement timeout")
+        if "LIMIT 1" in statement_text:
+            if self._transaction_failed:
+                raise SQLAlchemyError("current transaction is aborted")
+            symbol = None
+            if isinstance(params, dict):
+                symbol = params.get("route_symbol")
+            if str(symbol or "").upper() != "AAPL":
+                return _ExecuteResult([])
+            return _ExecuteResult(
+                [
+                    {
+                        "underlying_symbol": "AAPL",
+                        "last_seen_ts": datetime(2026, 5, 12, tzinfo=timezone.utc),
+                        "provider_updated_ts": datetime(
+                            2026, 5, 12, tzinfo=timezone.utc
+                        ),
+                        "close_price": Decimal("182.10"),
+                        "open_interest": Decimal("100"),
+                    }
+                ]
+            )
+        return _ExecuteResult([])
+
+
 class _FallbackOptionsFreshnessBlankSymbolSession:
     def __init__(self) -> None:
         self.calls: list[tuple[str, object | None]] = []
@@ -685,6 +729,25 @@ class TestTradingApi(TestCase):
         self.assertEqual(
             sum("LIMIT 1" in sql for sql, _params in fake_session.calls),
             2,
+        )
+
+    def test_options_catalog_freshness_summary_rolls_back_before_bounded_fallback(
+        self,
+    ) -> None:
+        fake_session = _FallbackOptionsFreshnessRequiresRollbackSession()
+
+        payload = _load_options_catalog_freshness_summary(
+            fake_session,  # type: ignore[arg-type]
+            route_symbols=["AAPL"],
+        )
+
+        self.assertEqual(payload["status"], "current")
+        self.assertTrue(payload["bounded"])
+        self.assertEqual(payload["active_contracts"], 1)
+        self.assertEqual(fake_session.rollback_count, 1)
+        self.assertEqual(
+            sum("LIMIT 1" in sql for sql, _params in fake_session.calls),
+            1,
         )
 
     def test_options_catalog_freshness_bounded_fallback_skips_blank_symbols(


### PR DESCRIPTION
## Summary

- Roll back the SQLAlchemy session after options-catalog freshness statement timeouts before attempting the bounded route-symbol fallback.
- Add regression coverage for the failed-transaction path that previously made the bounded fallback fail immediately.
- Keep paper-route evidence degraded and fail-closed when the options catalog is slow, instead of poisoning the request session.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen python -m pytest tests/test_trading_api.py -k 'options_catalog_freshness_summary' -q`
- `cd services/torghut && uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked. N/A: no docs or release notes needed for this bug fix.
