### PR TITLE
fix(torghut): prefer strategy signal proof metadata

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -343,6 +343,35 @@ def _first_text(row: Mapping[str, object], *keys: str) -> str | None:
     return None
 
 
+def _direct_text(row: Mapping[str, object], *keys: str) -> str | None:
+    for key in keys:
+        text = str(row.get(key) or "").strip()
+        if text:
+            return text
+    return None
+
+
+def _bool_value(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float | Decimal):
+        return bool(value)
+    text = str(value or "").strip().lower()
+    if text in {"1", "true", "yes", "on", "pass", "passed", "ok"}:
+        return True
+    if text in {"0", "false", "no", "off", "fail", "failed", "blocked"}:
+        return False
+    return None
+
+
+def _direct_bool(row: Mapping[str, object], *keys: str) -> bool | None:
+    for key in keys:
+        value = row.get(key)
+        if (parsed := _bool_value(value)) is not None:
+            return parsed
+    return None
+
+
 def _text_values(row: Mapping[str, object], *keys: str) -> set[str]:
     values: set[str] = set()
     for payload in _row_payloads(row):
@@ -365,24 +394,60 @@ def _text_values(row: Mapping[str, object], *keys: str) -> set[str]:
 def _first_bool(row: Mapping[str, object], *keys: str) -> bool | None:
     for payload in _row_payloads(row):
         for key in keys:
-            value = payload.get(key)
-            if isinstance(value, bool):
-                return value
-            if isinstance(value, int | float | Decimal):
-                return bool(value)
-            text = str(value or "").strip().lower()
-            if text in {"1", "true", "yes", "on", "pass", "passed", "ok"}:
-                return True
-            if text in {"0", "false", "no", "off", "fail", "failed", "blocked"}:
-                return False
+            if (parsed := _bool_value(payload.get(key))) is not None:
+                return parsed
     return None
 
 
+def _source_decision_priority_payloads(
+    row: Mapping[str, object],
+) -> list[Mapping[str, object]]:
+    payloads: list[Mapping[str, object]] = [row]
+    decision_json = _as_mapping(row.get("decision_json"))
+    if decision_json:
+        payloads.append(decision_json)
+        for key in (
+            "strategy_signal_paper",
+            "paper_route_target_plan",
+            "paper_route_target",
+        ):
+            if nested := _as_mapping(decision_json.get(key)):
+                payloads.append(nested)
+        params = _as_mapping(decision_json.get("params"))
+        if params:
+            for key in (
+                "strategy_signal_paper",
+                "paper_route_target_plan",
+                "paper_route_target",
+            ):
+                if nested := _as_mapping(params.get(key)):
+                    payloads.append(nested)
+    return payloads
+
+
 def _source_decision_mode(row: Mapping[str, object]) -> str | None:
+    for payload in _source_decision_priority_payloads(row):
+        explicit = normalize_source_decision_mode(
+            _direct_text(payload, "source_decision_mode")
+        )
+        if explicit is not None:
+            return explicit
     explicit = normalize_source_decision_mode(_first_text(row, "source_decision_mode"))
     if explicit is not None:
         return explicit
     return normalize_source_decision_mode(row.get("mode"))
+
+
+def _source_decision_profit_proof_flag(row: Mapping[str, object]) -> bool | None:
+    for payload in _source_decision_priority_payloads(row):
+        value = _direct_bool(
+            payload,
+            "profit_proof_eligible",
+            "post_cost_promotion_eligible",
+        )
+        if value is not None:
+            return value
+    return _first_bool(row, "profit_proof_eligible", "post_cost_promotion_eligible")
 
 
 def _source_decision_mode_counts(
@@ -533,11 +598,7 @@ def _source_decision_rows_profit_proof_eligible(
         return False
     explicit: list[bool] = []
     for row in rows:
-        value = _first_bool(
-            row,
-            "profit_proof_eligible",
-            "post_cost_promotion_eligible",
-        )
+        value = _source_decision_profit_proof_flag(row)
         if value is not None:
             explicit.append(value)
     if any(value is False for value in explicit):

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -890,6 +890,43 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             )
         )
 
+    def test_source_decision_helpers_prefer_strategy_signal_over_nested_probe(
+        self,
+    ) -> None:
+        row = {
+            "decision_json": {
+                "params": {
+                    "paper_route_probe": {
+                        "source_decision_mode": "route_acquisition_probe",
+                        "profit_proof_eligible": False,
+                    }
+                },
+                "source_decision_mode": "strategy_signal_paper",
+                "profit_proof_eligible": True,
+                "source_candidate_ids": ["c88421d619759b2cfaa6f4d0"],
+                "source_hypothesis_ids": ["H-PAIRS-01"],
+                "strategy_signal_paper": {
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                },
+            }
+        }
+
+        self.assertEqual(_source_decision_mode(row), "strategy_signal_paper")
+        self.assertEqual(
+            _source_decision_mode_counts([row]),
+            {"strategy_signal_paper": 1},
+        )
+        self.assertTrue(_source_decision_rows_profit_proof_eligible([row]))
+        self.assertTrue(
+            _source_row_matches_lineage(
+                row,
+                candidate_id="c88421d619759b2cfaa6f4d0",
+                hypothesis_id="H-PAIRS-01",
+                require_source_lineage=True,
+            )
+        )
+
     def test_runtime_ledger_tca_rows_from_durable_buckets_queries_matching_proof(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Prefer top-level strategy-signal source decision metadata before nested paper-route probe metadata when importing runtime windows.
- Keep route acquisition probe rows blocked when probe-only metadata is the only source decision evidence.
- Add a regression test using the H-PAIRS live-paper shape where nested probe metadata coexists with `strategy_signal_paper` proof fields.

## Related Issues

None

## Testing

- `uv sync --frozen --extra dev`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
