### PR TITLE
fix(synthesis): keep rollout available

### DIFF
--- a/argocd/applications/synthesis/deployment.yaml
+++ b/argocd/applications/synthesis/deployment.yaml
@@ -7,8 +7,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: synthesis


### PR DESCRIPTION
## Summary

- Keep Synthesis rolling updates available while a replacement pod pulls and becomes ready.
- Change the single-replica Deployment strategy from `maxSurge: 0` / `maxUnavailable: 1` to `maxSurge: 1` / `maxUnavailable: 0`.
- Prevent future autotrader scorecard/API reads from seeing a brief Synthesis outage during image promotion.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/synthesis | rg -n 'kind: Deployment|name: synthesis|maxSurge|maxUnavailable' -C 4`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
