### PR TITLE
fix(torghut): use psycopg for source-window repair

### DIFF
--- a/services/torghut/scripts/repair_order_feed_source_windows.py
+++ b/services/torghut/scripts/repair_order_feed_source_windows.py
@@ -60,6 +60,17 @@ def _payload(
     }
 
 
+def _sqlalchemy_dsn(dsn: str) -> str:
+    text = dsn.strip()
+    if text.startswith("postgresql+psycopg://"):
+        return text
+    if text.startswith("postgres://"):
+        return text.replace("postgres://", "postgresql+psycopg://", 1)
+    if text.startswith("postgresql://"):
+        return text.replace("postgresql://", "postgresql+psycopg://", 1)
+    return text
+
+
 def main() -> int:
     args = _parse_args()
     dsn = os.environ.get(str(args.dsn_env).strip())
@@ -69,7 +80,7 @@ def main() -> int:
     started_at = datetime.now(timezone.utc)
     batch_size = max(1, min(int(args.batch_size), 5000))
     max_batches = max(1, int(args.max_batches))
-    engine = create_engine(dsn, pool_pre_ping=True, future=True)
+    engine = create_engine(_sqlalchemy_dsn(dsn), pool_pre_ping=True, future=True)
     session_factory = sessionmaker(
         bind=engine,
         autoflush=False,

--- a/services/torghut/tests/test_repair_order_feed_source_windows_script.py
+++ b/services/torghut/tests/test_repair_order_feed_source_windows_script.py
@@ -90,7 +90,7 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(fake_session.commits, 0)
         self.assertEqual(fake_session.rollbacks, 1)
         create_engine.assert_called_once_with(
-            "postgresql://example/test",
+            "postgresql+psycopg://example/test",
             pool_pre_ping=True,
             future=True,
         )
@@ -179,3 +179,17 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         ):
             with self.assertRaisesRegex(SystemExit, "missing DSN env var: MISSING_DSN"):
                 script.main()
+
+    def test_sqlalchemy_dsn_uses_installed_psycopg_driver(self) -> None:
+        self.assertEqual(
+            script._sqlalchemy_dsn("postgresql://user:pass@postgres/torghut"),
+            "postgresql+psycopg://user:pass@postgres/torghut",
+        )
+        self.assertEqual(
+            script._sqlalchemy_dsn("postgres://user:pass@postgres/torghut"),
+            "postgresql+psycopg://user:pass@postgres/torghut",
+        )
+        self.assertEqual(
+            script._sqlalchemy_dsn("postgresql+psycopg://user:pass@postgres/torghut"),
+            "postgresql+psycopg://user:pass@postgres/torghut",
+        )


### PR DESCRIPTION
## Summary

- Normalize PostgreSQL DSNs in `repair_order_feed_source_windows.py` to `postgresql+psycopg://` before creating the SQLAlchemy engine.
- Fix the production CronJob failure caused by SQLAlchemy defaulting to missing `psycopg2`.
- Add a regression test covering `postgresql://`, `postgres://`, and already-normalized `postgresql+psycopg://` DSNs.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_repair_order_feed_source_windows_script.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/repair_order_feed_source_windows.py tests/test_repair_order_feed_source_windows_script.py`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
