### PR TITLE
fix(torghut): block dirty paper route target plans

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -50,6 +50,8 @@ PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL = "TORGHUT_SIM"
 PAPER_ROUTE_RUNTIME_IMPORT_SETTLEMENT_SECONDS = 3600
 PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_STALE_SECONDS = 900
 PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_AFTER_START_GRACE_SECONDS = 300
+PAPER_ROUTE_ACCOUNT_PRE_SESSION_READINESS_SECONDS = 900
+PAPER_ROUTE_ACCOUNT_PRE_SESSION_SNAPSHOT_STALE_SECONDS = 900
 PAPER_ROUTE_TARGET_PLAN_ENDPOINT = "/trading/paper-route-target-plan"
 DEFAULT_TORGHUT_LIVE_SERVICE_BASE_URL = "http://torghut.torghut.svc.cluster.local"
 DEFAULT_TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL = (
@@ -1233,6 +1235,33 @@ def _next_paper_route_runtime_window_targets(
                 }
             )
             continue
+        account_pre_session_state = _account_pre_session_snapshot_audit(
+            session,
+            account_label=PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
+            symbols=target_probe_symbols,
+            generated_at=generated_at,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        account_pre_session_blockers = _unique_text_items(
+            account_pre_session_state.get("blockers")
+        )
+        if account_pre_session_blockers:
+            skipped_targets.append(
+                {
+                    "hypothesis_id": hypothesis_id,
+                    "candidate_id": candidate_id,
+                    "reason": "paper_route_account_pre_session_not_clean",
+                    "missing_or_blocking_fields": account_pre_session_blockers,
+                    "paper_route_account_pre_session_state": (
+                        account_pre_session_state
+                    ),
+                    "paper_route_account_pre_session_blockers": (
+                        account_pre_session_blockers
+                    ),
+                }
+            )
+            continue
         planned_key = (
             hypothesis_id,
             candidate_id,
@@ -1357,6 +1386,8 @@ def _next_paper_route_runtime_window_targets(
             "paper_route_target_plan_source": paper_route_target_plan_source or "",
             "paper_route_probe_scope_authority": paper_route_probe_scope_authority
             or "",
+            "paper_route_account_pre_session_state": account_pre_session_state,
+            "paper_route_account_pre_session_blockers": (account_pre_session_blockers),
             "paper_route_execution_source_key": {
                 "strategy_family": strategy_family or "",
                 "strategy": execution_source_key[1],
@@ -1431,6 +1462,30 @@ def _next_paper_route_runtime_window_targets(
             for blocker in _unique_text_items(item.get("blockers"))
         }
     )
+    account_pre_session_items = [
+        _as_mapping(target.get("paper_route_account_pre_session_state"))
+        for target in planned_targets
+    ]
+    account_pre_session_items.extend(
+        _as_mapping(skipped_target.get("paper_route_account_pre_session_state"))
+        for skipped_target in skipped_targets
+    )
+    account_pre_session_required_count = sum(
+        1 for item in account_pre_session_items if bool(item.get("required"))
+    )
+    account_pre_session_blockers = sorted(
+        {
+            blocker
+            for item in account_pre_session_items
+            for blocker in _unique_text_items(item.get("blockers"))
+        }
+    )
+    account_pre_session_clean_count = sum(
+        1
+        for item in account_pre_session_items
+        if item.get("state") in {"clean", "not_required_until_pre_session"}
+        and not _unique_text_items(item.get("blockers"))
+    )
     return {
         "schema_version": NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION,
         "source": "paper_route_evidence_audit",
@@ -1461,6 +1516,16 @@ def _next_paper_route_runtime_window_targets(
                 len(source_decision_readiness_items) - source_decision_ready_count
             ),
             "blockers": source_decision_blockers,
+        },
+        "account_pre_session_readiness": {
+            "schema_version": "torghut.paper-route-account-pre-session-readiness-summary.v1",
+            "target_count": len(account_pre_session_items),
+            "required_target_count": account_pre_session_required_count,
+            "clean_target_count": account_pre_session_clean_count,
+            "blocked_target_count": (
+                len(account_pre_session_items) - account_pre_session_clean_count
+            ),
+            "blockers": account_pre_session_blockers,
         },
         "paper_route_probe": {
             "configured_enabled": bool(probe.get("configured_enabled")),
@@ -1968,6 +2033,118 @@ def _account_window_start_snapshot_audit(
         "gross_position_market_value": _decimal_text(gross_market_value),
         "sample_positions": positions[:10],
         "blockers": sorted(dict.fromkeys(blockers)),
+    }
+
+
+def _account_pre_session_snapshot_audit(
+    session: Session,
+    *,
+    account_label: str | None,
+    symbols: Sequence[str],
+    generated_at: datetime,
+    window_start: datetime,
+    window_end: datetime,
+) -> dict[str, object]:
+    symbol_filters = {
+        str(item).strip().upper() for item in symbols if str(item).strip()
+    }
+    required_after = window_start - timedelta(
+        seconds=PAPER_ROUTE_ACCOUNT_PRE_SESSION_READINESS_SECONDS
+    )
+    required = required_after <= generated_at < window_end
+    base_payload: dict[str, object] = {
+        "schema_version": "torghut.paper-route-account-pre-session-snapshot-audit.v1",
+        "scope": "account_position_snapshot_before_runtime_window_start",
+        "account_label": account_label,
+        "symbols": sorted(symbol_filters),
+        "generated_at": _isoformat(generated_at),
+        "window_start": _isoformat(window_start),
+        "required": required,
+        "required_after": _isoformat(required_after),
+        "snapshot_id": None,
+        "snapshot_as_of": None,
+        "snapshot_age_seconds": None,
+        "flat": None,
+        "position_count": 0,
+        "target_symbol_position_count": 0,
+        "non_target_symbol_position_count": 0,
+        "gross_position_market_value": "0",
+        "sample_positions": [],
+        "blockers": [],
+    }
+    if not required:
+        return {
+            **base_payload,
+            "state": "not_required_until_pre_session",
+        }
+    if account_label is None:
+        return {
+            **base_payload,
+            "state": "clean",
+            "flat": True,
+        }
+
+    snapshot = session.execute(
+        select(PositionSnapshot)
+        .where(PositionSnapshot.alpaca_account_label == account_label)
+        .where(PositionSnapshot.as_of <= generated_at)
+        .order_by(PositionSnapshot.as_of.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+    if snapshot is None:
+        return {
+            **base_payload,
+            "state": "blocked",
+            "flat": False,
+            "blockers": ["paper_route_account_pre_session_snapshot_missing"],
+        }
+
+    snapshot_as_of = snapshot.as_of
+    if snapshot_as_of.tzinfo is None:
+        snapshot_as_of = snapshot_as_of.replace(tzinfo=timezone.utc)
+    snapshot_as_of = snapshot_as_of.astimezone(timezone.utc)
+    snapshot_age_seconds = int((generated_at - snapshot_as_of).total_seconds())
+    blockers: list[str] = []
+    if snapshot_age_seconds > PAPER_ROUTE_ACCOUNT_PRE_SESSION_SNAPSHOT_STALE_SECONDS:
+        blockers.append("paper_route_account_pre_session_snapshot_stale")
+
+    positions = _normalized_open_positions(
+        snapshot.positions,
+        target_symbols=symbol_filters,
+    )
+    target_position_count = sum(
+        int(bool(position.get("target_symbol"))) for position in positions
+    )
+    non_target_position_count = len(positions) - target_position_count
+    if positions:
+        blockers.extend(
+            [
+                "paper_route_account_pre_session_not_flat",
+                "paper_route_account_pre_session_positions_present",
+            ]
+        )
+    if target_position_count:
+        blockers.append("paper_route_account_pre_session_target_positions_present")
+    if non_target_position_count:
+        blockers.append("paper_route_account_pre_session_non_target_positions_present")
+    gross_market_value = sum(
+        (_safe_decimal(position.get("market_value")) for position in positions),
+        Decimal("0"),
+    )
+    blockers = sorted(dict.fromkeys(blockers))
+    return {
+        **base_payload,
+        "state": "blocked" if blockers else "clean",
+        "snapshot_id": str(snapshot.id),
+        "snapshot_as_of": _isoformat(snapshot_as_of),
+        "snapshot_age_seconds": snapshot_age_seconds,
+        "flat": not positions and not blockers,
+        "position_count": len(positions),
+        "target_symbol_position_count": target_position_count,
+        "non_target_symbol_position_count": non_target_position_count,
+        "gross_position_market_value": _decimal_text(gross_market_value),
+        "sample_positions": positions[:10],
+        "blockers": blockers,
     }
 
 

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -266,7 +266,23 @@ def _paper_route_target_plan_summary(
         )
         if _text(reason)
     ]
+    runtime_window_audit = _mapping(evidence.get("runtime_window_import_audit"))
+    runtime_window_diagnostics = _mapping(runtime_window_audit.get("diagnostics"))
+    account_clean_blockers: list[str] = []
+
+    def add_account_blocker(reason: Any) -> None:
+        blocker = _text(reason)
+        if blocker and blocker not in account_clean_blockers:
+            account_clean_blockers.append(blocker)
+
+    account_pre_session_readiness = _mapping(plan.get("account_pre_session_readiness"))
+    for reason in _sequence(account_pre_session_readiness.get("blockers")):
+        add_account_blocker(reason)
+    for key in ("account_state_blockers", "account_contamination_blockers"):
+        for reason in _sequence(runtime_window_diagnostics.get(key)):
+            add_account_blocker(reason)
     target_summaries: list[dict[str, Any]] = []
+    skipped_target_summaries: list[dict[str, Any]] = []
     missing_identity_count = 0
     probe_contract_count = 0
     promotion_blocked_count = 0
@@ -371,6 +387,22 @@ def _paper_route_target_plan_summary(
             health_gate_continuity_reasons.append(continuity_reason)
         if drift_reason and drift_reason not in health_gate_drift_reasons:
             health_gate_drift_reasons.append(drift_reason)
+        target_account_state = _mapping(
+            target.get("paper_route_account_pre_session_state")
+        )
+        target_account_blockers = [
+            _text(reason)
+            for reason in _sequence(
+                target.get("paper_route_account_pre_session_blockers")
+            )
+            if _text(reason)
+        ]
+        for reason in _sequence(target_account_state.get("blockers")):
+            blocker = _text(reason)
+            if blocker and blocker not in target_account_blockers:
+                target_account_blockers.append(blocker)
+        for blocker in target_account_blockers:
+            add_account_blocker(blocker)
         target_summaries.append(
             {
                 "hypothesis_id": _text(target.get("hypothesis_id")),
@@ -395,7 +427,51 @@ def _paper_route_target_plan_summary(
                 "runtime_window_import_promotion_blockers": (
                     target_health_promotion_blockers
                 ),
+                "paper_route_account_pre_session_state": _text(
+                    target_account_state.get("state")
+                ),
+                "paper_route_account_pre_session_blockers": sorted(
+                    set(target_account_blockers)
+                ),
                 "missing_identity_fields": missing_identity,
+            }
+        )
+    for skipped_target in (
+        _mapping(target) for target in _sequence(plan.get("skipped_targets"))
+    ):
+        skipped_blockers = [
+            _text(reason)
+            for reason in _sequence(skipped_target.get("missing_or_blocking_fields"))
+            if _text(reason)
+        ]
+        for reason in _sequence(
+            skipped_target.get("paper_route_account_pre_session_blockers")
+        ):
+            blocker = _text(reason)
+            if blocker and blocker not in skipped_blockers:
+                skipped_blockers.append(blocker)
+        skipped_account_state = _mapping(
+            skipped_target.get("paper_route_account_pre_session_state")
+        )
+        for reason in _sequence(skipped_account_state.get("blockers")):
+            blocker = _text(reason)
+            if blocker and blocker not in skipped_blockers:
+                skipped_blockers.append(blocker)
+        if (
+            _text(skipped_target.get("reason"))
+            == "paper_route_account_pre_session_not_clean"
+        ):
+            for blocker in skipped_blockers:
+                add_account_blocker(blocker)
+        skipped_target_summaries.append(
+            {
+                "hypothesis_id": _text(skipped_target.get("hypothesis_id")),
+                "candidate_id": _text(skipped_target.get("candidate_id")),
+                "reason": _text(skipped_target.get("reason")),
+                "blockers": sorted(set(skipped_blockers)),
+                "paper_route_account_pre_session_state": _text(
+                    skipped_account_state.get("state")
+                ),
             }
         )
     target_count = _int(plan.get("target_count"), default=len(targets))
@@ -415,9 +491,12 @@ def _paper_route_target_plan_summary(
         "required_flags": sorted(required_flags),
         "missing_required_flags": missing_required_flags,
         "targets": target_summaries,
+        "skipped_targets": skipped_target_summaries,
         "missing_identity_count": missing_identity_count,
         "probe_contract_count": probe_contract_count,
         "promotion_blocked_count": promotion_blocked_count,
+        "account_clean": not account_clean_blockers,
+        "account_clean_blockers": sorted(account_clean_blockers),
         "runtime_window_import_health_gate": {
             "ready": bool(targets)
             and health_gate_ready_count == len(targets)
@@ -515,6 +594,9 @@ def _paper_route_preopen_evidence_collection_ready(
         )
         == _int(paper_route_target_plan.get("actual_target_count"))
         and _int(paper_route_target_plan.get("actual_target_count")) > 0,
+        "target_plan_account_clean": _bool(
+            paper_route_target_plan.get("account_clean")
+        ),
         "target_plan_health_gate_ready": _bool(target_plan_health_gate.get("ready")),
         "target_plan_import_blockers_only_session_not_open": all(
             blocker in allowed_import_blockers for blocker in import_blockers
@@ -527,6 +609,9 @@ def _paper_route_preopen_evidence_collection_ready(
         "softened_checks": sorted(_PAPER_ROUTE_PREOPEN_SOFT_CHECKS) if ready else [],
         "probe_blockers": probe_blockers,
         "import_blockers": import_blockers,
+        "account_clean_blockers": list(
+            _sequence(paper_route_target_plan.get("account_clean_blockers"))
+        ),
         "note": (
             "pre-open evidence collection only; not promotion, runtime-ledger, "
             "or profitability proof"
@@ -1162,6 +1247,20 @@ def evaluate_trading_readiness(
                 "targets": paper_route_target_plan["targets"],
             },
             expected="every_target_zero_notional_and_not_final_promotion",
+        )
+        _add_check(
+            checks,
+            "paper_route_target_plan_account_clean",
+            passed=bool(paper_route_target_plan["account_clean"]),
+            observed={
+                "account_clean": paper_route_target_plan["account_clean"],
+                "account_clean_blockers": paper_route_target_plan[
+                    "account_clean_blockers"
+                ],
+                "targets": paper_route_target_plan["targets"],
+                "skipped_targets": paper_route_target_plan["skipped_targets"],
+            },
+            expected={"account_clean": True, "account_clean_blockers": []},
         )
         import_health_gate = _mapping(
             paper_route_target_plan["runtime_window_import_health_gate"]

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -61,6 +61,84 @@ class TestPaperRouteEvidenceAudit(TestCase):
             )
         )
 
+    def _add_account_position_snapshot(
+        self,
+        session: Session,
+        *,
+        account_label: str,
+        as_of: datetime,
+        positions: list[dict[str, object]],
+    ) -> None:
+        session.add(
+            PositionSnapshot(
+                alpaca_account_label=account_label,
+                as_of=as_of,
+                equity=Decimal("100000"),
+                cash=Decimal("100000"),
+                buying_power=Decimal("200000"),
+                positions=positions,
+            )
+        )
+
+    def _build_basic_paper_route_target_plan(
+        self,
+        session: Session,
+        *,
+        generated_at: datetime,
+    ) -> dict[str, object]:
+        return build_paper_route_target_plan_payload(
+            session,
+            live_submission_gate={
+                "allowed": False,
+                "reason": "paper_route_probe_only",
+                "blocked_reasons": [],
+                "promotion_eligible_total": 0,
+                "dependency_quorum_decision": "allow",
+                "continuity_ok": True,
+                "continuity_reason": "signal_continuity_nominal",
+                "drift_ok": True,
+                "drift_reason": "drift_live_promotion_eligible",
+                "runtime_ledger_paper_probation_import_plan": {
+                    "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "candidate-pre-session",
+                            "observed_stage": "paper",
+                            "strategy_family": "microbar_pairs",
+                            "strategy_name": "paper-route-candidate-v1",
+                            "account_label": "TORGHUT_REPLAY",
+                            "source_kind": "durable_runtime_ledger_bucket",
+                            "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+                            "dataset_snapshot_ref": "dataset://paper-route",
+                            "paper_probation_authorized": True,
+                            "promotion_allowed": False,
+                            "final_promotion_authorized": False,
+                            "max_notional": "0",
+                        }
+                    ],
+                },
+            },
+            route_reacquisition_book={
+                "schema_version": "torghut.route-reacquisition-book.v1",
+                "state": "repair_only",
+                "summary": {
+                    "paper_route_probe_eligible_symbols": ["AAPL", "AMZN"],
+                    "paper_route_probe_active_symbols": [],
+                },
+                "paper_route_probe": {
+                    "configured_enabled": True,
+                    "active": False,
+                    "next_session_max_notional": "25",
+                    "eligible_symbol_count": 2,
+                    "eligible_symbols": ["AAPL", "AMZN"],
+                    "blocking_reasons": ["market_session_closed"],
+                },
+            },
+            generated_at=generated_at,
+        )
+
     def test_normalized_open_positions_handles_flat_short_and_implicit_market_value(
         self,
     ) -> None:
@@ -126,6 +204,79 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(
             audit["blockers"],
             ["paper_route_account_window_start_snapshot_stale"],
+        )
+
+    def test_pre_session_dirty_account_skips_next_paper_route_target(self) -> None:
+        generated_at = datetime(2026, 5, 26, 13, 20, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            self._add_account_position_snapshot(
+                session,
+                account_label="TORGHUT_SIM",
+                as_of=generated_at - timedelta(seconds=30),
+                positions=[
+                    {
+                        "symbol": "AAPL",
+                        "qty": "2",
+                        "side": "long",
+                        "market_value": "400",
+                    },
+                    {
+                        "symbol": "MSFT",
+                        "qty": "1",
+                        "side": "long",
+                        "market_value": "300",
+                    },
+                ],
+            )
+            session.commit()
+
+            payload = self._build_basic_paper_route_target_plan(
+                session,
+                generated_at=generated_at,
+            )
+
+        plan = payload["next_paper_route_runtime_window_targets"]
+        self.assertEqual(plan["target_count"], 0)
+        self.assertEqual(plan["runtime_window_import_handoff"]["target_count"], 0)
+        self.assertEqual(plan["skipped_target_count"], 1)
+        skipped = plan["skipped_targets"][0]
+        self.assertEqual(skipped["reason"], "paper_route_account_pre_session_not_clean")
+        self.assertEqual(
+            skipped["paper_route_account_pre_session_state"]["state"], "blocked"
+        )
+        blockers = skipped["paper_route_account_pre_session_blockers"]
+        self.assertIn("paper_route_account_pre_session_not_flat", blockers)
+        self.assertIn("paper_route_account_pre_session_positions_present", blockers)
+        self.assertIn(
+            "paper_route_account_pre_session_target_positions_present", blockers
+        )
+        self.assertIn(
+            "paper_route_account_pre_session_non_target_positions_present", blockers
+        )
+        readiness = plan["account_pre_session_readiness"]
+        self.assertEqual(readiness["required_target_count"], 1)
+        self.assertEqual(readiness["clean_target_count"], 0)
+        self.assertIn("paper_route_account_pre_session_not_flat", readiness["blockers"])
+
+    def test_pre_session_missing_account_snapshot_skips_target(self) -> None:
+        generated_at = datetime(2026, 5, 26, 13, 20, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            payload = self._build_basic_paper_route_target_plan(
+                session,
+                generated_at=generated_at,
+            )
+
+        plan = payload["next_paper_route_runtime_window_targets"]
+        self.assertEqual(plan["target_count"], 0)
+        self.assertEqual(plan["skipped_target_count"], 1)
+        skipped = plan["skipped_targets"][0]
+        self.assertEqual(
+            skipped["paper_route_account_pre_session_blockers"],
+            ["paper_route_account_pre_session_snapshot_missing"],
+        )
+        self.assertEqual(
+            plan["account_pre_session_readiness"]["blockers"],
+            ["paper_route_account_pre_session_snapshot_missing"],
         )
 
     def test_runtime_ledger_diagnostic_expectancy_prefers_payload_value(self) -> None:
@@ -1076,6 +1227,7 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self,
     ) -> None:
         window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, tzinfo=timezone.utc)
 
         def build(generated_at: datetime) -> dict[str, object]:
             with Session(self.engine) as session:
@@ -1089,6 +1241,13 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     account_label="TORGHUT_SIM",
                     window_start=window_start,
                 )
+                if window_start <= generated_at < window_end:
+                    self._add_account_position_snapshot(
+                        session,
+                        account_label="TORGHUT_SIM",
+                        as_of=generated_at - timedelta(seconds=30),
+                        positions=[],
+                    )
                 session.flush()
                 return build_paper_route_evidence_audit(
                     session,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -69,6 +69,7 @@ from app.models import (
     Execution,
     ExecutionTCAMetric,
     LLMDecisionReview,
+    PositionSnapshot,
     RejectedSignalOutcomeEvent,
     Strategy,
     StrategyHypothesisMetricWindow,
@@ -485,6 +486,18 @@ class TestTradingApi(TestCase):
                 created_at=datetime.now(timezone.utc),
             )
             session.add(review)
+            session.commit()
+
+            session.add(
+                PositionSnapshot(
+                    alpaca_account_label="TORGHUT_SIM",
+                    as_of=datetime.now(timezone.utc),
+                    equity=Decimal("100000"),
+                    cash=Decimal("100000"),
+                    buying_power=Decimal("200000"),
+                    positions=[],
+                )
+            )
             session.commit()
 
     def test_forecast_service_status_uses_empirical_job_lineage_when_registry_empty(

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -177,6 +177,8 @@ def _paper_route_evidence(
     import_blockers: list[str] | None = None,
     required_flags: list[str] | None = None,
     target_overrides: dict[str, object] | None = None,
+    account_state_blockers: list[str] | None = None,
+    account_contamination_blockers: list[str] | None = None,
 ) -> dict[str, object]:
     blockers = (
         import_blockers
@@ -246,6 +248,14 @@ def _paper_route_evidence(
                 "final_promotion_authorized": False,
             },
             "targets": [target],
+        },
+        "runtime_window_import_audit": {
+            "diagnostics": {
+                "account_state_blockers": account_state_blockers or [],
+                "account_contamination_blockers": (
+                    account_contamination_blockers or []
+                ),
+            }
         },
     }
 
@@ -734,6 +744,28 @@ class TestVerifyTradingReadiness(TestCase):
         )
         self.assertEqual(result["paper_route_target_plan"]["missing_identity_count"], 0)
 
+    def test_paper_route_target_plan_fails_closed_on_dirty_account(self) -> None:
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            paper_route_evidence=_paper_route_evidence(
+                account_state_blockers=["paper_route_account_window_start_not_flat"],
+                account_contamination_blockers=[
+                    "paper_route_account_contamination_detected"
+                ],
+            ),
+            require_paper_route_target_plan=True,
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertIn("paper_route_target_plan_account_clean", result["failed_checks"])
+        self.assertEqual(
+            result["paper_route_target_plan"]["account_clean_blockers"],
+            [
+                "paper_route_account_contamination_detected",
+                "paper_route_account_window_start_not_flat",
+            ],
+        )
+
     def test_preopen_paper_route_evidence_collection_softens_current_route_failures(
         self,
     ) -> None:
@@ -925,6 +957,75 @@ class TestVerifyTradingReadiness(TestCase):
         self.assertTrue(
             preopen_summary["conditions"]["probe_candidate_requirement_satisfied"]
         )
+
+    def test_preopen_softening_requires_clean_paper_account(self) -> None:
+        status = _ready_status()
+        metrics = status["metrics"]
+        assert isinstance(metrics, dict)
+        metrics["market_session_open"] = 0
+        proof_floor = status["proof_floor"]
+        assert isinstance(proof_floor, dict)
+        proof_floor.update(
+            {
+                "floor_state": "repair_only",
+                "route_state": "repair_only",
+                "capital_state": "zero_notional",
+                "max_notional": "0",
+                "blocking_reasons": [
+                    "alpha_readiness_not_promotion_eligible",
+                    "execution_tca_slippage_guardrail_exceeded",
+                ],
+            }
+        )
+        dimensions = proof_floor["proof_dimensions"]
+        assert isinstance(dimensions, list)
+        for dimension in dimensions:
+            if not isinstance(dimension, dict):
+                continue
+            if dimension.get("dimension") == "alpha_readiness":
+                dimension["state"] = "fail"
+                dimension["reason"] = "alpha_readiness_not_promotion_eligible"
+            if dimension.get("dimension") == "execution_tca":
+                dimension["state"] = "fail"
+                dimension["reason"] = "execution_tca_slippage_guardrail_exceeded"
+
+        route_book = status["route_reacquisition_book"]
+        assert isinstance(route_book, dict)
+        route_book["state"] = "repair_only"
+        probe = route_book["paper_route_probe"]
+        assert isinstance(probe, dict)
+        probe.update(
+            {
+                "active": False,
+                "effective_max_notional": "0",
+                "next_session_max_notional": "63180.0",
+                "eligible_symbol_count": 2,
+                "eligible_symbols": ["AAPL", "AMZN"],
+                "active_symbols": [],
+                "blocking_reasons": ["market_session_closed"],
+            }
+        )
+        summary = route_book["summary"]
+        assert isinstance(summary, dict)
+        summary["paper_route_probe_eligible_symbols"] = ["AAPL", "AMZN"]
+        summary["paper_route_probe_active_symbols"] = []
+
+        result = evaluate_trading_readiness(
+            status,
+            paper_route_evidence=_paper_route_evidence(
+                account_state_blockers=["paper_route_account_window_start_not_flat"],
+            ),
+            require_market_open=False,
+            require_quant_fresh=False,
+            require_paper_route_target_plan=True,
+            allow_paper_route_preopen_evidence_collection=True,
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertIn("paper_route_target_plan_account_clean", result["failed_checks"])
+        preopen_summary = result["paper_route_preopen_evidence_collection"]
+        self.assertFalse(preopen_summary["ready"])
+        self.assertFalse(preopen_summary["conditions"]["target_plan_account_clean"])
 
     def test_paper_route_target_plan_fails_closed_on_missing_handoff_or_identity(
         self,


### PR DESCRIPTION
## Summary

- Adds a pre-session `TORGHUT_SIM` account-position audit to paper-route target planning.
- Skips proof-window targets when the paper account is dirty, missing a fresh snapshot, or has target/non-target positions during the required pre-session/open window.
- Extends trading-readiness verification so dirty account diagnostics fail target-plan and pre-open softening checks.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py -k 'pre_session or next_paper_route or account_window_start'`
- `uv run --frozen pytest tests/test_verify_trading_readiness.py -k 'paper_route_target_plan or preopen'`
- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_evidence_endpoint_audits_probation_targets or paper_route_target_plan_returns_lightweight_plan or trading_paper_route_evidence_uses_external_plan_when_url_configured or external_paper_route_target_preserves_live_symbol_envelope'`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py scripts/verify_trading_readiness.py tests/test_paper_route_evidence.py tests/test_verify_trading_readiness.py tests/test_trading_api.py && uv run --frozen ruff check app/trading/paper_route_evidence.py scripts/verify_trading_readiness.py tests/test_paper_route_evidence.py tests/test_verify_trading_readiness.py tests/test_trading_api.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
