### PR TITLE
revert(torghut): rollback failed promotion b4224ca6fbbe143e53d06ce7bdea85648a649390

### DIFF
--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -23,7 +23,7 @@ workflow submissions in `torghut` do not rely on manual secret copies from `argo
 
 The `torghut-empirical-promotion-renewal` CronJob is also the scheduled runtime-ledger proof packet conductor for the
 paper-route proof lane. It first runs `renew_latest_empirical_promotion_jobs.py` with the sim
-`/trading/paper-route-target-plan` target plan, then runs `assemble_runtime_ledger_proof_packet.py` and uploads the packet
+`/trading/paper-route-evidence` target plan, then runs `assemble_runtime_ledger_proof_packet.py` and uploads the packet
 under `runtime-ledger-proof-packets/{run_id}`. When the paper-route window is import-ready, the packet now requires the
 live `runtime_window_import_audit` from `/trading/paper-route-evidence` and carries source-activity blockers such as
 `paper_route_source_activity_missing`, `source_decisions_missing`, `source_executions_missing`, and `source_tca_missing`

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -46,7 +46,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \
                     --runtime-window-import \
-                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan \
+                    --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-evidence \
                     --runtime-window-target-plan-url-timeout-seconds 45 \
                     --runtime-window-target-plan-url-attempts 3 \
                     --runtime-window-target-plan-url-retry-backoff-seconds 5 \

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -111,7 +111,7 @@ spec:
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
               value: "63180"
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_URL
-              value: http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan
+              value: http://torghut.torghut.svc.cluster.local/trading/paper-route-evidence
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS
               value: "10"
             - name: TRADING_KILL_SWITCH_ENABLED


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `b4224ca6fbbe143e53d06ce7bdea85648a649390`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/26637045238`
- Rollback source: `HEAD^` manifests from the failed run checkout