### PR TITLE
fix(torghut): require runtime ledger source authority

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -74,6 +74,8 @@ EXACT_REPLAY_ARTIFACT_AUTHORITY_BLOCKERS = (
     "runtime_ledger_source_window_missing",
     "runtime_ledger_source_refs_missing",
 )
+RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER = "runtime_ledger_source_window_missing"
+RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER = "runtime_ledger_source_refs_missing"
 _RUNTIME_LEDGER_DECISION_EVENTS = frozenset(
     {"decision", "trade_decision", "signal_decision"}
 )
@@ -669,6 +671,42 @@ def _mapping_hash_count(value: object) -> int:
     return sum(1 for key in value.keys() if str(key).strip())
 
 
+def _runtime_ledger_source_window_present(bucket: Mapping[str, object]) -> bool:
+    start = _parse_dt_or_none(
+        bucket.get("source_window_start")
+        or bucket.get("runtime_ledger_source_window_start")
+    )
+    end = _parse_dt_or_none(
+        bucket.get("source_window_end") or bucket.get("runtime_ledger_source_window_end")
+    )
+    return start is not None and end is not None and end > start
+
+
+def _positive_mapping_value_count(value: object) -> int:
+    if not isinstance(value, Mapping):
+        return 0
+    count = 0
+    for item in value.values():
+        parsed = _decimal_or_none(item)
+        if parsed is not None and parsed > 0:
+            count += 1
+    return count
+
+
+def _runtime_ledger_source_refs_present(bucket: Mapping[str, object]) -> bool:
+    source_refs = _metadata_text_list(bucket.get("source_refs"))
+    source_ref = bucket.get("source_ref")
+    source_ref_present = bool(source_refs)
+    if isinstance(source_ref, Mapping):
+        source_ref_present = source_ref_present or bool(source_ref)
+    elif _text_or_none(source_ref) is not None:
+        source_ref_present = True
+    return (
+        source_ref_present
+        and _positive_mapping_value_count(bucket.get("source_row_counts")) > 0
+    )
+
+
 def _runtime_ledger_bucket_profit_proof_blockers(
     bucket: Mapping[str, object],
 ) -> list[str]:
@@ -688,6 +726,10 @@ def _runtime_ledger_bucket_profit_proof_blockers(
         add("runtime_ledger_pnl_basis_not_runtime_ledger")
     if bucket.get("ledger_schema_version") not in RUNTIME_LEDGER_BUCKET_SCHEMAS:
         add("runtime_ledger_schema_not_supported")
+    if not _runtime_ledger_source_window_present(bucket):
+        add(RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER)
+    if not _runtime_ledger_source_refs_present(bucket):
+        add(RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER)
     for blocker in _metadata_text_list(bucket.get("blockers")):
         add(blocker)
     if _nonnegative_int(bucket.get("fill_count")) <= 0:
@@ -820,6 +862,31 @@ def _append_runtime_ledger_tca_row_blocker(
         row["runtime_ledger_bucket"] = bucket_payload
         row["runtime_ledger_blockers"] = blockers
         row["post_cost_promotion_eligible"] = False
+
+
+def _with_runtime_ledger_source_authority_context(
+    bucket: Mapping[str, object],
+    *,
+    source_window_start: datetime,
+    source_window_end: datetime,
+    source_refs: Sequence[str],
+    source_row_counts: Mapping[str, int],
+) -> dict[str, object]:
+    payload = dict(bucket)
+    payload.setdefault("source_window_start", source_window_start.isoformat())
+    payload.setdefault("source_window_end", source_window_end.isoformat())
+    if source_refs:
+        existing_refs = _metadata_text_list(payload.get("source_refs"))
+        payload["source_refs"] = list(dict.fromkeys([*existing_refs, *source_refs]))
+    existing_counts = _as_mapping(payload.get("source_row_counts"))
+    merged_counts: dict[str, int] = {
+        str(key): _nonnegative_int(value) for key, value in existing_counts.items()
+    }
+    for key, value in source_row_counts.items():
+        merged_counts.setdefault(str(key), max(0, int(value)))
+    if merged_counts:
+        payload["source_row_counts"] = dict(sorted(merged_counts.items()))
+    return payload
 
 
 def _mark_runtime_ledger_tca_rows_as_exact_replay_artifacts(
@@ -1974,6 +2041,16 @@ def _build_realized_strategy_pnl_rows(
     source_decision_profit_proof_eligible = _source_decision_rows_profit_proof_eligible(
         source_decision_rows
     )
+    source_row_counts = {
+        "trade_decisions": len(decision_lifecycle_rows or []),
+        "executions": len(execution_rows),
+        "execution_order_events": len(order_lifecycle_rows or []),
+    }
+    source_refs = (
+        "postgres:trade_decisions",
+        "postgres:executions",
+        "postgres:execution_order_events",
+    )
     realized_rows: list[dict[str, object]] = []
     for bucket in build_runtime_ledger_buckets(
         ledger_rows,
@@ -2021,6 +2098,15 @@ def _build_realized_strategy_pnl_rows(
                         SOURCE_DECISION_MODE_NOT_PROFIT_PROOF_ELIGIBLE_BLOCKER
                     )
                 row["runtime_ledger_bucket"] = bucket_payload
+        if isinstance(bucket_payload, Mapping):
+            bucket_payload = _with_runtime_ledger_source_authority_context(
+                bucket_payload,
+                source_window_start=bucket.bucket_started_at,
+                source_window_end=bucket.bucket_ended_at,
+                source_refs=source_refs,
+                source_row_counts=source_row_counts,
+            )
+            row["runtime_ledger_bucket"] = bucket_payload
         event_sourced_runtime_ledger = (
             allow_authoritative_runtime_ledger_materialization
             and event_sourced_lifecycle_rows > 0

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -209,6 +209,18 @@ class _SourceLedgerCursor:
                     {
                         "cost_basis_counts": {"broker_reported_commission_and_fees": 2},
                         "source_decision_mode_counts": {"strategy_signal_paper": 2},
+                        "source_window_start": "2026-03-06T14:30:00+00:00",
+                        "source_window_end": "2026-03-06T15:00:00+00:00",
+                        "source_refs": [
+                            "postgres:trade_decisions",
+                            "postgres:executions",
+                            "postgres:execution_order_events",
+                        ],
+                        "source_row_counts": {
+                            "trade_decisions": 2,
+                            "executions": 2,
+                            "execution_order_events": 4,
+                        },
                         "profit_proof_eligible": True,
                     },
                 )
@@ -274,6 +286,18 @@ def _complete_runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
         "cost_model_hash_counts": {"cost-sha": 2},
         "lineage_hash_counts": {"lineage-sha": 2},
         "source_decision_mode_counts": {"strategy_signal_paper": 2},
+        "source_window_start": "2026-03-06T14:30:00+00:00",
+        "source_window_end": "2026-03-06T15:00:00+00:00",
+        "source_refs": [
+            "postgres:trade_decisions",
+            "postgres:executions",
+            "postgres:execution_order_events",
+        ],
+        "source_row_counts": {
+            "trade_decisions": 2,
+            "executions": 2,
+            "execution_order_events": 4,
+        },
         "profit_proof_eligible": True,
         "blockers": [],
     }
@@ -650,6 +674,30 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
 
+    def test_runtime_ledger_profit_proof_rejects_missing_source_window_or_refs(
+        self,
+    ) -> None:
+        missing_window = _complete_runtime_ledger_bucket(
+            source_window_start=None,
+            source_window_end=None,
+        )
+        missing_refs = _complete_runtime_ledger_bucket(
+            source_refs=[],
+            source_ref=None,
+            source_row_counts={},
+        )
+
+        self.assertIn(
+            "runtime_ledger_source_window_missing",
+            _runtime_ledger_bucket_profit_proof_blockers(missing_window),
+        )
+        self.assertFalse(_runtime_ledger_bucket_profit_proof_present(missing_window))
+        self.assertIn(
+            "runtime_ledger_source_refs_missing",
+            _runtime_ledger_bucket_profit_proof_blockers(missing_refs),
+        )
+        self.assertFalse(_runtime_ledger_bucket_profit_proof_present(missing_refs))
+
     def test_runtime_ledger_profit_proof_rejects_modeled_cost_basis(
         self,
     ) -> None:
@@ -804,6 +852,18 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     blockers_json=[],
                     payload_json={
                         "source_decision_mode_counts": {"strategy_signal_paper": 2},
+                        "source_window_start": "2026-03-06T14:30:00+00:00",
+                        "source_window_end": "2026-03-06T15:00:00+00:00",
+                        "source_refs": [
+                            "postgres:trade_decisions",
+                            "postgres:executions",
+                            "postgres:execution_order_events",
+                        ],
+                        "source_row_counts": {
+                            "trade_decisions": 2,
+                            "executions": 2,
+                            "execution_order_events": 4,
+                        },
                         "profit_proof_eligible": True,
                     },
                 )
@@ -1669,6 +1729,20 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["source_materialization"], "execution_order_events")
         self.assertEqual(bucket["account_equity"], "10000")
         self.assertEqual(bucket["account_equity_source"], "equity")
+        self.assertEqual(bucket["source_window_start"], "2026-03-06T14:34:00+00:00")
+        self.assertEqual(bucket["source_window_end"], "2026-03-06T14:40:01.000001+00:00")
+        self.assertEqual(
+            bucket["source_refs"],
+            [
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+            ],
+        )
+        self.assertEqual(
+            bucket["source_row_counts"],
+            {"executions": 2, "execution_order_events": 4, "trade_decisions": 2},
+        )
         self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
 
     def test_build_realized_strategy_pnl_rows_requires_order_feed_fill_lifecycle(


### PR DESCRIPTION
## Summary

- Requires promotion-grade runtime-ledger buckets to carry an explicit source window and row-backed source refs before they count as profit proof.
- Stamps event-sourced runtime-ledger materializations with source window, source refs, and source row counts so real lifecycle-backed buckets can still become authoritative.
- Extends import-window tests for missing source authority blockers and event-sourced source metadata.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
