### PR TITLE
fix(torghut): require source-backed runtime ledger authority

### DIFF
--- a/services/torghut/app/trading/runtime_ledger_source_authority.py
+++ b/services/torghut/app/trading/runtime_ledger_source_authority.py
@@ -9,6 +9,36 @@ from typing import cast
 
 RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER = "runtime_ledger_source_window_missing"
 RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER = "runtime_ledger_source_refs_missing"
+RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER = (
+    "runtime_ledger_trade_decision_refs_missing"
+)
+RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER = "runtime_ledger_execution_refs_missing"
+RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER = (
+    "runtime_ledger_execution_order_event_refs_missing"
+)
+RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER = "runtime_ledger_source_offsets_missing"
+RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER = (
+    "runtime_ledger_source_materialization_missing"
+)
+RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER = (
+    "runtime_ledger_authority_class_missing"
+)
+
+_PROMOTION_GRADE_SOURCE_MATERIALIZATIONS = frozenset(
+    {
+        "execution_order_events",
+        "source_execution_lifecycle",
+    }
+)
+_PROMOTION_GRADE_AUTHORITY_CLASSES = frozenset(
+    {
+        "runtime_order_feed_execution_source",
+        "event_sourced_runtime_ledger_profit_proof",
+        "source_execution_runtime_ledger_materialized",
+        "execution_order_events_runtime_ledger",
+        "source_execution_lifecycle_materialized_runtime_ledger",
+    }
+)
 
 
 def _text(value: object) -> str | None:
@@ -58,6 +88,66 @@ def _positive_mapping_value_count(value: object) -> int:
     return count
 
 
