### PR TITLE
fix(torghut): split lifecycle proof from fill economics

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -283,10 +283,11 @@ def _build_bucket(
     for row in lifecycle_rows:
         if row.execution_policy_hash is not None:
             execution_policy_hash_counter[row.execution_policy_hash] += 1
-        if row.cost_model_hash is not None:
-            cost_model_hash_counter[row.cost_model_hash] += 1
         if (lineage_hash := row.lineage_hash or row.replay_data_hash) is not None:
             lineage_hash_counter[lineage_hash] += 1
+    for row in usable_fills:
+        if row.cost_model_hash is not None:
+            cost_model_hash_counter[row.cost_model_hash] += 1
 
     positions: dict[tuple[str | None, str | None, str | None], _PositionState] = (
         carried_positions if carried_positions is not None else {}
@@ -424,19 +425,15 @@ def _order_lifecycle_blockers(
     if unfilled_order_count > 0:
         blockers.append("unfilled_order_present")
 
-    if any(row.execution_policy_hash is None for row in lifecycle_rows):
+    if not usable_fills or any(row.execution_policy_hash is None for row in usable_fills):
         blockers.append("execution_policy_hash_missing")
-    if any(row.cost_model_hash is None for row in lifecycle_rows):
+    if not usable_fills or any(row.cost_model_hash is None for row in usable_fills):
         blockers.append("cost_model_hash_missing")
     if any(
         row.lineage_hash is None and row.replay_data_hash is None
         for row in lifecycle_rows
     ):
         blockers.append("proof_lineage_hash_missing")
-    if len(execution_policy_hash_counter) > 1:
-        blockers.append("execution_policy_hash_ambiguous")
-    if len(cost_model_hash_counter) > 1:
-        blockers.append("cost_model_hash_ambiguous")
     if len(lineage_hash_counter) > 1:
         blockers.append("proof_lineage_hash_ambiguous")
     return blockers

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -1668,7 +1668,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "cost_basis": "broker_reported_commission_and_fees",
                     "decision_hash": "decision-buy",
                     "alpaca_order_id": "order-buy",
-                    "execution_policy_hash": "policy-sha",
+                    "execution_policy_hash": "policy-buy",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
                 },
@@ -1684,7 +1684,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "cost_basis": "broker_reported_commission_and_fees",
                     "decision_hash": "decision-sell",
                     "alpaca_order_id": "order-sell",
-                    "execution_policy_hash": "policy-sha",
+                    "execution_policy_hash": "policy-sell",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
                 },
@@ -1736,8 +1736,6 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "cost_basis": "broker_reported_commission_and_fees",
                     "decision_hash": "decision-buy",
                     "alpaca_order_id": "order-buy",
-                    "execution_policy_hash": "policy-sha",
-                    "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
                 },
                 {
@@ -1750,8 +1748,6 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "cost_basis": "broker_reported_commission_and_fees",
                     "decision_hash": "decision-sell",
                     "alpaca_order_id": "order-sell",
-                    "execution_policy_hash": "policy-sha",
-                    "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
                 },
             ],
@@ -1799,7 +1795,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "cost_basis": "broker_reported_commission_and_fees",
                     "decision_hash": "decision-buy",
                     "alpaca_order_id": "order-buy",
-                    "execution_policy_hash": "policy-sha",
+                    "execution_policy_hash": "policy-buy",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
                 },
@@ -1813,7 +1809,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "cost_basis": "broker_reported_commission_and_fees",
                     "decision_hash": "decision-sell",
                     "alpaca_order_id": "order-sell",
-                    "execution_policy_hash": "policy-sha",
+                    "execution_policy_hash": "policy-sell",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
                 },
@@ -1830,8 +1826,6 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "decision_json": {"account": {"equity": "10000"}},
                     "source_decision_mode": "strategy_signal_paper",
                     "profit_proof_eligible": True,
-                    "execution_policy_hash": "policy-sha",
-                    "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
                 },
                 {
@@ -1845,8 +1839,6 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "decision_json": {"account": {"equity": "10000"}},
                     "source_decision_mode": "strategy_signal_paper",
                     "profit_proof_eligible": True,
-                    "execution_policy_hash": "policy-sha",
-                    "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
                 },
             ],
@@ -1861,8 +1853,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
                     "decision_hash": "decision-buy",
                     "alpaca_order_id": "order-buy",
-                    "execution_policy_hash": "policy-sha",
-                    "cost_model_hash": "cost-sha",
+                    "execution_policy_hash": "policy-buy",
                     "lineage_hash": "lineage-sha",
                     "source_topic": "alpaca.trade_updates",
                     "source_partition": 0,
@@ -1879,8 +1870,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
                     "decision_hash": "decision-sell",
                     "alpaca_order_id": "order-sell",
-                    "execution_policy_hash": "policy-sha",
-                    "cost_model_hash": "cost-sha",
+                    "execution_policy_hash": "policy-sell",
                     "lineage_hash": "lineage-sha",
                     "source_topic": "alpaca.trade_updates",
                     "source_partition": 0,
@@ -1901,7 +1891,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
                     "decision_hash": "decision-buy",
                     "alpaca_order_id": "order-buy",
-                    "execution_policy_hash": "policy-sha",
+                    "execution_policy_hash": "policy-buy",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
                     "source_topic": "alpaca.trade_updates",
