### PR TITLE
chore(analysis): deploy order queue atlas

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: b65b801cecea22dad6fc7a496f69b24e780eaa3e
+    newTag: d4f853bc3bea25697a14a5d1bfd940594ba65b9d


### PR DESCRIPTION
## Summary

- Promotes `analysis` to image tag `d4f853bc3bea25697a14a5d1bfd940594ba65b9d`.
- Publishes the AI buildout order queue atlas and generated infographic from the latest analysis repo build.
- Keeps the existing Tailscale-exposed `analysis` service and deployment shape unchanged.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl kustomize argocd/applications/analysis`
- Verified GitHub Actions `analysis-image` run `26666551650` succeeded and published `registry.ide-newton.ts.net/lab/analysis:d4f853bc3bea25697a14a5d1bfd940594ba65b9d`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
