### PR TITLE
fix(synthesis): require trader order identity

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml
@@ -25,6 +25,7 @@ spec:
     - Read Synthesis scorecards before grading new candidates and finalize every session with scorecard observations.
     - Use available Alpaca paper-account instruments and operations when justified by current account and market state.
     - Use stock/ETF bracket, OTO, or OCO protective order classes when feasible; otherwise record the exact managed-exit fallback.
+    - Use AgentRun-owned deterministic client order ids for every broker mutation, including entries, exits, risk reductions, flattens, cancels, and replacements.
     - Publish operator-visible status through Synthesis MCP autotrader tables; feed items are milestone summaries only.
     - Keep market-open runs active until market close, 500000 USD equity, or an unrecoverable blocker.
     - In dry-run mode, never call Alpaca order submission, cancel, replace, or close-position tools; still write scanner, no-trade, risk, status, and scorecard state to Synthesis.
@@ -39,6 +40,7 @@ spec:
     - Trade only through Alpaca MCP in the paper account.
     - Use stocks, ETFs, options, or any other financial instruments available in the account.
     - You may open, close, reduce, hedge, reverse, or stand down when the current signal and account state justify it.
+    - Use AgentRun-owned deterministic client order ids for every broker mutation, including entries, exits, risk reductions, flattens, cancels, and replacements.
 
     Execution contract:
     1. Bootstrap analysis before any market-open order:
@@ -86,7 +88,9 @@ spec:
        - For existing stock or ETF positions, prefer OCO exits when feasible.
        - For options, manage exits explicitly in the loop with max loss, target, invalidation, and near-close liquidation or hold decision because the current option MCP tool does not expose bracket/stop/take-profit fields.
        - Do not create a new unmanaged position unless broker-attached protection is unavailable and the active fallback monitor is recorded in `/workspace/.agentrun/autonomous-trader/protective-orders.jsonl`.
-       - Reconcile each submitted order by order id or client order id before the next action.
+       - For every Alpaca broker mutation in `market-open`, including stock/ETF entries, protective exits, risk reductions, residual flattens, option closes, cancels, and replacements, build a deterministic `client_order_id` prefixed with `AGENT_RUN_NAME`, record the planned order with `autotrader_record_order` before the broker call, submit or mutate with that exact `client_order_id` when the Alpaca MCP tool supports it, and reconcile by that exact id before the next action.
+       - Never rely on broker-generated or random client ids for AgentRun-owned orders. If an observed order has a generated/random client id or `source=access_key`, classify it as external/non-AgentRun, record it as external in Synthesis, and do not treat it as proof that this AgentRun submitted the order.
+       - Reconcile each submitted order by order id and AgentRun-prefixed client order id before the next action.
        - Write each cycle through Synthesis autotrader MCP: `autotrader_upsert_status` for current state, `autotrader_append_event` for decisions/no-trade/order lifecycle, `autotrader_create_trade_ticket` for every candidate selected or blocked, `autotrader_record_risk_check` for risk gates, `autotrader_record_order` and `autotrader_record_fill` for Alpaca reconciliation, and `autotrader_record_position_snapshot` after broker position reads.
        - After every broker-changing action, external account change, reconciled order, or reconciled fill, immediately refresh broker account/positions, call `autotrader_upsert_status`, and rewrite `current-status.json` before scanning or submitting another order.
        - Append local JSONL artifacts only as export/debug copies; Synthesis Postgres is primary runtime state.

--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml
@@ -15,6 +15,7 @@ data:
     - Reach 500000 USD account equity in the Alpaca paper account.
     - Trade stocks, ETFs, options, or any other financial instruments available in the account.
     - Open, close, reduce, hedge, reverse, or stand down when current signal quality and account state justify it.
+    - Use AgentRun-owned deterministic client order ids for every broker mutation, including entries, exits, risk reductions, flattens, cancels, and replacements.
 
     Operating requirements:
     - Route orders only to the Alpaca paper account.
@@ -59,7 +60,9 @@ data:
     - For existing stock or ETF positions, prefer OCO exits when feasible.
     - For options, explicitly manage exits in the loop with max loss, target, invalidation, and near-close liquidation or hold decision; the current option MCP tool does not expose bracket/stop/take-profit fields.
     - Do not create a new unmanaged position unless broker-attached protection is unavailable and the active fallback monitor is recorded in `protective-orders.jsonl`.
