### PR TITLE
fix(torghut): retain prior paper exposure ownership

### DIFF
--- a/services/torghut/app/trading/scheduler/pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline.py
@@ -164,10 +164,17 @@ _RUNTIME_UNCERTAINTY_DEGRADE_MAX_PARTICIPATION_RATE = Decimal("0.05")
 _RUNTIME_UNCERTAINTY_DEGRADE_MIN_EXECUTION_SECONDS = 120
 _RUNTIME_REGIME_CONFIDENCE_DEFAULT_THRESHOLDS = (Decimal("0.75"), Decimal("0.55"))
 _STRATEGY_POSITION_TAG_TOLERANCE = Decimal("0.0001")
+_STRATEGY_POSITION_TAG_LOOKBACK = timedelta(days=7)
 
 
 def _normalized_symbol(symbol: object) -> str:
     return str(symbol or "").strip().upper()
+
+
+def _aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 class TradingPipeline:
@@ -772,6 +779,7 @@ class TradingPipeline:
             REGULAR_OPEN_UTC,
             tzinfo=timezone.utc,
         )
+        lookback_start = session_open - _STRATEGY_POSITION_TAG_LOOKBACK
         try:
             rows = session.execute(
                 select(Execution, TradeDecision)
@@ -781,12 +789,12 @@ class TradingPipeline:
                     TradeDecision.alpaca_account_label == self.account_label,
                     Execution.status == "filled",
                     Execution.filled_qty > Decimal("0"),
-                    Execution.created_at >= session_open,
+                    Execution.created_at >= lookback_start,
                 )
             ).all()
         except Exception:
             logger.exception(
-                "Failed to resolve current-session strategy position tags account=%s",
+                "Failed to resolve strategy position tags account=%s",
                 self.account_label,
             )
             return positions
@@ -797,6 +805,7 @@ class TradingPipeline:
             strategy_id = str(decision_row.strategy_id)
             if not symbol or not strategy_id:
                 continue
+            execution_created_at = _aware_utc(execution.created_at)
             filled_qty = _optional_decimal(execution.filled_qty)
             if filled_qty is None or filled_qty <= 0:
                 continue
@@ -811,10 +820,16 @@ class TradingPipeline:
                     "qty": Decimal("0"),
                     "buy_qty": Decimal("0"),
                     "buy_notional": Decimal("0"),
+                    "session_qty": Decimal("0"),
                     "latest_execution_at": None,
+                    "earliest_execution_at": None,
                 },
             )
             exposure["qty"] = cast(Decimal, exposure["qty"]) + signed_qty
+            if execution_created_at >= session_open:
+                exposure["session_qty"] = (
+                    cast(Decimal, exposure["session_qty"]) + signed_qty
+                )
             avg_fill_price = _optional_decimal(execution.avg_fill_price)
             if side == "buy" and avg_fill_price is not None and avg_fill_price > 0:
                 exposure["buy_qty"] = cast(Decimal, exposure["buy_qty"]) + filled_qty
@@ -822,12 +837,18 @@ class TradingPipeline:
                     Decimal,
                     exposure["buy_notional"],
                 ) + (filled_qty * avg_fill_price)
+            earliest_execution_at = exposure.get("earliest_execution_at")
+            if (
+                earliest_execution_at is None
+                or execution_created_at < earliest_execution_at
+            ):
+                exposure["earliest_execution_at"] = execution_created_at
             latest_execution_at = exposure.get("latest_execution_at")
             if (
                 latest_execution_at is None
-                or execution.created_at > latest_execution_at
+                or execution_created_at > latest_execution_at
             ):
-                exposure["latest_execution_at"] = execution.created_at
+                exposure["latest_execution_at"] = execution_created_at
 
         if not exposures:
             return positions
@@ -988,8 +1009,25 @@ class TradingPipeline:
         tagged["strategy_id"] = strategy_id
         tagged["qty"] = str(qty)
         tagged["side"] = side or "long"
-        tagged["strategy_position_source"] = "current_session_filled_executions"
+        earliest_execution_at = exposure.get("earliest_execution_at")
+        stale_position = (
+            isinstance(earliest_execution_at, datetime)
+            and earliest_execution_at < session_open
+        )
+        tagged["strategy_position_source"] = (
+            "open_exposure_filled_executions"
+            if stale_position
+            else "current_session_filled_executions"
+        )
         tagged["strategy_position_session_open"] = session_open.isoformat()
+        if stale_position and isinstance(earliest_execution_at, datetime):
+            tagged["strategy_position_stale_session_repair"] = True
+            tagged["strategy_position_lookback_start"] = (
+                session_open - _STRATEGY_POSITION_TAG_LOOKBACK
+            ).isoformat()
+            tagged["strategy_position_earliest_execution_at"] = (
+                earliest_execution_at.isoformat()
+            )
         if split_from_aggregate:
             tagged["strategy_position_split_from_aggregate"] = True
         latest_execution_at = exposure.get("latest_execution_at")

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -12349,6 +12349,174 @@ class TestTradingPipeline(TestCase):
             session_open.isoformat(),
         )
 
