### PR TITLE
fix(torghut): require runtime ledger source proof packets

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -86,6 +86,8 @@ RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
         "torghut.runtime-ledger-bucket.v1",
     }
 )
+RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER = "runtime_ledger_source_window_missing"
+RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER = "runtime_ledger_source_refs_missing"
 
 
 @dataclass(frozen=True)
@@ -258,6 +260,45 @@ def _hash_count(value: Any) -> int:
     return sum(1 for key in mapping.keys() if str(key).strip())
 
 
+def _runtime_ledger_source_window_present(bucket: Mapping[str, Any]) -> bool:
+    start = _parse_observation_datetime(
+        bucket.get("source_window_start")
+        or bucket.get("runtime_ledger_source_window_start")
+    )
+    end = _parse_observation_datetime(
+        bucket.get("source_window_end")
+        or bucket.get("runtime_ledger_source_window_end")
+    )
+    return start is not None and end is not None and end > start
+
+
+def _positive_mapping_value_count(value: Any) -> int:
+    if not isinstance(value, Mapping):
+        return 0
+    count = 0
+    for item in cast(Mapping[object, object], value).values():
+        parsed = _optional_decimal(item)
+        if parsed is not None and parsed > 0:
+            count += 1
+    return count
+
+
+def _runtime_ledger_source_refs_present(bucket: Mapping[str, Any]) -> bool:
+    source_refs = _string_list(bucket.get("source_refs"))
+    source_ref = bucket.get("source_ref")
+    source_ref_present = bool(source_refs)
+    if isinstance(source_ref, Mapping):
+        source_ref_present = (
+            source_ref_present or len(cast(Mapping[object, object], source_ref)) > 0
+        )
+    elif _text(source_ref) is not None:
+        source_ref_present = True
+    return (
+        source_ref_present
+        and _positive_mapping_value_count(bucket.get("source_row_counts")) > 0
+    )
+
+
 def _persisted_runtime_ledger_bucket_evidence_grade(
     row: StrategyRuntimeLedgerBucket,
 ) -> bool:
@@ -299,6 +340,10 @@ def _runtime_ledger_bucket_blockers(bucket: Mapping[str, Any]) -> list[str]:
         blockers.append("runtime_ledger_pnl_basis_missing")
     elif pnl_basis != POST_COST_PNL_BASIS:
         blockers.append("runtime_ledger_pnl_basis_invalid")
