### PR TITLE
fix(torghut): keep probe exits out of signal proof

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -109,7 +109,7 @@ spec:
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
-              value: "63180"
+              value: "25"
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_URL
               value: http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -92,7 +92,7 @@ spec:
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
-              value: "63180"
+              value: "25"
             - name: TRADING_MARKET_CONTEXT_URL
               value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context
             - name: TRADING_JANGAR_CONTROL_PLANE_STATUS_URL

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -32,6 +32,7 @@ from ..proof_floor import build_profitability_proof_floor_receipt
 from ..runtime_decision_authority import (
     ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
     STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+    normalize_source_decision_mode,
 )
 from ..session_context import REGULAR_OPEN_UTC
 from ..simple_risk import (
@@ -334,6 +335,35 @@ def _paper_route_probe_lineage_from_params(params: Mapping[str, Any]) -> dict[st
     elif fallback_profit_proof_values:
         lineage["profit_proof_eligible"] = all(fallback_profit_proof_values)
     return lineage
+
+
+def _paper_route_probe_entry_metadata(
+    params: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    metadata = params.get("paper_route_probe")
+    if not isinstance(metadata, Mapping):
+        return None
+
+    source_decision_mode = normalize_source_decision_mode(
+        params.get("source_decision_mode")
+    )
+    if source_decision_mode == STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE:
+        return None
+    if _target_bool(params.get("profit_proof_eligible")) is True:
+        return None
+
+    probe_metadata = cast(Mapping[str, Any], metadata)
+    probe_source_decision_mode = normalize_source_decision_mode(
+        probe_metadata.get("source_decision_mode")
+    )
+    if (
+        probe_source_decision_mode is not None
+        and probe_source_decision_mode != ROUTE_ACQUISITION_SOURCE_DECISION_MODE
+    ):
+        return None
+    if _target_bool(probe_metadata.get("profit_proof_eligible")) is True:
+        return None
+    return probe_metadata
 
 
 def _lineage_target_from_mapping(raw_target: Mapping[str, object]) -> dict[str, str]:
@@ -984,7 +1014,7 @@ class SimpleTradingPipeline(TradingPipeline):
             if not isinstance(decision_json, Mapping):
                 continue
             params = decision.params
-            is_entry = isinstance(params.get("paper_route_probe"), Mapping)
+            is_entry = _paper_route_probe_entry_metadata(params) is not None
             is_exit = isinstance(params.get("paper_route_probe_exit"), Mapping)
             if not is_entry and not is_exit:
                 continue
@@ -2520,6 +2550,8 @@ class SimpleTradingPipeline(TradingPipeline):
         if isinstance(
             decision.params.get("paper_route_target_plan_source_decision"), Mapping
         ):
+            return None
+        if isinstance(decision.params.get("paper_route_probe_exit"), Mapping):
             return None
         existing_mode = (
             str(decision.params.get("source_decision_mode") or "")

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -609,7 +609,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertEqual(
             sim_env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
-            "63180",
+            "25",
         )
         self.assertEqual(
             sim_env.get("TRADING_PAPER_ROUTE_TARGET_PLAN_URL"),
@@ -1352,7 +1352,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertFalse(_manifest_bool(env, "TRADING_SIMPLE_SUBMIT_ENABLED"))
         self.assertTrue(_manifest_bool(env, "TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED"))
         self.assertEqual(
-            env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"), "63180"
+            env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"), "25"
         )
         self.assertTrue(_manifest_bool(env, "TRADING_ALPACA_QUOTE_FALLBACK_ENABLED"))
         self.assertEqual(env.get("TRADING_ALPACA_QUOTE_FEED"), "iex")

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -56,6 +56,7 @@ from app.trading.risk import RiskEngine
 from app.trading.scheduler.pipeline import TradingPipeline
 from app.trading.scheduler.simple_pipeline import (
     SimpleTradingPipeline,
+    _paper_route_probe_entry_metadata,
     _paper_route_probe_lineage_from_params,
     _parse_target_datetime,
     _safe_int,
@@ -4502,7 +4503,7 @@ class TestTradingPipeline(TestCase):
             payload = cast(dict[str, Any], exit_row.decision_json)
             self.assertNotIn("max_notional_exceeded", payload.get("risk_reasons", []))
 
-    def test_simple_pipeline_probe_exit_inherits_profit_proof_source_mode(
+    def test_simple_pipeline_does_not_close_strategy_signal_paper_as_probe_inventory(
         self,
     ) -> None:
         self._seed_filled_paper_route_probe_entry(
@@ -4521,30 +4522,66 @@ class TestTradingPipeline(TestCase):
             now=datetime(2026, 3, 26, 15, 31, tzinfo=timezone.utc),
         )
 
-        self.assertEqual(len(alpaca_client.submitted), 1)
+        self.assertEqual(alpaca_client.submitted, [])
         with self.session_local() as session:
-            exit_row = (
-                session.execute(
-                    select(TradeDecision)
-                    .where(TradeDecision.symbol == "AAPL")
-                    .order_by(TradeDecision.created_at.desc())
-                )
+            decisions = (
+                session.execute(select(TradeDecision).order_by(TradeDecision.created_at))
                 .scalars()
-                .first()
+                .all()
             )
-            assert exit_row is not None
-            payload = cast(dict[str, Any], exit_row.decision_json)
+            self.assertEqual(len(decisions), 1)
+            payload = cast(dict[str, Any], decisions[0].decision_json)
             params = cast(dict[str, Any], payload["params"])
-            exit_metadata = cast(dict[str, Any], params["paper_route_probe_exit"])
-
             self.assertEqual(params["source_decision_mode"], "strategy_signal_paper")
             self.assertTrue(params["profit_proof_eligible"])
-            self.assertEqual(
-                exit_metadata["source_decision_mode"], "strategy_signal_paper"
+            self.assertNotIn("paper_route_probe_exit", params)
+
+    def test_paper_route_probe_entry_metadata_rejects_proof_and_non_probe_rows(
+        self,
+    ) -> None:
+        self.assertIsNone(_paper_route_probe_entry_metadata({}))
+        self.assertIsNone(
+            _paper_route_probe_entry_metadata(
+                {
+                    "profit_proof_eligible": True,
+                    "paper_route_probe": {"mode": "paper_route_acquisition"},
+                }
             )
-            self.assertTrue(exit_metadata["profit_proof_eligible"])
-            self.assertEqual(exit_metadata["source_candidate_ids"], ["cand-h-pairs"])
-            self.assertEqual(exit_metadata["source_hypothesis_ids"], ["H-PAIRS-01"])
+        )
+        self.assertIsNone(
+            _paper_route_probe_entry_metadata(
+                {
+                    "paper_route_probe": {
+                        "mode": "paper_route_acquisition",
+                        "source_decision_mode": "strategy_signal_paper",
+                    }
+                }
+            )
+        )
+        self.assertIsNone(
+            _paper_route_probe_entry_metadata(
+                {
+                    "paper_route_probe": {
+                        "mode": "paper_route_acquisition",
+                        "profit_proof_eligible": True,
+                    }
+                }
+            )
+        )
+        self.assertEqual(
+            _paper_route_probe_entry_metadata(
+                {
+                    "paper_route_probe": {
+                        "mode": "paper_route_acquisition",
+                        "source_decision_mode": "route_acquisition_probe",
+                    }
+                }
+            ),
+            {
+                "mode": "paper_route_acquisition",
+                "source_decision_mode": "route_acquisition_probe",
+            },
+        )
 
     def test_paper_route_probe_lineage_parses_profit_proof_eligibility(self) -> None:
         self.assertTrue(
@@ -6960,6 +6997,11 @@ class TestTradingPipeline(TestCase):
                 make_decision(
                     params={"paper_route_target_plan_source_decision": {"mode": "x"}}
                 ),
+                [good_target],
+            ),
+            (
+                "paper route probe exit",
+                make_decision(params={"paper_route_probe_exit": {"mode": "x"}}),
                 [good_target],
             ),
             (


### PR DESCRIPTION
## Summary

- Prevent paper-route exit generation from treating profit-proof `strategy_signal_paper` decisions as route-acquisition probe inventory.
- Keep generated paper-route probe exits out of `strategy_signal_paper` authority tagging.
- Reduce Torghut paper-route probe max notional from `63180` to `25` in GitOps manifests so route-acquisition probes stay bounded.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -k 'probe_exit or strategy_signal_paper_target' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `bun run lint:argocd`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