+def _source_ref_present(value: object) -> bool:
+    if isinstance(value, Mapping):
+        return len(cast(Mapping[object, object], value)) > 0
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return bool(_string_list(cast(Sequence[object], value)))
+    return bool(_string_list(value) or _text(value) is not None)
+
+
+def _source_refs_present(bucket: Mapping[str, object], *keys: str) -> bool:
+    return any(_source_ref_present(bucket.get(key)) for key in keys)
+
+
+def _source_offsets_present(bucket: Mapping[str, object]) -> bool:
+    source_offsets = bucket.get("source_offsets")
+    if isinstance(source_offsets, Mapping):
+        return len(cast(Mapping[object, object], source_offsets)) > 0
+    if isinstance(source_offsets, Sequence) and not isinstance(
+        source_offsets, (str, bytes, bytearray)
+    ):
+        for item in cast(Sequence[object], source_offsets):
+            if isinstance(item, Mapping):
+                offset = cast(Mapping[object, object], item)
+                if (
+                    _text(offset.get("topic")) is not None
+                    and offset.get("partition") is not None
+                    and offset.get("offset") is not None
+                ):
+                    return True
+            elif _text(item) is not None:
+                return True
+    return (
+        _text(bucket.get("source_topic")) is not None
+        and bucket.get("source_partition") is not None
+        and bucket.get("source_offset") is not None
+    )
+
+
+def _promotion_grade_source_materialization_present(
+    bucket: Mapping[str, object],
+) -> bool:
+    source_materialization = _text(bucket.get("source_materialization"))
+    return (
+        source_materialization is not None
+        and source_materialization in _PROMOTION_GRADE_SOURCE_MATERIALIZATIONS
+    )
+
+
+def _promotion_grade_authority_class_present(bucket: Mapping[str, object]) -> bool:
+    authority_values = (
+        bucket.get("authority_class"),
+        bucket.get("authority_reason"),
+        bucket.get("pnl_derivation"),
+    )
+    for value in authority_values:
+        text = _text(value)
+        if text in _PROMOTION_GRADE_AUTHORITY_CLASSES:
+            return True
+    return False
+
+
 def runtime_ledger_source_window_present(bucket: Mapping[str, object]) -> bool:
     start = _parse_datetime(
         bucket.get("source_window_start")
@@ -97,9 +187,59 @@ def runtime_ledger_source_authority_blockers(
     return blockers
 
 
+def runtime_ledger_promotion_source_authority_blockers(
+    bucket: Mapping[str, object],
+) -> list[str]:
+    """Return blockers for promotion-grade runtime/order-feed source proof.
+
+    Aggregate bucket fields are not enough for promotion authority. The bucket must
+    also carry row-level runtime lineage back to order-feed lifecycle and execution
+    sources so durable/source imports cannot become proof by shape alone.
+    """
+
+    blockers = runtime_ledger_source_authority_blockers(bucket)
+    if not _source_refs_present(
+        bucket,
+        "trade_decision_ids",
+        "trade_decision_refs",
+        "trade_decision_id",
+        "decision_ids",
+        "decision_id",
+    ):
+        blockers.append(RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER)
+    if not _source_refs_present(
+        bucket,
+        "execution_ids",
+        "execution_refs",
+        "execution_id",
+    ):
+        blockers.append(RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER)
+    if not _source_refs_present(
+        bucket,
+        "execution_order_event_ids",
+        "execution_order_event_refs",
+        "execution_order_event_id",
+    ):
+        blockers.append(RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER)
+    if not _source_offsets_present(bucket):
+        blockers.append(RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER)
+    if not _promotion_grade_source_materialization_present(bucket):
+        blockers.append(RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER)
+    if not _promotion_grade_authority_class_present(bucket):
+        blockers.append(RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER)
+    return list(dict.fromkeys(blockers))
+
+
 __all__ = [
+    "RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER",
+    "RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER",
+    "RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER",
+    "RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER",
+    "RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER",
     "RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER",
     "RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER",
+    "RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER",
+    "runtime_ledger_promotion_source_authority_blockers",
     "runtime_ledger_source_authority_blockers",
     "runtime_ledger_source_refs_present",
     "runtime_ledger_source_window_present",

--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -40,7 +40,9 @@ from .runtime_decision_authority import (
     source_decision_mode_is_profit_proof_eligible,
 )
 from .runtime_ledger_proof_policy import runtime_ledger_proof_policy_from_env
-from .runtime_ledger_source_authority import runtime_ledger_source_authority_blockers
+from .runtime_ledger_source_authority import (
+    runtime_ledger_promotion_source_authority_blockers,
+)
 
 US_EQUITIES_REGULAR_TIMEZONE = "America/New_York"
 US_EQUITIES_REGULAR_OPEN = time(hour=9, minute=30)
@@ -263,6 +265,7 @@ def _persisted_runtime_ledger_bucket_evidence_grade(
     row: StrategyRuntimeLedgerBucket,
 ) -> bool:
     blockers = _string_list(row.blockers_json)
+    payload_json = _mapping(row.payload_json)
     return (
         row.pnl_basis == POST_COST_PNL_BASIS
         and int(row.fill_count or 0) > 0
@@ -275,8 +278,9 @@ def _persisted_runtime_ledger_bucket_evidence_grade(
         and _hash_count(row.cost_model_hash_counts) > 0
         and _hash_count(row.lineage_hash_counts) > 0
         and not cost_basis_counts_have_non_promotion_grade_costs(
-            _mapping(row.payload_json).get("cost_basis_counts")
+            payload_json.get("cost_basis_counts")
         )
+        and not runtime_ledger_promotion_source_authority_blockers(payload_json)
         and not blockers
     )
 
@@ -300,7 +304,7 @@ def _runtime_ledger_bucket_blockers(bucket: Mapping[str, Any]) -> list[str]:
         blockers.append("runtime_ledger_pnl_basis_missing")
     elif pnl_basis != POST_COST_PNL_BASIS:
         blockers.append("runtime_ledger_pnl_basis_invalid")
-    blockers.extend(runtime_ledger_source_authority_blockers(bucket))
+    blockers.extend(runtime_ledger_promotion_source_authority_blockers(bucket))
     if _observation_int(bucket.get("fill_count")) <= 0:
         blockers.append("runtime_fills_missing")
     if _observation_int(bucket.get("decision_count")) <= 0:

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -45,7 +45,9 @@ from .discovery.profit_target_oracle import evaluate_profit_target_oracle
 from .profit_windows import build_profit_window_contract
 from .profit_leases import build_profit_lease_projection
 from .runtime_ledger import POST_COST_PNL_BASIS
-from .runtime_ledger_source_authority import runtime_ledger_source_authority_blockers
+from .runtime_ledger_source_authority import (
+    runtime_ledger_promotion_source_authority_blockers,
+)
 from .tca import build_tca_gate_inputs
 
 _CAPITAL_STAGE_ORDER = (
@@ -657,6 +659,16 @@ def _runtime_ledger_bucket_payload(
         "source_refs": payload_json.get("source_refs") or [],
         "source_ref": payload_json.get("source_ref"),
         "source_row_counts": payload_json.get("source_row_counts") or {},
+        "trade_decision_ids": payload_json.get("trade_decision_ids") or [],
+        "execution_ids": payload_json.get("execution_ids") or [],
+        "execution_order_event_ids": (
+            payload_json.get("execution_order_event_ids") or []
+        ),
+        "source_offsets": payload_json.get("source_offsets") or [],
+        "source_materialization": payload_json.get("source_materialization"),
+        "authority_class": payload_json.get("authority_class"),
+        "authority_reason": payload_json.get("authority_reason"),
+        "pnl_derivation": payload_json.get("pnl_derivation"),
         "blockers": row.blockers_json or [],
     }
 
@@ -1153,7 +1165,7 @@ def _runtime_ledger_repair_reason_codes(
         for reason in cast(Sequence[object], payload.get("blockers") or [])
         if str(reason).strip()
     ]
-    reasons.extend(runtime_ledger_source_authority_blockers(payload))
+    reasons.extend(runtime_ledger_promotion_source_authority_blockers(payload))
     reasons.extend(_runtime_ledger_target_reason_codes(payload, manifest=manifest))
     if _safe_text(payload.get("observed_stage")) != "live":
         reasons.append("runtime_ledger_stage_not_live")

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -26,6 +26,9 @@ from app.trading.runtime_ledger import (
     RuntimeLedgerBucket,
     build_runtime_ledger_buckets,
 )
+from app.trading.runtime_ledger_source_authority import (
+    runtime_ledger_promotion_source_authority_blockers,
+)
 from app.trading.runtime_cost_authority import (
     cost_basis_counts_have_non_promotion_grade_costs,
     is_non_promotion_grade_runtime_cost_basis,
@@ -677,7 +680,8 @@ def _runtime_ledger_source_window_present(bucket: Mapping[str, object]) -> bool:
         or bucket.get("runtime_ledger_source_window_start")
     )
     end = _parse_dt_or_none(
-        bucket.get("source_window_end") or bucket.get("runtime_ledger_source_window_end")
+        bucket.get("source_window_end")
+        or bucket.get("runtime_ledger_source_window_end")
     )
     return start is not None and end is not None and end > start
 
@@ -726,10 +730,8 @@ def _runtime_ledger_bucket_profit_proof_blockers(
         add("runtime_ledger_pnl_basis_not_runtime_ledger")
     if bucket.get("ledger_schema_version") not in RUNTIME_LEDGER_BUCKET_SCHEMAS:
         add("runtime_ledger_schema_not_supported")
-    if not _runtime_ledger_source_window_present(bucket):
-        add(RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER)
-    if not _runtime_ledger_source_refs_present(bucket):
-        add(RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER)
+    for blocker in runtime_ledger_promotion_source_authority_blockers(bucket):
+        add(blocker)
     for blocker in _metadata_text_list(bucket.get("blockers")):
         add(blocker)
     if _nonnegative_int(bucket.get("fill_count")) <= 0:
@@ -871,6 +873,12 @@ def _with_runtime_ledger_source_authority_context(
     source_window_end: datetime,
     source_refs: Sequence[str],
     source_row_counts: Mapping[str, int],
+    trade_decision_ids: Sequence[object] = (),
+    execution_ids: Sequence[object] = (),
+    execution_order_event_ids: Sequence[object] = (),
+    source_offsets: Sequence[Mapping[str, object]] = (),
+    source_materialization: str | None = None,
+    authority_class: str | None = None,
 ) -> dict[str, object]:
     payload = dict(bucket)
     payload.setdefault("source_window_start", source_window_start.isoformat())
@@ -878,6 +886,54 @@ def _with_runtime_ledger_source_authority_context(
     if source_refs:
         existing_refs = _metadata_text_list(payload.get("source_refs"))
         payload["source_refs"] = list(dict.fromkeys([*existing_refs, *source_refs]))
+    for key, values in (
+        ("trade_decision_ids", trade_decision_ids),
+        ("execution_ids", execution_ids),
+        ("execution_order_event_ids", execution_order_event_ids),
+    ):
+        merged_values = _metadata_text_list(payload.get(key))
+        merged_values.extend(
+            _text for value in values if (_text := _text_or_none(value))
+        )
+        if merged_values:
+            payload[key] = list(dict.fromkeys(merged_values))
+    if source_offsets:
+        existing_offsets = [
+            dict(item)
+            for item in cast(Sequence[object], payload.get("source_offsets") or [])
+            if isinstance(item, Mapping)
+        ]
+        seen_offsets = {
+            (
+                str(item.get("topic") or ""),
+                str(item.get("partition") or ""),
+                str(item.get("offset") or ""),
+            )
+            for item in existing_offsets
+        }
+        for item in source_offsets:
+            offset = {
+                "topic": item.get("topic"),
+                "partition": item.get("partition"),
+                "offset": item.get("offset"),
+            }
+            topic = offset.get("topic")
+            partition = offset.get("partition")
+            source_offset = offset.get("offset")
+            key = (
+                str(topic or ""),
+                "" if partition is None else str(partition),
+                "" if source_offset is None else str(source_offset),
+            )
+            if all(key) and key not in seen_offsets:
+                existing_offsets.append(offset)
+                seen_offsets.add(key)
+        if existing_offsets:
+            payload["source_offsets"] = existing_offsets
+    if source_materialization:
+        payload.setdefault("source_materialization", source_materialization)
+    if authority_class:
+        payload.setdefault("authority_class", authority_class)
     existing_counts = _as_mapping(payload.get("source_row_counts"))
     merged_counts: dict[str, int] = {
         str(key): _nonnegative_int(value) for key, value in existing_counts.items()
@@ -887,6 +943,171 @@ def _with_runtime_ledger_source_authority_context(
     if merged_counts:
         payload["source_row_counts"] = dict(sorted(merged_counts.items()))
     return payload
+
+
+def _source_identifier_values(
+    rows: Sequence[Mapping[str, object]] | None,
+    *keys: str,
+) -> list[str]:
+    values: list[str] = []
+    for row in rows or ():
+        for key in keys:
+            value = _text_or_none(row.get(key))
+            if value is not None:
+                values.append(value)
+                break
+    return list(dict.fromkeys(values))
+
+
+def _source_offset_values(
+    rows: Sequence[Mapping[str, object]] | None,
+) -> list[dict[str, object]]:
+    offsets: list[dict[str, object]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for row in rows or ():
+        topic = _text_or_none(row.get("source_topic"))
+        partition = row.get("source_partition")
+        offset = row.get("source_offset")
+        if topic is None or partition is None or offset is None:
+            continue
+        key = (topic, str(partition), str(offset))
+        if key in seen:
+            continue
+        offsets.append({"topic": topic, "partition": partition, "offset": offset})
+        seen.add(key)
+    return offsets
+
+
+def _decision_lifecycle_query_row(row: Sequence[object]) -> dict[str, object]:
+    if len(row) >= 7:
+        return {
+            "trade_decision_id": str(row[0]),
+            "computed_at": row[1],
+            "event_type": "decision",
+            "symbol": row[2],
+            "account_label": row[3],
+            "strategy_id": row[4],
+            "decision_hash": row[5],
+            "decision_json": row[6],
+        }
+    return {
+        "trade_decision_id": str(row[4]),
+        "computed_at": row[0],
+        "event_type": "decision",
+        "symbol": row[1],
+        "account_label": row[2],
+        "strategy_id": row[3],
+        "decision_hash": row[4],
+        "decision_json": row[5],
+    }
+
+
+def _decision_lifecycle_query_row_has_time(row: Sequence[object]) -> bool:
+    return (row[1] if len(row) >= 7 else row[0]) is not None
+
+
+def _execution_query_row(row: Sequence[object]) -> dict[str, object]:
+    if len(row) >= 19:
+        return {
+            "execution_id": str(row[0]),
+            "trade_decision_id": str(row[1]),
+            "decision_created_at": row[2],
+            "computed_at": row[3],
+            "execution_event_at": row[3],
+            "execution_created_at": row[4],
+            "symbol": row[5],
+            "side": row[6],
+            "filled_qty": row[7],
+            "avg_fill_price": row[8],
+            "shortfall_notional": row[9],
+            "execution_audit_json": row[10],
+            "raw_order": row[11],
+            "account_label": row[12],
+            "strategy_id": row[13],
+            "decision_hash": row[14],
+            "decision_json": row[15],
+            "alpaca_order_id": row[16],
+            "client_order_id": row[17],
+            "order_status": row[18],
+        }
+    return {
+        "execution_id": None,
+        "trade_decision_id": str(row[12]),
+        "decision_created_at": row[0],
+        "computed_at": row[1],
+        "execution_event_at": row[1],
+        "execution_created_at": row[2],
+        "symbol": row[3],
+        "side": row[4],
+        "filled_qty": row[5],
+        "avg_fill_price": row[6],
+        "shortfall_notional": row[7],
+        "execution_audit_json": row[8],
+        "raw_order": row[9],
+        "account_label": row[10],
+        "strategy_id": row[11],
+        "decision_hash": row[12],
+        "decision_json": row[13],
+        "alpaca_order_id": row[14],
+        "client_order_id": row[15],
+        "order_status": row[16],
+    }
+
+
+def _execution_query_row_has_time(row: Sequence[object]) -> bool:
+    return (row[3] if len(row) >= 19 else row[1]) is not None
+
+
+def _order_lifecycle_query_row(row: Sequence[object]) -> dict[str, object]:
+    if len(row) >= 20:
+        return {
+            "execution_order_event_id": str(row[0]),
+            "trade_decision_id": str(row[1]),
+            "execution_id": str(row[2]) if row[2] is not None else None,
+            "event_ts": row[3],
+            "symbol": row[4],
+            "account_label": row[5],
+            "strategy_id": row[6],
+            "decision_hash": row[7],
+            "decision_json": row[8],
+            "alpaca_order_id": row[9],
+            "client_order_id": row[10],
+            "event_type": row[11],
+            "order_status": row[12],
+            "event_fingerprint": row[13],
+            "source_topic": row[14],
+            "source_partition": row[15],
+            "source_offset": row[16],
+            "raw_event": row[17],
+            "execution_audit_json": row[18],
+            "raw_order": row[19],
+        }
+    return {
+        "execution_order_event_id": str(row[10]),
+        "trade_decision_id": str(row[4]),
+        "execution_id": None,
+        "event_ts": row[0],
+        "symbol": row[1],
+        "account_label": row[2],
+        "strategy_id": row[3],
+        "decision_hash": row[4],
+        "decision_json": row[5],
+        "alpaca_order_id": row[6],
+        "client_order_id": row[7],
+        "event_type": row[8],
+        "order_status": row[9],
+        "event_fingerprint": row[10],
+        "source_topic": row[11],
+        "source_partition": row[12],
+        "source_offset": row[13],
+        "raw_event": row[14],
+        "execution_audit_json": row[15],
+        "raw_order": row[16],
+    }
+
+
+def _order_lifecycle_query_row_has_time(row: Sequence[object]) -> bool:
+    return (row[3] if len(row) >= 20 else row[0]) is not None
 
 
 def _mark_runtime_ledger_tca_rows_as_exact_replay_artifacts(
@@ -2051,6 +2272,22 @@ def _build_realized_strategy_pnl_rows(
         "postgres:executions",
         "postgres:execution_order_events",
     )
+    trade_decision_ids = _source_identifier_values(
+        source_decision_rows,
+        "trade_decision_id",
+        "decision_id",
+        "decision_hash",
+    )
+    execution_ids = _source_identifier_values(
+        [*execution_rows, *(order_lifecycle_rows or [])],
+        "execution_id",
+    )
+    execution_order_event_ids = _source_identifier_values(
+        order_lifecycle_rows,
+        "execution_order_event_id",
+        "event_fingerprint",
+    )
+    source_offsets = _source_offset_values(order_lifecycle_rows)
     realized_rows: list[dict[str, object]] = []
     for bucket in build_runtime_ledger_buckets(
         ledger_rows,
@@ -2105,6 +2342,20 @@ def _build_realized_strategy_pnl_rows(
                 source_window_end=bucket.bucket_ended_at,
                 source_refs=source_refs,
                 source_row_counts=source_row_counts,
+                trade_decision_ids=trade_decision_ids,
+                execution_ids=execution_ids,
+                execution_order_event_ids=execution_order_event_ids,
+                source_offsets=source_offsets,
+                source_materialization=(
+                    "execution_order_events"
+                    if source_offsets and execution_order_event_ids
+                    else None
+                ),
+                authority_class=(
+                    "runtime_order_feed_execution_source"
+                    if source_offsets and execution_order_event_ids
+                    else None
+                ),
             )
             row["runtime_ledger_bucket"] = bucket_payload
         event_sourced_runtime_ledger = (
@@ -2558,6 +2809,19 @@ def _runtime_ledger_tca_row_from_payload(
     )
     filled_notional = _decimal_or_none(payload.get("filled_notional"))
     cost_amount = _decimal_or_none(payload.get("cost_amount"))
+    proof_blockers = _runtime_ledger_bucket_profit_proof_blockers(payload)
+    runtime_ledger_blockers = list(
+        dict.fromkeys(
+            [
+                *_metadata_text_list(payload.get("blockers")),
+                *proof_blockers,
+            ]
+        )
+    )
+    bucket_payload = dict(payload)
+    if proof_blockers:
+        bucket_payload["runtime_ledger_profit_proof_blockers"] = proof_blockers
+        bucket_payload["blockers"] = runtime_ledger_blockers
     return {
         "computed_at": computed_at or datetime.now(timezone.utc),
         "abs_slippage_bps": (
@@ -2579,10 +2843,10 @@ def _runtime_ledger_tca_row_from_payload(
             payload.get("net_strategy_pnl_after_costs")
         ),
         "turnover_notional": filled_notional,
-        "runtime_ledger_blockers": payload.get("blockers") or [],
+        "runtime_ledger_blockers": runtime_ledger_blockers,
         "runtime_ledger_cost_basis_counts": payload.get("cost_basis_counts") or {},
         "runtime_ledger_pnl_basis": payload.get("pnl_basis"),
-        "runtime_ledger_bucket": dict(payload),
+        "runtime_ledger_bucket": bucket_payload,
     }
 
 
@@ -2941,6 +3205,7 @@ def _query_timestamps(
             cur.execute(
                 f"""
                 select
+                    d.id,
                     d.created_at,
                     d.symbol,
                     d.alpaca_account_label,
@@ -2967,17 +3232,9 @@ def _query_timestamps(
                 ),
             )
             decision_lifecycle_rows = [
-                {
-                    "computed_at": row[0],
-                    "event_type": "decision",
-                    "symbol": row[1],
-                    "account_label": row[2],
-                    "strategy_id": row[3],
-                    "decision_hash": row[4],
-                    "decision_json": row[5],
-                }
+                _decision_lifecycle_query_row(row)
                 for row in cur.fetchall()
-                if row[0] is not None
+                if _decision_lifecycle_query_row_has_time(row)
             ]
             if source_activity_diagnostics is not None:
                 source_activity_diagnostics["decision_rows_before_lineage_filter"] = (
@@ -3010,6 +3267,8 @@ def _query_timestamps(
             cur.execute(
                 f"""
                 select
+                    e.id,
+                    d.id,
                     d.created_at,
                     coalesce(
                         e.order_feed_last_event_ts,
@@ -3069,28 +3328,9 @@ def _query_timestamps(
                 ),
             )
             execution_rows = [
-                {
-                    "decision_created_at": row[0],
-                    "computed_at": row[1],
-                    "execution_event_at": row[1],
-                    "execution_created_at": row[2],
-                    "symbol": row[3],
-                    "side": row[4],
-                    "filled_qty": row[5],
-                    "avg_fill_price": row[6],
-                    "shortfall_notional": row[7],
-                    "execution_audit_json": row[8],
-                    "raw_order": row[9],
-                    "account_label": row[10],
-                    "strategy_id": row[11],
-                    "decision_hash": row[12],
-                    "decision_json": row[13],
-                    "alpaca_order_id": row[14],
-                    "client_order_id": row[15],
-                    "order_status": row[16],
-                }
+                _execution_query_row(row)
                 for row in cur.fetchall()
-                if row[1] is not None
+                if _execution_query_row_has_time(row)
             ]
             if source_activity_diagnostics is not None:
                 source_activity_diagnostics["execution_rows_before_lineage_filter"] = (
@@ -3129,6 +3369,9 @@ def _query_timestamps(
             cur.execute(
                 f"""
                 select
+                    oe.id,
+                    coalesce(oe.trade_decision_id, e.trade_decision_id),
+                    e.id,
                     coalesce(oe.event_ts, oe.created_at),
                     oe.symbol,
                     oe.alpaca_account_label,
@@ -3169,27 +3412,9 @@ def _query_timestamps(
                 ),
             )
             order_lifecycle_rows = [
-                {
-                    "event_ts": row[0],
-                    "symbol": row[1],
-                    "account_label": row[2],
-                    "strategy_id": row[3],
-                    "decision_hash": row[4],
-                    "decision_json": row[5],
-                    "alpaca_order_id": row[6],
-                    "client_order_id": row[7],
-                    "event_type": row[8],
-                    "order_status": row[9],
-                    "event_fingerprint": row[10],
-                    "source_topic": row[11],
-                    "source_partition": row[12],
-                    "source_offset": row[13],
-                    "raw_event": row[14],
-                    "execution_audit_json": row[15],
-                    "raw_order": row[16],
-                }
+                _order_lifecycle_query_row(row)
                 for row in cur.fetchall()
-                if row[0] is not None
+                if _order_lifecycle_query_row_has_time(row)
             ]
             if source_activity_diagnostics is not None:
                 source_activity_diagnostics[

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -70,6 +70,7 @@ class _FakeCursor:
         self._results = [
             [
                 (
+                    "decision-id-1",
                     datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
                     "AAPL",
                     "TORGHUT_SIM",
@@ -80,6 +81,8 @@ class _FakeCursor:
             ],
             [
                 (
+                    "execution-id-1",
+                    "decision-id-1",
                     datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
                     datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
                     datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
@@ -104,6 +107,9 @@ class _FakeCursor:
             ],
             [
                 (
+                    "event-id-1",
+                    "decision-id-1",
+                    "execution-id-1",
                     datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
                     "AAPL",
                     "TORGHUT_SIM",
@@ -221,6 +227,23 @@ class _SourceLedgerCursor:
                             "executions": 2,
                             "execution_order_events": 4,
                         },
+                        "trade_decision_ids": ["decision-buy", "decision-sell"],
+                        "execution_ids": ["execution-buy", "execution-sell"],
+                        "execution_order_event_ids": [
+                            "event-new-buy",
+                            "event-fill-buy",
+                            "event-new-sell",
+                            "event-fill-sell",
+                        ],
+                        "source_offsets": [
+                            {
+                                "topic": "alpaca.trade_updates",
+                                "partition": 0,
+                                "offset": 100,
+                            }
+                        ],
+                        "source_materialization": "execution_order_events",
+                        "authority_class": "runtime_order_feed_execution_source",
                         "profit_proof_eligible": True,
                     },
                 )
@@ -298,6 +321,24 @@ def _complete_runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
             "executions": 2,
             "execution_order_events": 4,
         },
+        "trade_decision_ids": ["decision-buy", "decision-sell"],
+        "execution_ids": ["execution-buy", "execution-sell"],
+        "execution_order_event_ids": [
+            "event-new-buy",
+            "event-fill-buy",
+            "event-new-sell",
+            "event-fill-sell",
+        ],
+        "source_offsets": [
+            {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100},
+            {"topic": "alpaca.trade_updates", "partition": 0, "offset": 101},
+            {"topic": "alpaca.trade_updates", "partition": 0, "offset": 102},
+            {"topic": "alpaca.trade_updates", "partition": 0, "offset": 103},
+        ],
+        "source_materialization": "execution_order_events",
+        "authority_class": "runtime_order_feed_execution_source",
+        "authority_reason": "event_sourced_runtime_ledger_profit_proof",
+        "pnl_derivation": "execution_order_events_runtime_ledger",
         "profit_proof_eligible": True,
         "blockers": [],
     }
@@ -698,6 +739,30 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(missing_refs))
 
+    def test_runtime_ledger_profit_proof_rejects_aggregate_only_source_refs(
+        self,
+    ) -> None:
+        aggregate_only = _complete_runtime_ledger_bucket(
+            trade_decision_ids=[],
+            execution_ids=[],
+            execution_order_event_ids=[],
+            source_offsets=[],
+            source_materialization=None,
+            authority_class=None,
+            authority_reason=None,
+            pnl_derivation=None,
+        )
+
+        blockers = _runtime_ledger_bucket_profit_proof_blockers(aggregate_only)
+
+        self.assertIn("runtime_ledger_trade_decision_refs_missing", blockers)
+        self.assertIn("runtime_ledger_execution_refs_missing", blockers)
+        self.assertIn("runtime_ledger_execution_order_event_refs_missing", blockers)
+        self.assertIn("runtime_ledger_source_offsets_missing", blockers)
+        self.assertIn("runtime_ledger_source_materialization_missing", blockers)
+        self.assertIn("runtime_ledger_authority_class_missing", blockers)
+        self.assertFalse(_runtime_ledger_bucket_profit_proof_present(aggregate_only))
+
     def test_runtime_ledger_profit_proof_rejects_modeled_cost_basis(
         self,
     ) -> None:
@@ -864,6 +929,23 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                             "executions": 2,
                             "execution_order_events": 4,
                         },
+                        "trade_decision_ids": ["decision-buy", "decision-sell"],
+                        "execution_ids": ["execution-buy", "execution-sell"],
+                        "execution_order_event_ids": [
+                            "event-new-buy",
+                            "event-fill-buy",
+                            "event-new-sell",
+                            "event-fill-sell",
+                        ],
+                        "source_offsets": [
+                            {
+                                "topic": "alpaca.trade_updates",
+                                "partition": 0,
+                                "offset": 100,
+                            }
+                        ],
+                        "source_materialization": "execution_order_events",
+                        "authority_class": "runtime_order_feed_execution_source",
                         "profit_proof_eligible": True,
                     },
                 )
@@ -921,6 +1003,96 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         assert isinstance(bucket, dict)
         self.assertEqual(bucket["run_id"], "runtime-proof-1")
         self.assertEqual(bucket["closed_trade_count"], 1)
+
+    def test_runtime_ledger_tca_rows_from_durable_buckets_block_aggregate_only_proof(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+
+        with session_local() as session:
+            session.add(
+                StrategyRuntimeLedgerBucket(
+                    run_id="runtime-aggregate-only",
+                    candidate_id="H-TSMOM-LIQ-01",
+                    hypothesis_id="H-TSMOM-LIQ-01",
+                    observed_stage="paper",
+                    bucket_started_at=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    bucket_ended_at=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                    account_label="TORGHUT_SIM",
+                    runtime_strategy_name="intraday-tsmom-profit-v3",
+                    strategy_family="intraday_tsmom_consistent",
+                    fill_count=2,
+                    decision_count=2,
+                    submitted_order_count=2,
+                    cancelled_order_count=0,
+                    rejected_order_count=0,
+                    unfilled_order_count=0,
+                    closed_trade_count=1,
+                    open_position_count=0,
+                    filled_notional=Decimal("200"),
+                    gross_strategy_pnl=Decimal("1"),
+                    cost_amount=Decimal("0.20"),
+                    net_strategy_pnl_after_costs=Decimal("0.80"),
+                    post_cost_expectancy_bps=Decimal("40"),
+                    ledger_schema_version="torghut.exact_replay_ledger.v1",
+                    pnl_basis=POST_COST_BASIS_RUNTIME_LEDGER,
+                    execution_policy_hash_counts={"policy-sha": 2},
+                    cost_model_hash_counts={"cost-sha": 2},
+                    lineage_hash_counts={"lineage-sha": 2},
+                    blockers_json=[],
+                    payload_json={
+                        "source_decision_mode_counts": {"strategy_signal_paper": 2},
+                        "source_window_start": "2026-03-06T14:30:00+00:00",
+                        "source_window_end": "2026-03-06T15:00:00+00:00",
+                        "source_refs": [
+                            "postgres:trade_decisions",
+                            "postgres:executions",
+                            "postgres:execution_order_events",
+                        ],
+                        "source_row_counts": {
+                            "trade_decisions": 2,
+                            "executions": 2,
+                            "execution_order_events": 4,
+                        },
+                        "profit_proof_eligible": True,
+                    },
+                )
+            )
+            session.commit()
+
+            rows, metadata = _runtime_ledger_tca_rows_from_durable_buckets(
+                session=session,
+                candidate_id="H-TSMOM-LIQ-01",
+                hypothesis_id="H-TSMOM-LIQ-01",
+                observed_stage="paper",
+                strategy_names=["intraday-tsmom-profit-v3"],
+                account_label="TORGHUT_SIM",
+                window_start=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                window_end=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+            )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(metadata["runtime_ledger_durable_bucket_count"], 1)
+        self.assertEqual(
+            metadata["runtime_ledger_durable_bucket_profit_proof_count"],
+            0,
+        )
+        self.assertIn(
+            "runtime_ledger_execution_order_event_refs_missing",
+            metadata["runtime_ledger_durable_bucket_profit_proof_blockers"],
+        )
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
+        self.assertIn(
+            "runtime_ledger_authority_class_missing",
+            rows[0]["runtime_ledger_blockers"],
+        )
 
     def test_runtime_ledger_tca_rows_from_source_dsn_queries_matching_proof(
         self,
@@ -1459,6 +1631,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         rows = _build_realized_strategy_pnl_rows(
             [
                 {
+                    "execution_id": "execution-buy",
                     "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
                     "symbol": "AAPL",
                     "side": "buy",
@@ -1474,6 +1647,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "lineage_hash": "lineage-sha",
                 },
                 {
+                    "execution_id": "execution-sell",
                     "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
                     "symbol": "AAPL",
                     "side": "sell",
@@ -1620,6 +1794,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ],
             decision_lifecycle_rows=[
                 {
+                    "trade_decision_id": "decision-buy-id",
                     "computed_at": datetime(2026, 3, 6, 14, 34, tzinfo=timezone.utc),
                     "event_type": "decision",
                     "symbol": "AAPL",
@@ -1634,6 +1809,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "lineage_hash": "lineage-sha",
                 },
                 {
+                    "trade_decision_id": "decision-sell-id",
                     "computed_at": datetime(2026, 3, 6, 14, 39, tzinfo=timezone.utc),
                     "event_type": "decision",
                     "symbol": "AAPL",
@@ -1650,6 +1826,8 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ],
             order_lifecycle_rows=[
                 {
+                    "execution_order_event_id": "event-new-buy",
+                    "trade_decision_id": "decision-buy-id",
                     "event_ts": datetime(2026, 3, 6, 14, 34, 1, tzinfo=timezone.utc),
                     "event_type": "new",
                     "symbol": "AAPL",
@@ -1660,8 +1838,13 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_policy_hash": "policy-sha",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 100,
                 },
                 {
+                    "execution_order_event_id": "event-new-sell",
+                    "trade_decision_id": "decision-sell-id",
                     "event_ts": datetime(2026, 3, 6, 14, 39, 1, tzinfo=timezone.utc),
                     "event_type": "new",
                     "symbol": "AAPL",
@@ -1672,8 +1855,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_policy_hash": "policy-sha",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 101,
                 },
                 {
+                    "execution_order_event_id": "event-fill-buy",
+                    "trade_decision_id": "decision-buy-id",
+                    "execution_id": "execution-buy",
                     "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
                     "event_type": "filled",
                     "symbol": "AAPL",
@@ -1689,8 +1878,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_policy_hash": "policy-sha",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 102,
                 },
                 {
+                    "execution_order_event_id": "event-fill-sell",
+                    "trade_decision_id": "decision-sell-id",
+                    "execution_id": "execution-sell",
                     "event_ts": datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
                     "event_type": "filled",
                     "symbol": "AAPL",
@@ -1706,6 +1901,9 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_policy_hash": "policy-sha",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 103,
                 },
             ],
             allow_authoritative_runtime_ledger_materialization=True,
@@ -1730,7 +1928,9 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["account_equity"], "10000")
         self.assertEqual(bucket["account_equity_source"], "equity")
         self.assertEqual(bucket["source_window_start"], "2026-03-06T14:34:00+00:00")
-        self.assertEqual(bucket["source_window_end"], "2026-03-06T14:40:01.000001+00:00")
+        self.assertEqual(
+            bucket["source_window_end"], "2026-03-06T14:40:01.000001+00:00"
+        )
         self.assertEqual(
             bucket["source_refs"],
             [
@@ -1811,6 +2011,8 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ],
             order_lifecycle_rows=[
                 {
+                    "execution_order_event_id": "dedupe-event-new-buy",
+                    "trade_decision_id": "decision-buy",
                     "event_ts": datetime(2026, 3, 6, 14, 34, 1, tzinfo=timezone.utc),
                     "event_type": "new",
                     "symbol": "AAPL",
@@ -1821,8 +2023,13 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_policy_hash": "policy-sha",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 110,
                 },
                 {
+                    "execution_order_event_id": "dedupe-event-new-sell",
+                    "trade_decision_id": "decision-sell",
                     "event_ts": datetime(2026, 3, 6, 14, 39, 1, tzinfo=timezone.utc),
                     "event_type": "new",
                     "symbol": "AAPL",
@@ -1833,8 +2040,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_policy_hash": "policy-sha",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 111,
                 },
                 {
+                    "execution_order_event_id": "dedupe-event-fill-buy",
+                    "trade_decision_id": "decision-buy",
+                    "execution_id": "dedupe-execution-buy",
                     "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
                     "event_type": "filled",
                     "symbol": "AAPL",
@@ -1845,8 +2058,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_policy_hash": "policy-sha",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 112,
                 },
                 {
+                    "execution_order_event_id": "dedupe-event-fill-sell",
+                    "trade_decision_id": "decision-sell",
+                    "execution_id": "dedupe-execution-sell",
                     "event_ts": datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
                     "event_type": "filled",
                     "symbol": "AAPL",
@@ -1857,6 +2076,9 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_policy_hash": "policy-sha",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 113,
                 },
             ],
             allow_authoritative_runtime_ledger_materialization=True,
@@ -1952,6 +2174,8 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ],
             order_lifecycle_rows=[
                 {
+                    "execution_order_event_id": "dedupe-event-new-buy",
+                    "trade_decision_id": "decision-buy",
                     "event_ts": datetime(2026, 3, 6, 14, 34, 1, tzinfo=timezone.utc),
                     "event_type": "new",
                     "symbol": "AAPL",
@@ -1962,8 +2186,13 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_policy_hash": "policy-sha",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 110,
                 },
                 {
+                    "execution_order_event_id": "dedupe-event-new-sell",
+                    "trade_decision_id": "decision-sell",
                     "event_ts": datetime(2026, 3, 6, 14, 39, 1, tzinfo=timezone.utc),
                     "event_type": "new",
                     "symbol": "AAPL",
@@ -1974,8 +2203,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_policy_hash": "policy-sha",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 111,
                 },
                 {
+                    "execution_order_event_id": "dedupe-event-fill-buy",
+                    "trade_decision_id": "decision-buy",
+                    "execution_id": "dedupe-execution-buy",
                     "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
                     "event_type": "filled",
                     "symbol": "AAPL",
@@ -1991,8 +2226,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_policy_hash": "policy-sha",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 112,
                 },
                 {
+                    "execution_order_event_id": "dedupe-event-fill-sell",
+                    "trade_decision_id": "decision-sell",
+                    "execution_id": "dedupe-execution-sell",
                     "event_ts": datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
                     "event_type": "filled",
                     "symbol": "AAPL",
@@ -2008,6 +2249,9 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_policy_hash": "policy-sha",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 113,
                 },
             ],
             allow_authoritative_runtime_ledger_materialization=True,
@@ -2258,6 +2502,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "runtime_ledger_bucket": _complete_runtime_ledger_bucket(
                         pnl_basis=POST_COST_BASIS_EXECUTION_RECONSTRUCTION,
                         blockers=["execution_reconstruction_not_runtime_ledger_proof"],
+                        source_materialization=None,
+                        authority_class=None,
+                        authority_reason=None,
+                        pnl_derivation=None,
                     ),
                 },
             ]
@@ -2278,14 +2526,18 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             metadata["runtime_ledger_materialization_blockers"],
             [
                 "execution_reconstruction_not_runtime_ledger_proof",
+                "runtime_ledger_authority_class_missing",
                 "runtime_ledger_pnl_basis_not_runtime_ledger",
+                "runtime_ledger_source_materialization_missing",
             ],
         )
         self.assertEqual(
             metadata["runtime_ledger_profit_proof_blockers"],
             [
                 "execution_reconstruction_not_runtime_ledger_proof",
+                "runtime_ledger_authority_class_missing",
                 "runtime_ledger_pnl_basis_not_runtime_ledger",
+                "runtime_ledger_source_materialization_missing",
             ],
         )
 

--- a/services/torghut/tests/test_runtime_ledger_source_authority.py
+++ b/services/torghut/tests/test_runtime_ledger_source_authority.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from unittest import TestCase
 
 from app.trading.runtime_ledger_source_authority import (
+    runtime_ledger_promotion_source_authority_blockers,
     runtime_ledger_source_authority_blockers,
     runtime_ledger_source_refs_present,
     runtime_ledger_source_window_present,
@@ -66,4 +67,48 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                 "runtime_ledger_source_window_missing",
                 "runtime_ledger_source_refs_missing",
             ],
+        )
+
+    def test_promotion_source_authority_requires_row_level_runtime_lineage(
+        self,
+    ) -> None:
+        aggregate_only = {
+            "source_window_start": "2026-05-29T14:30:00+00:00",
+            "source_window_end": "2026-05-29T15:00:00+00:00",
+            "source_refs": [
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+            ],
+            "source_row_counts": {
+                "trade_decisions": 2,
+                "executions": 2,
+                "execution_order_events": 4,
+            },
+        }
+
+        blockers = runtime_ledger_promotion_source_authority_blockers(aggregate_only)
+
+        self.assertIn("runtime_ledger_trade_decision_refs_missing", blockers)
+        self.assertIn("runtime_ledger_execution_refs_missing", blockers)
+        self.assertIn("runtime_ledger_execution_order_event_refs_missing", blockers)
+        self.assertIn("runtime_ledger_source_offsets_missing", blockers)
+        self.assertIn("runtime_ledger_source_materialization_missing", blockers)
+        self.assertIn("runtime_ledger_authority_class_missing", blockers)
+
+        source_backed = {
+            **aggregate_only,
+            "trade_decision_ids": ["decision-1", "decision-2"],
+            "execution_ids": ["execution-1", "execution-2"],
+            "execution_order_event_ids": ["event-1", "event-2"],
+            "source_offsets": [
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+            ],
+            "source_materialization": "execution_order_events",
+            "authority_class": "runtime_order_feed_execution_source",
+        }
+
+        self.assertEqual(
+            runtime_ledger_promotion_source_authority_blockers(source_backed),
+            [],
         )

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -87,6 +87,14 @@ def _runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
             "executions": 2,
             "execution_order_events": 2,
         },
+        "trade_decision_ids": ["decision-buy", "decision-sell"],
+        "execution_ids": ["execution-buy", "execution-sell"],
+        "execution_order_event_ids": ["event-fill-buy", "event-fill-sell"],
+        "source_offsets": [
+            {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100}
+        ],
+        "source_materialization": "execution_order_events",
+        "authority_class": "runtime_order_feed_execution_source",
         "blockers": [],
     }
     payload.update(overrides)
@@ -502,6 +510,55 @@ class TestRuntimeWindowImport(TestCase):
         )
 
         self.assertFalse(_persisted_runtime_ledger_bucket_evidence_grade(row))
+
+    def test_persisted_runtime_ledger_bucket_evidence_grade_requires_source_proof(
+        self,
+    ) -> None:
+        source_backed_payload = _runtime_ledger_bucket()
+        aggregate_only_payload = {
+            key: value
+            for key, value in source_backed_payload.items()
+            if key
+            not in {
+                "trade_decision_ids",
+                "execution_ids",
+                "execution_order_event_ids",
+                "source_offsets",
+                "source_materialization",
+                "authority_class",
+            }
+        }
+        row = StrategyRuntimeLedgerBucket(
+            run_id="run-aggregate-only",
+            candidate_id="cand",
+            hypothesis_id="hyp",
+            observed_stage="paper",
+            bucket_started_at=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+            bucket_ended_at=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+            account_label="TORGHUT_SIM",
+            runtime_strategy_name="strategy",
+            fill_count=2,
+            decision_count=2,
+            submitted_order_count=2,
+            closed_trade_count=1,
+            open_position_count=0,
+            filled_notional=Decimal("200"),
+            gross_strategy_pnl=Decimal("1"),
+            cost_amount=Decimal("0.20"),
+            net_strategy_pnl_after_costs=Decimal("0.80"),
+            post_cost_expectancy_bps=Decimal("40"),
+            pnl_basis="realized_strategy_pnl_after_explicit_costs",
+            ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+            execution_policy_hash_counts={"policy-sha": 2},
+            cost_model_hash_counts={"cost-sha": 2},
+            lineage_hash_counts={"lineage-sha": 2},
+            blockers_json=[],
+            payload_json=aggregate_only_payload,
+        )
+
+        self.assertFalse(_persisted_runtime_ledger_bucket_evidence_grade(row))
+        row.payload_json = source_backed_payload
+        self.assertTrue(_persisted_runtime_ledger_bucket_evidence_grade(row))
 
     def test_runtime_ledger_bucket_payloads_accept_single_bucket_payload(
         self,

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -222,6 +222,26 @@ class TestSubmissionCouncil(TestCase):
             "execution_policy_hash_counts": {"policy": 42},
             "cost_model_hash_counts": {"cost": 42},
             "lineage_hash_counts": {"lineage": 42},
+            "source_window_start": datetime.now(timezone.utc).isoformat(),
+            "source_window_end": datetime.now(timezone.utc).isoformat(),
+            "source_refs": [
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+            ],
+            "source_row_counts": {
+                "trade_decisions": 2,
+                "executions": 2,
+                "execution_order_events": 4,
+            },
+            "trade_decision_ids": ["decision-buy", "decision-sell"],
+            "execution_ids": ["execution-buy", "execution-sell"],
+            "execution_order_event_ids": ["event-fill-buy", "event-fill-sell"],
+            "source_offsets": [
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100}
+            ],
+            "source_materialization": "execution_order_events",
+            "authority_class": "runtime_order_feed_execution_source",
             "blockers": [],
         }
 
@@ -578,6 +598,17 @@ class TestSubmissionCouncil(TestCase):
                     "trade_order_events": 2,
                     "strategy_runtime_ledger_buckets": 1,
                 },
+                "trade_decision_ids": ["pairs-decision-buy", "pairs-decision-sell"],
+                "execution_ids": ["pairs-execution-buy", "pairs-execution-sell"],
+                "execution_order_event_ids": [
+                    "pairs-event-new-buy",
+                    "pairs-event-fill-buy",
+                ],
+                "source_offsets": [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100}
+                ],
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
             }
             reversal_source_payload = {
                 "source_window_start": (now - timedelta(minutes=75)).isoformat(),
@@ -590,6 +621,14 @@ class TestSubmissionCouncil(TestCase):
                     "trade_order_events": 1,
                     "strategy_runtime_ledger_buckets": 1,
                 },
+                "trade_decision_ids": ["reversal-decision"],
+                "execution_ids": ["reversal-execution"],
+                "execution_order_event_ids": ["reversal-event-fill"],
+                "source_offsets": [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 200}
+                ],
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
             }
             session.add_all(
                 [
@@ -884,6 +923,8 @@ class TestSubmissionCouncil(TestCase):
 
         self.assertIn("runtime_ledger_source_window_missing", reasons)
         self.assertIn("runtime_ledger_source_refs_missing", reasons)
+        self.assertIn("runtime_ledger_execution_order_event_refs_missing", reasons)
+        self.assertIn("runtime_ledger_source_offsets_missing", reasons)
         self.assertIn("runtime_ledger_stage_not_live", reasons)
 
         source_backed_reasons = _runtime_ledger_repair_reason_codes(
@@ -899,6 +940,14 @@ class TestSubmissionCouncil(TestCase):
                     "trade_order_events": 2,
                     "strategy_runtime_ledger_buckets": 1,
                 },
+                "trade_decision_ids": ["decision-buy", "decision-sell"],
+                "execution_ids": ["execution-buy", "execution-sell"],
+                "execution_order_event_ids": ["event-fill-buy", "event-fill-sell"],
+                "source_offsets": [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100}
+                ],
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
             },
             manifest={"candidate_id": "c88421d619759b2cfaa6f4d0"},
         )
@@ -908,6 +957,10 @@ class TestSubmissionCouncil(TestCase):
             source_backed_reasons,
         )
         self.assertNotIn("runtime_ledger_source_refs_missing", source_backed_reasons)
+        self.assertNotIn(
+            "runtime_ledger_execution_order_event_refs_missing",
+            source_backed_reasons,
+        )
         self.assertEqual(source_backed_reasons, ["runtime_ledger_stage_not_live"])
 
     def test_runtime_ledger_paper_probation_import_plan_falls_back_and_skips_incomplete_targets(


### PR DESCRIPTION
## Summary

- Require promotion-grade runtime-ledger buckets to carry row-level source proof: trade-decision refs, execution refs, order-event refs, source offsets, materialization, and authority class.
- Apply the stricter predicate across runtime-window import, durable/source bucket imports, and submission-council repair reasons.
- Preserve source IDs and Kafka offsets when materializing runtime-ledger rows from source decisions, executions, and order-feed events.
- Add regressions proving aggregate-only durable/source buckets stay blocked while source-backed buckets remain eligible.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger_source_authority.py app/trading/runtime_window_import.py app/trading/submission_council.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_ledger_source_authority.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger_source_authority.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_submission_council.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check HEAD~1..HEAD`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
