### PR TITLE
fix(torghut): flatten paper account before proof windows

### DIFF
--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -36,6 +36,7 @@ resources:
   - empirical-promotion-renewal-cronjob.yaml
   - empirical-artifacts-retention-cronjob.yaml
   - execution-tca-refresh-cronjob.yaml
+  - paper-account-flatten-cronjob.yaml
   - whitepaper-autoresearch-workflowtemplate.yaml
   - empirical-promotion-workflowtemplate.yaml
   - historical-simulation-workflowtemplate.yaml

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -1,0 +1,81 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: torghut-paper-account-flatten
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: paper-account-flatten
+spec:
+  schedule: "5,20,35,50 19 * * 1-5"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 180
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: torghut-runtime
+          nodeSelector:
+            kubernetes.io/arch: arm64
+          containers:
+            - name: flatten-paper-account
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: 250m
+                  memory: 256Mi
+                  ephemeral-storage: 512Mi
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -euo pipefail
+                  cd /app
+                  /opt/venv/bin/python scripts/flatten_paper_account_positions.py \
+                    --account-label TORGHUT_SIM \
+                    --expected-account-label TORGHUT_SIM \
+                    --trading-mode paper \
+                    --paper-base-url https://paper-api.alpaca.markets \
+                    --max-gross-market-value 2500 \
+                    --max-position-count 25 \
+                    --apply \
+                    --json
+              env:
+                - name: APCA_API_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-alpaca
+                      key: APCA_API_KEY_ID
+                      optional: true
+                - name: APCA_API_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-alpaca
+                      key: APCA_API_SECRET_KEY
+                      optional: true
+                - name: APCA_API_BASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-alpaca
+                      key: APCA_API_BASE_URL
+                      optional: true
+                - name: TRADING_MODE
+                  value: paper
+                - name: TRADING_ACCOUNT_LABEL
+                  value: TORGHUT_SIM
+                - name: TRADING_ACCOUNTS_JSON
+                  value: >
+                    [{"label":"TORGHUT_SIM","mode":"paper","enabled":true}]
+                - name: TRADING_KILL_SWITCH_ENABLED
+                  value: "false"

