### PR TITLE
chore(torghut): promote image c39dcf4b

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.580.11-18-gdb3f3d121
+              value: v0.580.11-22-gc39dcf4b6
             - name: TORGHUT_OPTIONS_COMMIT
-              value: db3f3d121061f9a4b4c1aae123dcbc554df689ed
+              value: c39dcf4b68fd671324184649894bd698c1fe495f
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.580.11-18-gdb3f3d121
+              value: v0.580.11-22-gc39dcf4b6
             - name: TORGHUT_OPTIONS_COMMIT
-              value: db3f3d121061f9a4b4c1aae123dcbc554df689ed
+              value: c39dcf4b68fd671324184649894bd698c1fe495f
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -105,7 +105,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+                  value: sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-29T22:17:16Z"
+        client.knative.dev/updateTimestamp: "2026-05-29T22:45:24Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
           ports:
             - name: http1
               containerPort: 8181
@@ -513,11 +513,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.580.11-18-gdb3f3d121
+              value: v0.580.11-22-gc39dcf4b6
             - name: TORGHUT_COMMIT
-              value: db3f3d121061f9a4b4c1aae123dcbc554df689ed
+              value: c39dcf4b68fd671324184649894bd698c1fe495f
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+              value: sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-29T22:17:16Z"
+        client.knative.dev/updateTimestamp: "2026-05-29T22:45:24Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
           ports:
             - name: http1
               containerPort: 8181
@@ -332,11 +332,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.580.11-18-gdb3f3d121
+              value: v0.580.11-22-gc39dcf4b6
             - name: TORGHUT_COMMIT
-              value: db3f3d121061f9a4b4c1aae123dcbc554df689ed
+              value: c39dcf4b68fd671324184649894bd698c1fe495f
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+              value: sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:48dad6cd2a60a18844e2acb869b705d61d5186102bd768f2d301ad20c5b6c3cc
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `c39dcf4b68fd671324184649894bd698c1fe495f`
- Image tag: `c39dcf4b`
- Image digest: `sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3`