### PR TITLE
fix(torghut): route paper import through sim plan

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -46,7 +46,7 @@ spec:
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \
                     --runtime-window-import \
-                    --runtime-window-target-plan-url http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan \
+                    --runtime-window-target-plan-url http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan \
                     --runtime-window-target-plan-url-timeout-seconds 45 \
                     --runtime-window-target-plan-url-attempts 3 \
                     --runtime-window-target-plan-url-retry-backoff-seconds 5 \

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1105,6 +1105,7 @@ def _next_paper_route_runtime_window_targets(
     probe: Mapping[str, object],
     live_submission_gate: Mapping[str, Any],
     generated_at: datetime,
+    require_clean_pre_session: bool = True,
 ) -> dict[str, object]:
     window_start, window_end = _next_regular_equities_session_window(generated_at)
     probe_symbols = _paper_route_probe_symbols(probe)
@@ -1246,7 +1247,7 @@ def _next_paper_route_runtime_window_targets(
         account_pre_session_blockers = _unique_text_items(
             account_pre_session_state.get("blockers")
         )
-        if account_pre_session_blockers:
+        if account_pre_session_blockers and require_clean_pre_session:
             skipped_targets.append(
                 {
                     "hypothesis_id": hypothesis_id,
@@ -3391,6 +3392,14 @@ def build_paper_route_target_plan_payload(
         live_submission_gate=live_submission_gate,
         generated_at=resolved_generated_at,
     )
+    source_targets = _next_paper_route_runtime_window_targets(
+        session=session,
+        targets=targets,
+        probe=probe,
+        live_submission_gate=live_submission_gate,
+        generated_at=resolved_generated_at,
+        require_clean_pre_session=False,
+    )
     return {
         "schema_version": PAPER_ROUTE_TARGET_PLAN_PAYLOAD_SCHEMA_VERSION,
         "generated_at": _isoformat(resolved_generated_at),
@@ -3427,11 +3436,15 @@ def build_paper_route_target_plan_payload(
         },
         "paper_route_probe": probe,
         "runtime_window_import_plan": next_targets,
+        "source_runtime_window_import_plan": source_targets,
         "next_paper_route_runtime_window_targets": next_targets,
         "summary": {
             "source_target_count": len(targets),
             "next_runtime_window_target_count": _safe_int(
                 next_targets.get("target_count")
+            ),
+            "source_runtime_window_target_count": _safe_int(
+                source_targets.get("target_count")
             ),
             "skipped_target_count": _safe_int(next_targets.get("skipped_target_count")),
             "promotion_authority": {

--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -33,6 +33,9 @@ def paper_route_target_plan_targets(plan: Mapping[str, Any]) -> list[dict[str, A
 def paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
     live_gate = _to_str_map(payload.get("live_submission_gate"))
     runtime_window_plan = _to_str_map(payload.get("runtime_window_import_plan"))
+    source_runtime_window_plan = _to_str_map(
+        payload.get("source_runtime_window_import_plan")
+    )
     next_paper_route_plan = _to_str_map(
         payload.get("next_paper_route_runtime_window_targets")
     )
@@ -43,6 +46,7 @@ def paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str
     candidate_plans = [
         runtime_window_plan,
         *paper_route_plans,
+        source_runtime_window_plan,
         _to_str_map(live_gate.get("runtime_ledger_paper_probation_import_plan")),
         _to_str_map(payload.get("runtime_ledger_paper_probation_import_plan")),
         *([] if paper_route_payload else [next_paper_route_plan]),

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -934,13 +934,18 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn(
             "--runtime-window-target-plan-url "
-            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan",
+            "http://torghut-sim.torghut.svc.cluster.local/trading/paper-route-target-plan",
             args,
         )
         self.assertIn("--runtime-window-target-plan-url-timeout-seconds 45", args)
         self.assertIn("--runtime-window-target-plan-url-attempts 3", args)
         self.assertIn(
             "--runtime-window-target-plan-url-retry-backoff-seconds 5",
+            args,
+        )
+        self.assertNotIn(
+            "--runtime-window-target-plan-url "
+            "http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan",
             args,
         )
         self.assertNotIn(

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -278,6 +278,19 @@ class TestPaperRouteEvidenceAudit(TestCase):
             plan["account_pre_session_readiness"]["blockers"],
             ["paper_route_account_pre_session_snapshot_missing"],
         )
+        source_plan = payload["source_runtime_window_import_plan"]
+        self.assertEqual(source_plan["target_count"], 1)
+        self.assertEqual(
+            source_plan["targets"][0]["candidate_id"], "candidate-pre-session"
+        )
+        self.assertEqual(
+            source_plan["targets"][0]["paper_route_account_pre_session_blockers"],
+            ["paper_route_account_pre_session_snapshot_missing"],
+        )
+        self.assertEqual(
+            payload["summary"]["source_runtime_window_target_count"],
+            1,
+        )
 
     def test_runtime_ledger_diagnostic_expectancy_prefers_payload_value(self) -> None:
         row = StrategyRuntimeLedgerBucket(

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7621,6 +7621,38 @@ class TestTradingApi(TestCase):
 
         self.assertEqual(plan["targets"][0]["candidate_id"], "c88421d619759b2cfaa6f4d0")
 
+    def test_paper_route_target_plan_from_payload_falls_back_to_source_plan(
+        self,
+    ) -> None:
+        plan = _paper_route_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-target-plan.v1",
+                "runtime_window_import_plan": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 0,
+                    "targets": [],
+                },
+                "source_runtime_window_import_plan": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "candidate-source-scope",
+                            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                        }
+                    ],
+                },
+                "next_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 0,
+                    "targets": [],
+                },
+            }
+        )
+
+        self.assertEqual(plan["targets"][0]["candidate_id"], "candidate-source-scope")
+
     def test_paper_route_target_plan_from_payload_requires_targets(self) -> None:
         self.assertEqual(
             _paper_route_target_plan_from_payload(


### PR DESCRIPTION
## Summary

- Adds a source-scoped paper-route import plan to the target-plan payload so sim can receive candidate identity and probe-symbol scope even when live-side pre-session auditing has no sim snapshot.
- Keeps the strict next-window runtime import plan fail-closed behind the local pre-session account snapshot gate.
- Points the empirical promotion renewal runtime-window import at the `torghut-sim` target-plan endpoint so proof import uses the sim DB/account evidence path.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_live_config_manifest_contract.py tests/test_run_empirical_promotion_jobs.py`
- `uv run --frozen ruff format --check app/trading/paper_route_evidence.py app/trading/paper_route_target_plan.py tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py app/trading/paper_route_target_plan.py tests/test_paper_route_evidence.py tests/test_trading_api.py tests/test_live_config_manifest_contract.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
