### PR TITLE
chore(analysis): promote backlog conversion image

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 62196bb501a0e091d06621a4495a96374035d850
+    newTag: 88ee11b06c6cf450cdf9046578af56e3f77996f2


### PR DESCRIPTION
## Summary

- Promotes the analysis static site image built from `gregkonush/analysis@88ee11b06c6cf450cdf9046578af56e3f77996f2`.
- Updates the ArgoCD analysis application image tag so the new backlog conversion board and infographic publish to Tailscale.
- Keeps the existing analysis service, Tailscale exposure, and rollout shape unchanged.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/analysis >/tmp/analysis-kustomize.yaml`
- `rg -n '88ee11b06c6cf450cdf9046578af56e3f77996f2|kind: Deployment|kind: Service' /tmp/analysis-kustomize.yaml`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
