### PR TITLE
chore(jangar): promote image c39dcf4b

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-25T08:21:21Z
+    deploy.knative.dev/rollout: 2026-05-29T22:57:43Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: fee7acbbeb0240081676845df598886f439033c3
+              value: c39dcf4b68fd671324184649894bd698c1fe495f
             - name: JANGAR_GITOPS_REVISION
-              value: fee7acbbeb0240081676845df598886f439033c3
+              value: c39dcf4b68fd671324184649894bd698c1fe495f
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -361,15 +361,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26390845614"
+              value: "26666410716"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:8475ba0446fcc3ef6ea84e95bd6aec2835a2a441f49b89352c1eac7609d474a0
+              value: sha256:f3c2c63c9c6b3098247264792c311107f39397e5d06399e14909f4e147c41253
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: fee7acbbeb0240081676845df598886f439033c3
+              value: c39dcf4b68fd671324184649894bd698c1fe495f
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:8475ba0446fcc3ef6ea84e95bd6aec2835a2a441f49b89352c1eac7609d474a0
+              value: sha256:f3c2c63c9c6b3098247264792c311107f39397e5d06399e14909f4e147c41253
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -38,5 +38,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: fee7acbb
-    digest: sha256:8475ba0446fcc3ef6ea84e95bd6aec2835a2a441f49b89352c1eac7609d474a0
+    newTag: c39dcf4b
+    digest: sha256:f3c2c63c9c6b3098247264792c311107f39397e5d06399e14909f4e147c41253


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `c39dcf4b68fd671324184649894bd698c1fe495f`
- Image tag: `c39dcf4b`
- Image digest: `sha256:f3c2c63c9c6b3098247264792c311107f39397e5d06399e14909f4e147c41253`
- Source CI run: `26666410716`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates