### PR TITLE
fix(torghut): backfill order-feed source windows

### DIFF
--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -42,6 +42,13 @@ spec:
                   RENEWAL_OUTPUT=/tmp/torghut-empirical-renewal/runtime-window-renewal.json
                   PROOF_PACKET_OUTPUT=/tmp/torghut-empirical-renewal/runtime-ledger-proof-packet.json
                   mkdir -p "$(dirname "${RENEWAL_OUTPUT}")" "$(dirname "${PROOF_PACKET_OUTPUT}")"
+                  /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
+                    --batch-size 1000 \
+                    --max-batches 2 \
+                    --apply \
+                    --json
                   /opt/venv/bin/python scripts/renew_latest_empirical_promotion_jobs.py \
                     --output-dir /tmp/torghut-empirical-renewal \
                     --strategy-spec-ref microbar_cross_sectional_pairs_v1@research \

--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -28,6 +28,11 @@ from .tca import upsert_execution_tca_metric
 
 logger = logging.getLogger(__name__)
 
+ORDER_FEED_SOURCE_REVISION = "alpaca_trade_updates_v1"
+HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION = (
+    "execution_order_events_existing_source_offsets_v1"
+)
+
 
 @dataclass(frozen=True)
 class NormalizedOrderEvent:
@@ -496,7 +501,7 @@ def _create_order_feed_source_window(
         alpaca_account_label=alpaca_account_label,
         assignment_mode=settings.trading_order_feed_assignment_mode,
         collector_identity=collector_identity,
-        source_revision="alpaca_trade_updates_v1",
+        source_revision=ORDER_FEED_SOURCE_REVISION,
         window_started_at=now,
         window_ended_at=now,
         start_offset=source_offset,
@@ -954,6 +959,59 @@ def link_order_events_to_execution(session: Session, execution: Execution) -> in
     return linked
 
 
+def backfill_order_feed_source_windows(
+    session: Session,
+    *,
+    account_label: str | None = None,
+    limit: int = 1000,
+) -> dict[str, int]:
+    """Attach source-window rows to persisted order events that already have offsets.
+
+    These windows are audit lineage for old already-consumed events. They are not
+    Kafka cursor authority, so manual assignment will not use them to skip offsets.
+    """
+
+    bounded_limit = max(1, min(int(limit), 5000))
+    stmt = (
+        select(ExecutionOrderEvent)
+        .where(
+            ExecutionOrderEvent.source_window_id.is_(None),
+            ExecutionOrderEvent.source_topic.is_not(None),
+            ExecutionOrderEvent.source_partition.is_not(None),
+            ExecutionOrderEvent.source_offset.is_not(None),
+        )
+        .order_by(
+            ExecutionOrderEvent.source_topic.asc(),
+            ExecutionOrderEvent.source_partition.asc().nullsfirst(),
+            ExecutionOrderEvent.source_offset.asc().nullsfirst(),
+            ExecutionOrderEvent.created_at.asc(),
+        )
+        .limit(bounded_limit)
+    )
+    if account_label:
+        stmt = stmt.where(ExecutionOrderEvent.alpaca_account_label == account_label)
+
+    events = session.execute(stmt).scalars().all()
+    counters = {
+        "selected": len(events),
+        "source_windows_created": 0,
+        "source_windows_reused": 0,
+        "events_linked": 0,
+    }
+    for event in events:
+        source_window = _find_existing_source_window_for_event(session, event)
+        if source_window is None:
+            source_window = _create_historical_source_window_for_event(session, event)
+            counters["source_windows_created"] += 1
+        else:
+            counters["source_windows_reused"] += 1
+        event.source_window_id = source_window.id
+        session.add(event)
+        _refresh_source_window_linkage_counts(session, event)
+        counters["events_linked"] += 1
+    return counters
+
+
 def _resolve_execution(
     session: Session, event: NormalizedOrderEvent
 ) -> Execution | None:
@@ -971,6 +1029,86 @@ def _resolve_execution(
     if not clauses:
         return None
     return session.execute(select(Execution).where(or_(*clauses))).scalar_one_or_none()
+
+
+def _find_existing_source_window_for_event(
+    session: Session,
+    event: ExecutionOrderEvent,
+) -> OrderFeedSourceWindow | None:
+    if event.source_partition is None or event.source_offset is None:
+        return None
+    return (
+        session.execute(
+            select(OrderFeedSourceWindow)
+            .where(
+                OrderFeedSourceWindow.source_topic == event.source_topic,
+                OrderFeedSourceWindow.source_partition == event.source_partition,
+                OrderFeedSourceWindow.alpaca_account_label
+                == event.alpaca_account_label,
+                OrderFeedSourceWindow.start_offset <= event.source_offset,
+                OrderFeedSourceWindow.end_offset >= event.source_offset,
+            )
+            .order_by(OrderFeedSourceWindow.created_at.desc())
+            .limit(1)
+        )
+        .scalars()
+        .first()
+    )
+
+
+def _create_historical_source_window_for_event(
+    session: Session,
+    event: ExecutionOrderEvent,
+) -> OrderFeedSourceWindow:
+    if event.source_partition is None or event.source_offset is None:
+        raise ValueError("historical_source_window_requires_source_offset")
+    event_ts = _event_timestamp_for_source_window(event)
+    source_window = OrderFeedSourceWindow(
+        consumer_group=_order_feed_cursor_consumer_group(),
+        source_topic=event.source_topic,
+        source_partition=event.source_partition,
+        alpaca_account_label=event.alpaca_account_label,
+        assignment_mode=settings.trading_order_feed_assignment_mode,
+        collector_identity=settings.trading_order_feed_client_id.strip() or None,
+        source_revision=HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION,
+        window_started_at=event_ts,
+        window_ended_at=event_ts,
+        start_offset=event.source_offset,
+        end_offset=event.source_offset,
+        broker_high_watermark=None,
+        consumed_count=1,
+        inserted_count=1,
+        duplicate_count=0,
+        malformed_count=0,
+        missing_payload_count=0,
+        missing_identity_count=0,
+        out_of_scope_account_count=0,
+        unlinked_execution_count=0 if event.execution_id is not None else 1,
+        unlinked_decision_count=0 if event.trade_decision_id is not None else 1,
+        failed_unhandled_count=0,
+        dropped_count=0,
+        gap_count=0,
+        gap_ranges=None,
+        first_event_ts=event.event_ts,
+        last_event_ts=event.event_ts,
+        status="inserted",
+        status_reason="historical_execution_order_event_backfill",
+        payload_json={
+            "cursor_authority": False,
+            "source": "execution_order_events",
+            "execution_order_event_id": str(event.id),
+        },
+    )
+    session.add(source_window)
+    session.flush()
+    return source_window
+
+
+def _event_timestamp_for_source_window(event: ExecutionOrderEvent) -> datetime:
+    event_ts = event.event_ts or event.created_at or datetime.now(timezone.utc)
+    if event_ts.tzinfo is None:
+        return event_ts.replace(tzinfo=timezone.utc)
+    return event_ts.astimezone(timezone.utc)
 
 
 def _refresh_source_window_linkage_counts(
@@ -1086,6 +1224,7 @@ def _latest_persisted_source_offsets(session: Session) -> dict[tuple[str, int], 
         )
         .where(
             OrderFeedSourceWindow.consumer_group == consumer_group,
+            OrderFeedSourceWindow.source_revision == ORDER_FEED_SOURCE_REVISION,
             OrderFeedSourceWindow.status != "failed_unhandled",
             OrderFeedSourceWindow.end_offset.is_not(None),
         )
@@ -1294,9 +1433,12 @@ __all__ = [
     "NormalizedOrderEvent",
     "NormalizationResult",
     "OrderFeedIngestor",
+    "HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION",
+    "ORDER_FEED_SOURCE_REVISION",
     "normalize_order_feed_record",
     "persist_order_event",
     "apply_order_event_to_execution",
+    "backfill_order_feed_source_windows",
     "link_order_events_to_execution",
     "latest_order_event_for_execution",
 ]

--- a/services/torghut/scripts/repair_order_feed_source_windows.py
+++ b/services/torghut/scripts/repair_order_feed_source_windows.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Repair source-window lineage for persisted order-feed events."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.trading.order_feed import backfill_order_feed_source_windows
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Attach non-cursor-authoritative source-window rows to existing order-feed events.",
+    )
+    parser.add_argument("--dsn-env", default="DB_DSN")
+    parser.add_argument("--account-label", default=None)
+    parser.add_argument("--batch-size", type=int, default=1000)
+    parser.add_argument("--max-batches", type=int, default=1)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Commit repaired source-window links. Default is dry-run.",
+    )
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def _payload(
+    *,
+    args: argparse.Namespace,
+    started_at: datetime,
+    batches: list[dict[str, int]],
+) -> dict[str, Any]:
+    totals = {
+        "selected": sum(batch["selected"] for batch in batches),
+        "source_windows_created": sum(
+            batch["source_windows_created"] for batch in batches
+        ),
+        "source_windows_reused": sum(batch["source_windows_reused"] for batch in batches),
+        "events_linked": sum(batch["events_linked"] for batch in batches),
+    }
+    return {
+        "status": "ok",
+        "apply": bool(args.apply),
+        "dsn_env": args.dsn_env,
+        "account_label": args.account_label,
+        "batch_size": max(1, min(int(args.batch_size), 5000)),
+        "max_batches": max(1, int(args.max_batches)),
+        "started_at": started_at.isoformat(),
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        **totals,
+        "batches": batches,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    dsn = os.environ.get(str(args.dsn_env).strip())
+    if not dsn:
+        raise SystemExit(f"missing DSN env var: {args.dsn_env}")
+
+    started_at = datetime.now(timezone.utc)
+    batch_size = max(1, min(int(args.batch_size), 5000))
+    max_batches = max(1, int(args.max_batches))
+    engine = create_engine(dsn, pool_pre_ping=True, future=True)
+    session_factory = sessionmaker(
+        bind=engine,
+        autoflush=False,
+        autocommit=False,
+        expire_on_commit=False,
+        future=True,
+    )
+    batches: list[dict[str, int]] = []
+    with session_factory() as session:
+        for _ in range(max_batches):
+            batch = backfill_order_feed_source_windows(
+                session,
+                account_label=args.account_label,
+                limit=batch_size,
+            )
+            batches.append(batch)
+            if args.apply:
+                session.commit()
+            else:
+                session.rollback()
+                break
+            if int(batch.get("selected") or 0) < batch_size:
+                break
+
+    payload = _payload(args=args, started_at=started_at, batches=batches)
+    print(
+        json.dumps(payload, separators=(",", ":"))
+        if args.json
+        else json.dumps(payload, indent=2, default=str)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -992,6 +992,11 @@ class TestLiveConfigManifestContract(TestCase):
             )
 
         args = "\n".join(str(item) for item in container.get("args", []))
+        self.assertIn("scripts/repair_order_feed_source_windows.py", args)
+        self.assertIn("--dsn-env SIM_DB_DSN", args)
+        self.assertIn("--account-label TORGHUT_SIM", args)
+        self.assertIn("--batch-size 1000", args)
+        self.assertIn("--max-batches 2", args)
         self.assertIn("scripts/renew_latest_empirical_promotion_jobs.py", args)
         self.assertIn(
             "--runtime-window-target-plan-url "

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -24,9 +24,13 @@ from app.models import (
     Strategy,
     TradeDecision,
 )
+from app.trading import order_feed as order_feed_module
 from app.trading.order_feed import (
+    HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION,
+    ORDER_FEED_SOURCE_REVISION,
     OrderFeedIngestor,
     apply_order_event_to_execution,
+    backfill_order_feed_source_windows,
     latest_order_event_for_execution,
     merge_execution_raw_order_update,
     normalize_order_feed_record,
@@ -756,6 +760,7 @@ class TestOrderFeed(TestCase):
                 source_partition=0,
                 alpaca_account_label="paper",
                 assignment_mode="manual",
+                source_revision=ORDER_FEED_SOURCE_REVISION,
                 window_started_at=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
                 window_ended_at=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
                 start_offset=41,
@@ -815,6 +820,7 @@ class TestOrderFeed(TestCase):
                     source_partition=0,
                     alpaca_account_label="paper",
                     assignment_mode="manual",
+                    source_revision=ORDER_FEED_SOURCE_REVISION,
                     window_started_at=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
                     window_ended_at=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
                     start_offset=49,
@@ -843,6 +849,185 @@ class TestOrderFeed(TestCase):
             [(TopicPartition("torghut.trade-updates.v1", 0), 58)],
         )
         self.assertEqual(consumer.seek_to_beginning_calls, [])
+
+    def test_backfill_source_windows_links_legacy_events_without_cursor_authority(
+        self,
+    ) -> None:
+        settings.trading_order_feed_assignment_mode = "manual"
+        settings.trading_order_feed_auto_offset_reset = "earliest"
+        settings.trading_order_feed_group_id = "torghut-order-feed-v1"
+        consumer = FakeManualConsumer(
+            [],
+            partitions={"torghut.trade-updates.v1": {0}},
+        )
+
+        with Session(self.engine) as session:
+            execution = self._seed_execution(session)
+            event = ExecutionOrderEvent(
+                event_fingerprint="legacy-fill-with-source-offset",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=88,
+                alpaca_account_label="paper",
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id=execution.alpaca_order_id,
+                client_order_id=execution.client_order_id,
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("191.25"),
+                raw_event={"event": "fill"},
+                execution_id=execution.id,
+                trade_decision_id=execution.trade_decision_id,
+            )
+            session.add(event)
+            session.commit()
+
+            result = backfill_order_feed_source_windows(
+                session,
+                account_label="paper",
+                limit=10,
+            )
+            session.commit()
+            session.refresh(event)
+            source_window = session.get(OrderFeedSourceWindow, event.source_window_id)
+            self.assertIsNotNone(source_window)
+            assert source_window is not None
+            ingestor = OrderFeedIngestor(consumer_factory=lambda: consumer)
+            counters = ingestor.ingest_once(session)
+
+        self.assertEqual(
+            result,
+            {
+                "selected": 1,
+                "source_windows_created": 1,
+                "source_windows_reused": 0,
+                "events_linked": 1,
+            },
+        )
+        self.assertEqual(
+            source_window.source_revision,
+            HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION,
+        )
+        self.assertEqual(source_window.status, "inserted")
+        self.assertEqual(
+            source_window.status_reason, "historical_execution_order_event_backfill"
+        )
+        self.assertEqual(source_window.inserted_count, 1)
+        self.assertEqual(source_window.unlinked_execution_count, 0)
+        self.assertEqual(source_window.unlinked_decision_count, 0)
+        self.assertEqual(source_window.payload_json["cursor_authority"], False)
+        self.assertEqual(counters["messages_total"], 0)
+        self.assertEqual(consumer.seek_calls, [])
+        self.assertEqual(
+            consumer.seek_to_beginning_calls,
+            [(TopicPartition("torghut.trade-updates.v1", 0),)],
+        )
+
+    def test_backfill_source_windows_reuses_existing_source_window(self) -> None:
+        settings.trading_order_feed_assignment_mode = "manual"
+        with Session(self.engine) as session:
+            execution = self._seed_execution(session)
+            source_window = OrderFeedSourceWindow(
+                consumer_group="torghut-order-feed-v1",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                alpaca_account_label="paper",
+                assignment_mode="manual",
+                source_revision=HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION,
+                window_started_at=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                window_ended_at=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                start_offset=88,
+                end_offset=90,
+                consumed_count=3,
+                inserted_count=3,
+                status="inserted",
+            )
+            session.add(source_window)
+            session.flush()
+            source_window_id = source_window.id
+            event = ExecutionOrderEvent(
+                event_fingerprint="legacy-fill-existing-source-window",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=89,
+                alpaca_account_label="paper",
+                event_ts=datetime(2026, 2, 1, 10, 1, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id=execution.alpaca_order_id,
+                client_order_id=execution.client_order_id,
+                event_type="fill",
+                status="filled",
+                raw_event={"event": "fill"},
+                execution_id=execution.id,
+                trade_decision_id=execution.trade_decision_id,
+            )
+            session.add(event)
+            session.commit()
+
+            result = backfill_order_feed_source_windows(
+                session,
+                account_label="paper",
+                limit=10,
+            )
+            session.commit()
+            session.refresh(event)
+
+        self.assertEqual(
+            result,
+            {
+                "selected": 1,
+                "source_windows_created": 0,
+                "source_windows_reused": 1,
+                "events_linked": 1,
+            },
+        )
+        self.assertEqual(event.source_window_id, source_window_id)
+
+    def test_historical_source_window_helpers_handle_missing_and_aware_offsets(
+        self,
+    ) -> None:
+        event = ExecutionOrderEvent(
+            event_fingerprint="legacy-fill-missing-offset",
+            source_topic="torghut.trade-updates.v1",
+            source_partition=None,
+            source_offset=None,
+            alpaca_account_label="paper",
+            event_ts=datetime(
+                2026,
+                2,
+                1,
+                2,
+                0,
+                tzinfo=timezone(timedelta(hours=-8)),
+            ),
+            symbol="AAPL",
+            event_type="fill",
+            status="filled",
+            raw_event={"event": "fill"},
+        )
+
+        with Session(self.engine) as session:
+            self.assertIsNone(
+                order_feed_module._find_existing_source_window_for_event(
+                    session,
+                    event,
+                )
+            )
+            with self.assertRaisesRegex(
+                ValueError,
+                "historical_source_window_requires_source_offset",
+            ):
+                order_feed_module._create_historical_source_window_for_event(
+                    session,
+                    event,
+                )
+
+        self.assertEqual(
+            order_feed_module._event_timestamp_for_source_window(event),
+            datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+        )
 
     def test_ingest_persists_durable_consumer_cursor_for_valid_event(self) -> None:
         record = FakeRecord(

--- a/services/torghut/tests/test_portfolio_sizing.py
+++ b/services/torghut/tests/test_portfolio_sizing.py
@@ -988,6 +988,7 @@ class TestPortfolioSizing(TestCase):
         self.assertIn("cap_per_symbol_zero", portfolio_output.get("methods", []))
 
     def test_symbol_capacity_clip_below_one_share_reports_capacity_reason(self) -> None:
+        config.settings.trading_fractional_equities_enabled = False
         sizer = PortfolioSizer(
             PortfolioSizingConfig(
                 notional_per_position=None,

--- a/services/torghut/tests/test_repair_order_feed_source_windows_script.py
+++ b/services/torghut/tests/test_repair_order_feed_source_windows_script.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from unittest import TestCase
+from unittest.mock import patch
+
+from scripts import repair_order_feed_source_windows as script
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.commits = 0
+        self.rollbacks = 0
+
+    def __enter__(self) -> _FakeSession:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class _FakeSessionFactory:
+    def __init__(self, session: _FakeSession) -> None:
+        self.session = session
+
+    def __call__(self) -> _FakeSession:
+        return self.session
+
+
+class TestRepairOrderFeedSourceWindowsScript(TestCase):
+    def test_main_defaults_to_dry_run_and_rolls_back(self) -> None:
+        fake_session = _FakeSession()
+        stdout = io.StringIO()
+
+        with (
+            patch.dict(os.environ, {"TEST_DSN": "postgresql://example/test"}),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "repair_order_feed_source_windows.py",
+                    "--dsn-env",
+                    "TEST_DSN",
+                    "--json",
+                    "--batch-size",
+                    "6000",
+                    "--max-batches",
+                    "3",
+                ],
+            ),
+            patch.object(script, "create_engine", return_value=object()) as create_engine,
+            patch.object(
+                script,
+                "sessionmaker",
+                return_value=_FakeSessionFactory(fake_session),
+            ),
+            patch.object(
+                script,
+                "backfill_order_feed_source_windows",
+                return_value={
+                    "selected": 5,
+                    "source_windows_created": 3,
+                    "source_windows_reused": 2,
+                    "events_linked": 5,
+                },
+            ) as backfill,
+            patch("sys.stdout", stdout),
+        ):
+            exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["apply"], False)
+        self.assertEqual(payload["dsn_env"], "TEST_DSN")
+        self.assertEqual(payload["batch_size"], 5000)
+        self.assertEqual(payload["max_batches"], 3)
+        self.assertEqual(payload["selected"], 5)
+        self.assertEqual(payload["source_windows_created"], 3)
+        self.assertEqual(payload["source_windows_reused"], 2)
+        self.assertEqual(payload["events_linked"], 5)
+        self.assertEqual(fake_session.commits, 0)
+        self.assertEqual(fake_session.rollbacks, 1)
+        create_engine.assert_called_once_with(
+            "postgresql://example/test",
+            pool_pre_ping=True,
+            future=True,
+        )
+        backfill.assert_called_once_with(
+            fake_session,
+            account_label=None,
+            limit=5000,
+        )
+
+    def test_main_applies_until_selection_drops_below_batch_size(self) -> None:
+        fake_session = _FakeSession()
+        stdout = io.StringIO()
+
+        with (
+            patch.dict(os.environ, {"SIM_DSN": "postgresql://example/sim"}),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "repair_order_feed_source_windows.py",
+                    "--dsn-env",
+                    "SIM_DSN",
+                    "--account-label",
+                    "TORGHUT_SIM",
+                    "--batch-size",
+                    "2",
+                    "--max-batches",
+                    "3",
+                    "--apply",
+                ],
+            ),
+            patch.object(script, "create_engine", return_value=object()),
+            patch.object(
+                script,
+                "sessionmaker",
+                return_value=_FakeSessionFactory(fake_session),
+            ),
+            patch.object(
+                script,
+                "backfill_order_feed_source_windows",
+                side_effect=[
+                    {
+                        "selected": 2,
+                        "source_windows_created": 2,
+                        "source_windows_reused": 0,
+                        "events_linked": 2,
+                    },
+                    {
+                        "selected": 1,
+                        "source_windows_created": 0,
+                        "source_windows_reused": 1,
+                        "events_linked": 1,
+                    },
+                ],
+            ) as backfill,
+            patch("sys.stdout", stdout),
+        ):
+            exit_code = script.main()
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["apply"], True)
+        self.assertEqual(payload["account_label"], "TORGHUT_SIM")
+        self.assertEqual(payload["selected"], 3)
+        self.assertEqual(payload["source_windows_created"], 2)
+        self.assertEqual(payload["source_windows_reused"], 1)
+        self.assertEqual(payload["events_linked"], 3)
+        self.assertEqual(fake_session.commits, 2)
+        self.assertEqual(fake_session.rollbacks, 0)
+        self.assertEqual(backfill.call_count, 2)
+        self.assertEqual(backfill.call_args.kwargs["account_label"], "TORGHUT_SIM")
+        self.assertEqual(backfill.call_args.kwargs["limit"], 2)
+
+    def test_main_requires_configured_dsn_env(self) -> None:
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "repair_order_feed_source_windows.py",
+                    "--dsn-env",
+                    "MISSING_DSN",
+                ],
+            ),
+        ):
+            with self.assertRaisesRegex(SystemExit, "missing DSN env var: MISSING_DSN"):
+                script.main()


