### PR TITLE
fix(torghut): unblock symmetric hpairs paper exits

### DIFF
--- a/services/torghut/app/trading/decisions.py
+++ b/services/torghut/app/trading/decisions.py
@@ -73,9 +73,6 @@ _BUY_EXIT_ONLY_STRATEGY_TYPES = {
     "mean_reversion_exhaustion_short_v1",
     "microbar_cross_sectional_short_v1",
 }
-_LEGACY_BUY_EXIT_ONLY_UNIVERSE_TYPES = {
-    "microbar_cross_sectional_pairs_v1",
-}
 _MICROBAR_PAIR_EXIT_RATIONALE = "microbar_cross_sectional_pair_exit"
 
 
@@ -2195,9 +2192,16 @@ def _strategy_uses_position_isolation(strategy: Strategy) -> bool:
     if isolation_mode == "per_strategy":
         return True
     normalized = str(strategy.universe_type or "").strip().lower()
+    runtime_type = _strategy_catalog_runtime_type(strategy)
+    if (
+        normalized == "microbar_cross_sectional_pairs_v1"
+        and runtime_type != "microbar_cross_sectional_pairs_v1"
+    ):
+        return False
     return normalized in {
         "momentum_pullback_long_v1",
         "breakout_continuation_long_v1",
+        "microbar_cross_sectional_pairs_v1",
         "mean_reversion_rebound_long_v1",
         "late_day_continuation_long_v1",
         "end_of_day_reversal_long_v1",
@@ -2270,9 +2274,7 @@ def _treats_sell_as_exit_only(strategy: Strategy) -> bool:
 
 
 def _treats_buy_as_exit_only(strategy: Strategy) -> bool:
-    return _strategy_exit_semantics_type(strategy) in (
-        _BUY_EXIT_ONLY_STRATEGY_TYPES | _LEGACY_BUY_EXIT_ONLY_UNIVERSE_TYPES
-    )
+    return _strategy_exit_semantics_type(strategy) in _BUY_EXIT_ONLY_STRATEGY_TYPES
 
 
 def _strategy_exit_semantics_type(strategy: Strategy) -> str:
@@ -2284,7 +2286,6 @@ def _strategy_exit_semantics_type(strategy: Strategy) -> str:
     if universe_type in (
         _SELL_EXIT_ONLY_STRATEGY_TYPES
         | _BUY_EXIT_ONLY_STRATEGY_TYPES
-        | _LEGACY_BUY_EXIT_ONLY_UNIVERSE_TYPES
     ):
         return universe_type
     return runtime_type

--- a/services/torghut/app/trading/scheduler/pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline.py
@@ -912,11 +912,20 @@ class TradingPipeline:
             or position.get("qty_available")
             or "0"
         )
-        position_qty = _optional_decimal(raw_qty)
-        if position_qty is None or position_qty <= 0:
+        raw_position_qty = _optional_decimal(raw_qty)
+        if raw_position_qty is None or raw_position_qty == 0:
             return [position]
         side = str(position.get("side") or "").strip().lower()
-        signed_position_qty = -position_qty if side == "short" else position_qty
+        signed_position_qty = (
+            -abs(raw_position_qty)
+            if side == "short" or raw_position_qty < 0
+            else raw_position_qty
+        )
+        position_qty = abs(raw_position_qty)
+        if signed_position_qty < 0:
+            side = "short"
+        elif side not in {"long", "short"}:
+            side = "long"
         same_side_exposures = [
             (strategy_id, exposure)
             for strategy_id, exposure in symbol_exposures.items()

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -30,7 +30,12 @@ from app.models import (
     VNextDatasetSnapshot,
 )
 from app import config
-from app.trading.decisions import DecisionEngine
+from app.trading.decisions import (
+    DecisionEngine,
+    _is_entry_action_for_strategies,
+    _is_exit_action_for_strategies,
+    _strategy_uses_position_isolation,
+)
 from app.trading.execution_adapters import SimulationExecutionAdapter
 from app.trading.execution import OrderExecutor
 from app.trading.firewall import OrderFirewall
@@ -13092,6 +13097,48 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(
             tagged["strategy_position_latest_execution_at"],
             (session_open + timedelta(minutes=1)).isoformat(),
+        )
+
+    def test_attach_strategy_position_tag_handles_signed_short_qty(self) -> None:
+        session_open = datetime(2026, 3, 26, 13, 30, tzinfo=timezone.utc)
+        tagged = TradingPipeline._attach_strategy_position_tag(
+            {"symbol": "AMZN", "qty": "-41"},
+            exposures={
+                "AMZN": {
+                    "strategy-pairs": {
+                        "qty": Decimal("-41"),
+                        "latest_execution_at": session_open + timedelta(minutes=61),
+                    }
+                }
+            },
+            session_open=session_open,
+        )
+
+        self.assertEqual(tagged["strategy_id"], "strategy-pairs")
+        self.assertEqual(tagged["qty"], "41")
+        self.assertEqual(tagged["side"], "short")
+
+    def test_microbar_pairs_are_symmetric_entries_with_position_isolation(self) -> None:
+        strategy = Strategy(
+            name="microbar-cross-sectional-pairs-v1",
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+        )
+
+        self.assertTrue(_strategy_uses_position_isolation(strategy))
+        self.assertTrue(
+            _is_entry_action_for_strategies(strategies=[strategy], action="buy")
+        )
+        self.assertTrue(
+            _is_entry_action_for_strategies(strategies=[strategy], action="sell")
+        )
+        self.assertFalse(
+            _is_exit_action_for_strategies(strategies=[strategy], action="buy")
+        )
+        self.assertFalse(
+            _is_exit_action_for_strategies(strategies=[strategy], action="sell")
         )
 
     def test_pipeline_runtime_uncertainty_rechecks_after_llm_adjustment(self) -> None:


### PR DESCRIPTION
## Summary

- Removes the legacy `microbar_cross_sectional_pairs_v1` buy-exit-only classification so H-PAIRS can produce both long and short pair entries.
- Marks microbar pairs as per-strategy position-isolated so runtime exits evaluate against their own sleeve exposure.
- Handles signed negative short quantities when tagging live/paper positions back to strategy fills.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/decisions.py app/trading/scheduler/pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
