### PR TITLE
chore(torghut): promote image 9480b512

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.580.11-22-gc39dcf4b6
+              value: v0.580.11-34-g9480b5121
             - name: TORGHUT_OPTIONS_COMMIT
-              value: c39dcf4b68fd671324184649894bd698c1fe495f
+              value: 9480b5121279f71890ce50ff65498ad9d0c802ae
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.580.11-22-gc39dcf4b6
+              value: v0.580.11-34-g9480b5121
             - name: TORGHUT_OPTIONS_COMMIT
-              value: c39dcf4b68fd671324184649894bd698c1fe495f
+              value: 9480b5121279f71890ce50ff65498ad9d0c802ae
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -105,7 +105,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+                  value: sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-29T22:45:24Z"
+        client.knative.dev/updateTimestamp: "2026-05-29T23:44:36Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
           ports:
             - name: http1
               containerPort: 8181
@@ -513,11 +513,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.580.11-22-gc39dcf4b6
+              value: v0.580.11-34-g9480b5121
             - name: TORGHUT_COMMIT
-              value: c39dcf4b68fd671324184649894bd698c1fe495f
+              value: 9480b5121279f71890ce50ff65498ad9d0c802ae
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+              value: sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-29T22:45:24Z"
+        client.knative.dev/updateTimestamp: "2026-05-29T23:44:36Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
           ports:
             - name: http1
               containerPort: 8181
@@ -332,11 +332,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.580.11-22-gc39dcf4b6
+              value: v0.580.11-34-g9480b5121
             - name: TORGHUT_COMMIT
-              value: c39dcf4b68fd671324184649894bd698c1fe495f
+              value: 9480b5121279f71890ce50ff65498ad9d0c802ae
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+              value: sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:cd5b1b0fe44b622206b6d5aa1325f55e1a7fb0dc863220f4eb6a37ed0cbb2bb3
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `9480b5121279f71890ce50ff65498ad9d0c802ae`
- Image tag: `9480b512`
- Image digest: `sha256:4ee01815d1fa22a29943fb81a4655490beda2b850b96ea5adc6329c16ac0cdff`