### PR TITLE
fix(torghut): snapshot paper route account before open

### DIFF
--- a/services/torghut/app/trading/scheduler/pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline.py
@@ -24,6 +24,7 @@ from ...db import SessionLocal
 from ...models import (
     Execution,
     LLMDecisionReview,
+    PositionSnapshot,
     RejectedSignalOutcomeEvent,
     Strategy,
     TradeDecision,
@@ -67,6 +68,10 @@ from ..market_context_domains import (
 )
 from ..models import SignalEnvelope, StrategyDecision
 from ..order_feed import OrderFeedIngestor
+from ..paper_route_evidence import (
+    PAPER_ROUTE_ACCOUNT_PRE_SESSION_READINESS_SECONDS,
+    PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_AFTER_START_GRACE_SECONDS,
+)
 from ..portfolio import (
     AllocationResult,
     PortfolioSizingResult,
@@ -220,6 +225,7 @@ class TradingPipeline:
             )
         )
         self._session_context_warmup_day: date | None = None
+        self._runtime_window_account_snapshot_day: date | None = None
 
     def run_once(self) -> None:
         self._label_mature_rejected_signal_outcome_events()
@@ -228,6 +234,7 @@ class TradingPipeline:
             strategies = self._prepare_run_once(session)
             if not strategies:
                 return
+            self._capture_runtime_window_account_snapshot_if_due(session)
             self._warm_session_context_from_open(session, strategies=strategies)
 
             batch = self.ingestor.fetch_signals(session)
@@ -386,6 +393,65 @@ class TradingPipeline:
             warmed,
             max_warmup_seconds,
             max_warmup_signals,
+        )
+
+    def _capture_runtime_window_account_snapshot_if_due(self, session: Session) -> None:
+        if not (
+            settings.trading_simple_paper_route_probe_enabled
+            or str(settings.trading_paper_route_target_plan_url or "").strip()
+        ):
+            return
+
+        now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
+        session_day = now.date()
+        if self._runtime_window_account_snapshot_day == session_day:
+            return
+
+        session_open = datetime.combine(
+            session_day,
+            REGULAR_OPEN_UTC,
+            tzinfo=timezone.utc,
+        )
+        capture_start = session_open - timedelta(
+            seconds=PAPER_ROUTE_ACCOUNT_PRE_SESSION_READINESS_SECONDS
+        )
+        capture_end = session_open + timedelta(
+            seconds=PAPER_ROUTE_ACCOUNT_START_SNAPSHOT_AFTER_START_GRACE_SECONDS
+        )
+        if now < capture_start or now > capture_end:
+            return
+
+        existing_snapshot = session.execute(
+            select(PositionSnapshot.id)
+            .where(PositionSnapshot.alpaca_account_label == self.account_label)
+            .where(PositionSnapshot.as_of >= capture_start)
+            .where(PositionSnapshot.as_of <= capture_end)
+            .limit(1)
+        ).first()
+        if existing_snapshot is not None:
+            self._runtime_window_account_snapshot_day = session_day
+            return
+
+        try:
+            snapshot = self._get_account_snapshot(session)
+        except Exception:
+            session.rollback()
+            logger.exception(
+                "Failed to capture runtime-window account snapshot account=%s window_start=%s window_end=%s",
+                self.account_label,
+                capture_start.isoformat(),
+                capture_end.isoformat(),
+            )
+            return
+
+        self._runtime_window_account_snapshot_day = session_day
+        logger.info(
+            "Captured runtime-window account snapshot account=%s snapshot_id=%s as_of=%s window_start=%s window_end=%s",
+            self.account_label,
+            getattr(snapshot, "id", None),
+            getattr(snapshot, "as_of", None),
+            capture_start.isoformat(),
+            capture_end.isoformat(),
         )
 
     def _record_ingest_window(self, batch: SignalBatch) -> None:

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -393,6 +393,7 @@ class SimpleTradingPipeline(TradingPipeline):
             strategies = self._prepare_run_once(session)
             if not strategies:
                 return
