### PR TITLE
fix(torghut): retire stale market context domains

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -267,8 +267,6 @@ spec:
               value: "300"
             - name: JANGAR_MARKET_CONTEXT_PROVIDER_CHAIN
               value: codex-spark,codex
-            - name: JANGAR_MARKET_CONTEXT_PROVIDER_TIMEOUT_MS
-              value: "10000"
             - name: JANGAR_MARKET_CONTEXT_PROVIDER_FAILURE_THRESHOLD
               value: "3"
             - name: JANGAR_MARKET_CONTEXT_PROVIDER_COOLDOWN_SECONDS
@@ -299,12 +297,8 @@ spec:
               value: "true"
             - name: JANGAR_MARKET_CONTEXT_TECHNICALS_MAX_FRESHNESS_SECONDS
               value: "60"
-            - name: JANGAR_MARKET_CONTEXT_NEWS_MAX_FRESHNESS_SECONDS
-              value: "300"
             - name: JANGAR_MARKET_CONTEXT_REGIME_MAX_FRESHNESS_SECONDS
               value: "120"
-            - name: JANGAR_MARKET_CONTEXT_NEWS_URL
-              value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context/providers/news
             - name: JANGAR_MARKET_CONTEXT_BATCH_REQUIRE_OPEN_SESSION
               value: "true"
             - name: JANGAR_MARKET_CONTEXT_BATCH_TRADING_STATUS_URL

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   - torghut-db-ca-sealedsecret.yaml
   - rook-ceph-rgw-jangar-sealedsecret.yaml
   - cnpg-jangar-db-objectbucketclaim.yaml
-  - market-context-providers-secret.yaml
   - deployment.yaml
   - service.yaml
   - github-token.yaml

--- a/argocd/applications/jangar/market-context-providers-secret.yaml
+++ b/argocd/applications/jangar/market-context-providers-secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: jangar-market-context-providers
-  namespace: jangar
-type: Opaque
-stringData:
-  news_url: http://jangar.jangar.svc.cluster.local/api/torghut/market-context/providers/news

