### PR TITLE
chore(analysis): promote SLAB package

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: fd0dbec954b9c19b1ce394bc999ff113eb063c51
+    newTag: 7d2c52e5a6f20c66875b1f9531151a23a7b3a467


### PR DESCRIPTION
Promotes the analysis app image to 7d2c52e5a6f20c66875b1f9531151a23a7b3a467 after the SLAB wireless IoT package build passed.