### PR TITLE
chore(torghut): promote image 8cd7578a

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.580.9-89-g0fdeb46e7
+              value: v0.580.11-1-g8cd7578a3
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 0fdeb46e7e3fc164ca16c52a4bcd9f9c06ed0088
+              value: 8cd7578a33af9bb1096cc79ce792e65b78a6ae53
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.580.9-89-g0fdeb46e7
+              value: v0.580.11-1-g8cd7578a3
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 0fdeb46e7e3fc164ca16c52a4bcd9f9c06ed0088
+              value: 8cd7578a33af9bb1096cc79ce792e65b78a6ae53
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -105,7 +105,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+                  value: sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-29T18:38:20Z"
+        client.knative.dev/updateTimestamp: "2026-05-29T19:58:44Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
           ports:
             - name: http1
               containerPort: 8181
@@ -513,11 +513,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.580.9-89-g0fdeb46e7
+              value: v0.580.11-1-g8cd7578a3
             - name: TORGHUT_COMMIT
-              value: 0fdeb46e7e3fc164ca16c52a4bcd9f9c06ed0088
+              value: 8cd7578a33af9bb1096cc79ce792e65b78a6ae53
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+              value: sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-29T18:38:20Z"
+        client.knative.dev/updateTimestamp: "2026-05-29T19:58:44Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
           ports:
             - name: http1
               containerPort: 8181
@@ -332,11 +332,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.580.9-89-g0fdeb46e7
+              value: v0.580.11-1-g8cd7578a3
             - name: TORGHUT_COMMIT
-              value: 0fdeb46e7e3fc164ca16c52a4bcd9f9c06ed0088
+              value: 8cd7578a33af9bb1096cc79ce792e65b78a6ae53
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+              value: sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `8cd7578a33af9bb1096cc79ce792e65b78a6ae53`
- Image tag: `8cd7578a`
- Image digest: `sha256:c72465e18d8ae05fb0dcc7f1785c8f8b81c250fecbdfdc13c687c7884f8f0175`