### PR TITLE
fix(torghut): require structured runtime ledger source authority

### DIFF
--- a/services/torghut/app/trading/runtime_ledger_source_authority.py
+++ b/services/torghut/app/trading/runtime_ledger_source_authority.py
@@ -42,6 +42,14 @@ _PROMOTION_GRADE_AUTHORITY_CLASSES = frozenset(
         "source_execution_lifecycle_materialized_runtime_ledger",
     }
 )
+_PROMOTION_GRADE_SOURCE_REF_TABLES = frozenset(
+    {
+        "trade_decisions",
+        "executions",
+        "execution_order_events",
+        "order_feed_source_windows",
+    }
+)
 
 
 def _text(value: object) -> str | None:
@@ -103,24 +111,61 @@ def _source_refs_present(bucket: Mapping[str, object], *keys: str) -> bool:
     return any(_source_ref_present(bucket.get(key)) for key in keys)
 
 
+def _source_ref_table_names(value: object) -> set[str]:
+    refs = _string_list(value)
+    table_names: set[str] = set()
+    for ref in refs:
+        normalized = ref.strip().lower()
+        if normalized:
+            table_names.add(normalized)
+        if ":" in normalized:
+            tail = normalized.rsplit(":", maxsplit=1)[-1]
+            if tail:
+                table_names.add(tail)
+    return table_names
+
+
+def _source_row_counts_have_positive_rows(
+    bucket: Mapping[str, object], table_name: str
+) -> bool:
+    source_row_counts = bucket.get("source_row_counts")
+    if not isinstance(source_row_counts, Mapping):
+        return False
+    value = cast(Mapping[object, object], source_row_counts).get(table_name)
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return False
+    return parsed.is_finite() and parsed > 0
+
+
+def _promotion_grade_source_refs_present(bucket: Mapping[str, object]) -> bool:
+    source_ref_tables = _source_ref_table_names(bucket.get("source_refs"))
+    return all(
+        table_name in source_ref_tables
+        and _source_row_counts_have_positive_rows(bucket, table_name)
+        for table_name in _PROMOTION_GRADE_SOURCE_REF_TABLES
+    )
+
+
 def _source_offsets_present(bucket: Mapping[str, object]) -> bool:
+    def has_source_offset_triplet(value: Mapping[object, object]) -> bool:
+        return (
+            _text(value.get("topic")) is not None
+            and value.get("partition") is not None
+            and value.get("offset") is not None
+        )
+
     source_offsets = bucket.get("source_offsets")
     if isinstance(source_offsets, Mapping):
-        return len(cast(Mapping[object, object], source_offsets)) > 0
+        return has_source_offset_triplet(cast(Mapping[object, object], source_offsets))
     if isinstance(source_offsets, Sequence) and not isinstance(
         source_offsets, (str, bytes, bytearray)
     ):
         for item in cast(Sequence[object], source_offsets):
             if isinstance(item, Mapping):
-                offset = cast(Mapping[object, object], item)
-                if (
-                    _text(offset.get("topic")) is not None
-                    and offset.get("partition") is not None
-                    and offset.get("offset") is not None
-                ):
+                if has_source_offset_triplet(cast(Mapping[object, object], item)):
                     return True
