### PR TITLE
chore(bilig): promote app image baf4a88

### DIFF
--- a/argocd/applications/bilig/kustomization.yaml
+++ b/argocd/applications/bilig/kustomization.yaml
@@ -23,4 +23,4 @@ resources:
 images:
   - name: registry.ide-newton.ts.net/lab/bilig-app
     newName: registry.ide-newton.ts.net/lab/bilig-app
-    newTag: 44a7fa210fdf38c17ecfcf4f154c7e1c5a1c647b
+    newTag: baf4a887f0a3fd44bf800b60c1e6d2df07f0f32e


### PR DESCRIPTION
## Summary

- Promotes the Bilig app deployment image from `44a7fa210fdf38c17ecfcf4f154c7e1c5a1c647b` to `baf4a887f0a3fd44bf800b60c1e6d2df07f0f32e`.
- Deploys the current Bilig main image that includes the toolbar overflow fix and cache-doctor report versioning fix.
- Leaves the change scoped to the Bilig app image pin in the Argo CD application.

## Related Issues

None

## Testing

- `docker manifest inspect registry.ide-newton.ts.net/lab/bilig-app:baf4a887f0a3fd44bf800b60c1e6d2df07f0f32e`
- `git diff --check`
- `bun run lint:argocd`
- `kubectl -n bilig get deploy bilig-app -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}{.status.readyReplicas}{"/"}{.spec.replicas}{" ready\n"}'`

## Screenshots (if applicable)

N/A. GitOps image promotion only; live toolbar verification will happen after rollout.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
