### PR TITLE
refactor(torghut): retire news and fundamentals blockers

### DIFF
--- a/.github/workflows/torghut-ci.yml
+++ b/.github/workflows/torghut-ci.yml
@@ -662,18 +662,25 @@ jobs:
         working-directory: services/torghut
         run: uv sync --frozen --extra dev
 
-      - name: Run coverage suite
+      - name: Download shard coverage data
+        uses: actions/download-artifact@v4
+        with:
+          pattern: torghut-coverage-*
+          path: services/torghut
+          merge-multiple: true
+
+      - name: Combine coverage data
         working-directory: services/torghut
         run: |
           set -euo pipefail
-          uv run --frozen pytest \
-            -n auto \
-            --dist=worksteal \
-            --cov \
-            --cov-branch \
-            --cov-report=term \
-            --cov-report=xml:coverage.xml \
-            --cov-fail-under=70
+          coverage_files=(.coverage.*)
+          if [ "${coverage_files[0]}" = ".coverage.*" ]; then
+            echo "No shard coverage files were downloaded"
+            exit 1
+          fi
+          uv run --frozen python -m coverage combine "${coverage_files[@]}"
+          uv run --frozen python -m coverage report --fail-under=70
+          uv run --frozen python -m coverage xml -o coverage.xml
 
       - name: Changed-file coverage
         working-directory: services/torghut

--- a/argocd/applications/feature-flags/gitops/default/features.yaml
+++ b/argocd/applications/feature-flags/gitops/default/features.yaml
@@ -180,11 +180,6 @@ flags:
     description: Requires market context for LLM reviews.
     type: BOOLEAN_FLAG_TYPE
     enabled: false
-  - key: torghut_trading_market_context_allow_degraded_last_good
-    name: Torghut Trading Market Context Allow Degraded Last Good
-    description: Allows degraded last-good market context bundles within configured hard staleness caps.
-    type: BOOLEAN_FLAG_TYPE
-    enabled: true
   - key: torghut_trading_readiness_dependency_cache_enabled
     name: Torghut Trading Readiness Dependency Cache Enabled
     description: Enables caching for readiness dependency checks in trading probes.

