### PR TITLE
fix(torghut): scope unlinked fill blockers to strategy lineage

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -93,6 +93,16 @@ ORDER_FEED_FILL_LIFECYCLE_ORDER_ID_MISSING_BLOCKER = (
 ORDER_FEED_UNLINKED_FILL_LIFECYCLE_PRESENT_BLOCKER = (
     "order_feed_unlinked_fill_lifecycle_present"
 )
+_RUNTIME_LIFECYCLE_IDENTIFIER_KEYS = (
+    "execution_id",
+    "trade_decision_id",
+    "decision_id",
+    "decision_hash",
+    "order_id",
+    "alpaca_order_id",
+    "client_order_id",
+    "execution_correlation_id",
+)
 ALPACA_2026_EQUITY_SEC_FEE_RATE = Decimal("20.60") / Decimal("1000000")
 ALPACA_2026_EQUITY_TAF_RATE_PER_SHARE = Decimal("0.000195")
 ALPACA_2026_EQUITY_TAF_CAP = Decimal("9.79")
@@ -2072,6 +2082,57 @@ def _execution_row_has_fill(row: Mapping[str, object]) -> bool:
     )
 
 
+def _runtime_lifecycle_identifier_values(row: Mapping[str, object]) -> set[str]:
+    values = _text_values(row, *_RUNTIME_LIFECYCLE_IDENTIFIER_KEYS)
+    return {value for value in values if value}
+
+
+def _runtime_lifecycle_strategy_identifier_values(
+    rows: Sequence[Mapping[str, object]],
+) -> set[str]:
+    identifiers: set[str] = set()
+    for row in rows:
+        identifiers.update(_runtime_lifecycle_identifier_values(row))
+    return identifiers
+
+
+def _strategy_relevant_unlinked_fill_lifecycle_rows(
+    *,
+    execution_rows: Sequence[Mapping[str, object]],
+    order_lifecycle_rows: Sequence[Mapping[str, object]] | None,
+    unlinked_order_lifecycle_rows: Sequence[Mapping[str, object]] | None,
+    candidate_id: str | None = None,
+    hypothesis_id: str | None = None,
+) -> list[dict[str, object]]:
+    strategy_identifiers = _runtime_lifecycle_strategy_identifier_values(
+        [
+            *execution_rows,
+            *(order_lifecycle_rows or ()),
+        ]
+    )
+    lineage_filter_present = candidate_id is not None or hypothesis_id is not None
+    relevant_rows: list[dict[str, object]] = []
+    for row in unlinked_order_lifecycle_rows or ():
+        normalized = {str(key): value for key, value in row.items()}
+        if _runtime_ledger_event_type(normalized) not in _RUNTIME_LEDGER_FILL_EVENTS:
+            continue
+        if lineage_filter_present and _source_row_matches_lineage(
+            normalized,
+            candidate_id=candidate_id,
+            hypothesis_id=hypothesis_id,
+            require_source_lineage=True,
+        ):
+            relevant_rows.append(normalized)
+            continue
+        if (
+            strategy_identifiers
+            and _runtime_lifecycle_identifier_values(normalized)
+            & strategy_identifiers
+        ):
+            relevant_rows.append(normalized)
+    return relevant_rows
+
+
 def _order_feed_fill_lifecycle_blockers(
     *,
     execution_rows: list[dict[str, object]],
@@ -2108,10 +2169,10 @@ def _order_feed_fill_lifecycle_blockers(
             complete_fill_order_ids.add(order_id)
 
     blockers: list[str] = []
-    if any(
-        _runtime_ledger_event_type({str(key): value for key, value in row.items()})
-        in _RUNTIME_LEDGER_FILL_EVENTS
-        for row in unlinked_order_lifecycle_rows or []
+    if _strategy_relevant_unlinked_fill_lifecycle_rows(
+        execution_rows=execution_rows,
+        order_lifecycle_rows=order_lifecycle_rows,
+        unlinked_order_lifecycle_rows=unlinked_order_lifecycle_rows,
     ):
         blockers.append(ORDER_FEED_UNLINKED_FILL_LIFECYCLE_PRESENT_BLOCKER)
     if missing_execution_order_id:
@@ -2167,6 +2228,12 @@ def _source_activity_diagnostics_blockers(
     unlinked_fill_lifecycle_count = _nonnegative_int(
         diagnostics.get("order_feed_unlinked_fill_lifecycle_count")
     )
+    if "order_feed_unlinked_strategy_fill_lifecycle_count" in diagnostics:
+        strategy_unlinked_fill_lifecycle_count = _nonnegative_int(
+            diagnostics.get("order_feed_unlinked_strategy_fill_lifecycle_count")
+        )
+    else:
+        strategy_unlinked_fill_lifecycle_count = unlinked_fill_lifecycle_count
 
     if (
         decision_query_count
@@ -2190,7 +2257,7 @@ def _source_activity_diagnostics_blockers(
         add(ORDER_FEED_FILL_LIFECYCLE_MISSING_BLOCKER)
     if execution_lineage_count > 0 and tca_lineage_count <= 0:
         add("execution_tca_rows_missing")
-    if unlinked_fill_lifecycle_count > 0:
+    if strategy_unlinked_fill_lifecycle_count > 0:
         add(ORDER_FEED_UNLINKED_FILL_LIFECYCLE_PRESENT_BLOCKER)
     if source_bucket_count <= 0:
         add("runtime_ledger_source_bucket_missing")
@@ -3759,6 +3826,36 @@ def _query_timestamps(
                     for row in cur.fetchall()
                     if _order_lifecycle_query_row_has_time(row)
                 ]
+                strategy_unlinked_order_lifecycle_rows = (
+                    _strategy_relevant_unlinked_fill_lifecycle_rows(
+                        execution_rows=execution_rows,
+                        order_lifecycle_rows=order_lifecycle_rows,
+                        unlinked_order_lifecycle_rows=unlinked_order_lifecycle_rows,
+                        candidate_id=candidate_id,
+                        hypothesis_id=hypothesis_id,
+                    )
+                )
+                strategy_unlinked_ids = set(
+                    _source_identifier_values(
+                        strategy_unlinked_order_lifecycle_rows,
+                        "execution_order_event_id",
+                        "event_fingerprint",
+                    )
+                )
+                unattributed_unlinked_order_lifecycle_rows = [
+                    row
+                    for row in unlinked_order_lifecycle_rows
+                    if not (
+                        set(
+                            _source_identifier_values(
+                                [row],
+                                "execution_order_event_id",
+                                "event_fingerprint",
+                            )
+                        )
+                        & strategy_unlinked_ids
+                    )
+                ]
                 if source_activity_diagnostics is not None:
                     source_activity_diagnostics[
                         "order_feed_unlinked_fill_lifecycle_count"
@@ -3770,6 +3867,27 @@ def _query_timestamps(
                         "execution_order_event_id",
                         "event_fingerprint",
                     )
+                    source_activity_diagnostics[
+                        "order_feed_unlinked_strategy_fill_lifecycle_count"
+                    ] = len(strategy_unlinked_order_lifecycle_rows)
+                    source_activity_diagnostics[
+                        "order_feed_unlinked_strategy_fill_lifecycle_event_ids"
+                    ] = _source_identifier_values(
+                        strategy_unlinked_order_lifecycle_rows,
+                        "execution_order_event_id",
+                        "event_fingerprint",
+                    )
+                    source_activity_diagnostics[
+                        "order_feed_unattributed_fill_lifecycle_count"
+                    ] = len(unattributed_unlinked_order_lifecycle_rows)
+                    source_activity_diagnostics[
+                        "order_feed_unattributed_fill_lifecycle_event_ids"
+                    ] = _source_identifier_values(
+                        unattributed_unlinked_order_lifecycle_rows,
+                        "execution_order_event_id",
+                        "event_fingerprint",
+                    )
+                unlinked_order_lifecycle_rows = strategy_unlinked_order_lifecycle_rows
             cur.execute(
                 f"""
                 select

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -3421,7 +3421,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     ),
                     "symbol": "AAPL",
                     "account_label": "TORGHUT_SIM",
-                    "alpaca_order_id": "external-close-order",
+                    "alpaca_order_id": "order-sell",
                     "event_type": "fill",
                     "source_topic": "alpaca-trade-updates",
                     "source_partition": 0,
@@ -3449,6 +3449,38 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             "order_feed_unlinked_fill_lifecycle_present", bucket["blockers"]
         )
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
+
+        rows = _build_realized_strategy_pnl_rows(
+            execution_rows,
+            order_lifecycle_rows=order_lifecycle_rows,
+            unlinked_order_lifecycle_rows=[
+                {
+                    "execution_order_event_id": "external-fill",
+                    "event_ts": datetime(
+                        2026, 3, 6, 14, 41, 2, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "alpaca_order_id": "external-close-order",
+                    "event_type": "fill",
+                    "source_topic": "alpaca-trade-updates",
+                    "source_partition": 0,
+                    "source_offset": 16,
+                    "source_window_id": "source-window-external",
+                }
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertNotIn(
+            "order_feed_unlinked_fill_lifecycle_present",
+            row["runtime_ledger_blockers"],
+        )
+        bucket = cast(Mapping[str, object], row["runtime_ledger_bucket"])
+        self.assertNotIn(
+            "order_feed_unlinked_fill_lifecycle_present", bucket["blockers"]
+        )
 
     def test_build_realized_strategy_pnl_rows_preserves_source_backed_blocked_basis(
         self,
@@ -3824,7 +3856,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(diagnostics["order_lifecycle_rows_before_lineage_filter"], 1)
         self.assertEqual(diagnostics["tca_rows_before_lineage_filter"], 1)
 
-    def test_query_timestamps_records_unlinked_fill_lifecycle_diagnostics(
+    def test_query_timestamps_records_unattributed_fill_lifecycle_diagnostics(
         self,
     ) -> None:
         cursor = _FakeCursor()
@@ -3889,6 +3921,89 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(
             diagnostics["order_feed_unlinked_fill_lifecycle_event_ids"],
             ["unlinked-event-id"],
+        )
+        self.assertEqual(
+            diagnostics["order_feed_unlinked_strategy_fill_lifecycle_count"], 0
+        )
+        self.assertEqual(
+            diagnostics["order_feed_unlinked_strategy_fill_lifecycle_event_ids"],
+            [],
+        )
+        self.assertEqual(
+            diagnostics["order_feed_unattributed_fill_lifecycle_count"], 1
+        )
+        self.assertEqual(
+            diagnostics["order_feed_unattributed_fill_lifecycle_event_ids"],
+            ["unlinked-event-id"],
+        )
+        self.assertNotIn(
+            "order_feed_unlinked_fill_lifecycle_present",
+            _source_activity_diagnostics_blockers(diagnostics),
+        )
+
+    def test_query_timestamps_blocks_strategy_matching_unlinked_fill_lifecycle(
+        self,
+    ) -> None:
+        cursor = _FakeCursor()
+        execution_row = _FakeCursor()._results[1][0]
+        cursor._results = [
+            [],
+            [execution_row],
+            [],
+            [
+                (
+                    "unlinked-event-id",
+                    None,
+                    None,
+                    datetime(2026, 3, 6, 14, 41, tzinfo=timezone.utc),
+                    "AAPL",
+                    "TORGHUT_SIM",
+                    None,
+                    None,
+                    None,
+                    "alpaca-order-1",
+                    "client-order-1",
+                    "fill",
+                    "filled",
+                    "unlinked-event-fingerprint",
+                    "alpaca-trade-updates",
+                    0,
+                    42,
+                    "source-window-external",
+                    {},
+                    None,
+                    None,
+                )
+            ],
+            [],
+        ]
+        connection = _FakeConnection(cursor)
+        diagnostics: dict[str, object] = {}
+
+        with patch(
+            "scripts.import_hypothesis_runtime_windows.psycopg.connect",
+            return_value=connection,
+        ):
+            _query_timestamps(
+                dsn="postgresql://example",
+                strategy_names=["microbar-cross-sectional-pairs-v1"],
+                account_label="TORGHUT_SIM",
+                window_start=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                window_end=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                symbols=["AAPL"],
+                source_activity_diagnostics=diagnostics,
+            )
+
+        self.assertEqual(diagnostics["order_feed_unlinked_fill_lifecycle_count"], 1)
+        self.assertEqual(
+            diagnostics["order_feed_unlinked_strategy_fill_lifecycle_count"], 1
+        )
+        self.assertEqual(
+            diagnostics["order_feed_unlinked_strategy_fill_lifecycle_event_ids"],
+            ["unlinked-event-id"],
+        )
+        self.assertEqual(
+            diagnostics["order_feed_unattributed_fill_lifecycle_count"], 0
         )
         self.assertIn(
             "order_feed_unlinked_fill_lifecycle_present",


### PR DESCRIPTION
## Summary

- Scope unlinked order-feed fill lifecycle blockers to fills that match strategy lineage or expected execution/order identifiers.
- Preserve explicit diagnostics for unattributed same-account fills so they are visible but cannot become H-PAIRS proof.
- Keep strategy-matching unlinked fills fail-closed as promotion blockers and add regression coverage for both paths.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
