### PR TITLE
fix(torghut): raise sim proof headroom

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -544,11 +544,11 @@ spec:
             timeoutSeconds: 10
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 250m
+              memory: 512Mi
             limits:
-              cpu: 500m
-              memory: 1Gi
+              cpu: "1"
+              memory: 2Gi
           volumeMounts:
             - name: strategy-config
               mountPath: /etc/torghut


### PR DESCRIPTION
## Summary

- Raises only the `torghut-sim` Knative user-container resource request from `100m/256Mi` to `250m/512Mi`.
- Raises only the `torghut-sim` user-container limit from `500m/1Gi` to `1 CPU/2Gi`.
- Keeps the live `torghut` service, image digest, scheduler settings, and candidate gates unchanged.
- Addresses the observed `torghut-sim` OOMKilled restart during the 2026-05-29 paper-route proof window.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/torghut` rendered successfully to `/tmp/torghut-kustomize-render.yaml`.
- `rg -n "name: torghut-sim|memory: 2Gi|cpu: \"1\"|memory: 512Mi|cpu: 250m" /tmp/torghut-kustomize-render.yaml | head -n 20`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
