### PR TITLE
fix(torghut): unblock paper account cleanup window

### DIFF
--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -47,7 +47,7 @@ spec:
                     --expected-account-label TORGHUT_SIM \
                     --trading-mode paper \
                     --paper-base-url https://paper-api.alpaca.markets \
-                    --max-gross-market-value 2500 \
+                    --max-gross-market-value 100000 \
                     --max-position-count 25 \
                     --apply \
                     --json

--- a/services/torghut/app/trading/routeability_repair_acceptance.py
+++ b/services/torghut/app/trading/routeability_repair_acceptance.py
@@ -10,6 +10,7 @@ import json
 from typing import Any, cast
 
 from .market_context_domains import (
+    ACTIVE_MARKET_CONTEXT_DOMAINS,
     active_market_context_reasons,
     is_active_market_context_domain,
 )
@@ -596,7 +597,9 @@ def build_routeability_repair_acceptance_ledger(
             expected_gate_delta="retire_stale_market_context_domains",
             required_receipts=["market_context_domain_receipt"],
             blockers=market_blockers,
-            acceptance_condition="fundamentals, technicals, news, and regime domains are fresh or not required",
+            acceptance_condition=(
+                f"{', '.join(ACTIVE_MARKET_CONTEXT_DOMAINS)} domains are fresh or not required"
+            ),
             next_repair_action="refresh_stale_market_context_domains",
             rollback_trigger="market-context repair accepts a stale domain",
             symbols=_symbols(route_repair_rows),

--- a/services/torghut/scripts/flatten_paper_account_positions.py
+++ b/services/torghut/scripts/flatten_paper_account_positions.py
@@ -17,7 +17,7 @@ from app.trading.firewall import OrderFirewall
 
 DEFAULT_ACCOUNT_LABEL = "TORGHUT_SIM"
 DEFAULT_PAPER_BASE_URL = "https://paper-api.alpaca.markets"
-DEFAULT_MAX_GROSS_MARKET_VALUE = Decimal("2500")
+DEFAULT_MAX_GROSS_MARKET_VALUE = Decimal("100000")
 DEFAULT_MAX_POSITION_COUNT = 25
 TERMINAL_CLEAN_STATUSES = frozenset({"clean", "dry_run", "submitted"})
 

--- a/services/torghut/tests/test_flatten_paper_account_positions.py
+++ b/services/torghut/tests/test_flatten_paper_account_positions.py
@@ -161,6 +161,81 @@ class TestFlattenPaperAccountPositions(TestCase):
         self.assertFalse(client.cancelled)
         self.assertEqual(client.submitted, [])
 
+    def test_default_guardrail_can_unwind_dirty_paper_proof_account_shape(
+        self,
+    ) -> None:
+        client = FakeFlattenClient(
+            [
+                {
+                    "symbol": "AAPL",
+                    "qty": "-81",
+                    "side": "short",
+                    "market_value": "25264.710000",
+                },
+                {
+                    "symbol": "AMZN",
+                    "qty": "184",
+                    "side": "long",
+                    "market_value": "49961.520000",
+                },
+                {
+                    "symbol": "AMZN250530C00190000",
+                    "qty": "1",
+                    "side": "long",
+                    "market_value": "42.00",
+                },
+                {
+                    "symbol": "AMAT",
+                    "qty": "0.8761",
+                    "side": "long",
+                    "market_value": "396.65",
+                },
+                {
+                    "symbol": "INTC",
+                    "qty": "0.0477",
+                    "side": "long",
+                    "market_value": "5.90",
+                },
+                {
+                    "symbol": "MU",
+                    "qty": "0.0757",
+                    "side": "long",
+                    "market_value": "72.44",
+                },
+                {
+                    "symbol": "SPY",
+                    "qty": "0.00266",
+                    "side": "long",
+                    "market_value": "2.01",
+                },
+                {
+                    "symbol": "TSM",
+                    "qty": "0.3321",
+                    "side": "long",
+                    "market_value": "141.80",
+                },
+            ]
+        )
+
+        payload = flatten_paper_account_positions(
+            client=client,
+            account_label="TORGHUT_SIM",
+            expected_account_label="TORGHUT_SIM",
+            trading_mode="paper",
+            apply=True,
+            max_gross_market_value=flatten_script.DEFAULT_MAX_GROSS_MARKET_VALUE,
+            max_position_count=25,
+            generated_at=datetime(2026, 5, 29, 19, 50, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(payload["status"], "submitted")
+        self.assertEqual(payload["position_count"], 8)
+        self.assertEqual(payload["max_gross_market_value"], "100000")
+        self.assertTrue(client.cancelled)
+        self.assertEqual(payload["submitted_order_count"], 8)
+        self.assertEqual(client.submitted[0]["symbol"], "AAPL")
+        self.assertEqual(client.submitted[0]["side"], "buy")
+
     def test_normalizes_dirty_positions_and_refuses_position_count_above_limit(
         self,
     ) -> None:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -872,6 +872,67 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--max-batches 1", args)
         self.assertIn("--apply", args)
 
+    def test_paper_account_flatten_cronjob_can_clean_dirty_paper_proof_account(
+        self,
+    ) -> None:
+        spec, container = _load_cronjob_container(
+            "argocd/applications/torghut/paper-account-flatten-cronjob.yaml"
+        )
+
+        self.assertEqual(spec.get("schedule"), "5,20,35,50 19 * * 1-5")
+        self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
+        job_spec = cast(
+            Mapping[str, object],
+            cast(Mapping[str, object], spec.get("jobTemplate", {})).get("spec", {}),
+        )
+        template = cast(
+            Mapping[str, object],
+            cast(Mapping[str, object], job_spec.get("template", {})),
+        )
+        pod_spec = cast(Mapping[str, object], template.get("spec", {}))
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 180)
+        self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
+        self.assertEqual(
+            pod_spec.get("nodeSelector"),
+            {"kubernetes.io/arch": "arm64"},
+        )
+        resources = cast(Mapping[str, object], container.get("resources", {}))
+        self.assertEqual(
+            resources,
+            {
+                "requests": {
+                    "cpu": "50m",
+                    "memory": "128Mi",
+                    "ephemeral-storage": "128Mi",
+                },
+                "limits": {
+                    "cpu": "250m",
+                    "memory": "256Mi",
+                    "ephemeral-storage": "512Mi",
+                },
+            },
+        )
+
+        env = {
+            item.get("name"): item
+            for item in cast(list[Mapping[str, object]], container.get("env", []))
+        }
+        self.assertEqual(env["TRADING_MODE"].get("value"), "paper")
+        self.assertEqual(env["TRADING_ACCOUNT_LABEL"].get("value"), "TORGHUT_SIM")
+        self.assertEqual(env["TRADING_KILL_SWITCH_ENABLED"].get("value"), "false")
+
+        args = "\n".join(str(item) for item in container.get("args", []))
+        self.assertIn("scripts/flatten_paper_account_positions.py", args)
+        self.assertIn("--account-label TORGHUT_SIM", args)
+        self.assertIn("--expected-account-label TORGHUT_SIM", args)
+        self.assertIn("--trading-mode paper", args)
+        self.assertIn("--paper-base-url https://paper-api.alpaca.markets", args)
+        self.assertIn("--max-gross-market-value 100000", args)
+        self.assertNotIn("--max-gross-market-value 2500", args)
+        self.assertIn("--max-position-count 25", args)
+        self.assertIn("--apply", args)
+        self.assertIn("--json", args)
+
     def test_empirical_promotion_renewal_imports_authoritative_sim_paper_plan_and_sim_db(
         self,
     ) -> None:

--- a/services/torghut/tests/test_routeability_repair_acceptance.py
+++ b/services/torghut/tests/test_routeability_repair_acceptance.py
@@ -211,6 +211,10 @@ def test_stale_market_context_domains_keep_acceptance_unsettled() -> None:
     market_lot = _lot(ledger, "market_context_domain_repair")
 
     assert market_lot["current_state"] == "stale"
+    assert (
+        market_lot["acceptance_condition"]
+        == "technicals, regime domains are fresh or not required"
+    )
     assert "market_context_technicals_stale" in market_lot["blocking_reason_codes"]
     assert "market_context_news_stale" not in market_lot["blocking_reason_codes"]
     assert "market_context_regime_stale" in market_lot["blocking_reason_codes"]


### PR DESCRIPTION
## Summary

- Raises the paper-account flatten gross-value envelope to `100000` so the TORGHUT_SIM cleanup job can unwind the contaminated proof account shape observed in the current window.
- Keeps the flatten path paper-only and account-label guarded, with manifest coverage for TORGHUT_SIM, paper mode, Alpaca paper endpoint, low resources, and explicit apply/json args.
- Removes stale retired-domain wording from routeability repair acceptance so market-context repair text matches active `technicals` and `regime` domains.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_paper_account_flatten_cronjob_can_clean_dirty_paper_proof_account tests/test_routeability_repair_acceptance.py::test_stale_market_context_domains_keep_acceptance_unsettled -q`
- `ruff format --check scripts/flatten_paper_account_positions.py app/trading/routeability_repair_acceptance.py tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py tests/test_routeability_repair_acceptance.py`
- `ruff check scripts/flatten_paper_account_positions.py app/trading/routeability_repair_acceptance.py tests/test_flatten_paper_account_positions.py tests/test_live_config_manifest_contract.py tests/test_routeability_repair_acceptance.py`
- `uv run --frozen pytest tests/test_flatten_paper_account_positions.py tests/test_routeability_repair_acceptance.py tests/test_live_config_manifest_contract.py -q`
- `bun run lint:argocd`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
