### PR TITLE
fix(torghut): tighten authority proof risk gates

### DIFF
--- a/services/torghut/app/trading/runtime_ledger_proof_policy.py
+++ b/services/torghut/app/trading/runtime_ledger_proof_policy.py
@@ -34,7 +34,9 @@ class RuntimeLedgerProofPolicy:
     authority_min_p10_daily_net_pnl_after_costs: Decimal = Decimal("-250")
     authority_min_worst_day_net_pnl_after_costs: Decimal = Decimal("-750")
     authority_max_intraday_drawdown: Decimal = Decimal("1500")
+    authority_max_drawdown_pct_equity: Decimal = Decimal("0.03")
     authority_max_best_day_share: Decimal = Decimal("0.25")
+    authority_max_symbol_concentration_share: Decimal = Decimal("0.35")
 
     def target_payload(
         self,
@@ -52,6 +54,15 @@ class RuntimeLedgerProofPolicy:
                 _target_decimal(targets, "min_daily_net_pnl_after_costs")
             ),
             "min_runtime_ledger_trading_days": targets["min_trading_days"],
+            "max_runtime_ledger_drawdown_pct_equity": _decimal_text(
+                _target_decimal(targets, "max_drawdown_pct_equity")
+            ),
+            "max_runtime_ledger_best_day_share": _decimal_text(
+                _target_decimal(targets, "max_best_day_share")
+            ),
+            "max_runtime_ledger_symbol_concentration_share": _decimal_text(
+                _target_decimal(targets, "max_symbol_concentration_share")
+            ),
         }
 
     def targets_for_mode(self, proof_mode: str) -> dict[str, object]:
@@ -59,6 +70,9 @@ class RuntimeLedgerProofPolicy:
         min_days = self.min_trading_days
         min_daily = self.min_daily_net_pnl_after_costs
         min_net = self.min_net_pnl_after_costs
+        max_drawdown_pct_equity = self.max_drawdown_pct_equity
+        max_best_day_share = self.max_best_day_share
+        max_symbol_concentration_share = self.max_symbol_concentration_share
         if mode == "probation":
             min_days = max(min_days, self.probation_min_trading_days)
             min_net = max(min_net, min_daily * Decimal(min_days))
@@ -69,6 +83,18 @@ class RuntimeLedgerProofPolicy:
                 self.authority_min_mean_daily_net_pnl_after_costs,
             )
             min_net = max(min_net, min_daily * Decimal(min_days))
+            max_drawdown_pct_equity = min(
+                max_drawdown_pct_equity,
+                self.authority_max_drawdown_pct_equity,
+            )
+            max_best_day_share = min(
+                max_best_day_share,
+                self.authority_max_best_day_share,
+            )
+            max_symbol_concentration_share = min(
+                max_symbol_concentration_share,
+                self.authority_max_symbol_concentration_share,
+            )
         return {
             "proof_mode": mode,
             "final_authority": mode == "authority",
@@ -76,6 +102,9 @@ class RuntimeLedgerProofPolicy:
             "min_net_pnl_after_costs": min_net,
             "min_daily_net_pnl_after_costs": min_daily,
             "min_trading_days": min_days,
+            "max_drawdown_pct_equity": max_drawdown_pct_equity,
+            "max_best_day_share": max_best_day_share,
+            "max_symbol_concentration_share": max_symbol_concentration_share,
         }
 
 
