### PR TITLE
fix(torghut): retry target source price prechecks

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -1211,9 +1211,7 @@ class SimpleTradingPipeline(TradingPipeline):
                 Sequence[object], raw_previous_risk_reasons
             )
         previous_risk_reasons = [
-            str(item)
-            for item in previous_risk_reason_items
-            if str(item).strip()
+            str(item) for item in previous_risk_reason_items if str(item).strip()
         ]
         self.executor.sync_decision_state(session, decision_row, decision)
         raw_decision_json = decision_row.decision_json
@@ -1253,6 +1251,114 @@ class SimpleTradingPipeline(TradingPipeline):
             decision.symbol,
             previous_stage,
             ",".join(previous_risk_reasons),
+        )
+        return decision_row
+
+    @staticmethod
+    def _paper_route_target_price_retry_metadata(
+        decision_row: TradeDecision,
+    ) -> dict[str, object] | None:
+        if decision_row.status != "rejected":
+            return None
+        decision_json_raw = decision_row.decision_json
+        if not isinstance(decision_json_raw, Mapping):
+            return None
+        decision_json = cast(Mapping[str, object], decision_json_raw)
+        if decision_json.get("submission_stage") != "rejected_pre_submit":
+            return None
+        params_raw = decision_json.get("params")
+        if not isinstance(params_raw, Mapping):
+            return None
+        params = cast(Mapping[str, object], params_raw)
+        if not isinstance(params.get("paper_route_target_plan"), Mapping):
+            return None
+        precheck_raw = params.get("simple_lane_precheck")
+        if not isinstance(precheck_raw, Mapping):
+            return None
+        precheck = cast(Mapping[str, object], precheck_raw)
+        if precheck.get("price") is not None:
+            return None
+        raw_risk_reasons = decision_json.get("risk_reasons")
+        risk_reason_items: Sequence[object] = []
+        if isinstance(raw_risk_reasons, Sequence) and not isinstance(
+            raw_risk_reasons,
+            (str, bytes, bytearray),
+        ):
+            risk_reason_items = cast(Sequence[object], raw_risk_reasons)
+        risk_reasons = [
+            str(item).strip() for item in risk_reason_items if str(item).strip()
+        ]
+        if "broker_precheck_failed" not in risk_reasons:
+            return None
+        retry_attempts = _safe_int(
+            decision_json.get("paper_route_target_price_retry_attempts")
+        )
+        retry_limit = max(
+            _safe_int(settings.trading_simple_paper_route_probe_retry_attempt_limit),
+            0,
+        )
+        if retry_limit <= 0 or retry_attempts >= retry_limit:
+            return None
+        return {
+            "previous_decision_status": "rejected",
+            "previous_submission_stage": "rejected_pre_submit",
+            "previous_risk_reasons": risk_reasons,
+            "previous_retry_attempts": retry_attempts,
+        }
+
+    def _reopen_rejected_paper_route_target_price_decision(
+        self,
+        *,
+        session: Session,
+        decision: StrategyDecision,
+        decision_row: TradeDecision,
+    ) -> TradeDecision | None:
+        retry_metadata = self._paper_route_target_price_retry_metadata(decision_row)
+        if retry_metadata is None:
+            return None
+        if self.executor.execution_exists(session, decision_row):
+            return None
+
+        self.executor.sync_decision_state(session, decision_row, decision)
+        raw_decision_json = decision_row.decision_json
+        decision_json = (
+            dict(cast(Mapping[str, Any], raw_decision_json))
+            if isinstance(raw_decision_json, Mapping)
+            else {}
+        )
+        retry_attempts = _safe_int(
+            decision_json.get("paper_route_target_price_retry_attempts")
+        )
+        decision_json["submission_stage"] = "paper_route_target_price_retry_pending"
+        decision_json["paper_route_target_price_retry_attempts"] = retry_attempts + 1
+        decision_json["paper_route_target_price_retry"] = {
+            **retry_metadata,
+            "submission_stage": "paper_route_target_price_retry_pending",
+            "symbol": decision.symbol.strip().upper(),
+            "strategy_id": decision.strategy_id,
+        }
+        for key in (
+            "risk_reasons",
+            "reject_reason_atomic",
+            "reject_class",
+            "reject_origin",
+            "broker_precheck",
+        ):
+            decision_json.pop(key, None)
+        decision_row.status = "planned"
+        decision_row.created_at = trading_now(account_label=self.account_label)
+        decision_row.decision_json = decision_json
+        session.add(decision_row)
+        session.commit()
+        session.refresh(decision_row)
+        logger.warning(
+            "Reopening paper route target source decision after transient price precheck failure strategy_id=%s decision_id=%s symbol=%s previous_reasons=%s",
+            decision.strategy_id,
+            decision_row.id,
+            decision.symbol,
+            ",".join(
+                cast(list[str], retry_metadata.get("previous_risk_reasons") or [])
+            ),
         )
         return decision_row
 
