### PR TITLE
chore(synthesis): promote image 0.580.12

### DIFF
--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    newTag: 0.580.11
+    newTag: 0.580.12
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promotes the Synthesis Deployment image from `0.580.11` to `0.580.12`.
- Rolls out the image built from merged autotrader P0 reliability commit `594b1582d245716c2ef7f468ced93110f20e4b86`.
- Keeps the change scoped to the GitOps kustomization image tag.

## Related Issues

None

## Testing

- `bun run lint:argocd`
- `crane digest registry.ide-newton.ts.net/lab/synthesis:0.580.12`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
