### PR TITLE
fix(torghut): isolate runtime position evaluation

### DIFF
--- a/services/torghut/app/trading/decisions.py
+++ b/services/torghut/app/trading/decisions.py
@@ -42,7 +42,10 @@ from .quantity_rules import (
 from .session_context import SessionContextTracker
 from .simulation import resolve_simulation_context
 from .strategy_runtime import (
+    AggregatedIntent,
     RuntimeErrorRecord,
+    RuntimeDecision,
+    RuntimeEvaluation,
     RuntimeObservation,
     StrategyRegistry,
     StrategyRuntime,
@@ -122,6 +125,88 @@ class DecisionRuntimeTelemetry:
     errors: tuple[RuntimeErrorRecord, ...] = field(default_factory=tuple)
     observation: RuntimeObservation | None = None
     traces: tuple[StrategyTrace, ...] = field(default_factory=tuple)
+
+
+def _runtime_position_side(position_qty: Decimal | None) -> str | None:
+    if position_qty is None:
+        return None
+    if position_qty > 0:
+        return "long"
+    if position_qty < 0:
+        return "short"
+    return "flat"
+
+
+def _feature_vector_with_positions(
+    feature_vector: FeatureVectorV3,
+    *,
+    positions: Optional[list[dict[str, Any]]],
+    symbol: str,
+) -> FeatureVectorV3:
+    position_qty = _position_qty_for_symbol(positions, symbol)
+    if position_qty is None:
+        return feature_vector
+    return _feature_vector_with_runtime_position(
+        feature_vector,
+        position_qty=position_qty,
+        position_side=_runtime_position_side(position_qty),
+    )
+
+
+def _merge_runtime_counter(
+    target: dict[str, int],
+    source: Mapping[str, int],
+) -> None:
+    for key, value in source.items():
+        target[str(key)] = target.get(str(key), 0) + int(value)
+
+
+def _merge_runtime_evaluations(
+    evaluations: Iterable[RuntimeEvaluation],
+) -> RuntimeEvaluation:
+    intents: list[AggregatedIntent] = []
+    raw_intents: list[RuntimeDecision] = []
+    traces: list[StrategyTrace] = []
+    errors: list[RuntimeErrorRecord] = []
+    observation = RuntimeObservation()
+    for evaluation in evaluations:
+        intents.extend(evaluation.intents)
+        raw_intents.extend(evaluation.raw_intents)
+        traces.extend(evaluation.traces)
+        errors.extend(evaluation.errors)
+        _merge_runtime_counter(
+            observation.strategy_events_total,
+            evaluation.observation.strategy_events_total,
+        )
+        _merge_runtime_counter(
+            observation.strategy_intents_total,
+            evaluation.observation.strategy_intents_total,
+        )
+        _merge_runtime_counter(
+            observation.strategy_intent_suppression_total,
+            evaluation.observation.strategy_intent_suppression_total,
+        )
+        _merge_runtime_counter(
+            observation.strategy_errors_total,
+            evaluation.observation.strategy_errors_total,
+        )
+        _merge_runtime_counter(
+            observation.strategy_latency_ms,
+            evaluation.observation.strategy_latency_ms,
+        )
+        observation.intent_conflicts_total += (
+            evaluation.observation.intent_conflicts_total
+        )
+        observation.isolated_failures_total += (
+            evaluation.observation.isolated_failures_total
+        )
+    return RuntimeEvaluation(
+        intents=intents,
+        raw_intents=raw_intents,
+        traces=traces,
+        errors=errors,
+        observation=observation,
+    )
 
 
 @dataclass
@@ -260,12 +345,7 @@ class DecisionEngine:
         runtime_position_side: str | None = None
         if runtime_position_qty is not None:
             normalized_payload["runtime_position_qty"] = str(runtime_position_qty)
-            if runtime_position_qty > 0:
-                runtime_position_side = "long"
-            elif runtime_position_qty < 0:
-                runtime_position_side = "short"
-            else:
-                runtime_position_side = "flat"
+            runtime_position_side = _runtime_position_side(runtime_position_qty)
             normalized_payload["runtime_position_side"] = runtime_position_side
         normalized_signal = signal.model_copy(update={"payload": normalized_payload})
         try:
@@ -278,16 +358,60 @@ class DecisionEngine:
                 fallback_to_legacy=False,
             )
             return []
+        account_feature_vector = feature_vector
         if runtime_position_qty is not None:
-            feature_vector = _feature_vector_with_runtime_position(
+            account_feature_vector = _feature_vector_with_runtime_position(
                 feature_vector,
                 position_qty=runtime_position_qty,
                 position_side=runtime_position_side,
             )
 
-        runtime_eval = self.strategy_runtime.evaluate_all(
-            strategies, feature_vector, timeframe=timeframe
-        )
+        strategies_by_id = {str(strategy.id): strategy for strategy in strategies}
+        isolated_strategy_ids = {
+            str(strategy.id)
+            for strategy in strategies
+            if _strategy_uses_position_isolation(strategy)
+        }
+        non_isolated_strategy_ids = {
+            str(strategy.id)
+            for strategy in strategies
+            if str(strategy.id) not in isolated_strategy_ids
+        }
+        runtime_evaluations: list[RuntimeEvaluation] = []
+        non_isolated_strategies = [
+            strategy
+            for strategy in strategies
+            if str(strategy.id) in non_isolated_strategy_ids
+        ]
+        if non_isolated_strategies:
+            runtime_evaluations.append(
+                self.strategy_runtime.evaluate_all(
+                    non_isolated_strategies,
+                    account_feature_vector,
+                    timeframe=timeframe,
+                )
+            )
+        for isolated_strategy_id in sorted(isolated_strategy_ids):
+            strategy = strategies_by_id.get(isolated_strategy_id)
+            if strategy is None:
+                continue
+            isolated_positions = _positions_for_strategy_action(
+                actual_positions,
+                strategy_id=isolated_strategy_id,
+                action="sell",
+            )
+            runtime_evaluations.append(
+                self.strategy_runtime.evaluate_all(
+                    [strategy],
+                    _feature_vector_with_positions(
+                        feature_vector,
+                        positions=isolated_positions,
+                        symbol=signal.symbol,
+                    ),
+                    timeframe=timeframe,
+                )
+            )
+        runtime_eval = _merge_runtime_evaluations(runtime_evaluations)
         self._last_runtime_telemetry = DecisionRuntimeTelemetry(
             mode=settings.trading_strategy_runtime_mode,
             runtime_enabled=True,
@@ -300,20 +424,9 @@ class DecisionEngine:
         decisions: list[StrategyDecision] = []
         self._last_forecast_telemetry = []
 
-        strategies_by_id = {str(strategy.id): strategy for strategy in strategies}
         raw_runtime_by_strategy_id = {
             item.intent.strategy_id: item.metadata()
             for item in runtime_eval.raw_intents
-        }
-        isolated_strategy_ids = {
-            str(strategy.id)
-            for strategy in strategies
-            if _strategy_uses_position_isolation(strategy)
-        }
-        non_isolated_strategy_ids = {
-            str(strategy.id)
-            for strategy in strategies
-            if str(strategy.id) not in isolated_strategy_ids
         }
         aggregated_intents, _ = self.strategy_runtime.aggregator.aggregate(
             [

--- a/services/torghut/tests/test_decisions.py
+++ b/services/torghut/tests/test_decisions.py
@@ -2592,6 +2592,121 @@ class TestDecisionEngine(TestCase):
         self.assertEqual(position_exit.get("type"), "runtime_signal_exit")
         self.assertEqual(position_exit.get("position_side"), "short")
 
+    def test_scheduler_runtime_microbar_pairs_signal_exit_uses_isolated_short_when_account_long(
+        self,
+    ) -> None:
+        strategy_id = uuid.uuid4()
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=strategy_id,
+            name="microbar-pairs-runtime",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="microbar-pairs-runtime",
+                    strategy_id="microbar_cross_sectional_pairs_v1@research",
+                    strategy_type="microbar_cross_sectional_pairs_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="microbar_cross_sectional_pairs_v1",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_position_pct_equity=Decimal("1.0"),
+                    max_notional_per_trade=Decimal("100"),
+                    params={
+                        "entry_minute_after_open": "60",
+                        "exit_minute_after_open": "120",
+                        "signal_motif": "vwap_close_continuation",
+                        "rank_feature": "cross_section_vwap_w5m_rank",
+                        "selection_mode": "continuation",
+                        "max_pair_legs": "2",
+                        "position_isolation_mode": "per_strategy",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+            max_position_pct_equity=Decimal("1.0"),
+            max_notional_per_trade=Decimal("100"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 15, 30, 0, tzinfo=timezone.utc),
+            symbol="AMZN",
+            timeframe="1Sec",
+            seq=1,
+            payload={
+                "price": 99,
+                "spread": 0.02,
+                "imbalance_bid_px": 98.99,
+                "imbalance_ask_px": 99.01,
+                "macd": 0.010,
+                "macd_signal": 0.008,
+                "rsi14": 56.4,
+                "vwap_w5m": 100,
+                "session_minutes_elapsed": 120,
+                "cross_section_continuation_breadth": 0.5,
+                "cross_section_session_open_rank": 0.5,
+                "cross_section_vwap_w5m_rank": 0.5,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+            patch.object(settings, "trading_allow_shorts", True),
+        ):
+            engine.evaluate(
+                signal.model_copy(
+                    update={
+                        "symbol": "AAPL",
+                        "payload": {
+                            **signal.payload,
+                            "price": 101,
+                            "imbalance_bid_px": 100.99,
+                            "imbalance_ask_px": 101.01,
+                            "vwap_w5m": 100,
+                        },
+                    }
+                ),
+                [strategy],
+                positions=[],
+            )
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "strategy_id": "route-acquisition-probe",
+                        "symbol": "AMZN",
+                        "qty": "1.00",
+                        "side": "long",
+                        "market_value": "99",
+                        "avg_entry_price": "99",
+                    },
+                    {
+                        "strategy_id": str(strategy_id),
+                        "symbol": "AMZN",
+                        "qty": "0.25",
+                        "side": "short",
+                        "market_value": "-24.75",
+                        "avg_entry_price": "100",
+                    },
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "buy")
+        self.assertEqual(decisions[0].qty, Decimal("0.25"))
+        self.assertIn("microbar_cross_sectional_pair_exit", decisions[0].rationale)
+        position_exit = decisions[0].params.get("position_exit")
+        assert isinstance(position_exit, dict)
+        self.assertEqual(position_exit.get("type"), "runtime_signal_exit")
+        self.assertEqual(position_exit.get("position_side"), "short")
+        runtime_params = decisions[0].params.get("strategy_runtime")
+        assert isinstance(runtime_params, dict)
+        self.assertEqual(runtime_params.get("position_isolation_mode"), "per_strategy")
+
     def test_scheduler_runtime_isolated_buy_cooldown_is_scoped_per_strategy(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Evaluates `position_isolation_mode=per_strategy` runtime strategies with a per-strategy position snapshot instead of account-level inventory.
- Keeps non-isolated strategies on the existing account-level runtime position feature vector.
- Merges scoped runtime telemetry back into the decision engine and adds a H-PAIRS regression for account-long but strategy-short AMZN exits.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_decisions.py -k "microbar_pairs_signal_exit" -q`
- `uv run --frozen pytest tests/test_decisions.py tests/test_strategy_runtime.py -q`
- `uv run --frozen ruff check app/trading/decisions.py tests/test_decisions.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A (service-side trading decision change).

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