--- a/services/torghut/app/config.py
+++ b/services/torghut/app/config.py
@@ -59,9 +59,6 @@ FEATURE_FLAG_BOOLEAN_KEY_BY_FIELD: dict[str, str] = {
     "trading_kill_switch_enabled": "torghut_trading_kill_switch_enabled",
     "trading_emergency_stop_enabled": "torghut_trading_emergency_stop_enabled",
     "trading_market_context_required": "torghut_trading_market_context_required",
-    "trading_market_context_allow_degraded_last_good": (
-        "torghut_trading_market_context_allow_degraded_last_good"
-    ),
     "llm_enabled": "torghut_llm_enabled",
     "llm_fail_open_live_approved": "torghut_llm_fail_open_live_approved",
     "llm_adjustment_allowed": "torghut_llm_adjustment_allowed",
@@ -1599,21 +1596,6 @@ class Settings(BaseSettings):
         default=300,
         alias="TRADING_MARKET_CONTEXT_MAX_STALENESS_SECONDS",
         description="Maximum accepted market-context staleness.",
-    )
-    trading_market_context_allow_degraded_last_good: bool = Field(
-        default=True,
-        alias="TRADING_MARKET_CONTEXT_ALLOW_DEGRADED_LAST_GOOD",
-        description="Allow degraded last-good market context when generation failed but a bounded stale snapshot exists.",
-    )
-    trading_market_context_fundamentals_degraded_max_staleness_seconds: int = Field(
-        default=86400,
-        alias="TRADING_MARKET_CONTEXT_FUNDAMENTALS_DEGRADED_MAX_STALENESS_SECONDS",
-        description="Hard stale cap for degraded last-good fundamentals context.",
-    )
-    trading_market_context_news_degraded_max_staleness_seconds: int = Field(
-        default=1800,
-        alias="TRADING_MARKET_CONTEXT_NEWS_DEGRADED_MAX_STALENESS_SECONDS",
-        description="Hard stale cap for degraded last-good news context.",
     )
     trading_clickhouse_url: Optional[str] = Field(
         default=None, alias="TA_CLICKHOUSE_URL"

--- a/services/torghut/app/trading/freshness_carry.py
+++ b/services/torghut/app/trading/freshness_carry.py
@@ -9,6 +9,8 @@ from hashlib import sha256
 import json
 from typing import Any, cast
 
+from .market_context_domains import active_market_context_reasons
+
 
 FRESHNESS_CARRY_LEDGER_SCHEMA_VERSION = "torghut.freshness-carry-ledger.v1"
 
@@ -289,15 +291,22 @@ def _market_context_dimension(
     last_checked_at = market_context_status.get(
         "last_checked_at"
     ) or market_context_status.get("last_as_of")
-    reasons = [
-        *_strings(market_context_status.get("last_risk_flags")),
-        *_strings(market_context_status.get("reason_codes")),
-        *_strings(market_context_status.get("blocking_reasons")),
-    ]
+    reasons = active_market_context_reasons(
+        [
+            *_strings(market_context_status.get("last_risk_flags")),
+            *_strings(market_context_status.get("reason_codes")),
+            *_strings(market_context_status.get("blocking_reasons")),
+        ]
+    )
     if _bool(market_context_status.get("alert_active")):
-        reasons.append(
-            _text(
-                market_context_status.get("alert_reason"), "market_context_alert_active"
+        reasons.extend(
+            active_market_context_reasons(
+                [
+                    _text(
+                        market_context_status.get("alert_reason"),
+                        "market_context_alert_active",
+                    )
+                ]
             )
         )
     if market_context_status.get("health_error"):

--- a/services/torghut/app/trading/market_context.py
+++ b/services/torghut/app/trading/market_context.py
@@ -13,6 +13,12 @@ from urllib.parse import urlencode, urlsplit, urlunsplit
 
 from ..config import settings
 from .llm.schema import MarketContextBundle
+from .market_context_domains import (
+    active_market_context_domain_states,
+    active_market_context_freshness_seconds,
+    active_market_context_quality_score,
+    active_market_context_reasons,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -20,19 +26,11 @@ _BLOCKING_RISK_FLAGS = {
     "market_context_stale",
     "market_context_quality_low",
     "market_context_disabled",
-    "fundamentals_error",
-    "news_error",
     "technicals_error",
     "regime_error",
     "technicals_source_error",
     "regime_source_error",
     "market_context_domain_error",
-}
-
-_DEGRADED_LAST_GOOD_FLAGS = {
-    "market_context_degraded_last_good",
-    "fundamentals_generation_failed_all_models",
-    "news_generation_failed_all_models",
 }
 
 _REASON_PRIORITY = [
@@ -50,35 +48,6 @@ class MarketContextStatus:
     allow_llm: bool
     reason: Optional[str]
     risk_flags: list[str]
-
-
-def _degraded_domains_within_hard_caps(bundle: MarketContextBundle) -> bool:
-    degraded_domains: list[tuple[str, Any, int]] = []
-    risk_flags = set(bundle.risk_flags)
-    if "fundamentals_generation_failed_all_models" in risk_flags:
-        degraded_domains.append(
-            (
-                "fundamentals",
-                bundle.domains.fundamentals,
-                settings.trading_market_context_fundamentals_degraded_max_staleness_seconds,
-            )
-        )
-    if "news_generation_failed_all_models" in risk_flags:
-        degraded_domains.append(
-            (
-                "news",
-                bundle.domains.news,
-                settings.trading_market_context_news_degraded_max_staleness_seconds,
-            )
-        )
-    if not degraded_domains:
-        return False
-    for _, domain, hard_cap_seconds in degraded_domains:
-        if domain.state in {"missing", "error"}:
-            return False
-        if domain.freshness_seconds is None or domain.freshness_seconds > hard_cap_seconds:
-            return False
-    return True
 
 
 class _HttpRequest:
@@ -100,10 +69,12 @@ class _HttpRequest:
 
 
 class _HttpResponseHandle:
-    def __init__(self, connection: HTTPConnection | HTTPSConnection, response: Any) -> None:
+    def __init__(
+        self, connection: HTTPConnection | HTTPSConnection, response: Any
+    ) -> None:
         self._connection = connection
         self._response = response
-        self.status = int(getattr(response, 'status', 200))
+        self.status = int(getattr(response, "status", 200))
 
     def read(self) -> bytes:
         return cast(bytes, self._response.read())
@@ -122,14 +93,14 @@ class _HttpResponseHandle:
 def urlopen(request: _HttpRequest, timeout: int) -> _HttpResponseHandle:
     parsed = urlsplit(request.full_url)
     scheme = parsed.scheme.lower()
-    if scheme not in {'http', 'https'}:
-        raise RuntimeError(f'market_context_invalid_url_scheme:{scheme or "missing"}')
+    if scheme not in {"http", "https"}:
+        raise RuntimeError(f"market_context_invalid_url_scheme:{scheme or 'missing'}")
     if not parsed.hostname:
-        raise RuntimeError('market_context_invalid_url_host')
-    request_path = parsed.path or '/'
+        raise RuntimeError("market_context_invalid_url_host")
+    request_path = parsed.path or "/"
     if parsed.query:
-        request_path = f'{request_path}?{parsed.query}'
-    connection_class = HTTPSConnection if scheme == 'https' else HTTPConnection
+        request_path = f"{request_path}?{parsed.query}"
+    connection_class = HTTPSConnection if scheme == "https" else HTTPConnection
     connection = connection_class(parsed.hostname, parsed.port, timeout=max(timeout, 1))
     try:
         connection.request(request.method, request_path, headers=request.headers)
@@ -160,19 +131,19 @@ class MarketContextClient:
         query = urlencode(query_payload)
         url = self._base_url
         delimiter = "&" if "?" in url else "?"
-        request_url = f'{url}{delimiter}{query}'
+        request_url = f"{url}{delimiter}{query}"
         request = _HttpRequest(
             full_url=request_url,
-            method='GET',
-            headers={'accept': 'application/json'},
+            method="GET",
+            headers={"accept": "application/json"},
         )
-        payload = ''
+        payload = ""
         with urlopen(request, self._timeout_seconds) as response:
-            raw_status = getattr(response, 'status', 200)
+            raw_status = getattr(response, "status", 200)
             status = raw_status if isinstance(raw_status, int) else 200
             if status < 200 or status >= 300:
-                raise RuntimeError(f'market_context_http_{status}')
-            payload = response.read().decode('utf-8')
+                raise RuntimeError(f"market_context_http_{status}")
+            payload = response.read().decode("utf-8")
         data = json.loads(payload)
         if not isinstance(data, dict):
             raise RuntimeError("market_context_invalid_payload")
@@ -192,7 +163,7 @@ class MarketContextClient:
             return None
         cache_key = symbol.strip().upper() or "default"
         if as_of is not None:
-            cache_key = f'{cache_key}:{as_of.astimezone(timezone.utc).isoformat()}'
+            cache_key = f"{cache_key}:{as_of.astimezone(timezone.utc).isoformat()}"
         now = time.monotonic()
         cached = self._health_cache.get(cache_key)
         if cached is not None and now - cached[0] <= 15.0:
@@ -239,44 +210,44 @@ class MarketContextClient:
         return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
 
 
-def evaluate_market_context(bundle: Optional[MarketContextBundle]) -> MarketContextStatus:
+def evaluate_market_context(
+    bundle: Optional[MarketContextBundle],
+) -> MarketContextStatus:
     """Evaluate market context against deterministic quality/staleness policy."""
 
     if bundle is None:
         if settings.trading_market_context_required:
-            return MarketContextStatus(allow_llm=False, reason="market_context_required_missing", risk_flags=[])
+            return MarketContextStatus(
+                allow_llm=False, reason="market_context_required_missing", risk_flags=[]
+            )
         return MarketContextStatus(allow_llm=True, reason=None, risk_flags=[])
 
-    risk_flags = sorted(set(bundle.risk_flags))
-    domain_states = {
-        "technicals": bundle.domains.technicals.state,
-        "fundamentals": bundle.domains.fundamentals.state,
-        "news": bundle.domains.news.state,
-        "regime": bundle.domains.regime.state,
-    }
-    degraded_last_good_allowed = (
-        settings.trading_market_context_allow_degraded_last_good
-        and any(flag in _DEGRADED_LAST_GOOD_FLAGS for flag in risk_flags)
-        and _degraded_domains_within_hard_caps(bundle)
-    )
+    risk_flags = sorted(set(active_market_context_reasons(bundle.risk_flags)))
+    domain_states = active_market_context_domain_states(bundle)
+    effective_freshness_seconds = active_market_context_freshness_seconds(bundle)
+    effective_quality_score = active_market_context_quality_score(bundle)
     blocking_flags = [flag for flag in risk_flags if flag in _BLOCKING_RISK_FLAGS]
     if any(state == "error" for state in domain_states.values()):
         risk_flags.append("market_context_domain_error")
         blocking_flags.append("market_context_domain_error")
     if (
-        bundle.freshness_seconds > settings.trading_market_context_max_staleness_seconds
-        and not degraded_last_good_allowed
+        effective_freshness_seconds
+        > settings.trading_market_context_max_staleness_seconds
     ):
         risk_flags.append("market_context_stale")
         blocking_flags.append("market_context_stale")
-    if bundle.quality_score < settings.trading_market_context_min_quality and not degraded_last_good_allowed:
+    if effective_quality_score < settings.trading_market_context_min_quality:
         risk_flags.append("market_context_quality_low")
         blocking_flags.append("market_context_quality_low")
 
     if blocking_flags:
         unique_blocking_flags = sorted(set(blocking_flags))
         reason = next(
-            (candidate for candidate in _REASON_PRIORITY if candidate in unique_blocking_flags),
+            (
+                candidate
+                for candidate in _REASON_PRIORITY
+                if candidate in unique_blocking_flags
+            ),
             unique_blocking_flags[0],
         )
         return MarketContextStatus(
@@ -284,7 +255,9 @@ def evaluate_market_context(bundle: Optional[MarketContextBundle]) -> MarketCont
             reason=reason,
             risk_flags=sorted(set(risk_flags)),
         )
-    return MarketContextStatus(allow_llm=True, reason=None, risk_flags=sorted(set(risk_flags)))
+    return MarketContextStatus(
+        allow_llm=True, reason=None, risk_flags=sorted(set(risk_flags))
+    )
 
 
 __all__ = ["MarketContextClient", "MarketContextStatus", "evaluate_market_context"]

--- a/services/torghut/app/trading/market_context_domains.py
+++ b/services/torghut/app/trading/market_context_domains.py
@@ -1,0 +1,100 @@
+"""Market-context domain policy for Torghut decision gates."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any, cast
+
+ACTIVE_MARKET_CONTEXT_DOMAINS: tuple[str, ...] = ("technicals", "regime")
+RETIRED_MARKET_CONTEXT_DOMAINS: frozenset[str] = frozenset({"fundamentals", "news"})
+
+
+def is_active_market_context_domain(value: object) -> bool:
+    return str(value).strip().lower() in ACTIVE_MARKET_CONTEXT_DOMAINS
+
+
+def is_retired_market_context_reason(value: object) -> bool:
+    normalized = str(value).strip().lower().replace("-", "_")
+    if not normalized:
+        return False
+    return bool(RETIRED_MARKET_CONTEXT_DOMAINS.intersection(normalized.split("_")))
+
+
+def active_market_context_reasons(values: object) -> list[str]:
+    if isinstance(values, str):
+        raw_values: tuple[object, ...] = (values,)
+    elif isinstance(values, (list, tuple, set)):
+        raw_values = tuple(cast(Iterable[object], values))
+    else:
+        raw_values = ()
+    reasons: list[str] = []
+    for value in raw_values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text and not is_retired_market_context_reason(text):
+            reasons.append(text)
+    return reasons
+
+
+def active_market_context_mapping(domains: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        str(name).strip().lower(): value
+        for name, value in domains.items()
+        if is_active_market_context_domain(name)
+    }
+
+
+def active_market_context_bundle_domains(bundle: object) -> dict[str, Any]:
+    domains = getattr(bundle, "domains", None)
+    if domains is None:
+        return {}
+    active: dict[str, Any] = {}
+    for name in ACTIVE_MARKET_CONTEXT_DOMAINS:
+        domain = getattr(domains, name, None)
+        if domain is not None:
+            active[name] = domain
+    return active
+
+
+def active_market_context_domain_states(bundle: object) -> dict[str, str]:
+    return {
+        name: str(getattr(domain, "state", "")).strip().lower()
+        for name, domain in active_market_context_bundle_domains(bundle).items()
+    }
+
+
+def active_market_context_freshness_seconds(bundle: object) -> int:
+    freshness_values = [
+        int(freshness)
+        for domain in active_market_context_bundle_domains(bundle).values()
+        if (freshness := getattr(domain, "freshness_seconds", None)) is not None
+    ]
+    if freshness_values:
+        return max(freshness_values)
+    return int(getattr(bundle, "freshness_seconds", 0))
+
+
+def active_market_context_quality_score(bundle: object) -> float:
+    quality_values = [
+        float(getattr(domain, "quality_score"))
+        for domain in active_market_context_bundle_domains(bundle).values()
+        if getattr(domain, "quality_score", None) is not None
+    ]
+    if quality_values:
+        return min(quality_values)
+    return float(getattr(bundle, "quality_score", 0.0))
+
+
+__all__ = [
+    "ACTIVE_MARKET_CONTEXT_DOMAINS",
+    "RETIRED_MARKET_CONTEXT_DOMAINS",
+    "active_market_context_bundle_domains",
+    "active_market_context_domain_states",
+    "active_market_context_freshness_seconds",
+    "active_market_context_mapping",
+    "active_market_context_quality_score",
+    "active_market_context_reasons",
+    "is_active_market_context_domain",
+    "is_retired_market_context_reason",
+]

--- a/services/torghut/app/trading/profit_freshness_frontier.py
+++ b/services/torghut/app/trading/profit_freshness_frontier.py
@@ -9,6 +9,11 @@ from hashlib import sha256
 import json
 from typing import Any, cast
 
+from .market_context_domains import (
+    active_market_context_mapping,
+    active_market_context_reasons,
+)
+
 
 PROFIT_FRESHNESS_FRONTIER_SCHEMA_VERSION = "torghut.profit-freshness-frontier.v1"
 
@@ -357,11 +362,13 @@ def _market_dimension(
     hypothesis_payload: Mapping[str, Any],
     generated_at: datetime,
 ) -> dict[str, object]:
-    reasons = [
-        *_strings(market_context_status.get("blocking_reasons")),
-        *_strings(market_context_status.get("reason_codes")),
-        *_strings(market_context_status.get("last_risk_flags")),
-    ]
+    reasons = active_market_context_reasons(
+        [
+            *_strings(market_context_status.get("blocking_reasons")),
+            *_strings(market_context_status.get("reason_codes")),
+            *_strings(market_context_status.get("last_risk_flags")),
+        ]
+    )
     status = _text(
         _mapping(market_context_status.get("health")).get("status")
         or market_context_status.get("status")
@@ -369,15 +376,22 @@ def _market_dimension(
         or market_context_status.get("last_reason")
     ).lower()
     stale_domains: list[str] = []
-    for domain_name, raw_domain in _market_domain_states(market_context_status).items():
+    for domain_name, raw_domain in active_market_context_mapping(
+        _market_domain_states(market_context_status)
+    ).items():
         domain = _mapping(raw_domain)
         domain_state = _text(domain.get("status") or domain.get("state")).lower()
         if domain_state == "stale" or domain.get("stale") is True:
             stale_domains.append(str(domain_name))
     if _bool(market_context_status.get("alert_active")):
-        reasons.append(
-            _text(
-                market_context_status.get("alert_reason"), "market_context_alert_active"
+        reasons.extend(
+            active_market_context_reasons(
+                [
+                    _text(
+                        market_context_status.get("alert_reason"),
+                        "market_context_alert_active",
+                    )
+                ]
             )
         )
     if status and status not in _CURRENT_STATES and status != "fresh":

--- a/services/torghut/app/trading/profit_signal_quorum.py
+++ b/services/torghut/app/trading/profit_signal_quorum.py
@@ -10,6 +10,11 @@ from hashlib import sha256
 import json
 from typing import Any, cast
 
+from .market_context_domains import (
+    active_market_context_reasons,
+    is_active_market_context_domain,
+)
+
 
 PROFIT_SIGNAL_QUORUM_SCHEMA_VERSION = "torghut.profit-signal-quorum.v1"
 
@@ -235,16 +240,13 @@ def _market_context_signal(market: Mapping[str, Any]) -> dict[str, object]:
         reasons.append(f"market_context_route_{state}")
     if market.get("alert_active") is True:
         reasons.append(_text(market.get("alert_reason"), "market_context_alert_active"))
-    for key, reason in (
-        ("stale_snapshot_count", "market_context_snapshot_stale"),
-        ("stale_fundamentals_count", "market_context_fundamentals_stale"),
-        ("stale_news_count", "market_context_news_stale"),
-    ):
-        if _int(market.get(key)) > 0:
-            reasons.append(reason)
-    if _int(market.get("risk_flag_count")) > 0 or _strings(market.get("risk_flags")):
+    if _int(market.get("stale_snapshot_count")) > 0:
+        reasons.append("market_context_snapshot_stale")
+    if active_market_context_reasons(_strings(market.get("risk_flags"))):
         reasons.append("market_context_risk_flags")
     for domain_name, raw_domain in _mapping(market.get("domains")).items():
+        if not is_active_market_context_domain(domain_name):
+            continue
         domain = _mapping(raw_domain)
         domain_state = _first(domain, "state", "status", default="unknown").lower()
         if domain_state in _BAD_STATES:

--- a/services/torghut/app/trading/profit_windows.py
+++ b/services/torghut/app/trading/profit_windows.py
@@ -9,6 +9,11 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from typing import Any, cast
 
+from .market_context_domains import (
+    active_market_context_mapping,
+    active_market_context_reasons,
+)
+
 PROFIT_WINDOW_CONTRACT_SCHEMA_VERSION = "torghut.profit-window-contract.v1"
 
 _CLICKHOUSE_FRESHNESS_REASONS = frozenset(
@@ -236,8 +241,12 @@ def _market_context_escrow(
     segment_summary: Mapping[str, Mapping[str, object]],
 ) -> dict[str, object]:
     segment = _as_mapping(segment_summary.get("market-context"))
-    reason_codes = _string_list(segment.get("reason_codes") or [])
-    domain_states = _as_mapping(market_context_ref.get("last_domain_states"))
+    reason_codes = active_market_context_reasons(
+        _string_list(segment.get("reason_codes") or [])
+    )
+    domain_states = active_market_context_mapping(
+        _as_mapping(market_context_ref.get("last_domain_states"))
+    )
     source_ref = market_context_ref.get("last_as_of") or market_context_ref.get(
         "last_checked_at"
     )
@@ -251,9 +260,13 @@ def _market_context_escrow(
     ]
     reason_codes.extend(stale_domains)
     if bool(market_context_ref.get("alert_active")):
-        reason_codes.append(
-            _safe_text(market_context_ref.get("alert_reason"))
-            or "market_context_alert_active"
+        reason_codes.extend(
+            active_market_context_reasons(
+                [
+                    _safe_text(market_context_ref.get("alert_reason"))
+                    or "market_context_alert_active"
+                ]
+            )
         )
     missing_required_evidence = required and source_ref is None and not domain_states
     if missing_required_evidence and not reason_codes:

--- a/services/torghut/app/trading/quality_adjusted_profit_frontier.py
+++ b/services/torghut/app/trading/quality_adjusted_profit_frontier.py
@@ -8,6 +8,11 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from typing import Any, cast
 
+from .market_context_domains import (
+    ACTIVE_MARKET_CONTEXT_DOMAINS,
+    active_market_context_reasons,
+)
+
 
 SCHEMA_VERSION = "torghut.quality-adjusted-profit-frontier.v1"
 
@@ -205,13 +210,10 @@ def _market_receipts(market: Mapping[str, Any]) -> list[str]:
         _number(market.get(key))
         for key in (
             "stale_snapshot_count",
-            "stale_fundamentals_count",
-            "stale_news_count",
+            *(f"stale_{domain}_count" for domain in ACTIVE_MARKET_CONTEXT_DOMAINS),
         )
     )
-    risk_count = _number(market.get("risk_flag_count")) + len(
-        _strings(market.get("risk_flags"))
-    )
+    risk_count = len(active_market_context_reasons(_strings(market.get("risk_flags"))))
     if stale_count > 0:
         receipts.add("market_context_stale")
     if risk_count > 0:

--- a/services/torghut/app/trading/routeability_repair_acceptance.py
+++ b/services/torghut/app/trading/routeability_repair_acceptance.py
@@ -9,6 +9,11 @@ from hashlib import sha256
 import json
 from typing import Any, cast
 
+from .market_context_domains import (
+    active_market_context_reasons,
+    is_active_market_context_domain,
+)
+
 
 ROUTEABILITY_REPAIR_ACCEPTANCE_LEDGER_SCHEMA_VERSION = (
     "torghut.routeability-repair-acceptance-ledger.v1"
@@ -29,9 +34,7 @@ _FORECAST_READY = {
     "shadow_ready",
 }
 _MARKET_STALE_COUNT_FIELDS = {
-    "fundamentals": "stale_fundamentals_count",
     "technicals": "stale_technicals_count",
-    "news": "stale_news_count",
     "regime": "stale_regime_count",
 }
 _PROMOTION_FRAGMENTS = (
@@ -248,10 +251,12 @@ def _market_domain_states(
 def _market_context_blockers(market_context_status: Mapping[str, Any]) -> list[str]:
     if not market_context_status:
         return ["market_context_missing"]
-    blockers = [
-        *_strings(market_context_status.get("blocking_reasons")),
-        *_strings(market_context_status.get("reason_codes")),
-    ]
+    blockers = active_market_context_reasons(
+        [
+            *_strings(market_context_status.get("blocking_reasons")),
+            *_strings(market_context_status.get("reason_codes")),
+        ]
+    )
     health = _mapping(market_context_status.get("health"))
     status = _text(
         health.get("status")
@@ -262,11 +267,17 @@ def _market_context_blockers(market_context_status: Mapping[str, Any]) -> list[s
     if status and status not in _ACCEPTED_STATES and status != "fresh":
         blockers.append(f"market_context_{status}")
 
-    stale_domains = _strings(
-        market_context_status.get("stale_domains")
-        or market_context_status.get("market_context_stale_domains")
-    )
+    stale_domains = [
+        domain
+        for domain in _strings(
+            market_context_status.get("stale_domains")
+            or market_context_status.get("market_context_stale_domains")
+        )
+        if is_active_market_context_domain(domain)
+    ]
     for domain_name, raw_domain in _market_domain_states(market_context_status).items():
+        if not is_active_market_context_domain(domain_name):
+            continue
         domain = _mapping(raw_domain)
         domain_status = _text(domain.get("status") or domain.get("state")).lower()
         if domain.get("stale") is True or domain_status in {

--- a/services/torghut/app/trading/scheduler/pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline.py
@@ -61,6 +61,10 @@ from ..market_context import (
     MarketContextStatus,
     evaluate_market_context,
 )
+from ..market_context_domains import (
+    active_market_context_domain_states,
+    active_market_context_reasons,
+)
 from ..models import SignalEnvelope, StrategyDecision
 from ..order_feed import OrderFeedIngestor
 from ..portfolio import (
@@ -4436,13 +4440,12 @@ class TradingPipeline:
         self.state.last_market_context_quality_score = float(
             market_context.quality_score
         )
-        self.state.last_market_context_domain_states = {
-            "technicals": market_context.domains.technicals.state,
-            "fundamentals": market_context.domains.fundamentals.state,
-            "news": market_context.domains.news.state,
-            "regime": market_context.domains.regime.state,
-        }
-        self.state.last_market_context_risk_flags = list(market_context.risk_flags)
+        self.state.last_market_context_domain_states = (
+            active_market_context_domain_states(market_context)
+        )
+        self.state.last_market_context_risk_flags = active_market_context_reasons(
+            market_context.risk_flags
+        )
         self.state.last_market_context_allow_llm = market_context_status.allow_llm
         self.state.last_market_context_reason = (
             market_context_error or market_context_status.reason

--- a/services/torghut/app/trading/scheduler/runtime.py
+++ b/services/torghut/app/trading/scheduler/runtime.py
@@ -25,6 +25,11 @@ from ..llm.dspy_programs.runtime import (
 )
 from ..llm.guardrails import evaluate_llm_guardrails
 from ..market_context import MarketContextClient, evaluate_market_context
+from ..market_context_domains import (
+    active_market_context_domain_states,
+    active_market_context_mapping,
+    active_market_context_reasons,
+)
 from ..order_feed import OrderFeedIngestor
 from ..prices import ClickHousePriceFetcher
 from ..reconcile import Reconciler
@@ -211,12 +216,28 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
         last_as_of = self.state.last_market_context_as_of
         last_freshness_seconds = self.state.last_market_context_freshness_seconds
         last_quality_score = self.state.last_market_context_quality_score
-        last_domain_states = dict(self.state.last_market_context_domain_states)
-        last_risk_flags = list(self.state.last_market_context_risk_flags)
+        last_domain_states = {
+            key: str(value).strip().lower()
+            for key, value in active_market_context_mapping(
+                self.state.last_market_context_domain_states
+            ).items()
+        }
+        last_risk_flags = active_market_context_reasons(
+            self.state.last_market_context_risk_flags
+        )
         last_allow_llm = self.state.last_market_context_allow_llm
         last_reason = self.state.last_market_context_reason
         alert_active = self.state.market_context_alert_active
         alert_reason = self.state.market_context_alert_reason
+        if alert_active:
+            active_alert_reasons = active_market_context_reasons(
+                [alert_reason or "market_context_alert_active"]
+            )
+            if active_alert_reasons:
+                alert_reason = active_alert_reasons[0]
+            else:
+                alert_active = False
+                alert_reason = None
         probe_symbol = self._market_context_probe_symbol()
         fetch_symbol = last_symbol or probe_symbol
         if fetch_symbol:
@@ -260,13 +281,8 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
                     last_as_of = bundle.as_of_utc
                     last_freshness_seconds = int(bundle.freshness_seconds)
                     last_quality_score = float(bundle.quality_score)
-                    last_domain_states = {
-                        "technicals": bundle.domains.technicals.state,
-                        "fundamentals": bundle.domains.fundamentals.state,
-                        "news": bundle.domains.news.state,
-                        "regime": bundle.domains.regime.state,
-                    }
-                    last_risk_flags = list(bundle.risk_flags)
+                    last_domain_states = active_market_context_domain_states(bundle)
+                    last_risk_flags = active_market_context_reasons(bundle.risk_flags)
                     last_allow_llm = verdict.allow_llm
                     last_reason = verdict.reason
                     alert_active = not verdict.allow_llm
@@ -290,11 +306,8 @@ class TradingScheduler(TradingSchedulerGovernanceMixin):
         return {
             "required": settings.trading_market_context_required,
             "fail_mode": settings.trading_market_context_fail_mode,
-            "allow_degraded_last_good": settings.trading_market_context_allow_degraded_last_good,
             "min_quality": settings.trading_market_context_min_quality,
             "max_staleness_seconds": settings.trading_market_context_max_staleness_seconds,
-            "fundamentals_degraded_max_staleness_seconds": settings.trading_market_context_fundamentals_degraded_max_staleness_seconds,
-            "news_degraded_max_staleness_seconds": settings.trading_market_context_news_degraded_max_staleness_seconds,
             "last_symbol": last_symbol,
             "last_checked_at": last_checked_at,
             "last_as_of": last_as_of,

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -37,6 +37,10 @@ from .hypotheses import (
     resolve_hypothesis_dependency_quorum,
     summarize_hypothesis_runtime_statuses,
 )
+from .market_context_domains import (
+    active_market_context_mapping,
+    active_market_context_reasons,
+)
 from .discovery.profit_target_oracle import evaluate_profit_target_oracle
 from .profit_windows import build_profit_window_contract
 from .profit_leases import build_profit_lease_projection
@@ -1776,6 +1780,27 @@ def _refresh_runtime_summary_totals(
 
 
 def build_submission_gate_market_context_status(state: object) -> dict[str, object]:
+    last_domain_states = {
+        key: str(value).strip().lower()
+        for key, value in active_market_context_mapping(
+            cast(
+                Mapping[str, Any],
+                getattr(state, "last_market_context_domain_states", {}),
+            )
+        ).items()
+    }
+    last_risk_flags = active_market_context_reasons(
+        cast(Sequence[str], getattr(state, "last_market_context_risk_flags", []))
+    )
+    raw_alert_active = bool(getattr(state, "market_context_alert_active", False))
+    alert_reason = (
+        getattr(state, "market_context_alert_reason", None)
+        or "market_context_alert_active"
+        if raw_alert_active
+        else None
+    )
+    active_alert_reasons = active_market_context_reasons([alert_reason])
+    filtered_alert_reason = active_alert_reasons[0] if active_alert_reasons else None
     return {
         "last_symbol": getattr(state, "last_market_context_symbol", None),
         "last_checked_at": getattr(state, "last_market_context_checked_at", None),
@@ -1783,17 +1808,10 @@ def build_submission_gate_market_context_status(state: object) -> dict[str, obje
         "last_freshness_seconds": getattr(
             state, "last_market_context_freshness_seconds", None
         ),
-        "last_domain_states": dict(
-            cast(
-                Mapping[str, str],
-                getattr(state, "last_market_context_domain_states", {}),
-            )
-        ),
-        "last_risk_flags": list(
-            cast(Sequence[str], getattr(state, "last_market_context_risk_flags", []))
-        ),
-        "alert_active": bool(getattr(state, "market_context_alert_active", False)),
-        "alert_reason": getattr(state, "market_context_alert_reason", None),
+        "last_domain_states": last_domain_states,
+        "last_risk_flags": last_risk_flags,
+        "alert_active": raw_alert_active and filtered_alert_reason is not None,
+        "alert_reason": filtered_alert_reason,
     }
 
 
@@ -2288,16 +2306,22 @@ def _segment_summary(
 ) -> dict[str, dict[str, object]]:
     market_context_ref = build_submission_gate_market_context_status(state)
     domain_states = {
-        str(key): str(value).strip().lower()
-        for key, value in cast(
-            Mapping[str, Any], market_context_ref.get("last_domain_states", {})
+        key: str(value).strip().lower()
+        for key, value in active_market_context_mapping(
+            cast(Mapping[str, Any], market_context_ref.get("last_domain_states", {}))
         ).items()
-        if str(key).strip()
     }
     market_context_reasons: list[str] = []
     if bool(market_context_ref.get("alert_active")):
-        market_context_reasons.append(
-            str(market_context_ref.get("alert_reason") or "market_context_alert_active")
+        market_context_reasons.extend(
+            active_market_context_reasons(
+                [
+                    str(
+                        market_context_ref.get("alert_reason")
+                        or "market_context_alert_active"
+                    )
+                ]
+            )
         )
     stale_domains = [
         domain

--- a/services/torghut/tests/test_market_context.py
+++ b/services/torghut/tests/test_market_context.py
@@ -2,12 +2,65 @@ from __future__ import annotations
 
 import io
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
 
 from app import config
 from app.trading.llm.schema import MarketContextBundle
-from app.trading.market_context import MarketContextClient, evaluate_market_context
+from app.trading.market_context import (
+    _HttpRequest,
+    MarketContextClient,
+    evaluate_market_context,
+    urlopen,
+)
+from app.trading.market_context_domains import (
+    active_market_context_bundle_domains,
+    active_market_context_freshness_seconds,
+    active_market_context_quality_score,
+    active_market_context_reasons,
+    is_retired_market_context_reason,
+)
+
+
+class _MarketContextResponse:
+    def __init__(self, payload: bytes, *, status: object = 200) -> None:
+        self.status = status
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def __enter__(self) -> "_MarketContextResponse":
+        return self
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> bool:
+        return False
+
+
+class _FakeConnection:
+    last: "_FakeConnection | None" = None
+
+    def __init__(self, host: str, port: int | None = None, timeout: int = 1) -> None:
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.request_method: str | None = None
+        self.request_path: str | None = None
+        self.request_headers: dict[str, str] | None = None
+        self.closed = False
+        _FakeConnection.last = self
+
+    def request(self, method: str, path: str, *, headers: dict[str, str]) -> None:
+        self.request_method = method
+        self.request_path = path
+        self.request_headers = dict(headers)
+
+    def getresponse(self) -> _MarketContextResponse:
+        return _MarketContextResponse(b"{}", status="204")
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class TestMarketContextClient(TestCase):
@@ -16,15 +69,8 @@ class TestMarketContextClient(TestCase):
         self._original_timeout = config.settings.trading_market_context_timeout_seconds
         self._original_required = config.settings.trading_market_context_required
         self._original_min_quality = config.settings.trading_market_context_min_quality
-        self._original_max_staleness = config.settings.trading_market_context_max_staleness_seconds
-        self._original_allow_degraded_last_good = (
-            config.settings.trading_market_context_allow_degraded_last_good
-        )
-        self._original_fundamentals_degraded_max_staleness = (
-            config.settings.trading_market_context_fundamentals_degraded_max_staleness_seconds
-        )
-        self._original_news_degraded_max_staleness = (
-            config.settings.trading_market_context_news_degraded_max_staleness_seconds
+        self._original_max_staleness = (
+            config.settings.trading_market_context_max_staleness_seconds
         )
 
     def tearDown(self) -> None:
@@ -32,43 +78,134 @@ class TestMarketContextClient(TestCase):
         config.settings.trading_market_context_timeout_seconds = self._original_timeout
         config.settings.trading_market_context_required = self._original_required
         config.settings.trading_market_context_min_quality = self._original_min_quality
-        config.settings.trading_market_context_max_staleness_seconds = self._original_max_staleness
-        config.settings.trading_market_context_allow_degraded_last_good = (
-            self._original_allow_degraded_last_good
-        )
-        config.settings.trading_market_context_fundamentals_degraded_max_staleness_seconds = (
-            self._original_fundamentals_degraded_max_staleness
-        )
-        config.settings.trading_market_context_news_degraded_max_staleness_seconds = (
-            self._original_news_degraded_max_staleness
+        config.settings.trading_market_context_max_staleness_seconds = (
+            self._original_max_staleness
         )
 
+    def test_urlopen_validates_url_and_preserves_query(self) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError, "market_context_invalid_url_scheme:ftp"
+        ):
+            urlopen(
+                _HttpRequest(
+                    full_url="ftp://jangar.test/api/context",
+                    method="GET",
+                    headers={},
+                ),
+                timeout=1,
+            )
+
+        with self.assertRaisesRegex(RuntimeError, "market_context_invalid_url_host"):
+            urlopen(
+                _HttpRequest(
+                    full_url="http:///api/context",
+                    method="GET",
+                    headers={},
+                ),
+                timeout=1,
+            )
+
+        _FakeConnection.last = None
+        request = _HttpRequest(
+            full_url="http://jangar.test:8080/api/context?symbol=AAPL",
+            method="GET",
+            headers={"accept": "application/json"},
+        )
+        with patch("app.trading.market_context.HTTPConnection", _FakeConnection):
+            with urlopen(request, timeout=0) as response:
+                self.assertEqual(response.status, 204)
+                self.assertEqual(response.read(), b"{}")
+
+        connection = _FakeConnection.last
+        assert connection is not None
+        self.assertEqual(connection.host, "jangar.test")
+        self.assertEqual(connection.port, 8080)
+        self.assertEqual(connection.timeout, 1)
+        self.assertEqual(connection.request_method, "GET")
+        self.assertEqual(connection.request_path, "/api/context?symbol=AAPL")
+        self.assertEqual(connection.request_headers, {"accept": "application/json"})
+        self.assertTrue(connection.closed)
+
     def test_fetch_parses_bundle(self) -> None:
-        config.settings.trading_market_context_url = 'http://jangar.test/api/torghut/market-context'
+        config.settings.trading_market_context_url = (
+            "http://jangar.test/api/torghut/market-context"
+        )
         config.settings.trading_market_context_timeout_seconds = 2
 
         payload = io.BytesIO(
             b'{"ok":true,"context":{"contextVersion":"torghut.market-context.v1","symbol":"AAPL","asOfUtc":"2026-02-19T12:00:00Z","freshnessSeconds":10,"qualityScore":0.8,"sourceCount":1,"riskFlags":[],"domains":{"technicals":{"domain":"technicals","state":"ok","asOf":"2026-02-19T12:00:00Z","freshnessSeconds":10,"maxFreshnessSeconds":60,"sourceCount":1,"qualityScore":1,"payload":{"price":100},"citations":[],"riskFlags":[]},"fundamentals":{"domain":"fundamentals","state":"missing","asOf":null,"freshnessSeconds":null,"maxFreshnessSeconds":86400,"sourceCount":0,"qualityScore":0,"payload":{},"citations":[],"riskFlags":["fundamentals_missing"]},"news":{"domain":"news","state":"missing","asOf":null,"freshnessSeconds":null,"maxFreshnessSeconds":300,"sourceCount":0,"qualityScore":0,"payload":{},"citations":[],"riskFlags":["news_missing"]},"regime":{"domain":"regime","state":"ok","asOf":"2026-02-19T12:00:00Z","freshnessSeconds":10,"maxFreshnessSeconds":120,"sourceCount":1,"qualityScore":1,"payload":{"volatility":0.1},"citations":[],"riskFlags":[]}}}}'
         )
 
-        with patch('app.trading.market_context.urlopen', return_value=payload):
-            bundle = MarketContextClient().fetch('AAPL')
+        with patch("app.trading.market_context.urlopen", return_value=payload):
+            bundle = MarketContextClient().fetch("AAPL")
         self.assertIsNotNone(bundle)
-        self.assertEqual(bundle.symbol, 'AAPL')
-        self.assertEqual(bundle.context_version, 'torghut.market-context.v1')
+        self.assertEqual(bundle.symbol, "AAPL")
+        self.assertEqual(bundle.context_version, "torghut.market-context.v1")
+
+    def test_fetch_rejects_non_success_status(self) -> None:
+        config.settings.trading_market_context_url = (
+            "http://jangar.test/api/torghut/market-context"
+        )
+        config.settings.trading_market_context_timeout_seconds = 2
+
+        with patch(
+            "app.trading.market_context.urlopen",
+            return_value=_MarketContextResponse(b"{}", status=503),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "market_context_http_503"):
+                MarketContextClient().fetch("AAPL")
 
     def test_fetch_appends_as_of_timestamp(self) -> None:
-        config.settings.trading_market_context_url = 'http://jangar.test/api/torghut/market-context'
+        config.settings.trading_market_context_url = (
+            "http://jangar.test/api/torghut/market-context"
+        )
         config.settings.trading_market_context_timeout_seconds = 2
         payload = io.BytesIO(
             b'{"ok":true,"context":{"contextVersion":"torghut.market-context.v1","symbol":"AAPL","asOfUtc":"2026-02-19T12:00:00Z","freshnessSeconds":10,"qualityScore":0.8,"sourceCount":1,"riskFlags":[],"domains":{"technicals":{"domain":"technicals","state":"ok","asOf":"2026-02-19T12:00:00Z","freshnessSeconds":10,"maxFreshnessSeconds":60,"sourceCount":1,"qualityScore":1,"payload":{"price":100},"citations":[],"riskFlags":[]},"fundamentals":{"domain":"fundamentals","state":"missing","asOf":null,"freshnessSeconds":null,"maxFreshnessSeconds":86400,"sourceCount":0,"qualityScore":0,"payload":{},"citations":[],"riskFlags":["fundamentals_missing"]},"news":{"domain":"news","state":"missing","asOf":null,"freshnessSeconds":null,"maxFreshnessSeconds":300,"sourceCount":0,"qualityScore":0,"payload":{},"citations":[],"riskFlags":["news_missing"]},"regime":{"domain":"regime","state":"ok","asOf":"2026-02-19T12:00:00Z","freshnessSeconds":10,"maxFreshnessSeconds":120,"sourceCount":1,"qualityScore":1,"payload":{"volatility":0.1},"citations":[],"riskFlags":[]}}}}'
         )
 
         as_of = datetime(2026, 3, 6, 18, 15, tzinfo=timezone.utc)
-        with patch('app.trading.market_context.urlopen', return_value=payload) as mock_urlopen:
-            MarketContextClient().fetch('AAPL', as_of=as_of)
+        with patch(
+            "app.trading.market_context.urlopen", return_value=payload
+        ) as mock_urlopen:
+            MarketContextClient().fetch("AAPL", as_of=as_of)
         request = mock_urlopen.call_args.args[0]
-        self.assertIn('asOf=2026-03-06T18%3A15%3A00%2B00%3A00', request.full_url)
+        self.assertIn("asOf=2026-03-06T18%3A15%3A00%2B00%3A00", request.full_url)
+
+    def test_fetch_health_appends_as_of_timestamp(self) -> None:
+        config.settings.trading_market_context_url = (
+            "http://jangar.test/api/torghut/market-context"
+        )
+        config.settings.trading_market_context_timeout_seconds = 2
+        payload = _MarketContextResponse(
+            b'{"ok":true,"health":{"overallState":"ok","activeDomains":["technicals","regime"]}}'
+        )
+
+        as_of = datetime(2026, 3, 6, 18, 15, tzinfo=timezone.utc)
+        with patch(
+            "app.trading.market_context.urlopen", return_value=payload
+        ) as mock_urlopen:
+            health = MarketContextClient().fetch_health("aapl", as_of=as_of)
+
+        self.assertEqual(
+            health, {"overallState": "ok", "activeDomains": ["technicals", "regime"]}
+        )
+        request = mock_urlopen.call_args.args[0]
+        self.assertIn("/market-context/health?symbol=aapl", request.full_url)
+        self.assertIn("asOf=2026-03-06T18%3A15%3A00%2B00%3A00", request.full_url)
+
+    def test_active_market_context_helpers_ignore_retired_edges(self) -> None:
+        self.assertFalse(is_retired_market_context_reason(" "))
+        self.assertEqual(active_market_context_reasons("news-stale"), [])
+        self.assertEqual(
+            active_market_context_reasons("regime_stale"), ["regime_stale"]
+        )
+        self.assertEqual(active_market_context_reasons(object()), [])
+
+        fallback_bundle = SimpleNamespace(freshness_seconds=77, quality_score=0.42)
+        self.assertEqual(active_market_context_bundle_domains(fallback_bundle), {})
+        self.assertEqual(active_market_context_freshness_seconds(fallback_bundle), 77)
+        self.assertEqual(active_market_context_quality_score(fallback_bundle), 0.42)
 
     def test_evaluate_blocks_low_quality_or_stale(self) -> None:
         config.settings.trading_market_context_required = True
@@ -77,73 +214,73 @@ class TestMarketContextClient(TestCase):
 
         status_missing = evaluate_market_context(None)
         self.assertFalse(status_missing.allow_llm)
-        self.assertEqual(status_missing.reason, 'market_context_required_missing')
+        self.assertEqual(status_missing.reason, "market_context_required_missing")
 
         bundle = MarketContextBundle.model_validate(
             {
-                'contextVersion': 'torghut.market-context.v1',
-                'symbol': 'AAPL',
-                'asOfUtc': '2026-02-19T12:00:00Z',
-                'freshnessSeconds': 45,
-                'qualityScore': 0.4,
-                'sourceCount': 1,
-                'riskFlags': [],
-                'domains': {
-                    'technicals': {
-                        'domain': 'technicals',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T12:00:00Z',
-                        'freshnessSeconds': 45,
-                        'maxFreshnessSeconds': 60,
-                        'sourceCount': 1,
-                        'qualityScore': 1,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                "contextVersion": "torghut.market-context.v1",
+                "symbol": "AAPL",
+                "asOfUtc": "2026-02-19T12:00:00Z",
+                "freshnessSeconds": 45,
+                "qualityScore": 0.4,
+                "sourceCount": 1,
+                "riskFlags": [],
+                "domains": {
+                    "technicals": {
+                        "domain": "technicals",
+                        "state": "ok",
+                        "asOf": "2026-02-19T12:00:00Z",
+                        "freshnessSeconds": 45,
+                        "maxFreshnessSeconds": 60,
+                        "sourceCount": 1,
+                        "qualityScore": 0.4,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
-                    'fundamentals': {
-                        'domain': 'fundamentals',
-                        'state': 'missing',
-                        'asOf': None,
-                        'freshnessSeconds': None,
-                        'maxFreshnessSeconds': 86400,
-                        'sourceCount': 0,
-                        'qualityScore': 0,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': ['fundamentals_missing'],
+                    "fundamentals": {
+                        "domain": "fundamentals",
+                        "state": "missing",
+                        "asOf": None,
+                        "freshnessSeconds": None,
+                        "maxFreshnessSeconds": 86400,
+                        "sourceCount": 0,
+                        "qualityScore": 0,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": ["fundamentals_missing"],
                     },
-                    'news': {
-                        'domain': 'news',
-                        'state': 'missing',
-                        'asOf': None,
-                        'freshnessSeconds': None,
-                        'maxFreshnessSeconds': 300,
-                        'sourceCount': 0,
-                        'qualityScore': 0,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': ['news_missing'],
+                    "news": {
+                        "domain": "news",
+                        "state": "missing",
+                        "asOf": None,
+                        "freshnessSeconds": None,
+                        "maxFreshnessSeconds": 300,
+                        "sourceCount": 0,
+                        "qualityScore": 0,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": ["news_missing"],
                     },
-                    'regime': {
-                        'domain': 'regime',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T12:00:00Z',
-                        'freshnessSeconds': 45,
-                        'maxFreshnessSeconds': 120,
-                        'sourceCount': 1,
-                        'qualityScore': 1,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                    "regime": {
+                        "domain": "regime",
+                        "state": "ok",
+                        "asOf": "2026-02-19T12:00:00Z",
+                        "freshnessSeconds": 45,
+                        "maxFreshnessSeconds": 120,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
                 },
             }
         )
         status = evaluate_market_context(bundle)
         self.assertFalse(status.allow_llm)
-        self.assertIn('market_context_stale', status.risk_flags)
-        self.assertIn('market_context_quality_low', status.risk_flags)
+        self.assertIn("market_context_stale", status.risk_flags)
+        self.assertIn("market_context_quality_low", status.risk_flags)
 
     def test_evaluate_allows_informational_risk_flags(self) -> None:
         config.settings.trading_market_context_required = True
@@ -152,61 +289,61 @@ class TestMarketContextClient(TestCase):
 
         bundle = MarketContextBundle.model_validate(
             {
-                'contextVersion': 'torghut.market-context.v1',
-                'symbol': 'AAPL',
-                'asOfUtc': '2026-02-19T12:00:00Z',
-                'freshnessSeconds': 10,
-                'qualityScore': 0.9,
-                'sourceCount': 1,
-                'riskFlags': ['fundamentals_missing', 'news_missing'],
-                'domains': {
-                    'technicals': {
-                        'domain': 'technicals',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T12:00:00Z',
-                        'freshnessSeconds': 10,
-                        'maxFreshnessSeconds': 60,
-                        'sourceCount': 1,
-                        'qualityScore': 1,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                "contextVersion": "torghut.market-context.v1",
+                "symbol": "AAPL",
+                "asOfUtc": "2026-02-19T12:00:00Z",
+                "freshnessSeconds": 10,
+                "qualityScore": 0.9,
+                "sourceCount": 1,
+                "riskFlags": ["fundamentals_missing", "news_missing"],
+                "domains": {
+                    "technicals": {
+                        "domain": "technicals",
+                        "state": "ok",
+                        "asOf": "2026-02-19T12:00:00Z",
+                        "freshnessSeconds": 10,
+                        "maxFreshnessSeconds": 60,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
-                    'fundamentals': {
-                        'domain': 'fundamentals',
-                        'state': 'missing',
-                        'asOf': None,
-                        'freshnessSeconds': None,
-                        'maxFreshnessSeconds': 86400,
-                        'sourceCount': 0,
-                        'qualityScore': 0,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': ['fundamentals_missing'],
+                    "fundamentals": {
+                        "domain": "fundamentals",
+                        "state": "missing",
+                        "asOf": None,
+                        "freshnessSeconds": None,
+                        "maxFreshnessSeconds": 86400,
+                        "sourceCount": 0,
+                        "qualityScore": 0,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": ["fundamentals_missing"],
                     },
-                    'news': {
-                        'domain': 'news',
-                        'state': 'missing',
-                        'asOf': None,
-                        'freshnessSeconds': None,
-                        'maxFreshnessSeconds': 300,
-                        'sourceCount': 0,
-                        'qualityScore': 0,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': ['news_missing'],
+                    "news": {
+                        "domain": "news",
+                        "state": "missing",
+                        "asOf": None,
+                        "freshnessSeconds": None,
+                        "maxFreshnessSeconds": 300,
+                        "sourceCount": 0,
+                        "qualityScore": 0,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": ["news_missing"],
                     },
-                    'regime': {
-                        'domain': 'regime',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T12:00:00Z',
-                        'freshnessSeconds': 10,
-                        'maxFreshnessSeconds': 120,
-                        'sourceCount': 1,
-                        'qualityScore': 1,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                    "regime": {
+                        "domain": "regime",
+                        "state": "ok",
+                        "asOf": "2026-02-19T12:00:00Z",
+                        "freshnessSeconds": 10,
+                        "maxFreshnessSeconds": 120,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
                 },
             }
@@ -214,79 +351,80 @@ class TestMarketContextClient(TestCase):
         status = evaluate_market_context(bundle)
         self.assertTrue(status.allow_llm)
         self.assertIsNone(status.reason)
-        self.assertIn('fundamentals_missing', status.risk_flags)
-        self.assertIn('news_missing', status.risk_flags)
+        self.assertNotIn("fundamentals_missing", status.risk_flags)
+        self.assertNotIn("news_missing", status.risk_flags)
 
-    def test_evaluate_blocks_domain_error_states(self) -> None:
+    def test_evaluate_ignores_retired_domain_error_states(self) -> None:
         config.settings.trading_market_context_required = False
         config.settings.trading_market_context_min_quality = 0.2
         config.settings.trading_market_context_max_staleness_seconds = 300
 
         bundle = MarketContextBundle.model_validate(
             {
-                'contextVersion': 'torghut.market-context.v1',
-                'symbol': 'AAPL',
-                'asOfUtc': '2026-02-19T12:00:00Z',
-                'freshnessSeconds': 20,
-                'qualityScore': 0.8,
-                'sourceCount': 2,
-                'riskFlags': ['news_error'],
-                'domains': {
-                    'technicals': {
-                        'domain': 'technicals',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T12:00:00Z',
-                        'freshnessSeconds': 20,
-                        'maxFreshnessSeconds': 60,
-                        'sourceCount': 1,
-                        'qualityScore': 1,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                "contextVersion": "torghut.market-context.v1",
+                "symbol": "AAPL",
+                "asOfUtc": "2026-02-19T12:00:00Z",
+                "freshnessSeconds": 20,
+                "qualityScore": 0.8,
+                "sourceCount": 2,
+                "riskFlags": ["news_error"],
+                "domains": {
+                    "technicals": {
+                        "domain": "technicals",
+                        "state": "ok",
+                        "asOf": "2026-02-19T12:00:00Z",
+                        "freshnessSeconds": 20,
+                        "maxFreshnessSeconds": 60,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
-                    'fundamentals': {
-                        'domain': 'fundamentals',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T11:00:00Z',
-                        'freshnessSeconds': 3600,
-                        'maxFreshnessSeconds': 86400,
-                        'sourceCount': 1,
-                        'qualityScore': 1,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                    "fundamentals": {
+                        "domain": "fundamentals",
+                        "state": "ok",
+                        "asOf": "2026-02-19T11:00:00Z",
+                        "freshnessSeconds": 3600,
+                        "maxFreshnessSeconds": 86400,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
-                    'news': {
-                        'domain': 'news',
-                        'state': 'error',
-                        'asOf': None,
-                        'freshnessSeconds': None,
-                        'maxFreshnessSeconds': 300,
-                        'sourceCount': 0,
-                        'qualityScore': 0,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': ['news_error'],
+                    "news": {
+                        "domain": "news",
+                        "state": "error",
+                        "asOf": None,
+                        "freshnessSeconds": None,
+                        "maxFreshnessSeconds": 300,
+                        "sourceCount": 0,
+                        "qualityScore": 0,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": ["news_error"],
                     },
-                    'regime': {
-                        'domain': 'regime',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T12:00:00Z',
-                        'freshnessSeconds': 20,
-                        'maxFreshnessSeconds': 120,
-                        'sourceCount': 1,
-                        'qualityScore': 1,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                    "regime": {
+                        "domain": "regime",
+                        "state": "ok",
+                        "asOf": "2026-02-19T12:00:00Z",
+                        "freshnessSeconds": 20,
+                        "maxFreshnessSeconds": 120,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
                 },
             }
         )
         status = evaluate_market_context(bundle)
-        self.assertFalse(status.allow_llm)
-        self.assertEqual(status.reason, 'market_context_domain_error')
-        self.assertIn('news_error', status.risk_flags)
+        self.assertTrue(status.allow_llm)
+        self.assertIsNone(status.reason)
+        self.assertNotIn("news_error", status.risk_flags)
+        self.assertNotIn("market_context_domain_error", status.risk_flags)
 
     def test_evaluate_prioritizes_domain_error_reason_over_staleness(self) -> None:
         config.settings.trading_market_context_required = True
@@ -295,144 +433,142 @@ class TestMarketContextClient(TestCase):
 
         bundle = MarketContextBundle.model_validate(
             {
-                'contextVersion': 'torghut.market-context.v1',
-                'symbol': 'MSFT',
-                'asOfUtc': '2026-02-19T12:00:00Z',
-                'freshnessSeconds': 120,
-                'qualityScore': 0.8,
-                'sourceCount': 2,
-                'riskFlags': ['technicals_source_error'],
-                'domains': {
-                    'technicals': {
-                        'domain': 'technicals',
-                        'state': 'error',
-                        'asOf': None,
-                        'freshnessSeconds': None,
-                        'maxFreshnessSeconds': 60,
-                        'sourceCount': 0,
-                        'qualityScore': 0,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': ['technicals_source_error'],
+                "contextVersion": "torghut.market-context.v1",
+                "symbol": "MSFT",
+                "asOfUtc": "2026-02-19T12:00:00Z",
+                "freshnessSeconds": 120,
+                "qualityScore": 0.8,
+                "sourceCount": 2,
+                "riskFlags": ["technicals_source_error"],
+                "domains": {
+                    "technicals": {
+                        "domain": "technicals",
+                        "state": "error",
+                        "asOf": None,
+                        "freshnessSeconds": None,
+                        "maxFreshnessSeconds": 60,
+                        "sourceCount": 0,
+                        "qualityScore": 0,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": ["technicals_source_error"],
                     },
-                    'fundamentals': {
-                        'domain': 'fundamentals',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T11:00:00Z',
-                        'freshnessSeconds': 3600,
-                        'maxFreshnessSeconds': 86400,
-                        'sourceCount': 1,
-                        'qualityScore': 1,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                    "fundamentals": {
+                        "domain": "fundamentals",
+                        "state": "ok",
+                        "asOf": "2026-02-19T11:00:00Z",
+                        "freshnessSeconds": 3600,
+                        "maxFreshnessSeconds": 86400,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
-                    'news': {
-                        'domain': 'news',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T11:59:00Z',
-                        'freshnessSeconds': 60,
-                        'maxFreshnessSeconds': 300,
-                        'sourceCount': 1,
-                        'qualityScore': 1,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                    "news": {
+                        "domain": "news",
+                        "state": "ok",
+                        "asOf": "2026-02-19T11:59:00Z",
+                        "freshnessSeconds": 60,
+                        "maxFreshnessSeconds": 300,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
-                    'regime': {
-                        'domain': 'regime',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T12:00:00Z',
-                        'freshnessSeconds': 0,
-                        'maxFreshnessSeconds': 120,
-                        'sourceCount': 1,
-                        'qualityScore': 1,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                    "regime": {
+                        "domain": "regime",
+                        "state": "ok",
+                        "asOf": "2026-02-19T12:00:00Z",
+                        "freshnessSeconds": 120,
+                        "maxFreshnessSeconds": 120,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
                 },
             }
         )
         status = evaluate_market_context(bundle)
         self.assertFalse(status.allow_llm)
-        self.assertEqual(status.reason, 'market_context_domain_error')
-        self.assertIn('market_context_stale', status.risk_flags)
+        self.assertEqual(status.reason, "market_context_domain_error")
+        self.assertIn("market_context_stale", status.risk_flags)
 
-    def test_evaluate_allows_degraded_last_good_within_hard_caps(self) -> None:
+    def test_evaluate_uses_active_domains_for_staleness_and_quality(self) -> None:
         config.settings.trading_market_context_required = True
         config.settings.trading_market_context_min_quality = 0.8
         config.settings.trading_market_context_max_staleness_seconds = 60
-        config.settings.trading_market_context_allow_degraded_last_good = True
-        config.settings.trading_market_context_news_degraded_max_staleness_seconds = 1800
 
         bundle = MarketContextBundle.model_validate(
             {
-                'contextVersion': 'torghut.market-context.v1',
-                'symbol': 'AAPL',
-                'asOfUtc': '2026-02-19T12:00:00Z',
-                'freshnessSeconds': 120,
-                'qualityScore': 0.55,
-                'sourceCount': 4,
-                'riskFlags': [
-                    'market_context_degraded_last_good',
-                    'news_generation_failed_all_models',
+                "contextVersion": "torghut.market-context.v1",
+                "symbol": "AAPL",
+                "asOfUtc": "2026-02-19T12:00:00Z",
+                "freshnessSeconds": 120,
+                "qualityScore": 0.55,
+                "sourceCount": 4,
+                "riskFlags": [
+                    "market_context_degraded_last_good",
+                    "news_generation_failed_all_models",
                 ],
-                'domains': {
-                    'technicals': {
-                        'domain': 'technicals',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T12:00:00Z',
-                        'freshnessSeconds': 15,
-                        'maxFreshnessSeconds': 60,
-                        'sourceCount': 1,
-                        'qualityScore': 1,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                "domains": {
+                    "technicals": {
+                        "domain": "technicals",
+                        "state": "ok",
+                        "asOf": "2026-02-19T12:00:00Z",
+                        "freshnessSeconds": 15,
+                        "maxFreshnessSeconds": 60,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
-                    'fundamentals': {
-                        'domain': 'fundamentals',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T11:00:00Z',
-                        'freshnessSeconds': 3600,
-                        'maxFreshnessSeconds': 86400,
-                        'sourceCount': 1,
-                        'qualityScore': 0.9,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                    "fundamentals": {
+                        "domain": "fundamentals",
+                        "state": "ok",
+                        "asOf": "2026-02-19T11:00:00Z",
+                        "freshnessSeconds": 3600,
+                        "maxFreshnessSeconds": 86400,
+                        "sourceCount": 1,
+                        "qualityScore": 0.9,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
-                    'news': {
-                        'domain': 'news',
-                        'state': 'stale',
-                        'asOf': '2026-02-19T11:40:00Z',
-                        'freshnessSeconds': 1200,
-                        'maxFreshnessSeconds': 300,
-                        'sourceCount': 2,
-                        'qualityScore': 0.3,
-                        'payload': {
-                            'generationFailed': True,
-                            'lastSuccessfulAsOfUtc': '2026-02-19T11:40:00Z',
+                    "news": {
+                        "domain": "news",
+                        "state": "stale",
+                        "asOf": "2026-02-19T11:40:00Z",
+                        "freshnessSeconds": 1200,
+                        "maxFreshnessSeconds": 300,
+                        "sourceCount": 2,
+                        "qualityScore": 0.3,
+                        "payload": {
+                            "generationFailed": True,
+                            "lastSuccessfulAsOfUtc": "2026-02-19T11:40:00Z",
                         },
-                        'citations': [],
-                        'riskFlags': [
-                            'news_stale',
-                            'news_generation_failed_all_models',
-                            'market_context_degraded_last_good',
+                        "citations": [],
+                        "riskFlags": [
+                            "news_stale",
+                            "news_generation_failed_all_models",
+                            "market_context_degraded_last_good",
                         ],
                     },
-                    'regime': {
-                        'domain': 'regime',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T12:00:00Z',
-                        'freshnessSeconds': 15,
-                        'maxFreshnessSeconds': 120,
-                        'sourceCount': 1,
-                        'qualityScore': 1,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                    "regime": {
+                        "domain": "regime",
+                        "state": "ok",
+                        "asOf": "2026-02-19T12:00:00Z",
+                        "freshnessSeconds": 15,
+                        "maxFreshnessSeconds": 120,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
                 },
             }
@@ -441,79 +577,77 @@ class TestMarketContextClient(TestCase):
         status = evaluate_market_context(bundle)
         self.assertTrue(status.allow_llm)
         self.assertIsNone(status.reason)
-        self.assertIn('market_context_degraded_last_good', status.risk_flags)
+        self.assertIn("market_context_degraded_last_good", status.risk_flags)
 
-    def test_evaluate_blocks_degraded_last_good_when_news_hard_cap_exceeded(self) -> None:
+    def test_evaluate_blocks_stale_active_domain(self) -> None:
         config.settings.trading_market_context_required = True
         config.settings.trading_market_context_min_quality = 0.8
         config.settings.trading_market_context_max_staleness_seconds = 60
-        config.settings.trading_market_context_allow_degraded_last_good = True
-        config.settings.trading_market_context_news_degraded_max_staleness_seconds = 900
 
         bundle = MarketContextBundle.model_validate(
             {
-                'contextVersion': 'torghut.market-context.v1',
-                'symbol': 'AAPL',
-                'asOfUtc': '2026-02-19T12:00:00Z',
-                'freshnessSeconds': 120,
-                'qualityScore': 0.55,
-                'sourceCount': 4,
-                'riskFlags': [
-                    'market_context_degraded_last_good',
-                    'news_generation_failed_all_models',
+                "contextVersion": "torghut.market-context.v1",
+                "symbol": "AAPL",
+                "asOfUtc": "2026-02-19T12:00:00Z",
+                "freshnessSeconds": 120,
+                "qualityScore": 0.55,
+                "sourceCount": 4,
+                "riskFlags": [
+                    "market_context_degraded_last_good",
+                    "news_generation_failed_all_models",
                 ],
-                'domains': {
-                    'technicals': {
-                        'domain': 'technicals',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T12:00:00Z',
-                        'freshnessSeconds': 15,
-                        'maxFreshnessSeconds': 60,
-                        'sourceCount': 1,
-                        'qualityScore': 1,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                "domains": {
+                    "technicals": {
+                        "domain": "technicals",
+                        "state": "ok",
+                        "asOf": "2026-02-19T12:00:00Z",
+                        "freshnessSeconds": 15,
+                        "maxFreshnessSeconds": 60,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
-                    'fundamentals': {
-                        'domain': 'fundamentals',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T11:00:00Z',
-                        'freshnessSeconds': 3600,
-                        'maxFreshnessSeconds': 86400,
-                        'sourceCount': 1,
-                        'qualityScore': 0.9,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                    "fundamentals": {
+                        "domain": "fundamentals",
+                        "state": "ok",
+                        "asOf": "2026-02-19T11:00:00Z",
+                        "freshnessSeconds": 3600,
+                        "maxFreshnessSeconds": 86400,
+                        "sourceCount": 1,
+                        "qualityScore": 0.9,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
-                    'news': {
-                        'domain': 'news',
-                        'state': 'stale',
-                        'asOf': '2026-02-19T11:40:00Z',
-                        'freshnessSeconds': 1200,
-                        'maxFreshnessSeconds': 300,
-                        'sourceCount': 2,
-                        'qualityScore': 0.3,
-                        'payload': {'generationFailed': True},
-                        'citations': [],
-                        'riskFlags': [
-                            'news_stale',
-                            'news_generation_failed_all_models',
-                            'market_context_degraded_last_good',
+                    "news": {
+                        "domain": "news",
+                        "state": "stale",
+                        "asOf": "2026-02-19T11:40:00Z",
+                        "freshnessSeconds": 1200,
+                        "maxFreshnessSeconds": 300,
+                        "sourceCount": 2,
+                        "qualityScore": 0.3,
+                        "payload": {"generationFailed": True},
+                        "citations": [],
+                        "riskFlags": [
+                            "news_stale",
+                            "news_generation_failed_all_models",
+                            "market_context_degraded_last_good",
                         ],
                     },
-                    'regime': {
-                        'domain': 'regime',
-                        'state': 'ok',
-                        'asOf': '2026-02-19T12:00:00Z',
-                        'freshnessSeconds': 15,
-                        'maxFreshnessSeconds': 120,
-                        'sourceCount': 1,
-                        'qualityScore': 1,
-                        'payload': {},
-                        'citations': [],
-                        'riskFlags': [],
+                    "regime": {
+                        "domain": "regime",
+                        "state": "ok",
+                        "asOf": "2026-02-19T11:58:00Z",
+                        "freshnessSeconds": 120,
+                        "maxFreshnessSeconds": 120,
+                        "sourceCount": 1,
+                        "qualityScore": 1,
+                        "payload": {},
+                        "citations": [],
+                        "riskFlags": [],
                     },
                 },
             }
@@ -521,4 +655,4 @@ class TestMarketContextClient(TestCase):
 
         status = evaluate_market_context(bundle)
         self.assertFalse(status.allow_llm)
-        self.assertEqual(status.reason, 'market_context_stale')
+        self.assertEqual(status.reason, "market_context_stale")

--- a/services/torghut/tests/test_profit_freshness_frontier.py
+++ b/services/torghut/tests/test_profit_freshness_frontier.py
@@ -434,7 +434,8 @@ def test_stale_market_context_and_empirical_jobs_are_explicit_dimensions() -> No
 
     assert market["state"] == "stale"
     assert "market_context_technicals_stale" in market["reason_codes"]
-    assert "market_context:news" in market["evidence_refs"]
+    assert "market_context:regime" in market["evidence_refs"]
+    assert "market_context:news" not in market["evidence_refs"]
     assert empirical["state"] == "stale"
     assert "empirical_job_stale:benchmark_parity" in empirical["reason_codes"]
     assert "dataset-nvda" in empirical["evidence_refs"]

--- a/services/torghut/tests/test_profit_signal_quorum.py
+++ b/services/torghut/tests/test_profit_signal_quorum.py
@@ -151,7 +151,7 @@ def test_degraded_inputs_emit_scoped_repair_reasons_without_capital():
             ],
         )
     )
-    expected = "quant_health_fetch_failed quant_status_degraded quant_latest_metrics_empty quant_latest_metrics_degraded pipeline_ingestion_alarm quant_pipeline_stage_ingestion_degraded quant_pipeline_stage_ingestion_stale market_context_snapshot_stale market_context_domain_news_stale route_tca_blocked execution_tca_slippage_above_guardrail".split()
+    expected = "quant_health_fetch_failed quant_status_degraded quant_latest_metrics_empty quant_latest_metrics_degraded pipeline_ingestion_alarm quant_pipeline_stage_ingestion_degraded quant_pipeline_stage_ingestion_stale market_context_snapshot_stale route_tca_blocked execution_tca_slippage_above_guardrail".split()
 
     assert quorum["decision"] == "repair_only"
     assert set(expected) <= set(quorum["reason_codes"])

--- a/services/torghut/tests/test_quality_adjusted_profit_frontier.py
+++ b/services/torghut/tests/test_quality_adjusted_profit_frontier.py
@@ -107,9 +107,10 @@ def _packet(frontier: Mapping[str, object], repair_class: str) -> Mapping[str, A
         (
             "market_context_status",
             {
-                "stale_fundamentals_count": 9,
-                "stale_news_count": 15,
+                "stale_technicals_count": 9,
+                "stale_regime_count": 15,
                 "risk_flag_count": 25,
+                "risk_flags": ["technicals_source_error"],
             },
             "market_context",
             {"market_context_stale", "market_context_risk_flags"},

--- a/services/torghut/tests/test_routeability_repair_acceptance.py
+++ b/services/torghut/tests/test_routeability_repair_acceptance.py
@@ -212,7 +212,7 @@ def test_stale_market_context_domains_keep_acceptance_unsettled() -> None:
 
     assert market_lot["current_state"] == "stale"
     assert "market_context_technicals_stale" in market_lot["blocking_reason_codes"]
-    assert "market_context_news_stale" in market_lot["blocking_reason_codes"]
+    assert "market_context_news_stale" not in market_lot["blocking_reason_codes"]
     assert "market_context_regime_stale" in market_lot["blocking_reason_codes"]
 
 
@@ -412,7 +412,9 @@ def test_blocked_autoresearch_portfolios_keep_promotion_repair_unsettled() -> No
 
     assert ledger["accepted_routeable_candidate_count"] == 0
     assert promotion_lot["current_state"] == "missing"
-    assert "autoresearch_portfolio_ready_empty" in promotion_lot["blocking_reason_codes"]
+    assert (
+        "autoresearch_portfolio_ready_empty" in promotion_lot["blocking_reason_codes"]
+    )
     assert (
         "autoresearch_portfolio_candidates_blocked"
         in promotion_lot["blocking_reason_codes"]

--- a/services/torghut/tests/test_scheduler_market_context_status.py
+++ b/services/torghut/tests/test_scheduler_market_context_status.py
@@ -184,8 +184,6 @@ class TestTradingSchedulerMarketContextStatus(TestCase):
             status["last_domain_states"],
             {
                 "technicals": "ok",
-                "fundamentals": "ok",
-                "news": "ok",
                 "regime": "ok",
             },
         )
@@ -292,12 +290,14 @@ class TestTradingSchedulerMarketContextStatus(TestCase):
         scheduler.state.last_market_context_domain_states = {
             "technicals": "ok",
             "fundamentals": "ok",
-            "news": "stale",
-            "regime": "ok",
+            "news": "ok",
+            "regime": "stale",
         }
-        scheduler.state.last_market_context_risk_flags = ["news_stale"]
+        scheduler.state.last_market_context_risk_flags = ["regime_stale"]
         scheduler.state.market_context_alert_active = True
-        scheduler.state.market_context_alert_reason = "market_context_domain_news_stale"
+        scheduler.state.market_context_alert_reason = (
+            "market_context_domain_regime_stale"
+        )
 
         with patch("app.trading.market_context.urlopen", side_effect=fake_urlopen):
             status = scheduler.market_context_status()
@@ -310,14 +310,25 @@ class TestTradingSchedulerMarketContextStatus(TestCase):
             status["last_domain_states"],
             {
                 "technicals": "ok",
-                "fundamentals": "ok",
-                "news": "ok",
                 "regime": "ok",
             },
         )
         self.assertFalse(status["alert_active"])
         self.assertFalse(scheduler.state.market_context_alert_active)
         self.assertIsNone(scheduler.state.market_context_alert_reason)
+
+    def test_status_clears_retired_market_context_alert_reason(self) -> None:
+        config.settings.trading_market_context_url = ""
+        config.settings.trading_static_symbols_raw = ""
+
+        scheduler = TradingScheduler()
+        scheduler.state.market_context_alert_active = True
+        scheduler.state.market_context_alert_reason = "market_context_domain_news_stale"
+
+        status = scheduler.market_context_status()
+
+        self.assertFalse(status["alert_active"])
+        self.assertIsNone(status["alert_reason"])
 
     def test_status_records_context_fetch_error(self) -> None:
         config.settings.trading_market_context_url = (

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -2490,7 +2490,7 @@ class TestTradingPipeline(TestCase):
         last_domain_states = cast(
             dict[str, str], captured_market_context["last_domain_states"]
         )
-        self.assertEqual(last_domain_states["news"], "ok")
+        self.assertEqual(last_domain_states, {"technicals": "ok", "regime": "ok"})
         self.assertEqual(receipt["floor_state"], "paper_ready")
         proof_dimensions = cast(list[dict[str, object]], receipt["proof_dimensions"])
         dimensions = {cast(str, item["dimension"]): item for item in proof_dimensions}


### PR DESCRIPTION
## Summary

- Retires Torghut Python service blockers tied to the removed `fundamentals` and `news` market-context domains.
- Adds a shared active-domain policy so market-context gates evaluate only `technicals` and `regime` while still parsing old bundle shape.
- Filters retired-domain risk flags/reasons out of scheduler status, submission gates, freshness ledgers, profit frontiers, routeability repair projections, and the feature-flag manifest.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen ruff check app/trading/market_context.py app/trading/market_context_domains.py app/trading/scheduler/runtime.py app/trading/scheduler/pipeline.py app/trading/profit_signal_quorum.py app/trading/quality_adjusted_profit_frontier.py app/trading/routeability_repair_acceptance.py app/trading/submission_council.py app/trading/profit_windows.py app/trading/freshness_carry.py app/trading/profit_freshness_frontier.py scripts/flatten_paper_account_positions.py tests/test_market_context.py tests/test_scheduler_market_context_status.py tests/test_profit_signal_quorum.py tests/test_quality_adjusted_profit_frontier.py tests/test_routeability_repair_acceptance.py tests/test_trading_pipeline.py tests/test_submission_council.py tests/test_profit_windows.py tests/test_freshness_carry.py tests/test_profit_freshness_frontier.py tests/test_trading_api.py tests/test_flatten_paper_account_positions.py`
- `uv run --frozen ruff format --check tests/test_market_context.py tests/test_scheduler_market_context_status.py`
- `uv run --frozen pytest tests/test_market_context.py tests/test_scheduler_market_context_status.py tests/test_profit_signal_quorum.py tests/test_quality_adjusted_profit_frontier.py tests/test_routeability_repair_acceptance.py tests/test_trading_pipeline.py tests/test_submission_council.py tests/test_profit_windows.py tests/test_freshness_carry.py tests/test_profit_freshness_frontier.py tests/test_trading_api.py tests/test_flatten_paper_account_positions.py -q`
- `uv run --frozen pytest tests/test_config.py::TestConfig::test_torghut_feature_flag_manifest_matches_config_mapping tests/test_market_context.py tests/test_scheduler_market_context_status.py -q`
- `uv run --frozen pytest tests/test_market_context.py tests/test_scheduler_market_context_status.py tests/test_profit_signal_quorum.py tests/test_quality_adjusted_profit_frontier.py tests/test_routeability_repair_acceptance.py tests/test_trading_pipeline.py tests/test_submission_council.py tests/test_profit_windows.py tests/test_freshness_carry.py tests/test_profit_freshness_frontier.py tests/test_trading_api.py tests/test_flatten_paper_account_positions.py --cov --cov-branch --cov-report=xml:coverage.xml --cov-report=term -q` (tests passed and wrote `coverage.xml`; command exits nonzero locally because the intentionally narrow slice is below repo-wide total coverage)
- `uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None. Torghut still parses legacy market-context bundles that contain `fundamentals` and `news`; those retired domains no longer create blockers or proof-debt reasons.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
