### PR TITLE
refactor(torghut): centralize runtime ledger proof policy

### DIFF
--- a/services/torghut/app/trading/executable_alpha_receipts.py
+++ b/services/torghut/app/trading/executable_alpha_receipts.py
@@ -9,6 +9,8 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from typing import Any, Literal, cast
 
+from .runtime_ledger import POST_COST_PNL_BASIS
+
 CAPITAL_REPLAY_BOARD_SCHEMA_VERSION = "torghut.capital-replay-board.v1"
 EXECUTABLE_ALPHA_RECEIPTS_SCHEMA_VERSION = "torghut.executable-alpha-receipts.v1"
 EXECUTABLE_ALPHA_REPAIR_RECEIPT_SCHEMA_VERSION = (
@@ -158,7 +160,6 @@ _RUNTIME_LEDGER_PAPER_PROBATION_REASON = "runtime_ledger_stage_not_live"
 _RUNTIME_LEDGER_PAPER_PROBATION_ALLOWED_REASONS = {
     _RUNTIME_LEDGER_PAPER_PROBATION_REASON
 }
-_RUNTIME_LEDGER_PROMOTION_PNL_BASIS = "realized_strategy_pnl_after_explicit_costs"
 _ZERO_RUNTIME_EVIDENCE_REASONS = {
     "hypothesis_window_decisions_missing",
     "hypothesis_window_orders_missing",
@@ -1400,7 +1401,7 @@ def _runtime_ledger_paper_probation_eligible(
     return (
         _text(item.get("observed_stage")) == "paper"
         and reasons == _RUNTIME_LEDGER_PAPER_PROBATION_ALLOWED_REASONS
-        and _text(item.get("pnl_basis")) == _RUNTIME_LEDGER_PROMOTION_PNL_BASIS
+        and _text(item.get("pnl_basis")) == POST_COST_PNL_BASIS
         and (_float(item.get("filled_notional")) or 0.0) > 0.0
         and _int(item.get("fill_count")) > 0
         and _int(item.get("closed_trade_count")) > 0
@@ -1568,7 +1569,7 @@ def _runtime_ledger_economic_repair_item(
                 "status": "blocked",
                 "required_stage": "live",
                 "observed_stage": item.get("observed_stage"),
-                "required_basis": "realized_strategy_pnl_after_explicit_costs",
+                "required_basis": POST_COST_PNL_BASIS,
             },
             {
                 "code": "promotion_certificate_required",

--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -31,6 +31,7 @@ from ..models import (
 )
 from .runtime_cost_authority import cost_basis_counts_have_non_promotion_grade_costs
 from .runtime_ledger import POST_COST_PNL_BASIS
+from .runtime_ledger_proof_policy import runtime_ledger_proof_policy_from_env
 
 
 PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION = "torghut.paper-route-evidence.v1"
@@ -61,9 +62,6 @@ RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE = "artifacts/runtime-ledger-proof-packet
 RUNTIME_WINDOW_IMPORT_OUTPUT_FILE = "artifacts/runtime-window-import.json"
 RUNTIME_LEDGER_PROOF_PACKET_ARTIFACT_PREFIX = "runtime-ledger-proof-packets/{run_id}"
 RUNTIME_LEDGER_SUMMARY_ROW_LIMIT = 50
-MIN_RUNTIME_LEDGER_PROOF_NET_PNL = "500"
-MIN_RUNTIME_LEDGER_PROOF_DAILY_NET_PNL = "500"
-MIN_RUNTIME_LEDGER_PROOF_TRADING_DAYS = 1
 US_EQUITIES_TIMEZONE = "America/New_York"
 US_EQUITIES_OPEN = time(hour=9, minute=30)
 US_EQUITIES_CLOSE = time(hour=16, minute=0)
@@ -3221,6 +3219,7 @@ def _runtime_ledger_proof_packet_handoff(
     next_targets: Mapping[str, object],
     runtime_window_import_audit: Mapping[str, object],
 ) -> dict[str, object]:
+    proof_policy = runtime_ledger_proof_policy_from_env()
     runtime_import_handoff = _as_mapping(
         next_targets.get("runtime_window_import_handoff")
     )
@@ -3248,11 +3247,11 @@ def _runtime_ledger_proof_packet_handoff(
         "--completion-service-base-url",
         "$TORGHUT_LIVE_SERVICE_BASE_URL",
         "--min-runtime-ledger-net-pnl",
-        MIN_RUNTIME_LEDGER_PROOF_NET_PNL,
+        str(proof_policy.min_net_pnl_after_costs),
         "--min-runtime-ledger-daily-net-pnl",
-        MIN_RUNTIME_LEDGER_PROOF_DAILY_NET_PNL,
+        str(proof_policy.min_daily_net_pnl_after_costs),
         "--min-runtime-ledger-trading-days",
-        str(MIN_RUNTIME_LEDGER_PROOF_TRADING_DAYS),
+        str(proof_policy.min_trading_days),
         "--output-file",
         RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE,
     ]
@@ -3291,13 +3290,7 @@ def _runtime_ledger_proof_packet_handoff(
             "completion_doc29": "/trading/completion/doc29",
         },
         "targets": {
-            "min_runtime_ledger_net_pnl_after_costs": (
-                MIN_RUNTIME_LEDGER_PROOF_NET_PNL
-            ),
-            "min_runtime_ledger_daily_net_pnl_after_costs": (
-                MIN_RUNTIME_LEDGER_PROOF_DAILY_NET_PNL
-            ),
-            "min_runtime_ledger_trading_days": MIN_RUNTIME_LEDGER_PROOF_TRADING_DAYS,
+            **proof_policy.target_payload(),
         },
         "runtime_window": {
             "import_ready": import_ready,

--- a/services/torghut/app/trading/runtime_ledger_proof_policy.py
+++ b/services/torghut/app/trading/runtime_ledger_proof_policy.py
@@ -1,0 +1,120 @@
+"""Single source of truth for runtime-ledger proof thresholds."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+
+
+@dataclass(frozen=True)
+class RuntimeLedgerProofPolicy:
+    min_net_pnl_after_costs: Decimal = Decimal("500")
+    min_daily_net_pnl_after_costs: Decimal = Decimal("500")
+    min_trading_days: int = 1
+    max_drawdown_pct_equity: Decimal = Decimal("0.08")
+    max_best_day_share: Decimal = Decimal("0.25")
+    max_symbol_concentration_share: Decimal = Decimal("0.50")
+    authority_min_trading_days: int = 20
+    authority_min_mean_daily_net_pnl_after_costs: Decimal = Decimal("500")
+    authority_min_median_daily_net_pnl_after_costs: Decimal = Decimal("250")
+    authority_min_p10_daily_net_pnl_after_costs: Decimal = Decimal("-250")
+    authority_min_worst_day_net_pnl_after_costs: Decimal = Decimal("-750")
+    authority_max_intraday_drawdown: Decimal = Decimal("1500")
+    authority_max_best_day_share: Decimal = Decimal("0.25")
+
+    def target_payload(self) -> dict[str, object]:
+        return {
+            "min_runtime_ledger_net_pnl_after_costs": _decimal_text(
+                self.min_net_pnl_after_costs
+            ),
+            "min_runtime_ledger_daily_net_pnl_after_costs": _decimal_text(
+                self.min_daily_net_pnl_after_costs
+            ),
+            "min_runtime_ledger_trading_days": self.min_trading_days,
+        }
+
+
+DEFAULT_RUNTIME_LEDGER_PROOF_POLICY = RuntimeLedgerProofPolicy()
+
+_DECIMAL_ENV_FIELDS = {
+    "TORGHUT_RUNTIME_LEDGER_PROOF_MIN_NET_PNL_AFTER_COSTS": ("min_net_pnl_after_costs"),
+    "TORGHUT_RUNTIME_LEDGER_PROOF_MIN_DAILY_NET_PNL_AFTER_COSTS": (
+        "min_daily_net_pnl_after_costs"
+    ),
+    "TORGHUT_RUNTIME_LEDGER_PROOF_MAX_DRAWDOWN_PCT_EQUITY": ("max_drawdown_pct_equity"),
+    "TORGHUT_RUNTIME_LEDGER_PROOF_MAX_BEST_DAY_SHARE": "max_best_day_share",
+    "TORGHUT_RUNTIME_LEDGER_PROOF_MAX_SYMBOL_CONCENTRATION_SHARE": (
+        "max_symbol_concentration_share"
+    ),
+    "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MIN_MEAN_DAILY_NET_PNL_AFTER_COSTS": (
+        "authority_min_mean_daily_net_pnl_after_costs"
+    ),
+    "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MIN_MEDIAN_DAILY_NET_PNL_AFTER_COSTS": (
+        "authority_min_median_daily_net_pnl_after_costs"
+    ),
+    "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MIN_P10_DAILY_NET_PNL_AFTER_COSTS": (
+        "authority_min_p10_daily_net_pnl_after_costs"
+    ),
+    "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MIN_WORST_DAY_NET_PNL_AFTER_COSTS": (
+        "authority_min_worst_day_net_pnl_after_costs"
+    ),
+    "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MAX_INTRADAY_DRAWDOWN": (
+        "authority_max_intraday_drawdown"
+    ),
+    "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MAX_BEST_DAY_SHARE": (
+        "authority_max_best_day_share"
+    ),
+}
+_INT_ENV_FIELDS = {
+    "TORGHUT_RUNTIME_LEDGER_PROOF_MIN_TRADING_DAYS": "min_trading_days",
+    "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MIN_TRADING_DAYS": ("authority_min_trading_days"),
+}
+
+
+def runtime_ledger_proof_policy_from_env(
+    environ: Mapping[str, str] | None = None,
+) -> RuntimeLedgerProofPolicy:
+    source = os.environ if environ is None else environ
+    values = DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.__dict__.copy()
+    for env_name, field_name in _DECIMAL_ENV_FIELDS.items():
+        raw_value = source.get(env_name)
+        if raw_value is None or not raw_value.strip():
+            continue
+        values[field_name] = _parse_decimal_env(env_name, raw_value)
+    for env_name, field_name in _INT_ENV_FIELDS.items():
+        raw_value = source.get(env_name)
+        if raw_value is None or not raw_value.strip():
+            continue
+        values[field_name] = _parse_int_env(env_name, raw_value)
+    return RuntimeLedgerProofPolicy(**values)
+
+
+def _parse_decimal_env(name: str, value: str) -> Decimal:
+    try:
+        return Decimal(value.strip())
+    except InvalidOperation as exc:
+        raise ValueError(f"{name} must be a decimal: {value!r}") from exc
+
+
+def _parse_int_env(name: str, value: str) -> int:
+    try:
+        parsed = int(value.strip())
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer: {value!r}") from exc
+    if parsed < 0:
+        raise ValueError(f"{name} must be non-negative: {value!r}")
+    return parsed
+
+
+def _decimal_text(value: Decimal) -> str:
+    text = format(value.normalize(), "f")
+    return text.rstrip("0").rstrip(".") if "." in text else text
+
+
+__all__ = [
+    "DEFAULT_RUNTIME_LEDGER_PROOF_POLICY",
+    "RuntimeLedgerProofPolicy",
+    "runtime_ledger_proof_policy_from_env",
+]

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -39,15 +39,17 @@ from .runtime_decision_authority import (
     source_decision_mode_counts_have_profit_proof_modes,
     source_decision_mode_is_profit_proof_eligible,
 )
+from .runtime_ledger_proof_policy import runtime_ledger_proof_policy_from_env
 
 US_EQUITIES_REGULAR_TIMEZONE = "America/New_York"
 US_EQUITIES_REGULAR_OPEN = time(hour=9, minute=30)
 US_EQUITIES_REGULAR_CLOSE = time(hour=16, minute=0)
 PROMOTION_GRADE_POST_COST_BASES = frozenset(
     {
-        "realized_strategy_pnl_after_explicit_costs",
+        POST_COST_PNL_BASIS,
     }
 )
+RUNTIME_LEDGER_PROOF_POLICY = runtime_ledger_proof_policy_from_env()
 _RUNTIME_LEDGER_PROOF_SATISFIED_METADATA_BLOCKERS = frozenset(
     {
         "paper_route_runtime_ledger_import_pending",
@@ -84,13 +86,6 @@ RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
         "torghut.runtime-ledger-bucket.v1",
     }
 )
-RUNTIME_LEDGER_AUTHORITY_MIN_TRADING_DAYS = 20
-RUNTIME_LEDGER_AUTHORITY_MIN_MEAN_DAILY_NET_PNL = Decimal("500")
-RUNTIME_LEDGER_AUTHORITY_MIN_MEDIAN_DAILY_NET_PNL = Decimal("250")
-RUNTIME_LEDGER_AUTHORITY_MIN_P10_DAILY_NET_PNL = Decimal("-250")
-RUNTIME_LEDGER_AUTHORITY_MIN_WORST_DAY_NET_PNL = Decimal("-750")
-RUNTIME_LEDGER_AUTHORITY_MAX_INTRADAY_DRAWDOWN = Decimal("1500")
-RUNTIME_LEDGER_AUTHORITY_MAX_BEST_DAY_SHARE = Decimal("0.25")
 
 
 @dataclass(frozen=True)
@@ -782,28 +777,34 @@ def _runtime_ledger_authority_gate_targets(
     average_post_cost_bps: Decimal,
 ) -> dict[str, Any]:
     target_implied_notional = (
-        RUNTIME_LEDGER_AUTHORITY_MIN_MEAN_DAILY_NET_PNL
+        RUNTIME_LEDGER_PROOF_POLICY.authority_min_mean_daily_net_pnl_after_costs
         * Decimal("10000")
         / average_post_cost_bps
         if average_post_cost_bps > 0
         else None
     )
     return {
-        "min_observed_trading_days": RUNTIME_LEDGER_AUTHORITY_MIN_TRADING_DAYS,
+        "min_observed_trading_days": (
+            RUNTIME_LEDGER_PROOF_POLICY.authority_min_trading_days
+        ),
         "min_mean_daily_net_pnl_after_costs": str(
-            RUNTIME_LEDGER_AUTHORITY_MIN_MEAN_DAILY_NET_PNL
+            RUNTIME_LEDGER_PROOF_POLICY.authority_min_mean_daily_net_pnl_after_costs
         ),
         "min_median_daily_net_pnl_after_costs": str(
-            RUNTIME_LEDGER_AUTHORITY_MIN_MEDIAN_DAILY_NET_PNL
+            RUNTIME_LEDGER_PROOF_POLICY.authority_min_median_daily_net_pnl_after_costs
         ),
         "min_p10_daily_net_pnl_after_costs": str(
-            RUNTIME_LEDGER_AUTHORITY_MIN_P10_DAILY_NET_PNL
+            RUNTIME_LEDGER_PROOF_POLICY.authority_min_p10_daily_net_pnl_after_costs
         ),
         "min_worst_day_net_pnl_after_costs": str(
-            RUNTIME_LEDGER_AUTHORITY_MIN_WORST_DAY_NET_PNL
+            RUNTIME_LEDGER_PROOF_POLICY.authority_min_worst_day_net_pnl_after_costs
         ),
-        "max_intraday_drawdown": str(RUNTIME_LEDGER_AUTHORITY_MAX_INTRADAY_DRAWDOWN),
-        "max_best_day_share": str(RUNTIME_LEDGER_AUTHORITY_MAX_BEST_DAY_SHARE),
+        "max_intraday_drawdown": str(
+            RUNTIME_LEDGER_PROOF_POLICY.authority_max_intraday_drawdown
+        ),
+        "max_best_day_share": str(
+            RUNTIME_LEDGER_PROOF_POLICY.authority_max_best_day_share
+        ),
         "target_implied_avg_daily_filled_notional": (
             _decimal_text(target_implied_notional)
             if target_implied_notional is not None
@@ -914,28 +915,43 @@ def _runtime_promotion_blocking_reasons(
         "runtime_ledger_avg_daily_filled_notional",
     )
 
-    if observed_trading_days < RUNTIME_LEDGER_AUTHORITY_MIN_TRADING_DAYS:
+    if observed_trading_days < RUNTIME_LEDGER_PROOF_POLICY.authority_min_trading_days:
         reasons.append(
             "runtime_ledger_observed_trading_day_count_below_authority_minimum"
         )
-    if mean_daily_net_pnl < RUNTIME_LEDGER_AUTHORITY_MIN_MEAN_DAILY_NET_PNL:
+    if (
+        mean_daily_net_pnl
+        < RUNTIME_LEDGER_PROOF_POLICY.authority_min_mean_daily_net_pnl_after_costs
+    ):
         reasons.append("runtime_ledger_mean_daily_net_pnl_after_costs_below_target")
-    if median_daily_net_pnl < RUNTIME_LEDGER_AUTHORITY_MIN_MEDIAN_DAILY_NET_PNL:
+    if (
+        median_daily_net_pnl
+        < RUNTIME_LEDGER_PROOF_POLICY.authority_min_median_daily_net_pnl_after_costs
+    ):
         reasons.append("runtime_ledger_median_daily_net_pnl_after_costs_below_floor")
-    if p10_daily_net_pnl < RUNTIME_LEDGER_AUTHORITY_MIN_P10_DAILY_NET_PNL:
+    if (
+        p10_daily_net_pnl
+        < RUNTIME_LEDGER_PROOF_POLICY.authority_min_p10_daily_net_pnl_after_costs
+    ):
         reasons.append("runtime_ledger_p10_daily_net_pnl_after_costs_below_floor")
-    if worst_day_net_pnl < RUNTIME_LEDGER_AUTHORITY_MIN_WORST_DAY_NET_PNL:
+    if (
+        worst_day_net_pnl
+        < RUNTIME_LEDGER_PROOF_POLICY.authority_min_worst_day_net_pnl_after_costs
+    ):
         reasons.append("runtime_ledger_worst_day_net_pnl_after_costs_below_floor")
-    if max_intraday_drawdown > RUNTIME_LEDGER_AUTHORITY_MAX_INTRADAY_DRAWDOWN:
+    if (
+        max_intraday_drawdown
+        > RUNTIME_LEDGER_PROOF_POLICY.authority_max_intraday_drawdown
+    ):
         reasons.append("runtime_ledger_max_intraday_drawdown_above_limit")
     if (
         best_day_share is not None
-        and best_day_share > RUNTIME_LEDGER_AUTHORITY_MAX_BEST_DAY_SHARE
+        and best_day_share > RUNTIME_LEDGER_PROOF_POLICY.authority_max_best_day_share
     ):
         reasons.append("runtime_ledger_best_day_share_above_limit")
     if average_post_cost > 0:
         target_implied_notional = (
-            RUNTIME_LEDGER_AUTHORITY_MIN_MEAN_DAILY_NET_PNL
+            RUNTIME_LEDGER_PROOF_POLICY.authority_min_mean_daily_net_pnl_after_costs
             * Decimal("10000")
             / average_post_cost
         )

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -44,6 +44,7 @@ from .market_context_domains import (
 from .discovery.profit_target_oracle import evaluate_profit_target_oracle
 from .profit_windows import build_profit_window_contract
 from .profit_leases import build_profit_lease_projection
+from .runtime_ledger import POST_COST_PNL_BASIS
 from .tca import build_tca_gate_inputs
 
 _CAPITAL_STAGE_ORDER = (
@@ -81,7 +82,6 @@ _AUTORESEARCH_PORTFOLIO_READY_STATUSES = (
     "accepted",
     "promoted",
 )
-_PROMOTION_GRADE_RUNTIME_LEDGER_PNL_BASIS = "realized_strategy_pnl_after_explicit_costs"
 _RUNTIME_LEDGER_REPAIR_SCAN_LIMIT = 256
 _RUNTIME_LEDGER_REPAIR_CANDIDATE_LIMIT = 8
 _RUNTIME_WINDOW_IMPORT_CONTINUITY_READY_STATES = frozenset(
@@ -860,10 +860,7 @@ def _certificate_runtime_ledger_reason_codes(
     ]
     reasons.extend(blockers)
 
-    if (
-        _safe_text(ledger_payload.get("pnl_basis"))
-        != "realized_strategy_pnl_after_explicit_costs"
-    ):
+    if _safe_text(ledger_payload.get("pnl_basis")) != POST_COST_PNL_BASIS:
         reasons.append("runtime_ledger_pnl_basis_missing")
 
     filled_notional = _safe_decimal(ledger_payload.get("filled_notional"))
@@ -1031,10 +1028,7 @@ def _runtime_ledger_selection_score(payload: Mapping[str, object] | None) -> int
     ]
     if not blockers:
         score += 1
-    if (
-        _safe_text(payload.get("pnl_basis"))
-        == "realized_strategy_pnl_after_explicit_costs"
-    ):
+    if _safe_text(payload.get("pnl_basis")) == POST_COST_PNL_BASIS:
         score += 1
     if (_safe_decimal(payload.get("filled_notional")) or Decimal("0")) > 0:
         score += 1
@@ -1145,10 +1139,7 @@ def _runtime_ledger_repair_reason_codes(
     reasons.extend(_runtime_ledger_target_reason_codes(payload, manifest=manifest))
     if _safe_text(payload.get("observed_stage")) != "live":
         reasons.append("runtime_ledger_stage_not_live")
-    if (
-        _safe_text(payload.get("pnl_basis"))
-        != _PROMOTION_GRADE_RUNTIME_LEDGER_PNL_BASIS
-    ):
+    if _safe_text(payload.get("pnl_basis")) != POST_COST_PNL_BASIS:
         reasons.append("runtime_ledger_pnl_basis_missing")
     if (_safe_decimal(payload.get("filled_notional")) or Decimal("0")) <= 0:
         reasons.append("runtime_ledger_filled_notional_missing")
@@ -1273,8 +1264,7 @@ def _runtime_ledger_paper_probation_eligible(
     return (
         _safe_text(candidate.get("observed_stage")) == "paper"
         and reasons == _RUNTIME_LEDGER_PAPER_PROBATION_ALLOWED_REASONS
-        and _safe_text(candidate.get("pnl_basis"))
-        == _PROMOTION_GRADE_RUNTIME_LEDGER_PNL_BASIS
+        and _safe_text(candidate.get("pnl_basis")) == POST_COST_PNL_BASIS
         and (_safe_decimal(candidate.get("filled_notional")) or Decimal("0")) > 0
         and _safe_int(candidate.get("fill_count")) > 0
         and _safe_int(candidate.get("closed_trade_count")) > 0

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -23,15 +23,12 @@ from typing import Any, Protocol, cast
 from urllib.parse import urljoin
 from urllib.request import urlopen
 
+from app.trading.runtime_ledger_proof_policy import runtime_ledger_proof_policy_from_env
+
 
 SCHEMA_VERSION = "torghut.runtime-ledger-live-paper-proof-packet.v1"
 DOC29_LIVE_SCALE_GATE = "live_scale_observed"
-DEFAULT_MIN_RUNTIME_LEDGER_NET_PNL = Decimal("500")
-DEFAULT_MIN_RUNTIME_LEDGER_DAILY_NET_PNL = Decimal("500")
-DEFAULT_MIN_RUNTIME_LEDGER_TRADING_DAYS = 1
-DEFAULT_MAX_RUNTIME_LEDGER_DRAWDOWN_PCT_EQUITY = Decimal("0.08")
-DEFAULT_MAX_RUNTIME_LEDGER_BEST_DAY_SHARE = Decimal("0.25")
-DEFAULT_MAX_RUNTIME_LEDGER_SYMBOL_CONCENTRATION_SHARE = Decimal("0.50")
+DEFAULT_RUNTIME_LEDGER_PROOF_POLICY = runtime_ledger_proof_policy_from_env()
 STATUS_ENDPOINT = "/trading/status"
 PAPER_ROUTE_EVIDENCE_ENDPOINT = "/trading/paper-route-evidence"
 COMPLETION_DOC29_ENDPOINT = "/trading/completion/doc29"
@@ -1227,17 +1224,23 @@ def build_runtime_ledger_proof_packet(
     paper_route_evidence: Mapping[str, Any] | None = None,
     runtime_window_import: Mapping[str, Any] | None = None,
     completion_status: Mapping[str, Any] | None = None,
-    min_runtime_ledger_net_pnl: Decimal = DEFAULT_MIN_RUNTIME_LEDGER_NET_PNL,
-    min_runtime_ledger_daily_net_pnl: Decimal = DEFAULT_MIN_RUNTIME_LEDGER_DAILY_NET_PNL,
-    min_runtime_ledger_trading_days: int = DEFAULT_MIN_RUNTIME_LEDGER_TRADING_DAYS,
+    min_runtime_ledger_net_pnl: Decimal = (
+        DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.min_net_pnl_after_costs
+    ),
+    min_runtime_ledger_daily_net_pnl: Decimal = (
+        DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.min_daily_net_pnl_after_costs
+    ),
+    min_runtime_ledger_trading_days: int = (
+        DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.min_trading_days
+    ),
     max_runtime_ledger_drawdown_pct_equity: Decimal = (
-        DEFAULT_MAX_RUNTIME_LEDGER_DRAWDOWN_PCT_EQUITY
+        DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.max_drawdown_pct_equity
     ),
     max_runtime_ledger_best_day_share: Decimal = (
-        DEFAULT_MAX_RUNTIME_LEDGER_BEST_DAY_SHARE
+        DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.max_best_day_share
     ),
     max_runtime_ledger_symbol_concentration_share: Decimal = (
-        DEFAULT_MAX_RUNTIME_LEDGER_SYMBOL_CONCENTRATION_SHARE
+        DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.max_symbol_concentration_share
     ),
     generated_at: str | None = None,
 ) -> dict[str, Any]:
@@ -1911,33 +1914,33 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--min-runtime-ledger-net-pnl",
-        default=str(DEFAULT_MIN_RUNTIME_LEDGER_NET_PNL),
+        default=str(DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.min_net_pnl_after_costs),
         help="Minimum total runtime-ledger net strategy PnL after costs.",
     )
     parser.add_argument(
         "--min-runtime-ledger-daily-net-pnl",
-        default=str(DEFAULT_MIN_RUNTIME_LEDGER_DAILY_NET_PNL),
+        default=str(DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.min_daily_net_pnl_after_costs),
         help="Minimum runtime-ledger net strategy PnL after costs per observed trading day.",
     )
     parser.add_argument(
         "--min-runtime-ledger-trading-days",
         type=int,
-        default=DEFAULT_MIN_RUNTIME_LEDGER_TRADING_DAYS,
+        default=DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.min_trading_days,
         help="Minimum observed runtime-ledger trading days.",
     )
     parser.add_argument(
         "--max-runtime-ledger-drawdown-pct-equity",
-        default=str(DEFAULT_MAX_RUNTIME_LEDGER_DRAWDOWN_PCT_EQUITY),
+        default=str(DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.max_drawdown_pct_equity),
         help="Maximum observed runtime-ledger drawdown as a fraction of equity.",
     )
     parser.add_argument(
         "--max-runtime-ledger-best-day-share",
-        default=str(DEFAULT_MAX_RUNTIME_LEDGER_BEST_DAY_SHARE),
+        default=str(DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.max_best_day_share),
         help="Maximum share of post-cost runtime-ledger PnL attributable to one trading day.",
     )
     parser.add_argument(
         "--max-runtime-ledger-symbol-concentration-share",
-        default=str(DEFAULT_MAX_RUNTIME_LEDGER_SYMBOL_CONCENTRATION_SHARE),
+        default=str(DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.max_symbol_concentration_share),
         help="Maximum share of post-cost runtime-ledger PnL attributable to one symbol.",
     )
     parser.add_argument("--generated-at", default=None)

--- a/services/torghut/tests/test_runtime_ledger_proof_policy.py
+++ b/services/torghut/tests/test_runtime_ledger_proof_policy.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest import TestCase
+
+from app.trading.runtime_ledger_proof_policy import (
+    DEFAULT_RUNTIME_LEDGER_PROOF_POLICY,
+    runtime_ledger_proof_policy_from_env,
+)
+
+
+class TestRuntimeLedgerProofPolicy(TestCase):
+    def test_default_policy_matches_goal_and_risk_gates(self) -> None:
+        self.assertEqual(
+            DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.target_payload(),
+            {
+                "min_runtime_ledger_net_pnl_after_costs": "500",
+                "min_runtime_ledger_daily_net_pnl_after_costs": "500",
+                "min_runtime_ledger_trading_days": 1,
+            },
+        )
+        self.assertEqual(
+            DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.max_drawdown_pct_equity,
+            Decimal("0.08"),
+        )
+
+    def test_policy_can_be_overridden_without_touching_call_sites(self) -> None:
+        policy = runtime_ledger_proof_policy_from_env(
+            {
+                "TORGHUT_RUNTIME_LEDGER_PROOF_MIN_NET_PNL_AFTER_COSTS": "750",
+                "TORGHUT_RUNTIME_LEDGER_PROOF_MIN_DAILY_NET_PNL_AFTER_COSTS": "625",
+                "TORGHUT_RUNTIME_LEDGER_PROOF_MIN_TRADING_DAYS": "3",
+                "TORGHUT_RUNTIME_LEDGER_PROOF_MAX_DRAWDOWN_PCT_EQUITY": "0.12",
+                "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MIN_TRADING_DAYS": "10",
+            }
+        )
+
+        self.assertEqual(policy.min_net_pnl_after_costs, Decimal("750"))
+        self.assertEqual(policy.min_daily_net_pnl_after_costs, Decimal("625"))
+        self.assertEqual(policy.min_trading_days, 3)
+        self.assertEqual(policy.max_drawdown_pct_equity, Decimal("0.12"))
+        self.assertEqual(policy.authority_min_trading_days, 10)
+
+    def test_invalid_policy_env_fails_closed(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must be a decimal"):
+            runtime_ledger_proof_policy_from_env(
+                {
+                    "TORGHUT_RUNTIME_LEDGER_PROOF_MIN_NET_PNL_AFTER_COSTS": "nope",
+                }
+            )
+
+        with self.assertRaisesRegex(ValueError, "must be non-negative"):
+            runtime_ledger_proof_policy_from_env(
+                {
+                    "TORGHUT_RUNTIME_LEDGER_PROOF_MIN_TRADING_DAYS": "-1",
+                }
+            )


### PR DESCRIPTION
## Summary

- Centralizes Torghut runtime-ledger proof and authority thresholds in one policy module.
- Wires the proof-packet handoff, packet assembler, and runtime-window import gates to that shared policy instead of duplicated local constants.
- Replaces duplicate runtime-ledger PnL-basis strings in repair and submission paths with the shared ledger constant.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_ledger_proof_policy.py app/trading/paper_route_evidence.py app/trading/runtime_window_import.py app/trading/submission_council.py app/trading/executable_alpha_receipts.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_ledger_proof_policy.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger_proof_policy.py app/trading/paper_route_evidence.py app/trading/runtime_window_import.py app/trading/submission_council.py app/trading/executable_alpha_receipts.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_ledger_proof_policy.py`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger_proof_policy.py tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_builder_exports_next_paper_route_runtime_window_targets tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_persist_observed_runtime_windows_allows_authority_grade_live_ledger tests/test_assemble_runtime_ledger_proof_packet.py::TestRuntimeLedgerProofPacket::test_packet_allows_only_complete_post_cost_runtime_ledger_proof tests/test_submission_council.py::TestSubmissionCouncil::test_build_live_submission_gate_payload_surfaces_runtime_ledger_repair_candidates tests/test_submission_council.py::TestSubmissionCouncil::test_runtime_ledger_paper_probation_import_plan_falls_back_and_skips_incomplete_targets tests/test_executable_alpha_receipts.py::test_capital_replay_board_prioritizes_runtime_ledger_economic_repair_candidate -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