+    if not _runtime_ledger_source_window_present(bucket):
+        blockers.append(RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER)
+    if not _runtime_ledger_source_refs_present(bucket):
+        blockers.append(RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER)
     if _observation_int(bucket.get("fill_count")) <= 0:
         blockers.append("runtime_fills_missing")
     if _observation_int(bucket.get("decision_count")) <= 0:

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -967,6 +967,10 @@ def _runtime_import_materialization_summary(
             target_blockers.append("runtime_window_import_target_profit_proof_missing")
         _extend_unique(
             target_blockers,
+            _text_list(observation.get("runtime_ledger_profit_proof_blockers")),
+        )
+        _extend_unique(
+            target_blockers,
             _runtime_import_target_surface_blockers(
                 summary=summary,
                 profit_proof_count=profit_proof_count,
@@ -983,6 +987,10 @@ def _runtime_import_materialization_summary(
         _extend_unique(
             materialization_blockers,
             _text_list(observation.get("runtime_ledger_materialization_blockers")),
+        )
+        _extend_unique(
+            materialization_blockers,
+            _text_list(observation.get("runtime_ledger_profit_proof_blockers")),
         )
         _extend_unique(
             materialization_blockers,

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -190,6 +190,21 @@ def _runtime_import(
             "runtime_ledger_tca_profit_proof_count": 1 if authoritative else 0,
             "runtime_ledger_tca_runtime_bucket_row_count": 1 if authoritative else 0,
             "runtime_ledger_tca_authoritative_bucket_count": 1 if authoritative else 0,
+            "runtime_ledger_source_execution_materialized_bucket_count": 1
+            if authoritative
+            else 0,
+            "runtime_ledger_source_bucket_profit_proof_count": 1
+            if authoritative
+            else 0,
+            "runtime_ledger_source_materializations": ["execution_order_events"]
+            if authoritative
+            else [],
+            "runtime_ledger_materialization_pnl_derivations": [
+                "execution_order_events_runtime_ledger"
+            ]
+            if authoritative
+            else [],
+            "runtime_ledger_profit_proof_blockers": [],
             "runtime_ledger_filled_notional": "50000" if authoritative else "0",
             "runtime_ledger_net_strategy_pnl_after_costs": "650"
             if authoritative
@@ -1239,6 +1254,36 @@ class TestRuntimeLedgerProofPacket(TestCase):
         )
         self.assertTrue(materialization["materialized_targets"][0]["materialized"])
 
+    def test_packet_blocks_runtime_import_profit_proof_blockers(self) -> None:
+        runtime_import = _runtime_import()
+        observation = runtime_import["imports"][0]["summary"]["runtime_observation"]
+        assert isinstance(observation, dict)
+        observation["runtime_ledger_profit_proof_blockers"] = [
+            "runtime_ledger_source_window_missing",
+            "runtime_ledger_source_refs_missing",
+        ]
+
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=runtime_import,
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        materialization = result["evidence"]["runtime_window_import"]["materialization"]
+        self.assertFalse(
+            result["checks"]["runtime_window_import_materialization"]["passed"]
+        )
+        self.assertEqual(materialization["materialized_target_count"], 0)
+        self.assertEqual(materialization["unmaterialized_target_count"], 1)
+        self.assertIn("runtime_ledger_source_window_missing", materialization["blockers"])
+        self.assertIn("runtime_ledger_source_refs_missing", materialization["blockers"])
+        self.assertIn(
+            "runtime_ledger_source_window_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+
     def test_packet_does_not_treat_promotion_only_import_metadata_as_unmaterialized(
         self,
     ) -> None:
@@ -1487,6 +1532,8 @@ class TestRuntimeLedgerProofPacket(TestCase):
                 "runtime_ledger_profit_proof_present": False,
                 "runtime_ledger_tca_profit_proof_count": 0,
                 "runtime_ledger_tca_authoritative_bucket_count": 0,
+                "runtime_ledger_source_execution_materialized_bucket_count": 0,
+                "runtime_ledger_source_bucket_profit_proof_count": 0,
             }
         )
         runtime_import["imports"].append(

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -75,6 +75,18 @@ def _runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
         "lineage_hash_counts": {"lineage-sha": 2},
         "source_decision_mode_counts": {"strategy_signal_paper": 2},
         "profit_proof_eligible": True,
+        "source_window_start": "2026-03-06T14:30:00+00:00",
+        "source_window_end": "2026-03-06T15:00:00+00:00",
+        "source_refs": [
+            "postgres:trade_decisions",
+            "postgres:executions",
+            "postgres:execution_order_events",
+        ],
+        "source_row_counts": {
+            "trade_decisions": 2,
+            "executions": 2,
+            "execution_order_events": 2,
+        },
         "blockers": [],
     }
     payload.update(overrides)
@@ -397,24 +409,7 @@ class TestRuntimeWindowImport(TestCase):
         ):
             with self.subTest(basis=basis):
                 blockers = _runtime_ledger_bucket_blockers(
-                    {
-                        "ledger_schema_version": "torghut.runtime-ledger-bucket.v1",
-                        "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
-                        "fill_count": 2,
-                        "decision_count": 2,
-                        "submitted_order_count": 2,
-                        "closed_trade_count": 1,
-                        "open_position_count": 0,
-                        "filled_notional": "200",
-                        "cost_amount": "0.20",
-                        "cost_basis_counts": {basis: 2},
-                        "source_decision_mode_counts": {"strategy_signal_paper": 2},
-                        "profit_proof_eligible": True,
-                        "post_cost_expectancy_bps": "40",
-                        "execution_policy_hash_counts": {"policy-sha": 2},
-                        "cost_model_hash_counts": {"cost-sha": 2},
-                        "lineage_hash_counts": {"lineage-sha": 2},
-                    }
+                    _runtime_ledger_bucket(cost_basis_counts={basis: 2})
                 )
 
                 self.assertEqual(
@@ -431,23 +426,10 @@ class TestRuntimeWindowImport(TestCase):
         self,
     ) -> None:
         blockers = _runtime_ledger_bucket_blockers(
-            {
-                "ledger_schema_version": "torghut.runtime-ledger-bucket.v1",
-                "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
-                "fill_count": 2,
-                "decision_count": 2,
-                "submitted_order_count": 2,
-                "closed_trade_count": 1,
-                "open_position_count": 0,
-                "filled_notional": "200",
-                "cost_amount": "0.20",
-                "cost_basis_counts": {"broker_reported_commission_and_fees": 2},
-                "source_decision_mode_counts": {"route_acquisition_probe": 2},
-                "post_cost_expectancy_bps": "40",
-                "execution_policy_hash_counts": {"policy-sha": 2},
-                "cost_model_hash_counts": {"cost-sha": 2},
-                "lineage_hash_counts": {"lineage-sha": 2},
-            }
+            _runtime_ledger_bucket(
+                cost_basis_counts={"broker_reported_commission_and_fees": 2},
+                source_decision_mode_counts={"route_acquisition_probe": 2},
+            )
         )
 
         self.assertEqual(blockers, ["source_decision_mode_not_profit_proof_eligible"])
@@ -1223,6 +1205,32 @@ class TestRuntimeWindowImport(TestCase):
                 "target_implied_avg_daily_filled_notional"
             ],
             "625000",
+        )
+
+    def test_runtime_ledger_bucket_blocks_missing_source_authority(self) -> None:
+        missing_window = _runtime_ledger_bucket(
+            source_window_start=None,
+            source_window_end=None,
+        )
+        self.assertIn(
+            "runtime_ledger_source_window_missing",
+            _runtime_ledger_bucket_blockers(missing_window),
+        )
+
+        missing_refs = _runtime_ledger_bucket(source_refs=[], source_row_counts={})
+        self.assertIn(
+            "runtime_ledger_source_refs_missing",
+            _runtime_ledger_bucket_blockers(missing_refs),
+        )
+
+        complete = _runtime_ledger_bucket()
+        self.assertNotIn(
+            "runtime_ledger_source_window_missing",
+            _runtime_ledger_bucket_blockers(complete),
+        )
+        self.assertNotIn(
+            "runtime_ledger_source_refs_missing",
+            _runtime_ledger_bucket_blockers(complete),
         )
 
     def test_persist_observed_runtime_windows_allows_authority_grade_live_ledger(


### PR DESCRIPTION
## Summary

- Require runtime-ledger buckets to carry source-window bounds before they can count as profit-proof evidence.
- Require runtime-ledger buckets to carry source references and positive source row counts before they can count as profit-proof evidence.
- Thread runtime-ledger profit-proof blockers into proof-packet materialization blockers so missing source authority cannot be hidden behind an authoritative import flag.
- Add focused regression coverage for source-authority blockers in runtime-window import and proof-packet assembly.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `uv run --frozen ruff check app/trading/runtime_window_import.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check origin/main...HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
