### PR TITLE
fix(torghut): allow preopen target-plan readiness

### DIFF
--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -479,7 +479,9 @@ def _paper_route_preopen_evidence_collection_ready(
         "profile_allows_paper": profile in {"paper", "either"},
         "market_open_not_required": not require_market_open,
         "market_closed": not market_open,
-        "probe_candidate_required": require_paper_route_probe_candidate,
+        "probe_candidate_requirement_satisfied": (
+            require_paper_route_probe_candidate or require_paper_route_target_plan
+        ),
         "target_plan_required": require_paper_route_target_plan,
         "import_ready_not_required": not require_paper_route_import_ready,
         "runtime_profit_proof_not_required": not require_runtime_ledger_profit_proof,

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -856,6 +856,76 @@ class TestVerifyTradingReadiness(TestCase):
             ]
         )
 
+    def test_preopen_target_plan_check_does_not_require_separate_probe_flag(
+        self,
+    ) -> None:
+        status = _ready_status()
+        metrics = status["metrics"]
+        assert isinstance(metrics, dict)
+        metrics["market_session_open"] = 0
+        proof_floor = status["proof_floor"]
+        assert isinstance(proof_floor, dict)
+        proof_floor.update(
+            {
+                "floor_state": "repair_only",
+                "route_state": "repair_only",
+                "capital_state": "zero_notional",
+                "max_notional": "0",
+                "blocking_reasons": [
+                    "alpha_readiness_not_promotion_eligible",
+                    "execution_tca_slippage_guardrail_exceeded",
+                ],
+            }
+        )
+        dimensions = proof_floor["proof_dimensions"]
+        assert isinstance(dimensions, list)
+        for dimension in dimensions:
+            if not isinstance(dimension, dict):
+                continue
+            if dimension.get("dimension") == "alpha_readiness":
+                dimension["state"] = "fail"
+                dimension["reason"] = "alpha_readiness_not_promotion_eligible"
+            if dimension.get("dimension") == "execution_tca":
+                dimension["state"] = "fail"
+                dimension["reason"] = "execution_tca_slippage_guardrail_exceeded"
+
+        route_book = status["route_reacquisition_book"]
+        assert isinstance(route_book, dict)
+        route_book["state"] = "repair_only"
+        probe = route_book["paper_route_probe"]
+        assert isinstance(probe, dict)
+        probe.update(
+            {
+                "active": False,
+                "effective_max_notional": "0",
+                "next_session_max_notional": "63180.0",
+                "eligible_symbol_count": 2,
+                "eligible_symbols": ["AAPL", "AMZN"],
+                "active_symbols": [],
+                "blocking_reasons": ["market_session_closed"],
+            }
+        )
+        summary = route_book["summary"]
+        assert isinstance(summary, dict)
+        summary["paper_route_probe_eligible_symbols"] = ["AAPL", "AMZN"]
+        summary["paper_route_probe_active_symbols"] = []
+
+        result = evaluate_trading_readiness(
+            status,
+            paper_route_evidence=_paper_route_evidence(),
+            require_market_open=False,
+            require_quant_fresh=False,
+            require_paper_route_target_plan=True,
+            allow_paper_route_preopen_evidence_collection=True,
+        )
+
+        self.assertTrue(result["ok"], result)
+        preopen_summary = result["paper_route_preopen_evidence_collection"]
+        self.assertTrue(preopen_summary["ready"])
+        self.assertTrue(
+            preopen_summary["conditions"]["probe_candidate_requirement_satisfied"]
+        )
+
     def test_paper_route_target_plan_fails_closed_on_missing_handoff_or_identity(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Fixes Torghut trading readiness pre-open evidence collection so a required paper-route target plan can satisfy the probe requirement without also passing `--require-paper-route-probe-candidate`.
- Preserves fail-closed behavior for promotion, runtime-ledger import, and profitability proof; this only softens pre-open monitoring checks when the target plan already proves probe symbols, notional, identity, and blocked-promotion state.
- Adds a regression test for the live monitoring mode used against `torghut-sim` before the regular session opens.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_verify_trading_readiness.py -k 'preopen'`
- `uv run --frozen pytest tests/test_verify_trading_readiness.py`
- `uv run --frozen ruff check scripts/verify_trading_readiness.py tests/test_verify_trading_readiness.py`
- `uv run --frozen ruff format --check scripts/verify_trading_readiness.py tests/test_verify_trading_readiness.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Live payload verification through `torghut-sim`: local updated verifier returned `ok: true` for pre-open target-plan evidence collection while still labeling it as not promotion, runtime-ledger, or profitability proof.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
