### PR TITLE
fix(torghut): surface source collection targets

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -711,10 +711,15 @@ def _target_allows_strategy_universe_probe_fallback(
     target: Mapping[str, object],
 ) -> bool:
     source_kind = _safe_text(target.get("source_kind"))
-    return bool(target.get("paper_probation_authorized")) or source_kind in {
-        "durable_runtime_ledger_bucket",
-        "runtime_ledger_paper_probation_candidates",
-    }
+    return (
+        bool(target.get("paper_probation_authorized"))
+        or bool(target.get("source_collection_authorized"))
+        or source_kind
+        in {
+            "durable_runtime_ledger_bucket",
+            "runtime_ledger_paper_probation_candidates",
+        }
+    )
 
 
 def _strategy_universe_symbols(

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -46,6 +46,15 @@ from .profit_windows import build_profit_window_contract
 from .profit_leases import build_profit_lease_projection
 from .runtime_ledger import POST_COST_PNL_BASIS
 from .runtime_ledger_source_authority import (
+    RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER,
+    RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER,
+    RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
     runtime_ledger_promotion_source_authority_blockers,
 )
 from .tca import build_tca_gate_inputs
@@ -1311,6 +1320,33 @@ _RUNTIME_LEDGER_PAPER_PROBATION_PROMOTION_BLOCKERS = (
     "paper_probation_evidence_collection_only",
     "live_runtime_ledger_required",
 )
+_RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_KIND = (
+    "runtime_ledger_source_collection_candidate"
+)
+_RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_DSN_ENV = "SIM_DB_DSN"
+_RUNTIME_LEDGER_SOURCE_COLLECTION_TRIGGER_REASONS = frozenset(
+    {
+        RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER,
+        RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER,
+        RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER,
+        RUNTIME_LEDGER_AUTHORITY_CLASS_MISSING_BLOCKER,
+        "execution_reconstruction_not_runtime_ledger_proof",
+        "source_decision_mode_not_profit_proof_eligible",
+        "runtime_ledger_pnl_basis_invalid",
+        "runtime_ledger_pnl_basis_missing",
+        "runtime_ledger_expectancy_missing",
+    }
+)
+_RUNTIME_LEDGER_SOURCE_COLLECTION_PROMOTION_BLOCKERS = (
+    "runtime_ledger_source_collection_only",
+    "runtime_ledger_source_window_evidence_pending",
+    "live_runtime_ledger_required",
+)
 
 
 def _runtime_ledger_paper_probation_eligible(
@@ -1352,6 +1388,58 @@ def _runtime_ledger_paper_probation_candidates(
         }
         for candidate in candidates
         if _runtime_ledger_paper_probation_eligible(candidate)
+    ]
+
+
+def _runtime_ledger_source_collection_candidate(
+    candidate: Mapping[str, object],
+) -> bool:
+    if _runtime_ledger_paper_probation_eligible(candidate):
+        return False
+    reasons = {
+        str(reason).strip()
+        for reason in cast(Sequence[object], candidate.get("reason_codes") or [])
+        if str(reason).strip()
+    }
+    return (
+        _safe_text(candidate.get("observed_stage")) == "paper"
+        and bool(reasons & _RUNTIME_LEDGER_SOURCE_COLLECTION_TRIGGER_REASONS)
+        and (_safe_decimal(candidate.get("filled_notional")) or Decimal("0")) > 0
+        and _safe_int(candidate.get("fill_count")) > 0
+        and _safe_int(candidate.get("closed_trade_count")) > 0
+        and (
+            _safe_decimal(candidate.get("net_strategy_pnl_after_costs")) or Decimal("0")
+        )
+        > 0
+    )
+
+
+def _runtime_ledger_source_collection_candidates(
+    candidates: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    return [
+        {
+            **dict(candidate),
+            "source_collection_candidate": True,
+            "source_collection_authorized": True,
+            "source_collection_scope": "source_window_evidence_collection_only",
+            "source_collection_reason_codes": [
+                reason
+                for reason in _normalize_reason_codes(
+                    [
+                        str(raw_reason).strip()
+                        for raw_reason in cast(
+                            Sequence[object], candidate.get("reason_codes") or []
+                        )
+                        if str(raw_reason).strip()
+                    ]
+                )
+                if reason in _RUNTIME_LEDGER_SOURCE_COLLECTION_TRIGGER_REASONS
+            ],
+            "max_notional": "0",
+        }
+        for candidate in candidates
+        if _runtime_ledger_source_collection_candidate(candidate)
     ]
 
 
@@ -1457,6 +1545,22 @@ def _runtime_ledger_paper_probation_import_plan(
             )
             continue
 
+        source_collection = bool(candidate.get("source_collection_candidate"))
+        source_kind = (
+            _RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_KIND
+            if source_collection
+            else _RUNTIME_LEDGER_PAPER_PROBATION_SOURCE_KIND
+        )
+        source_dsn_env = (
+            _RUNTIME_LEDGER_SOURCE_COLLECTION_SOURCE_DSN_ENV
+            if source_collection
+            else _RUNTIME_LEDGER_PAPER_PROBATION_SOURCE_DSN_ENV
+        )
+        final_blockers = list(
+            _RUNTIME_LEDGER_SOURCE_COLLECTION_PROMOTION_BLOCKERS
+            if source_collection
+            else _RUNTIME_LEDGER_PAPER_PROBATION_PROMOTION_BLOCKERS
+        )
         target_key = (
             hypothesis_id or "",
             candidate_id or "",
@@ -1465,7 +1569,7 @@ def _runtime_ledger_paper_probation_import_plan(
             account_label,
             dataset_snapshot_ref or "",
             source_manifest_ref or "",
-            _RUNTIME_LEDGER_PAPER_PROBATION_SOURCE_KIND,
+            source_kind,
             window_start or "",
             window_end or "",
         )
@@ -1505,31 +1609,59 @@ def _runtime_ledger_paper_probation_import_plan(
             "runtime_strategy_name": strategy_name,
             "strategy_lookup_names": strategy_lookup_names,
             "account_label": account_label,
-            "source_dsn_env": _RUNTIME_LEDGER_PAPER_PROBATION_SOURCE_DSN_ENV,
+            "source_dsn_env": source_dsn_env,
             "dataset_snapshot_ref": dataset_snapshot_ref or "",
             "source_manifest_ref": source_manifest_ref,
-            "source_kind": _RUNTIME_LEDGER_PAPER_PROBATION_SOURCE_KIND,
+            "source_kind": source_kind,
             "window_start": window_start,
             "window_end": window_end,
-            "paper_probation_authorized": True,
-            "paper_probation_authorization_scope": "evidence_collection_only",
+            "paper_probation_authorized": not source_collection,
+            "paper_probation_authorization_scope": (
+                "evidence_collection_only" if not source_collection else ""
+            ),
+            "source_collection_authorized": source_collection,
+            "source_collection_authorization_scope": (
+                "source_window_evidence_collection_only" if source_collection else ""
+            ),
+            "source_collection_reason_codes": (
+                list(
+                    cast(
+                        Sequence[object],
+                        candidate.get("source_collection_reason_codes") or [],
+                    )
+                )
+                if source_collection
+                else []
+            ),
             "evidence_collection_stage": "paper",
-            "probation_allowed": True,
-            "probation_reason": "paper_stage_runtime_ledger_positive_after_costs",
+            "probation_allowed": not source_collection,
+            "probation_reason": (
+                "source_window_evidence_collection_pending"
+                if source_collection
+                else "paper_stage_runtime_ledger_positive_after_costs"
+            ),
             "promotion_allowed": False,
             "final_promotion_authorized": False,
             "final_promotion_allowed": False,
-            "final_promotion_blockers": list(
-                _RUNTIME_LEDGER_PAPER_PROBATION_PROMOTION_BLOCKERS
-            ),
+            "final_promotion_blockers": final_blockers,
             "candidate_blockers": reason_codes,
-            "runtime_ledger_target_metadata_blockers": list(
-                _RUNTIME_LEDGER_PAPER_PROBATION_PROMOTION_BLOCKERS
+            "runtime_ledger_target_metadata_blockers": final_blockers,
+            "handoff": (
+                "runtime_ledger_source_collection_import"
+                if source_collection
+                else "runtime_ledger_paper_probation_import"
             ),
-            "handoff": "runtime_ledger_paper_probation_import",
             "promotion_gate": "runtime_ledger_live_or_live_paper_required",
-            "selected_by": "runtime_ledger_paper_probation",
-            "selection_reason": "positive_post_cost_runtime_ledger_bucket",
+            "selected_by": (
+                "runtime_ledger_source_collection"
+                if source_collection
+                else "runtime_ledger_paper_probation"
+            ),
+            "selection_reason": (
+                "positive_activity_needs_source_window_runtime_evidence"
+                if source_collection
+                else "positive_post_cost_runtime_ledger_bucket"
+            ),
             "max_notional": "0",
         }
         if bucket_ref:
@@ -1538,12 +1670,18 @@ def _runtime_ledger_paper_probation_import_plan(
 
     return {
         "schema_version": _RUNTIME_LEDGER_PAPER_PROBATION_IMPORT_SCHEMA_VERSION,
-        "source": "runtime_ledger_paper_probation_candidates",
-        "purpose": "paper_stage_runtime_ledger_evidence_collection",
+        "source": "runtime_ledger_paper_probation_and_source_collection_candidates",
+        "purpose": "paper_stage_runtime_ledger_source_evidence_collection",
         "promotion_allowed": False,
         "final_promotion_authorized": False,
         "final_promotion_allowed": False,
         "target_count": len(targets),
+        "paper_probation_target_count": sum(
+            1 for target in targets if bool(target.get("paper_probation_authorized"))
+        ),
+        "source_collection_target_count": sum(
+            1 for target in targets if bool(target.get("source_collection_authorized"))
+        ),
         "skipped_target_count": len(skipped_targets),
         "targets": targets,
         "skipped_targets": skipped_targets,
@@ -3144,9 +3282,15 @@ def build_live_submission_gate_payload(
     runtime_ledger_paper_probation_candidates = (
         _runtime_ledger_paper_probation_candidates(runtime_ledger_repair_candidates)
     )
+    runtime_ledger_source_collection_candidates = (
+        _runtime_ledger_source_collection_candidates(runtime_ledger_repair_candidates)
+    )
     runtime_ledger_paper_probation_import_plan = (
         _runtime_ledger_paper_probation_import_plan(
-            runtime_ledger_paper_probation_candidates
+            [
+                *runtime_ledger_paper_probation_candidates,
+                *runtime_ledger_source_collection_candidates,
+            ]
         )
     )
     evidence_rows = (
@@ -3296,6 +3440,12 @@ def build_live_submission_gate_payload(
             "runtime_ledger_paper_probation_candidates": (
                 runtime_ledger_paper_probation_candidates
             ),
+            "runtime_ledger_source_collection_candidates": (
+                runtime_ledger_source_collection_candidates
+            ),
+            "runtime_ledger_source_collection_candidate_total": len(
+                runtime_ledger_source_collection_candidates
+            ),
             "runtime_ledger_paper_probation_eligible_total": len(
                 runtime_ledger_paper_probation_candidates
             ),
@@ -3313,6 +3463,8 @@ def build_live_submission_gate_payload(
         blocked_reasons.append("alpha_readiness_not_promotion_eligible")
         if runtime_ledger_paper_probation_candidates:
             blocked_reasons.append("paper_probation_evidence_collection_only")
+        if runtime_ledger_source_collection_candidates:
+            blocked_reasons.append("runtime_ledger_source_collection_pending")
     if empirical_ready is False:
         blocked_reasons.append("empirical_jobs_not_ready")
     if dspy_live_ready is False:
@@ -3506,6 +3658,12 @@ def build_live_submission_gate_payload(
         "runtime_ledger_repair_candidates": runtime_ledger_repair_candidates,
         "runtime_ledger_paper_probation_candidates": (
             runtime_ledger_paper_probation_candidates
+        ),
+        "runtime_ledger_source_collection_candidates": (
+            runtime_ledger_source_collection_candidates
+        ),
+        "runtime_ledger_source_collection_candidate_total": len(
+            runtime_ledger_source_collection_candidates
         ),
         "runtime_ledger_paper_probation_eligible_total": len(
             runtime_ledger_paper_probation_candidates

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -74,6 +74,8 @@ RUNTIME_WINDOW_TARGET_METADATA_KEYS = (
     "paper_required_evidence_count",
     "paper_probation_authorized",
     "paper_probation_authorization_scope",
+    "source_collection_authorized",
+    "source_collection_authorization_scope",
     "evidence_collection_stage",
     "probation_allowed",
     "probation_reason",
@@ -936,6 +938,15 @@ def _runtime_window_target_metadata(payload: Mapping[str, Any]) -> dict[str, Any
     if bool(metadata.get("paper_probation_authorized")):
         metadata.setdefault(
             "paper_probation_authorization_scope", "evidence_collection_only"
+        )
+        metadata.setdefault("evidence_collection_stage", "paper")
+        metadata.setdefault("promotion_allowed", False)
+        metadata.setdefault("final_promotion_authorized", False)
+        metadata.setdefault("final_promotion_allowed", False)
+    if bool(metadata.get("source_collection_authorized")):
+        metadata.setdefault(
+            "source_collection_authorization_scope",
+            "source_window_evidence_collection_only",
         )
         metadata.setdefault("evidence_collection_stage", "paper")
         metadata.setdefault("promotion_allowed", False)

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1083,6 +1083,91 @@ class TestPaperRouteEvidenceAudit(TestCase):
             ["AAPL", "AMZN"],
         )
 
+    def test_source_collection_target_uses_strategy_universe_when_route_probe_empty(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 5, 24, 12, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            session.add(
+                Strategy(
+                    name="microbar-cross-sectional-pairs-v1",
+                    description="source collection strategy",
+                    enabled=True,
+                    base_timeframe="1Sec",
+                    universe_type="static",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_notional_per_trade=Decimal("31590"),
+                )
+            )
+            session.commit()
+            payload = build_paper_route_target_plan_payload(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "source_collection_pending",
+                    "blocked_reasons": ["runtime_ledger_source_collection_pending"],
+                    "promotion_eligible_total": 0,
+                    "dependency_quorum_decision": "allow",
+                    "continuity_ok": True,
+                    "continuity_reason": "signal_continuity_nominal",
+                    "drift_ok": True,
+                    "drift_reason": "drift_live_promotion_eligible",
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "source_collection_target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-PAIRS-01",
+                                "candidate_id": "c88421d619759b2cfaa6f4d0",
+                                "observed_stage": "paper",
+                                "strategy_family": "microbar_cross_sectional_pairs",
+                                "strategy_name": "microbar-cross-sectional-pairs-v1",
+                                "runtime_strategy_name": (
+                                    "microbar-cross-sectional-pairs-v1"
+                                ),
+                                "strategy_lookup_names": [
+                                    "microbar-cross-sectional-pairs-v1"
+                                ],
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": (
+                                    "runtime_ledger_source_collection_candidate"
+                                ),
+                                "source_manifest_ref": "config/trading/hypotheses/h-pairs-01.json",
+                                "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                                "source_collection_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": False,
+                        "next_session_max_notional": "63180",
+                        "eligible_symbol_count": 0,
+                        "eligible_symbols": [],
+                        "active_symbols": [],
+                        "blocking_reasons": ["market_session_closed"],
+                    },
+                },
+                generated_at=generated_at,
+            )
+
+        plan = payload["runtime_window_import_plan"]
+        self.assertEqual(plan["target_count"], 1)
+        target = plan["targets"][0]
+        self.assertEqual(target["paper_route_probe_symbols"], ["AAPL", "AMZN"])
+        self.assertTrue(target["paper_route_probe_strategy_universe_fallback"])
+        self.assertEqual(
+            target["paper_route_probe_scope_authority"], "strategy_universe"
+        )
+
     def test_builder_exports_missing_runtime_window_health_gate_as_blockers(
         self,
     ) -> None:

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -2100,6 +2100,25 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertFalse(metadata["promotion_allowed"])
         self.assertFalse(metadata["final_promotion_authorized"])
 
+    def test_runtime_window_target_metadata_defaults_source_collection_blockers(
+        self,
+    ) -> None:
+        metadata = renewal._runtime_window_target_metadata(
+            {
+                "source_collection_authorized": True,
+            }
+        )
+
+        self.assertTrue(metadata["source_collection_authorized"])
+        self.assertEqual(
+            metadata["source_collection_authorization_scope"],
+            "source_window_evidence_collection_only",
+        )
+        self.assertEqual(metadata["evidence_collection_stage"], "paper")
+        self.assertFalse(metadata["promotion_allowed"])
+        self.assertFalse(metadata["final_promotion_authorized"])
+        self.assertFalse(metadata["final_promotion_allowed"])
+
     def test_runtime_window_import_runs_same_hypothesis_plan_candidate_lanes(
         self,
     ) -> None:

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -39,6 +39,7 @@ from app.trading.submission_council import (
     _runtime_ledger_repair_reason_codes,
     _refresh_runtime_summary_totals,
     _runtime_ledger_paper_probation_import_plan,
+    _runtime_ledger_source_collection_candidates,
     build_hypothesis_runtime_summary,
     build_live_submission_gate_payload,
     load_quant_evidence_status,
@@ -1085,6 +1086,189 @@ class TestSubmissionCouncil(TestCase):
             "strategy_runtime_ledger_buckets:duplicate-runtime-ledger:"
             "2026-05-21T17:00:00+00:00:2026-05-21T17:30:00+00:00",
         )
+
+    def test_runtime_ledger_source_collection_target_does_not_grant_probation(
+        self,
+    ) -> None:
+        candidates = _runtime_ledger_source_collection_candidates(
+            [
+                {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                    "strategy_family": "microbar_cross_sectional_pairs",
+                    "account": "TORGHUT_SIM",
+                    "observed_stage": "paper",
+                    "bucket_started_at": "2026-05-29T17:00:00+00:00",
+                    "bucket_ended_at": "2026-05-29T20:00:00+00:00",
+                    "fill_count": 35,
+                    "closed_trade_count": 12,
+                    "open_position_count": 4,
+                    "filled_notional": "157941.50000000",
+                    "net_strategy_pnl_after_costs": "5514.86354020",
+                    "reason_codes": [
+                        "runtime_ledger_stage_not_live",
+                        "runtime_ledger_source_window_missing",
+                        "runtime_ledger_source_refs_missing",
+                        "execution_reconstruction_not_runtime_ledger_proof",
+                        "unclosed_position",
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(len(candidates), 1)
+        self.assertTrue(candidates[0]["source_collection_authorized"])
+        self.assertFalse(candidates[0].get("paper_probation_eligible", False))
+        plan = _runtime_ledger_paper_probation_import_plan(candidates)
+
+        self.assertEqual(plan["target_count"], 1)
+        self.assertEqual(plan["paper_probation_target_count"], 0)
+        self.assertEqual(plan["source_collection_target_count"], 1)
+        target = plan["targets"][0]
+        self.assertEqual(target["source_dsn_env"], "SIM_DB_DSN")
+        self.assertEqual(
+            target["source_kind"], "runtime_ledger_source_collection_candidate"
+        )
+        self.assertFalse(target["paper_probation_authorized"])
+        self.assertTrue(target["source_collection_authorized"])
+        self.assertFalse(target["probation_allowed"])
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_allowed"])
+        self.assertIn(
+            "runtime_ledger_source_window_evidence_pending",
+            target["final_promotion_blockers"],
+        )
+        self.assertIn(
+            "runtime_ledger_source_window_missing",
+            target["source_collection_reason_codes"],
+        )
+
+    def test_live_gate_marks_source_collection_pending_without_probation(
+        self,
+    ) -> None:
+        engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+        now = datetime.now(timezone.utc)
+
+        class _RegistryItem:
+            hypothesis_id = "H-PAIRS-01"
+
+            def model_dump(self, *, mode: str = "json") -> dict[str, object]:
+                return {
+                    "hypothesis_id": "H-PAIRS-01",
+                    "candidate_id": "c88421d619759b2cfaa6f4d0",
+                    "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                    "strategy_family": "microbar_cross_sectional_pairs",
+                    "lane_id": "microbar_cross_sectional_pairs",
+                    "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                }
+
+        registry = SimpleNamespace(
+            loaded=True,
+            path="test-registry",
+            errors=[],
+            items=[_RegistryItem()],
+        )
+
+        with session_local() as session:
+            session.add(
+                StrategyRuntimeLedgerBucket(
+                    run_id="pairs-source-missing-runtime",
+                    candidate_id="c88421d619759b2cfaa6f4d0",
+                    hypothesis_id="H-PAIRS-01",
+                    observed_stage="paper",
+                    bucket_started_at=now - timedelta(hours=3),
+                    bucket_ended_at=now - timedelta(hours=1),
+                    account_label="TORGHUT_SIM",
+                    runtime_strategy_name="microbar-cross-sectional-pairs-v1",
+                    strategy_family="microbar_cross_sectional_pairs",
+                    fill_count=35,
+                    decision_count=72,
+                    submitted_order_count=35,
+                    cancelled_order_count=0,
+                    rejected_order_count=0,
+                    unfilled_order_count=0,
+                    closed_trade_count=12,
+                    open_position_count=4,
+                    filled_notional=Decimal("157941.50000000"),
+                    gross_strategy_pnl=Decimal("5530.86354020"),
+                    cost_amount=Decimal("16"),
+                    net_strategy_pnl_after_costs=Decimal("5514.86354020"),
+                    post_cost_expectancy_bps=None,
+                    ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+                    pnl_basis="runtime_reconstructed_pnl",
+                    execution_policy_hash_counts={},
+                    cost_model_hash_counts={},
+                    lineage_hash_counts={},
+                    blockers_json=["execution_reconstruction_not_runtime_ledger_proof"],
+                )
+            )
+            session.commit()
+
+            with patch(
+                "app.trading.submission_council.load_hypothesis_registry",
+                return_value=registry,
+            ):
+                gate = build_live_submission_gate_payload(
+                    SimpleNamespace(
+                        market_session_open=True,
+                        last_autonomy_promotion_eligible=False,
+                        last_autonomy_promotion_action=None,
+                        drift_live_promotion_eligible=False,
+                        last_market_context_freshness_seconds=45,
+                        metrics=SimpleNamespace(
+                            feature_batch_rows_total=9,
+                            feature_null_rate={"price": 0.0},
+                            feature_staleness_ms_p95=250,
+                            feature_duplicate_ratio=0.0,
+                            decision_state_total={},
+                        ),
+                    ),
+                    hypothesis_summary={
+                        "summary": {
+                            "promotion_eligible_total": 0,
+                            "capital_stage_totals": {"shadow": 1},
+                            "dependency_quorum": {
+                                "decision": "allow",
+                                "reasons": [],
+                                "message": "ready",
+                            },
+                        },
+                        "items": [],
+                    },
+                    empirical_jobs_status={"ready": True, "status": "healthy"},
+                    dspy_runtime_status={"mode": "inactive"},
+                    quant_health_status=self._healthy_quant_status(),
+                    promotion_certificate_evidence=[],
+                    session=session,
+                )
+
+        self.assertEqual(gate["paper_probation_eligible_total"], 0)
+        self.assertEqual(gate["runtime_ledger_paper_probation_eligible_total"], 0)
+        self.assertIn(
+            "runtime_ledger_source_collection_pending", gate["blocked_reasons"]
+        )
+        self.assertEqual(gate["runtime_ledger_source_collection_candidate_total"], 1)
+        source_candidates = gate["runtime_ledger_source_collection_candidates"]
+        self.assertEqual(len(source_candidates), 1)
+        self.assertEqual(
+            source_candidates[0]["source_collection_scope"],
+            "source_window_evidence_collection_only",
+        )
+        import_plan = gate["runtime_ledger_paper_probation_import_plan"]
+        self.assertEqual(import_plan["paper_probation_target_count"], 0)
+        self.assertEqual(import_plan["source_collection_target_count"], 1)
+        target = import_plan["targets"][0]
+        self.assertFalse(target["paper_probation_authorized"])
+        self.assertTrue(target["source_collection_authorized"])
+        self.assertFalse(target["promotion_allowed"])
 
     def test_metric_window_activity_rejects_tca_proxy_expectancy(self) -> None:
         metric_window = SimpleNamespace(


### PR DESCRIPTION
## Summary

- Adds a non-authority runtime-ledger source-collection lane for paper candidates with positive activity but missing source-window/source-ref proof.
- Keeps paper probation and promotion blocked while surfacing explicit source-collection targets for the paper-route runtime-window planner.
- Preserves source-collection metadata through empirical renewal target parsing and allows strategy-universe fallback for those collection targets.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/submission_council.py app/trading/paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_submission_council.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/submission_council.py app/trading/paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_submission_council.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
