### PR TITLE
chore(analysis): deploy software backlog board

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 9a9c67ab6f01a9937a533909227fbcb4c7cc1aab
+    newTag: d96b5be1f01826c57b390b864360171805ac0407


### PR DESCRIPTION
## Summary

- Pins the `analysis` Argo CD application to image tag `d96b5be1f01826c57b390b864360171805ac0407`.
- Publishes the new software/data/security backlog conversion board from `gregkonush/analysis`.
- Keeps the existing Tailscale-exposed `analysis` service shape unchanged.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl kustomize argocd/applications/analysis`
- Verified GitHub Actions image run `26668022892` published `registry.ide-newton.ts.net/lab/analysis:d96b5be1f01826c57b390b864360171805ac0407` at `sha256:62ef62c75e48e44c1f04b5a80a3965333e044e35568973285d2a5f7a32f54996`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