-    - Reconcile every submitted order by order id or client order id before the next action.
+    - For every Alpaca broker mutation in market-open mode, including stock/ETF entries, protective exits, risk reductions, residual flattens, option closes, cancels, and replacements, build a deterministic `client_order_id` prefixed with `AGENT_RUN_NAME`, record the planned order with `autotrader_record_order` before the broker call, submit or mutate with that exact `client_order_id` when the Alpaca MCP tool supports it, and reconcile by that exact id before the next action.
+    - Never rely on broker-generated or random client ids for AgentRun-owned orders. If an observed order has a generated/random client id or `source=access_key`, classify it as external/non-AgentRun, record it as external in Synthesis, and do not treat it as proof that this AgentRun submitted the order.
+    - Reconcile every submitted order by order id and AgentRun-prefixed client order id before the next action.
     - Write each cycle through Synthesis autotrader MCP: `autotrader_upsert_status` for current state, `autotrader_append_event` for decisions/no-trade/order lifecycle, `autotrader_create_trade_ticket` for every candidate selected or blocked, `autotrader_record_risk_check` for risk gates, `autotrader_record_order` and `autotrader_record_fill` for Alpaca reconciliation, and `autotrader_record_position_snapshot` after broker position reads.
     - After every broker-changing action, external account change, reconciled order, or reconciled fill, immediately refresh broker account/positions, call `autotrader_upsert_status`, and rewrite `current-status.json` before scanning or submitting another order.
     - Append local JSONL artifacts only as export/debug copies; Synthesis Postgres is primary runtime state.

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -687,6 +687,7 @@ describe('synthesis autonomous trader provider', () => {
     expect(prompt).toContain('Reach 500000 USD account equity')
     expect(prompt).toContain('Trade stocks, ETFs, options, or any other financial instruments available in the account')
     expect(prompt).toContain('Open, close, reduce, hedge, reverse, or stand down')
+    expect(prompt).toContain('Use AgentRun-owned deterministic client order ids for every broker mutation')
     expect(prompt).toContain('Route orders only to the Alpaca paper account')
     expect(prompt).toContain('or any other financial instruments available in the account')
     expect(prompt).not.toContain('Target the requested account value as actual paper account equity')
@@ -756,6 +757,13 @@ describe('synthesis autonomous trader provider', () => {
     expect(prompt).toContain('bracket or OTO orders')
     expect(prompt).toContain('prefer OCO exits')
     expect(prompt).toContain('protective-orders.jsonl')
+    expect(prompt).toContain('For every Alpaca broker mutation in market-open mode')
+    expect(prompt).toContain('build a deterministic `client_order_id` prefixed with `AGENT_RUN_NAME`')
+    expect(prompt).toContain('submit or mutate with that exact `client_order_id` when the Alpaca MCP tool supports it')
+    expect(prompt).toContain('Never rely on broker-generated or random client ids for AgentRun-owned orders')
+    expect(prompt).toContain('`source=access_key`')
+    expect(prompt).toContain('classify it as external/non-AgentRun')
+    expect(prompt).toContain('Reconcile every submitted order by order id and AgentRun-prefixed client order id')
     expect(prompt).toContain('Use Synthesis MCP autotrader tools as the canonical operator-visible runtime state')
     expect(prompt).toContain('Read the exact Kubernetes AgentRun name from `AGENT_RUN_NAME`')
     expect(prompt).toContain('Do not invent, normalize, shorten, timestamp, or replace the `AGENT_RUN_NAME` value')
@@ -788,6 +796,16 @@ describe('synthesis autonomous trader provider', () => {
     expect(taskPrompt).toContain('bracket or OTO orders')
     expect(taskPrompt).toContain('prefer OCO exits')
     expect(taskPrompt).toContain('protective-orders.jsonl')
+    expect(taskPrompt).toContain('Use AgentRun-owned deterministic client order ids for every broker mutation')
+    expect(taskPrompt).toContain('For every Alpaca broker mutation in `market-open`')
+    expect(taskPrompt).toContain('build a deterministic `client_order_id` prefixed with `AGENT_RUN_NAME`')
+    expect(taskPrompt).toContain(
+      'submit or mutate with that exact `client_order_id` when the Alpaca MCP tool supports it',
+    )
+    expect(taskPrompt).toContain('Never rely on broker-generated or random client ids for AgentRun-owned orders')
+    expect(taskPrompt).toContain('`source=access_key`')
+    expect(taskPrompt).toContain('classify it as external/non-AgentRun')
+    expect(taskPrompt).toContain('Reconcile each submitted order by order id and AgentRun-prefixed client order id')
     expect(taskPrompt).toContain('Synthesis visibility')
     expect(taskPrompt).toContain(
       'Read the exact Kubernetes AgentRun name from the `AGENT_RUN_NAME` environment variable',


### PR DESCRIPTION
## Summary

- Require AgentRun-owned deterministic client order ids for every autonomous-trader broker mutation.
- Classify generated/random client ids and `source=access_key` orders as external/non-AgentRun in Synthesis.
- Extend prompt smoke assertions so future prompt edits keep order identity and reconciliation requirements.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t 'synthesis autonomous trader'`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `kubectl kustomize argocd/applications/synthesis/agents-domain >/tmp/synthesis-agents-domain.yaml && wc -l /tmp/synthesis-agents-domain.yaml`
- `git diff --check -- argocd/applications/synthesis/agents-domain/autonomous-trader-implspec.yaml argocd/applications/synthesis/agents-domain/autonomous-trader-system-prompt-configmap.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
