### PR TITLE
fix(torghut): preserve source-backed runtime ledger blockers

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -2385,10 +2385,15 @@ def _build_realized_strategy_pnl_rows(
                 ),
             )
             row["runtime_ledger_bucket"] = bucket_payload
-        event_sourced_runtime_ledger = (
+        source_backed_runtime_ledger = (
             allow_authoritative_runtime_ledger_materialization
             and event_sourced_lifecycle_rows > 0
             and not order_feed_fill_lifecycle_blockers
+            and isinstance(bucket_payload, Mapping)
+            and not runtime_ledger_promotion_source_authority_blockers(bucket_payload)
+        )
+        event_sourced_runtime_ledger = (
+            source_backed_runtime_ledger
             and isinstance(bucket_payload, Mapping)
             and _runtime_ledger_bucket_profit_proof_present(bucket_payload)
         )
@@ -2404,6 +2409,36 @@ def _build_realized_strategy_pnl_rows(
                     **dict(bucket_payload),
                     "authoritative": True,
                     "authority_reason": "event_sourced_runtime_ledger_profit_proof",
+                    "pnl_derivation": "execution_order_events_runtime_ledger",
+                    "source_materialization": "execution_order_events",
+                }
+                if equity_denominator is not None:
+                    runtime_bucket["account_equity"] = str(equity_denominator[0])
+                    runtime_bucket["account_equity_source"] = equity_denominator[1]
+                row["runtime_ledger_bucket"] = runtime_bucket
+        elif source_backed_runtime_ledger:
+            row["post_cost_expectancy_basis"] = POST_COST_BASIS_RUNTIME_LEDGER
+            row["post_cost_promotion_eligible"] = False
+            row["authoritative"] = False
+            row["authority_reason"] = (
+                "source_execution_lifecycle_materialized_runtime_ledger"
+            )
+            row["pnl_derivation"] = "execution_order_events_runtime_ledger"
+            blockers = list(row.get("runtime_ledger_blockers") or [])
+            row["runtime_ledger_blockers"] = blockers
+            if blockers:
+                row["promotion_blocker"] = blockers[0]
+            else:
+                row.pop("promotion_blocker", None)
+            if isinstance(bucket_payload, Mapping):
+                runtime_bucket = {
+                    **dict(bucket_payload),
+                    "blockers": blockers,
+                    "pnl_basis": POST_COST_BASIS_RUNTIME_LEDGER,
+                    "authoritative": False,
+                    "authority_reason": (
+                        "source_execution_lifecycle_materialized_runtime_ledger"
+                    ),
                     "pnl_derivation": "execution_order_events_runtime_ledger",
                     "source_materialization": "execution_order_events",
                 }

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -3026,6 +3026,202 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
 
+    def test_build_realized_strategy_pnl_rows_preserves_source_backed_blocked_basis(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "execution_id": "exec-buy",
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "route_acquisition_probe",
+                },
+                {
+                    "execution_id": "exec-sell",
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "route_acquisition_probe",
+                },
+            ],
+            decision_lifecycle_rows=[
+                {
+                    "trade_decision_id": "decision-buy",
+                    "executed_at": datetime(
+                        2026, 3, 6, 14, 35, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "event_type": "decision",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "route_acquisition_probe",
+                },
+                {
+                    "trade_decision_id": "decision-sell",
+                    "executed_at": datetime(
+                        2026, 3, 6, 14, 40, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "event_type": "decision",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "route_acquisition_probe",
+                },
+            ],
+            order_lifecycle_rows=[
+                {
+                    "execution_order_event_id": "event-new-buy",
+                    "trade_decision_id": "decision-buy",
+                    "execution_id": "exec-buy",
+                    "event_ts": datetime(
+                        2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "event_type": "new",
+                    "source_topic": "alpaca-trade-updates",
+                    "source_partition": 0,
+                    "source_offset": 11,
+                    "source_window_id": "source-window-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "route_acquisition_probe",
+                },
+                {
+                    "execution_order_event_id": "event-fill-buy",
+                    "trade_decision_id": "decision-buy",
+                    "execution_id": "exec-buy",
+                    "event_ts": datetime(
+                        2026, 3, 6, 14, 35, 2, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "event_type": "fill",
+                    "source_topic": "alpaca-trade-updates",
+                    "source_partition": 0,
+                    "source_offset": 12,
+                    "source_window_id": "source-window-buy",
+                    "source_decision_mode": "route_acquisition_probe",
+                },
+                {
+                    "execution_order_event_id": "event-new-sell",
+                    "trade_decision_id": "decision-sell",
+                    "execution_id": "exec-sell",
+                    "event_ts": datetime(
+                        2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "event_type": "new",
+                    "source_topic": "alpaca-trade-updates",
+                    "source_partition": 0,
+                    "source_offset": 13,
+                    "source_window_id": "source-window-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "route_acquisition_probe",
+                },
+                {
+                    "execution_order_event_id": "event-fill-sell",
+                    "trade_decision_id": "decision-sell",
+                    "execution_id": "exec-sell",
+                    "event_ts": datetime(
+                        2026, 3, 6, 14, 40, 2, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "event_type": "fill",
+                    "source_topic": "alpaca-trade-updates",
+                    "source_partition": 0,
+                    "source_offset": 14,
+                    "source_window_id": "source-window-sell",
+                    "source_decision_mode": "route_acquisition_probe",
+                },
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertFalse(row["post_cost_promotion_eligible"])
+        self.assertFalse(row["authoritative"])
+        self.assertEqual(
+            row["authority_reason"],
+            "source_execution_lifecycle_materialized_runtime_ledger",
+        )
+        self.assertEqual(row["pnl_derivation"], "execution_order_events_runtime_ledger")
+        self.assertEqual(
+            row["promotion_blocker"],
+            "source_decision_mode_not_profit_proof_eligible",
+        )
+        self.assertNotIn(
+            "execution_reconstruction_not_runtime_ledger_proof",
+            row["runtime_ledger_blockers"],
+        )
+
+        bucket = row["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["pnl_basis"], POST_COST_BASIS_RUNTIME_LEDGER)
+        self.assertEqual(bucket["source_materialization"], "execution_order_events")
+        self.assertEqual(
+            bucket["authority_reason"],
+            "source_execution_lifecycle_materialized_runtime_ledger",
+        )
+        self.assertEqual(
+            bucket["source_decision_mode_counts"], {"route_acquisition_probe": 8}
+        )
+        self.assertIn(
+            "source_decision_mode_not_profit_proof_eligible", bucket["blockers"]
+        )
+        self.assertNotIn(
+            "runtime_ledger_pnl_basis_not_runtime_ledger",
+            _runtime_ledger_bucket_profit_proof_blockers(bucket),
+        )
+        self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
+
     def test_runtime_ledger_tca_row_separates_explicit_cost_from_slippage(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Preserves source-backed execution/order-feed runtime-ledger materialization when buckets are blocked for promotion.
- Stops relabeling source-backed but blocked rows as execution reconstruction solely because final profit-proof gates are not satisfied.
- Keeps promotion blocked by carrying the real bucket blockers, including route-acquisition and unclosed-position blockers.
- Adds regression coverage for source-window/order-feed backed route-acquisition rows staying non-promotable while retaining runtime-ledger basis.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'preserves_source_backed_blocked_basis or marks_route_acquisition_not_profit_proof' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
