### PR TITLE
fix(torghut): split order feed lifecycle from economics

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -1971,14 +1971,7 @@ def _order_feed_fill_lifecycle_blockers(
         if order_id is None:
             continue
         observed_fill_order_ids.add(order_id)
-        if (
-            _runtime_lifecycle_ledger_row(
-                row,
-                event_type=event_type,
-                require_complete_fill=True,
-            )
-            is not None
-        ):
+        if _runtime_ledger_row_time(row) is not None:
             complete_fill_order_ids.add(order_id)
 
     blockers: list[str] = []
@@ -2083,7 +2076,6 @@ def _build_realized_strategy_pnl_rows(
     ledger_rows: list[RuntimeLedgerFill | dict[str, object]] = []
     event_times: list[datetime] = []
     event_sourced_lifecycle_rows = 0
-    materialized_order_fill_ids: set[str] = set()
     order_feed_fill_lifecycle_blockers = _order_feed_fill_lifecycle_blockers(
         execution_rows=execution_rows,
         order_lifecycle_rows=order_lifecycle_rows,
@@ -2101,19 +2093,19 @@ def _build_realized_strategy_pnl_rows(
         event_type = _runtime_ledger_event_type(
             {str(key): value for key, value in row.items()}
         )
+        if event_type in _RUNTIME_LEDGER_FILL_EVENTS:
+            event_time = _runtime_ledger_row_time(row)
+            if isinstance(event_time, datetime):
+                event_times.append(event_time)
+            continue
         lifecycle_row = _runtime_lifecycle_ledger_row(
             row,
             event_type=event_type,
-            require_complete_fill=event_type in _RUNTIME_LEDGER_FILL_EVENTS,
         )
         if lifecycle_row is None:
             continue
         ledger_rows.append(lifecycle_row)
         event_sourced_lifecycle_rows += 1
-        if event_type in _RUNTIME_LEDGER_FILL_EVENTS:
-            order_id = _runtime_order_id(lifecycle_row)
-            if order_id is not None:
-                materialized_order_fill_ids.add(order_id)
         event_time = lifecycle_row.get("executed_at")
         if isinstance(event_time, datetime):
             event_times.append(event_time)
@@ -2164,8 +2156,6 @@ def _build_realized_strategy_pnl_rows(
             "client_order_id",
             "execution_correlation_id",
         )
-        if order_id is not None and order_id in materialized_order_fill_ids:
-            continue
         event_times.append(ledger_computed_at)
         if isinstance(fill_event_at, datetime):
             event_times.append(fill_event_at)

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -1896,8 +1896,6 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "side": "buy",
                     "filled_qty": Decimal("1"),
                     "avg_fill_price": Decimal("100"),
-                    "cost_amount": Decimal("0.20"),
-                    "cost_basis": "broker_reported_commission_and_fees",
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
                     "decision_hash": "decision-buy",
@@ -1920,8 +1918,6 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "side": "sell",
                     "filled_qty": Decimal("1"),
                     "avg_fill_price": Decimal("101"),
-                    "cost_amount": Decimal("0.10"),
-                    "cost_basis": "broker_reported_commission_and_fees",
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
                     "decision_hash": "decision-sell",
@@ -1953,6 +1949,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         assert isinstance(bucket, dict)
         self.assertEqual(bucket["blockers"], [])
         self.assertEqual(bucket["pnl_basis"], POST_COST_BASIS_RUNTIME_LEDGER)
+        self.assertEqual(bucket["cost_amount"], "0.30")
+        self.assertEqual(
+            bucket["cost_basis_counts"], {"broker_reported_commission_and_fees": 2}
+        )
         self.assertEqual(bucket["source_materialization"], "execution_order_events")
         self.assertEqual(bucket["account_equity"], "10000")
         self.assertEqual(bucket["account_equity_source"], "equity")
@@ -2119,7 +2119,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
                     "decision_hash": "decision-sell",
-                    "alpaca_order_id": "order-sell",
+                    "alpaca_order_id": "order-unmatched",
                     "execution_policy_hash": "policy-sha",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
@@ -2150,7 +2150,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["pnl_basis"], POST_COST_BASIS_EXECUTION_RECONSTRUCTION)
         self.assertEqual(bucket["authoritative"], False)
 
-    def test_build_realized_strategy_pnl_rows_materializes_order_feed_fills_once(
+    def test_build_realized_strategy_pnl_rows_does_not_count_order_feed_fill_economics(
         self,
     ) -> None:
         rows = _build_realized_strategy_pnl_rows(
@@ -2165,7 +2165,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "filled_qty": Decimal("1"),
                     "avg_fill_price": Decimal("100"),
                     "cost_amount": Decimal("0.20"),
-                    "cost_basis": "execution_reconstruction_should_not_count",
+                    "cost_basis": "modeled_paper_cost_budget",
                     "decision_hash": "decision-buy",
                     "alpaca_order_id": "order-buy",
                     "execution_policy_hash": "policy-sha",
@@ -2182,7 +2182,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "filled_qty": Decimal("1"),
                     "avg_fill_price": Decimal("101"),
                     "cost_amount": Decimal("0.10"),
-                    "cost_basis": "execution_reconstruction_should_not_count",
+                    "cost_basis": "modeled_paper_cost_budget",
                     "decision_hash": "decision-sell",
                     "alpaca_order_id": "order-sell",
                     "execution_policy_hash": "policy-sha",
@@ -2314,16 +2314,22 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             rows[0]["computed_at"],
             datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
         )
-        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.70"))
+        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0"))
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
+        self.assertEqual(rows[0]["authoritative"], False)
         bucket = rows[0]["runtime_ledger_bucket"]
         self.assertIsInstance(bucket, dict)
         assert isinstance(bucket, dict)
-        self.assertEqual(bucket["fill_count"], 2)
-        self.assertEqual(
-            bucket["cost_basis_counts"],
-            {"broker_reported_commission_and_fees": 2},
+        self.assertEqual(bucket["fill_count"], 0)
+        self.assertEqual(bucket["cost_basis_counts"], {})
+        self.assertIn(
+            "runtime_ledger_cost_basis_non_promotion_grade",
+            bucket["blockers"],
         )
-        self.assertEqual(bucket["blockers"], [])
+        self.assertNotIn(
+            "broker_reported_commission_and_fees",
+            bucket["cost_basis_counts"],
+        )
         self.assertEqual(bucket["source_materialization"], "execution_order_events")
 
     def test_order_event_lifecycle_uses_execution_raw_order_metadata(self) -> None:


### PR DESCRIPTION
## Summary

- Splits order-feed fill lifecycle proof from execution economics in the runtime-window importer.
- Treats order-feed fill rows as source/lifecycle evidence only, while execution rows remain responsible for filled notional, PnL, and explicit costs.
- Adds regression coverage for cost-free order-feed fill lifecycle, incomplete fill lifecycle, and ignoring order-feed economic fields when execution economics are not promotion-grade.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py::TestImportHypothesisRuntimeWindows::test_build_realized_strategy_pnl_rows_authorizes_event_sourced_lifecycle -q`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_runtime_ledger_source_authority.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv sync --frozen --extra dev && uv run --frozen pyright --project pyrightconfig.json && uv run --frozen pyright --project pyrightconfig.alpha.json && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
