### PR TITLE
chore(torghut): promote image b9960bb2

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.580.11-64-g30ec209de
+              value: v0.580.11-72-gb9960bb24
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 30ec209de7a5afc33c8a29dfdf06b2dd05ab7969
+              value: b9960bb248489246cb6478502c4a68a54c6db8ab
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.580.11-64-g30ec209de
+              value: v0.580.11-72-gb9960bb24
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 30ec209de7a5afc33c8a29dfdf06b2dd05ab7969
+              value: b9960bb248489246cb6478502c4a68a54c6db8ab
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -105,7 +105,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+                  value: sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-30T02:53:43Z"
+        client.knative.dev/updateTimestamp: "2026-05-30T03:44:49Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
           ports:
             - name: http1
               containerPort: 8181
@@ -513,11 +513,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.580.11-64-g30ec209de
+              value: v0.580.11-72-gb9960bb24
             - name: TORGHUT_COMMIT
-              value: 30ec209de7a5afc33c8a29dfdf06b2dd05ab7969
+              value: b9960bb248489246cb6478502c4a68a54c6db8ab
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+              value: sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-30T02:53:43Z"
+        client.knative.dev/updateTimestamp: "2026-05-30T03:44:49Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
           ports:
             - name: http1
               containerPort: 8181
@@ -332,11 +332,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.580.11-64-g30ec209de
+              value: v0.580.11-72-gb9960bb24
             - name: TORGHUT_COMMIT
-              value: 30ec209de7a5afc33c8a29dfdf06b2dd05ab7969
+              value: b9960bb248489246cb6478502c4a68a54c6db8ab
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+              value: sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:74337c85fd98db83eae1d70ef040877810a438280c0a6de10b454296c3240083
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `b9960bb248489246cb6478502c4a68a54c6db8ab`
- Image tag: `b9960bb2`
- Image digest: `sha256:215597510ad733d75cb4c8af628f96c7d738f19263469907998fa6cb0e294671`