### PR TITLE
fix(torghut): add bounded source-window repair cadence

### DIFF
--- a/.github/workflows/torghut-deploy-automerge.yml
+++ b/.github/workflows/torghut-deploy-automerge.yml
@@ -59,6 +59,7 @@ jobs:
             'argocd/applications/torghut/analysis-template-artifact-bundle.yaml'
             'argocd/applications/torghut/empirical-jobs-backfill-job.yaml'
             'argocd/applications/torghut/execution-tca-refresh-cronjob.yaml'
+            'argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml'
             'argocd/applications/torghut/paper-account-flatten-cronjob.yaml'
             'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
             'argocd/applications/torghut-options/catalog/deployment.yaml'

--- a/.github/workflows/torghut-release.yml
+++ b/.github/workflows/torghut-release.yml
@@ -256,6 +256,7 @@ jobs:
             argocd/applications/torghut/analysis-template-artifact-bundle.yaml \
             argocd/applications/torghut/empirical-jobs-backfill-job.yaml \
             argocd/applications/torghut/execution-tca-refresh-cronjob.yaml \
+            argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml \
             argocd/applications/torghut/paper-account-flatten-cronjob.yaml \
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml \
             argocd/applications/torghut-options/catalog/deployment.yaml \
@@ -296,6 +297,7 @@ jobs:
             argocd/applications/torghut/analysis-template-artifact-bundle.yaml
             argocd/applications/torghut/empirical-jobs-backfill-job.yaml
             argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+            argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
             argocd/applications/torghut/paper-account-flatten-cronjob.yaml
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut-options/catalog/deployment.yaml
@@ -339,6 +341,7 @@ jobs:
             argocd/applications/torghut/analysis-template-artifact-bundle.yaml
             argocd/applications/torghut/empirical-jobs-backfill-job.yaml
             argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+            argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
             argocd/applications/torghut/paper-account-flatten-cronjob.yaml
             argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
             argocd/applications/torghut-options/catalog/deployment.yaml

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -34,6 +34,7 @@ resources:
   - empirical-artifacts-objectbucketclaim.yaml
   - empirical-jobs-backfill-job.yaml
   - empirical-promotion-renewal-cronjob.yaml
+  - order-feed-source-window-repair-cronjob.yaml
   - empirical-artifacts-retention-cronjob.yaml
   - execution-tca-refresh-cronjob.yaml
   - paper-account-flatten-cronjob.yaml

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -1,0 +1,74 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: torghut-order-feed-source-window-repair
+  namespace: torghut
+  labels:
+    app.kubernetes.io/name: torghut
+    app.kubernetes.io/component: order-feed-source-window-repair
+spec:
+  schedule: "13,28,43,58 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 180
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: torghut-runtime
+          nodeSelector:
+            kubernetes.io/arch: arm64
+          containers:
+            - name: repair-source-windows
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:808ec6bab34ba6ee3565bfd7b291969cacfd106134eb0808d01b4a1d5c2dbe74
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: 250m
+                  memory: 256Mi
+                  ephemeral-storage: 512Mi
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -euo pipefail
+                  cd /app
+                  /opt/venv/bin/python scripts/repair_order_feed_source_windows.py \
+                    --dsn-env SIM_DB_DSN \
+                    --account-label TORGHUT_SIM \
+                    --batch-size 500 \
+                    --max-batches 1 \
+                    --apply \
+                    --json
+              env:
+                - name: TORGHUT_SIM_DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: host
+                - name: TORGHUT_SIM_DB_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: port
+                - name: TORGHUT_SIM_DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: username
+                - name: TORGHUT_SIM_DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: password
+                - name: SIM_DB_DSN
+                  value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default

