### PR TITLE
fix(torghut): block unlinked fill lifecycle proof

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -90,6 +90,9 @@ ORDER_FEED_FILL_LIFECYCLE_INCOMPLETE_BLOCKER = "order_feed_fill_lifecycle_incomp
 ORDER_FEED_FILL_LIFECYCLE_ORDER_ID_MISSING_BLOCKER = (
     "order_feed_fill_lifecycle_order_id_missing"
 )
+ORDER_FEED_UNLINKED_FILL_LIFECYCLE_PRESENT_BLOCKER = (
+    "order_feed_unlinked_fill_lifecycle_present"
+)
 ALPACA_2026_EQUITY_SEC_FEE_RATE = Decimal("20.60") / Decimal("1000000")
 ALPACA_2026_EQUITY_TAF_RATE_PER_SHARE = Decimal("0.000195")
 ALPACA_2026_EQUITY_TAF_CAP = Decimal("9.79")
@@ -2073,6 +2076,7 @@ def _order_feed_fill_lifecycle_blockers(
     *,
     execution_rows: list[dict[str, object]],
     order_lifecycle_rows: list[dict[str, object]] | None,
+    unlinked_order_lifecycle_rows: list[dict[str, object]] | None = None,
 ) -> list[str]:
     expected_order_ids: set[str] = set()
     missing_execution_order_id = False
