### PR TITLE
chore(torghut): scale hpairs paper evidence collection

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -109,7 +109,7 @@ spec:
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
-              value: "25"
+              value: "75000"
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_URL
               value: http://torghut.torghut.svc.cluster.local/trading/paper-route-target-plan
             - name: TRADING_PAPER_ROUTE_TARGET_PLAN_TIMEOUT_SECONDS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -92,7 +92,7 @@ spec:
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
-              value: "25"
+              value: "75000"
             - name: TRADING_MARKET_CONTEXT_URL
               value: http://jangar.jangar.svc.cluster.local/api/torghut/market-context
             - name: TRADING_JANGAR_CONTROL_PLANE_STATUS_URL

--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -427,24 +427,32 @@ data:
         strategy_id: microbar_cross_sectional_pairs_v1@research
         strategy_type: microbar_cross_sectional_pairs_v1
         version: 1.0.0
-        description: Paper-only H-PAIRS microbar cross-sectional continuation sleeve for the runtime-ledger proof lane; production approval blocked pending live-paper runtime evidence, version=1.0.0
+        description: Paper-only H-PAIRS microbar cross-sectional continuation sleeve sized for bounded runtime-ledger evidence collection; production approval blocked pending live-paper runtime evidence, version=1.0.0
         enabled: true
         base_timeframe: "1Sec"
         universe_type: microbar_cross_sectional_pairs_v1
         universe_symbols: ["AAPL", "AMZN"]
-        max_notional_per_trade: 31590
-        max_position_pct_equity: 1.0
+        max_notional_per_trade: 75000
+        max_position_pct_equity: 6.0
         params:
           entry_minute_after_open: "60"
           exit_minute_after_open: "120"
           signal_motif: "vwap_close_continuation"
           rank_feature: "cross_section_vwap_w5m_rank"
           selection_mode: "continuation"
-          top_n: "2"
-          max_gross_exposure_pct_equity: "2.0"
+          top_n: "1"
+          min_cross_section_continuation_rank: "0.55"
+          max_gross_exposure_pct_equity: "4.0"
           max_pair_legs: "2"
           max_entries_per_session: "1"
           entry_cooldown_seconds: "600"
+          long_stop_loss_bps: "10"
+          long_trailing_stop_activation_profit_bps: "8"
+          long_trailing_stop_drawdown_bps: "4"
+          max_hold_seconds: "7200"
+          max_session_negative_exit_bps: "10"
+          max_stop_loss_exits_per_session: "1"
+          stop_loss_lockout_seconds: "1800"
           position_isolation_mode: "per_strategy"
       - name: microbar-volume-continuation-long-top2-v11
         strategy_id: microbar_volume_continuation_long_top2@prod

--- a/services/torghut/config/trading/hypotheses/h-pairs-01.json
+++ b/services/torghut/config/trading/hypotheses/h-pairs-01.json
@@ -19,7 +19,7 @@
   "max_allowed_slippage_bps": "8",
   "min_sample_count_for_live_canary": 60,
   "min_sample_count_for_scale_up": 120,
-  "max_rolling_drawdown_bps": "1000",
+  "max_rolling_drawdown_bps": "300",
   "rollback_triggers": [
     "required_feature_set_unavailable",
     "drift_checks_missing",

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -393,7 +393,7 @@ class TestLiveConfigManifestContract(TestCase):
                 self.assertEqual(
                     tuple(str(symbol) for symbol in cast(list[object], raw_symbols)),
                     ("AAPL", "AMZN"),
-                    f"{name} must stay aligned to the active H-PAIRS paper-route probe symbols",
+                    f"{name} must stay aligned to the active H-PAIRS candidate pair",
                 )
             else:
                 self.assertIn("$300/day", description)
@@ -419,17 +419,26 @@ class TestLiveConfigManifestContract(TestCase):
                 self.assertEqual(name, "microbar-cross-sectional-pairs-v1")
                 self.assertEqual(
                     _strategy_decimal(strategy, "max_notional_per_trade"),
-                    Decimal("31590"),
+                    Decimal("75000"),
                 )
                 self.assertEqual(
                     _strategy_decimal(strategy, "max_position_pct_equity"),
-                    Decimal("1.0"),
+                    Decimal("6.0"),
                 )
                 self.assertEqual(params.get("position_isolation_mode"), "per_strategy")
-                self.assertEqual(params.get("max_gross_exposure_pct_equity"), "2.0")
+                self.assertEqual(params.get("max_gross_exposure_pct_equity"), "4.0")
                 self.assertEqual(params.get("max_pair_legs"), "2")
+                self.assertEqual(params.get("top_n"), "1")
+                self.assertEqual(params.get("min_cross_section_continuation_rank"), "0.55")
                 self.assertEqual(params.get("entry_minute_after_open"), "60")
                 self.assertEqual(params.get("exit_minute_after_open"), "120")
+                self.assertEqual(params.get("long_stop_loss_bps"), "10")
+                self.assertEqual(params.get("long_trailing_stop_activation_profit_bps"), "8")
+                self.assertEqual(params.get("long_trailing_stop_drawdown_bps"), "4")
+                self.assertEqual(params.get("max_hold_seconds"), "7200")
+                self.assertEqual(params.get("max_session_negative_exit_bps"), "10")
+                self.assertEqual(params.get("max_stop_loss_exits_per_session"), "1")
+                self.assertEqual(params.get("stop_loss_lockout_seconds"), "1800")
             elif str(strategy.get("strategy_type")) == "intraday_tsmom_v1":
                 self.assertEqual(name, "intraday-tsmom-profit-v3")
                 self.assertEqual(
@@ -609,7 +618,7 @@ class TestLiveConfigManifestContract(TestCase):
         )
         self.assertEqual(
             sim_env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"),
-            "25",
+            "75000",
         )
         self.assertEqual(
             sim_env.get("TRADING_PAPER_ROUTE_TARGET_PLAN_URL"),
@@ -1352,7 +1361,7 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertFalse(_manifest_bool(env, "TRADING_SIMPLE_SUBMIT_ENABLED"))
         self.assertTrue(_manifest_bool(env, "TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED"))
         self.assertEqual(
-            env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"), "25"
+            env.get("TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL"), "75000"
         )
         self.assertTrue(_manifest_bool(env, "TRADING_ALPACA_QUOTE_FALLBACK_ENABLED"))
         self.assertEqual(env.get("TRADING_ALPACA_QUOTE_FEED"), "iex")


### PR DESCRIPTION
## Summary

- Scales H-PAIRS paper-route evidence collection from the inert `$25` probe cap to a bounded `$75,000` per-trade SIM cap.
- Expands the active H-PAIRS runtime universe to `AAPL`, `AMZN`, `INTC`, and `NVDA` while keeping the lane paper-only and final promotion blocked.
- Tightens the H-PAIRS manifest drawdown cap from `1000` bps to `300` bps so larger paper collection does not relax risk semantics.

## Related Issues

None

## Testing

- `git diff --check`
- `python -m json.tool services/torghut/config/trading/hypotheses/h-pairs-01.json >/tmp/h-pairs-01.json.check`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut >/tmp/torghut-kustomize-render.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