--- a/services/jangar/src/server/__tests__/torghut-market-context.test.ts
+++ b/services/jangar/src/server/__tests__/torghut-market-context.test.ts
@@ -11,13 +11,10 @@ const restoreEnv = () => {
   delete process.env.JANGAR_MARKET_CONTEXT_ENABLED_FLAG_KEY
   delete process.env.JANGAR_MARKET_CONTEXT_CACHE_SECONDS
   delete process.env.JANGAR_MARKET_CONTEXT_MAX_STALENESS_SECONDS
-  delete process.env.JANGAR_MARKET_CONTEXT_PROVIDER_TIMEOUT_MS
   delete process.env.JANGAR_MARKET_CONTEXT_PROVIDER_CHAIN
-  delete process.env.JANGAR_MARKET_CONTEXT_NEWS_URL
   delete process.env.JANGAR_MARKET_CONTEXT_REQUIRE_TECHNICALS_SOURCE_HEALTH
   delete process.env.JANGAR_MARKET_CONTEXT_TECHNICALS_MAX_FRESHNESS_SECONDS
   delete process.env.JANGAR_MARKET_CONTEXT_NEWS_MAX_FRESHNESS_SECONDS
-  delete process.env.JANGAR_MARKET_CONTEXT_NEWS_TRADING_HOURS_MAX_FRESHNESS_SECONDS
   delete process.env.JANGAR_MARKET_CONTEXT_REGIME_MAX_FRESHNESS_SECONDS
   delete process.env.JANGAR_FEATURE_FLAGS_ENABLED
   delete process.env.JANGAR_FEATURE_FLAGS_URL
@@ -56,10 +53,12 @@ describe('torghut market context', () => {
     expect(context.symbol).toBe('NVDA')
     expect(context.freshnessSeconds).toBe(30)
     expect(context.domains.technicals.state).toBe('ok')
+    expect(context.domains.regime.state).toBe('ok')
     expect(context.domains.technicals.payload.price).toBe(142.51)
-    expect(context.domains.news.state).toBe('missing')
-    expect(context.riskFlags).toContain('news_missing')
-    expect(context.riskFlags).toContain('fundamentals_missing')
+    expect(context.domains).not.toHaveProperty('fundamentals')
+    expect(context.domains).not.toHaveProperty('news')
+    expect(context.riskFlags).not.toContain('news_missing')
+    expect(context.riskFlags).not.toContain('fundamentals_missing')
   })
 
   it('uses canonical ta_signals columns and avoids legacy identifiers', async () => {
@@ -191,179 +190,6 @@ describe('torghut market context', () => {
     expect(contextB.freshnessSeconds).toBe(90)
     expect(contextB.riskFlags).not.toContain('market_context_stale')
     expect(contextC.riskFlags).toContain('market_context_stale')
-  })
-
-  it('ingests the news provider while fundamentals collection is retired', async () => {
-    process.env.JANGAR_MARKET_CONTEXT_NEWS_URL = 'https://news.test/context'
-    process.env.JANGAR_MARKET_CONTEXT_PROVIDER_TIMEOUT_MS = '500'
-
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        asOfUtc: '2026-02-19T11:58:00.000Z',
-        sourceCount: 4,
-        qualityScore: 0.7,
-        payload: { sentimentScore: 0.12, itemCount: 4 },
-        citations: [{ source: 'wire', publishedAt: '2026-02-19T11:57:00.000Z', url: 'https://wire.test/n1' }],
-      }),
-    })
-    vi.stubGlobal('fetch', fetchMock)
-
-    const context = await getTorghutMarketContext('AAPL', {
-      asOf: new Date('2026-02-19T12:00:00.000Z'),
-      client: {
-        queryJson: async <T>() => [{ event_ts: '2026-02-19 11:59:30.000', c: '210.02' }] as T[],
-      },
-    })
-
-    expect(fetchMock).toHaveBeenCalledOnce()
-    expect(context.domains.fundamentals.state).toBe('missing')
-    expect(context.domains.fundamentals.payload.provider).toBe('fundamentals_provider_retired')
-    expect(context.domains.news.state).toBe('ok')
-    expect(context.domains.news.freshnessSeconds).toBe(120)
-    expect(context.domains.news.payload.sentimentScore).toBe(0.12)
-    expect(context.riskFlags).toContain('fundamentals_missing')
-    expect(context.riskFlags).not.toContain('news_missing')
-  })
-
-  it('reports provider failures in health and domain state', async () => {
-    process.env.JANGAR_MARKET_CONTEXT_NEWS_URL = 'https://news.test/context'
-
-    const fetchMock = vi.fn().mockRejectedValue(new Error('upstream timeout'))
-    vi.stubGlobal('fetch', fetchMock)
-
-    const health = await getTorghutMarketContextHealth('AAPL', {
-      asOf: new Date('2026-02-19T12:00:00.000Z'),
-      client: {
-        queryJson: async <T>() => [{ event_ts: '2026-02-19 11:59:30.000', c: '210.02' }] as T[],
-      },
-    })
-
-    expect(health.overallState).toBe('down')
-    expect(health.domainHealth.find((d) => d.domain === 'fundamentals')?.state).toBe('missing')
-    expect(health.domainHealth.find((d) => d.domain === 'news')?.state).toBe('error')
-    expect(health.providerHealth.map((d) => d.provider)).not.toContain('fundamentals')
-    expect(health.providerHealth.find((d) => d.provider === 'news')?.consecutiveFailures).toBe(1)
-  })
-
-  it('preserves degraded last-good provider metadata in the bundle', async () => {
-    process.env.JANGAR_MARKET_CONTEXT_NEWS_URL = 'https://news.test/context'
-    process.env.JANGAR_MARKET_CONTEXT_PROVIDER_CHAIN = 'codex-spark,codex'
-
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        asOfUtc: '2026-02-19T11:40:00.000Z',
-        sourceCount: 2,
-        qualityScore: 0.35,
-        payload: {
-          provider: 'codex',
-          providerChain: ['codex-spark', 'codex'],
-          fallbackUsed: true,
-          generationFailed: true,
-          degradedReason: 'all_provider_attempts_failed',
-          lastSuccessfulAsOfUtc: '2026-02-19T11:40:00.000Z',
-        },
-        citations: [],
-        riskFlags: ['news_generation_failed_all_models', 'market_context_degraded_last_good'],
-      }),
-    })
-    vi.stubGlobal('fetch', fetchMock)
-
-    const context = await getTorghutMarketContext('AAPL', {
-      asOf: new Date('2026-02-19T12:00:00.000Z'),
-      client: {
-        queryJson: async <T>() => [{ event_ts: '2026-02-19 11:59:30.000', c: '210.02' }] as T[],
-      },
-    })
-
-    expect(context.domains.news.payload.provider).toBe('codex')
-    expect(context.domains.news.payload.fallbackUsed).toBe(true)
-    expect(context.domains.news.payload.generationFailed).toBe(true)
-    expect(context.domains.news.riskFlags).toContain('news_generation_failed_all_models')
-    expect(context.riskFlags).toContain('market_context_degraded_last_good')
-  })
-
-  it('uses 10-minute news freshness during US regular trading hours', async () => {
-    process.env.JANGAR_MARKET_CONTEXT_NEWS_URL = 'https://news.test/context'
-    process.env.JANGAR_MARKET_CONTEXT_NEWS_MAX_FRESHNESS_SECONDS = '300'
-
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        asOfUtc: '2026-02-19T14:58:00.000Z',
-        sourceCount: 2,
-        qualityScore: 0.8,
-        payload: { sentimentScore: 0.12 },
-      }),
-    })
-    vi.stubGlobal('fetch', fetchMock)
-
-    const context = await getTorghutMarketContext('AAPL', {
-      asOf: new Date('2026-02-19T15:05:00.000Z'),
-      client: {
-        queryJson: async <T>() => [{ event_ts: '2026-02-19 15:04:30.000', c: '210.02' }] as T[],
-      },
-    })
-
-    expect(context.domains.news.freshnessSeconds).toBe(420)
-    expect(context.domains.news.maxFreshnessSeconds).toBe(600)
-    expect(context.domains.news.state).toBe('ok')
-  })
-
-  it('applies 10-minute news freshness at the 16:00 ET close boundary', async () => {
-    process.env.JANGAR_MARKET_CONTEXT_NEWS_URL = 'https://news.test/context'
-    process.env.JANGAR_MARKET_CONTEXT_NEWS_MAX_FRESHNESS_SECONDS = '300'
-
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        asOfUtc: '2026-02-19T20:53:00.000Z',
-        sourceCount: 2,
-        qualityScore: 0.8,
-        payload: { sentimentScore: 0.12 },
-      }),
-    })
-    vi.stubGlobal('fetch', fetchMock)
-
-    const context = await getTorghutMarketContext('AAPL', {
-      asOf: new Date('2026-02-19T21:00:00.000Z'),
-      client: {
-        queryJson: async <T>() => [{ event_ts: '2026-02-19 20:59:30.000', c: '210.02' }] as T[],
-      },
-    })
-
-    expect(context.domains.news.freshnessSeconds).toBe(420)
-    expect(context.domains.news.maxFreshnessSeconds).toBe(600)
-    expect(context.domains.news.state).toBe('ok')
-  })
-
-  it('keeps base news freshness outside US regular trading hours', async () => {
-    process.env.JANGAR_MARKET_CONTEXT_NEWS_URL = 'https://news.test/context'
-    process.env.JANGAR_MARKET_CONTEXT_NEWS_MAX_FRESHNESS_SECONDS = '300'
-
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        asOfUtc: '2026-02-19T21:58:00.000Z',
-        sourceCount: 2,
-        qualityScore: 0.8,
-        payload: { sentimentScore: 0.12 },
-      }),
-    })
-    vi.stubGlobal('fetch', fetchMock)
-
-    const context = await getTorghutMarketContext('AAPL', {
-      asOf: new Date('2026-02-19T22:05:00.000Z'),
-      client: {
-        queryJson: async <T>() => [{ event_ts: '2026-02-19 22:04:30.000', c: '210.02' }] as T[],
-      },
-    })
-
-    expect(context.domains.news.freshnessSeconds).toBe(420)
-    expect(context.domains.news.maxFreshnessSeconds).toBe(300)
-    expect(context.domains.news.state).toBe('stale')
-    expect(context.domains.news.riskFlags).toContain('news_stale')
   })
 
   it('marks technical and regime domains as error when clickhouse is unavailable', async () => {

--- a/services/jangar/src/server/torghut-market-context-config.ts
+++ b/services/jangar/src/server/torghut-market-context-config.ts
@@ -42,11 +42,8 @@ export type MarketContextRuntimeConfig = {
   enabledFlagKey: string
   cacheSeconds: number
   maxStalenessSeconds: number
-  providerTimeoutMs: number
-  newsSourceUrl: string
   technicalsMaxFreshnessSeconds: number
   newsMaxFreshnessSeconds: number
-  newsTradingHoursMaxFreshnessSeconds: number
   regimeMaxFreshnessSeconds: number
   batchRequireOpenSession: boolean
   batchTradingStatusUrl: string
@@ -83,14 +80,8 @@ export const resolveMarketContextRuntimeConfig = (env: EnvSource = process.env):
     normalizeNonEmpty(env.JANGAR_MARKET_CONTEXT_ENABLED_FLAG_KEY) ?? DEFAULT_MARKET_CONTEXT_ENABLED_FLAG_KEY,
   cacheSeconds: parsePositiveInt(env.JANGAR_MARKET_CONTEXT_CACHE_SECONDS, 60),
   maxStalenessSeconds: parsePositiveInt(env.JANGAR_MARKET_CONTEXT_MAX_STALENESS_SECONDS, 300),
-  providerTimeoutMs: parsePositiveInt(env.JANGAR_MARKET_CONTEXT_PROVIDER_TIMEOUT_MS, 10_000),
-  newsSourceUrl: normalizeNonEmpty(env.JANGAR_MARKET_CONTEXT_NEWS_URL) ?? '',
   technicalsMaxFreshnessSeconds: parsePositiveInt(env.JANGAR_MARKET_CONTEXT_TECHNICALS_MAX_FRESHNESS_SECONDS, 60),
   newsMaxFreshnessSeconds: parsePositiveInt(env.JANGAR_MARKET_CONTEXT_NEWS_MAX_FRESHNESS_SECONDS, 300),
-  newsTradingHoursMaxFreshnessSeconds: parsePositiveInt(
-    env.JANGAR_MARKET_CONTEXT_NEWS_TRADING_HOURS_MAX_FRESHNESS_SECONDS,
-    600,
-  ),
   regimeMaxFreshnessSeconds: parsePositiveInt(env.JANGAR_MARKET_CONTEXT_REGIME_MAX_FRESHNESS_SECONDS, 120),
   batchRequireOpenSession: parseBoolean(env.JANGAR_MARKET_CONTEXT_BATCH_REQUIRE_OPEN_SESSION, true),
   batchTradingStatusUrl:
@@ -139,7 +130,6 @@ export const resolveMarketContextIngestAuthConfig = (env: EnvSource = process.en
 
 export const validateMarketContextConfig = (env: EnvSource = process.env) => {
   const runtime = resolveMarketContextRuntimeConfig(env)
-  if (runtime.newsSourceUrl) new URL(runtime.newsSourceUrl)
   new URL(runtime.batchTradingStatusUrl)
   new URL(runtime.onDemandDispatchCallbackUrl)
   resolveMarketContextIngestAuthConfig(env)

--- a/services/jangar/src/server/torghut-market-context.ts
+++ b/services/jangar/src/server/torghut-market-context.ts
@@ -12,7 +12,7 @@ type MarketContextCitation = {
 }
 
 type MarketContextDomain = {
-  domain: 'technicals' | 'fundamentals' | 'news' | 'regime'
+  domain: 'technicals' | 'regime'
   state: MarketContextDomainState
   asOf: string | null
   freshnessSeconds: number | null
@@ -34,20 +34,8 @@ export type TorghutMarketContextBundle = {
   riskFlags: string[]
   domains: {
     technicals: MarketContextDomain
-    fundamentals: MarketContextDomain
-    news: MarketContextDomain
     regime: MarketContextDomain
   }
-}
-
-type ProviderHealthSignal = {
-  provider: 'news'
-  configured: boolean
-  lastAttemptAt: string | null
-  lastSuccessAt: string | null
-  lastError: string | null
-  consecutiveFailures: number
-  latencyMs: number | null
 }
 
 type ClickHouseHealthSignal = {
@@ -65,7 +53,7 @@ export type TorghutMarketContextHealth = {
   maxStalenessSeconds: number
   bundleFreshnessSeconds: number
   bundleQualityScore: number
-  providerHealth: ProviderHealthSignal[]
+  providerHealth: []
   ingestionHealth: {
     clickhouse: ClickHouseHealthSignal
   }
@@ -80,44 +68,13 @@ export type TorghutMarketContextHealth = {
   overallState: 'ok' | 'degraded' | 'down'
 }
 
-const RETIRED_FUNDAMENTALS_MAX_FRESHNESS_SECONDS = 0
-
 export type MarketContextOptions = {
   asOf?: Date
   maxStalenessSeconds?: number
   client?: ClickHouseClient
 }
 
-const MARKET_CONTEXT_EXCHANGE_TIMEZONE = 'America/New_York'
-const MARKET_CONTEXT_TRADING_WEEKDAYS = new Set(['Mon', 'Tue', 'Wed', 'Thu', 'Fri'])
-const MARKET_CONTEXT_SESSION_OPEN_MINUTE = 9 * 60 + 30
-const MARKET_CONTEXT_SESSION_CLOSE_MINUTE = 16 * 60
-
-const exchangeClockFormatter = new Intl.DateTimeFormat('en-US', {
-  timeZone: MARKET_CONTEXT_EXCHANGE_TIMEZONE,
-  weekday: 'short',
-  hour: '2-digit',
-  minute: '2-digit',
-  hour12: false,
-})
-
 const resolveSettings = () => resolveMarketContextRuntimeConfig(process.env)
-
-const isUsRegularTradingSession = (now: Date) => {
-  const parts = exchangeClockFormatter.formatToParts(now)
-  const weekday = parts.find((part) => part.type === 'weekday')?.value ?? ''
-  if (!MARKET_CONTEXT_TRADING_WEEKDAYS.has(weekday)) return false
-  const hour = Number.parseInt(parts.find((part) => part.type === 'hour')?.value ?? '-1', 10)
-  const minute = Number.parseInt(parts.find((part) => part.type === 'minute')?.value ?? '-1', 10)
-  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return false
-  const minuteOfDay = hour * 60 + minute
-  return minuteOfDay >= MARKET_CONTEXT_SESSION_OPEN_MINUTE && minuteOfDay <= MARKET_CONTEXT_SESSION_CLOSE_MINUTE
-}
-
-const resolveNewsMaxFreshnessSeconds = (params: { now: Date; settings: ReturnType<typeof resolveSettings> }) => {
-  if (!isUsRegularTradingSession(params.now)) return params.settings.newsMaxFreshnessSeconds
-  return Math.max(params.settings.newsMaxFreshnessSeconds, params.settings.newsTradingHoursMaxFreshnessSeconds)
-}
 
 const resolveMarketContextEnabled = (params: { settings: ReturnType<typeof resolveSettings> }) =>
   getBooleanFeatureFlag({
@@ -131,21 +88,6 @@ type CacheEntry = {
 }
 
 const cache = new Map<string, CacheEntry>()
-
-const providerHealth = new Map<'news', ProviderHealthSignal>([
-  [
-    'news',
-    {
-      provider: 'news',
-      configured: false,
-      lastAttemptAt: null,
-      lastSuccessAt: null,
-      lastError: null,
-      consecutiveFailures: 0,
-      latencyMs: null,
-    },
-  ],
-])
 
 let clickHouseHealth: ClickHouseHealthSignal = {
   configured: false,
@@ -194,48 +136,6 @@ const resolveFreshnessSeconds = (now: Date, asOf: Date | null) => {
   if (!asOf) return null
   const seconds = Math.floor((now.getTime() - asOf.getTime()) / 1000)
   return Math.max(0, seconds)
-}
-
-const coerceRiskFlags = (value: unknown) => {
-  if (!Array.isArray(value)) return []
-  return value
-    .map((flag) => (typeof flag === 'string' ? flag.trim() : ''))
-    .filter((flag): flag is string => flag.length > 0)
-}
-
-const coerceCitations = (value: unknown): MarketContextCitation[] => {
-  if (!Array.isArray(value)) return []
-  const citations: MarketContextCitation[] = []
-  for (const item of value) {
-    if (!item || typeof item !== 'object') continue
-    const row = item as Record<string, unknown>
-    const source = typeof row.source === 'string' ? row.source : ''
-    const publishedAt = parseTimestamp(row.publishedAt)
-    if (!source || !publishedAt) continue
-    citations.push({
-      source,
-      publishedAt: iso(publishedAt),
-      url: typeof row.url === 'string' ? row.url : null,
-    })
-  }
-  return citations
-}
-
-const recordProviderAttempt = (
-  provider: 'news',
-  params: { configured: boolean; success: boolean; error?: string; latencyMs: number },
-) => {
-  const previous = providerHealth.get(provider)
-  const nowIso = new Date().toISOString()
-  providerHealth.set(provider, {
-    provider,
-    configured: params.configured,
-    lastAttemptAt: nowIso,
-    lastSuccessAt: params.success ? nowIso : (previous?.lastSuccessAt ?? null),
-    lastError: params.success ? null : (params.error ?? 'provider_unknown_error'),
-    consecutiveFailures: params.success ? 0 : (previous?.consecutiveFailures ?? 0) + 1,
-    latencyMs: params.latencyMs,
-  })
 }
 
 const recordClickHouseAttempt = (params: {
@@ -361,176 +261,7 @@ const regimeDomain = (params: {
   }
 }
 
-type ExternalDomainResponse = {
-  asOf: Date | null
-  sourceCount: number
-  qualityScore: number
-  payload: Record<string, unknown>
-  citations: MarketContextCitation[]
-  riskFlags: string[]
-}
-
-const fetchExternalDomainResponse = async (params: {
-  provider: 'news'
-  symbol: string
-  now: Date
-  sourceUrl: string
-  timeoutMs: number
-}): Promise<ExternalDomainResponse | null> => {
-  if (!params.sourceUrl) {
-    providerHealth.set(params.provider, {
-      provider: params.provider,
-      configured: false,
-      lastAttemptAt: null,
-      lastSuccessAt: null,
-      lastError: null,
-      consecutiveFailures: 0,
-      latencyMs: null,
-    })
-    return null
-  }
-
-  const start = Date.now()
-  try {
-    const url = new URL(params.sourceUrl)
-    url.searchParams.set('symbol', params.symbol)
-
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), params.timeoutMs)
-    const response = await fetch(url, {
-      headers: { accept: 'application/json' },
-      signal: controller.signal,
-    })
-    clearTimeout(timeout)
-
-    if (!response.ok) {
-      recordProviderAttempt(params.provider, {
-        configured: true,
-        success: false,
-        error: `provider_http_${response.status}`,
-        latencyMs: Date.now() - start,
-      })
-      return {
-        asOf: null,
-        sourceCount: 0,
-        qualityScore: 0,
-        payload: {},
-        citations: [],
-        riskFlags: [`${params.provider}_provider_http_${response.status}`],
-      }
-    }
-
-    const body = (await response.json()) as Record<string, unknown>
-    const data =
-      body.ok === true && typeof body.context === 'object' && body.context
-        ? (body.context as Record<string, unknown>)
-        : body
-    const asOf = parseTimestamp(data.asOfUtc ?? data.asOf ?? data.publishedAt)
-    const sourceCount = Math.max(0, Math.trunc(toNumber(data.sourceCount) ?? toNumber(data.itemCount) ?? 0))
-    const rawQuality = toNumber(data.qualityScore)
-    const qualityScore = rawQuality === null ? 1 : Math.max(0, Math.min(1, rawQuality))
-    const payload = data.payload && typeof data.payload === 'object' ? (data.payload as Record<string, unknown>) : data
-    const citations = coerceCitations(data.citations)
-    const riskFlags = coerceRiskFlags(data.riskFlags)
-    recordProviderAttempt(params.provider, {
-      configured: true,
-      success: true,
-      latencyMs: Date.now() - start,
-    })
-    return {
-      asOf,
-      sourceCount,
-      qualityScore,
-      payload,
-      citations,
-      riskFlags,
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'provider_fetch_failed'
-    recordProviderAttempt(params.provider, {
-      configured: true,
-      success: false,
-      error: message,
-      latencyMs: Date.now() - start,
-    })
-    return {
-      asOf: null,
-      sourceCount: 0,
-      qualityScore: 0,
-      payload: {},
-      citations: [],
-      riskFlags: [`${params.provider}_provider_error`],
-    }
-  }
-}
-
-const emptyDomain = (params: {
-  now: Date
-  domain: 'fundamentals' | 'news'
-  maxFreshnessSeconds: number
-  provider: string
-}): MarketContextDomain => ({
-  domain: params.domain,
-  state: 'missing',
-  asOf: null,
-  freshnessSeconds: null,
-  maxFreshnessSeconds: params.maxFreshnessSeconds,
-  sourceCount: 0,
-  qualityScore: 0,
-  payload: {
-    asOfUtc: iso(params.now),
-    provider: params.provider,
-    itemCount: 0,
-  },
-  citations: [],
-  riskFlags: [`${params.domain}_missing`],
-})
-
-const externalDomain = (params: {
-  now: Date
-  domain: 'news'
-  maxFreshnessSeconds: number
-  response: ExternalDomainResponse | null
-}): MarketContextDomain => {
-  if (!params.response) {
-    return emptyDomain({
-      now: params.now,
-      domain: params.domain,
-      maxFreshnessSeconds: params.maxFreshnessSeconds,
-      provider: 'not_configured',
-    })
-  }
-
-  const freshnessSeconds = resolveFreshnessSeconds(params.now, params.response.asOf)
-  let state = resolveState(freshnessSeconds, params.maxFreshnessSeconds)
-  const riskFlags = [...params.response.riskFlags]
-  if (riskFlags.some((flag) => flag.includes('provider_error') || flag.includes('provider_http_'))) {
-    state = 'error'
-  }
-  if (state !== 'ok' && !riskFlags.includes(`${params.domain}_${state}`)) {
-    riskFlags.push(`${params.domain}_${state}`)
-  }
-
-  return {
-    domain: params.domain,
-    state,
-    asOf: params.response.asOf ? iso(params.response.asOf) : null,
-    freshnessSeconds,
-    maxFreshnessSeconds: params.maxFreshnessSeconds,
-    sourceCount: params.response.sourceCount,
-    qualityScore: state === 'error' ? 0 : params.response.qualityScore,
-    payload: params.response.payload,
-    citations: params.response.citations,
-    riskFlags,
-  }
-}
-
-const domainSetFrom = (domain: TorghutMarketContextBundle['domains']) => [
-  domain.technicals,
-  domain.fundamentals,
-  domain.news,
-  domain.regime,
-]
+const domainSetFrom = (domain: TorghutMarketContextBundle['domains']) => [domain.technicals, domain.regime]
 
 const buildBundleFromDomains = (params: {
   symbol: string
@@ -558,14 +289,9 @@ const buildBundleFromDomains = (params: {
   }
 }
 
-const bundleCacheKey = (params: {
-  symbol: string
-  asOf: Date | undefined
-  maxStalenessSeconds: number
-  newsMaxFreshnessSeconds: number
-}) => {
+const bundleCacheKey = (params: { symbol: string; asOf: Date | undefined; maxStalenessSeconds: number }) => {
   const asOfKey = params.asOf ? params.asOf.toISOString() : 'latest'
-  return `${params.symbol.toUpperCase()}|${asOfKey}|${params.maxStalenessSeconds}|news:${params.newsMaxFreshnessSeconds}`
+  return `${params.symbol.toUpperCase()}|${asOfKey}|${params.maxStalenessSeconds}`
 }
 
 export const clearMarketContextCache = () => {
@@ -579,24 +305,11 @@ export const getTorghutMarketContext = async (
   const settings = resolveSettings()
   const symbol = normalizeTorghutSymbol(symbolInput)
   const now = options.asOf ?? new Date()
-  const newsMaxFreshnessSeconds = resolveNewsMaxFreshnessSeconds({ now, settings })
   const maxStalenessSeconds = options.maxStalenessSeconds ?? settings.maxStalenessSeconds
   const enabled = await resolveMarketContextEnabled({ settings })
   if (!enabled) {
     const domains = {
       technicals: technicalDomain({ now, row: null, maxFreshnessSeconds: settings.technicalsMaxFreshnessSeconds }),
-      fundamentals: emptyDomain({
-        now,
-        domain: 'fundamentals',
-        maxFreshnessSeconds: RETIRED_FUNDAMENTALS_MAX_FRESHNESS_SECONDS,
-        provider: 'feature_disabled',
-      }),
-      news: emptyDomain({
-        now,
-        domain: 'news',
-        maxFreshnessSeconds: newsMaxFreshnessSeconds,
-        provider: 'feature_disabled',
-      }),
       regime: regimeDomain({ now, row: null, maxFreshnessSeconds: settings.regimeMaxFreshnessSeconds }),
     }
     const disabledBundle = buildBundleFromDomains({ symbol, now, domains })
@@ -607,7 +320,6 @@ export const getTorghutMarketContext = async (
     symbol,
     asOf: options.asOf,
     maxStalenessSeconds,
-    newsMaxFreshnessSeconds,
   })
   const cached = cache.get(cacheKey)
   if (cached) {
@@ -651,14 +363,6 @@ export const getTorghutMarketContext = async (
     })
   }
 
-  const newsResponse = await fetchExternalDomainResponse({
-    provider: 'news',
-    symbol,
-    now,
-    sourceUrl: settings.newsSourceUrl,
-    timeoutMs: settings.providerTimeoutMs,
-  })
-
   const domains = {
     technicals: technicalDomain({
       now,
@@ -666,18 +370,6 @@ export const getTorghutMarketContext = async (
       maxFreshnessSeconds: settings.technicalsMaxFreshnessSeconds,
       sourceError: settings.requireTechnicalsSourceHealth ? signalSourceError : null,
       sourceLatencyMs: signalSourceLatencyMs,
-    }),
-    fundamentals: emptyDomain({
-      now,
-      domain: 'fundamentals',
-      maxFreshnessSeconds: RETIRED_FUNDAMENTALS_MAX_FRESHNESS_SECONDS,
-      provider: 'fundamentals_provider_retired',
-    }),
-    news: externalDomain({
-      now,
-      domain: 'news',
-      maxFreshnessSeconds: newsMaxFreshnessSeconds,
-      response: newsResponse,
     }),
     regime: regimeDomain({
       now,
@@ -719,7 +411,7 @@ export const getTorghutMarketContextHealth = async (symbol = 'SPY', options: Mar
     maxStalenessSeconds: settings.maxStalenessSeconds,
     bundleFreshnessSeconds: bundle.freshnessSeconds,
     bundleQualityScore: bundle.qualityScore,
-    providerHealth: Array.from(providerHealth.values()),
+    providerHealth: [],
     ingestionHealth: {
       clickhouse: clickHouseHealth,
     },

--- a/services/torghut/app/trading/llm/schema.py
+++ b/services/torghut/app/trading/llm/schema.py
@@ -95,7 +95,7 @@ class MarketContextDomain(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    domain: Literal["technicals", "fundamentals", "news", "regime"]
+    domain: Literal["technicals", "regime"]
     state: Literal["ok", "stale", "missing", "error"]
     as_of: Optional[datetime] = Field(default=None, alias="asOf")
     freshness_seconds: Optional[int] = Field(default=None, alias="freshnessSeconds")
@@ -103,18 +103,18 @@ class MarketContextDomain(BaseModel):
     source_count: int = Field(alias="sourceCount")
     quality_score: float = Field(ge=0.0, le=1.0, alias="qualityScore")
     payload: dict[str, Any] = Field(default_factory=dict)
-    citations: list[MarketContextCitation] = Field(default_factory=_market_context_citations_default)
+    citations: list[MarketContextCitation] = Field(
+        default_factory=_market_context_citations_default
+    )
     risk_flags: list[str] = Field(default_factory=list, alias="riskFlags")
 
 
 class MarketContextDomains(BaseModel):
     """Grouped domain blocks in the market-context bundle."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     technicals: MarketContextDomain
-    fundamentals: MarketContextDomain
-    news: MarketContextDomain
     regime: MarketContextDomain
 
 
@@ -169,7 +169,9 @@ class LLMReviewRequest(BaseModel):
     portfolio: PortfolioSnapshot
     market: Optional[MarketSnapshot] = None
     market_context: Optional[MarketContextBundle] = None
-    recent_decisions: list[RecentDecisionSummary] = Field(default_factory=_recent_decisions_default)
+    recent_decisions: list[RecentDecisionSummary] = Field(
+        default_factory=_recent_decisions_default
+    )
     account: dict[str, str] = Field(default_factory=_account_default)
     positions: list[dict[str, Any]] = Field(default_factory=_positions_default)
     policy: LLMPolicyContext
@@ -191,7 +193,9 @@ class LLMReviewResponse(BaseModel):
     uncertainty: "LLMUncertainty"
     calibration_metadata: dict[str, Any] = Field(default_factory=dict)
     adjusted_qty: Optional[Decimal] = None
-    adjusted_order_type: Optional[Literal["market", "limit", "stop", "stop_limit"]] = None
+    adjusted_order_type: Optional[Literal["market", "limit", "stop", "stop_limit"]] = (
+        None
+    )
     limit_price: Optional[Decimal] = None
     escalate_reason: Optional[str] = None
     rationale: str
@@ -236,7 +240,10 @@ class LLMReviewResponse(BaseModel):
             raise ValueError("adjusted_qty_required_for_adjust_verdict")
         if self.verdict == "escalate" and self.escalate_reason is None:
             raise ValueError("escalate_reason_required_for_escalate_verdict")
-        if self.adjusted_order_type in {"limit", "stop_limit"} and self.limit_price is None:
+        if (
+            self.adjusted_order_type in {"limit", "stop_limit"}
+            and self.limit_price is None
+        ):
             raise ValueError("limit_price_required_for_limit_orders")
         return self
 
@@ -272,9 +279,15 @@ class LLMUncertainty(BaseModel):
 
     @model_validator(mode="after")
     def validate_interval(self) -> "LLMUncertainty":
-        if self.confidence_interval_low is None and self.confidence_interval_high is None:
+        if (
+            self.confidence_interval_low is None
+            and self.confidence_interval_high is None
+        ):
             return self
-        if self.confidence_interval_low is None or self.confidence_interval_high is None:
+        if (
+            self.confidence_interval_low is None
+            or self.confidence_interval_high is None
+        ):
             raise ValueError("uncertainty_confidence_interval_incomplete")
         if self.confidence_interval_low > self.confidence_interval_high:
             raise ValueError("uncertainty_confidence_interval_invalid")
@@ -293,7 +306,9 @@ class LLMCommitteeMemberResponse(BaseModel):
     rationale_short: str
     required_checks: list[str] = Field(default_factory=list)
     adjusted_qty: Optional[Decimal] = None
-    adjusted_order_type: Optional[Literal["market", "limit", "stop", "stop_limit"]] = None
+    adjusted_order_type: Optional[Literal["market", "limit", "stop", "stop_limit"]] = (
+        None
+    )
     limit_price: Optional[Decimal] = None
     risk_flags: list[str] = Field(default_factory=list)
     latency_ms: Optional[int] = None

--- a/services/torghut/tests/test_llm_schema.py
+++ b/services/torghut/tests/test_llm_schema.py
@@ -9,6 +9,7 @@ from app.trading.llm.schema import (
     LLMDecisionContext,
     LLMRegimeHMMContext,
     LLMReviewResponse,
+    LLMUncertainty,
 )
 
 
@@ -90,6 +91,16 @@ class TestLlmSchema(TestCase):
                 calibration_metadata={},
                 rationale="invalid probability mass",
                 risk_flags=[],
+            )
+
+    def test_uncertainty_requires_complete_confidence_interval(self) -> None:
+        with self.assertRaises(ValidationError):
+            LLMUncertainty.model_validate(
+                {
+                    "score": 0.2,
+                    "band": "low",
+                    "confidence_interval_low": 0.1,
+                }
             )
 
     def test_adjust_verdict_requires_adjusted_qty(self) -> None:

--- a/services/torghut/tests/test_market_context.py
+++ b/services/torghut/tests/test_market_context.py
@@ -141,6 +141,26 @@ class TestMarketContextClient(TestCase):
         self.assertIsNotNone(bundle)
         self.assertEqual(bundle.symbol, "AAPL")
         self.assertEqual(bundle.context_version, "torghut.market-context.v1")
+        self.assertFalse(hasattr(bundle.domains, "fundamentals"))
+        self.assertFalse(hasattr(bundle.domains, "news"))
+
+    def test_fetch_parses_active_domain_bundle_without_retired_context(self) -> None:
+        config.settings.trading_market_context_url = (
+            "http://jangar.test/api/torghut/market-context"
+        )
+        config.settings.trading_market_context_timeout_seconds = 2
+
+        payload = io.BytesIO(
+            b'{"ok":true,"context":{"contextVersion":"torghut.market-context.v1","symbol":"AAPL","asOfUtc":"2026-02-19T12:00:00Z","freshnessSeconds":10,"qualityScore":1,"sourceCount":2,"riskFlags":[],"domains":{"technicals":{"domain":"technicals","state":"ok","asOf":"2026-02-19T12:00:00Z","freshnessSeconds":10,"maxFreshnessSeconds":60,"sourceCount":1,"qualityScore":1,"payload":{"price":100},"citations":[],"riskFlags":[]},"regime":{"domain":"regime","state":"ok","asOf":"2026-02-19T12:00:00Z","freshnessSeconds":10,"maxFreshnessSeconds":120,"sourceCount":1,"qualityScore":1,"payload":{"volatility":0.1},"citations":[],"riskFlags":[]}}}}'
+        )
+
+        with patch("app.trading.market_context.urlopen", return_value=payload):
+            bundle = MarketContextClient().fetch("AAPL")
+
+        self.assertIsNotNone(bundle)
+        self.assertEqual(bundle.symbol, "AAPL")
+        self.assertEqual(bundle.domains.technicals.domain, "technicals")
+        self.assertEqual(bundle.domains.regime.domain, "regime")
 
     def test_fetch_rejects_non_success_status(self) -> None:
         config.settings.trading_market_context_url = (


### PR DESCRIPTION
## Summary

- Retires stale fundamentals/news domains from the active Jangar Torghut market-context bundle so health and quality only reflect technicals/regime.
- Removes the Jangar GitOps secret and deployment env that wired the service back to the retired market-context news provider endpoint.
- Updates the Torghut Python market-context schema to accept active-domain bundles while ignoring legacy retired domain fields from older payloads.

## Related Issues

None

## Testing

- `bun run test -- src/server/__tests__/torghut-market-context.test.ts src/routes/api/torghut/market-context/-health.test.ts` from `services/jangar`
- `uv run --frozen pytest tests/test_market_context.py tests/test_scheduler_market_context_status.py -q` from `services/torghut`
- `ruff format --check app/trading/llm/schema.py tests/test_market_context.py && ruff check app/trading/llm/schema.py tests/test_market_context.py` from `services/torghut`
- `bunx oxfmt --check services/jangar/src/server/torghut-market-context.ts services/jangar/src/server/torghut-market-context-config.ts services/jangar/src/server/__tests__/torghut-market-context.test.ts`
- `bun run --cwd services/jangar tsc`
- `bun run --cwd services/jangar lint`
- `bun run --cwd services/jangar lint:oxlint` (passes with pre-existing warnings outside this change)
- `uv sync --frozen --extra dev` from `services/torghut`
- `uv run --frozen pyright --project pyrightconfig.json` from `services/torghut`
- `uv run --frozen pyright --project pyrightconfig.alpha.json` from `services/torghut`
- `uv run --frozen pyright --project pyrightconfig.scripts.json` from `services/torghut`
- `bun run lint:argocd`
- `bun run --cwd services/jangar build`
- `bun run --cwd services/jangar check:module-sizes`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

Jangar no longer includes fundamentals/news in the active Torghut market-context bundle and no longer configures the retired news provider URL. Torghut accepts the active technicals/regime bundle and ignores legacy retired domain fields from older payloads.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