@@ -1923,7 +1913,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
                     "decision_hash": "decision-sell",
                     "alpaca_order_id": "order-sell",
-                    "execution_policy_hash": "policy-sha",
+                    "execution_policy_hash": "policy-sell",
                     "cost_model_hash": "cost-sha",
                     "lineage_hash": "lineage-sha",
                     "source_topic": "alpaca.trade_updates",
@@ -1953,6 +1943,11 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["cost_amount"], "0.30")
         self.assertEqual(
             bucket["cost_basis_counts"], {"broker_reported_commission_and_fees": 2}
+        )
+        self.assertEqual(bucket["cost_model_hash_counts"], {"cost-sha": 2})
+        self.assertEqual(
+            bucket["execution_policy_hash_counts"],
+            {"policy-buy": 2, "policy-sell": 2},
         )
         self.assertEqual(bucket["source_materialization"], "execution_order_events")
         self.assertEqual(bucket["account_equity"], "10000")

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -582,7 +582,7 @@ def test_exact_replay_ledger_requires_order_lifecycle_and_hash_lineage() -> None
     assert bucket.fill_count == 2
     assert bucket.net_strategy_pnl_after_costs == Decimal("97")
     assert bucket.execution_policy_hash_counts == {"policy-sha": 6}
-    assert bucket.cost_model_hash_counts == {"cost-sha": 6}
+    assert bucket.cost_model_hash_counts == {"cost-sha": 2}
     assert bucket.lineage_hash_counts == {"lineage-sha": 6}
     assert bucket.post_cost_expectancy_bps is not None
 
@@ -659,8 +659,85 @@ def test_exact_replay_ledger_does_not_use_idempotency_key_as_policy_hash() -> No
     assert bucket.execution_policy_hash_counts == {}
     assert "execution_policy_hash_missing" in bucket.blockers
     assert "execution_policy_hash_ambiguous" not in bucket.blockers
-    assert bucket.cost_model_hash_counts == {"cost-sha": 6}
+    assert bucket.cost_model_hash_counts == {"cost-sha": 2}
     assert bucket.lineage_hash_counts == {"lineage-sha": 6}
+
+
+def test_runtime_ledger_cost_hash_belongs_to_fill_economics_not_lifecycle() -> None:
+    lifecycle_common = {
+        "account_label": "paper",
+        "strategy_id": "strategy-1",
+        "symbol": "NVDA",
+        "lineage_hash": "lineage-sha",
+    }
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                **lifecycle_common,
+                "event_type": "decision",
+                "executed_at": _ts(1),
+                "decision_id": "decision-buy",
+            },
+            {
+                **lifecycle_common,
+                "event_type": "order_submitted",
+                "executed_at": _ts(2),
+                "decision_id": "decision-buy",
+                "order_id": "order-buy",
+                "execution_policy_hash": "policy-buy",
+            },
+            {
+                **lifecycle_common,
+                "event_type": "fill",
+                "executed_at": _ts(3),
+                "decision_id": "decision-buy",
+                "order_id": "order-buy",
+                "side": "buy",
+                "filled_qty": "10",
+                "avg_fill_price": "100",
+                "cost_amount": "1",
+                "cost_basis": "broker_reported_commission_and_fees",
+                "execution_policy_hash": "policy-buy",
+                "cost_model_hash": "cost-sha",
+            },
+            {
+                **lifecycle_common,
+                "event_type": "decision",
+                "executed_at": _ts(10),
+                "decision_id": "decision-sell",
+            },
+            {
+                **lifecycle_common,
+                "event_type": "order_submitted",
+                "executed_at": _ts(11),
+                "decision_id": "decision-sell",
+                "order_id": "order-sell",
+                "execution_policy_hash": "policy-sell",
+            },
+            {
+                **lifecycle_common,
+                "event_type": "fill",
+                "executed_at": _ts(12),
+                "decision_id": "decision-sell",
+                "order_id": "order-sell",
+                "side": "sell",
+                "filled_qty": "10",
+                "avg_fill_price": "110",
+                "cost_amount": "2",
+                "cost_basis": "broker_reported_commission_and_fees",
+                "execution_policy_hash": "policy-sell",
+                "cost_model_hash": "cost-sha",
+            },
+        ],
+        bucket_ranges=[(_ts(), _ts(60))],
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.blockers == []
+    assert bucket.execution_policy_hash_counts == {"policy-buy": 2, "policy-sell": 2}
+    assert bucket.cost_model_hash_counts == {"cost-sha": 2}
+    assert bucket.lineage_hash_counts == {"lineage-sha": 6}
+    assert bucket.post_cost_expectancy_bps is not None
 
 
 def test_runtime_ledger_blocks_non_promotion_grade_cost_basis_at_builder() -> None:


### PR DESCRIPTION
## Summary

- Split runtime-ledger lifecycle proof from fill economics so order-feed lifecycle rows prove source/order state while fill rows carry cost-model authority.
- Keep proof fail-closed by still requiring execution policy and cost model hashes on usable fills before lifecycle buckets can become blocker-free.
- Preserve per-order execution policy lineage as counts instead of treating multiple real policy hashes as an ambiguity blocker.
- Add regression coverage for source-backed runtime buckets where non-economics lifecycle rows omit cost hashes but fill rows provide authoritative cost lineage.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
