### PR TITLE
fix(torghut): keep route probes off active symbols

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -1649,6 +1649,7 @@ class SimpleTradingPipeline(TradingPipeline):
         decisions = self._paper_route_target_source_decisions(
             strategies=strategies,
             allowed_symbols=allowed_symbols,
+            positions=positions,
         )
         for decision in decisions:
             self.state.metrics.decisions_total += 1
@@ -2351,6 +2352,7 @@ class SimpleTradingPipeline(TradingPipeline):
         *,
         strategies: Sequence[Strategy],
         allowed_symbols: set[str],
+        positions: Sequence[Mapping[str, Any]] | None = None,
     ) -> list[StrategyDecision]:
         if settings.trading_mode != "paper":
             return []
@@ -2395,6 +2397,11 @@ class SimpleTradingPipeline(TradingPipeline):
             if action == "sell" and not settings.trading_allow_shorts:
                 continue
             for symbol in symbols:
+                if self._paper_route_target_symbol_has_open_position(
+                    positions,
+                    symbol,
+                ):
+                    continue
                 key = (str(strategy.id), symbol, window_start.isoformat(), action)
                 if key in seen:
                     continue
@@ -2450,6 +2457,28 @@ class SimpleTradingPipeline(TradingPipeline):
                     )
                 )
         return decisions
+
+    @staticmethod
+    def _paper_route_target_symbol_has_open_position(
+        positions: Sequence[Mapping[str, Any]] | None,
+        symbol: str,
+    ) -> bool:
+        if not positions:
+            return False
+        normalized_symbol = symbol.strip().upper()
+        if not normalized_symbol:
+            return False
+        for position in positions:
+            if str(position.get("symbol") or "").strip().upper() != normalized_symbol:
+                continue
+            for qty_key in ("qty", "quantity", "qty_available"):
+                qty = _optional_decimal(position.get(qty_key))
+                if qty is not None and qty != 0:
+                    return True
+            market_value = _optional_decimal(position.get("market_value"))
+            if market_value is not None and market_value != 0:
+                return True
+        return False
 
     def _paper_route_target_lineage_for_decision(
         self,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -5701,6 +5701,18 @@ class TestTradingPipeline(TestCase):
             ),
             set(),
         )
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_target_symbol_has_open_position(
+                [{"symbol": "AAPL", "qty": "10"}],
+                " ",
+            )
+        )
+        self.assertTrue(
+            SimpleTradingPipeline._paper_route_target_symbol_has_open_position(
+                [{"symbol": "AAPL", "qty": "0", "market_value": "25.50"}],
+                "AAPL",
+            )
+        )
 
     def test_paper_route_target_source_decisions_guard_paths_and_dedupes(
         self,
@@ -5821,6 +5833,68 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(decisions[0].symbol, "AAPL")
         self.assertEqual(decisions[0].action, "buy")
 
+    def test_paper_route_target_source_decisions_skip_symbols_with_open_exposure(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 5, 26, 14, 0, tzinfo=timezone.utc)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+
+        strategy = Strategy(
+            name="paper-route-candidate-v1",
+            description="paper route candidate",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL", "AMZN"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        target = {
+            "strategy_name": "paper-route-candidate-v1",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_route_probe_next_session_max_notional": "25",
+            "paper_route_probe_window_start": window_start.isoformat(),
+            "paper_route_probe_window_end": window_end.isoformat(),
+        }
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+        with (
+            patch.object(
+                SimpleTradingPipeline,
+                "_external_paper_route_target_probe_symbols_cached",
+                return_value=({"AAPL", "AMZN"}, None, [target]),
+            ),
+            patch(
+                "app.trading.scheduler.simple_pipeline.trading_now",
+                return_value=now,
+            ),
+        ):
+            decisions = pipeline._paper_route_target_source_decisions(
+                strategies=[strategy],
+                allowed_symbols={"AAPL", "AMZN"},
+                positions=[{"symbol": "AMZN", "qty": "41", "side": "short"}],
+            )
+
+        self.assertEqual([decision.symbol for decision in decisions], ["AAPL"])
+
     def test_process_paper_route_target_source_decisions_records_submit_failure(
         self,
     ) -> None:
@@ -5859,13 +5933,14 @@ class TestTradingPipeline(TestCase):
             rationale="target-plan-source-decision",
             params={"price": "100"},
         )
+        positions: list[dict[str, Any]] = []
 
         with (
             patch.object(
                 pipeline,
                 "_paper_route_target_source_decisions",
                 return_value=[decision],
-            ),
+            ) as source_decisions,
             patch.object(
                 pipeline,
                 "_handle_decision",
@@ -5877,10 +5952,15 @@ class TestTradingPipeline(TestCase):
                 session=session,
                 strategies=[strategy],
                 account={"equity": "10000", "cash": "10000", "buying_power": "10000"},
-                positions=[],
+                positions=positions,
                 allowed_symbols={"AAPL"},
             )
 
+        source_decisions.assert_called_once_with(
+            strategies=[strategy],
+            allowed_symbols={"AAPL"},
+            positions=positions,
+        )
         self.assertEqual(state.metrics.decisions_total, 1)
         self.assertEqual(state.metrics.orders_rejected_total, 1)
         self.assertEqual(


### PR DESCRIPTION
## Summary

- Prevent external paper-route target source decisions from submitting route-acquisition probes on symbols that already have open account exposure.
- Thread current broker positions into the target-source route-acquisition builder so H-PAIRS strategy paper exposure is not contaminated by same-symbol acquisition probes.
- Add regression coverage for the May 29 failure shape: target plan includes AAPL and AMZN, AMZN has open exposure, and only AAPL receives a route-acquisition source decision.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py::TestTradingPipeline::test_paper_route_target_source_decisions_guard_paths_and_dedupes tests/test_trading_pipeline.py::TestTradingPipeline::test_paper_route_target_source_decisions_skip_symbols_with_open_exposure tests/test_trading_pipeline.py::TestTradingPipeline::test_process_paper_route_target_source_decisions_records_submit_failure -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -k "paper_route_target_source or paper_route_probe_can_repair_symbol_outside_candidates or paper_route_probe_context" -q`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
