### PR TITLE
chore(symphony): promote image c39dcf4b

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-27T14:37:22Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-29T22:45:08Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "8662ef9c"
-    digest: sha256:2066dc09b1d5cf29029bb55835f1e5e68afbf9a3134988d9d73bc0c28a61a198
+    newTag: "c39dcf4b"
+    digest: sha256:cd29281bc803aea0fe494b40bd5c95cbff41a5580d2fe4d7f9df20d89f4ac2cf

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-27T14:37:22Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-29T22:45:08Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "8662ef9c"
-    digest: sha256:2066dc09b1d5cf29029bb55835f1e5e68afbf9a3134988d9d73bc0c28a61a198
+    newTag: "c39dcf4b"
+    digest: sha256:cd29281bc803aea0fe494b40bd5c95cbff41a5580d2fe4d7f9df20d89f4ac2cf

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-27T14:37:22Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-29T22:45:08Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "8662ef9c"
-    digest: sha256:2066dc09b1d5cf29029bb55835f1e5e68afbf9a3134988d9d73bc0c28a61a198
+    newTag: "c39dcf4b"
+    digest: sha256:cd29281bc803aea0fe494b40bd5c95cbff41a5580d2fe4d7f9df20d89f4ac2cf


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `c39dcf4b68fd671324184649894bd698c1fe495f`
- Image tag: `c39dcf4b`
- Image digest: `sha256:cd29281bc803aea0fe494b40bd5c95cbff41a5580d2fe4d7f9df20d89f4ac2cf`