### PR TITLE
fix(torghut): promote paper flatten image

### DIFF
--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -59,6 +59,7 @@ jobs:
             'argocd/applications/torghut/analysis-template-artifact-bundle.yaml'
             'argocd/applications/torghut/empirical-jobs-backfill-job.yaml'
             'argocd/applications/torghut/execution-tca-refresh-cronjob.yaml'
+            'argocd/applications/torghut/paper-account-flatten-cronjob.yaml'
             'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
             'argocd/applications/torghut-options/catalog/deployment.yaml'
             'argocd/applications/torghut-options/enricher/deployment.yaml'

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -256,6 +256,7 @@ jobs:
             argocd/applications/torghut/analysis-template-artifact-bundle.yaml \
             argocd/applications/torghut/empirical-jobs-backfill-job.yaml \
             argocd/applications/torghut/execution-tca-refresh-cronjob.yaml \
+            argocd/applications/torghut/paper-account-flatten-cronjob.yaml \
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml \
             argocd/applications/torghut-options/catalog/deployment.yaml \
             argocd/applications/torghut-options/enricher/deployment.yaml; then
@@ -295,6 +296,7 @@ jobs:
             argocd/applications/torghut/analysis-template-artifact-bundle.yaml
             argocd/applications/torghut/empirical-jobs-backfill-job.yaml
             argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+            argocd/applications/torghut/paper-account-flatten-cronjob.yaml
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut-options/catalog/deployment.yaml
             argocd/applications/torghut-options/enricher/deployment.yaml