-            elif _text(item) is not None:
-                return True
     return (
         _text(bucket.get("source_topic")) is not None
         and bucket.get("source_partition") is not None
@@ -142,7 +187,6 @@ def _promotion_grade_authority_class_present(bucket: Mapping[str, object]) -> bo
     authority_values = (
         bucket.get("authority_class"),
         bucket.get("authority_reason"),
-        bucket.get("pnl_derivation"),
     )
     for value in authority_values:
         text = _text(value)
@@ -201,6 +245,8 @@ def runtime_ledger_promotion_source_authority_blockers(
     """
 
     blockers = runtime_ledger_source_authority_blockers(bucket)
+    if not _promotion_grade_source_refs_present(bucket):
+        blockers.append(RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER)
     if not _source_refs_present(
         bucket,
         "source_window_ids",

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -323,6 +323,7 @@ def _complete_runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
             "postgres:trade_decisions",
             "postgres:executions",
             "postgres:execution_order_events",
+            "postgres:order_feed_source_windows",
         ],
         "source_row_counts": {
             "trade_decisions": 2,

--- a/services/torghut/tests/test_runtime_ledger_source_authority.py
+++ b/services/torghut/tests/test_runtime_ledger_source_authority.py
@@ -79,11 +79,13 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                 "postgres:trade_decisions",
                 "postgres:executions",
                 "postgres:execution_order_events",
+                "postgres:order_feed_source_windows",
             ],
             "source_row_counts": {
                 "trade_decisions": 2,
                 "executions": 2,
                 "execution_order_events": 4,
+                "order_feed_source_windows": 4,
             },
         }
 
@@ -114,3 +116,104 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
             runtime_ledger_promotion_source_authority_blockers(source_backed),
             [],
         )
+
+    def test_promotion_source_authority_rejects_unstructured_source_offsets(
+        self,
+    ) -> None:
+        base = {
+            "source_window_start": "2026-05-29T14:30:00+00:00",
+            "source_window_end": "2026-05-29T15:00:00+00:00",
+            "source_refs": [
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+                "postgres:order_feed_source_windows",
+            ],
+            "source_row_counts": {
+                "trade_decisions": 2,
+                "executions": 2,
+                "execution_order_events": 4,
+                "order_feed_source_windows": 4,
+            },
+            "trade_decision_ids": ["decision-1", "decision-2"],
+            "execution_ids": ["execution-1", "execution-2"],
+            "execution_order_event_ids": ["event-1", "event-2"],
+            "source_window_ids": ["source-window-1", "source-window-2"],
+            "source_materialization": "execution_order_events",
+            "authority_class": "runtime_order_feed_execution_source",
+        }
+
+        for malformed_offsets in (
+            ["alpaca.trade_updates:0:42"],
+            [{"topic": "alpaca.trade_updates", "offset": 42}],
+            {"topic": "alpaca.trade_updates", "partition": 0},
+        ):
+            blockers = runtime_ledger_promotion_source_authority_blockers(
+                {**base, "source_offsets": malformed_offsets}
+            )
+            self.assertIn("runtime_ledger_source_offsets_missing", blockers)
+
+    def test_promotion_source_authority_rejects_pnl_derivation_only_authority(
+        self,
+    ) -> None:
+        blockers = runtime_ledger_promotion_source_authority_blockers(
+            {
+                "source_window_start": "2026-05-29T14:30:00+00:00",
+                "source_window_end": "2026-05-29T15:00:00+00:00",
+                "source_refs": [
+                    "postgres:trade_decisions",
+                    "postgres:executions",
+                    "postgres:execution_order_events",
+                    "postgres:order_feed_source_windows",
+                ],
+                "source_row_counts": {
+                    "trade_decisions": 2,
+                    "executions": 2,
+                    "execution_order_events": 4,
+                    "order_feed_source_windows": 4,
+                },
+                "trade_decision_ids": ["decision-1", "decision-2"],
+                "execution_ids": ["execution-1", "execution-2"],
+                "execution_order_event_ids": ["event-1", "event-2"],
+                "source_window_ids": ["source-window-1", "source-window-2"],
+                "source_offsets": [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+                ],
+                "source_materialization": "execution_order_events",
+                "pnl_derivation": "execution_order_events_runtime_ledger",
+            }
+        )
+
+        self.assertIn("runtime_ledger_authority_class_missing", blockers)
+
+    def test_promotion_source_authority_requires_named_source_ref_tables(
+        self,
+    ) -> None:
+        blockers = runtime_ledger_promotion_source_authority_blockers(
+            {
+                "source_window_start": "2026-05-29T14:30:00+00:00",
+                "source_window_end": "2026-05-29T15:00:00+00:00",
+                "source_refs": [
+                    "postgres:trade_decisions",
+                    "postgres:executions",
+                    "postgres:execution_order_events",
+                ],
+                "source_row_counts": {
+                    "trade_decisions": 2,
+                    "executions": 2,
+                    "execution_order_events": 4,
+                    "order_feed_source_windows": 4,
+                },
+                "trade_decision_ids": ["decision-1", "decision-2"],
+                "execution_ids": ["execution-1", "execution-2"],
+                "execution_order_event_ids": ["event-1", "event-2"],
+                "source_window_ids": ["source-window-1", "source-window-2"],
+                "source_offsets": [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+                ],
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
+            }
+        )
+
+        self.assertIn("runtime_ledger_source_refs_missing", blockers)

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -1300,6 +1300,33 @@ class TestRuntimeWindowImport(TestCase):
             _runtime_ledger_bucket_blockers(missing_source_window_ids),
         )
 
+    def test_runtime_ledger_bucket_requires_structured_source_offsets(self) -> None:
+        for malformed_offsets in (
+            ["alpaca.trade_updates:0:100"],
+            [{"topic": "alpaca.trade_updates", "offset": 100}],
+            [{"topic": "alpaca.trade_updates", "partition": 0}],
+            {"topic": "alpaca.trade_updates", "offset": 100},
+        ):
+            bucket = _runtime_ledger_bucket(source_offsets=malformed_offsets)
+            self.assertIn(
+                "runtime_ledger_source_offsets_missing",
+                _runtime_ledger_bucket_blockers(bucket),
+            )
+
+    def test_runtime_ledger_bucket_requires_explicit_source_authority_class(
+        self,
+    ) -> None:
+        bucket = _runtime_ledger_bucket(
+            authority_class=None,
+            authority_reason=None,
+            pnl_derivation="execution_order_events_runtime_ledger",
+        )
+
+        self.assertIn(
+            "runtime_ledger_authority_class_missing",
+            _runtime_ledger_bucket_blockers(bucket),
+        )
+
     def test_persist_observed_runtime_windows_allows_authority_grade_live_ledger(
         self,
     ) -> None:

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -609,11 +609,15 @@ class TestSubmissionCouncil(TestCase):
                 "source_window_end": (now - timedelta(minutes=30)).isoformat(),
                 "source_refs": [
                     "strategy_runtime_ledger_buckets:pairs-realized-runtime",
+                    "postgres:trade_decisions",
+                    "postgres:executions",
+                    "postgres:execution_order_events",
                     "postgres:order_feed_source_windows",
                 ],
                 "source_row_counts": {
                     "trade_decisions": 2,
-                    "trade_order_events": 2,
+                    "executions": 2,
+                    "execution_order_events": 2,
                     "strategy_runtime_ledger_buckets": 1,
                     "order_feed_source_windows": 2,
                 },
@@ -638,11 +642,15 @@ class TestSubmissionCouncil(TestCase):
                 "source_window_end": (now - timedelta(minutes=60)).isoformat(),
                 "source_refs": [
                     "strategy_runtime_ledger_buckets:pairs-reversal-runtime",
+                    "postgres:trade_decisions",
+                    "postgres:executions",
+                    "postgres:execution_order_events",
                     "postgres:order_feed_source_windows",
                 ],
                 "source_row_counts": {
                     "trade_decisions": 1,
-                    "trade_order_events": 1,
+                    "executions": 1,
+                    "execution_order_events": 1,
                     "strategy_runtime_ledger_buckets": 1,
                     "order_feed_source_windows": 1,
                 },
@@ -848,6 +856,9 @@ class TestSubmissionCouncil(TestCase):
             candidates[0]["source_refs"],
             [
                 "strategy_runtime_ledger_buckets:pairs-realized-runtime",
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
                 "postgres:order_feed_source_windows",
             ],
         )
@@ -964,11 +975,15 @@ class TestSubmissionCouncil(TestCase):
                 "source_window_end": "2026-05-29T15:00:00+00:00",
                 "source_refs": [
                     "strategy_runtime_ledger_buckets:pairs-realized-runtime",
+                    "postgres:trade_decisions",
+                    "postgres:executions",
+                    "postgres:execution_order_events",
                     "postgres:order_feed_source_windows",
                 ],
                 "source_row_counts": {
                     "trade_decisions": 2,
-                    "trade_order_events": 2,
+                    "executions": 2,
+                    "execution_order_events": 2,
                     "strategy_runtime_ledger_buckets": 1,
                     "order_feed_source_windows": 2,
                 },


### PR DESCRIPTION
## Summary

- Require promotion-grade runtime-ledger source refs to name the concrete runtime tables: trade decisions, executions, execution order events, and order-feed source windows.
- Require source offsets to be structured topic/partition/offset triples instead of accepting arbitrary strings or partial mappings.
- Require an explicit runtime/order-feed `authority_class` or `authority_reason`; `pnl_derivation` alone no longer satisfies source authority.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_runtime_ledger_source_authority.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen ruff check app/trading/runtime_ledger_source_authority.py tests/test_runtime_ledger_source_authority.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