### PR DESCRIPTION
## Summary

- Adds a bounded repair path that attaches non-cursor-authoritative source-window lineage to persisted order-feed events that already carry Kafka topic, partition, and offset metadata.
- Keeps historical repair windows out of Kafka resume-offset authority so old rows cannot cause manual assignment to skip unconsumed offsets.
- Runs the repair in the Torghut empirical promotion renewal CronJob against `SIM_DB_DSN` before runtime-window import, and covers the manifest contract plus order-feed behavior with regression tests.
- Stabilizes a portfolio sizing test by making the intended whole-share quantity-resolution assumption explicit.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py tests/test_live_config_manifest_contract.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger_source_authority.py tests/test_runtime_ledger.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/order_feed.py scripts/repair_order_feed_source_windows.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen pytest tests/test_portfolio_sizing.py::TestPortfolioSizing::test_symbol_capacity_clip_below_one_share_reports_capacity_reason -q`
- `bash -lc 'cd services/torghut && TEST_FILES=($(find tests -name "test_*.py" ! -path "tests/test_run_whitepaper_autoresearch_profit_target.py" -print | sort | awk -v shard="2" -v total="4" "((NR - 1) % total) == shard")); uv run --frozen pytest -n auto --dist=worksteal "${TEST_FILES[@]}" -q'`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
