### PR TITLE
fix(torghut): run scheduled proof packets as authority

### DIFF
--- a/argocd/applications/torghut/README.md
+++ b/argocd/applications/torghut/README.md
@@ -23,12 +23,14 @@ workflow submissions in `torghut` do not rely on manual secret copies from `argo
 
 The `torghut-empirical-promotion-renewal` CronJob is also the scheduled runtime-ledger proof packet conductor for the
 paper-route proof lane. It first runs `renew_latest_empirical_promotion_jobs.py` with the sim
-`/trading/paper-route-target-plan` target plan, then runs `assemble_runtime_ledger_proof_packet.py` and uploads the packet
-under `runtime-ledger-proof-packets/{run_id}`. When the paper-route window is import-ready, the packet now requires the
-live `runtime_window_import_audit` from `/trading/paper-route-evidence` and carries source-activity blockers such as
-`paper_route_source_activity_missing`, `source_decisions_missing`, `source_executions_missing`, and `source_tca_missing`
-into the final verdict. Treat those as the next repair target before rerunning import; do not collapse them into a
-generic runtime-ledger-missing diagnosis.
+`/trading/paper-route-target-plan` target plan, then runs `assemble_runtime_ledger_proof_packet.py` in explicit
+`authority` mode and uploads the packet under `runtime-ledger-proof-packets/{run_id}`. The scheduled packet uses the
+final authority thresholds: 20 runtime-ledger trading days, $10,000 total post-cost net PnL, $500/day post-cost net PnL,
+3% max drawdown/equity, 25% best-day share, and 35% symbol concentration. When the paper-route window is import-ready,
+the packet now requires the live `runtime_window_import_audit` from `/trading/paper-route-evidence` and carries
+source-activity blockers such as `paper_route_source_activity_missing`, `source_decisions_missing`,
+`source_executions_missing`, and `source_tca_missing` into the final verdict. Treat those as the next repair target
+before rerunning import; do not collapse them into a generic runtime-ledger-missing diagnosis.
 
 Trigger a simulation run via Argo:
 

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -78,7 +78,14 @@ spec:
                     --status-service-base-url http://torghut.torghut.svc.cluster.local \
                     --paper-route-service-base-url http://torghut-sim.torghut.svc.cluster.local \
                     --completion-service-base-url http://torghut.torghut.svc.cluster.local \
+                    --proof-mode authority \
                     --runtime-window-import-file "${RENEWAL_OUTPUT}" \
+                    --min-runtime-ledger-net-pnl 10000 \
+                    --min-runtime-ledger-daily-net-pnl 500 \
+                    --min-runtime-ledger-trading-days 20 \
+                    --max-runtime-ledger-drawdown-pct-equity 0.03 \
+                    --max-runtime-ledger-best-day-share 0.25 \
+                    --max-runtime-ledger-symbol-concentration-share 0.35 \
                     --output-file "${PROOF_PACKET_OUTPUT}" \
                     --artifact-prefix 'runtime-ledger-proof-packets/{run_id}' \
                     --require-artifact-upload \

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -1166,7 +1166,14 @@ class TestLiveConfigManifestContract(TestCase):
             "--completion-service-base-url http://torghut.torghut.svc.cluster.local",
             args,
         )
+        self.assertIn("--proof-mode authority", args)
         self.assertIn('--runtime-window-import-file "${RENEWAL_OUTPUT}"', args)
+        self.assertIn("--min-runtime-ledger-net-pnl 10000", args)
+        self.assertIn("--min-runtime-ledger-daily-net-pnl 500", args)
+        self.assertIn("--min-runtime-ledger-trading-days 20", args)
+        self.assertIn("--max-runtime-ledger-drawdown-pct-equity 0.03", args)
+        self.assertIn("--max-runtime-ledger-best-day-share 0.25", args)
+        self.assertIn("--max-runtime-ledger-symbol-concentration-share 0.35", args)
         self.assertIn('--output-file "${PROOF_PACKET_OUTPUT}"', args)
         self.assertIn(
             "--artifact-prefix 'runtime-ledger-proof-packets/{run_id}'",


### PR DESCRIPTION
## Summary

- Run the scheduled Torghut runtime-ledger proof packet in explicit `authority` mode.
- Pass final authority thresholds to the renewal CronJob: 20 days, $10,000 total post-cost net PnL, $500/day post-cost net PnL, 3% drawdown/equity, 25% best-day share, and 35% symbol concentration.
- Update the Torghut GitOps README and manifest contract test so future edits do not regress the scheduled proof mode back to smoke.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `cd services/torghut && uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