+            self._capture_runtime_window_account_snapshot_if_due(session)
             self._warm_session_context_from_open(session, strategies=strategies)
 
             batch = self.ingestor.fetch_signals(session)

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 import tempfile
@@ -19,6 +19,7 @@ from app.models import (
     Base,
     Execution,
     LLMDecisionReview,
+    PositionSnapshot,
     RejectedSignalOutcomeEvent,
     Strategy,
     StrategyHypothesis,
@@ -1898,6 +1899,164 @@ class TestTradingPipeline(TestCase):
             config.settings.trading_enabled = original["trading_enabled"]
             config.settings.trading_mode = original["trading_mode"]
             config.settings.trading_live_enabled = original["trading_live_enabled"]
+
+    def test_simple_pipeline_snapshots_account_for_paper_route_window_without_signals(
+        self,
+    ) -> None:
+        from app import config
+
+        config.settings.trading_enabled = True
+        config.settings.trading_mode = "paper"
+        config.settings.trading_live_enabled = False
+        config.settings.trading_pipeline_mode = "simple"
+        config.settings.trading_simple_submit_enabled = True
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = ""
+        config.settings.trading_universe_source = "static"
+        config.settings.trading_static_symbols_raw = "AAPL"
+        config.settings.trading_universe_static_fallback_enabled = True
+        config.settings.trading_universe_static_fallback_symbols_raw = "AAPL"
+
+        with self.session_local() as session:
+            session.add(
+                Strategy(
+                    name="paper-route-window-snapshot",
+                    description="pre-open account snapshot regression",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=["AAPL"],
+                    max_notional_per_trade=Decimal("1000"),
+                )
+            )
+            session.commit()
+
+        alpaca_client = CountingAlpacaClient()
+        ingestor = FakeIngestor([])
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=ingestor,
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: False  # type: ignore[method-assign]
+
+        with patch(
+            "app.trading.scheduler.pipeline.trading_now",
+            return_value=datetime(2026, 3, 26, 13, 20, tzinfo=timezone.utc),
+        ):
+            pipeline.run_once()
+            pipeline.run_once()
+
+        with self.session_local() as session:
+            snapshots = session.scalars(select(PositionSnapshot)).all()
+
+        self.assertEqual(len(snapshots), 1)
+        self.assertEqual(snapshots[0].alpaca_account_label, "TORGHUT_SIM")
+        self.assertEqual(alpaca_client.account_calls, 1)
+        self.assertEqual(alpaca_client.position_calls, 1)
+        self.assertEqual(ingestor.committed_batches, 2)
+
+    def test_runtime_window_account_snapshot_skips_existing_snapshot(self) -> None:
+        from app import config
+
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = ""
+
+        alpaca_client = CountingAlpacaClient()
+        pipeline = TradingPipeline(
+            alpaca_client=alpaca_client,
+            order_firewall=OrderFirewall(alpaca_client),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=alpaca_client,
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+        )
+
+        with self.session_local() as session:
+            session.add(
+                PositionSnapshot(
+                    alpaca_account_label="TORGHUT_SIM",
+                    as_of=datetime(2026, 3, 26, 13, 20, tzinfo=timezone.utc),
+                    equity=Decimal("100000"),
+                    cash=Decimal("100000"),
+                    buying_power=Decimal("200000"),
+                    positions=[],
+                )
+            )
+            session.commit()
+
+            with patch(
+                "app.trading.scheduler.pipeline.trading_now",
+                return_value=datetime(2026, 3, 26, 13, 20, tzinfo=timezone.utc),
+            ):
+                pipeline._capture_runtime_window_account_snapshot_if_due(session)
+
+        self.assertEqual(
+            pipeline._runtime_window_account_snapshot_day, date(2026, 3, 26)
+        )
+        self.assertEqual(alpaca_client.account_calls, 0)
+        self.assertEqual(alpaca_client.position_calls, 0)
+
+    def test_runtime_window_account_snapshot_rolls_back_capture_failure(self) -> None:
+        from app import config
+
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = ""
+
+        pipeline = TradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="TORGHUT_SIM",
+            session_factory=self.session_local,
+        )
+        pipeline._get_account_snapshot = Mock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("broker unavailable")
+        )
+
+        with self.session_local() as session:
+            with patch(
+                "app.trading.scheduler.pipeline.trading_now",
+                return_value=datetime(2026, 3, 26, 13, 20, tzinfo=timezone.utc),
+            ):
+                with self.assertLogs(
+                    "app.trading.scheduler.pipeline",
+                    level="ERROR",
+                ) as logs:
+                    pipeline._capture_runtime_window_account_snapshot_if_due(session)
+
+            snapshot_count = session.query(PositionSnapshot).count()
+
+        self.assertEqual(snapshot_count, 0)
+        self.assertIsNone(pipeline._runtime_window_account_snapshot_day)
+        self.assertTrue(
+            any(
+                "Failed to capture runtime-window account snapshot" in message
+                for message in logs.output
+            )
+        )
 
     def test_pipeline_warms_session_context_with_bounded_replay_window(self) -> None:
         from app import config


### PR DESCRIPTION
## Summary

- Capture a real account/position snapshot during the paper-route runtime-window pre-open/open-start proof window, even when no signals arrive.
- Reuse the same timing constants as the paper-route evidence audit, and skip duplicate snapshots once a window snapshot already exists.
- Wire the shared snapshot hook through both the base trading pipeline and the simple pipeline override.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_route_window_without_signals or empty_signal_batch_commits_cursor' -q`
- `ruff format --check app/trading/scheduler/pipeline.py app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `ruff check app/trading/scheduler/pipeline.py app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
