### PR TITLE
chore(analysis): promote Dell backlog scorecard

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 3e99d8e70b55a8b54f27e648f0d7a206a888570e
+    newTag: 62196bb501a0e091d06621a4495a96374035d850


### PR DESCRIPTION
## Summary

- Promotes the `analysis` application image to `62196bb501a0e091d06621a4495a96374035d850`.
- Publishes the Dell Q1 FY2027 AI backlog refresh and new backlog-to-cash scorecard.
- Keeps the change scoped to the Argo CD image tag for the existing `analysis` app.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/analysis >/tmp/analysis-kustomize.yaml`
- `rg -n '62196bb501a0e091d06621a4495a96374035d850|image:' /tmp/analysis-kustomize.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