@@ -337,6 +339,7 @@ jobs:
             argocd/applications/torghut/analysis-template-artifact-bundle.yaml
             argocd/applications/torghut/empirical-jobs-backfill-job.yaml
             argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+            argocd/applications/torghut/paper-account-flatten-cronjob.yaml
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut-options/catalog/deployment.yaml
             argocd/applications/torghut-options/enricher/deployment.yaml

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:bca1e2504ee4668024435cc1bd606268f0eaceb63321ef643ac7fc3566d3d499
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:389dfc79074248c8ac37e3f26bcd574ad76b9e419068651a0fae18ba38073355
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -21,6 +21,7 @@ const createFixture = () => {
   const empiricalBackfillManifestPath = join(dir, 'empirical-jobs-backfill-job.yaml')
   const empiricalPromotionRenewalManifestPath = join(dir, 'empirical-promotion-renewal-cronjob.yaml')
   const executionTcaRefreshManifestPath = join(dir, 'execution-tca-refresh-cronjob.yaml')
+  const paperAccountFlattenManifestPath = join(dir, 'paper-account-flatten-cronjob.yaml')
   const whitepaperSemanticBackfillManifestPath = join(dir, 'whitepaper-semantic-backfill-job.yaml')
   const optionsCatalogManifestPath = join(dir, 'options-catalog-deployment.yaml')
   const optionsEnricherManifestPath = join(dir, 'options-enricher-deployment.yaml')
@@ -97,6 +98,7 @@ spec:
     empiricalBackfillManifestPath,
     empiricalPromotionRenewalManifestPath,
     executionTcaRefreshManifestPath,
+    paperAccountFlattenManifestPath,
     whitepaperSemanticBackfillManifestPath,
   ]) {
     writeFileSync(
@@ -151,6 +153,7 @@ spec:
     empiricalBackfillManifestPath,
     empiricalPromotionRenewalManifestPath,
     executionTcaRefreshManifestPath,
+    paperAccountFlattenManifestPath,
     whitepaperSemanticBackfillManifestPath,
     optionsCatalogManifestPath,
     optionsEnricherManifestPath,
@@ -221,6 +224,7 @@ describe('update-manifests', () => {
       empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
       empiricalPromotionRenewalManifestPath: relative(repoRoot, fixture.empiricalPromotionRenewalManifestPath),
       executionTcaRefreshManifestPath: relative(repoRoot, fixture.executionTcaRefreshManifestPath),
+      paperAccountFlattenManifestPath: relative(repoRoot, fixture.paperAccountFlattenManifestPath),
       whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
       optionsCatalogManifestPath: relative(repoRoot, fixture.optionsCatalogManifestPath),
       optionsEnricherManifestPath: relative(repoRoot, fixture.optionsEnricherManifestPath),
@@ -242,6 +246,7 @@ describe('update-manifests', () => {
     const empiricalBackfillManifest = readFileSync(fixture.empiricalBackfillManifestPath, 'utf8')
     const empiricalPromotionRenewalManifest = readFileSync(fixture.empiricalPromotionRenewalManifestPath, 'utf8')
     const executionTcaRefreshManifest = readFileSync(fixture.executionTcaRefreshManifestPath, 'utf8')
+    const paperAccountFlattenManifest = readFileSync(fixture.paperAccountFlattenManifestPath, 'utf8')
     const whitepaperSemanticBackfillManifest = readFileSync(fixture.whitepaperSemanticBackfillManifestPath, 'utf8')
     const optionsCatalogManifest = readFileSync(fixture.optionsCatalogManifestPath, 'utf8')
     const optionsEnricherManifest = readFileSync(fixture.optionsEnricherManifestPath, 'utf8')
@@ -276,6 +281,7 @@ describe('update-manifests', () => {
       empiricalBackfillManifest,
       empiricalPromotionRenewalManifest,
       executionTcaRefreshManifest,
+      paperAccountFlattenManifest,
       whitepaperSemanticBackfillManifest,
     ]) {
       expect(manifest).toContain(
@@ -294,7 +300,7 @@ describe('update-manifests', () => {
     expect(result.imageRef).toBe(
       'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
-    expect(result.changedPaths.length).toBe(16)
+    expect(result.changedPaths.length).toBe(17)
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })
@@ -323,6 +329,7 @@ describe('update-manifests', () => {
       empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
       empiricalPromotionRenewalManifestPath: relative(repoRoot, fixture.empiricalPromotionRenewalManifestPath),
       executionTcaRefreshManifestPath: relative(repoRoot, fixture.executionTcaRefreshManifestPath),
+      paperAccountFlattenManifestPath: relative(repoRoot, fixture.paperAccountFlattenManifestPath),
       whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
       optionsCatalogManifestPath: relative(repoRoot, fixture.optionsCatalogManifestPath),
       optionsEnricherManifestPath: relative(repoRoot, fixture.optionsEnricherManifestPath),

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -27,6 +27,7 @@ const defaultEmpiricalBackfillManifestPath = 'argocd/applications/torghut/empiri
 const defaultEmpiricalPromotionRenewalManifestPath =
   'argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml'
 const defaultExecutionTcaRefreshManifestPath = 'argocd/applications/torghut/execution-tca-refresh-cronjob.yaml'
+const defaultPaperAccountFlattenManifestPath = 'argocd/applications/torghut/paper-account-flatten-cronjob.yaml'
 const defaultWhitepaperSemanticBackfillManifestPath =
   'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
 const defaultOptionsCatalogManifestPath = 'argocd/applications/torghut-options/catalog/deployment.yaml'
@@ -53,6 +54,7 @@ type UpdateManifestsOptions = {
   empiricalBackfillManifestPath?: string
   empiricalPromotionRenewalManifestPath?: string
   executionTcaRefreshManifestPath?: string
+  paperAccountFlattenManifestPath?: string
   whitepaperSemanticBackfillManifestPath?: string
   optionsCatalogManifestPath?: string
   optionsEnricherManifestPath?: string
@@ -79,6 +81,7 @@ type CliOptions = {
   empiricalBackfillManifestPath?: string
   empiricalPromotionRenewalManifestPath?: string
   executionTcaRefreshManifestPath?: string
+  paperAccountFlattenManifestPath?: string
   whitepaperSemanticBackfillManifestPath?: string
   optionsCatalogManifestPath?: string
   optionsEnricherManifestPath?: string
@@ -315,6 +318,11 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     options.executionTcaRefreshManifestPath ?? defaultExecutionTcaRefreshManifestPath,
     'torghut-execution-tca-refresh image reference',
   )
+  const paperAccountFlatten = updateImageOnlyManifest(
+    options,
+    options.paperAccountFlattenManifestPath ?? defaultPaperAccountFlattenManifestPath,
+    'torghut-paper-account-flatten image reference',
+  )
   const whitepaperSemanticBackfill = updateImageOnlyManifest(
     options,
     options.whitepaperSemanticBackfillManifestPath ?? defaultWhitepaperSemanticBackfillManifestPath,
@@ -350,6 +358,7 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     empiricalBackfill,
     empiricalPromotionRenewal,
     executionTcaRefresh,
+    paperAccountFlatten,
     whitepaperSemanticBackfill,
     optionsCatalog,
     optionsEnricher,
@@ -392,6 +401,7 @@ Options:
   --empirical-backfill-manifest-path <path>
   --empirical-promotion-renewal-manifest-path <path>
   --execution-tca-refresh-manifest-path <path>
+  --paper-account-flatten-manifest-path <path>
   --whitepaper-semantic-backfill-manifest-path <path>
   --options-catalog-manifest-path <path>
   --options-enricher-manifest-path <path>`)
@@ -472,6 +482,9 @@ Options:
       case '--execution-tca-refresh-manifest-path':
         options.executionTcaRefreshManifestPath = value
         break
+      case '--paper-account-flatten-manifest-path':
+        options.paperAccountFlattenManifestPath = value
+        break
       case '--whitepaper-semantic-backfill-manifest-path':
         options.whitepaperSemanticBackfillManifestPath = value
         break
@@ -536,6 +549,8 @@ const main = (cliOptions?: CliOptions) => {
       parsed.empiricalPromotionRenewalManifestPath ?? process.env.TORGHUT_EMPIRICAL_PROMOTION_RENEWAL_MANIFEST_PATH,
     executionTcaRefreshManifestPath:
       parsed.executionTcaRefreshManifestPath ?? process.env.TORGHUT_EXECUTION_TCA_REFRESH_MANIFEST_PATH,
+    paperAccountFlattenManifestPath:
+      parsed.paperAccountFlattenManifestPath ?? process.env.TORGHUT_PAPER_ACCOUNT_FLATTEN_MANIFEST_PATH,
     whitepaperSemanticBackfillManifestPath:
       parsed.whitepaperSemanticBackfillManifestPath ?? process.env.TORGHUT_WHITEPAPER_SEMANTIC_BACKFILL_MANIFEST_PATH,
     optionsCatalogManifestPath: parsed.optionsCatalogManifestPath ?? process.env.TORGHUT_OPTIONS_CATALOG_MANIFEST_PATH,


### PR DESCRIPTION
## Summary

- Adds `paper-account-flatten-cronjob.yaml` to the Torghut image release updater so the cleanup job is promoted with the service image.
- Adds the same manifest to release PR change detection, release PR paths, and deploy-automerge allowlists.
- Updates the current GitOps CronJob digest from stale `bca1e250` to the deployed Torghut digest `389dfc790742`.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts packages/scripts/src/torghut/__tests__/manifest-scheduling.test.ts packages/scripts/src/torghut/__tests__/post-deploy-workflow.test.ts`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py -k paper_account_flatten -q`
- `bunx oxfmt --check packages/scripts/src/torghut/update-manifests.ts packages/scripts/src/torghut/__tests__/update-manifests.test.ts .github/workflows/torghut-release.yml .github/workflows/torghut-deploy-automerge.yml argocd/applications/torghut/paper-account-flatten-cronjob.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
