### PR TITLE
chore(analysis): deploy terminology page

### DIFF
--- a/argocd/applications/analysis/kustomization.yaml
+++ b/argocd/applications/analysis/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/analysis
     newName: registry.ide-newton.ts.net/lab/analysis
-    newTag: 093c02b389779dbf94415af2b61be28005398d10
+    newTag: 13f9cc8fd64693dfde1f80e94c1080286dc932ac

--- a/argocd/applications/registry/pvc.yaml
+++ b/argocd/applications/registry/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: rook-ceph-block
   resources:
     requests:
-      storage: 500Gi
+      storage: 1Ti


### PR DESCRIPTION
## Summary

- Deploys Analysis image `13f9cc8fd64693dfde1f80e94c1080286dc932ac`, which adds the AI buildout terminology page and navigation links.
- Persists the registry PVC expansion from `500Gi` to `1Ti` after the live registry hit `100%` usage and blocked image pushes.
- Keeps the change scoped to the Analysis image tag and registry storage capacity.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `kubectl kustomize argocd/applications/analysis >/tmp/analysis-kustomize-terminology.yaml && rg -n 'analysis:13f9cc8fd64693dfde1f80e94c1080286dc932ac|kind: Deployment|kind: Service' /tmp/analysis-kustomize-terminology.yaml`
- `kubectl kustomize argocd/applications/registry >/tmp/registry-kustomize-resize.yaml && rg -n 'storage: 1Ti|kind: PersistentVolumeClaim|name: registry-data' /tmp/registry-kustomize-resize.yaml`
- `git diff --check`
- Live registry proof after emergency expansion: `kubectl exec -n registry deploy/registry -- df -h /var/lib/registry` showed `1Ti` capacity and `49%` used.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
