### PR TITLE
fix(torghut): block proof on dirty paper account start

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -21,6 +21,7 @@ from ..models import (
     Execution,
     ExecutionOrderEvent,
     ExecutionTCAMetric,
+    PositionSnapshot,
     RejectedSignalOutcomeEvent,
     Strategy,
     StrategyHypothesisMetricWindow,
@@ -47,6 +48,8 @@ DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS = 72
 DEFAULT_PAPER_ROUTE_EVIDENCE_TARGET_LIMIT = 20
 PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL = "TORGHUT_SIM"
 PAPER_ROUTE_RUNTIME_IMPORT_SETTLEMENT_SECONDS = 3600
+PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_STALE_SECONDS = 900
+PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_AFTER_START_GRACE_SECONDS = 300
 PAPER_ROUTE_TARGET_PLAN_ENDPOINT = "/trading/paper-route-target-plan"
 DEFAULT_TORGHUT_LIVE_SERVICE_BASE_URL = "http://torghut.torghut.svc.cluster.local"
 DEFAULT_TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL = (
@@ -1792,6 +1795,184 @@ def _account_contamination_audit(
     }
 
 
+def _position_quantity(position: Mapping[str, object]) -> Decimal:
+    qty = _safe_decimal(
+        position.get("qty")
+        or position.get("quantity")
+        or position.get("position_qty")
+        or position.get("shares")
+    )
+    if qty == 0:
+        return Decimal("0")
+    side = (_safe_text(position.get("side")) or "").lower()
+    if side == "short" and qty > 0:
+        return -qty
+    return qty
+
+
+def _position_market_value(position: Mapping[str, object]) -> Decimal:
+    for key in ("market_value", "marketValue", "notional", "position_value"):
+        if key in position:
+            return _safe_decimal(position.get(key)).copy_abs()
+    qty = _position_quantity(position).copy_abs()
+    price = _safe_decimal(
+        position.get("current_price")
+        or position.get("currentPrice")
+        or position.get("avg_entry_price")
+        or position.get("avgEntryPrice")
+    ).copy_abs()
+    return qty * price
+
+
+def _normalized_open_positions(
+    positions: object,
+    *,
+    target_symbols: set[str],
+) -> list[dict[str, object]]:
+    normalized: list[dict[str, object]] = []
+    for raw_position in _as_sequence(positions):
+        position = _as_mapping(raw_position)
+        symbol = (_safe_text(position.get("symbol")) or "").upper()
+        qty = _position_quantity(position)
+        if not symbol or qty == 0:
+            continue
+        normalized.append(
+            {
+                "symbol": symbol,
+                "qty": _decimal_text(qty),
+                "side": _safe_text(position.get("side")),
+                "market_value": _decimal_text(_position_market_value(position)),
+                "target_symbol": symbol in target_symbols,
+            }
+        )
+    return sorted(
+        normalized,
+        key=lambda item: (
+            not bool(item.get("target_symbol")),
+            str(item.get("symbol") or ""),
+        ),
+    )
+
+
+def _account_window_start_snapshot_audit(
+    session: Session,
+    *,
+    account_label: str | None,
+    symbols: Sequence[str],
+    window_start: datetime,
+) -> dict[str, object]:
+    symbol_filters = {
+        str(item).strip().upper() for item in symbols if str(item).strip()
+    }
+    base_payload: dict[str, object] = {
+        "schema_version": "torghut.paper-route-account-window-start-snapshot-audit.v1",
+        "scope": "account_position_snapshot_at_runtime_window_start",
+        "account_label": account_label,
+        "symbols": sorted(symbol_filters),
+        "window_start": _isoformat(window_start),
+        "snapshot_id": None,
+        "snapshot_as_of": None,
+        "snapshot_source": None,
+        "snapshot_offset_seconds": None,
+        "flat": False,
+        "position_count": 0,
+        "target_symbol_position_count": 0,
+        "non_target_symbol_position_count": 0,
+        "gross_position_market_value": "0",
+        "sample_positions": [],
+        "blockers": [],
+    }
+    if account_label is None:
+        return {
+            **base_payload,
+            "flat": True,
+        }
+
+    before_snapshot = session.execute(
+        select(PositionSnapshot)
+        .where(PositionSnapshot.alpaca_account_label == account_label)
+        .where(PositionSnapshot.as_of <= window_start)
+        .order_by(PositionSnapshot.as_of.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+    after_snapshot = None
+    if before_snapshot is None:
+        after_snapshot = session.execute(
+            select(PositionSnapshot)
+            .where(PositionSnapshot.alpaca_account_label == account_label)
+            .where(PositionSnapshot.as_of > window_start)
+            .where(
+                PositionSnapshot.as_of
+                <= window_start
+                + timedelta(
+                    seconds=PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_AFTER_START_GRACE_SECONDS
+                )
+            )
+            .order_by(PositionSnapshot.as_of.asc())
+            .limit(1)
+        ).scalar_one_or_none()
+
+    snapshot = before_snapshot or after_snapshot
+    if snapshot is None:
+        return {
+            **base_payload,
+            "blockers": ["paper_route_account_window_start_snapshot_missing"],
+        }
+
+    snapshot_as_of = snapshot.as_of
+    if snapshot_as_of.tzinfo is None:
+        snapshot_as_of = snapshot_as_of.replace(tzinfo=timezone.utc)
+    snapshot_as_of = snapshot_as_of.astimezone(timezone.utc)
+    offset_seconds = int((snapshot_as_of - window_start).total_seconds())
+    blockers: list[str] = []
+    if offset_seconds < -PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_STALE_SECONDS:
+        blockers.append("paper_route_account_window_start_snapshot_stale")
+    if offset_seconds > PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_AFTER_START_GRACE_SECONDS:
+        blockers.append("paper_route_account_window_start_snapshot_stale")
+
+    positions = _normalized_open_positions(
+        snapshot.positions,
+        target_symbols=symbol_filters,
+    )
+    target_position_count = sum(
+        int(bool(position.get("target_symbol"))) for position in positions
+    )
+    non_target_position_count = len(positions) - target_position_count
+    if positions:
+        blockers.extend(
+            [
+                "paper_route_account_window_start_not_flat",
+                "paper_route_account_window_start_positions_present",
+            ]
+        )
+    if target_position_count:
+        blockers.append("paper_route_account_window_start_target_positions_present")
+    if non_target_position_count:
+        blockers.append("paper_route_account_window_start_non_target_positions_present")
+    gross_market_value = sum(
+        (_safe_decimal(position.get("market_value")) for position in positions),
+        Decimal("0"),
+    )
+    return {
+        **base_payload,
+        "snapshot_id": str(snapshot.id),
+        "snapshot_as_of": _isoformat(snapshot_as_of),
+        "snapshot_source": (
+            "latest_before_window_start"
+            if before_snapshot is not None
+            else "first_after_window_start"
+        ),
+        "snapshot_offset_seconds": offset_seconds,
+        "flat": not positions and not blockers,
+        "position_count": len(positions),
+        "target_symbol_position_count": target_position_count,
+        "non_target_symbol_position_count": non_target_position_count,
+        "gross_position_market_value": _decimal_text(gross_market_value),
+        "sample_positions": positions[:10],
+        "blockers": sorted(dict.fromkeys(blockers)),
+    }
+
+
 def _rejected_signal_activity(
     session: Session,
     *,
@@ -2227,6 +2408,7 @@ def _readiness_blockers(
     probe: Mapping[str, object],
     source_activity: Mapping[str, object],
     account_contamination: Mapping[str, object],
+    account_state: Mapping[str, object],
     rejected_signal_activity: Mapping[str, object],
     runtime_ledger: Mapping[str, object],
     hypothesis_windows: Mapping[str, object],
@@ -2266,6 +2448,11 @@ def _readiness_blockers(
     blockers.update(
         str(item).strip()
         for item in _as_sequence(account_contamination.get("blockers"))
+        if str(item).strip()
+    )
+    blockers.update(
+        str(item).strip()
+        for item in _as_sequence(account_state.get("blockers"))
         if str(item).strip()
     )
     if bool(source_activity.get("missing")):
@@ -2329,6 +2516,12 @@ def _target_audit(
         window_start=window_start,
         window_end=window_end,
     )
+    account_state = _account_window_start_snapshot_audit(
+        session,
+        account_label=cast(str | None, target.get("account_label")),
+        symbols=_target_probe_symbols(target, probe),
+        window_start=window_start,
+    )
     rejected_signal_activity = _rejected_signal_activity(
         session,
         account_label=cast(str | None, target.get("account_label")),
@@ -2365,6 +2558,7 @@ def _target_audit(
         probe=probe,
         source_activity=source_activity,
         account_contamination=account_contamination,
+        account_state=account_state,
         rejected_signal_activity=rejected_signal_activity,
         runtime_ledger=runtime_ledger,
         hypothesis_windows=hypothesis_windows,
@@ -2383,6 +2577,7 @@ def _target_audit(
         },
         "source_activity": source_activity,
         "account_contamination": account_contamination,
+        "account_state": account_state,
         "rejected_signal_activity": rejected_signal_activity,
         "runtime_ledger": runtime_ledger,
         "hypothesis_windows": hypothesis_windows,
@@ -2465,6 +2660,16 @@ def _runtime_window_import_audit(
             if str(blocker).strip()
         }
     )
+    account_state_blockers = sorted(
+        {
+            str(blocker).strip()
+            for audit in next_target_audits
+            for blocker in _as_sequence(
+                _as_mapping(audit.get("account_state")).get("blockers")
+            )
+            if str(blocker).strip()
+        }
+    )
     source_runtime_ledger_blockers = _source_runtime_ledger_materialization_blockers(
         next_target_audits
     )
@@ -2505,6 +2710,10 @@ def _runtime_window_import_audit(
         state = "import_due_account_contamination_detected"
         next_action = "isolate_paper_account_or_discard_contaminated_window"
         blockers = account_contamination_blockers
+    elif account_state_blockers:
+        state = "import_due_account_state_not_clean"
+        next_action = "reset_paper_account_or_discard_contaminated_window"
+        blockers = account_state_blockers
     elif targets_with_source_activity < current_target_count:
         state = "import_due_source_activity_missing"
         next_action = "inspect_paper_route_source_activity_before_import"
@@ -2548,6 +2757,7 @@ def _runtime_window_import_audit(
                 source_runtime_ledger_blockers
             ),
             "account_contamination_blockers": account_contamination_blockers,
+            "account_state_blockers": account_state_blockers,
             "runtime_ledger_blockers": runtime_ledger_blockers,
             "target_blockers_effective_when": "runtime_window_import_ready",
         },
@@ -2605,6 +2815,7 @@ def _runtime_window_target_blockers(
         target = _as_mapping(audit.get("target"))
         source_activity = _as_mapping(audit.get("source_activity"))
         account_contamination = _as_mapping(audit.get("account_contamination"))
+        account_state = _as_mapping(audit.get("account_state"))
         rejected_signal_activity = _as_mapping(audit.get("rejected_signal_activity"))
         runtime_ledger = _as_mapping(audit.get("runtime_ledger"))
         promotion_decisions = _as_mapping(audit.get("promotion_decisions"))
@@ -2622,6 +2833,7 @@ def _runtime_window_target_blockers(
                     else []
                 ),
                 *_unique_text_items(account_contamination.get("blockers")),
+                *_unique_text_items(account_state.get("blockers")),
                 *(
                     ["runtime_ledger_bucket_missing"]
                     if _safe_int(runtime_ledger.get("bucket_count")) <= 0
@@ -2692,6 +2904,26 @@ def _runtime_window_target_blockers(
                     "last_event_at": _safe_text(
                         account_contamination.get("last_event_at")
                     ),
+                },
+                "account_state": {
+                    "flat": bool(account_state.get("flat")),
+                    "snapshot_id": _safe_text(account_state.get("snapshot_id")),
+                    "snapshot_as_of": _safe_text(account_state.get("snapshot_as_of")),
+                    "snapshot_source": _safe_text(account_state.get("snapshot_source")),
+                    "position_count": _safe_int(account_state.get("position_count")),
+                    "target_symbol_position_count": _safe_int(
+                        account_state.get("target_symbol_position_count")
+                    ),
+                    "non_target_symbol_position_count": _safe_int(
+                        account_state.get("non_target_symbol_position_count")
+                    ),
+                    "gross_position_market_value": _safe_text(
+                        account_state.get("gross_position_market_value")
+                    ),
+                    "sample_positions": [
+                        _as_mapping(item)
+                        for item in _as_sequence(account_state.get("sample_positions"))
+                    ],
                 },
                 "runtime_ledger": {
                     "bucket_count": _safe_int(runtime_ledger.get("bucket_count")),

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -13,6 +13,7 @@ from app.models import (
     Execution,
     ExecutionOrderEvent,
     ExecutionTCAMetric,
+    PositionSnapshot,
     RejectedSignalOutcomeEvent,
     Strategy,
     StrategyHypothesisMetricWindow,
@@ -39,6 +40,24 @@ class TestPaperRouteEvidenceAudit(TestCase):
             poolclass=StaticPool,
         )
         Base.metadata.create_all(self.engine)
+
+    def _add_flat_account_start_snapshot(
+        self,
+        session: Session,
+        *,
+        account_label: str,
+        window_start: datetime,
+    ) -> None:
+        session.add(
+            PositionSnapshot(
+                alpaca_account_label=account_label,
+                as_of=window_start - timedelta(seconds=30),
+                equity=Decimal("100000"),
+                cash=Decimal("100000"),
+                buying_power=Decimal("200000"),
+                positions=[],
+            )
+        )
 
     def test_runtime_ledger_diagnostic_expectancy_prefers_payload_value(self) -> None:
         row = StrategyRuntimeLedgerBucket(
@@ -987,8 +1006,21 @@ class TestPaperRouteEvidenceAudit(TestCase):
     def test_next_paper_route_session_readiness_tracks_collection_and_import(
         self,
     ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+
         def build(generated_at: datetime) -> dict[str, object]:
             with Session(self.engine) as session:
+                self._add_flat_account_start_snapshot(
+                    session,
+                    account_label="TORGHUT_REPLAY",
+                    window_start=window_start,
+                )
+                self._add_flat_account_start_snapshot(
+                    session,
+                    account_label="TORGHUT_SIM",
+                    window_start=window_start,
+                )
+                session.flush()
                 return build_paper_route_evidence_audit(
                     session,
                     live_submission_gate={
@@ -1263,6 +1295,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     updated_at=window_start + timedelta(minutes=13),
                 )
             )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+            )
             session.commit()
 
             missing_ledger_payload = build(session)
@@ -1415,6 +1452,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         event_payload_json={"event_id": "paper-route-reject-amzn"},
                     ),
                 ]
+            )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
             )
             session.commit()
 
@@ -1874,6 +1916,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     trade_decision_id=decision.id,
                     created_at=event_at,
                 )
+            )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
             )
             session.commit()
 
@@ -2658,6 +2705,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     ),
                 ]
             )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+            )
             session.commit()
 
             payload = build_paper_route_evidence_audit(
@@ -2947,6 +2999,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     ),
                 ]
             )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+            )
             session.commit()
 
             payload = build_paper_route_evidence_audit(
@@ -3019,6 +3076,196 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 "client_order_id_count"
             ],
             1,
