### PR TITLE
chore(analysis): promote cat package

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 7a09e0f4d10116c9b03e9d344e03fbb6300e2537
+    newTag: de9d05ca717024c7ae72a49daf46055a882eb1f1


### PR DESCRIPTION
## Summary

- Promotes the published `analysis` image for the CAT mining-autonomy package.
- Updates the Argo CD analysis application image tag to `de9d05ca717024c7ae72a49daf46055a882eb1f1`.
- Keeps the existing Tailscale-exposed analysis service and deployment shape unchanged.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/analysis`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
