### PR TITLE
chore(torghut): promote image 74f5398c

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.580.11-53-gea37ff676
+              value: v0.580.11-60-g74f5398c9
             - name: TORGHUT_OPTIONS_COMMIT
-              value: ea37ff67671d40e22026fcad5abeb0da825fadd1
+              value: 74f5398c9db00746aa93a1aa3d1caa99a8e7cbd4
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.580.11-53-gea37ff676
+              value: v0.580.11-60-g74f5398c9
             - name: TORGHUT_OPTIONS_COMMIT
-              value: ea37ff67671d40e22026fcad5abeb0da825fadd1
+              value: 74f5398c9db00746aa93a1aa3d1caa99a8e7cbd4
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -105,7 +105,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+                  value: sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-30T01:31:32Z"
+        client.knative.dev/updateTimestamp: "2026-05-30T02:43:04Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
           ports:
             - name: http1
               containerPort: 8181
@@ -513,11 +513,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.580.11-53-gea37ff676
+              value: v0.580.11-60-g74f5398c9
             - name: TORGHUT_COMMIT
-              value: ea37ff67671d40e22026fcad5abeb0da825fadd1
+              value: 74f5398c9db00746aa93a1aa3d1caa99a8e7cbd4
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+              value: sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-30T01:31:32Z"
+        client.knative.dev/updateTimestamp: "2026-05-30T02:43:04Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
           ports:
             - name: http1
               containerPort: 8181
@@ -332,11 +332,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.580.11-53-gea37ff676
+              value: v0.580.11-60-g74f5398c9
             - name: TORGHUT_COMMIT
-              value: ea37ff67671d40e22026fcad5abeb0da825fadd1
+              value: 74f5398c9db00746aa93a1aa3d1caa99a8e7cbd4
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+              value: sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:8065763eefdb02100e2437c9ca790f929a588c461312a9e03a0fbf72bd45c9f5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `74f5398c9db00746aa93a1aa3d1caa99a8e7cbd4`
- Image tag: `74f5398c`
- Image digest: `sha256:a577caeae84b9b4174f7a9d4cc42cf77a963180c3d81f7543680c9c39e91cf6d`