### PR TITLE
chore(analysis): promote zbra package

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 548926d85201df00f55c71bcec78d0b05a889641
+    newTag: ef8b6722aecec47fa4849eb46124725a2ce9f338


### PR DESCRIPTION
## Summary

- Promotes the `analysis` Argo image tag to `ef8b6722aecec47fa4849eb46124725a2ce9f338`.
- Publishes the ZBRA asset-visibility package through the existing GitOps deployment path.
- Leaves the analysis service, namespace, and Tailscale service shape unchanged.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/analysis | rg -n "image:"`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
