### PR TITLE
chore(analysis): promote image 4c02818

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: efbc0e685da0bfee70aca985ae4a8116feb732d3
+    newTag: 4c02818d1ce79491004a9f65ae56b3982deeabc1


### PR DESCRIPTION
## Summary
- promote analysis site image to 4c02818d1ce79491004a9f65ae56b3982deeabc1
- keeps the Tailscale-exposed analysis deployment on the latest pushed image

## Validation
- kubectl kustomize argocd/applications/analysis
- upstream analysis-image workflow 26645428509 passed