### PR TITLE
fix(torghut): carry source mode into probe exits

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -218,6 +218,19 @@ def _target_truthy(value: object) -> bool:
     return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _target_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float | Decimal):
+        return bool(value)
+    text = str(value or "").strip().lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    return None
+
+
 def _lineage_text_values(value: object) -> list[str]:
     raw_items: Sequence[object]
     if isinstance(value, str):
@@ -253,6 +266,10 @@ def _paper_route_probe_lineage_from_params(params: Mapping[str, Any]) -> dict[st
     strategy_names: list[str] = []
     lineage_targets: list[dict[str, str]] = []
     lineage_target_keys: set[tuple[str | None, str | None, str | None]] = set()
+    source_decision_mode = _safe_text(params.get("source_decision_mode"))
+    profit_proof_eligible = _target_bool(params.get("profit_proof_eligible"))
+    fallback_source_decision_modes: list[str] = []
+    fallback_profit_proof_values: list[bool] = []
     for payload in payloads:
         _merge_unique_texts(
             candidate_ids, _lineage_text_values(payload.get("source_candidate_id"))
@@ -272,6 +289,13 @@ def _paper_route_probe_lineage_from_params(params: Mapping[str, Any]) -> dict[st
         _merge_unique_texts(
             strategy_names, _lineage_text_values(payload.get("source_strategy_names"))
         )
+        if payload is not params:
+            if mode := _safe_text(payload.get("source_decision_mode")):
+                fallback_source_decision_modes.append(mode)
+            if (
+                eligible := _target_bool(payload.get("profit_proof_eligible"))
+            ) is not None:
+                fallback_profit_proof_values.append(eligible)
 
         raw_targets = payload.get("paper_route_probe_lineage_targets")
         if isinstance(raw_targets, Sequence) and not isinstance(
@@ -299,6 +323,16 @@ def _paper_route_probe_lineage_from_params(params: Mapping[str, Any]) -> dict[st
         lineage["source_strategy_names"] = strategy_names
     if lineage_targets:
         lineage["paper_route_probe_lineage_targets"] = lineage_targets
+    if source_decision_mode:
+        lineage["source_decision_mode"] = source_decision_mode
+    else:
+        unique_modes = list(dict.fromkeys(fallback_source_decision_modes))
+        if len(unique_modes) == 1:
+            lineage["source_decision_mode"] = unique_modes[0]
+    if profit_proof_eligible is not None:
+        lineage["profit_proof_eligible"] = profit_proof_eligible
+    elif fallback_profit_proof_values:
+        lineage["profit_proof_eligible"] = all(fallback_profit_proof_values)
     return lineage
 
 
@@ -339,6 +373,10 @@ def _merge_paper_route_probe_lineage(
         current = target.setdefault(key, [])
         if isinstance(current, list):
             _merge_unique_texts(cast(list[str], current), values)
+
+    for key in ("source_decision_mode", "profit_proof_eligible"):
+        if key in lineage and key not in target:
+            target[key] = lineage[key]
 
     raw_targets = lineage.get("paper_route_probe_lineage_targets")
     if not isinstance(raw_targets, Sequence) or isinstance(
@@ -1115,6 +1153,12 @@ class SimpleTradingPipeline(TradingPipeline):
                     },
                 },
             }
+            exit_lineage = cast(
+                Mapping[str, Any], exposure.get("paper_route_probe_lineage") or {}
+            )
+            for key in ("source_decision_mode", "profit_proof_eligible"):
+                if key in exit_lineage:
+                    params[key] = exit_lineage[key]
             if avg_entry_price is not None:
                 params["price"] = avg_entry_price
             decisions.append(

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -56,6 +56,7 @@ from app.trading.risk import RiskEngine
 from app.trading.scheduler.pipeline import TradingPipeline
 from app.trading.scheduler.simple_pipeline import (
     SimpleTradingPipeline,
+    _paper_route_probe_lineage_from_params,
     _parse_target_datetime,
     _safe_int,
     _target_probe_action,
@@ -848,6 +849,8 @@ class TestTradingPipeline(TestCase):
         source_candidate_ids: Sequence[str] | None = None,
         source_hypothesis_ids: Sequence[str] | None = None,
         source_strategy_names: Sequence[str] | None = None,
+        source_decision_mode: str | None = None,
+        profit_proof_eligible: bool | None = None,
     ) -> None:
         with self.session_local() as session:
             strategy = Strategy(
@@ -908,6 +911,12 @@ class TestTradingPipeline(TestCase):
                 ]
             if include_decision_exit_minute:
                 params["exit_minute_after_open"] = exit_minute_after_open
+            if source_decision_mode is not None:
+                params["source_decision_mode"] = source_decision_mode
+                paper_route_probe["source_decision_mode"] = source_decision_mode
+            if profit_proof_eligible is not None:
+                params["profit_proof_eligible"] = profit_proof_eligible
+                paper_route_probe["profit_proof_eligible"] = profit_proof_eligible
             decision = StrategyDecision(
                 strategy_id=str(strategy.id),
                 symbol=symbol,
@@ -4492,6 +4501,82 @@ class TestTradingPipeline(TestCase):
             self.assertEqual(exit_row.status, "submitted")
             payload = cast(dict[str, Any], exit_row.decision_json)
             self.assertNotIn("max_notional_exceeded", payload.get("risk_reasons", []))
+
+    def test_simple_pipeline_probe_exit_inherits_profit_proof_source_mode(
+        self,
+    ) -> None:
+        self._seed_filled_paper_route_probe_entry(
+            source_candidate_ids=["cand-h-pairs"],
+            source_hypothesis_ids=["H-PAIRS-01"],
+            source_strategy_names=["microbar-cross-sectional-pairs-v1"],
+            source_decision_mode="strategy_signal_paper",
+            profit_proof_eligible=True,
+        )
+        alpaca_client = PositionedAlpacaClient(
+            [{"symbol": "AAPL", "qty": "2", "side": "long"}]
+        )
+
+        self._run_simple_paper_pipeline(
+            alpaca_client=alpaca_client,
+            now=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(len(alpaca_client.submitted), 1)
+        with self.session_local() as session:
+            exit_row = (
+                session.execute(
+                    select(TradeDecision)
+                    .where(TradeDecision.symbol == "AAPL")
+                    .order_by(TradeDecision.created_at.desc())
+                )
+                .scalars()
+                .first()
+            )
+            assert exit_row is not None
+            payload = cast(dict[str, Any], exit_row.decision_json)
+            params = cast(dict[str, Any], payload["params"])
+            exit_metadata = cast(dict[str, Any], params["paper_route_probe_exit"])
+
+            self.assertEqual(params["source_decision_mode"], "strategy_signal_paper")
+            self.assertTrue(params["profit_proof_eligible"])
+            self.assertEqual(
+                exit_metadata["source_decision_mode"], "strategy_signal_paper"
+            )
+            self.assertTrue(exit_metadata["profit_proof_eligible"])
+            self.assertEqual(exit_metadata["source_candidate_ids"], ["cand-h-pairs"])
+            self.assertEqual(exit_metadata["source_hypothesis_ids"], ["H-PAIRS-01"])
+
+    def test_paper_route_probe_lineage_parses_profit_proof_eligibility(self) -> None:
+        self.assertTrue(
+            _paper_route_probe_lineage_from_params({"profit_proof_eligible": 1})[
+                "profit_proof_eligible"
+            ]
+        )
+        self.assertTrue(
+            _paper_route_probe_lineage_from_params({"profit_proof_eligible": "true"})[
+                "profit_proof_eligible"
+            ]
+        )
+        self.assertFalse(
+            _paper_route_probe_lineage_from_params({"profit_proof_eligible": "false"})[
+                "profit_proof_eligible"
+            ]
+        )
+
+    def test_paper_route_probe_lineage_falls_back_to_nested_source_mode(
+        self,
+    ) -> None:
+        lineage = _paper_route_probe_lineage_from_params(
+            {
+                "paper_route_probe": {
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                }
+            }
+        )
+
+        self.assertEqual(lineage["source_decision_mode"], "strategy_signal_paper")
+        self.assertTrue(lineage["profit_proof_eligible"])
 
     def test_simple_pipeline_reopens_rejected_paper_route_probe_exit(
         self,


### PR DESCRIPTION
## Summary

- Preserve paper-route source-decision authority when generating probe exit decisions.
- Carry `source_decision_mode` and `profit_proof_eligible` into exit metadata so runtime imports can classify strategy-signal exits correctly.
- Add a regression test for H-PAIRS-style strategy-signal paper exits inheriting source authority.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'probe_exit_inherits_profit_proof_source_mode or allows_large_position_reducing_probe_exit or reopens_rejected_paper_route_probe_exit' -q`
- `uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'source_decision_mode or source_execution or runtime_ledger_source' -q`
- `uv run --frozen pytest tests/test_runtime_window_import.py -k 'source or runtime_ledger' -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_trading_pipeline.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
