### PR TITLE
fix(synthesis): restore trader market schedule

### DIFF
--- a/argocd/applications/synthesis/agents-domain/autonomous-trader-schedule.yaml
+++ b/argocd/applications/synthesis/agents-domain/autonomous-trader-schedule.yaml
@@ -1,0 +1,17 @@
+apiVersion: schedules.proompteng.ai/v1alpha1
+kind: Schedule
+metadata:
+  name: autonomous-trader-market-open
+  namespace: synthesis
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  labels:
+    app.kubernetes.io/part-of: synthesis
+    app.kubernetes.io/component: autonomous-trader
+spec:
+  cron: "15 9 * * 1-5"
+  timezone: America/New_York
+  targetRef:
+    apiVersion: agents.proompteng.ai/v1alpha1
+    kind: AgentRun
+    name: autonomous-trader-template

--- a/argocd/applications/synthesis/agents-domain/kustomization.yaml
+++ b/argocd/applications/synthesis/agents-domain/kustomization.yaml
@@ -18,5 +18,6 @@ resources:
   - autonomous-trader-secretbinding.yaml
   - autonomous-trader-implspec.yaml
   - autonomous-trader-agentrun-template.yaml
+  - autonomous-trader-schedule.yaml
   - autonomous-trader-scorecard-readback-template.yaml
   - autonomous-trader-scorecard-readback-schedule.yaml

--- a/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
+++ b/packages/scripts/src/agents/__tests__/smoke-agents.test.ts
@@ -595,9 +595,12 @@ describe('scheduled AgentRun templates', () => {
 })
 
 describe('synthesis autonomous trader provider', () => {
-  it('keeps the market-open trader template manual-only while recurring broker mutation is disabled', () => {
+  it('schedules the market-open trader and protects it from accidental pruning', () => {
     const kustomization = readYamlObjects('argocd/applications/synthesis/agents-domain/kustomization.yaml')[0]
     const resources = objectAt(kustomization, 'resources') as string[] | undefined
+    const schedule = readYamlObjects(
+      'argocd/applications/synthesis/agents-domain/autonomous-trader-schedule.yaml',
+    ).find((manifest) => objectAt(manifest, 'kind') === 'Schedule')
     const template = readYamlObjects(
       'argocd/applications/synthesis/agents-domain/autonomous-trader-agentrun-template.yaml',
     ).find((manifest) => objectAt(manifest, 'kind') === 'AgentRun')
@@ -605,12 +608,18 @@ describe('synthesis autonomous trader provider', () => {
       'argocd/applications/synthesis/agents-domain/autonomous-trader-agentprovider.yaml',
     ).find((manifest) => objectAt(manifest, 'kind') === 'AgentProvider')
     const templateSpec = objectAt(template, 'spec')
+    const scheduleSpec = objectAt(schedule, 'spec')
+    const scheduleAnnotations = objectAt(objectAt(schedule, 'metadata'), 'annotations')
     const parameters = objectAt(templateSpec, 'parameters')
     const envTemplate = objectAt(objectAt(provider, 'spec'), 'envTemplate')
     const goal = objectAt(templateSpec, 'goal') as Record<string, unknown>
     const overallTimeoutSeconds = Number(objectAt(envTemplate, 'CODEX_MARKET_CONTEXT_OVERALL_TIMEOUT_SECONDS'))
 
-    expect(resources).not.toContain('autonomous-trader-schedule.yaml')
+    expect(resources).toContain('autonomous-trader-schedule.yaml')
+    expect(objectAt(scheduleSpec, 'cron')).toBe('15 9 * * 1-5')
+    expect(objectAt(scheduleSpec, 'timezone')).toBe('America/New_York')
+    expect(objectAt(objectAt(scheduleSpec, 'targetRef'), 'name')).toBe('autonomous-trader-template')
+    expect(objectAt(scheduleAnnotations, 'argocd.argoproj.io/sync-options')).toBe('Prune=false')
     expect(objectAt(parameters, 'mode')).toBe('market-open')
     expect(objectAt(parameters, 'synthesisSessionMode')).toBe('market_open')
     expect(objectAt(parameters, 'premarketBootstrapMinutes')).toBe('15')


### PR DESCRIPTION
## Summary

- Restore the Synthesis autonomous-trader market-open Schedule that was removed from main.
- Add `Prune=false` so Argo cannot cascade-delete the schedule-owned market-session AgentRun during trading.
- Update the smoke assertion to require the 09:15 ET market-open schedule and prune protection.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/agents/__tests__/smoke-agents.test.ts -t 'synthesis autonomous trader'`
- `bunx oxfmt --check packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- `kubectl kustomize argocd/applications/synthesis >/tmp/synthesis-app.yaml`
- `git diff --check -- argocd/applications/synthesis/agents-domain/autonomous-trader-schedule.yaml argocd/applications/synthesis/agents-domain/kustomization.yaml packages/scripts/src/agents/__tests__/smoke-agents.test.ts`
- Live emergency correction applied the same Schedule manifest; readback showed `autonomous-trader-market-open` Active and a replacement no-budget market-open AgentRun Running.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
