### PR TITLE
test(torghut): cover account start proof gate

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1927,8 +1927,6 @@ def _account_window_start_snapshot_audit(
     blockers: list[str] = []
     if offset_seconds < -PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_STALE_SECONDS:
         blockers.append("paper_route_account_window_start_snapshot_stale")
-    if offset_seconds > PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_AFTER_START_GRACE_SECONDS:
-        blockers.append("paper_route_account_window_start_snapshot_stale")
 
     positions = _normalized_open_positions(
         snapshot.positions,

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -23,7 +23,9 @@ from app.models import (
 )
 from app.trading.paper_route_evidence import (
     RUNTIME_LEDGER_PROOF_PACKET_HANDOFF_SCHEMA_VERSION,
+    _account_window_start_snapshot_audit,
     _next_regular_equities_session_window,
+    _normalized_open_positions,
     _paper_route_probe_summary,
     _runtime_ledger_row_diagnostic_expectancy_bps,
     build_paper_route_evidence_audit,
@@ -57,6 +59,73 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 buying_power=Decimal("200000"),
                 positions=[],
             )
+        )
+
+    def test_normalized_open_positions_handles_flat_short_and_implicit_market_value(
+        self,
+    ) -> None:
+        positions = _normalized_open_positions(
+            [
+                {
+                    "symbol": "FLAT",
+                    "qty": "0",
+                    "market_value": "100",
+                },
+                {
+                    "symbol": "AAPL",
+                    "qty": "2",
+                    "side": "short",
+                    "avg_entry_price": "150",
+                },
+                {
+                    "symbol": "",
+                    "qty": "1",
+                    "market_value": "10",
+                },
+            ],
+            target_symbols={"AAPL"},
+        )
+
+        self.assertEqual(
+            positions,
+            [
+                {
+                    "symbol": "AAPL",
+                    "qty": "-2",
+                    "side": "short",
+                    "market_value": "300",
+                    "target_symbol": True,
+                }
+            ],
+        )
+
+    def test_account_window_start_snapshot_audit_blocks_stale_snapshot(self) -> None:
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            session.add(
+                PositionSnapshot(
+                    alpaca_account_label="TORGHUT_SIM",
+                    as_of=window_start - timedelta(minutes=16),
+                    equity=Decimal("100000"),
+                    cash=Decimal("100000"),
+                    buying_power=Decimal("200000"),
+                    positions=[],
+                )
+            )
+            session.commit()
+
+            audit = _account_window_start_snapshot_audit(
+                session,
+                account_label="TORGHUT_SIM",
+                symbols=["AAPL"],
+                window_start=window_start,
+            )
+
+        self.assertFalse(audit["flat"])
+        self.assertEqual(audit["snapshot_offset_seconds"], -960)
+        self.assertEqual(
+            audit["blockers"],
+            ["paper_route_account_window_start_snapshot_stale"],
         )
 
     def test_runtime_ledger_diagnostic_expectancy_prefers_payload_value(self) -> None:


### PR DESCRIPTION
## Summary

- Adds focused regression coverage for account-start proof normalization: zero positions, short-side quantities, and implicit market value fallback.
- Adds stale account-start snapshot coverage for the fail-closed proof gate.
- Removes a redundant post-window stale check that cannot be reached because the snapshot query already enforces the grace window bound.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'normalized_open_positions or stale_snapshot or account_window_start_positions'`
- `uv run --frozen pytest tests/test_paper_route_evidence.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_paper_route_evidence.py --cov=app.trading.paper_route_evidence --cov-report=xml:/tmp/torghut-paper-route-coverage.xml --cov-report=term-missing:skip-covered && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml /tmp/torghut-paper-route-coverage.xml --threshold 90`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
