### PR TITLE
fix(torghut): make proof packet modes explicit

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -3234,29 +3234,55 @@ def _runtime_ledger_proof_packet_handoff(
         for blocker in _unique_text_items(runtime_import_handoff.get("import_blockers"))
         if blocker not in _unique_text_items(session_readiness.get("import_blockers"))
     ]
-    base_args = [
-        "uv",
-        "run",
-        "--frozen",
-        "python",
-        "scripts/assemble_runtime_ledger_proof_packet.py",
+    smoke_targets = proof_policy.target_payload("smoke")
+    authority_targets = proof_policy.target_payload("authority")
+    smoke_threshold_args = [
+        "--proof-mode",
+        "smoke",
+        "--min-runtime-ledger-net-pnl",
+        str(smoke_targets["min_runtime_ledger_net_pnl_after_costs"]),
+        "--min-runtime-ledger-daily-net-pnl",
+        str(smoke_targets["min_runtime_ledger_daily_net_pnl_after_costs"]),
+        "--min-runtime-ledger-trading-days",
+        str(smoke_targets["min_runtime_ledger_trading_days"]),
+    ]
+    authority_threshold_args = [
+        "--proof-mode",
+        "authority",
+        "--min-runtime-ledger-net-pnl",
+        str(authority_targets["min_runtime_ledger_net_pnl_after_costs"]),
+        "--min-runtime-ledger-daily-net-pnl",
+        str(authority_targets["min_runtime_ledger_daily_net_pnl_after_costs"]),
+        "--min-runtime-ledger-trading-days",
+        str(authority_targets["min_runtime_ledger_trading_days"]),
+    ]
+    service_args = [
         "--status-service-base-url",
         "$TORGHUT_LIVE_SERVICE_BASE_URL",
         "--paper-route-service-base-url",
         "$TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL",
         "--completion-service-base-url",
         "$TORGHUT_LIVE_SERVICE_BASE_URL",
-        "--min-runtime-ledger-net-pnl",
-        str(proof_policy.min_net_pnl_after_costs),
-        "--min-runtime-ledger-daily-net-pnl",
-        str(proof_policy.min_daily_net_pnl_after_costs),
-        "--min-runtime-ledger-trading-days",
-        str(proof_policy.min_trading_days),
+    ]
+    base_args = [
+        "uv",
+        "run",
+        "--frozen",
+        "python",
+        "scripts/assemble_runtime_ledger_proof_packet.py",
+        *service_args,
+        *smoke_threshold_args,
         "--output-file",
         RUNTIME_LEDGER_PROOF_PACKET_OUTPUT_FILE,
     ]
     authority_args = [
-        *base_args[:-2],
+        "uv",
+        "run",
+        "--frozen",
+        "python",
+        "scripts/assemble_runtime_ledger_proof_packet.py",
+        *service_args,
+        *authority_threshold_args,
         "--runtime-window-import-file",
         RUNTIME_WINDOW_IMPORT_OUTPUT_FILE,
         "--output-file",
@@ -3290,7 +3316,7 @@ def _runtime_ledger_proof_packet_handoff(
             "completion_doc29": "/trading/completion/doc29",
         },
         "targets": {
-            **proof_policy.target_payload(),
+            **authority_targets,
         },
         "runtime_window": {
             "import_ready": import_ready,

--- a/services/torghut/app/trading/runtime_ledger_proof_policy.py
+++ b/services/torghut/app/trading/runtime_ledger_proof_policy.py
@@ -6,13 +6,25 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
+from typing import Literal
+
+
+RuntimeLedgerProofMode = Literal["smoke", "probation", "authority"]
+RUNTIME_LEDGER_PROOF_MODES: tuple[RuntimeLedgerProofMode, ...] = (
+    "smoke",
+    "probation",
+    "authority",
+)
+DEFAULT_RUNTIME_LEDGER_PROOF_MODE: RuntimeLedgerProofMode = "smoke"
 
 
 @dataclass(frozen=True)
 class RuntimeLedgerProofPolicy:
+    proof_mode: RuntimeLedgerProofMode = DEFAULT_RUNTIME_LEDGER_PROOF_MODE
     min_net_pnl_after_costs: Decimal = Decimal("500")
     min_daily_net_pnl_after_costs: Decimal = Decimal("500")
     min_trading_days: int = 1
+    probation_min_trading_days: int = 5
     max_drawdown_pct_equity: Decimal = Decimal("0.08")
     max_best_day_share: Decimal = Decimal("0.25")
     max_symbol_concentration_share: Decimal = Decimal("0.50")
@@ -24,15 +36,46 @@ class RuntimeLedgerProofPolicy:
     authority_max_intraday_drawdown: Decimal = Decimal("1500")
     authority_max_best_day_share: Decimal = Decimal("0.25")
 
-    def target_payload(self) -> dict[str, object]:
+    def target_payload(
+        self,
+        proof_mode: str | None = None,
+    ) -> dict[str, object]:
+        targets = self.targets_for_mode(proof_mode or self.proof_mode)
         return {
+            "proof_mode": targets["proof_mode"],
+            "final_authority": targets["final_authority"],
+            "evidence_collection_only": targets["evidence_collection_only"],
             "min_runtime_ledger_net_pnl_after_costs": _decimal_text(
-                self.min_net_pnl_after_costs
+                _target_decimal(targets, "min_net_pnl_after_costs")
             ),
             "min_runtime_ledger_daily_net_pnl_after_costs": _decimal_text(
-                self.min_daily_net_pnl_after_costs
+                _target_decimal(targets, "min_daily_net_pnl_after_costs")
             ),
-            "min_runtime_ledger_trading_days": self.min_trading_days,
+            "min_runtime_ledger_trading_days": targets["min_trading_days"],
+        }
+
+    def targets_for_mode(self, proof_mode: str) -> dict[str, object]:
+        mode = normalize_runtime_ledger_proof_mode(proof_mode)
+        min_days = self.min_trading_days
+        min_daily = self.min_daily_net_pnl_after_costs
+        min_net = self.min_net_pnl_after_costs
+        if mode == "probation":
+            min_days = max(min_days, self.probation_min_trading_days)
+            min_net = max(min_net, min_daily * Decimal(min_days))
+        elif mode == "authority":
+            min_days = max(min_days, self.authority_min_trading_days)
+            min_daily = max(
+                min_daily,
+                self.authority_min_mean_daily_net_pnl_after_costs,
+            )
+            min_net = max(min_net, min_daily * Decimal(min_days))
+        return {
+            "proof_mode": mode,
+            "final_authority": mode == "authority",
+            "evidence_collection_only": mode != "authority",
+            "min_net_pnl_after_costs": min_net,
+            "min_daily_net_pnl_after_costs": min_daily,
+            "min_trading_days": min_days,
         }
 
 
@@ -69,6 +112,9 @@ _DECIMAL_ENV_FIELDS = {
 }
 _INT_ENV_FIELDS = {
     "TORGHUT_RUNTIME_LEDGER_PROOF_MIN_TRADING_DAYS": "min_trading_days",
+    "TORGHUT_RUNTIME_LEDGER_PROOF_PROBATION_MIN_TRADING_DAYS": (
+        "probation_min_trading_days"
+    ),
     "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MIN_TRADING_DAYS": ("authority_min_trading_days"),
 }
 
@@ -78,6 +124,9 @@ def runtime_ledger_proof_policy_from_env(
 ) -> RuntimeLedgerProofPolicy:
     source = os.environ if environ is None else environ
     values = DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.__dict__.copy()
+    raw_mode = source.get("TORGHUT_RUNTIME_LEDGER_PROOF_MODE")
+    if raw_mode is not None and raw_mode.strip():
+        values["proof_mode"] = normalize_runtime_ledger_proof_mode(raw_mode)
     for env_name, field_name in _DECIMAL_ENV_FIELDS.items():
         raw_value = source.get(env_name)
         if raw_value is None or not raw_value.strip():
@@ -89,6 +138,25 @@ def runtime_ledger_proof_policy_from_env(
             continue
         values[field_name] = _parse_int_env(env_name, raw_value)
     return RuntimeLedgerProofPolicy(**values)
+
+
+def normalize_runtime_ledger_proof_mode(value: str) -> RuntimeLedgerProofMode:
+    mode = value.strip().lower().replace("_", "-")
+    if mode in {"paper-probation", "paper"}:
+        mode = "probation"
+    if mode not in RUNTIME_LEDGER_PROOF_MODES:
+        allowed = ", ".join(RUNTIME_LEDGER_PROOF_MODES)
+        raise ValueError(
+            f"TORGHUT_RUNTIME_LEDGER_PROOF_MODE must be one of {allowed}: {value!r}"
+        )
+    return mode
+
+
+def _target_decimal(targets: Mapping[str, object], key: str) -> Decimal:
+    value = targets[key]
+    if isinstance(value, Decimal):
+        return value
+    raise TypeError(f"{key} must be Decimal")
 
 
 def _parse_decimal_env(name: str, value: str) -> Decimal:
@@ -114,7 +182,11 @@ def _decimal_text(value: Decimal) -> str:
 
 
 __all__ = [
+    "DEFAULT_RUNTIME_LEDGER_PROOF_MODE",
     "DEFAULT_RUNTIME_LEDGER_PROOF_POLICY",
+    "RUNTIME_LEDGER_PROOF_MODES",
     "RuntimeLedgerProofPolicy",
+    "RuntimeLedgerProofMode",
+    "normalize_runtime_ledger_proof_mode",
     "runtime_ledger_proof_policy_from_env",
 ]

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -23,12 +23,20 @@ from typing import Any, Protocol, cast
 from urllib.parse import urljoin
 from urllib.request import urlopen
 
-from app.trading.runtime_ledger_proof_policy import runtime_ledger_proof_policy_from_env
+from app.trading.runtime_ledger_proof_policy import (
+    DEFAULT_RUNTIME_LEDGER_PROOF_MODE,
+    RUNTIME_LEDGER_PROOF_MODES,
+    normalize_runtime_ledger_proof_mode,
+    runtime_ledger_proof_policy_from_env,
+)
 
 
 SCHEMA_VERSION = "torghut.runtime-ledger-live-paper-proof-packet.v1"
 DOC29_LIVE_SCALE_GATE = "live_scale_observed"
 DEFAULT_RUNTIME_LEDGER_PROOF_POLICY = runtime_ledger_proof_policy_from_env()
+RUNTIME_LEDGER_PROOF_MODE_NOT_AUTHORITY_BLOCKER = (
+    "runtime_ledger_proof_mode_not_authority"
+)
 STATUS_ENDPOINT = "/trading/status"
 PAPER_ROUTE_EVIDENCE_ENDPOINT = "/trading/paper-route-evidence"
 COMPLETION_DOC29_ENDPOINT = "/trading/completion/doc29"
@@ -1184,6 +1192,8 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
                 actions,
                 ["improve_runtime_ledger_drawdown_concentration_or_position_sizing"],
             )
+        elif blocker == RUNTIME_LEDGER_PROOF_MODE_NOT_AUTHORITY_BLOCKER:
+            _extend_unique(actions, ["rerun_proof_packet_in_authority_mode"])
         elif blocker.startswith("runtime_ledger_") or blocker in {
             "filled_notional_missing",
             "closed_round_trip_missing",
@@ -1229,6 +1239,7 @@ def _required_actions(blockers: Sequence[str], *, verdict: str) -> list[str]:
 def build_runtime_ledger_proof_packet(
     status: Mapping[str, Any],
     *,
+    proof_mode: str = "authority",
     paper_route_evidence: Mapping[str, Any] | None = None,
     runtime_window_import: Mapping[str, Any] | None = None,
     completion_status: Mapping[str, Any] | None = None,
@@ -1255,6 +1266,43 @@ def build_runtime_ledger_proof_packet(
     checks: dict[str, dict[str, Any]] = {}
     blockers: list[str] = []
     generated_at = generated_at or _utc_now()
+    resolved_proof_mode = normalize_runtime_ledger_proof_mode(proof_mode)
+    proof_mode_targets = DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.targets_for_mode(
+        resolved_proof_mode
+    )
+    min_runtime_ledger_net_pnl = max(
+        min_runtime_ledger_net_pnl,
+        cast(Decimal, proof_mode_targets["min_net_pnl_after_costs"]),
+    )
+    min_runtime_ledger_daily_net_pnl = max(
+        min_runtime_ledger_daily_net_pnl,
+        cast(Decimal, proof_mode_targets["min_daily_net_pnl_after_costs"]),
+    )
+    min_runtime_ledger_trading_days = max(
+        min_runtime_ledger_trading_days,
+        cast(int, proof_mode_targets["min_trading_days"]),
+    )
+    final_authority_mode = bool(proof_mode_targets["final_authority"])
+    mode_authority_blockers = (
+        []
+        if final_authority_mode
+        else [RUNTIME_LEDGER_PROOF_MODE_NOT_AUTHORITY_BLOCKER]
+    )
+    mode_authority_failed_checks = (
+        [] if final_authority_mode else ["runtime_ledger_proof_mode_authority_required"]
+    )
+    _check(
+        checks,
+        "runtime_ledger_proof_mode_contract",
+        passed=True,
+        observed={
+            "proof_mode": resolved_proof_mode,
+            "final_authority": final_authority_mode,
+            "evidence_collection_only": not final_authority_mode,
+        },
+        expected="explicit proof mode; only authority mode can grant promotion authority",
+        blockers=[],
+    )
 
     status_gate = _status_gate_blocker_summary(status)
     raw_live_blockers = status_gate["raw_blockers"]
@@ -1730,13 +1778,25 @@ def build_runtime_ledger_proof_packet(
     _extend_unique(blockers, risk_blockers)
 
     failed_checks = [key for key, value in checks.items() if not value["passed"]]
-    post_cost_proof_allowed = not failed_checks
-    promotion_prerequisite_blockers = list(capital_status_blockers)
+    post_cost_proof_satisfied = not failed_checks
+    post_cost_proof_authority_allowed = (
+        post_cost_proof_satisfied and final_authority_mode
+    )
+    authority_blockers = list(blockers)
+    _extend_unique(authority_blockers, mode_authority_blockers)
+    authority_failed_checks = list(failed_checks)
+    _extend_unique(authority_failed_checks, mode_authority_failed_checks)
+    promotion_prerequisite_blockers = list(mode_authority_blockers)
+    _extend_unique(promotion_prerequisite_blockers, capital_status_blockers)
     _extend_unique(promotion_prerequisite_blockers, health_gate_promotion_blockers)
     capital_promotion_allowed = (
-        post_cost_proof_allowed and not promotion_prerequisite_blockers
+        post_cost_proof_authority_allowed and not promotion_prerequisite_blockers
     )
     capital_promotion_failed_checks: list[str] = []
+    if mode_authority_blockers:
+        capital_promotion_failed_checks.append(
+            "runtime_ledger_proof_mode_authority_required"
+        )
     if capital_status_blockers:
         capital_promotion_failed_checks.append("capital_promotion_gate")
     if health_gate_promotion_blockers:
@@ -1751,12 +1811,12 @@ def build_runtime_ledger_proof_packet(
         "paper_route_session_settlement_pending",
         "paper_route_import_not_ready",
     }
-    if post_cost_proof_allowed and not promotion_prerequisite_blockers:
+    if post_cost_proof_authority_allowed and not promotion_prerequisite_blockers:
         verdict = "promotion_authority_allowed"
         reason = "runtime_ledger_live_paper_post_cost_proof_satisfied"
         promotion_reason = reason
         capital_reason = "live_capital_promotion_gate_clear"
-    elif post_cost_proof_allowed:
+    elif post_cost_proof_authority_allowed:
         verdict = "post_cost_proof_authority_allowed_capital_promotion_blocked"
         reason = (
             "runtime_ledger_live_paper_post_cost_proof_satisfied_"
@@ -1764,6 +1824,11 @@ def build_runtime_ledger_proof_packet(
         )
         promotion_reason = "live_capital_promotion_gate_blocked"
         capital_reason = "live_capital_promotion_gate_blocked"
+    elif post_cost_proof_satisfied and not final_authority_mode:
+        verdict = f"{resolved_proof_mode}_proof_satisfied_evidence_collection_only"
+        reason = f"runtime_ledger_{resolved_proof_mode}_proof_satisfied"
+        promotion_reason = RUNTIME_LEDGER_PROOF_MODE_NOT_AUTHORITY_BLOCKER
+        capital_reason = RUNTIME_LEDGER_PROOF_MODE_NOT_AUTHORITY_BLOCKER
     elif set(blockers).issubset(waiting_blockers):
         verdict = "waiting_for_runtime_window"
         reason = "paper_route_runtime_window_not_importable_yet"
@@ -1778,21 +1843,25 @@ def build_runtime_ledger_proof_packet(
     return {
         "schema_version": SCHEMA_VERSION,
         "generated_at": generated_at,
+        "proof_mode": resolved_proof_mode,
         "verdict": verdict,
-        "ok": post_cost_proof_allowed,
+        "ok": post_cost_proof_satisfied,
+        "final_authority_ok": post_cost_proof_authority_allowed,
+        "evidence_collection_only": not final_authority_mode,
         "post_cost_proof_authority": {
-            "allowed": post_cost_proof_allowed,
+            "allowed": post_cost_proof_authority_allowed,
+            "proof_satisfied": post_cost_proof_satisfied,
             "reason": reason,
-            "blocking_reasons": blockers,
-            "failed_checks": failed_checks,
+            "blocking_reasons": authority_blockers,
+            "failed_checks": authority_failed_checks,
         },
         "capital_promotion_authority": {
             "allowed": capital_promotion_allowed,
             "reason": capital_reason,
             "blocking_reasons": promotion_prerequisite_blockers,
-            "proof_prerequisite_blocking_reasons": blockers,
+            "proof_prerequisite_blocking_reasons": authority_blockers,
             "failed_checks": capital_promotion_failed_checks
-            if post_cost_proof_allowed
+            if post_cost_proof_authority_allowed
             else promotion_failed_checks,
         },
         "promotion_authority": {
@@ -1802,6 +1871,9 @@ def build_runtime_ledger_proof_packet(
             "failed_checks": promotion_failed_checks,
         },
         "target": {
+            "proof_mode": resolved_proof_mode,
+            "final_authority": final_authority_mode,
+            "evidence_collection_only": not final_authority_mode,
             "min_runtime_ledger_net_pnl_after_costs": _decimal_text(
                 min_runtime_ledger_net_pnl
             ),
@@ -1919,6 +1991,15 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--completion-url", help="URL returning /trading/completion/doc29 JSON."
+    )
+    parser.add_argument(
+        "--proof-mode",
+        choices=RUNTIME_LEDGER_PROOF_MODES,
+        default=DEFAULT_RUNTIME_LEDGER_PROOF_MODE,
+        help=(
+            "Proof packet mode. smoke/probation prove plumbing or bounded "
+            "evidence collection only; authority is required for promotion."
+        ),
     )
     parser.add_argument(
         "--min-runtime-ledger-net-pnl",
@@ -2060,6 +2141,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     assert status is not None
     packet = build_runtime_ledger_proof_packet(
         status,
+        proof_mode=args.proof_mode,
         paper_route_evidence=paper_route_evidence,
         runtime_window_import=runtime_window_import,
         completion_status=completion_status,

--- a/services/torghut/scripts/verify_trading_readiness.py
+++ b/services/torghut/scripts/verify_trading_readiness.py
@@ -706,6 +706,8 @@ def _add_runtime_ledger_proof_packet_check(
         observed={
             "present": bool(packet),
             "schema_version": schema_version,
+            "proof_mode": _text(packet.get("proof_mode")),
+            "final_authority_ok": packet.get("final_authority_ok"),
             "ok": packet.get("ok"),
             "verdict": _text(packet.get("verdict")),
             "authority_allowed": authority.get("allowed"),

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -240,8 +240,8 @@ def _runtime_import(
 def _completion(
     *,
     status: str = "satisfied",
-    net_pnl: str = "650",
-    trading_days: int = 1,
+    net_pnl: str = "10000",
+    trading_days: int = 20,
     expectancy_bps: str = "13",
     drawdown_pct: str | None = "0.04",
     best_day_share: str | None = "0.20",
@@ -400,7 +400,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result["checks"]["runtime_ledger_post_cost_profit_target"]["observed"][
                 "daily_net_pnl_after_costs"
             ],
-            "650",
+            "500",
         )
         self.assertEqual(
             result["checks"]["runtime_ledger_risk_quality"]["observed"][
@@ -411,6 +411,36 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertEqual(
             result["target"]["max_runtime_ledger_drawdown_pct_equity"],
             "0.08",
+        )
+        self.assertEqual(result["proof_mode"], "authority")
+        self.assertTrue(result["final_authority_ok"])
+        self.assertFalse(result["evidence_collection_only"])
+
+    def test_smoke_packet_cannot_grant_promotion_authority(self) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            proof_mode="smoke",
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertTrue(result["ok"], result)
+        self.assertFalse(result["final_authority_ok"])
+        self.assertEqual(result["proof_mode"], "smoke")
+        self.assertEqual(
+            result["verdict"],
+            "smoke_proof_satisfied_evidence_collection_only",
+        )
+        self.assertFalse(result["promotion_authority"]["allowed"])
+        self.assertIn(
+            "runtime_ledger_proof_mode_not_authority",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "rerun_proof_packet_in_authority_mode",
+            result["required_actions"],
         )
 
     def test_packet_splits_post_cost_proof_from_capital_promotion_gate(self) -> None:
@@ -577,6 +607,8 @@ class TestRuntimeLedgerProofPacket(TestCase):
                         str(runtime_path),
                         "--completion-file",
                         str(completion_path),
+                        "--proof-mode",
+                        "authority",
                         "--output-file",
                         str(output_path),
                         "--generated-at",
@@ -1277,7 +1309,9 @@ class TestRuntimeLedgerProofPacket(TestCase):
         )
         self.assertEqual(materialization["materialized_target_count"], 0)
         self.assertEqual(materialization["unmaterialized_target_count"], 1)
-        self.assertIn("runtime_ledger_source_window_missing", materialization["blockers"])
+        self.assertIn(
+            "runtime_ledger_source_window_missing", materialization["blockers"]
+        )
         self.assertIn("runtime_ledger_source_refs_missing", materialization["blockers"])
         self.assertIn(
             "runtime_ledger_source_window_missing",
@@ -1997,6 +2031,8 @@ class TestRuntimeLedgerProofPacket(TestCase):
                         "http://torghut.local/",
                         "--runtime-window-import-file",
                         str(import_path),
+                        "--proof-mode",
+                        "authority",
                         "--output-file",
                         str(output_path),
                     ]
@@ -2063,6 +2099,8 @@ class TestRuntimeLedgerProofPacket(TestCase):
                         "http://torghut-live.local/",
                         "--runtime-window-import-file",
                         str(import_path),
+                        "--proof-mode",
+                        "authority",
                         "--output-file",
                         str(output_path),
                     ]

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -787,9 +787,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertEqual(
             proof_handoff["targets"],
             {
-                "min_runtime_ledger_net_pnl_after_costs": "500",
+                "proof_mode": "authority",
+                "final_authority": True,
+                "evidence_collection_only": False,
+                "min_runtime_ledger_net_pnl_after_costs": "10000",
                 "min_runtime_ledger_daily_net_pnl_after_costs": "500",
-                "min_runtime_ledger_trading_days": 1,
+                "min_runtime_ledger_trading_days": 20,
             },
         )
         self.assertEqual(
@@ -832,10 +835,16 @@ class TestPaperRouteEvidenceAudit(TestCase):
         self.assertIn("--completion-service-base-url", waiting_argv)
         self.assertIn("$TORGHUT_LIVE_SERVICE_BASE_URL", waiting_argv)
         self.assertIn("$TORGHUT_PAPER_ROUTE_SERVICE_BASE_URL", waiting_argv)
+        self.assertIn("--proof-mode", waiting_argv)
+        self.assertIn("smoke", waiting_argv)
         self.assertIn("--min-runtime-ledger-net-pnl", waiting_argv)
         authority_argv = proof_handoff["commands"]["authority_packet_after_import"][
             "argv"
         ]
+        self.assertIn("--proof-mode", authority_argv)
+        self.assertIn("authority", authority_argv)
+        self.assertIn("10000", authority_argv)
+        self.assertIn("20", authority_argv)
         self.assertIn("--runtime-window-import-file", authority_argv)
         self.assertIn("artifacts/runtime-window-import.json", authority_argv)
         self.assertIn("--artifact-prefix", authority_argv)

--- a/services/torghut/tests/test_runtime_ledger_proof_policy.py
+++ b/services/torghut/tests/test_runtime_ledger_proof_policy.py
@@ -14,6 +14,9 @@ class TestRuntimeLedgerProofPolicy(TestCase):
         self.assertEqual(
             DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.target_payload(),
             {
+                "proof_mode": "smoke",
+                "final_authority": False,
+                "evidence_collection_only": True,
                 "min_runtime_ledger_net_pnl_after_costs": "500",
                 "min_runtime_ledger_daily_net_pnl_after_costs": "500",
                 "min_runtime_ledger_trading_days": 1,
@@ -30,6 +33,8 @@ class TestRuntimeLedgerProofPolicy(TestCase):
                 "TORGHUT_RUNTIME_LEDGER_PROOF_MIN_NET_PNL_AFTER_COSTS": "750",
                 "TORGHUT_RUNTIME_LEDGER_PROOF_MIN_DAILY_NET_PNL_AFTER_COSTS": "625",
                 "TORGHUT_RUNTIME_LEDGER_PROOF_MIN_TRADING_DAYS": "3",
+                "TORGHUT_RUNTIME_LEDGER_PROOF_MODE": "probation",
+                "TORGHUT_RUNTIME_LEDGER_PROOF_PROBATION_MIN_TRADING_DAYS": "6",
                 "TORGHUT_RUNTIME_LEDGER_PROOF_MAX_DRAWDOWN_PCT_EQUITY": "0.12",
                 "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MIN_TRADING_DAYS": "10",
             }
@@ -38,8 +43,32 @@ class TestRuntimeLedgerProofPolicy(TestCase):
         self.assertEqual(policy.min_net_pnl_after_costs, Decimal("750"))
         self.assertEqual(policy.min_daily_net_pnl_after_costs, Decimal("625"))
         self.assertEqual(policy.min_trading_days, 3)
+        self.assertEqual(policy.proof_mode, "probation")
+        self.assertEqual(policy.probation_min_trading_days, 6)
         self.assertEqual(policy.max_drawdown_pct_equity, Decimal("0.12"))
         self.assertEqual(policy.authority_min_trading_days, 10)
+        self.assertEqual(
+            policy.target_payload(),
+            {
+                "proof_mode": "probation",
+                "final_authority": False,
+                "evidence_collection_only": True,
+                "min_runtime_ledger_net_pnl_after_costs": "3750",
+                "min_runtime_ledger_daily_net_pnl_after_costs": "625",
+                "min_runtime_ledger_trading_days": 6,
+            },
+        )
+        self.assertEqual(
+            DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.target_payload("authority"),
+            {
+                "proof_mode": "authority",
+                "final_authority": True,
+                "evidence_collection_only": False,
+                "min_runtime_ledger_net_pnl_after_costs": "10000",
+                "min_runtime_ledger_daily_net_pnl_after_costs": "500",
+                "min_runtime_ledger_trading_days": 20,
+            },
+        )
 
     def test_invalid_policy_env_fails_closed(self) -> None:
         with self.assertRaisesRegex(ValueError, "must be a decimal"):
@@ -53,5 +82,12 @@ class TestRuntimeLedgerProofPolicy(TestCase):
             runtime_ledger_proof_policy_from_env(
                 {
                     "TORGHUT_RUNTIME_LEDGER_PROOF_MIN_TRADING_DAYS": "-1",
+                }
+            )
+
+        with self.assertRaisesRegex(ValueError, "must be one of"):
+            runtime_ledger_proof_policy_from_env(
+                {
+                    "TORGHUT_RUNTIME_LEDGER_PROOF_MODE": "pretend",
                 }
             )

--- a/services/torghut/tests/test_verify_trading_readiness.py
+++ b/services/torghut/tests/test_verify_trading_readiness.py
@@ -270,7 +270,9 @@ def _runtime_ledger_proof_packet(
     )
     return {
         "schema_version": verifier.RUNTIME_LEDGER_PROOF_PACKET_SCHEMA_VERSION,
+        "proof_mode": "authority",
         "ok": allowed,
+        "final_authority_ok": allowed,
         "verdict": "promotion_authority_allowed" if allowed else "blocked",
         "promotion_authority": {
             "allowed": allowed,
@@ -431,6 +433,30 @@ class TestVerifyTradingReadiness(TestCase):
             ],
             ["runtime_ledger_daily_net_pnl_below_target"],
         )
+
+    def test_runtime_ledger_proof_packet_rejects_smoke_mode_as_final_authority(
+        self,
+    ) -> None:
+        packet = _runtime_ledger_proof_packet()
+        packet["proof_mode"] = "smoke"
+        packet["final_authority_ok"] = False
+        packet["promotion_authority"] = {
+            "allowed": False,
+            "reason": "runtime_ledger_proof_mode_not_authority",
+            "blocking_reasons": ["runtime_ledger_proof_mode_not_authority"],
+            "failed_checks": ["runtime_ledger_proof_mode_authority_required"],
+        }
+
+        result = evaluate_trading_readiness(
+            _ready_status(),
+            runtime_ledger_proof_packet=packet,
+            require_runtime_ledger_proof_packet=True,
+        )
+
+        self.assertFalse(result["ok"])
+        observed = result["checks"]["runtime_ledger_proof_packet_authority"]["observed"]
+        self.assertEqual(observed["proof_mode"], "smoke")
+        self.assertFalse(observed["authority_allowed"])
 
     def test_runtime_ledger_profit_proof_requires_observed_days_and_daily_pnl(
         self,


### PR DESCRIPTION
## Summary

- Add explicit runtime-ledger proof modes: `smoke`, `probation`, and `authority`.
- Keep `smoke`/`probation` packets as evidence-collection only; they cannot grant promotion authority.
- Floor authority-mode proof packets to 20 trading days and at least 10000 USD total / 500 USD daily post-cost runtime-ledger PnL.
- Update the paper-route proof-packet handoff so waiting packets are `smoke` and post-import authority packets are explicitly `authority`.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger_proof_policy.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_paper_route_evidence.py tests/test_verify_trading_readiness.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger_proof_policy.py scripts/assemble_runtime_ledger_proof_packet.py app/trading/paper_route_evidence.py scripts/verify_trading_readiness.py tests/test_runtime_ledger_proof_policy.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_paper_route_evidence.py tests/test_verify_trading_readiness.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_ledger_proof_policy.py scripts/assemble_runtime_ledger_proof_packet.py app/trading/paper_route_evidence.py scripts/verify_trading_readiness.py tests/test_runtime_ledger_proof_policy.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_paper_route_evidence.py tests/test_verify_trading_readiness.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