@@ -106,8 +135,14 @@ _DECIMAL_ENV_FIELDS = {
     "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MAX_INTRADAY_DRAWDOWN": (
         "authority_max_intraday_drawdown"
     ),
+    "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MAX_DRAWDOWN_PCT_EQUITY": (
+        "authority_max_drawdown_pct_equity"
+    ),
     "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MAX_BEST_DAY_SHARE": (
         "authority_max_best_day_share"
+    ),
+    "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MAX_SYMBOL_CONCENTRATION_SHARE": (
+        "authority_max_symbol_concentration_share"
     ),
 }
 _INT_ENV_FIELDS = {

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1282,6 +1282,18 @@ def build_runtime_ledger_proof_packet(
         min_runtime_ledger_trading_days,
         cast(int, proof_mode_targets["min_trading_days"]),
     )
+    max_runtime_ledger_drawdown_pct_equity = min(
+        max_runtime_ledger_drawdown_pct_equity,
+        cast(Decimal, proof_mode_targets["max_drawdown_pct_equity"]),
+    )
+    max_runtime_ledger_best_day_share = min(
+        max_runtime_ledger_best_day_share,
+        cast(Decimal, proof_mode_targets["max_best_day_share"]),
+    )
+    max_runtime_ledger_symbol_concentration_share = min(
+        max_runtime_ledger_symbol_concentration_share,
+        cast(Decimal, proof_mode_targets["max_symbol_concentration_share"]),
+    )
     final_authority_mode = bool(proof_mode_targets["final_authority"])
     mode_authority_blockers = (
         []

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -243,7 +243,7 @@ def _completion(
     net_pnl: str = "10000",
     trading_days: int = 20,
     expectancy_bps: str = "13",
-    drawdown_pct: str | None = "0.04",
+    drawdown_pct: str | None = "0.02",
     best_day_share: str | None = "0.20",
     symbol_concentration_share: str | None = "0.35",
     ledger_refs: list[str] | None = None,
@@ -406,11 +406,11 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result["checks"]["runtime_ledger_risk_quality"]["observed"][
                 "drawdown_pct_equity"
             ],
-            "0.04",
+            "0.02",
         )
         self.assertEqual(
             result["target"]["max_runtime_ledger_drawdown_pct_equity"],
-            "0.08",
+            "0.03",
         )
         self.assertEqual(result["proof_mode"], "authority")
         self.assertTrue(result["final_authority_ok"])
@@ -434,6 +434,13 @@ class TestRuntimeLedgerProofPacket(TestCase):
             "smoke_proof_satisfied_evidence_collection_only",
         )
         self.assertFalse(result["promotion_authority"]["allowed"])
+        self.assertEqual(
+            result["target"]["max_runtime_ledger_drawdown_pct_equity"], "0.08"
+        )
+        self.assertEqual(
+            result["target"]["max_runtime_ledger_symbol_concentration_share"],
+            "0.5",
+        )
         self.assertIn(
             "runtime_ledger_proof_mode_not_authority",
             result["promotion_authority"]["blocking_reasons"],
@@ -1158,9 +1165,9 @@ class TestRuntimeLedgerProofPacket(TestCase):
         self.assertEqual(
             result["checks"]["runtime_ledger_risk_quality"]["expected"],
             {
-                "max_drawdown_pct_equity": "0.08",
+                "max_drawdown_pct_equity": "0.03",
                 "max_best_day_share": "0.25",
-                "max_symbol_concentration_share": "0.5",
+                "max_symbol_concentration_share": "0.35",
             },
         )
 

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -793,6 +793,9 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 "min_runtime_ledger_net_pnl_after_costs": "10000",
                 "min_runtime_ledger_daily_net_pnl_after_costs": "500",
                 "min_runtime_ledger_trading_days": 20,
+                "max_runtime_ledger_drawdown_pct_equity": "0.03",
+                "max_runtime_ledger_best_day_share": "0.25",
+                "max_runtime_ledger_symbol_concentration_share": "0.35",
             },
         )
         self.assertEqual(

--- a/services/torghut/tests/test_runtime_ledger_proof_policy.py
+++ b/services/torghut/tests/test_runtime_ledger_proof_policy.py
@@ -20,11 +20,20 @@ class TestRuntimeLedgerProofPolicy(TestCase):
                 "min_runtime_ledger_net_pnl_after_costs": "500",
                 "min_runtime_ledger_daily_net_pnl_after_costs": "500",
                 "min_runtime_ledger_trading_days": 1,
+                "max_runtime_ledger_drawdown_pct_equity": "0.08",
+                "max_runtime_ledger_best_day_share": "0.25",
+                "max_runtime_ledger_symbol_concentration_share": "0.5",
             },
         )
         self.assertEqual(
             DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.max_drawdown_pct_equity,
             Decimal("0.08"),
+        )
+        self.assertEqual(
+            DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.target_payload("authority")[
+                "max_runtime_ledger_drawdown_pct_equity"
+            ],
+            "0.03",
         )
 
     def test_policy_can_be_overridden_without_touching_call_sites(self) -> None:
