### PR TITLE
fix(torghut): block contaminated paper account proof

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1708,6 +1708,90 @@ def _strategy_source_activity(
     }
 
 
+def _account_contamination_audit(
+    session: Session,
+    *,
+    account_label: str | None,
+    symbols: Sequence[str],
+    window_start: datetime,
+    window_end: datetime,
+) -> dict[str, object]:
+    symbol_filters = [
+        str(item).strip().upper() for item in symbols if str(item).strip()
+    ]
+    blockers: list[str] = []
+    if account_label is None:
+        return {
+            "schema_version": "torghut.paper-route-account-contamination-audit.v1",
+            "scope": "target_window_account_symbol_order_events",
+            "account_label": None,
+            "symbols": symbol_filters,
+            "window_start": _isoformat(window_start),
+            "window_end": _isoformat(window_end),
+            "contaminated": False,
+            "unlinked_order_event_count": 0,
+            "client_order_id_count": 0,
+            "sample_client_order_ids": [],
+            "symbol_counts": {},
+            "event_type_counts": {},
+            "status_counts": {},
+            "last_event_at": None,
+            "blockers": [],
+        }
+    order_event_activity_ts = _order_event_activity_timestamp()
+    stmt = (
+        select(ExecutionOrderEvent)
+        .where(ExecutionOrderEvent.alpaca_account_label == account_label)
+        .where(order_event_activity_ts >= window_start)
+        .where(order_event_activity_ts < window_end)
+        .where(ExecutionOrderEvent.trade_decision_id.is_(None))
+    )
+    if symbol_filters:
+        stmt = stmt.where(func.upper(ExecutionOrderEvent.symbol).in_(symbol_filters))
+    rows = list(
+        session.execute(
+            stmt.order_by(order_event_activity_ts.desc()).limit(500)
+        ).scalars()
+    )
+    if rows:
+        blockers.extend(
+            [
+                "paper_route_account_contamination_detected",
+                "unlinked_order_events_present",
+            ]
+        )
+    client_order_ids: list[str] = []
+    symbol_counts: Counter[str] = Counter()
+    event_type_counts: Counter[str] = Counter()
+    status_counts: Counter[str] = Counter()
+    for row in rows:
+        if client_order_id := _safe_text(row.client_order_id):
+            if client_order_id not in client_order_ids:
+                client_order_ids.append(client_order_id)
+        symbol_counts[_safe_text(row.symbol) or "missing"] += 1
+        event_type_counts[_safe_text(row.event_type) or "missing"] += 1
+        status_counts[_safe_text(row.status) or "missing"] += 1
+    return {
+        "schema_version": "torghut.paper-route-account-contamination-audit.v1",
+        "scope": "target_window_account_symbol_order_events",
+        "account_label": account_label,
+        "symbols": symbol_filters,
+        "window_start": _isoformat(window_start),
+        "window_end": _isoformat(window_end),
+        "contaminated": bool(rows),
+        "unlinked_order_event_count": len(rows),
+        "client_order_id_count": len(client_order_ids),
+        "sample_client_order_ids": client_order_ids[:10],
+        "symbol_counts": dict(sorted(symbol_counts.items())),
+        "event_type_counts": dict(sorted(event_type_counts.items())),
+        "status_counts": dict(sorted(status_counts.items())),
+        "last_event_at": _isoformat(
+            _order_event_activity_at(rows[0]) if rows else None
+        ),
+        "blockers": blockers,
+    }
+
+
 def _rejected_signal_activity(
     session: Session,
     *,
@@ -2142,6 +2226,7 @@ def _readiness_blockers(
     target: Mapping[str, object],
     probe: Mapping[str, object],
     source_activity: Mapping[str, object],
+    account_contamination: Mapping[str, object],
     rejected_signal_activity: Mapping[str, object],
     runtime_ledger: Mapping[str, object],
     hypothesis_windows: Mapping[str, object],
@@ -2176,6 +2261,11 @@ def _readiness_blockers(
     blockers.update(
         str(item).strip()
         for item in _as_sequence(source_activity.get("missing_reasons"))
+        if str(item).strip()
+    )
+    blockers.update(
+        str(item).strip()
+        for item in _as_sequence(account_contamination.get("blockers"))
         if str(item).strip()
     )
     if bool(source_activity.get("missing")):
@@ -2232,6 +2322,13 @@ def _target_audit(
         hypothesis_id=hypothesis_id,
         require_source_lineage=_target_requires_source_lineage(target),
     )
+    account_contamination = _account_contamination_audit(
+        session,
+        account_label=cast(str | None, target.get("account_label")),
+        symbols=_target_probe_symbols(target, probe),
+        window_start=window_start,
+        window_end=window_end,
+    )
     rejected_signal_activity = _rejected_signal_activity(
         session,
         account_label=cast(str | None, target.get("account_label")),
@@ -2267,6 +2364,7 @@ def _target_audit(
         target=target,
         probe=probe,
         source_activity=source_activity,
+        account_contamination=account_contamination,
         rejected_signal_activity=rejected_signal_activity,
         runtime_ledger=runtime_ledger,
         hypothesis_windows=hypothesis_windows,
@@ -2284,6 +2382,7 @@ def _target_audit(
             "end": _isoformat(window_end),
         },
         "source_activity": source_activity,
+        "account_contamination": account_contamination,
         "rejected_signal_activity": rejected_signal_activity,
         "runtime_ledger": runtime_ledger,
         "hypothesis_windows": hypothesis_windows,
@@ -2356,6 +2455,16 @@ def _runtime_window_import_audit(
             if str(blocker).strip()
         }
     )
+    account_contamination_blockers = sorted(
+        {
+            str(blocker).strip()
+            for audit in next_target_audits
+            for blocker in _as_sequence(
+                _as_mapping(audit.get("account_contamination")).get("blockers")
+            )
+            if str(blocker).strip()
+        }
+    )
     source_runtime_ledger_blockers = _source_runtime_ledger_materialization_blockers(
         next_target_audits
     )
@@ -2392,6 +2501,10 @@ def _runtime_window_import_audit(
         state = "next_runtime_window_target_missing"
         next_action = "repair_next_paper_route_runtime_window_target_plan"
         blockers = ["next_runtime_window_target_missing"]
+    elif account_contamination_blockers:
+        state = "import_due_account_contamination_detected"
+        next_action = "isolate_paper_account_or_discard_contaminated_window"
+        blockers = account_contamination_blockers
     elif targets_with_source_activity < current_target_count:
         state = "import_due_source_activity_missing"
         next_action = "inspect_paper_route_source_activity_before_import"
@@ -2434,6 +2547,7 @@ def _runtime_window_import_audit(
             "source_activity_to_runtime_ledger_blockers": (
                 source_runtime_ledger_blockers
             ),
+            "account_contamination_blockers": account_contamination_blockers,
             "runtime_ledger_blockers": runtime_ledger_blockers,
             "target_blockers_effective_when": "runtime_window_import_ready",
         },
@@ -2490,6 +2604,7 @@ def _runtime_window_target_blockers(
     for audit in target_audits:
         target = _as_mapping(audit.get("target"))
         source_activity = _as_mapping(audit.get("source_activity"))
+        account_contamination = _as_mapping(audit.get("account_contamination"))
         rejected_signal_activity = _as_mapping(audit.get("rejected_signal_activity"))
         runtime_ledger = _as_mapping(audit.get("runtime_ledger"))
         promotion_decisions = _as_mapping(audit.get("promotion_decisions"))
@@ -2506,6 +2621,7 @@ def _runtime_window_target_blockers(
                     if _rejected_signal_reasons_actionable(source_activity)
                     else []
                 ),
+                *_unique_text_items(account_contamination.get("blockers")),
                 *(
                     ["runtime_ledger_bucket_missing"]
                     if _safe_int(runtime_ledger.get("bucket_count")) <= 0
@@ -2561,6 +2677,21 @@ def _runtime_window_target_blockers(
                         source_activity.get("last_execution_at")
                     ),
                     "last_tca_at": _safe_text(source_activity.get("last_tca_at")),
+                },
+                "account_contamination": {
+                    "contaminated": bool(account_contamination.get("contaminated")),
+                    "unlinked_order_event_count": _safe_int(
+                        account_contamination.get("unlinked_order_event_count")
+                    ),
+                    "client_order_id_count": _safe_int(
+                        account_contamination.get("client_order_id_count")
+                    ),
+                    "sample_client_order_ids": _unique_text_items(
+                        account_contamination.get("sample_client_order_ids")
+                    ),
+                    "last_event_at": _safe_text(
+                        account_contamination.get("last_event_at")
+                    ),
                 },
                 "runtime_ledger": {
                     "bucket_count": _safe_int(runtime_ledger.get("bucket_count")),

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -2837,6 +2837,190 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertFalse(import_audit["promotion_authority"]["allowed"])
 
+    def test_account_contamination_blocks_runtime_window_import(self) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        now = datetime(2026, 5, 26, 21, 5, tzinfo=timezone.utc)
+
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="contamination-proof-strategy",
+                description="paper account contamination fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "action": "sell",
+                    "qty": "1",
+                    "candidate_id": "candidate-contamination",
+                    "hypothesis_id": "H-CONTAMINATION",
+                },
+                rationale="paper route contamination fixture",
+                status="executed",
+                created_at=window_start + timedelta(minutes=10),
+                executed_at=window_start + timedelta(minutes=11),
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="torghut-linked-order",
+                client_order_id="torghut-linked-client",
+                symbol="AAPL",
+                side="sell",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=window_start + timedelta(minutes=12),
+                updated_at=window_start + timedelta(minutes=12),
+                last_update_at=window_start + timedelta(minutes=12),
+            )
+            session.add(execution)
+            session.flush()
+            session.add_all(
+                [
+                    ExecutionTCAMetric(
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        strategy_id=strategy.id,
+                        alpaca_account_label="TORGHUT_SIM",
+                        symbol="AAPL",
+                        side="sell",
+                        arrival_price=Decimal("101"),
+                        avg_fill_price=Decimal("100"),
+                        filled_qty=Decimal("1"),
+                        signed_qty=Decimal("-1"),
+                        slippage_bps=Decimal("5"),
+                        shortfall_notional=Decimal("1"),
+                        realized_shortfall_bps=Decimal("5"),
+                        churn_qty=Decimal("0"),
+                        churn_ratio=Decimal("0"),
+                        computed_at=window_start + timedelta(minutes=13),
+                        created_at=window_start + timedelta(minutes=13),
+                        updated_at=window_start + timedelta(minutes=13),
+                    ),
+                    StrategyPromotionDecision(
+                        run_id="paper-route-contamination-run",
+                        candidate_id="candidate-contamination",
+                        hypothesis_id="H-CONTAMINATION",
+                        promotion_target="paper",
+                        state="allowed",
+                        allowed=True,
+                        reason_summary="paper_evidence_collecting",
+                        created_at=now,
+                        updated_at=now,
+                    ),
+                    ExecutionOrderEvent(
+                        event_fingerprint="external-autonomous-trader-order-event",
+                        source_topic="alpaca.trade_updates",
+                        source_partition=0,
+                        source_offset=42,
+                        alpaca_account_label="TORGHUT_SIM",
+                        event_ts=window_start + timedelta(minutes=20),
+                        symbol="AAPL",
+                        alpaca_order_id="external-order-1",
+                        client_order_id="autonomous-trader-AAPL-cover-external-1",
+                        event_type="fill",
+                        status="filled",
+                        qty=Decimal("1"),
+                        filled_qty=Decimal("1"),
+                        avg_fill_price=Decimal("101"),
+                        raw_event={"source": "external_autonomous_trader"},
+                        execution_id=None,
+                        trade_decision_id=None,
+                    ),
+                ]
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": "1",
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-CONTAMINATION",
+                                "candidate_id": "candidate-contamination",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": "contamination-proof-strategy",
+                                "strategy_id": "contamination_proof_strategy@research",
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "source_manifest_ref": "config/trading/hypotheses/h-contamination.json",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": ["AAPL"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                    },
+                },
+                generated_at=now,
+            )
+
+        audit = payload["next_runtime_window_target_audits"][0]
+        contamination = audit["account_contamination"]
+        self.assertTrue(contamination["contaminated"])
+        self.assertEqual(contamination["unlinked_order_event_count"], 1)
+        self.assertEqual(
+            contamination["sample_client_order_ids"],
+            ["autonomous-trader-AAPL-cover-external-1"],
+        )
+        self.assertIn(
+            "paper_route_account_contamination_detected",
+            audit["readiness"]["blockers"],
+        )
+        import_audit = payload["runtime_window_import_audit"]
+        self.assertEqual(
+            import_audit["state"], "import_due_account_contamination_detected"
+        )
+        self.assertEqual(
+            import_audit["next_action"],
+            "isolate_paper_account_or_discard_contaminated_window",
+        )
+        self.assertIn("unlinked_order_events_present", import_audit["blockers"])
+        self.assertEqual(
+            import_audit["target_blockers"][0]["account_contamination"][
+                "client_order_id_count"
+            ],
+            1,
+        )
+
     def test_paper_route_source_activity_requires_candidate_lineage(self) -> None:
         window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
         window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary

- Adds a paper-route account-contamination audit for scoped order-feed events in the target account, symbols, and runtime window.
- Fails the paper-route readiness/import audit closed when unlinked order events are present, so external account activity cannot be counted as clean Torghut proof.
- Adds regression coverage for an external autonomous-trader-style client order contaminating an otherwise Torghut-linked paper-route window.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k account_contamination_blocks_runtime_window_import`
- `uv run --frozen pytest tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
