### PR TITLE
chore(analysis): deploy upstream semiconductor backlog board

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: d4f853bc3bea25697a14a5d1bfd940594ba65b9d
+    newTag: 9a9c67ab6f01a9937a533909227fbcb4c7cc1aab


### PR DESCRIPTION
## Summary

- Deploys the Analysis site image built from `gregkonush/analysis@9a9c67ab6f01a9937a533909227fbcb4c7cc1aab`.
- Updates the Argo CD `analysis` application image tag to publish the upstream semiconductor backlog conversion board.
- Uses the registry-verified image digest `sha256:7fe0d3833d068246700f5faceedeaaaa130b13c46d6dd987edf308e2c1c674f9`.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl kustomize argocd/applications/analysis`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
