### PR TITLE
fix(torghut): split runtime ledger source decision modes

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -121,6 +121,7 @@ SOURCE_LINEAGE_HYPOTHESIS_KEYS = (
     "source_hypothesis_id",
     "source_hypothesis_ids",
 )
+SOURCE_DECISION_MODE_MISSING_PARTITION = "source_decision_mode_missing"
 
 
 def _parse_args() -> argparse.Namespace:
@@ -381,6 +382,134 @@ def _source_decision_mode_counts(
             continue
         counts[mode] = counts.get(mode, 0) + 1
     return dict(sorted(counts.items()))
+
+
+def _source_decision_identifier_values(row: Mapping[str, object]) -> set[str]:
+    return _text_values(
+        row,
+        "trade_decision_id",
+        "decision_id",
+        "decision_hash",
+    )
+
+
+def _source_decision_mode_lookup(
+    rows: Sequence[Mapping[str, object]],
+) -> dict[str, str]:
+    modes_by_identifier: dict[str, str] = {}
+    conflicting_identifiers: set[str] = set()
+    for row in rows:
+        mode = _source_decision_mode(row)
+        if mode is None:
+            continue
+        for identifier in _source_decision_identifier_values(row):
+            existing = modes_by_identifier.get(identifier)
+            if existing is not None and existing != mode:
+                conflicting_identifiers.add(identifier)
+                continue
+            modes_by_identifier[identifier] = mode
+    for identifier in conflicting_identifiers:
+        modes_by_identifier.pop(identifier, None)
+    return modes_by_identifier
+
+
+def _source_decision_mode_partition_key(
+    row: Mapping[str, object],
+    *,
+    modes_by_identifier: Mapping[str, str],
+) -> str:
+    explicit = _source_decision_mode(row)
+    if explicit is not None:
+        return explicit
+    inferred_modes = {
+        modes_by_identifier[identifier]
+        for identifier in _source_decision_identifier_values(row)
+        if identifier in modes_by_identifier
+    }
+    if len(inferred_modes) == 1:
+        return next(iter(inferred_modes))
+    return SOURCE_DECISION_MODE_MISSING_PARTITION
+
+
+def _partition_runtime_source_rows_by_decision_mode(
+    *,
+    execution_rows: list[dict[str, object]],
+    decision_lifecycle_rows: list[dict[str, object]] | None,
+    order_lifecycle_rows: list[dict[str, object]] | None,
+) -> (
+    list[
+        tuple[
+            str,
+            list[dict[str, object]],
+            list[dict[str, object]] | None,
+            list[dict[str, object]] | None,
+        ]
+    ]
+    | None
+):
+    source_rows: list[dict[str, object]] = [
+        *execution_rows,
+        *(decision_lifecycle_rows or []),
+        *(order_lifecycle_rows or []),
+    ]
+    if not source_rows:
+        return None
+    modes_by_identifier = _source_decision_mode_lookup(source_rows)
+    mode_keys = {
+        _source_decision_mode_partition_key(
+            row,
+            modes_by_identifier=modes_by_identifier,
+        )
+        for row in source_rows
+    }
+    if len(mode_keys) <= 1:
+        return None
+
+    partitions: list[
+        tuple[
+            str,
+            list[dict[str, object]],
+            list[dict[str, object]] | None,
+            list[dict[str, object]] | None,
+        ]
+    ] = []
+    for mode_key in sorted(mode_keys):
+        partition_execution_rows = [
+            row
+            for row in execution_rows
+            if _source_decision_mode_partition_key(
+                row,
+                modes_by_identifier=modes_by_identifier,
+            )
+            == mode_key
+        ]
+        partition_decision_rows = [
+            row
+            for row in decision_lifecycle_rows or []
+            if _source_decision_mode_partition_key(
+                row,
+                modes_by_identifier=modes_by_identifier,
+            )
+            == mode_key
+        ]
+        partition_order_rows = [
+            row
+            for row in order_lifecycle_rows or []
+            if _source_decision_mode_partition_key(
+                row,
+                modes_by_identifier=modes_by_identifier,
+            )
+            == mode_key
+        ]
+        partitions.append(
+            (
+                mode_key,
+                partition_execution_rows,
+                partition_decision_rows or None,
+                partition_order_rows or None,
+            )
+        )
+    return partitions
 
 
 def _source_decision_rows_profit_proof_eligible(
@@ -2072,7 +2201,41 @@ def _build_realized_strategy_pnl_rows(
     decision_lifecycle_rows: list[dict[str, object]] | None = None,
     order_lifecycle_rows: list[dict[str, object]] | None = None,
     allow_authoritative_runtime_ledger_materialization: bool = False,
+    split_mixed_source_decision_modes: bool = True,
 ) -> list[dict[str, object]]:
+    if split_mixed_source_decision_modes:
+        partitions = _partition_runtime_source_rows_by_decision_mode(
+            execution_rows=execution_rows,
+            decision_lifecycle_rows=decision_lifecycle_rows,
+            order_lifecycle_rows=order_lifecycle_rows,
+        )
+        if partitions is not None:
+            partition_rows: list[dict[str, object]] = []
+            for (
+                mode_key,
+                partition_execution_rows,
+                partition_decision_rows,
+                partition_order_rows,
+            ) in partitions:
+                for row in _build_realized_strategy_pnl_rows(
+                    partition_execution_rows,
+                    decision_lifecycle_rows=partition_decision_rows,
+                    order_lifecycle_rows=partition_order_rows,
+                    allow_authoritative_runtime_ledger_materialization=(
+                        allow_authoritative_runtime_ledger_materialization
+                    ),
+                    split_mixed_source_decision_modes=False,
+                ):
+                    row["source_decision_mode_partition"] = mode_key
+                    bucket = row.get("runtime_ledger_bucket")
+                    if isinstance(bucket, Mapping):
+                        row["runtime_ledger_bucket"] = {
+                            **dict(bucket),
+                            "source_decision_mode_partition": mode_key,
+                        }
+                    partition_rows.append(row)
+            return partition_rows
+
     ledger_rows: list[RuntimeLedgerFill | dict[str, object]] = []
     event_times: list[datetime] = []
     event_sourced_lifecycle_rows = 0
@@ -2340,11 +2503,18 @@ def _build_realized_strategy_pnl_rows(
             row["source_decision_mode_counts"] = source_decision_mode_counts
             row["profit_proof_eligible"] = source_decision_profit_proof_eligible
             if isinstance(bucket_payload, Mapping):
+                source_decision_mode = next(
+                    iter(source_decision_mode_counts),
+                    None,
+                )
                 bucket_payload = {
                     **dict(bucket_payload),
                     "source_decision_mode_counts": source_decision_mode_counts,
                     "profit_proof_eligible": source_decision_profit_proof_eligible,
                 }
+                if len(source_decision_mode_counts) == 1:
+                    row["source_decision_mode"] = source_decision_mode
+                    bucket_payload["source_decision_mode"] = source_decision_mode
                 if not source_decision_profit_proof_eligible:
                     blockers = list(bucket_payload.get("blockers") or [])
                     if (

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -3026,6 +3026,261 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
 
+    def test_build_realized_strategy_pnl_rows_partitions_mixed_source_decision_modes(
+        self,
+    ) -> None:
+        def execution_row(
+            *,
+            decision_id: str,
+            execution_id: str,
+            mode: str,
+            side: str,
+            price: str,
+            minute: int,
+        ) -> dict[str, object]:
+            return {
+                "execution_id": execution_id,
+                "trade_decision_id": decision_id,
+                "computed_at": datetime(2026, 3, 6, 14, minute, tzinfo=timezone.utc),
+                "execution_event_at": datetime(
+                    2026,
+                    3,
+                    6,
+                    14,
+                    minute,
+                    tzinfo=timezone.utc,
+                ),
+                "symbol": "AAPL",
+                "side": side,
+                "filled_qty": Decimal("1"),
+                "avg_fill_price": Decimal(price),
+                "cost_amount": Decimal("0.10"),
+                "cost_basis": "broker_reported_commission_and_fees",
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "microbar-cross-sectional-pairs-v1",
+                "decision_hash": f"{decision_id}-hash",
+                "alpaca_order_id": f"{execution_id}-order",
+                "execution_policy_hash": "policy-sha",
+                "cost_model_hash": "cost-sha",
+                "lineage_hash": "lineage-sha",
+                "source_decision_mode": mode,
+            }
+
+        def decision_row(
+            *,
+            decision_id: str,
+            mode: str,
+            minute: int,
+        ) -> dict[str, object]:
+            return {
+                "trade_decision_id": decision_id,
+                "computed_at": datetime(2026, 3, 6, 14, minute, tzinfo=timezone.utc),
+                "symbol": "AAPL",
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "microbar-cross-sectional-pairs-v1",
+                "decision_hash": f"{decision_id}-hash",
+                "event_type": "decision",
+                "execution_policy_hash": "policy-sha",
+                "cost_model_hash": "cost-sha",
+                "lineage_hash": "lineage-sha",
+                "source_decision_mode": mode,
+            }
+
+        def order_event_row(
+            *,
+            decision_id: str,
+            execution_id: str,
+            mode: str,
+            event_id: str,
+            event_type: str,
+            offset: int,
+            minute: int,
+        ) -> dict[str, object]:
+            return {
+                "execution_order_event_id": event_id,
+                "trade_decision_id": decision_id,
+                "execution_id": execution_id,
+                "event_ts": datetime(2026, 3, 6, 14, minute, 1, tzinfo=timezone.utc),
+                "symbol": "AAPL",
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "microbar-cross-sectional-pairs-v1",
+                "decision_hash": f"{decision_id}-hash",
+                "alpaca_order_id": f"{execution_id}-order",
+                "event_type": event_type,
+                "source_topic": "alpaca-trade-updates",
+                "source_partition": 0,
+                "source_offset": offset,
+                "source_window_id": f"source-window-{mode}",
+                "execution_policy_hash": "policy-sha",
+                "cost_model_hash": "cost-sha",
+                "lineage_hash": "lineage-sha",
+                "source_decision_mode": mode,
+            }
+
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                execution_row(
+                    decision_id="route-buy",
+                    execution_id="route-buy-exec",
+                    mode="route_acquisition_probe",
+                    side="buy",
+                    price="100",
+                    minute=35,
+                ),
+                execution_row(
+                    decision_id="route-sell",
+                    execution_id="route-sell-exec",
+                    mode="route_acquisition_probe",
+                    side="sell",
+                    price="101",
+                    minute=36,
+                ),
+                execution_row(
+                    decision_id="signal-buy",
+                    execution_id="signal-buy-exec",
+                    mode="strategy_signal_paper",
+                    side="buy",
+                    price="110",
+                    minute=45,
+                ),
+                execution_row(
+                    decision_id="signal-sell",
+                    execution_id="signal-sell-exec",
+                    mode="strategy_signal_paper",
+                    side="sell",
+                    price="112",
+                    minute=50,
+                ),
+            ],
+            decision_lifecycle_rows=[
+                decision_row(
+                    decision_id="route-buy",
+                    mode="route_acquisition_probe",
+                    minute=35,
+                ),
+                decision_row(
+                    decision_id="route-sell",
+                    mode="route_acquisition_probe",
+                    minute=36,
+                ),
+                decision_row(
+                    decision_id="signal-buy",
+                    mode="strategy_signal_paper",
+                    minute=45,
+                ),
+                decision_row(
+                    decision_id="signal-sell",
+                    mode="strategy_signal_paper",
+                    minute=50,
+                ),
+            ],
+            order_lifecycle_rows=[
+                order_event_row(
+                    decision_id="route-buy",
+                    execution_id="route-buy-exec",
+                    mode="route_acquisition_probe",
+                    event_id="route-buy-new",
+                    event_type="new",
+                    offset=11,
+                    minute=35,
+                ),
+                order_event_row(
+                    decision_id="route-buy",
+                    execution_id="route-buy-exec",
+                    mode="route_acquisition_probe",
+                    event_id="route-buy-fill",
+                    event_type="fill",
+                    offset=12,
+                    minute=35,
+                ),
+                order_event_row(
+                    decision_id="route-sell",
+                    execution_id="route-sell-exec",
+                    mode="route_acquisition_probe",
+                    event_id="route-sell-new",
+                    event_type="new",
+                    offset=13,
+                    minute=36,
+                ),
+                order_event_row(
+                    decision_id="route-sell",
+                    execution_id="route-sell-exec",
+                    mode="route_acquisition_probe",
+                    event_id="route-sell-fill",
+                    event_type="fill",
+                    offset=14,
+                    minute=36,
+                ),
+                order_event_row(
+                    decision_id="signal-buy",
+                    execution_id="signal-buy-exec",
+                    mode="strategy_signal_paper",
+                    event_id="signal-buy-new",
+                    event_type="new",
+                    offset=21,
+                    minute=45,
+                ),
+                order_event_row(
+                    decision_id="signal-buy",
+                    execution_id="signal-buy-exec",
+                    mode="strategy_signal_paper",
+                    event_id="signal-buy-fill",
+                    event_type="fill",
+                    offset=22,
+                    minute=45,
+                ),
+                order_event_row(
+                    decision_id="signal-sell",
+                    execution_id="signal-sell-exec",
+                    mode="strategy_signal_paper",
+                    event_id="signal-sell-new",
+                    event_type="new",
+                    offset=23,
+                    minute=50,
+                ),
+                order_event_row(
+                    decision_id="signal-sell",
+                    execution_id="signal-sell-exec",
+                    mode="strategy_signal_paper",
+                    event_id="signal-sell-fill",
+                    event_type="fill",
+                    offset=24,
+                    minute=50,
+                ),
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 2)
+        rows_by_mode = {str(row["source_decision_mode"]): row for row in rows}
+        self.assertEqual(
+            sorted(rows_by_mode),
+            ["route_acquisition_probe", "strategy_signal_paper"],
+        )
+
+        route_row = rows_by_mode["route_acquisition_probe"]
+        self.assertFalse(route_row["post_cost_promotion_eligible"])
+        self.assertIn(
+            "source_decision_mode_not_profit_proof_eligible",
+            route_row["runtime_ledger_blockers"],
+        )
+
+        signal_row = rows_by_mode["strategy_signal_paper"]
+        self.assertTrue(signal_row["post_cost_promotion_eligible"])
+        self.assertEqual(
+            signal_row["authority_reason"],
+            "event_sourced_runtime_ledger_profit_proof",
+        )
+        signal_bucket = cast(Mapping[str, object], signal_row["runtime_ledger_bucket"])
+        self.assertEqual(
+            signal_bucket["source_decision_mode_counts"],
+            {"strategy_signal_paper": 8},
+        )
+        self.assertEqual(
+            signal_bucket["source_materialization"], "execution_order_events"
+        )
+        self.assertTrue(_runtime_ledger_bucket_profit_proof_present(signal_bucket))
+
     def test_build_realized_strategy_pnl_rows_preserves_source_backed_blocked_basis(
         self,
     ) -> None:
@@ -3067,9 +3322,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             decision_lifecycle_rows=[
                 {
                     "trade_decision_id": "decision-buy",
-                    "executed_at": datetime(
-                        2026, 3, 6, 14, 35, tzinfo=timezone.utc
-                    ),
+                    "executed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
                     "symbol": "AAPL",
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
@@ -3082,9 +3335,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 },
                 {
                     "trade_decision_id": "decision-sell",
-                    "executed_at": datetime(
-                        2026, 3, 6, 14, 40, tzinfo=timezone.utc
-                    ),
+                    "executed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
                     "symbol": "AAPL",
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
@@ -3101,9 +3352,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_order_event_id": "event-new-buy",
                     "trade_decision_id": "decision-buy",
                     "execution_id": "exec-buy",
-                    "event_ts": datetime(
-                        2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc
-                    ),
+                    "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
                     "symbol": "AAPL",
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
@@ -3123,9 +3372,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_order_event_id": "event-fill-buy",
                     "trade_decision_id": "decision-buy",
                     "execution_id": "exec-buy",
-                    "event_ts": datetime(
-                        2026, 3, 6, 14, 35, 2, tzinfo=timezone.utc
-                    ),
+                    "event_ts": datetime(2026, 3, 6, 14, 35, 2, tzinfo=timezone.utc),
                     "symbol": "AAPL",
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
@@ -3142,9 +3389,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_order_event_id": "event-new-sell",
                     "trade_decision_id": "decision-sell",
                     "execution_id": "exec-sell",
-                    "event_ts": datetime(
-                        2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc
-                    ),
+                    "event_ts": datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
                     "symbol": "AAPL",
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
@@ -3164,9 +3409,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "execution_order_event_id": "event-fill-sell",
                     "trade_decision_id": "decision-sell",
                     "execution_id": "exec-sell",
-                    "event_ts": datetime(
-                        2026, 3, 6, 14, 40, 2, tzinfo=timezone.utc
-                    ),
+                    "event_ts": datetime(2026, 3, 6, 14, 40, 2, tzinfo=timezone.utc),
                     "symbol": "AAPL",
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "microbar-cross-sectional-pairs-v1",


### PR DESCRIPTION
## Summary

- Partition runtime-ledger import rows by source-decision mode before building source-backed PnL buckets.
- Keep `route_acquisition_probe` evidence blocked while allowing `strategy_signal_paper` rows to stand or fail on their own lifecycle/source/cost proof.
- Persist single-mode source-decision labels into the runtime bucket payload for clearer blocker diagnostics.
- Add a regression test covering mixed acquisition and strategy-signal evidence in the same runtime window.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