@@ -2104,6 +2108,12 @@ def _order_feed_fill_lifecycle_blockers(
             complete_fill_order_ids.add(order_id)
 
     blockers: list[str] = []
+    if any(
+        _runtime_ledger_event_type({str(key): value for key, value in row.items()})
+        in _RUNTIME_LEDGER_FILL_EVENTS
+        for row in unlinked_order_lifecycle_rows or []
+    ):
+        blockers.append(ORDER_FEED_UNLINKED_FILL_LIFECYCLE_PRESENT_BLOCKER)
     if missing_execution_order_id:
         blockers.append(ORDER_FEED_FILL_LIFECYCLE_ORDER_ID_MISSING_BLOCKER)
     if not observed_fill_order_ids:
@@ -2154,6 +2164,9 @@ def _source_activity_diagnostics_blockers(
     source_bucket_profit_proof_count = _nonnegative_int(
         diagnostics.get("runtime_ledger_source_bucket_profit_proof_count")
     )
+    unlinked_fill_lifecycle_count = _nonnegative_int(
+        diagnostics.get("order_feed_unlinked_fill_lifecycle_count")
+    )
 
     if (
         decision_query_count
@@ -2177,6 +2190,8 @@ def _source_activity_diagnostics_blockers(
         add(ORDER_FEED_FILL_LIFECYCLE_MISSING_BLOCKER)
     if execution_lineage_count > 0 and tca_lineage_count <= 0:
         add("execution_tca_rows_missing")
+    if unlinked_fill_lifecycle_count > 0:
+        add(ORDER_FEED_UNLINKED_FILL_LIFECYCLE_PRESENT_BLOCKER)
     if source_bucket_count <= 0:
         add("runtime_ledger_source_bucket_missing")
     elif source_bucket_profit_proof_count <= 0:
@@ -2200,6 +2215,7 @@ def _build_realized_strategy_pnl_rows(
     *,
     decision_lifecycle_rows: list[dict[str, object]] | None = None,
     order_lifecycle_rows: list[dict[str, object]] | None = None,
+    unlinked_order_lifecycle_rows: list[dict[str, object]] | None = None,
     allow_authoritative_runtime_ledger_materialization: bool = False,
     split_mixed_source_decision_modes: bool = True,
 ) -> list[dict[str, object]]:
@@ -2221,6 +2237,7 @@ def _build_realized_strategy_pnl_rows(
                     partition_execution_rows,
                     decision_lifecycle_rows=partition_decision_rows,
                     order_lifecycle_rows=partition_order_rows,
+                    unlinked_order_lifecycle_rows=unlinked_order_lifecycle_rows,
                     allow_authoritative_runtime_ledger_materialization=(
                         allow_authoritative_runtime_ledger_materialization
                     ),
@@ -2242,6 +2259,7 @@ def _build_realized_strategy_pnl_rows(
     order_feed_fill_lifecycle_blockers = _order_feed_fill_lifecycle_blockers(
         execution_rows=execution_rows,
         order_lifecycle_rows=order_lifecycle_rows,
+        unlinked_order_lifecycle_rows=unlinked_order_lifecycle_rows,
     )
     for row in decision_lifecycle_rows or []:
         lifecycle_row = _runtime_lifecycle_ledger_row(row, event_type="decision")
@@ -3390,6 +3408,7 @@ def _query_timestamps(
     execution_rows: list[dict[str, object]] = []
     decision_lifecycle_rows: list[dict[str, object]] = []
     order_lifecycle_rows: list[dict[str, object]] = []
+    unlinked_order_lifecycle_rows: list[dict[str, object]] = []
     symbol_filter = _metadata_symbol_list(symbols or ())
     if source_activity_diagnostics is not None:
         source_activity_diagnostics.update(
@@ -3422,6 +3441,9 @@ def _query_timestamps(
         "\n                  and upper(coalesce(oe.symbol, e.symbol, d.symbol)) = any(%s)"
         if symbol_filter
         else ""
+    )
+    unlinked_order_event_symbol_clause = (
+        "\n                  and upper(oe.symbol) = any(%s)" if symbol_filter else ""
     )
     decision_symbol_params: tuple[object, ...] = (
         (symbol_filter,) if symbol_filter else ()
@@ -3686,6 +3708,68 @@ def _query_timestamps(
                 candidate_id=candidate_id,
                 hypothesis_id=hypothesis_id,
             )
+            if symbol_filter:
+                cur.execute(
+                    f"""
+                    select
+                        oe.id,
+                        oe.trade_decision_id,
+                        oe.execution_id,
+                        coalesce(oe.event_ts, oe.created_at),
+                        oe.symbol,
+                        oe.alpaca_account_label,
+                        null,
+                        null,
+                        null,
+                        oe.alpaca_order_id,
+                        oe.client_order_id,
+                        oe.event_type,
+                        oe.status,
+                        oe.event_fingerprint,
+                        oe.source_topic,
+                        oe.source_partition,
+                        oe.source_offset,
+                        oe.source_window_id,
+                        oe.raw_event,
+                        null,
+                        null
+                    from execution_order_events oe
+                    where oe.alpaca_account_label = %s
+                      and coalesce(oe.event_ts, oe.created_at) >= %s
+                      and coalesce(oe.event_ts, oe.created_at) < %s
+                      and (oe.execution_id is null or oe.trade_decision_id is null)
+                      and (
+                            lower(coalesce(oe.event_type, oe.status, '')) in (
+                                'fill', 'filled', 'partial_fill', 'partially_filled'
+                            )
+                            or coalesce(oe.filled_qty, 0) > 0
+                          )
+                      {unlinked_order_event_symbol_clause}
+                    order by coalesce(oe.event_ts, oe.created_at), oe.created_at
+                    """,
+                    (
+                        account_label,
+                        window_start,
+                        window_end,
+                        *([symbol_filter] if symbol_filter else []),
+                    ),
+                )
+                unlinked_order_lifecycle_rows = [
+                    _order_lifecycle_query_row(row)
+                    for row in cur.fetchall()
+                    if _order_lifecycle_query_row_has_time(row)
+                ]
+                if source_activity_diagnostics is not None:
+                    source_activity_diagnostics[
+                        "order_feed_unlinked_fill_lifecycle_count"
+                    ] = len(unlinked_order_lifecycle_rows)
+                    source_activity_diagnostics[
+                        "order_feed_unlinked_fill_lifecycle_event_ids"
+                    ] = _source_identifier_values(
+                        unlinked_order_lifecycle_rows,
+                        "execution_order_event_id",
+                        "event_fingerprint",
+                    )
             cur.execute(
                 f"""
                 select
@@ -3771,6 +3855,7 @@ def _query_timestamps(
                 lifecycle_blockers = _order_feed_fill_lifecycle_blockers(
                     execution_rows=execution_rows,
                     order_lifecycle_rows=order_lifecycle_rows,
+                    unlinked_order_lifecycle_rows=unlinked_order_lifecycle_rows,
                 )
                 source_activity_diagnostics["order_feed_fill_lifecycle_blockers"] = (
                     lifecycle_blockers
@@ -3800,6 +3885,7 @@ def _query_timestamps(
             execution_rows,
             decision_lifecycle_rows=decision_lifecycle_rows,
             order_lifecycle_rows=order_lifecycle_rows,
+            unlinked_order_lifecycle_rows=unlinked_order_lifecycle_rows,
             allow_authoritative_runtime_ledger_materialization=(
                 allow_authoritative_runtime_ledger_materialization
             ),

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -3276,6 +3276,180 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertTrue(_runtime_ledger_bucket_profit_proof_present(signal_bucket))
 
+    def test_build_realized_strategy_pnl_rows_blocks_unlinked_fill_lifecycle(
+        self,
+    ) -> None:
+        execution_rows = [
+            {
+                "execution_id": "exec-buy",
+                "trade_decision_id": "decision-buy",
+                "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                "execution_event_at": datetime(
+                    2026, 3, 6, 14, 35, 2, tzinfo=timezone.utc
+                ),
+                "symbol": "AAPL",
+                "side": "buy",
+                "filled_qty": Decimal("1"),
+                "avg_fill_price": Decimal("100"),
+                "cost_amount": Decimal("0.10"),
+                "cost_basis": "broker_reported_commission_and_fees",
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "microbar-cross-sectional-pairs-v1",
+                "decision_hash": "decision-buy-hash",
+                "alpaca_order_id": "order-buy",
+                "execution_policy_hash": "policy-sha",
+                "cost_model_hash": "cost-sha",
+                "lineage_hash": "lineage-sha",
+                "source_decision_mode": "strategy_signal_paper",
+                "profit_proof_eligible": True,
+            },
+            {
+                "execution_id": "exec-sell",
+                "trade_decision_id": "decision-sell",
+                "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                "execution_event_at": datetime(
+                    2026, 3, 6, 14, 40, 2, tzinfo=timezone.utc
+                ),
+                "symbol": "AAPL",
+                "side": "sell",
+                "filled_qty": Decimal("1"),
+                "avg_fill_price": Decimal("101"),
+                "cost_amount": Decimal("0.10"),
+                "cost_basis": "broker_reported_commission_and_fees",
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "microbar-cross-sectional-pairs-v1",
+                "decision_hash": "decision-sell-hash",
+                "alpaca_order_id": "order-sell",
+                "execution_policy_hash": "policy-sha",
+                "cost_model_hash": "cost-sha",
+                "lineage_hash": "lineage-sha",
+                "source_decision_mode": "strategy_signal_paper",
+                "profit_proof_eligible": True,
+            },
+        ]
+        order_lifecycle_rows = [
+            {
+                "execution_order_event_id": "event-new-buy",
+                "trade_decision_id": "decision-buy",
+                "execution_id": "exec-buy",
+                "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+                "symbol": "AAPL",
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "microbar-cross-sectional-pairs-v1",
+                "decision_hash": "decision-buy-hash",
+                "alpaca_order_id": "order-buy",
+                "event_type": "new",
+                "source_topic": "alpaca-trade-updates",
+                "source_partition": 0,
+                "source_offset": 11,
+                "source_window_id": "source-window-buy",
+                "execution_policy_hash": "policy-sha",
+                "cost_model_hash": "cost-sha",
+                "lineage_hash": "lineage-sha",
+                "source_decision_mode": "strategy_signal_paper",
+                "profit_proof_eligible": True,
+            },
+            {
+                "execution_order_event_id": "event-fill-buy",
+                "trade_decision_id": "decision-buy",
+                "execution_id": "exec-buy",
+                "event_ts": datetime(2026, 3, 6, 14, 35, 2, tzinfo=timezone.utc),
+                "symbol": "AAPL",
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "microbar-cross-sectional-pairs-v1",
+                "decision_hash": "decision-buy-hash",
+                "alpaca_order_id": "order-buy",
+                "event_type": "fill",
+                "source_topic": "alpaca-trade-updates",
+                "source_partition": 0,
+                "source_offset": 12,
+                "source_window_id": "source-window-buy",
+                "lineage_hash": "lineage-sha",
+                "source_decision_mode": "strategy_signal_paper",
+                "profit_proof_eligible": True,
+            },
+            {
+                "execution_order_event_id": "event-new-sell",
+                "trade_decision_id": "decision-sell",
+                "execution_id": "exec-sell",
+                "event_ts": datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
+                "symbol": "AAPL",
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "microbar-cross-sectional-pairs-v1",
+                "decision_hash": "decision-sell-hash",
+                "alpaca_order_id": "order-sell",
+                "event_type": "new",
+                "source_topic": "alpaca-trade-updates",
+                "source_partition": 0,
+                "source_offset": 13,
+                "source_window_id": "source-window-sell",
+                "execution_policy_hash": "policy-sha",
+                "cost_model_hash": "cost-sha",
+                "lineage_hash": "lineage-sha",
+                "source_decision_mode": "strategy_signal_paper",
+                "profit_proof_eligible": True,
+            },
+            {
+                "execution_order_event_id": "event-fill-sell",
+                "trade_decision_id": "decision-sell",
+                "execution_id": "exec-sell",
+                "event_ts": datetime(2026, 3, 6, 14, 40, 2, tzinfo=timezone.utc),
+                "symbol": "AAPL",
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "microbar-cross-sectional-pairs-v1",
+                "decision_hash": "decision-sell-hash",
+                "alpaca_order_id": "order-sell",
+                "event_type": "fill",
+                "source_topic": "alpaca-trade-updates",
+                "source_partition": 0,
+                "source_offset": 14,
+                "source_window_id": "source-window-sell",
+                "lineage_hash": "lineage-sha",
+                "source_decision_mode": "strategy_signal_paper",
+                "profit_proof_eligible": True,
+            },
+        ]
+
+        rows = _build_realized_strategy_pnl_rows(
+            execution_rows,
+            order_lifecycle_rows=order_lifecycle_rows,
+            unlinked_order_lifecycle_rows=[
+                {
+                    "execution_order_event_id": "unlinked-fill",
+                    "event_ts": datetime(
+                        2026, 3, 6, 14, 41, 2, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "alpaca_order_id": "external-close-order",
+                    "event_type": "fill",
+                    "source_topic": "alpaca-trade-updates",
+                    "source_partition": 0,
+                    "source_offset": 15,
+                    "source_window_id": "source-window-external",
+                }
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertFalse(row["post_cost_promotion_eligible"])
+        self.assertFalse(row["authoritative"])
+        self.assertIn(
+            "order_feed_unlinked_fill_lifecycle_present",
+            row["runtime_ledger_blockers"],
+        )
+        self.assertEqual(
+            row["promotion_blocker"],
+            "execution_reconstruction_not_runtime_ledger_proof",
+        )
+        bucket = cast(Mapping[str, object], row["runtime_ledger_bucket"])
+        self.assertIn(
+            "order_feed_unlinked_fill_lifecycle_present", bucket["blockers"]
+        )
+        self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
+
     def test_build_realized_strategy_pnl_rows_preserves_source_backed_blocked_basis(
         self,
     ) -> None:
@@ -3650,6 +3824,77 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(diagnostics["order_lifecycle_rows_before_lineage_filter"], 1)
         self.assertEqual(diagnostics["tca_rows_before_lineage_filter"], 1)
 
+    def test_query_timestamps_records_unlinked_fill_lifecycle_diagnostics(
+        self,
+    ) -> None:
+        cursor = _FakeCursor()
+        cursor._results = [
+            [],
+            [],
+            [],
+            [
+                (
+                    "unlinked-event-id",
+                    None,
+                    None,
+                    datetime(2026, 3, 6, 14, 41, tzinfo=timezone.utc),
+                    "AAPL",
+                    "TORGHUT_SIM",
+                    None,
+                    None,
+                    None,
+                    "external-close-order",
+                    "external-close-client",
+                    "fill",
+                    "filled",
+                    "unlinked-event-fingerprint",
+                    "alpaca-trade-updates",
+                    0,
+                    42,
+                    "source-window-external",
+                    {},
+                    None,
+                    None,
+                )
+            ],
+            [],
+        ]
+        connection = _FakeConnection(cursor)
+        diagnostics: dict[str, object] = {}
+
+        with patch(
+            "scripts.import_hypothesis_runtime_windows.psycopg.connect",
+            return_value=connection,
+        ):
+            _query_timestamps(
+                dsn="postgresql://example",
+                strategy_names=["microbar-cross-sectional-pairs-v1"],
+                account_label="TORGHUT_SIM",
+                window_start=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                window_end=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                symbols=["AAPL"],
+                source_activity_diagnostics=diagnostics,
+            )
+
+        self.assertEqual(len(cursor.executed), 5)
+        unlinked_query, unlinked_params = cursor.executed[3]
+        self.assertIn("from execution_order_events oe", unlinked_query)
+        self.assertIn(
+            "and (oe.execution_id is null or oe.trade_decision_id is null)",
+            unlinked_query,
+        )
+        self.assertIn("upper(oe.symbol) = any(%s)", unlinked_query)
+        self.assertEqual(unlinked_params[-1], ["AAPL"])
+        self.assertEqual(diagnostics["order_feed_unlinked_fill_lifecycle_count"], 1)
+        self.assertEqual(
+            diagnostics["order_feed_unlinked_fill_lifecycle_event_ids"],
+            ["unlinked-event-id"],
+        )
+        self.assertIn(
+            "order_feed_unlinked_fill_lifecycle_present",
+            _source_activity_diagnostics_blockers(diagnostics),
+        )
+
     def test_query_timestamps_uses_source_account_but_materializes_target_account(
         self,
     ) -> None:
@@ -3754,6 +3999,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self,
     ) -> None:
         cursor = _FakeCursor()
+        cursor._results.insert(3, [])
         connection = _FakeConnection(cursor)
         window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
         window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
@@ -3771,11 +4017,12 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 symbols=[" aapl ", "AAPL"],
             )
 
-        self.assertEqual(len(cursor.executed), 4)
+        self.assertEqual(len(cursor.executed), 5)
         decision_query, decision_params = cursor.executed[0]
         execution_query, execution_params = cursor.executed[1]
         order_event_query, order_event_params = cursor.executed[2]
-        tca_query, tca_params = cursor.executed[3]
+        unlinked_query, unlinked_params = cursor.executed[3]
+        tca_query, tca_params = cursor.executed[4]
         self.assertIn("upper(d.symbol) = any(%s)", decision_query)
         self.assertEqual(decision_params[-1], ["AAPL"])
         self.assertIn("upper(d.symbol) = any(%s)", execution_query)
@@ -3787,6 +4034,13 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             order_event_query,
         )
         self.assertEqual(order_event_params[-2:], (["AAPL"], ["AAPL"]))
+        self.assertIn("from execution_order_events oe", unlinked_query)
+        self.assertIn(
+            "and (oe.execution_id is null or oe.trade_decision_id is null)",
+            unlinked_query,
+        )
+        self.assertIn("upper(oe.symbol) = any(%s)", unlinked_query)
+        self.assertEqual(unlinked_params[-1], ["AAPL"])
         self.assertIn("upper(d.symbol) = any(%s)", tca_query)
         self.assertIn("upper(e.symbol) = any(%s)", tca_query)
         self.assertEqual(tca_params[-2:], (["AAPL"], ["AAPL"]))


### PR DESCRIPTION
## Summary

- Add fail-closed `order_feed_unlinked_fill_lifecycle_present` blocking for source-window fill lifecycle rows missing Torghut execution or decision lineage.
- Record unlinked fill lifecycle diagnostics during runtime-window import for configured symbol/account/window scopes.
- Add regression coverage that unlinked real fills cannot become promotion-grade runtime-ledger proof.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