--- a/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
+++ b/packages/scripts/src/torghut/__tests__/update-manifests.test.ts
@@ -21,6 +21,7 @@ const createFixture = () => {
   const empiricalBackfillManifestPath = join(dir, 'empirical-jobs-backfill-job.yaml')
   const empiricalPromotionRenewalManifestPath = join(dir, 'empirical-promotion-renewal-cronjob.yaml')
   const executionTcaRefreshManifestPath = join(dir, 'execution-tca-refresh-cronjob.yaml')
+  const orderFeedSourceWindowRepairManifestPath = join(dir, 'order-feed-source-window-repair-cronjob.yaml')
   const paperAccountFlattenManifestPath = join(dir, 'paper-account-flatten-cronjob.yaml')
   const whitepaperSemanticBackfillManifestPath = join(dir, 'whitepaper-semantic-backfill-job.yaml')
   const optionsCatalogManifestPath = join(dir, 'options-catalog-deployment.yaml')
@@ -98,6 +99,7 @@ spec:
     empiricalBackfillManifestPath,
     empiricalPromotionRenewalManifestPath,
     executionTcaRefreshManifestPath,
+    orderFeedSourceWindowRepairManifestPath,
     paperAccountFlattenManifestPath,
     whitepaperSemanticBackfillManifestPath,
   ]) {
@@ -153,6 +155,7 @@ spec:
     empiricalBackfillManifestPath,
     empiricalPromotionRenewalManifestPath,
     executionTcaRefreshManifestPath,
+    orderFeedSourceWindowRepairManifestPath,
     paperAccountFlattenManifestPath,
     whitepaperSemanticBackfillManifestPath,
     optionsCatalogManifestPath,
@@ -224,6 +227,7 @@ describe('update-manifests', () => {
       empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
       empiricalPromotionRenewalManifestPath: relative(repoRoot, fixture.empiricalPromotionRenewalManifestPath),
       executionTcaRefreshManifestPath: relative(repoRoot, fixture.executionTcaRefreshManifestPath),
+      orderFeedSourceWindowRepairManifestPath: relative(repoRoot, fixture.orderFeedSourceWindowRepairManifestPath),
       paperAccountFlattenManifestPath: relative(repoRoot, fixture.paperAccountFlattenManifestPath),
       whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
       optionsCatalogManifestPath: relative(repoRoot, fixture.optionsCatalogManifestPath),
@@ -246,6 +250,7 @@ describe('update-manifests', () => {
     const empiricalBackfillManifest = readFileSync(fixture.empiricalBackfillManifestPath, 'utf8')
     const empiricalPromotionRenewalManifest = readFileSync(fixture.empiricalPromotionRenewalManifestPath, 'utf8')
     const executionTcaRefreshManifest = readFileSync(fixture.executionTcaRefreshManifestPath, 'utf8')
+    const orderFeedSourceWindowRepairManifest = readFileSync(fixture.orderFeedSourceWindowRepairManifestPath, 'utf8')
     const paperAccountFlattenManifest = readFileSync(fixture.paperAccountFlattenManifestPath, 'utf8')
     const whitepaperSemanticBackfillManifest = readFileSync(fixture.whitepaperSemanticBackfillManifestPath, 'utf8')
     const optionsCatalogManifest = readFileSync(fixture.optionsCatalogManifestPath, 'utf8')
@@ -281,6 +286,7 @@ describe('update-manifests', () => {
       empiricalBackfillManifest,
       empiricalPromotionRenewalManifest,
       executionTcaRefreshManifest,
+      orderFeedSourceWindowRepairManifest,
       paperAccountFlattenManifest,
       whitepaperSemanticBackfillManifest,
     ]) {
@@ -300,7 +306,7 @@ describe('update-manifests', () => {
     expect(result.imageRef).toBe(
       'registry.ide-newton.ts.net/lab/torghut@sha256:430763ebeeda8734e1da3ae8c6b665bcc1b380fb815317fffc98371cccea219e',
     )
-    expect(result.changedPaths.length).toBe(17)
+    expect(result.changedPaths.length).toBe(18)
 
     rmSync(fixture.dir, { recursive: true, force: true })
   })
@@ -329,6 +335,7 @@ describe('update-manifests', () => {
       empiricalBackfillManifestPath: relative(repoRoot, fixture.empiricalBackfillManifestPath),
       empiricalPromotionRenewalManifestPath: relative(repoRoot, fixture.empiricalPromotionRenewalManifestPath),
       executionTcaRefreshManifestPath: relative(repoRoot, fixture.executionTcaRefreshManifestPath),
+      orderFeedSourceWindowRepairManifestPath: relative(repoRoot, fixture.orderFeedSourceWindowRepairManifestPath),
       paperAccountFlattenManifestPath: relative(repoRoot, fixture.paperAccountFlattenManifestPath),
       whitepaperSemanticBackfillManifestPath: relative(repoRoot, fixture.whitepaperSemanticBackfillManifestPath),
       optionsCatalogManifestPath: relative(repoRoot, fixture.optionsCatalogManifestPath),

--- a/packages/scripts/src/torghut/update-manifests.ts
+++ b/packages/scripts/src/torghut/update-manifests.ts
@@ -27,6 +27,8 @@ const defaultEmpiricalBackfillManifestPath = 'argocd/applications/torghut/empiri
 const defaultEmpiricalPromotionRenewalManifestPath =
   'argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml'
 const defaultExecutionTcaRefreshManifestPath = 'argocd/applications/torghut/execution-tca-refresh-cronjob.yaml'
+const defaultOrderFeedSourceWindowRepairManifestPath =
+  'argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml'
 const defaultPaperAccountFlattenManifestPath = 'argocd/applications/torghut/paper-account-flatten-cronjob.yaml'
 const defaultWhitepaperSemanticBackfillManifestPath =
   'argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml'
@@ -54,6 +56,7 @@ type UpdateManifestsOptions = {
   empiricalBackfillManifestPath?: string
   empiricalPromotionRenewalManifestPath?: string
   executionTcaRefreshManifestPath?: string
+  orderFeedSourceWindowRepairManifestPath?: string
   paperAccountFlattenManifestPath?: string
   whitepaperSemanticBackfillManifestPath?: string
   optionsCatalogManifestPath?: string
@@ -81,6 +84,7 @@ type CliOptions = {
   empiricalBackfillManifestPath?: string
   empiricalPromotionRenewalManifestPath?: string
   executionTcaRefreshManifestPath?: string
+  orderFeedSourceWindowRepairManifestPath?: string
   paperAccountFlattenManifestPath?: string
   whitepaperSemanticBackfillManifestPath?: string
   optionsCatalogManifestPath?: string
@@ -318,6 +322,11 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     options.executionTcaRefreshManifestPath ?? defaultExecutionTcaRefreshManifestPath,
     'torghut-execution-tca-refresh image reference',
   )
+  const orderFeedSourceWindowRepair = updateImageOnlyManifest(
+    options,
+    options.orderFeedSourceWindowRepairManifestPath ?? defaultOrderFeedSourceWindowRepairManifestPath,
+    'torghut-order-feed-source-window-repair image reference',
+  )
   const paperAccountFlatten = updateImageOnlyManifest(
     options,
     options.paperAccountFlattenManifestPath ?? defaultPaperAccountFlattenManifestPath,
@@ -358,6 +367,7 @@ const updateTorghutManifests = (options: UpdateManifestsOptions) => {
     empiricalBackfill,
     empiricalPromotionRenewal,
     executionTcaRefresh,
+    orderFeedSourceWindowRepair,
     paperAccountFlatten,
     whitepaperSemanticBackfill,
     optionsCatalog,
@@ -401,6 +411,7 @@ Options:
   --empirical-backfill-manifest-path <path>
   --empirical-promotion-renewal-manifest-path <path>
   --execution-tca-refresh-manifest-path <path>
+  --order-feed-source-window-repair-manifest-path <path>
   --paper-account-flatten-manifest-path <path>
   --whitepaper-semantic-backfill-manifest-path <path>
   --options-catalog-manifest-path <path>
@@ -482,6 +493,9 @@ Options:
       case '--execution-tca-refresh-manifest-path':
         options.executionTcaRefreshManifestPath = value
         break
+      case '--order-feed-source-window-repair-manifest-path':
+        options.orderFeedSourceWindowRepairManifestPath = value
+        break
       case '--paper-account-flatten-manifest-path':
         options.paperAccountFlattenManifestPath = value
         break
@@ -549,6 +563,9 @@ const main = (cliOptions?: CliOptions) => {
       parsed.empiricalPromotionRenewalManifestPath ?? process.env.TORGHUT_EMPIRICAL_PROMOTION_RENEWAL_MANIFEST_PATH,
     executionTcaRefreshManifestPath:
       parsed.executionTcaRefreshManifestPath ?? process.env.TORGHUT_EXECUTION_TCA_REFRESH_MANIFEST_PATH,
+    orderFeedSourceWindowRepairManifestPath:
+      parsed.orderFeedSourceWindowRepairManifestPath ??
+      process.env.TORGHUT_ORDER_FEED_SOURCE_WINDOW_REPAIR_MANIFEST_PATH,
     paperAccountFlattenManifestPath:
       parsed.paperAccountFlattenManifestPath ?? process.env.TORGHUT_PAPER_ACCOUNT_FLATTEN_MANIFEST_PATH,
     whitepaperSemanticBackfillManifestPath:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -933,6 +933,83 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--apply", args)
         self.assertIn("--json", args)
 
+    def test_order_feed_source_window_repair_cronjob_is_bounded_sim_only(
+        self,
+    ) -> None:
+        spec, container = _load_cronjob_container(
+            "argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml"
+        )
+
+        self.assertEqual(spec.get("schedule"), "13,28,43,58 * * * *")
+        self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
+        self.assertEqual(spec.get("startingDeadlineSeconds"), 300)
+        job_spec = cast(
+            Mapping[str, object],
+            cast(Mapping[str, object], spec.get("jobTemplate", {})).get("spec", {}),
+        )
+        template = cast(
+            Mapping[str, object],
+            cast(Mapping[str, object], job_spec.get("template", {})),
+        )
+        pod_spec = cast(Mapping[str, object], template.get("spec", {}))
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 180)
+        self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
+        self.assertEqual(
+            pod_spec.get("nodeSelector"),
+            {"kubernetes.io/arch": "arm64"},
+        )
+        resources = cast(Mapping[str, object], container.get("resources", {}))
+        self.assertEqual(
+            resources,
+            {
+                "requests": {
+                    "cpu": "50m",
+                    "memory": "128Mi",
+                    "ephemeral-storage": "128Mi",
+                },
+                "limits": {
+                    "cpu": "250m",
+                    "memory": "256Mi",
+                    "ephemeral-storage": "512Mi",
+                },
+            },
+        )
+        self.assertIn(
+            "registry.ide-newton.ts.net/lab/torghut@sha256:",
+            str(container.get("image")),
+        )
+
+        env = {
+            item.get("name"): item
+            for item in cast(list[Mapping[str, object]], container.get("env", []))
+        }
+        self.assertEqual(
+            env["SIM_DB_DSN"].get("value"),
+            "postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@"
+            "$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default",
+        )
+        self.assertNotIn("DB_DSN", env)
+        for name, key in {
+            "TORGHUT_SIM_DB_HOST": "host",
+            "TORGHUT_SIM_DB_PORT": "port",
+            "TORGHUT_SIM_DB_USER": "username",
+            "TORGHUT_SIM_DB_PASSWORD": "password",
+        }.items():
+            value_from = cast(Mapping[str, object], env[name].get("valueFrom", {}))
+            self.assertEqual(
+                value_from.get("secretKeyRef"),
+                {"name": "torghut-db-app", "key": key},
+            )
+
+        args = "\n".join(str(item) for item in container.get("args", []))
+        self.assertIn("scripts/repair_order_feed_source_windows.py", args)
+        self.assertIn("--dsn-env SIM_DB_DSN", args)
+        self.assertIn("--account-label TORGHUT_SIM", args)
+        self.assertIn("--batch-size 500", args)
+        self.assertIn("--max-batches 1", args)
+        self.assertIn("--apply", args)
+        self.assertIn("--json", args)
+
     def test_empirical_promotion_renewal_imports_authoritative_sim_paper_plan_and_sim_db(
         self,
     ) -> None:

--- a/services/torghut/tests/test_torghut_release_workflow_manifest_paths.py
+++ b/services/torghut/tests/test_torghut_release_workflow_manifest_paths.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 RENEWAL_CRONJOB = "argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml"
+SOURCE_WINDOW_REPAIR_CRONJOB = (
+    "argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml"
+)
 
 
 def test_release_workflow_tracks_empirical_promotion_renewal_cronjob() -> None:
@@ -13,6 +16,7 @@ def test_release_workflow_tracks_empirical_promotion_renewal_cronjob() -> None:
     )
 
     assert workflow.count(RENEWAL_CRONJOB) == 3
+    assert workflow.count(SOURCE_WINDOW_REPAIR_CRONJOB) == 3
 
 
 def test_deploy_automerge_allows_empirical_promotion_renewal_cronjob() -> None:
@@ -21,3 +25,4 @@ def test_deploy_automerge_allows_empirical_promotion_renewal_cronjob() -> None:
     )
 
     assert RENEWAL_CRONJOB in workflow
+    assert SOURCE_WINDOW_REPAIR_CRONJOB in workflow


### PR DESCRIPTION
## Summary

- Add a bounded GitOps CronJob that repairs `TORGHUT_SIM` order-feed source-window links every 15 minutes.
- Keep the repair job low-resource and serialized with `concurrencyPolicy: Forbid`, one 500-row batch per run, and a 180-second deadline.
- Wire the new manifest into Torghut image-promotion/update tooling so future release PRs update this CronJob image digest with the rest of Torghut.
- Add manifest-contract tests that assert the job is SIM-only, bounded, and tracked by release/automerge workflows.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_order_feed_source_window_repair_cronjob_is_bounded_sim_only tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_empirical_promotion_renewal_imports_authoritative_sim_paper_plan_and_sim_db tests/test_torghut_release_workflow_manifest_paths.py -q`
- `bun test packages/scripts/src/torghut/__tests__/update-manifests.test.ts`
- `git diff --check`
- `cd services/torghut && uv run --frozen ruff check tests/test_live_config_manifest_contract.py tests/test_torghut_release_workflow_manifest_paths.py`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-kustomize.yaml && rg -n "torghut-order-feed-source-window-repair|repair_order_feed_source_windows.py|schedule: 13,28,43,58" /tmp/torghut-kustomize.yaml`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
