### PR TITLE
fix(torghut): add lightweight paper route target plan

### DIFF
--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -23,7 +23,7 @@ workflow submissions in `torghut` do not rely on manual secret copies from `argo
 
 The `torghut-empirical-promotion-renewal` CronJob is also the scheduled runtime-ledger proof packet conductor for the
 paper-route proof lane. It first runs `renew_latest_empirical_promotion_jobs.py` with the sim
-`/trading/paper-route-evidence` target plan, then runs `assemble_runtime_ledger_proof_packet.py` and uploads the packet
+`/trading/paper-route-target-plan` target plan, then runs `assemble_runtime_ledger_proof_packet.py` and uploads the packet
 under `runtime-ledger-proof-packets/{run_id}`. When the paper-route window is import-ready, the packet now requires the
 live `runtime_window_import_audit` from `/trading/paper-route-evidence` and carries source-activity blockers such as
 `paper_route_source_activity_missing`, `source_decisions_missing`, `source_executions_missing`, and `source_tca_missing`

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -46,7 +46,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \
                     --runtime-window-import \
-                    --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence \
+                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan \
                     --runtime-window-target-plan-url-timeout-seconds 45 \
                     --runtime-window-target-plan-url-attempts 3 \
                     --runtime-window-target-plan-url-retry-backoff-seconds 5 \

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -111,7 +111,7 @@ spec:
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
               value: "63180"
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_URL
-              value: http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence
+              value: http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS
               value: "10"
             - name: TRADING_KILL_SWITCH_ENABLED

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -130,7 +130,10 @@ from .trading.paper_route_target_plan import (
     mapping_items as _shared_mapping_items,
     paper_route_target_plan_from_payload as _shared_paper_route_target_plan_from_payload,
 )
-from .trading.paper_route_evidence import build_paper_route_evidence_audit
+from .trading.paper_route_evidence import (
+    build_paper_route_evidence_audit,
+    build_paper_route_target_plan_payload,
+)
 from .trading.runtime_cost_authority import (
     cost_basis_counts_have_non_promotion_grade_costs,
 )
@@ -4589,6 +4592,66 @@ def trading_paper_route_evidence(
         simple_lane_status=simple_lane_status,
     )
     payload = build_paper_route_evidence_audit(
+        session,
+        live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
+        route_reacquisition_book=cast(
+            Mapping[str, Any],
+            proof_floor.get("route_reacquisition_book") or {},
+        ),
+    )
+    return JSONResponse(status_code=200, content=jsonable_encoder(payload))
+
+
+@app.get("/trading/paper-route-target-plan")
+def trading_paper_route_target_plan(
+    session: Session = Depends(get_session),
+) -> JSONResponse:
+    """Return the lightweight next-window paper-route target plan."""
+
+    scheduler: TradingScheduler | None = getattr(app.state, "trading_scheduler", None)
+    if scheduler is None:
+        scheduler = TradingScheduler()
+        app.state.trading_scheduler = scheduler
+
+    empirical_jobs = _empirical_jobs_status()
+    quant_evidence = load_quant_evidence_status(
+        account_label=settings.trading_account_label,
+    )
+    tca_summary = _load_tca_summary(session, scheduler=scheduler)
+    market_context_status = scheduler.market_context_status()
+    hypothesis_payload, _hypothesis_summary, _dependency_quorum = (
+        _build_hypothesis_runtime_payload(
+            scheduler,
+            tca_summary=tca_summary,
+            market_context_status=market_context_status,
+        )
+    )
+    live_submission_gate = _build_live_submission_gate_payload(
+        scheduler.state,
+        session=session,
+        hypothesis_summary=hypothesis_payload,
+        empirical_jobs_status=empirical_jobs,
+        dspy_runtime_status=cast(
+            dict[str, object],
+            scheduler.llm_status().get("dspy_runtime", {}),
+        ),
+        quant_health_status=quant_evidence,
+    )
+    live_submission_gate = _merge_external_paper_route_target_plan(
+        cast(Mapping[str, Any], live_submission_gate)
+    )
+    proof_floor = _build_profitability_proof_floor_payload(
+        state=scheduler.state,
+        torghut_revision=BUILD_VERSION,
+        live_submission_gate=live_submission_gate,
+        hypothesis_payload=hypothesis_payload,
+        empirical_jobs_status=empirical_jobs,
+        quant_evidence=quant_evidence,
+        market_context_status=market_context_status,
+        tca_summary=tca_summary,
+        simple_lane_status=_build_simple_lane_status_payload(),
+    )
+    payload = build_paper_route_target_plan_payload(
         session,
         live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
         route_reacquisition_book=cast(

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -33,6 +33,7 @@ from .runtime_ledger import POST_COST_PNL_BASIS
 
 
 PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION = "torghut.paper-route-evidence.v1"
+PAPER_ROUTE_TARGET_PLAN_PAYLOAD_SCHEMA_VERSION = "torghut.paper-route-target-plan.v1"
 NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION = (
     "torghut.next-paper-route-runtime-window-targets.v1"
 )
@@ -46,6 +47,7 @@ DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS = 72
 DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT = 20
 PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL = "TORGHUT_SIM"
 PAPER_ROUTE_RUNTIME_IMPORT_SETTLEMENT_SECONDS = 3600
+PAPER_ROUTE_TARGET_PLAN_ENDPOINT = "/trading/paper-route-target-plan"
 DEFAULT_TORGHUT_LIVE_SERVICE_BASE_URL = "http://torghut.torghut.svc.cluster.local"
 DEFAULT_TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL = (
     "http://torghut-sim.torghut.svc.cluster.local"
@@ -702,6 +704,16 @@ def _target_probe_symbols(
     return _paper_route_probe_symbols(probe)
 
 
+def _target_allows_strategy_universe_probe_fallback(
+    target: Mapping[str, object],
+) -> bool:
+    source_kind = _safe_text(target.get("source_kind"))
+    return bool(target.get("paper_probation_authorized")) or source_kind in {
+        "durable_runtime_ledger_bucket",
+        "runtime_ledger_paper_probation_candidates",
+    }
+
+
 def _strategy_universe_symbols(
     session: Session,
     *,
@@ -1112,7 +1124,7 @@ def _next_paper_route_runtime_window_targets(
     ]
     import_handoff = {
         "runner": "scripts/renew_latest_empirical_promotion_jobs.py",
-        "target_plan_endpoint": "/trading/paper-route-evidence",
+        "target_plan_endpoint": PAPER_ROUTE_TARGET_PLAN_ENDPOINT,
         "required_flags": [
             "--runtime-window-import",
             "--runtime-window-target-plan-url",
@@ -1157,9 +1169,18 @@ def _next_paper_route_runtime_window_targets(
             strategy_lookup_names=strategy_lookup_names,
         )
         target_probe_symbols = raw_target_probe_symbols
+        source_readiness_raw_probe_symbols = raw_target_probe_symbols
         out_of_strategy_scope_symbols: list[str] = []
         missing_strategy_universe_symbols: list[str] = []
-        if strategy_universe_symbols:
+        strategy_universe_probe_fallback = (
+            not target_probe_symbols
+            and bool(strategy_universe_symbols)
+            and _target_allows_strategy_universe_probe_fallback(target)
+        )
+        if strategy_universe_probe_fallback:
+            target_probe_symbols = list(strategy_universe_symbols)
+            source_readiness_raw_probe_symbols = list(strategy_universe_symbols)
+        elif strategy_universe_symbols:
             (
                 target_probe_symbols,
                 out_of_strategy_scope_symbols,
@@ -1171,7 +1192,7 @@ def _next_paper_route_runtime_window_targets(
         source_decision_readiness = _strategy_source_decision_readiness(
             session,
             strategy_lookup_names=strategy_lookup_names,
-            raw_probe_symbols=raw_target_probe_symbols,
+            raw_probe_symbols=source_readiness_raw_probe_symbols,
             scoped_probe_symbols=target_probe_symbols,
         )
         target_probe_ready = (
@@ -1317,6 +1338,9 @@ def _next_paper_route_runtime_window_targets(
             "paper_route_probe_symbol_count": len(target_probe_symbols),
             "paper_route_probe_raw_target_symbols": raw_target_probe_symbols,
             "paper_route_probe_strategy_scope_applied": bool(strategy_universe_symbols),
+            "paper_route_probe_strategy_universe_fallback": (
+                strategy_universe_probe_fallback
+            ),
             "paper_route_probe_strategy_universe_symbols": (strategy_universe_symbols),
             "paper_route_probe_out_of_strategy_scope_symbols": (
                 out_of_strategy_scope_symbols
@@ -2796,6 +2820,91 @@ def _runtime_ledger_proof_packet_handoff(
     }
 
 
+def build_paper_route_target_plan_payload(
+    session: Session,
+    *,
+    live_submission_gate: Mapping[str, Any],
+    route_reacquisition_book: Mapping[str, Any],
+    generated_at: datetime | None = None,
+    target_limit: int = DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT,
+) -> dict[str, object]:
+    """Build the lightweight runtime-window target-plan payload."""
+
+    resolved_generated_at = generated_at or datetime.now(timezone.utc)
+    plan = _as_mapping(
+        live_submission_gate.get("runtime_ledger_paper_probation_import_plan")
+    )
+    targets = _as_mapping_items(plan.get("targets"))[: max(0, target_limit)]
+    probe = _paper_route_probe_summary(
+        route_reacquisition_book,
+        target_plan=plan,
+        target_plan_source=_safe_text(
+            live_submission_gate.get("paper_route_target_plan_source")
+        )
+        or _target_plan_source(plan),
+        target_plan_error=_safe_text(
+            live_submission_gate.get("paper_route_target_plan_error")
+        ),
+    )
+    next_targets = _next_paper_route_runtime_window_targets(
+        session=session,
+        targets=targets,
+        probe=probe,
+        live_submission_gate=live_submission_gate,
+        generated_at=resolved_generated_at,
+    )
+    return {
+        "schema_version": PAPER_ROUTE_TARGET_PLAN_PAYLOAD_SCHEMA_VERSION,
+        "generated_at": _isoformat(resolved_generated_at),
+        "source": "paper_route_target_plan_endpoint",
+        "live_submission_gate": {
+            "allowed": bool(live_submission_gate.get("allowed")),
+            "reason": _safe_text(live_submission_gate.get("reason")),
+            "blocked_reasons": [
+                str(item).strip()
+                for item in _as_sequence(live_submission_gate.get("blocked_reasons"))
+                if str(item).strip()
+            ],
+            "promotion_eligible_total": _safe_int(
+                live_submission_gate.get("promotion_eligible_total")
+            ),
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": _safe_text(plan.get("schema_version")),
+                "target_count": _safe_int(plan.get("target_count") or len(targets)),
+                "skipped_target_count": _safe_int(plan.get("skipped_target_count")),
+                "source_promotion_allowed": bool(plan.get("promotion_allowed")),
+                "source_final_promotion_allowed": bool(
+                    plan.get("final_promotion_allowed")
+                    or plan.get("final_promotion_authorized")
+                ),
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+            },
+            "paper_route_target_plan_source": _safe_text(
+                live_submission_gate.get("paper_route_target_plan_source")
+            ),
+            "paper_route_target_plan_error": _safe_text(
+                live_submission_gate.get("paper_route_target_plan_error")
+            ),
+        },
+        "paper_route_probe": probe,
+        "runtime_window_import_plan": next_targets,
+        "next_paper_route_runtime_window_targets": next_targets,
+        "summary": {
+            "source_target_count": len(targets),
+            "next_runtime_window_target_count": _safe_int(
+                next_targets.get("target_count")
+            ),
+            "skipped_target_count": _safe_int(next_targets.get("skipped_target_count")),
+            "promotion_authority": {
+                "allowed": False,
+                "reason": "paper_route_target_plan_observability_only",
+                "blockers": ["live_runtime_ledger_required"],
+            },
+        },
+    }
+
+
 def build_paper_route_evidence_audit(
     session: Session,
     *,
@@ -3042,7 +3151,9 @@ __all__ = [
     "DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS",
     "NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION",
     "PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION",
+    "PAPER_ROUTE_TARGET_PLAN_PAYLOAD_SCHEMA_VERSION",
     "PAPER_ROUTE_RUNTIME_WINDOW_IMPORT_AUDIT_SCHEMA_VERSION",
     "RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION",
     "build_paper_route_evidence_audit",
+    "build_paper_route_target_plan_payload",
 ]

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -613,7 +613,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertEqual(
             sim_env.get("TRADING_PAPER_ROUTE_TARGET_PLAN_URL"),
-            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan",
         )
         self.assertEqual(
             sim_env.get("TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS"),
@@ -934,7 +934,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn(
             "--runtime-window-target-plan-url "
-            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan",
             args,
         )
         self.assertIn("--runtime-window-target-plan-url-timeout-seconds 45", args)
@@ -946,6 +946,11 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertNotIn(
             "--runtime-window-target-plan-url "
             "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence",
+            args,
+        )
+        self.assertNotIn(
+            "--runtime-window-target-plan-url "
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence",
             args,
         )
         self.assertIn("--runtime-window-target-plan-exclusive", args)

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -26,6 +26,7 @@ from app.trading.paper_route_evidence import (
     _paper_route_probe_summary,
     _runtime_ledger_row_diagnostic_expectancy_bps,
     build_paper_route_evidence_audit,
+    build_paper_route_target_plan_payload,
 )
 
 
@@ -360,7 +361,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
             handoff["runner"], "scripts/renew_latest_empirical_promotion_jobs.py"
         )
         self.assertEqual(
-            handoff["target_plan_endpoint"], "/trading/paper-route-evidence"
+            handoff["target_plan_endpoint"], "/trading/paper-route-target-plan"
         )
         self.assertIn("--runtime-window-import", handoff["required_flags"])
         self.assertIn(
@@ -430,7 +431,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertEqual(
             target["paper_route_runtime_import_handoff"]["target_plan_endpoint"],
-            "/trading/paper-route-evidence",
+            "/trading/paper-route-target-plan",
         )
         import_audit = payload["runtime_window_import_audit"]
         self.assertEqual(
@@ -728,6 +729,98 @@ class TestPaperRouteEvidenceAudit(TestCase):
         summary_target = payload["summary"]["next_paper_route_targets"][0]
         self.assertTrue(summary_target["source_decision_ready"])
         self.assertEqual(summary_target["source_decision_blockers"], [])
+
+    def test_next_paper_route_targets_use_strategy_universe_when_route_probe_empty(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 5, 24, 12, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            session.add(
+                Strategy(
+                    name="microbar-cross-sectional-pairs-v1",
+                    description="paper route source strategy",
+                    enabled=True,
+                    base_timeframe="1Sec",
+                    universe_type="static",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_notional_per_trade=Decimal("31590"),
+                )
+            )
+            session.commit()
+            payload = build_paper_route_target_plan_payload(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "dependency_quorum_decision": "allow",
+                    "continuity_ok": True,
+                    "continuity_reason": "signal_continuity_nominal",
+                    "drift_ok": True,
+                    "drift_reason": "drift_live_promotion_eligible",
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "candidate-paper-route",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": (
+                                    "69cf50e3-4815-47c2-b802-1efbaac09ecb"
+                                ),
+                                "runtime_strategy_name": (
+                                    "69cf50e3-4815-47c2-b802-1efbaac09ecb"
+                                ),
+                                "strategy_lookup_names": [
+                                    "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                                    "microbar-cross-sectional-pairs-v1",
+                                ],
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "durable_runtime_ledger_bucket",
+                                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                                "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                                "paper_probation_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": False,
+                        "next_session_max_notional": "63180",
+                        "eligible_symbol_count": 0,
+                        "eligible_symbols": [],
+                        "active_symbols": [],
+                        "blocking_reasons": ["market_session_closed"],
+                    },
+                },
+                generated_at=generated_at,
+            )
+
+        plan = payload["runtime_window_import_plan"]
+        self.assertEqual(plan["target_count"], 1)
+        self.assertEqual(plan["source_decision_readiness"]["ready_target_count"], 1)
+        target = plan["targets"][0]
+        self.assertEqual(target["paper_route_probe_symbols"], ["AAPL", "AMZN"])
+        self.assertEqual(
+            target["paper_route_probe_scope_authority"], "strategy_universe"
+        )
+        self.assertTrue(target["paper_route_probe_strategy_scope_applied"])
+        self.assertTrue(target["paper_route_probe_strategy_universe_fallback"])
+        self.assertEqual(target["paper_route_probe_raw_target_symbols"], [])
+        self.assertEqual(
+            target["source_decision_readiness"]["scoped_probe_symbols"],
+            ["AAPL", "AMZN"],
+        )
 
     def test_builder_exports_missing_runtime_window_health_gate_as_blockers(
         self,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7355,13 +7355,107 @@ class TestTradingApi(TestCase):
             else:
                 app.state.trading_scheduler = original_scheduler
 
+    def test_trading_paper_route_target_plan_returns_lightweight_plan(self) -> None:
+        original_scheduler = getattr(app.state, "trading_scheduler", None)
+        target = {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "observed_stage": "paper",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "strategy_name": "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+            "account_label": "TORGHUT_REPLAY",
+            "source_kind": "runtime_ledger_paper_probation_candidates",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+            "dataset_snapshot_ref": "torghut-chip-full-day-20260505-4c330ce9-r1",
+            "window_start": "2026-05-22T13:30:00+00:00",
+            "window_end": "2026-05-22T20:00:00+00:00",
+            "paper_route_probe_symbols": ["AAPL"],
+            "paper_probation_authorized": True,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "max_notional": "0",
+        }
+        live_gate = {
+            "allowed": True,
+            "reason": "non_live_mode",
+            "blocked_reasons": [],
+            "promotion_eligible_total": 0,
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "skipped_target_count": 0,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "targets": [target],
+            },
+        }
+        proof_floor = {
+            "route_reacquisition_book": {
+                "schema_version": "torghut.route-reacquisition-book.v1",
+                "state": "repair_only",
+                "paper_route_probe": {
+                    "configured_enabled": True,
+                    "active": False,
+                    "effective_max_notional": "0",
+                    "next_session_max_notional": "63180",
+                    "eligible_symbol_count": 1,
+                    "eligible_symbols": ["AAPL"],
+                    "active_symbols": [],
+                    "blocking_reasons": ["market_session_closed"],
+                },
+            }
+        }
+        try:
+            if hasattr(app.state, "trading_scheduler"):
+                del app.state.trading_scheduler
+            with (
+                patch(
+                    "app.main._build_live_submission_gate_payload",
+                    return_value=live_gate,
+                ),
+                patch(
+                    "app.main._build_profitability_proof_floor_payload",
+                    return_value=proof_floor,
+                ),
+                patch(
+                    "app.main.build_paper_route_evidence_audit",
+                    side_effect=AssertionError("full audit should not run"),
+                ),
+            ):
+                response = self.client.get("/trading/paper-route-target-plan")
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(
+                payload["schema_version"], "torghut.paper-route-target-plan.v1"
+            )
+            self.assertNotIn("next_runtime_window_target_audits", payload)
+            plan = payload["runtime_window_import_plan"]
+            self.assertEqual(plan["target_count"], 1)
+            self.assertEqual(
+                payload["next_paper_route_runtime_window_targets"]["target_count"], 1
+            )
+            self.assertEqual(
+                plan["runtime_window_import_handoff"]["target_plan_endpoint"],
+                "/trading/paper-route-target-plan",
+            )
+            self.assertEqual(plan["targets"][0]["candidate_id"], target["candidate_id"])
+            self.assertEqual(plan["targets"][0]["paper_route_probe_symbols"], ["AAPL"])
+            self.assertFalse(plan["targets"][0]["promotion_allowed"])
+            self.assertFalse(plan["targets"][0]["final_promotion_allowed"])
+        finally:
+            if original_scheduler is None:
+                if hasattr(app.state, "trading_scheduler"):
+                    del app.state.trading_scheduler
+            else:
+                app.state.trading_scheduler = original_scheduler
+
     def test_trading_paper_route_evidence_uses_external_plan_when_url_configured(
         self,
     ) -> None:
         original_scheduler = getattr(app.state, "trading_scheduler", None)
         original_target_plan_url = settings.trading_paper_route_target_plan_url
         settings.trading_paper_route_target_plan_url = (
-            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence"
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan"
         )
         target = {
             "hypothesis_id": "H-PAIRS-01",
@@ -8204,7 +8298,7 @@ class TestTradingApi(TestCase):
         original_scheduler = getattr(app.state, "trading_scheduler", None)
         original_target_plan_url = settings.trading_paper_route_target_plan_url
         settings.trading_paper_route_target_plan_url = (
-            "http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence"
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan"
         )
         target = {
             "hypothesis_id": "H-PAIRS-01",

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -235,7 +235,7 @@ def _paper_route_evidence(
             },
             "runtime_window_import_handoff": {
                 "runner": "scripts/renew_latest_empirical_promotion_jobs.py",
-                "target_plan_endpoint": "/trading/paper-route-evidence",
+                "target_plan_endpoint": "/trading/paper-route-target-plan",
                 "required_flags": flags,
                 "source_dsn_env": "SIM_DB_DSN",
                 "account_label": "TORGHUT_SIM",


### PR DESCRIPTION
## Summary

- Adds `/trading/paper-route-target-plan` as a lightweight paper-route runtime-window plan endpoint.
- Keeps promotion authority blocked while returning scheduler-ready next-window paper-probation targets.
- Points sim and the empirical renewal CronJob at the lightweight target-plan URL instead of the full evidence audit.
- Adds strategy-universe fallback for paper-probation targets when the route-reacquisition book has no eligible symbols.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen python -m pytest tests/test_trading_api.py -k 'paper_route_target_plan or paper_route_evidence_uses_external_plan or external_paper_route_target_preserves_live_symbol_envelope' -q`
- `cd services/torghut && uv run --frozen python -m pytest tests/test_paper_route_evidence.py -k 'strategy_universe_when_route_probe_empty or source_decision_readiness' -q`
- `cd services/torghut && uv run --frozen python -m pytest tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_live_config_manifest_contract.py -k 'paper_route or torghut_sim_knative or empirical_promotion_renewal' -q`
- `cd services/torghut && uv run --frozen ruff check app/main.py app/trading/paper_route_evidence.py tests/test_trading_api.py tests/test_paper_route_evidence.py tests/test_verify_trading_readiness.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen ruff format --check app/main.py app/trading/paper_route_evidence.py tests/test_trading_api.py tests/test_paper_route_evidence.py tests/test_verify_trading_readiness.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
