### PR TITLE
fix(torghut): require runtime ledger source authority in status

### DIFF
--- a/services/torghut/app/trading/runtime_ledger_source_authority.py
+++ b/services/torghut/app/trading/runtime_ledger_source_authority.py
@@ -1,0 +1,106 @@
+"""Shared source-authority checks for runtime-ledger proof payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from typing import cast
+
+RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER = "runtime_ledger_source_window_missing"
+RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER = "runtime_ledger_source_refs_missing"
+
+
+def _text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        text = _text(value)
+        if text is None:
+            return None
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [
+        text
+        for item in cast(Sequence[object], value)
+        if (text := _text(item)) is not None
+    ]
+
+
+def _positive_mapping_value_count(value: object) -> int:
+    if not isinstance(value, Mapping):
+        return 0
+    count = 0
+    for item in cast(Mapping[object, object], value).values():
+        try:
+            parsed = Decimal(str(item))
+        except (InvalidOperation, ValueError):
+            continue
+        if parsed.is_finite() and parsed > 0:
+            count += 1
+    return count
+
+
+def runtime_ledger_source_window_present(bucket: Mapping[str, object]) -> bool:
+    start = _parse_datetime(
+        bucket.get("source_window_start")
+        or bucket.get("runtime_ledger_source_window_start")
+    )
+    end = _parse_datetime(
+        bucket.get("source_window_end")
+        or bucket.get("runtime_ledger_source_window_end")
+    )
+    return start is not None and end is not None and end > start
+
+
+def runtime_ledger_source_refs_present(bucket: Mapping[str, object]) -> bool:
+    source_refs = _string_list(bucket.get("source_refs"))
+    source_ref = bucket.get("source_ref")
+    source_ref_present = bool(source_refs)
+    if isinstance(source_ref, Mapping):
+        source_ref_present = (
+            source_ref_present or len(cast(Mapping[object, object], source_ref)) > 0
+        )
+    elif _text(source_ref) is not None:
+        source_ref_present = True
+    return (
+        source_ref_present
+        and _positive_mapping_value_count(bucket.get("source_row_counts")) > 0
+    )
+
+
+def runtime_ledger_source_authority_blockers(
+    bucket: Mapping[str, object],
+) -> list[str]:
+    blockers: list[str] = []
+    if not runtime_ledger_source_window_present(bucket):
+        blockers.append(RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER)
+    if not runtime_ledger_source_refs_present(bucket):
+        blockers.append(RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER)
+    return blockers
+
+
+__all__ = [
+    "RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER",
+    "RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER",
+    "runtime_ledger_source_authority_blockers",
+    "runtime_ledger_source_refs_present",
+    "runtime_ledger_source_window_present",
+]

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -40,6 +40,7 @@ from .runtime_decision_authority import (
     source_decision_mode_is_profit_proof_eligible,
 )
 from .runtime_ledger_proof_policy import runtime_ledger_proof_policy_from_env
+from .runtime_ledger_source_authority import runtime_ledger_source_authority_blockers
 
 US_EQUITIES_REGULAR_TIMEZONE = "America/New_York"
 US_EQUITIES_REGULAR_OPEN = time(hour=9, minute=30)
@@ -86,8 +87,6 @@ RUNTIME_LEDGER_BUCKET_SCHEMAS = frozenset(
         "torghut.runtime-ledger-bucket.v1",
     }
 )
-RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER = "runtime_ledger_source_window_missing"
-RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER = "runtime_ledger_source_refs_missing"
 
 
 @dataclass(frozen=True)
@@ -260,45 +259,6 @@ def _hash_count(value: Any) -> int:
     return sum(1 for key in mapping.keys() if str(key).strip())
 
 
-def _runtime_ledger_source_window_present(bucket: Mapping[str, Any]) -> bool:
-    start = _parse_observation_datetime(
-        bucket.get("source_window_start")
-        or bucket.get("runtime_ledger_source_window_start")
-    )
-    end = _parse_observation_datetime(
-        bucket.get("source_window_end")
-        or bucket.get("runtime_ledger_source_window_end")
-    )
-    return start is not None and end is not None and end > start
-
-
-def _positive_mapping_value_count(value: Any) -> int:
-    if not isinstance(value, Mapping):
-        return 0
-    count = 0
-    for item in cast(Mapping[object, object], value).values():
-        parsed = _optional_decimal(item)
-        if parsed is not None and parsed > 0:
-            count += 1
-    return count
-
-
-def _runtime_ledger_source_refs_present(bucket: Mapping[str, Any]) -> bool:
-    source_refs = _string_list(bucket.get("source_refs"))
-    source_ref = bucket.get("source_ref")
-    source_ref_present = bool(source_refs)
-    if isinstance(source_ref, Mapping):
-        source_ref_present = (
-            source_ref_present or len(cast(Mapping[object, object], source_ref)) > 0
-        )
-    elif _text(source_ref) is not None:
-        source_ref_present = True
-    return (
-        source_ref_present
-        and _positive_mapping_value_count(bucket.get("source_row_counts")) > 0
-    )
-
-
 def _persisted_runtime_ledger_bucket_evidence_grade(
     row: StrategyRuntimeLedgerBucket,
 ) -> bool:
@@ -340,10 +300,7 @@ def _runtime_ledger_bucket_blockers(bucket: Mapping[str, Any]) -> list[str]:
         blockers.append("runtime_ledger_pnl_basis_missing")
     elif pnl_basis != POST_COST_PNL_BASIS:
         blockers.append("runtime_ledger_pnl_basis_invalid")
-    if not _runtime_ledger_source_window_present(bucket):
-        blockers.append(RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER)
-    if not _runtime_ledger_source_refs_present(bucket):
-        blockers.append(RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER)
+    blockers.extend(runtime_ledger_source_authority_blockers(bucket))
     if _observation_int(bucket.get("fill_count")) <= 0:
         blockers.append("runtime_fills_missing")
     if _observation_int(bucket.get("decision_count")) <= 0:

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -45,6 +45,7 @@ from .discovery.profit_target_oracle import evaluate_profit_target_oracle
 from .profit_windows import build_profit_window_contract
 from .profit_leases import build_profit_lease_projection
 from .runtime_ledger import POST_COST_PNL_BASIS
+from .runtime_ledger_source_authority import runtime_ledger_source_authority_blockers
 from .tca import build_tca_gate_inputs
 
 _CAPITAL_STAGE_ORDER = (
@@ -610,6 +611,15 @@ def build_hypothesis_runtime_summary(
 def _runtime_ledger_bucket_payload(
     row: StrategyRuntimeLedgerBucket,
 ) -> dict[str, object]:
+    payload_json: Mapping[str, object]
+    raw_payload_json: object = row.payload_json
+    if isinstance(raw_payload_json, Mapping):
+        payload_json = {
+            str(key): value
+            for key, value in cast(Mapping[object, object], raw_payload_json).items()
+        }
+    else:
+        payload_json = {}
     return {
         "run_id": row.run_id,
         "candidate_id": row.candidate_id,
@@ -640,6 +650,13 @@ def _runtime_ledger_bucket_payload(
         "execution_policy_hash_counts": row.execution_policy_hash_counts or {},
         "cost_model_hash_counts": row.cost_model_hash_counts or {},
         "lineage_hash_counts": row.lineage_hash_counts or {},
+        "source_window_start": payload_json.get("source_window_start")
+        or payload_json.get("runtime_ledger_source_window_start"),
+        "source_window_end": payload_json.get("source_window_end")
+        or payload_json.get("runtime_ledger_source_window_end"),
+        "source_refs": payload_json.get("source_refs") or [],
+        "source_ref": payload_json.get("source_ref"),
+        "source_row_counts": payload_json.get("source_row_counts") or {},
         "blockers": row.blockers_json or [],
     }
 
@@ -1136,6 +1153,7 @@ def _runtime_ledger_repair_reason_codes(
         for reason in cast(Sequence[object], payload.get("blockers") or [])
         if str(reason).strip()
     ]
+    reasons.extend(runtime_ledger_source_authority_blockers(payload))
     reasons.extend(_runtime_ledger_target_reason_codes(payload, manifest=manifest))
     if _safe_text(payload.get("observed_stage")) != "live":
         reasons.append("runtime_ledger_stage_not_live")
@@ -1595,6 +1613,10 @@ def _load_runtime_ledger_repair_candidates(
                 "post_cost_expectancy_bps": payload.get("post_cost_expectancy_bps"),
                 "ledger_schema_version": payload.get("ledger_schema_version"),
                 "pnl_basis": payload.get("pnl_basis"),
+                "source_window_start": payload.get("source_window_start"),
+                "source_window_end": payload.get("source_window_end"),
+                "source_refs": payload.get("source_refs"),
+                "source_row_counts": payload.get("source_row_counts"),
                 "reason_codes": reason_codes,
                 "runtime_ledger_bucket": payload,
             }

--- a/services/torghut/tests/test_runtime_ledger_source_authority.py
+++ b/services/torghut/tests/test_runtime_ledger_source_authority.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from datetime import datetime
+from unittest import TestCase
+
+from app.trading.runtime_ledger_source_authority import (
+    runtime_ledger_source_authority_blockers,
+    runtime_ledger_source_refs_present,
+    runtime_ledger_source_window_present,
+)
+
+
+class TestRuntimeLedgerSourceAuthority(TestCase):
+    def test_source_window_accepts_naive_datetime_objects(self) -> None:
+        self.assertTrue(
+            runtime_ledger_source_window_present(
+                {
+                    "source_window_start": datetime(2026, 5, 29, 14, 30),
+                    "source_window_end": datetime(2026, 5, 29, 15, 0),
+                }
+            )
+        )
+
+    def test_source_window_rejects_invalid_datetime_text(self) -> None:
+        self.assertFalse(
+            runtime_ledger_source_window_present(
+                {
+                    "source_window_start": "not-a-date",
+                    "source_window_end": "2026-05-29T15:00:00+00:00",
+                }
+            )
+        )
+
+    def test_source_refs_accept_legacy_string_or_mapping_refs_with_rows(self) -> None:
+        self.assertTrue(
+            runtime_ledger_source_refs_present(
+                {
+                    "source_ref": "strategy_runtime_ledger_buckets:pairs",
+                    "source_row_counts": {
+                        "trade_decisions": "not-a-number",
+                        "trade_order_events": 2,
+                    },
+                }
+            )
+        )
+        self.assertTrue(
+            runtime_ledger_source_refs_present(
+                {
+                    "source_ref": {"strategy_runtime_ledger_buckets": "pairs"},
+                    "source_row_counts": {"strategy_runtime_ledger_buckets": 1},
+                }
+            )
+        )
+
+    def test_source_refs_require_row_counts(self) -> None:
+        self.assertFalse(
+            runtime_ledger_source_refs_present(
+                {"source_ref": "strategy_runtime_ledger_buckets:pairs"}
+            )
+        )
+
+    def test_source_authority_blockers_report_missing_parts(self) -> None:
+        self.assertEqual(
+            runtime_ledger_source_authority_blockers({}),
+            [
+                "runtime_ledger_source_window_missing",
+                "runtime_ledger_source_refs_missing",
+            ],
+        )

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -36,6 +36,7 @@ from app.trading.submission_council import (
     _load_profit_promotion_table_counts,
     _merge_runtime_certificate_evidence,
     _metric_window_activity_reason_codes,
+    _runtime_ledger_repair_reason_codes,
     _refresh_runtime_summary_totals,
     _runtime_ledger_paper_probation_import_plan,
     build_hypothesis_runtime_summary,
@@ -566,6 +567,30 @@ class TestSubmissionCouncil(TestCase):
         )
 
         with session_local() as session:
+            pairs_source_payload = {
+                "source_window_start": (now - timedelta(minutes=45)).isoformat(),
+                "source_window_end": (now - timedelta(minutes=30)).isoformat(),
+                "source_refs": [
+                    "strategy_runtime_ledger_buckets:pairs-realized-runtime"
+                ],
+                "source_row_counts": {
+                    "trade_decisions": 2,
+                    "trade_order_events": 2,
+                    "strategy_runtime_ledger_buckets": 1,
+                },
+            }
+            reversal_source_payload = {
+                "source_window_start": (now - timedelta(minutes=75)).isoformat(),
+                "source_window_end": (now - timedelta(minutes=60)).isoformat(),
+                "source_refs": [
+                    "strategy_runtime_ledger_buckets:pairs-reversal-runtime"
+                ],
+                "source_row_counts": {
+                    "trade_decisions": 1,
+                    "trade_order_events": 1,
+                    "strategy_runtime_ledger_buckets": 1,
+                },
+            }
             session.add_all(
                 [
                     StrategyRuntimeLedgerBucket(
@@ -627,6 +652,7 @@ class TestSubmissionCouncil(TestCase):
                         cost_model_hash_counts={"cost": 2},
                         lineage_hash_counts={"lineage": 2},
                         blockers_json=[],
+                        payload_json=pairs_source_payload,
                     ),
                     StrategyRuntimeLedgerBucket(
                         run_id="pairs-reversal-runtime",
@@ -657,6 +683,7 @@ class TestSubmissionCouncil(TestCase):
                         cost_model_hash_counts={"cost": 1},
                         lineage_hash_counts={"lineage": 1},
                         blockers_json=[],
+                        payload_json=reversal_source_payload,
                     ),
                 ]
             )
@@ -742,7 +769,19 @@ class TestSubmissionCouncil(TestCase):
         )
         self.assertIn("runtime_ledger_stage_not_live", candidates[0]["reason_codes"])
         self.assertNotIn(
+            "runtime_ledger_source_window_missing",
+            candidates[0]["reason_codes"],
+        )
+        self.assertNotIn(
+            "runtime_ledger_source_refs_missing",
+            candidates[0]["reason_codes"],
+        )
+        self.assertNotIn(
             "runtime_ledger_candidate_mismatch", candidates[0]["reason_codes"]
+        )
+        self.assertEqual(
+            candidates[0]["source_refs"],
+            ["strategy_runtime_ledger_buckets:pairs-realized-runtime"],
         )
         paper_candidates = gate["runtime_ledger_paper_probation_candidates"]
         self.assertEqual(gate["paper_probation_eligible_total"], 2)
@@ -818,6 +857,58 @@ class TestSubmissionCouncil(TestCase):
         self.assertTrue(
             any(candidate["hypothesis_id"] == "H-CONT-01" for candidate in candidates)
         )
+
+    def test_runtime_ledger_repair_reason_codes_require_source_authority(self) -> None:
+        payload = {
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "observed_stage": "paper",
+            "fill_count": 2,
+            "submitted_order_count": 2,
+            "closed_trade_count": 2,
+            "open_position_count": 0,
+            "filled_notional": "127090.02495200",
+            "net_strategy_pnl_after_costs": "567.44720578",
+            "post_cost_expectancy_bps": "44.64923238",
+            "ledger_schema_version": "torghut.runtime-ledger-bucket.v1",
+            "pnl_basis": "realized_strategy_pnl_after_explicit_costs",
+            "execution_policy_hash_counts": {"policy": 2},
+            "cost_model_hash_counts": {"cost": 2},
+            "lineage_hash_counts": {"lineage": 2},
+            "blockers": [],
+        }
+
+        reasons = _runtime_ledger_repair_reason_codes(
+            payload,
+            manifest={"candidate_id": "c88421d619759b2cfaa6f4d0"},
+        )
+
+        self.assertIn("runtime_ledger_source_window_missing", reasons)
+        self.assertIn("runtime_ledger_source_refs_missing", reasons)
+        self.assertIn("runtime_ledger_stage_not_live", reasons)
+
+        source_backed_reasons = _runtime_ledger_repair_reason_codes(
+            {
+                **payload,
+                "source_window_start": "2026-05-29T14:30:00+00:00",
+                "source_window_end": "2026-05-29T15:00:00+00:00",
+                "source_refs": [
+                    "strategy_runtime_ledger_buckets:pairs-realized-runtime"
+                ],
+                "source_row_counts": {
+                    "trade_decisions": 2,
+                    "trade_order_events": 2,
+                    "strategy_runtime_ledger_buckets": 1,
+                },
+            },
+            manifest={"candidate_id": "c88421d619759b2cfaa6f4d0"},
+        )
+
+        self.assertNotIn(
+            "runtime_ledger_source_window_missing",
+            source_backed_reasons,
+        )
+        self.assertNotIn("runtime_ledger_source_refs_missing", source_backed_reasons)
+        self.assertEqual(source_backed_reasons, ["runtime_ledger_stage_not_live"])
 
     def test_runtime_ledger_paper_probation_import_plan_falls_back_and_skips_incomplete_targets(
         self,


### PR DESCRIPTION
## Summary

- Centralizes runtime-ledger source-window/source-ref authority checks in a shared helper.
- Applies those authority blockers to live submission runtime-ledger repair candidates, so status cannot treat source-less economic rows as proof-ready.
- Surfaces source window/ref metadata from persisted runtime-ledger bucket payloads and adds regression coverage for source-backed versus source-missing candidates.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger_source_authority.py tests/test_submission_council.py tests/test_runtime_window_import.py -k 'source_authority or surfaces_runtime_ledger_repair_candidates or runtime_ledger_bucket_blocks_missing_source_authority' -q`
- `cd services/torghut && uv run --frozen coverage erase && uv run --frozen coverage run -m pytest tests/test_runtime_ledger_source_authority.py tests/test_submission_council.py tests/test_runtime_window_import.py -k 'source_authority or surfaces_runtime_ledger_repair_candidates or runtime_ledger_bucket_blocks_missing_source_authority' -q`
- `cd services/torghut && uv run --frozen coverage xml --fail-under=0 && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml coverage.xml --threshold 90`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger_source_authority.py app/trading/runtime_window_import.py app/trading/submission_council.py tests/test_runtime_ledger_source_authority.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_ledger_source_authority.py app/trading/runtime_window_import.py app/trading/submission_council.py tests/test_runtime_ledger_source_authority.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
