### PR TITLE
fix(torghut): canonicalize paper route strategy names

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -232,6 +232,19 @@ def _strategy_name_from_strategy_id(strategy_id: object) -> str | None:
     return base.replace("_", "-") if base else None
 
 
+def _looks_like_uuid_text(value: object) -> bool:
+    text = _safe_text(value)
+    if text is None:
+        return False
+    parts = text.split("-")
+    if [len(part) for part in parts] != [8, 4, 4, 4, 12]:
+        return False
+    return all(
+        part and all(char in "0123456789abcdefABCDEF" for char in part)
+        for part in parts
+    )
+
+
 def _strategy_lookup_names(*values: object) -> list[str]:
     names: list[str] = []
     for value in values:
@@ -247,6 +260,29 @@ def _strategy_lookup_names(*values: object) -> list[str]:
             if text is not None and text not in names:
                 names.append(text)
     return names
+
+
+def _canonical_runtime_strategy_name(
+    *,
+    strategy_name: object,
+    runtime_strategy_name: object,
+    strategy_id: object,
+    strategy_lookup_names: object,
+    matched_strategy: Mapping[str, object] | None = None,
+) -> str | None:
+    matched_name = _safe_text((matched_strategy or {}).get("strategy_name"))
+    derived_name = _strategy_name_from_strategy_id(strategy_id)
+    preferred = _strategy_lookup_names(
+        matched_name,
+        runtime_strategy_name,
+        strategy_name,
+        derived_name,
+        _strategy_lookup_names(strategy_lookup_names),
+    )
+    for name in preferred:
+        if not _looks_like_uuid_text(name):
+            return name
+    return preferred[0] if preferred else None
 
 
 def _health_gate_bool_text(value: object) -> str | None:
@@ -1205,6 +1241,21 @@ def _next_paper_route_runtime_window_targets(
             raw_probe_symbols=source_readiness_raw_probe_symbols,
             scoped_probe_symbols=target_probe_symbols,
         )