@@ -2636,6 +2742,13 @@ class SimpleTradingPipeline(TradingPipeline):
         )
         if reopened_exit is not None:
             return reopened_exit
+        reopened_price_retry = self._reopen_rejected_paper_route_target_price_decision(
+            session=session,
+            decision=decision,
+            decision_row=decision_row,
+        )
+        if reopened_price_retry is not None:
+            return reopened_price_retry
         if (
             decision_row.status == "planned"
             and self._paper_route_target_source_cap(decision.params) is not None

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -3147,6 +3147,207 @@ class TestTradingPipeline(TestCase):
             )
         )
 
+    def test_simple_pipeline_target_price_retry_metadata_requires_price_null_precheck(
+        self,
+    ) -> None:
+        def decision_row(
+            *,
+            status: str = "rejected",
+            decision_json: object,
+        ) -> TradeDecision:
+            return TradeDecision(
+                strategy_id=uuid4(),
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json=decision_json,
+                status=status,
+            )
+
+        base_params: dict[str, Any] = {
+            "paper_route_target_plan": {
+                "candidate_id": "candidate-1",
+                "hypothesis_id": "H-PAIRS-01",
+            },
+            "simple_lane_precheck": {
+                "price": None,
+                "requested_qty": "1",
+            },
+        }
+        base_json: dict[str, Any] = {
+            "submission_stage": "rejected_pre_submit",
+            "risk_reasons": ["broker_precheck_failed"],
+            "params": base_params,
+        }
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_target_price_retry_metadata(
+                decision_row(status="planned", decision_json=base_json)
+            )
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_target_price_retry_metadata(
+                decision_row(
+                    decision_json={
+                        **base_json,
+                        "params": {
+                            **base_params,
+                            "simple_lane_precheck": {"price": "100"},
+                        },
+                    }
+                )
+            )
+        )
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_target_price_retry_metadata(
+                decision_row(
+                    decision_json={
+                        **base_json,
+                        "risk_reasons": ["max_notional_exceeded"],
+                    }
+                )
+            )
+        )
+        self.assertEqual(
+            SimpleTradingPipeline._paper_route_target_price_retry_metadata(
+                decision_row(decision_json=base_json)
+            ),
+            {
+                "previous_decision_status": "rejected",
+                "previous_submission_stage": "rejected_pre_submit",
+                "previous_risk_reasons": ["broker_precheck_failed"],
+                "previous_retry_attempts": 0,
+            },
+        )
+
+        from app import config
+
+        config.settings.trading_simple_paper_route_probe_retry_attempt_limit = 1
+        self.assertIsNone(
+            SimpleTradingPipeline._paper_route_target_price_retry_metadata(
+                decision_row(
+                    decision_json={
+                        **base_json,
+                        "paper_route_target_price_retry_attempts": 1,
+                    }
+                )
+            )
+        )
+
+    def test_simple_pipeline_reopens_price_null_target_source_decision(self) -> None:
+        from app import config
+
+        config.settings.trading_simple_paper_route_probe_retry_attempt_limit = 2
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="simple-paper-target-price-retry",
+                description="simple paper target source price retry",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 5, 29, 13, 30, tzinfo=timezone.utc),
+                timeframe="1Min",
+                action="buy",
+                qty=Decimal("1"),
+                rationale="paper-route-target-source",
+                params={
+                    "paper_route_target_plan": {
+                        "candidate_id": "candidate-1",
+                        "hypothesis_id": "H-PAIRS-01",
+                    },
+                    "source_decision_mode": "route_acquisition_probe",
+                },
+            )
+            executor = OrderExecutor()
+            decision_row = executor.ensure_decision(
+                session,
+                decision,
+                strategy,
+                "paper",
+            )
+            decision_json = dict(cast(Mapping[str, Any], decision_row.decision_json))
+            params = dict(cast(Mapping[str, Any], decision_json.get("params") or {}))
+            params["simple_lane_precheck"] = {
+                "price": None,
+                "requested_qty": "1",
+            }
+            decision_json.update(
+                {
+                    "params": params,
+                    "submission_stage": "rejected_pre_submit",
+                    "risk_reasons": ["broker_precheck_failed"],
+                    "reject_reason_atomic": ["broker_precheck_failed"],
+                    "reject_class": "runtime",
+                    "reject_origin": "scheduler",
+                }
+            )
+            decision_row.status = "rejected"
+            decision_row.decision_json = decision_json
+            session.add(decision_row)
+            session.commit()
+            session.refresh(decision_row)
+
+            pipeline = SimpleTradingPipeline(
+                alpaca_client=FakeAlpacaClient(),
+                order_firewall=OrderFirewall(FakeAlpacaClient()),
+                ingestor=FakeIngestor([]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=executor,
+                execution_adapter=FakeAlpacaClient(),
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=TradingState(),
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+
+            pending = pipeline._ensure_pending_decision_row(
+                session=session,
+                decision=decision,
+                strategy=strategy,
+            )
+
+            self.assertIsNotNone(pending)
+            assert pending is not None
+            self.assertEqual(pending.id, decision_row.id)
+            refreshed = session.get(TradeDecision, decision_row.id)
+            assert refreshed is not None
+            self.assertEqual(refreshed.status, "planned")
+            refreshed_json = cast(dict[str, Any], refreshed.decision_json)
+            self.assertEqual(
+                refreshed_json.get("submission_stage"),
+                "paper_route_target_price_retry_pending",
+            )
+            self.assertNotIn("risk_reasons", refreshed_json)
+            self.assertNotIn("reject_reason_atomic", refreshed_json)
+            self.assertEqual(
+                refreshed_json.get("paper_route_target_price_retry_attempts"),
+                1,
+            )
+            retry = cast(
+                dict[str, Any],
+                refreshed_json.get("paper_route_target_price_retry"),
+            )
+            self.assertEqual(
+                retry.get("previous_risk_reasons"), ["broker_precheck_failed"]
+            )
+            self.assertEqual(retry.get("previous_retry_attempts"), 0)
+            self.assertEqual(
+                retry.get("submission_stage"),
+                "paper_route_target_price_retry_pending",
+            )
+
     def test_simple_pipeline_retry_helpers_filter_invalid_rows_and_limits(
         self,
     ) -> None:
@@ -4166,9 +4367,7 @@ class TestTradingPipeline(TestCase):
             ),
             self.session_local() as session,
         ):
-            exit_decisions = pipeline._paper_route_probe_exit_decisions(
-                session=session
-            )
+            exit_decisions = pipeline._paper_route_probe_exit_decisions(session=session)
             self.assertEqual(len(exit_decisions), 1)
             exit_decision = exit_decisions[0]
             strategy = (


### PR DESCRIPTION
## Summary

- Adds bounded retry metadata for paper-route target source decisions rejected by transient `broker_precheck_failed` with `price` equal to null.
- Reopens only rejected target-plan source decisions with no execution and retry attempts remaining.
- Preserves normal risk rejections, submitted decisions, and promotion/runtime-ledger gates.
- Adds regression coverage for retry eligibility and reopening behavior.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'target_price_retry or reopens_price_null_target_source_decision'`
- `uv run --frozen pytest tests/test_trading_pipeline.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