--- a/services/torghut/scripts/flatten_paper_account_positions.py
+++ b/services/torghut/scripts/flatten_paper_account_positions.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Flatten the Torghut paper account so runtime proof windows start clean."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Any, Protocol
+
+from app.alpaca_client import TorghutAlpacaClient
+from app.config import settings
+from app.trading.firewall import OrderFirewall
+
+DEFAULT_ACCOUNT_LABEL = "TORGHUT_SIM"
+DEFAULT_PAPER_BASE_URL = "https://paper-api.alpaca.markets"
+DEFAULT_MAX_GROSS_MARKET_VALUE = Decimal("2500")
+DEFAULT_MAX_POSITION_COUNT = 25
+TERMINAL_CLEAN_STATUSES = frozenset({"clean", "dry_run", "submitted"})
+
+
+class PaperFlattenClient(Protocol):
+    def list_positions(self) -> list[dict[str, Any]] | None: ...
+
+    def cancel_all_orders(self) -> list[dict[str, Any]]: ...
+
+    def submit_order(
+        self,
+        symbol: str,
+        side: str,
+        qty: float,
+        order_type: str,
+        time_in_force: str,
+        limit_price: float | None = None,
+        stop_price: float | None = None,
+        extra_params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]: ...
+
+
+@dataclass(frozen=True)
+class FlattenPosition:
+    symbol: str
+    qty: Decimal
+    side: str
+    market_value: Decimal
+
+    @property
+    def close_side(self) -> str:
+        return "buy" if self.side == "short" or self.qty < 0 else "sell"
+
+    @property
+    def close_qty(self) -> Decimal:
+        return abs(self.qty)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Cancel paper open orders and submit opposing market orders for open "
+            "paper positions. Defaults to dry-run and refuses live/non-TORGHUT_SIM use."
+        ),
+    )
+    parser.add_argument("--account-label", default=settings.trading_account_label)
+    parser.add_argument("--expected-account-label", default=DEFAULT_ACCOUNT_LABEL)
+    parser.add_argument("--trading-mode", default=settings.trading_mode)
+    parser.add_argument(
+        "--paper-base-url",
+        default=DEFAULT_PAPER_BASE_URL,
+        help="Alpaca paper endpoint to use; kept explicit to avoid inheriting live URLs.",
+    )
+    parser.add_argument(
+        "--max-gross-market-value",
+        default=str(DEFAULT_MAX_GROSS_MARKET_VALUE),
+        help="Refuse to submit flatten orders above this absolute market value.",
+    )
+    parser.add_argument(
+        "--max-position-count",
+        type=int,
+        default=DEFAULT_MAX_POSITION_COUNT,
+        help="Refuse to submit flatten orders above this number of open positions.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Submit flatten orders. Without this flag, only report the plan.",
+    )
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def _decimal(value: object, *, default: Decimal = Decimal("0")) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return default
+
+
+def _position_qty(position: Mapping[str, Any]) -> Decimal:
+    qty = _decimal(position.get("qty", position.get("quantity")))
+    side = str(position.get("side") or "").strip().lower()
+    if side == "short" and qty > 0:
+        return -qty
+    return qty
+
+
+def _position_market_value(position: Mapping[str, Any], qty: Decimal) -> Decimal:
+    raw_value = position.get("market_value", position.get("marketValue"))
+    value = _decimal(raw_value)
+    if value != 0:
+        return abs(value)
+    price = _decimal(
+        position.get("current_price", position.get("currentPrice")),
+        default=Decimal("0"),
+    )
+    return abs(qty) * abs(price)
+
+
+def _normalize_positions(
+    raw_positions: Sequence[Mapping[str, Any]] | None,
+) -> list[FlattenPosition]:
+    normalized: list[FlattenPosition] = []
+    for raw in raw_positions or []:
+        symbol = str(raw.get("symbol") or "").strip().upper()
+        if not symbol:
+            continue
+        qty = _position_qty(raw)
+        if qty == 0:
+            continue
+        side = str(raw.get("side") or "").strip().lower()
+        if side not in {"long", "short"}:
+            side = "short" if qty < 0 else "long"
+        normalized.append(
+            FlattenPosition(
+                symbol=symbol,
+                qty=qty,
+                side=side,
+                market_value=_position_market_value(raw, qty),
+            )
+        )
+    return sorted(normalized, key=lambda item: item.symbol)
+
+
+def _position_payload(position: FlattenPosition) -> dict[str, str]:
+    return {
+        "symbol": position.symbol,
+        "qty": str(position.qty),
+        "side": position.side,
+        "market_value": str(position.market_value),
+        "close_side": position.close_side,
+        "close_qty": str(position.close_qty),
+    }
+
+
+def flatten_paper_account_positions(
+    *,
+    client: PaperFlattenClient,
+    account_label: str,
+    expected_account_label: str,
+    trading_mode: str,
+    apply: bool,
+    max_gross_market_value: Decimal,
+    max_position_count: int,
+    generated_at: datetime | None = None,
+) -> dict[str, Any]:
+    generated_at = generated_at or datetime.now(timezone.utc)
+    normalized_mode = trading_mode.strip().lower()
+    normalized_label = account_label.strip()
+    expected_label = expected_account_label.strip()
+    blockers: list[str] = []
+
+    if normalized_mode != "paper":
+        blockers.append("paper_account_flatten_requires_paper_mode")
+    if normalized_label != expected_label:
+        blockers.append("paper_account_flatten_account_label_mismatch")
+
+    raw_positions = client.list_positions()
+    positions = _normalize_positions(raw_positions)
+    gross_market_value = sum(
+        (position.market_value for position in positions), Decimal("0")
+    )
+    if len(positions) > max(0, max_position_count):
+        blockers.append("paper_account_flatten_position_count_above_limit")
+    if gross_market_value > max_gross_market_value:
+        blockers.append("paper_account_flatten_gross_market_value_above_limit")
+
+    status = "clean" if not positions and not blockers else "blocked"
+    cancelled_orders: list[dict[str, Any]] = []
+    submitted_orders: list[dict[str, Any]] = []
+    if blockers:
+        status = "blocked"
+    elif not apply:
+        status = "dry_run" if positions else "clean"
+    elif positions:
+        cancelled_orders = client.cancel_all_orders()
+        for position in positions:
+            submitted_orders.append(
+                client.submit_order(
+                    symbol=position.symbol,
+                    side=position.close_side,
+                    qty=float(position.close_qty),
+                    order_type="market",
+                    time_in_force="day",
+                    extra_params={
+                        "client_order_id": (
+                            "torghut-paper-flatten-"
+                            f"{generated_at.strftime('%Y%m%d%H%M%S')}-"
+                            f"{position.symbol.lower()}"
+                        )
+                    },
+                )
+            )
+        status = "submitted"
+
+    return {
+        "schema_version": "torghut.paper-account-flatten.v1",
+        "status": status,
+        "apply": apply,
+        "generated_at": generated_at.isoformat(),
+        "account_label": normalized_label,
+        "expected_account_label": expected_label,
+        "trading_mode": normalized_mode,
+        "position_count": len(positions),
+        "gross_market_value": str(gross_market_value),
+        "max_gross_market_value": str(max_gross_market_value),
+        "max_position_count": max_position_count,
+        "blockers": blockers,
+        "positions": [_position_payload(position) for position in positions],
+        "cancelled_order_count": len(cancelled_orders),
+        "cancelled_orders": cancelled_orders,
+        "submitted_order_count": len(submitted_orders),
+        "submitted_orders": submitted_orders,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    max_gross_market_value = _decimal(
+        args.max_gross_market_value,
+        default=DEFAULT_MAX_GROSS_MARKET_VALUE,
+    )
+    client = TorghutAlpacaClient(paper=True, base_url=str(args.paper_base_url or ""))
+    firewall = OrderFirewall(client)
+    payload = flatten_paper_account_positions(
+        client=firewall,
+        account_label=str(args.account_label or ""),
+        expected_account_label=str(args.expected_account_label or ""),
+        trading_mode=str(args.trading_mode or ""),
+        apply=bool(args.apply),
+        max_gross_market_value=max_gross_market_value,
+        max_position_count=max(0, int(args.max_position_count)),
+    )
+    if args.json:
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print(
+            f"status={payload['status']} positions={payload['position_count']} "
+            f"submitted={payload['submitted_order_count']} blockers={','.join(payload['blockers'])}"
+        )
+    return 0 if payload["status"] in TERMINAL_CLEAN_STATUSES else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/tests/test_flatten_paper_account_positions.py
+++ b/services/torghut/tests/test_flatten_paper_account_positions.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import json
+import sys
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+from decimal import Decimal
+from io import StringIO
+from typing import Any
+from unittest import TestCase
+from unittest.mock import patch
+
+from scripts import flatten_paper_account_positions as flatten_script
+from scripts.flatten_paper_account_positions import (
+    flatten_paper_account_positions,
+)
+
+
+class FakeFlattenClient:
+    def __init__(self, positions: list[dict[str, Any]] | None = None) -> None:
+        self.positions = positions or []
+        self.cancelled = False
+        self.submitted: list[dict[str, Any]] = []
+
+    def list_positions(self) -> list[dict[str, Any]]:
+        return self.positions
+
+    def cancel_all_orders(self) -> list[dict[str, Any]]:
+        self.cancelled = True
+        return [{"id": "cancel-1", "status": "canceled"}]
+
+    def submit_order(
+        self,
+        symbol: str,
+        side: str,
+        qty: float,
+        order_type: str,
+        time_in_force: str,
+        limit_price: float | None = None,
+        stop_price: float | None = None,
+        extra_params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        _ = limit_price, stop_price
+        order = {
+            "id": f"order-{len(self.submitted) + 1}",
+            "symbol": symbol,
+            "side": side,
+            "qty": str(qty),
+            "type": order_type,
+            "time_in_force": time_in_force,
+            "client_order_id": (extra_params or {}).get("client_order_id"),
+        }
+        self.submitted.append(order)
+        return order
+
+
+class TestFlattenPaperAccountPositions(TestCase):
+    def test_dry_run_reports_close_orders_without_mutating(self) -> None:
+        client = FakeFlattenClient(
+            [
+                {
+                    "symbol": "AMAT",
+                    "qty": "0.8761",
+                    "side": "long",
+                    "market_value": "393.66",
+                }
+            ]
+        )
+
+        payload = flatten_paper_account_positions(
+            client=client,
+            account_label="TORGHUT_SIM",
+            expected_account_label="TORGHUT_SIM",
+            trading_mode="paper",
+            apply=False,
+            max_gross_market_value=Decimal("2500"),
+            max_position_count=10,
+            generated_at=datetime(2026, 5, 29, 19, 5, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(payload["status"], "dry_run")
+        self.assertEqual(payload["position_count"], 1)
+        self.assertEqual(payload["positions"][0]["close_side"], "sell")
+        self.assertFalse(client.cancelled)
+        self.assertEqual(client.submitted, [])
+
+    def test_apply_cancels_orders_and_submits_opposing_market_orders(self) -> None:
+        client = FakeFlattenClient(
+            [
+                {"symbol": "AMAT", "qty": "0.8761", "side": "long"},
+                {"symbol": "TSM", "qty": "0.3321", "side": "short"},
+            ]
+        )
+
+        payload = flatten_paper_account_positions(
+            client=client,
+            account_label="TORGHUT_SIM",
+            expected_account_label="TORGHUT_SIM",
+            trading_mode="paper",
+            apply=True,
+            max_gross_market_value=Decimal("2500"),
+            max_position_count=10,
+            generated_at=datetime(2026, 5, 29, 19, 5, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(payload["status"], "submitted")
+        self.assertTrue(client.cancelled)
+        self.assertEqual(payload["cancelled_order_count"], 1)
+        self.assertEqual(
+            [
+                (order["symbol"], order["side"], order["type"])
+                for order in client.submitted
+            ],
+            [("AMAT", "sell", "market"), ("TSM", "buy", "market")],
+        )
+        self.assertEqual(payload["submitted_order_count"], 2)
+
+    def test_refuses_live_mode_or_wrong_account(self) -> None:
+        client = FakeFlattenClient(
+            [{"symbol": "AAPL", "qty": "1", "side": "long", "market_value": "100"}]
+        )
+
+        payload = flatten_paper_account_positions(
+            client=client,
+            account_label="PA3SX7FYNUTF",
+            expected_account_label="TORGHUT_SIM",
+            trading_mode="live",
+            apply=True,
+            max_gross_market_value=Decimal("2500"),
+            max_position_count=10,
+        )
+
+        self.assertEqual(payload["status"], "blocked")
+        self.assertIn("paper_account_flatten_requires_paper_mode", payload["blockers"])
+        self.assertIn(
+            "paper_account_flatten_account_label_mismatch", payload["blockers"]
+        )
+        self.assertFalse(client.cancelled)
+        self.assertEqual(client.submitted, [])
+
+    def test_refuses_position_value_above_limit(self) -> None:
+        client = FakeFlattenClient(
+            [{"symbol": "AMAT", "qty": "100", "side": "long", "market_value": "3000"}]
+        )
+
+        payload = flatten_paper_account_positions(
+            client=client,
+            account_label="TORGHUT_SIM",
+            expected_account_label="TORGHUT_SIM",
+            trading_mode="paper",
+            apply=True,
+            max_gross_market_value=Decimal("2500"),
+            max_position_count=10,
+        )
+
+        self.assertEqual(payload["status"], "blocked")
+        self.assertIn(
+            "paper_account_flatten_gross_market_value_above_limit",
+            payload["blockers"],
+        )
+        self.assertFalse(client.cancelled)
+        self.assertEqual(client.submitted, [])
+
+    def test_normalizes_dirty_positions_and_refuses_position_count_above_limit(
+        self,
+    ) -> None:
+        client = FakeFlattenClient(
+            [
+                {"symbol": "", "qty": "10", "side": "long", "market_value": "10"},
+                {"symbol": "ZERO", "qty": "0", "side": "long", "market_value": "0"},
+                {"symbol": "mu", "qty": "-2", "current_price": "50"},
+                {"symbol": "tsm", "qty": "3", "current_price": "100"},
+            ]
+        )
+
+        payload = flatten_paper_account_positions(
+            client=client,
+            account_label="TORGHUT_SIM",
+            expected_account_label="TORGHUT_SIM",
+            trading_mode="paper",
+            apply=True,
+            max_gross_market_value=Decimal("1000"),
+            max_position_count=1,
+        )
+
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["position_count"], 2)
+        self.assertEqual(payload["gross_market_value"], "400")
+        self.assertIn(
+            "paper_account_flatten_position_count_above_limit",
+            payload["blockers"],
+        )
+        self.assertEqual(
+            [
+                (position["symbol"], position["side"], position["close_side"])
+                for position in payload["positions"]
+            ],
+            [("MU", "short", "buy"), ("TSM", "long", "sell")],
+        )
+        self.assertFalse(client.cancelled)
+
+    def test_parse_args_accepts_explicit_guardrails(self) -> None:
+        argv = [
+            "flatten_paper_account_positions.py",
+            "--account-label",
+            "TORGHUT_SIM",
+            "--expected-account-label",
+            "TORGHUT_SIM",
+            "--trading-mode",
+            "paper",
+            "--paper-base-url",
+            "https://paper-api.alpaca.markets",
+            "--max-gross-market-value",
+            "1234.56",
+            "--max-position-count",
+            "3",
+            "--apply",
+            "--json",
+        ]
+
+        with patch.object(sys, "argv", argv):
+            args = flatten_script._parse_args()
+
+        self.assertEqual(args.account_label, "TORGHUT_SIM")
+        self.assertEqual(args.expected_account_label, "TORGHUT_SIM")
+        self.assertEqual(args.trading_mode, "paper")
+        self.assertEqual(args.paper_base_url, "https://paper-api.alpaca.markets")
+        self.assertEqual(args.max_gross_market_value, "1234.56")
+        self.assertEqual(args.max_position_count, 3)
+        self.assertTrue(args.apply)
+        self.assertTrue(args.json)
+
+    def test_main_outputs_json_and_returns_clean_status(self) -> None:
+        client = FakeFlattenClient()
+        argv = [
+            "flatten_paper_account_positions.py",
+            "--account-label",
+            "TORGHUT_SIM",
+            "--expected-account-label",
+            "TORGHUT_SIM",
+            "--trading-mode",
+            "paper",
+            "--json",
+        ]
+
+        with (
+            patch.object(sys, "argv", argv),
+            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(
+                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+            ),
+            redirect_stdout(StringIO()) as output,
+        ):
+            exit_code = flatten_script.main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "clean")
+        self.assertEqual(payload["position_count"], 0)
+
+    def test_main_outputs_text_and_returns_blocked_status(self) -> None:
+        client = FakeFlattenClient(
+            [{"symbol": "AAPL", "qty": "1", "side": "long", "market_value": "100"}]
+        )
+        argv = [
+            "flatten_paper_account_positions.py",
+            "--trading-mode",
+            "live",
+            "--max-position-count",
+            "-1",
+        ]
+
+        with (
+            patch.object(sys, "argv", argv),
+            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(
+                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+            ),
+            redirect_stdout(StringIO()) as output,
+        ):
+            exit_code = flatten_script.main()
+
+        self.assertEqual(exit_code, 2)
+        self.assertIn("status=blocked", output.getvalue())
+        self.assertFalse(client.cancelled)


### PR DESCRIPTION
## Summary

- Adds a guarded Torghut paper-account flatten script for `TORGHUT_SIM` that defaults to dry-run, refuses live/wrong-account execution, caps gross exposure and position count, and emits JSON audit output.
- Adds focused tests covering dry-run, paper apply, live/wrong-account refusal, and gross-value guardrails.
- Adds a low-resource GitOps CronJob to flatten the paper account near the U.S. equity close so future H-PAIRS proof windows can start from a clean account.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_flatten_paper_account_positions.py tests/test_paper_route_evidence.py -q`
- `uv run --frozen ruff check scripts/flatten_paper_account_positions.py tests/test_flatten_paper_account_positions.py`
- `uv run --frozen ruff format --check scripts/flatten_paper_account_positions.py tests/test_flatten_paper_account_positions.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-kustomize.out`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
