### PR TITLE
fix(torghut): relink prior order feed events

### DIFF
--- a/services/torghut/app/snapshots.py
+++ b/services/torghut/app/snapshots.py
@@ -153,6 +153,7 @@ def sync_order_to_db(
     try:
         session.commit()
         session.refresh(execution)
+        _link_pending_order_feed_events(session, execution)
         return execution
     except IntegrityError:
         session.rollback()
@@ -361,7 +362,17 @@ def _persist_existing_execution(
     session.add(existing)
     session.commit()
     session.refresh(existing)
+    _link_pending_order_feed_events(session, existing)
     return existing
+
+
+def _link_pending_order_feed_events(session: Session, execution: Execution) -> None:
+    from .trading.order_feed import link_order_events_to_execution
+
+    if link_order_events_to_execution(session, execution) <= 0:
+        return
+    session.commit()
+    session.refresh(execution)
 
 
 def _attach_runtime_ledger_cost_payload(

--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -776,13 +776,25 @@ def latest_order_event_for_execution(
     """Fetch newest persisted order event linked to an execution."""
 
     filters: list[ColumnElement[bool]] = [
-        ExecutionOrderEvent.execution_id == execution.id,
-        ExecutionOrderEvent.alpaca_account_label == execution.alpaca_account_label,
+        (ExecutionOrderEvent.execution_id == execution.id)
+        & (ExecutionOrderEvent.alpaca_account_label == execution.alpaca_account_label)
     ]
     if execution.alpaca_order_id:
-        filters.append(ExecutionOrderEvent.alpaca_order_id == execution.alpaca_order_id)
+        filters.append(
+            (ExecutionOrderEvent.alpaca_order_id == execution.alpaca_order_id)
+            & (
+                ExecutionOrderEvent.alpaca_account_label
+                == execution.alpaca_account_label
+            )
+        )
     if execution.client_order_id:
-        filters.append(ExecutionOrderEvent.client_order_id == execution.client_order_id)
+        filters.append(
+            (ExecutionOrderEvent.client_order_id == execution.client_order_id)
+            & (
+                ExecutionOrderEvent.alpaca_account_label
+                == execution.alpaca_account_label
+            )
+        )
 
     stmt = (
         select(ExecutionOrderEvent)
@@ -795,6 +807,79 @@ def latest_order_event_for_execution(
         .limit(1)
     )
     return session.execute(stmt).scalar_one_or_none()
+
+
+def link_order_events_to_execution(session: Session, execution: Execution) -> int:
+    """Attach previously ingested order-feed events once their Execution exists."""
+
+    clauses: list[ColumnElement[bool]] = []
+    if execution.alpaca_order_id:
+        clauses.append(
+            (ExecutionOrderEvent.alpaca_order_id == execution.alpaca_order_id)
+            & (
+                ExecutionOrderEvent.alpaca_account_label
+                == execution.alpaca_account_label
+            )
+        )
+    if execution.client_order_id:
+        clauses.append(
+            (ExecutionOrderEvent.client_order_id == execution.client_order_id)
+            & (
+                ExecutionOrderEvent.alpaca_account_label
+                == execution.alpaca_account_label
+            )
+        )
+    if not clauses:
+        return 0
+
+    events = (
+        session.execute(
+            select(ExecutionOrderEvent)
+            .where(
+                or_(*clauses),
+                (
+                    (ExecutionOrderEvent.execution_id.is_(None))
+                    | (ExecutionOrderEvent.trade_decision_id.is_(None))
+                ),
+            )
+            .order_by(
+                ExecutionOrderEvent.event_ts.asc().nullsfirst(),
+                ExecutionOrderEvent.feed_seq.asc().nullsfirst(),
+                ExecutionOrderEvent.created_at.asc(),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not events:
+        return 0
+
+    linked = 0
+    latest_event: ExecutionOrderEvent | None = None
+    for event in events:
+        changed = False
+        if event.execution_id is None:
+            event.execution_id = execution.id
+            changed = True
+        if event.trade_decision_id is None and execution.trade_decision_id is not None:
+            event.trade_decision_id = execution.trade_decision_id
+            changed = True
+        if not changed:
+            continue
+        session.add(event)
+        _refresh_source_window_linkage_counts(session, event)
+        latest_event = event
+        linked += 1
+
+    if linked == 0 or latest_event is None:
+        return 0
+
+    updated, _ = apply_order_event_to_execution(execution, latest_event)
+    if updated:
+        _update_trade_decision_from_execution(session, execution)
+        upsert_execution_tca_metric(session, execution)
+        session.add(execution)
+    return linked
 
 
 def _resolve_execution(
@@ -814,6 +899,21 @@ def _resolve_execution(
     if not clauses:
         return None
     return session.execute(select(Execution).where(or_(*clauses))).scalar_one_or_none()
+
+
+def _refresh_source_window_linkage_counts(
+    session: Session, event: ExecutionOrderEvent
+) -> None:
+    if event.source_window_id is None:
+        return
+    source_window = session.get(OrderFeedSourceWindow, event.source_window_id)
+    if source_window is None:
+        return
+    source_window.unlinked_execution_count = 0 if event.execution_id is not None else 1
+    source_window.unlinked_decision_count = (
+        0 if event.trade_decision_id is not None else 1
+    )
+    session.add(source_window)
 
 
 def _extract_trade_update_payload(payload: Any) -> Mapping[str, Any] | None:
@@ -1106,5 +1206,6 @@ __all__ = [
     "normalize_order_feed_record",
     "persist_order_event",
     "apply_order_event_to_execution",
+    "link_order_events_to_execution",
     "latest_order_event_for_execution",
 ]

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -27,6 +27,7 @@ from app.models import (
 from app.trading.order_feed import (
     OrderFeedIngestor,
     apply_order_event_to_execution,
+    latest_order_event_for_execution,
     merge_execution_raw_order_update,
     normalize_order_feed_record,
     persist_order_event,
@@ -371,6 +372,39 @@ class TestOrderFeed(TestCase):
         self.assertEqual(counters["events_persisted_total"], 1)
         self.assertEqual(counters["duplicates_total"], 1)
         self.assertEqual(len(rows), 1)
+
+    def test_latest_order_event_for_execution_ignores_unrelated_same_account_event(
+        self,
+    ) -> None:
+        own_payload = (
+            b'{"channel":"trade_updates","payload":{"event":"accepted","timestamp":"2026-02-01T10:00:00Z",'
+            b'"order":{"id":"order-1","client_order_id":"client-1","symbol":"AAPL","status":"accepted",'
+            b'"qty":"1","filled_qty":"0"}},"seq":10}'
+        )
+        unrelated_payload = (
+            b'{"channel":"trade_updates","payload":{"event":"fill","timestamp":"2026-02-01T10:05:00Z",'
+            b'"order":{"id":"order-2","client_order_id":"client-2","symbol":"MSFT","status":"filled",'
+            b'"qty":"1","filled_qty":"1","filled_avg_price":"405.0"}},"seq":11}'
+        )
+
+        with Session(self.engine) as session:
+            execution = self._seed_execution(session)
+            for payload, offset in ((own_payload, 1), (unrelated_payload, 2)):
+                normalized = normalize_order_feed_record(
+                    FakeRecord(value=payload, offset=offset),
+                    default_topic="torghut.trade-updates.v1",
+                    default_account_label="paper",
+                )
+                assert normalized.event is not None
+                persist_order_event(session, normalized.event)
+            session.commit()
+
+            latest = latest_order_event_for_execution(session, execution)
+
+        self.assertIsNotNone(latest)
+        assert latest is not None
+        self.assertEqual(latest.alpaca_order_id, "order-1")
+        self.assertEqual(latest.client_order_id, "client-1")
 
     def test_out_of_order_event_does_not_regress_execution(self) -> None:
         with Session(self.engine) as session:

--- a/services/torghut/tests/test_snapshots.py
+++ b/services/torghut/tests/test_snapshots.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, List
 from unittest import TestCase
@@ -8,7 +9,7 @@ from unittest import TestCase
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
-from app.models import Base
+from app.models import Base, ExecutionOrderEvent, OrderFeedSourceWindow, Strategy, TradeDecision
 from app.snapshots import (
     _runtime_cost_payload_from_mapping,
     snapshot_account_and_positions,
@@ -128,6 +129,108 @@ class TestSnapshots(TestCase):
             self.assertEqual(first.id, updated.id)
             self.assertEqual(updated.filled_qty, Decimal("1"))
             self.assertEqual(updated.avg_fill_price, Decimal("10.50"))
+
+    def test_sync_order_to_db_links_prior_order_feed_event(self) -> None:
+        with Session(self.engine) as session:
+            strategy = Strategy(
+                name="demo",
+                description="demo",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="symbols_list",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.flush()
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                timeframe="1Min",
+                decision_json={"side": "buy"},
+                decision_hash="client-linked",
+                status="submitted",
+            )
+            session.add(decision)
+            session.flush()
+            source_window = OrderFeedSourceWindow(
+                consumer_group="paper-route-client",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                alpaca_account_label="paper",
+                assignment_mode="manual",
+                collector_identity="paper-route-client",
+                source_revision="alpaca_trade_updates_v1",
+                window_started_at=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                window_ended_at=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                start_offset=12,
+                end_offset=12,
+                consumed_count=1,
+                inserted_count=1,
+                duplicate_count=0,
+                malformed_count=0,
+                missing_payload_count=0,
+                missing_identity_count=0,
+                out_of_scope_account_count=0,
+                unlinked_execution_count=1,
+                unlinked_decision_count=1,
+                failed_unhandled_count=0,
+                dropped_count=0,
+                gap_count=0,
+                status="inserted",
+            )
+            session.add(source_window)
+            session.flush()
+            event = ExecutionOrderEvent(
+                event_fingerprint="order-linked-fill",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=12,
+                alpaca_account_label="paper",
+                feed_seq=10,
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id="order-linked",
+                client_order_id="client-linked",
+                event_type="fill",
+                status="filled",
+                qty=Decimal("1"),
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("190.20"),
+                raw_event={"channel": "trade_updates"},
+                source_window_id=source_window.id,
+            )
+            session.add(event)
+            session.commit()
+
+            execution = sync_order_to_db(
+                session,
+                {
+                    "id": "order-linked",
+                    "client_order_id": "client-linked",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "type": "market",
+                    "time_in_force": "day",
+                    "qty": "1",
+                    "filled_qty": "0",
+                    "status": "accepted",
+                },
+                trade_decision_id=str(decision.id),
+                alpaca_account_label="paper",
+            )
+            session.refresh(event)
+            session.refresh(source_window)
+            session.refresh(decision)
+
+            self.assertEqual(event.execution_id, execution.id)
+            self.assertEqual(event.trade_decision_id, decision.id)
+            self.assertEqual(source_window.unlinked_execution_count, 0)
+            self.assertEqual(source_window.unlinked_decision_count, 0)
+            self.assertEqual(execution.status, "filled")
+            self.assertEqual(execution.filled_qty, Decimal("1"))
+            self.assertEqual(execution.avg_fill_price, Decimal("190.20"))
+            self.assertEqual(decision.status, "filled")
 
     def test_sync_order_to_db_serializes_uuid_payloads(self) -> None:
         sample_id = uuid.uuid4()


### PR DESCRIPTION
## Summary

- Relinks previously ingested order-feed events to an execution once `sync_order_to_db` creates or updates the matching `Execution` row.
- Clears per-message source-window unlinked execution/decision counters after the late linkage succeeds, and applies the latest linked feed event to the execution/decision/TCA state.
- Tightens `latest_order_event_for_execution` so same-account unrelated order events cannot be selected as lifecycle proof for another execution.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py::TestOrderFeed::test_latest_order_event_for_execution_ignores_unrelated_same_account_event tests/test_snapshots.py::TestSnapshots::test_sync_order_to_db_links_prior_order_feed_event -q`
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_snapshots.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/order_feed.py app/snapshots.py tests/test_order_feed.py tests/test_snapshots.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