+        )
+
+    def test_account_window_start_positions_block_runtime_window_import(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
+        now = datetime(2026, 5, 26, 21, 5, tzinfo=timezone.utc)
+
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="account-state-proof-strategy",
+                description="paper account state fixture",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL"],
+                created_at=window_start,
+                updated_at=window_start,
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="TORGHUT_SIM",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={
+                    "action": "sell",
+                    "qty": "1",
+                    "candidate_id": "candidate-account-state",
+                    "hypothesis_id": "H-ACCOUNT-STATE",
+                },
+                rationale="paper route account state fixture",
+                status="executed",
+                created_at=window_start + timedelta(minutes=10),
+                executed_at=window_start + timedelta(minutes=11),
+            )
+            session.add(decision)
+            session.flush()
+            execution = Execution(
+                trade_decision_id=decision.id,
+                alpaca_account_label="TORGHUT_SIM",
+                alpaca_order_id="torghut-account-state-order",
+                client_order_id="torghut-account-state-client",
+                symbol="AAPL",
+                side="sell",
+                order_type="limit",
+                time_in_force="day",
+                submitted_qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("100"),
+                status="filled",
+                raw_order={},
+                created_at=window_start + timedelta(minutes=12),
+                updated_at=window_start + timedelta(minutes=12),
+                last_update_at=window_start + timedelta(minutes=12),
+            )
+            session.add(execution)
+            session.flush()
+            session.add_all(
+                [
+                    PositionSnapshot(
+                        alpaca_account_label="TORGHUT_SIM",
+                        as_of=window_start - timedelta(seconds=30),
+                        equity=Decimal("100000"),
+                        cash=Decimal("99500"),
+                        buying_power=Decimal("199000"),
+                        positions=[
+                            {
+                                "symbol": "AMAT",
+                                "qty": "0.5",
+                                "side": "long",
+                                "market_value": "250",
+                            },
+                            {
+                                "symbol": "AAPL",
+                                "qty": "1",
+                                "side": "long",
+                                "market_value": "200",
+                            },
+                        ],
+                    ),
+                    ExecutionTCAMetric(
+                        execution_id=execution.id,
+                        trade_decision_id=decision.id,
+                        strategy_id=strategy.id,
+                        alpaca_account_label="TORGHUT_SIM",
+                        symbol="AAPL",
+                        side="sell",
+                        arrival_price=Decimal("101"),
+                        avg_fill_price=Decimal("100"),
+                        filled_qty=Decimal("1"),
+                        signed_qty=Decimal("-1"),
+                        slippage_bps=Decimal("5"),
+                        shortfall_notional=Decimal("1"),
+                        realized_shortfall_bps=Decimal("5"),
+                        churn_qty=Decimal("0"),
+                        churn_ratio=Decimal("0"),
+                        computed_at=window_start + timedelta(minutes=13),
+                        created_at=window_start + timedelta(minutes=13),
+                        updated_at=window_start + timedelta(minutes=13),
+                    ),
+                    StrategyPromotionDecision(
+                        run_id="paper-route-account-state-run",
+                        candidate_id="candidate-account-state",
+                        hypothesis_id="H-ACCOUNT-STATE",
+                        promotion_target="paper",
+                        state="allowed",
+                        allowed=True,
+                        reason_summary="paper_evidence_collecting",
+                        created_at=now,
+                        updated_at=now,
+                    ),
+                ]
+            )
+            session.commit()
+
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": "1",
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-ACCOUNT-STATE",
+                                "candidate_id": "candidate-account-state",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_pairs",
+                                "strategy_name": "account-state-proof-strategy",
+                                "strategy_id": "account_state_proof_strategy@research",
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "paper_route_probe_runtime_observed",
+                                "source_manifest_ref": "config/trading/hypotheses/h-account-state.json",
+                                "window_start": window_start.isoformat(),
+                                "window_end": window_end.isoformat(),
+                                "paper_probation_authorized": True,
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["AAPL"],
+                        "paper_route_probe_active_symbols": ["AAPL"],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": True,
+                        "effective_max_notional": 25,
+                        "next_session_max_notional": 25,
+                    },
+                },
+                generated_at=now,
+            )
+
+        audit = payload["next_runtime_window_target_audits"][0]
+        account_state = audit["account_state"]
+        self.assertFalse(account_state["flat"])
+        self.assertEqual(account_state["position_count"], 2)
+        self.assertEqual(account_state["target_symbol_position_count"], 1)
+        self.assertEqual(account_state["non_target_symbol_position_count"], 1)
+        self.assertEqual(account_state["gross_position_market_value"], "450")
+        self.assertIn(
+            "paper_route_account_window_start_not_flat",
+            audit["readiness"]["blockers"],
+        )
+        self.assertIn(
+            "paper_route_account_window_start_non_target_positions_present",
+            audit["readiness"]["blockers"],
+        )
+        import_audit = payload["runtime_window_import_audit"]
+        self.assertEqual(import_audit["state"], "import_due_account_state_not_clean")
+        self.assertEqual(
+            import_audit["next_action"],
+            "reset_paper_account_or_discard_contaminated_window",
+        )
+        self.assertIn(
+            "paper_route_account_window_start_positions_present",
+            import_audit["blockers"],
+        )
+        self.assertEqual(
+            import_audit["target_blockers"][0]["account_state"]["position_count"],
+            2,
         )
 
     def test_paper_route_source_activity_requires_candidate_lineage(self) -> None:
@@ -3440,6 +3687,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     ),
                 ]
             )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=window_start,
+            )
             session.commit()
 
             payload = build_paper_route_evidence_audit(
@@ -3542,6 +3794,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         historical_start = datetime(2026, 5, 21, 17, tzinfo=timezone.utc)
         historical_end = datetime(2026, 5, 21, 17, 30, tzinfo=timezone.utc)
         now = datetime(2026, 5, 26, 21, tzinfo=timezone.utc)
+        next_window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
         strategy_name = "historical-paper-route"
         with Session(self.engine) as session:
             session.add(
@@ -3572,6 +3825,16 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     lineage_hash_counts={"lineage-a": 1},
                     blockers_json=[],
                 )
+            )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_REPLAY",
+                window_start=historical_start,
+            )
+            self._add_flat_account_start_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                window_start=next_window_start,
             )
             session.commit()
 


### PR DESCRIPTION
## Summary

- Adds a paper-route account window-start snapshot audit that checks persisted `PositionSnapshot` state at the proof window start.
- Blocks runtime-window import/proof when the paper account was not flat, when target/non-target residual positions were present, or when the start snapshot is missing/stale.
- Surfaces account-state blockers in target audits, import diagnostics, and target blocker summaries so contaminated account state cannot silently pass promotion review.
- Adds regression coverage for dirty start-account positions and explicit flat snapshots in existing paper-route fixtures.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

Paper-route proof/import now fails closed unless a fresh account-start `PositionSnapshot` proves the account was flat at the runtime proof window start. Existing contaminated or unmeasured windows must be discarded or repaired before promotion proof.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