+    def test_resolve_execution_context_positions_tags_prior_open_strategy_exposure(
+        self,
+    ) -> None:
+        session_open = datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc)
+        prior_session_open = session_open - timedelta(days=1)
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                description="runtime isolated paper proof",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="microbar_cross_sectional_pairs_v1",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+            decision = TradeDecision(
+                strategy_id=strategy.id,
+                alpaca_account_label="paper",
+                symbol="AAPL",
+                timeframe="1Sec",
+                decision_json={"action": "buy"},
+                rationale="paper-route-entry",
+                status="filled",
+                created_at=prior_session_open + timedelta(minutes=60),
+            )
+            session.add(decision)
+            session.commit()
+            session.refresh(decision)
+            session.add(
+                Execution(
+                    trade_decision_id=decision.id,
+                    alpaca_account_label="paper",
+                    alpaca_order_id="paper-aapl-prior-open",
+                    client_order_id="paper-aapl-prior-open-client",
+                    symbol="AAPL",
+                    side="buy",
+                    order_type="market",
+                    time_in_force="day",
+                    submitted_qty=Decimal("2"),
+                    filled_qty=Decimal("2"),
+                    avg_fill_price=Decimal("101"),
+                    status="filled",
+                    raw_order={},
+                    created_at=prior_session_open + timedelta(minutes=61),
+                    updated_at=prior_session_open + timedelta(minutes=61),
+                )
+            )
+            session.commit()
+
+            pipeline = TradingPipeline.__new__(TradingPipeline)
+            pipeline.account_label = "paper"
+
+            class AdapterWithoutOpenOrders:
+                name = "test"
+
+                def list_orders(self, status: str = "all") -> list[dict[str, str]]:
+                    return []
+
+            pipeline.execution_adapter = AdapterWithoutOpenOrders()
+
+            with patch(
+                "app.trading.scheduler.pipeline.trading_now",
+                return_value=session_open + timedelta(minutes=150),
+            ):
+                positions = pipeline._resolve_execution_context_positions(
+                    [
+                        {
+                            "symbol": "AAPL",
+                            "qty": "2",
+                            "side": "long",
+                            "avg_entry_price": "101",
+                        }
+                    ],
+                    session=session,
+                )
+
+        self.assertEqual(positions[0]["strategy_id"], str(strategy.id))
+        self.assertEqual(
+            positions[0]["strategy_position_source"],
+            "open_exposure_filled_executions",
+        )
+        self.assertTrue(positions[0]["strategy_position_stale_session_repair"])
+        self.assertEqual(
+            positions[0]["strategy_position_session_open"],
+            session_open.isoformat(),
+        )
+
+    def test_resolve_execution_context_positions_does_not_tag_closed_prior_exposure(
+        self,
+    ) -> None:
+        session_open = datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc)
+        prior_session_open = session_open - timedelta(days=1)
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                description="runtime isolated paper proof",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="microbar_cross_sectional_pairs_v1",
+                universe_symbols=["AAPL"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+            for index, (side, created_offset) in enumerate(
+                [("buy", 60), ("sell", 120)],
+                start=1,
+            ):
+                decision = TradeDecision(
+                    strategy_id=strategy.id,
+                    alpaca_account_label="paper",
+                    symbol="AAPL",
+                    timeframe="1Sec",
+                    decision_json={"action": side},
+                    rationale="paper-route-entry" if side == "buy" else "time-exit",
+                    status="filled",
+                    created_at=prior_session_open + timedelta(minutes=created_offset),
+                )
+                session.add(decision)
+                session.commit()
+                session.refresh(decision)
+                session.add(
+                    Execution(
+                        trade_decision_id=decision.id,
+                        alpaca_account_label="paper",
+                        alpaca_order_id=f"paper-aapl-prior-closed-{index}",
+                        client_order_id=f"paper-aapl-prior-closed-{index}-client",
+                        symbol="AAPL",
+                        side=side,
+                        order_type="market",
+                        time_in_force="day",
+                        submitted_qty=Decimal("2"),
+                        filled_qty=Decimal("2"),
+                        avg_fill_price=Decimal("101"),
+                        status="filled",
+                        raw_order={},
+                        created_at=prior_session_open
+                        + timedelta(minutes=created_offset + 1),
+                        updated_at=prior_session_open
+                        + timedelta(minutes=created_offset + 1),
+                    )
+                )
+            session.commit()
+
+            pipeline = TradingPipeline.__new__(TradingPipeline)
+            pipeline.account_label = "paper"
+
+            class AdapterWithoutOpenOrders:
+                name = "test"
+
+                def list_orders(self, status: str = "all") -> list[dict[str, str]]:
+                    return []
+
+            pipeline.execution_adapter = AdapterWithoutOpenOrders()
+
+            with patch(
+                "app.trading.scheduler.pipeline.trading_now",
+                return_value=session_open + timedelta(minutes=150),
+            ):
+                positions = pipeline._resolve_execution_context_positions(
+                    [{"symbol": "AAPL", "qty": "2", "side": "long"}],
+                    session=session,
+                )
+
+        self.assertNotIn("strategy_id", positions[0])
+
     def test_resolve_execution_context_positions_does_not_tag_mismatched_fill(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Retains per-strategy broker position ownership across a 7-day filled-execution lookback so prior-session H-PAIRS paper exposure can be repaired or exited instead of being treated as a fresh unowned short.
- Adds stale-session repair metadata to tagged execution-context positions for auditability.
- Adds regressions for prior open exposure tagging and closed prior exposure staying untagged.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py::TestTradingPipeline::test_resolve_execution_context_positions_tags_matching_strategy_fill tests/test_trading_pipeline.py::TestTradingPipeline::test_resolve_execution_context_positions_tags_prior_open_strategy_exposure tests/test_trading_pipeline.py::TestTradingPipeline::test_resolve_execution_context_positions_does_not_tag_closed_prior_exposure tests/test_trading_pipeline.py::TestTradingPipeline::test_resolve_execution_context_positions_splits_multi_strategy_symbol_position tests/test_decisions.py::TestDecisionEngine::test_scheduler_runtime_position_isolation_skips_unowned_sell_intent tests/test_decisions.py::TestDecisionEngine::test_scheduler_runtime_position_isolation_allows_owned_sell_intent -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A - service-side scheduler repair.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