+        matched_strategy = _as_mapping(source_decision_readiness.get("matched_strategy"))
+        canonical_strategy_name = _canonical_runtime_strategy_name(
+            strategy_name=strategy_name,
+            runtime_strategy_name=runtime_strategy_name,
+            strategy_id=strategy_id,
+            strategy_lookup_names=strategy_lookup_names,
+            matched_strategy=matched_strategy,
+        )
+        strategy_lookup_names = _strategy_lookup_names(
+            canonical_strategy_name,
+            strategy_lookup_names,
+            runtime_strategy_name,
+            strategy_name,
+            _strategy_name_from_strategy_id(strategy_id),
+        )
         target_probe_ready = (
             bool(probe.get("configured_enabled"))
             and _safe_decimal(next_notional) > 0
@@ -1217,7 +1268,7 @@ def _next_paper_route_runtime_window_targets(
                 ("hypothesis_id", hypothesis_id),
                 ("candidate_id", candidate_id),
                 ("strategy_family", strategy_family),
-                ("strategy_name", strategy_name),
+                ("strategy_name", canonical_strategy_name),
                 ("source_manifest_ref", source_manifest_ref),
             )
             if value is None
@@ -1271,7 +1322,7 @@ def _next_paper_route_runtime_window_targets(
             hypothesis_id,
             candidate_id,
             strategy_family,
-            strategy_name,
+            canonical_strategy_name,
             PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
             source_manifest_ref,
             _isoformat(window_start),
@@ -1294,8 +1345,8 @@ def _next_paper_route_runtime_window_targets(
             strategy_family=strategy_family,
             strategy_id=strategy_id,
             strategy_lookup_names=strategy_lookup_names,
-            strategy_name=strategy_name,
-            runtime_strategy_name=runtime_strategy_name,
+            strategy_name=canonical_strategy_name,
+            runtime_strategy_name=canonical_strategy_name,
             account_label=PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
             source_manifest_ref=source_manifest_ref,
             window_start=window_start,
@@ -1351,9 +1402,11 @@ def _next_paper_route_runtime_window_targets(
             "candidate_id": candidate_id,
             "observed_stage": "paper",
             "strategy_family": strategy_family,
-            "strategy_name": strategy_name,
+            "strategy_name": canonical_strategy_name,
             "strategy_id": strategy_id or "",
-            "runtime_strategy_name": runtime_strategy_name or "",
+            "runtime_strategy_name": canonical_strategy_name or "",
+            "source_strategy_name": strategy_name or "",
+            "source_runtime_strategy_name": runtime_strategy_name or "",
             "strategy_lookup_names": strategy_lookup_names,
             "account_label": PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
             "source_account_label": source_account_label or "",

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -4145,12 +4145,15 @@ def main() -> int:
         hypothesis_id=args.hypothesis_id,
         strategy_family=args.strategy_family.strip() or None,
     )
-    strategy_names = _strategy_name_candidates(
-        args.strategy_name,
-        getattr(manifest, "strategy_id", None),
-    )
     target_metadata = _parse_target_metadata(
         str(getattr(args, "target_metadata_json", "") or "")
+    )
+    strategy_names = _strategy_name_candidates(
+        args.strategy_name,
+        _text_or_none(target_metadata.get("runtime_strategy_name")),
+        _text_or_none(target_metadata.get("strategy_name")),
+        *_metadata_text_list(target_metadata.get("strategy_lookup_names")),
+        getattr(manifest, "strategy_id", None),
     )
     source_activity_symbols = _target_metadata_source_symbols(target_metadata)
     source_kind = args.source_kind.strip() or (

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -62,6 +62,11 @@ RUNTIME_WINDOW_TARGET_METADATA_KEYS = (
     "runtime_window_import_health_gate",
     "runtime_window_import_health_gate_blockers",
     "runtime_window_import_promotion_blockers",
+    "strategy_id",
+    "runtime_strategy_name",
+    "source_strategy_name",
+    "source_runtime_strategy_name",
+    "strategy_lookup_names",
     "window_start",
     "window_end",
     "max_notional",
@@ -668,6 +673,61 @@ def _strategy_name_from_strategy_id(strategy_id: str) -> str | None:
     return base.replace("_", "-") if base else None
 
 
+def _looks_like_uuid_text(value: object) -> bool:
+    text = _as_text(value)
+    if text is None:
+        return False
+    parts = text.split("-")
+    if [len(part) for part in parts] != [8, 4, 4, 4, 12]:
+        return False
+    return all(
+        part and all(char in "0123456789abcdefABCDEF" for char in part)
+        for part in parts
+    )
+
+
+def _strategy_lookup_names(*values: object) -> list[str]:
+    names: list[str] = []
+    for value in values:
+        raw_items: Sequence[object]
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            raw_items = value
+        else:
+            raw_items = (value,)
+        for raw_item in raw_items:
+            text = _as_text(raw_item)
+            if text is not None and text not in names:
+                names.append(text)
+    return names
+
+
+def _canonical_runtime_strategy_name(
+    *,
+    strategy_name: object,
+    runtime_strategy_name: object,
+    strategy_id: object,
+    strategy_lookup_names: object,
+) -> str | None:
+    strategy_id_text = _as_text(strategy_id)
+    derived_name = (
+        _strategy_name_from_strategy_id(strategy_id_text)
+        if strategy_id_text is not None
+        else None
+    )
+    preferred = _strategy_lookup_names(
+        runtime_strategy_name,
+        strategy_name,
+        derived_name,
+        strategy_lookup_names,
+    )
+    for name in preferred:
+        if not _looks_like_uuid_text(name):
+            return name
+    return preferred[0] if preferred else None
+
+
 def _registry_runtime_window_targets(
     args: argparse.Namespace,
 ) -> list[RuntimeWindowImportTarget]:
@@ -827,7 +887,16 @@ def _runtime_window_targets_from_plan(
         hypothesis_id = value("hypothesis_id", "runtime_window_hypothesis_id")
         candidate_id = value("candidate_id", "runtime_window_candidate_id")
         strategy_family = value("strategy_family", "runtime_window_strategy_family")
-        strategy_name = value("strategy_name", "runtime_window_strategy_name")
+        raw_strategy_name = value("strategy_name", "runtime_window_strategy_name")
+        strategy_name = (
+            _canonical_runtime_strategy_name(
+                strategy_name=raw_strategy_name,
+                runtime_strategy_name=payload.get("runtime_strategy_name"),
+                strategy_id=payload.get("strategy_id"),
+                strategy_lookup_names=payload.get("strategy_lookup_names"),
+            )
+            or raw_strategy_name
+        )
         missing = [
             field
             for field, item in (

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -979,6 +979,18 @@ class TestPaperRouteEvidenceAudit(TestCase):
         readiness = target["source_decision_readiness"]
         self.assertTrue(readiness["ready"])
         self.assertEqual(readiness["blockers"], [])
+        self.assertEqual(target["strategy_name"], "microbar-cross-sectional-pairs-v1")
+        self.assertEqual(
+            target["runtime_strategy_name"], "microbar-cross-sectional-pairs-v1"
+        )
+        self.assertEqual(
+            target["source_strategy_name"],
+            "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+        )
+        self.assertEqual(
+            target["source_runtime_strategy_name"],
+            "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+        )
         self.assertEqual(
             readiness["matched_strategy"]["strategy_name"],
             "microbar-cross-sectional-pairs-v1",

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -478,6 +478,12 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                                     "observed_stage": "paper",
                                     "strategy_family": "microbar_cross_sectional_pairs",
                                     "strategy_name": "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                                    "runtime_strategy_name": "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                                    "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                                    "strategy_lookup_names": [
+                                        "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                                        "microbar-cross-sectional-pairs-v1",
+                                    ],
                                     "account_label": "TORGHUT_REPLAY",
                                     "source_dsn_env": "TORGHUT_DURABLE_RUNTIME_LEDGER_SOURCE_DSN",
                                     "source_kind": "durable_runtime_ledger_bucket",
@@ -498,6 +504,12 @@ class TestRunEmpiricalPromotionJobs(TestCase):
                                     "observed_stage": "paper",
                                     "strategy_family": "microbar_cross_sectional_pairs",
                                     "strategy_name": "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                                    "runtime_strategy_name": "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                                    "strategy_id": "microbar_cross_sectional_pairs_v1@research",
+                                    "strategy_lookup_names": [
+                                        "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+                                        "microbar-cross-sectional-pairs-v1",
+                                    ],
                                     "account_label": "TORGHUT_REPLAY",
                                     "source_dsn_env": "TORGHUT_DURABLE_RUNTIME_LEDGER_SOURCE_DSN",
                                     "source_kind": "durable_runtime_ledger_bucket",
@@ -553,7 +565,12 @@ class TestRunEmpiricalPromotionJobs(TestCase):
             targets[0].source_dsn_env,
             "TORGHUT_DURABLE_RUNTIME_LEDGER_SOURCE_DSN",
         )
+        self.assertEqual(targets[0].strategy_name, "microbar-cross-sectional-pairs-v1")
         assert targets[0].target_metadata is not None
+        self.assertEqual(
+            targets[0].target_metadata["runtime_strategy_name"],
+            "69cf50e3-4815-47c2-b802-1efbaac09ecb",
+        )
         self.assertEqual(
             targets[0].target_metadata["runtime_ledger_bucket_ref"], "bucket:first"
         )


### PR DESCRIPTION
## Summary

- Canonicalize paper-route target-plan strategy names to prefer the matched runtime strategy or strategy-id alias over stale UUID-like source strategy names.
- Preserve the original source strategy/runtime identifiers in target metadata for auditability while passing canonical strategy names to runtime-window renewal/import paths.
- Teach runtime-window import candidate selection to consider target metadata aliases so old target plans can still resolve the correct runtime ledger strategy.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py tests/test_import_hypothesis_runtime_windows.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py scripts/import_hypothesis_runtime_windows.py tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py`
- `git diff --check`
- Read-only live target-plan check: current deployed `torghut-sim` plan parses H-PAIRS as `microbar-cross-sectional-pairs-v1` with this branch.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