@@ -36,7 +45,9 @@ class TestRuntimeLedgerProofPolicy(TestCase):
                 "TORGHUT_RUNTIME_LEDGER_PROOF_MODE": "probation",
                 "TORGHUT_RUNTIME_LEDGER_PROOF_PROBATION_MIN_TRADING_DAYS": "6",
                 "TORGHUT_RUNTIME_LEDGER_PROOF_MAX_DRAWDOWN_PCT_EQUITY": "0.12",
+                "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MAX_DRAWDOWN_PCT_EQUITY": "0.025",
                 "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MIN_TRADING_DAYS": "10",
+                "TORGHUT_RUNTIME_LEDGER_AUTHORITY_MAX_SYMBOL_CONCENTRATION_SHARE": "0.30",
             }
         )
 
@@ -47,6 +58,11 @@ class TestRuntimeLedgerProofPolicy(TestCase):
         self.assertEqual(policy.probation_min_trading_days, 6)
         self.assertEqual(policy.max_drawdown_pct_equity, Decimal("0.12"))
         self.assertEqual(policy.authority_min_trading_days, 10)
+        self.assertEqual(policy.authority_max_drawdown_pct_equity, Decimal("0.025"))
+        self.assertEqual(
+            policy.authority_max_symbol_concentration_share,
+            Decimal("0.30"),
+        )
         self.assertEqual(
             policy.target_payload(),
             {
@@ -56,17 +72,23 @@ class TestRuntimeLedgerProofPolicy(TestCase):
                 "min_runtime_ledger_net_pnl_after_costs": "3750",
                 "min_runtime_ledger_daily_net_pnl_after_costs": "625",
                 "min_runtime_ledger_trading_days": 6,
+                "max_runtime_ledger_drawdown_pct_equity": "0.12",
+                "max_runtime_ledger_best_day_share": "0.25",
+                "max_runtime_ledger_symbol_concentration_share": "0.5",
             },
         )
         self.assertEqual(
-            DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.target_payload("authority"),
+            policy.target_payload("authority"),
             {
                 "proof_mode": "authority",
                 "final_authority": True,
                 "evidence_collection_only": False,
-                "min_runtime_ledger_net_pnl_after_costs": "10000",
-                "min_runtime_ledger_daily_net_pnl_after_costs": "500",
-                "min_runtime_ledger_trading_days": 20,
+                "min_runtime_ledger_net_pnl_after_costs": "6250",
+                "min_runtime_ledger_daily_net_pnl_after_costs": "625",
+                "min_runtime_ledger_trading_days": 10,
+                "max_runtime_ledger_drawdown_pct_equity": "0.025",
+                "max_runtime_ledger_best_day_share": "0.25",
+                "max_runtime_ledger_symbol_concentration_share": "0.3",
             },
         )
 


### PR DESCRIPTION
## Summary

- Tighten authority-mode runtime-ledger risk targets to a 3% equity drawdown cap and 35% symbol concentration cap while keeping smoke/probation evidence modes looser.
- Carry mode-specific risk caps through `RuntimeLedgerProofPolicy` targets and `target_payload`, including authority env overrides.
- Clamp proof-packet risk checks by proof mode so authority packets cannot accidentally keep the older 8% drawdown default.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger_proof_policy.py tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger_proof_policy.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_ledger_proof_policy.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_ledger_proof_policy.py scripts/assemble_runtime_ledger_proof_packet.py tests/test_runtime_ledger_proof_policy.py tests/test_assemble_runtime_ledger_proof_packet.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
