### PR TITLE
fix(torghut): resolve market session boundaries from New York time

### DIFF
--- a/services/torghut/app/trading/discovery/replay_tape.py
+++ b/services/torghut/app/trading/discovery/replay_tape.py
@@ -7,19 +7,21 @@ import hashlib
 import json
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, TextIO, cast
 
 from app.trading.models import SignalEnvelope
+from app.trading.session_context import (
+    regular_session_close_utc_for,
+    regular_session_open_utc_for,
+)
 
 REPLAY_TAPE_SCHEMA_VERSION = "torghut.replay-tape.v1"
 REPLAY_TAPE_MANIFEST_SCHEMA_VERSION = "torghut.replay-tape-manifest.v1"
 _DECIMAL_TAG = "__torghut_decimal__"
 _DATETIME_TAG = "__torghut_datetime__"
-_REGULAR_OPEN_UTC = time(hour=13, minute=30)
-_REGULAR_CLOSE_UTC = time(hour=20, minute=0)
 
 
 def _empty_row_count_by_trading_day() -> dict[str, int]:
@@ -242,8 +244,8 @@ def materialize_signal_tape(
             content_hash.update(b"\n")
             handle.write(f"{line}\n")
 
-    start_ts = datetime.combine(start_date, _REGULAR_OPEN_UTC, tzinfo=timezone.utc)
-    end_ts = datetime.combine(end_date, _REGULAR_CLOSE_UTC, tzinfo=timezone.utc)
+    start_ts = regular_session_open_utc_for(start_date)
+    end_ts = regular_session_close_utc_for(end_date)
     resolved_artifact_refs = {
         "tape_path": str(tape_path),
         **dict(artifact_refs or {}),

--- a/services/torghut/app/trading/scheduler/pipeline.py
+++ b/services/torghut/app/trading/scheduler/pipeline.py
@@ -97,7 +97,7 @@ from ..regime_hmm import (
     resolve_regime_context_authority_reason,
 )
 from ..risk import RiskEngine
-from ..session_context import REGULAR_OPEN_UTC
+from ..session_context import regular_session_open_utc_for
 from ..tca import derive_adaptive_execution_policy
 from ..time_source import trading_now
 from ..universe import UniverseResolver
@@ -301,15 +301,11 @@ class TradingPipeline:
             return
 
         now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
-        session_day = now.date()
+        session_open = regular_session_open_utc_for(now)
+        session_day = session_open.date()
         if self._session_context_warmup_day == session_day:
             return
 
-        session_open = datetime.combine(
-            session_day,
-            REGULAR_OPEN_UTC,
-            tzinfo=timezone.utc,
-        )
         if now < session_open:
             return
 
@@ -410,15 +406,11 @@ class TradingPipeline:
             return
 
         now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
-        session_day = now.date()
+        session_open = regular_session_open_utc_for(now)
+        session_day = session_open.date()
         if self._runtime_window_account_snapshot_day == session_day:
             return
 
-        session_open = datetime.combine(
-            session_day,
-            REGULAR_OPEN_UTC,
-            tzinfo=timezone.utc,
-        )
         capture_start = session_open - timedelta(
             seconds=PAPER_ROUTE_ACCOUNT_PRE_SESSION_READINESS_SECONDS
         )
@@ -772,12 +764,8 @@ class TradingPipeline:
     ) -> list[dict[str, Any]]:
         if not positions:
             return positions
-        session_open = datetime.combine(
-            trading_now(account_label=self.account_label)
-            .astimezone(timezone.utc)
-            .date(),
-            REGULAR_OPEN_UTC,
-            tzinfo=timezone.utc,
+        session_open = regular_session_open_utc_for(
+            trading_now(account_label=self.account_label).astimezone(timezone.utc)
         )
         lookback_start = session_open - _STRATEGY_POSITION_TAG_LOOKBACK
         try:

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -34,7 +34,7 @@ from ..runtime_decision_authority import (
     STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
     normalize_source_decision_mode,
 )
-from ..session_context import REGULAR_OPEN_UTC
+from ..session_context import regular_session_open_utc_for
 from ..simple_risk import (
     position_qty_for_symbol,
     prepare_simple_decision,
@@ -762,7 +762,7 @@ class SimpleTradingPipeline(TradingPipeline):
 
     def _paper_route_probe_retry_session_open(self) -> datetime:
         now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
-        return datetime.combine(now.date(), REGULAR_OPEN_UTC, tzinfo=timezone.utc)
+        return regular_session_open_utc_for(now)
 
     @staticmethod
     def _paper_route_probe_strategy(
@@ -836,7 +836,7 @@ class SimpleTradingPipeline(TradingPipeline):
         ts = (
             value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
         ).astimezone(timezone.utc)
-        return datetime.combine(ts.date(), REGULAR_OPEN_UTC, tzinfo=timezone.utc)
+        return regular_session_open_utc_for(ts)
 
     @staticmethod
     def _paper_route_probe_exit_session_open(
@@ -875,11 +875,7 @@ class SimpleTradingPipeline(TradingPipeline):
         if exit_minute is None:
             return False
         now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
-        session_open = datetime.combine(
-            now.date(),
-            REGULAR_OPEN_UTC,
-            tzinfo=timezone.utc,
-        )
+        session_open = regular_session_open_utc_for(now)
         minutes_elapsed = int((now - session_open).total_seconds() // 60)
         return minutes_elapsed >= exit_minute
 
@@ -979,11 +975,7 @@ class SimpleTradingPipeline(TradingPipeline):
         if not self._is_market_session_open(now):
             return []
 
-        session_open = datetime.combine(
-            now.date(),
-            REGULAR_OPEN_UTC,
-            tzinfo=timezone.utc,
-        )
+        session_open = regular_session_open_utc_for(now)
         exit_lookback_hours = max(
             0,
             _safe_int(settings.trading_simple_paper_route_probe_exit_lookback_hours),
@@ -2751,11 +2743,7 @@ class SimpleTradingPipeline(TradingPipeline):
         if exit_minute is not None:
             effective_exit_minute = min(exit_minute, _REGULAR_SESSION_MINUTES - 1)
             now = trading_now(account_label=self.account_label).astimezone(timezone.utc)
-            session_open = datetime.combine(
-                now.date(),
-                REGULAR_OPEN_UTC,
-                tzinfo=timezone.utc,
-            )
+            session_open = regular_session_open_utc_for(now)
             exit_due_at = (
                 session_open + timedelta(minutes=effective_exit_minute)
             ).isoformat()

--- a/services/torghut/app/trading/session_context.py
+++ b/services/torghut/app/trading/session_context.py
@@ -7,42 +7,91 @@ from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from typing import Any
+from zoneinfo import ZoneInfo
 
-from .features import extract_price, nested_payload_value, optional_decimal, payload_value
+from .features import (
+    extract_price,
+    nested_payload_value,
+    optional_decimal,
+    payload_value,
+)
 from .models import SignalEnvelope
 from .quote_quality import QuoteQualityPolicy, assess_signal_quote_quality
 
-REGULAR_OPEN_UTC = time(hour=13, minute=30)
+US_EQUITIES_TIMEZONE = "America/New_York"
+REGULAR_OPEN_LOCAL = time(hour=9, minute=30)
+REGULAR_CLOSE_LOCAL = time(hour=16, minute=0)
 DEFAULT_OPENING_RANGE_MINUTES = 30
 DEFAULT_RECENT_WINDOW = 30
 DEFAULT_PRICE_HISTORY_WINDOW = 7200
-DEFAULT_POSITION_IN_RANGE = Decimal('0.5')
+DEFAULT_POSITION_IN_RANGE = Decimal("0.5")
+_MARKET_TZ = ZoneInfo(US_EQUITIES_TIMEZONE)
+
+
+def regular_session_open_utc_for(value: datetime | date) -> datetime:
+    return _regular_session_boundary_utc_for(value, boundary=REGULAR_OPEN_LOCAL)
+
+
+def regular_session_close_utc_for(value: datetime | date) -> datetime:
+    return _regular_session_boundary_utc_for(value, boundary=REGULAR_CLOSE_LOCAL)
+
+
+def _regular_session_boundary_utc_for(
+    value: datetime | date, *, boundary: time
+) -> datetime:
+    if isinstance(value, datetime):
+        aware = (
+            value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        )
+        session_day = aware.astimezone(_MARKET_TZ).date()
+    else:
+        session_day = value
+    return datetime.combine(session_day, boundary, tzinfo=_MARKET_TZ).astimezone(
+        timezone.utc
+    )
+
+
+def regular_session_minutes_elapsed(event_ts: datetime) -> int:
+    ts_utc = (
+        event_ts
+        if event_ts.tzinfo is not None
+        else event_ts.replace(tzinfo=timezone.utc)
+    ).astimezone(timezone.utc)
+    session_open = regular_session_open_utc_for(ts_utc)
+    delta = ts_utc - session_open
+    return max(0, int(delta.total_seconds() // 60))
 
 
 def _extract_price(payload: dict[str, Any]) -> Decimal | None:
     return extract_price(payload)
 
 
-def _extract_spread_bps(payload: dict[str, Any], price: Decimal | None) -> Decimal | None:
+def _extract_spread_bps(
+    payload: dict[str, Any], price: Decimal | None
+) -> Decimal | None:
     if price is None or price <= 0:
         return None
-    spread_value = payload_value(payload, 'spread')
+    spread_value = payload_value(payload, "spread")
     if spread_value is None:
-        spread_value = payload_value(payload, 'imbalance_spread')
+        spread_value = payload_value(payload, "imbalance_spread")
     if spread_value is None:
-        spread_value = nested_payload_value(payload, 'imbalance', 'spread')
+        spread_value = nested_payload_value(payload, "imbalance", "spread")
     spread = optional_decimal(spread_value)
     if spread is None:
         return None
-    return (abs(spread) / price) * Decimal('10000')
+    return (abs(spread) / price) * Decimal("10000")
 
 
 def _extract_imbalance_pressure(payload: dict[str, Any]) -> Decimal | None:
     bid_sz = optional_decimal(
-        payload_value(payload, 'imbalance_bid_sz', block='imbalance', nested_key='bid_sz')
+        payload_value(
+            payload, "imbalance_bid_sz", block="imbalance", nested_key="bid_sz"
+        )
     )
     ask_sz = optional_decimal(
-        payload_value(payload, 'imbalance_ask_sz', block='imbalance', nested_key='ask_sz')
+        payload_value(
+            payload, "imbalance_ask_sz", block="imbalance", nested_key="ask_sz"
+        )
     )
     if bid_sz is None or ask_sz is None:
         return None
@@ -54,16 +103,24 @@ def _extract_imbalance_pressure(payload: dict[str, Any]) -> Decimal | None:
 
 def _extract_microprice_bias_bps(payload: dict[str, Any]) -> Decimal | None:
     bid_px = optional_decimal(
-        payload_value(payload, 'imbalance_bid_px', block='imbalance', nested_key='bid_px')
+        payload_value(
+            payload, "imbalance_bid_px", block="imbalance", nested_key="bid_px"
+        )
     )
     ask_px = optional_decimal(
-        payload_value(payload, 'imbalance_ask_px', block='imbalance', nested_key='ask_px')
+        payload_value(
+            payload, "imbalance_ask_px", block="imbalance", nested_key="ask_px"
+        )
     )
     bid_sz = optional_decimal(
-        payload_value(payload, 'imbalance_bid_sz', block='imbalance', nested_key='bid_sz')
+        payload_value(
+            payload, "imbalance_bid_sz", block="imbalance", nested_key="bid_sz"
+        )
     )
     ask_sz = optional_decimal(
-        payload_value(payload, 'imbalance_ask_sz', block='imbalance', nested_key='ask_sz')
+        payload_value(
+            payload, "imbalance_ask_sz", block="imbalance", nested_key="ask_sz"
+        )
     )
     if (
         bid_px is None
@@ -81,12 +138,13 @@ def _extract_microprice_bias_bps(payload: dict[str, Any]) -> Decimal | None:
     if mid_price <= 0:
         return None
     microprice = ((ask_px * bid_sz) + (bid_px * ask_sz)) / total_size
-    return ((microprice - mid_price) / mid_price) * Decimal('10000')
+    return ((microprice - mid_price) / mid_price) * Decimal("10000")
+
 
 def _bps_delta(price: Decimal | None, reference: Decimal | None) -> Decimal | None:
     if price is None or reference is None or reference == 0:
         return None
-    return ((price - reference) / reference) * Decimal('10000')
+    return ((price - reference) / reference) * Decimal("10000")
 
 
 def _recent_return_bps(
@@ -106,7 +164,7 @@ def _recent_return_bps(
 def _mean_decimal(values: deque[Decimal]) -> Decimal | None:
     if not values:
         return None
-    return sum(values, Decimal('0')) / Decimal(len(values))
+    return sum(values, Decimal("0")) / Decimal(len(values))
 
 
 def _max_decimal(values: deque[Decimal]) -> Decimal | None:
@@ -119,7 +177,7 @@ def _average_decimal(values: list[Decimal | None]) -> Decimal | None:
     present = [value for value in values if value is not None]
     if not present:
         return None
-    return sum(present, Decimal('0')) / Decimal(len(present))
+    return sum(present, Decimal("0")) / Decimal(len(present))
 
 
 def _ratio_decimal(values: list[bool]) -> Decimal | None:
@@ -146,7 +204,7 @@ def _percentile_rank(
         return None
     ordered = sorted(values.items(), key=lambda item: (item[1], item[0]))
     if len(ordered) == 1:
-        return Decimal('1')
+        return Decimal("1")
     for index, (candidate_symbol, _value) in enumerate(ordered):
         if candidate_symbol == normalized_symbol:
             return Decimal(index) / Decimal(len(ordered) - 1)
@@ -154,10 +212,7 @@ def _percentile_rank(
 
 
 def _session_minutes_elapsed(event_ts: datetime) -> int:
-    ts_utc = event_ts.astimezone(timezone.utc)
-    session_open = datetime.combine(ts_utc.date(), REGULAR_OPEN_UTC, tzinfo=timezone.utc)
-    delta = ts_utc - session_open
-    return max(0, int(delta.total_seconds() // 60))
+    return regular_session_minutes_elapsed(event_ts)
 
 
 @dataclass
@@ -170,11 +225,21 @@ class _SymbolSessionState:
     opening_range_high: Decimal
     opening_range_low: Decimal
     opening_window_close_price: Decimal
-    spread_bps_window: deque[Decimal] = field(default_factory=lambda: deque(maxlen=DEFAULT_RECENT_WINDOW))
-    imbalance_pressure_window: deque[Decimal] = field(default_factory=lambda: deque(maxlen=DEFAULT_RECENT_WINDOW))
-    quote_validity_window: deque[Decimal] = field(default_factory=lambda: deque(maxlen=DEFAULT_RECENT_WINDOW))
-    quote_jump_bps_window: deque[Decimal] = field(default_factory=lambda: deque(maxlen=DEFAULT_RECENT_WINDOW))
-    microprice_bias_bps_window: deque[Decimal] = field(default_factory=lambda: deque(maxlen=DEFAULT_RECENT_WINDOW))
+    spread_bps_window: deque[Decimal] = field(
+        default_factory=lambda: deque(maxlen=DEFAULT_RECENT_WINDOW)
+    )
+    imbalance_pressure_window: deque[Decimal] = field(
+        default_factory=lambda: deque(maxlen=DEFAULT_RECENT_WINDOW)
+    )
+    quote_validity_window: deque[Decimal] = field(
+        default_factory=lambda: deque(maxlen=DEFAULT_RECENT_WINDOW)
+    )
+    quote_jump_bps_window: deque[Decimal] = field(
+        default_factory=lambda: deque(maxlen=DEFAULT_RECENT_WINDOW)
+    )
+    microprice_bias_bps_window: deque[Decimal] = field(
+        default_factory=lambda: deque(maxlen=DEFAULT_RECENT_WINDOW)
+    )
     above_opening_range_high_window: deque[Decimal] = field(
         default_factory=lambda: deque(maxlen=DEFAULT_RECENT_WINDOW)
     )
@@ -235,25 +300,23 @@ class SessionContextTracker:
 
         symbol = signal.symbol.strip().upper()
         signal_ts_utc = signal.event_ts.astimezone(timezone.utc)
-        session_day = signal_ts_utc.date()
-        session_open_ts = datetime.combine(
-            session_day,
-            REGULAR_OPEN_UTC,
-            tzinfo=timezone.utc,
-        )
+        session_open_ts = regular_session_open_utc_for(signal_ts_utc)
+        session_day = session_open_ts.astimezone(_MARKET_TZ).date()
         regular_session_started = signal_ts_utc >= session_open_ts
         self._roll_forward_completed_sessions(next_session_day=session_day)
         state = self._state_by_symbol.get(symbol)
         quote_quality = assess_signal_quote_quality(
             signal=signal,
-            previous_price=(state.last_valid_quote_price if state is not None else None),
+            previous_price=(
+                state.last_valid_quote_price if state is not None else None
+            ),
             policy=self.quote_quality_policy,
         )
         if state is None:
             if not regular_session_started:
                 previous_close = self._last_session_close_by_symbol.get(symbol)
                 if previous_close is not None:
-                    payload['prev_session_close_price'] = previous_close
+                    payload["prev_session_close_price"] = previous_close
                 return payload
             state = _SymbolSessionState(
                 session_day=session_day,
@@ -281,16 +344,18 @@ class SessionContextTracker:
         spread_bps = _extract_spread_bps(payload, price)
         imbalance_pressure = _extract_imbalance_pressure(payload)
         microprice_bias_bps = _extract_microprice_bias_bps(payload)
-        rsi14 = optional_decimal(payload_value(payload, 'rsi14', nested_key='rsi'))
-        macd_hist = optional_decimal(payload_value(payload, 'macd_hist', block='macd', nested_key='hist'))
-        microbar_volume = optional_decimal(payload_value(payload, 'microbar_volume'))
+        rsi14 = optional_decimal(payload_value(payload, "rsi14", nested_key="rsi"))
+        macd_hist = optional_decimal(
+            payload_value(payload, "macd_hist", block="macd", nested_key="hist")
+        )
+        microbar_volume = optional_decimal(payload_value(payload, "microbar_volume"))
         if microbar_volume is None:
-            microbar_volume = optional_decimal(payload_value(payload, 'volume'))
+            microbar_volume = optional_decimal(payload_value(payload, "volume"))
         vwap_w5m = optional_decimal(
-            payload_value(payload, 'vwap_w5m', block='vwap', nested_key='w5m')
+            payload_value(payload, "vwap_w5m", block="vwap", nested_key="w5m")
         )
         state.quote_validity_window.append(
-            Decimal('1') if quote_quality.valid else Decimal('0')
+            Decimal("1") if quote_quality.valid else Decimal("0")
         )
         if quote_quality.jump_bps is not None:
             state.quote_jump_bps_window.append(quote_quality.jump_bps)
@@ -316,14 +381,16 @@ class SessionContextTracker:
             if microprice_bias_bps is not None:
                 state.microprice_bias_bps_window.append(microprice_bias_bps)
             state.above_opening_range_high_window.append(
-                Decimal('1') if price >= state.opening_range_high else Decimal('0')
+                Decimal("1") if price >= state.opening_range_high else Decimal("0")
             )
             state.above_opening_window_close_window.append(
-                Decimal('1') if price >= state.opening_window_close_price else Decimal('0')
+                Decimal("1")
+                if price >= state.opening_window_close_price
+                else Decimal("0")
             )
             if vwap_w5m is not None:
                 state.above_vwap_w5m_window.append(
-                    Decimal('1') if price >= vwap_w5m else Decimal('0')
+                    Decimal("1") if price >= vwap_w5m else Decimal("0")
                 )
             state.price_history.append((signal_ts_utc, price))
             state.last_valid_quote_price = price
@@ -333,14 +400,20 @@ class SessionContextTracker:
         if session_range > 0:
             position_in_range = (price - state.session_low_price) / session_range
             position_in_range = min(
-                Decimal('1'),
-                max(Decimal('0'), position_in_range),
+                Decimal("1"),
+                max(Decimal("0"), position_in_range),
             )
 
-        opening_range_width_bps = _bps_delta(state.opening_range_high, state.opening_range_low)
-        session_range_bps = _bps_delta(state.session_high_price, state.session_low_price)
+        opening_range_width_bps = _bps_delta(
+            state.opening_range_high, state.opening_range_low
+        )
+        session_range_bps = _bps_delta(
+            state.session_high_price, state.session_low_price
+        )
         price_vs_session_open_bps = _bps_delta(price, state.session_open_price)
-        price_vs_prev_session_close_bps = _bps_delta(price, state.prev_session_close_price)
+        price_vs_prev_session_close_bps = _bps_delta(
+            price, state.prev_session_close_price
+        )
         opening_window_return_bps = _bps_delta(
             state.opening_window_close_price,
             state.session_open_price,
@@ -353,21 +426,21 @@ class SessionContextTracker:
         price_vs_session_low_bps = _bps_delta(price, state.session_low_price)
         price_vs_opening_range_high_bps = _bps_delta(price, state.opening_range_high)
         price_vs_opening_range_low_bps = _bps_delta(price, state.opening_range_low)
-        price_vs_opening_window_close_bps = _bps_delta(price, state.opening_window_close_price)
+        price_vs_opening_window_close_bps = _bps_delta(
+            price, state.opening_window_close_price
+        )
         recent_spread_bps_avg = _mean_decimal(state.spread_bps_window)
         recent_spread_bps_max = _max_decimal(state.spread_bps_window)
         recent_imbalance_pressure_avg = _mean_decimal(state.imbalance_pressure_window)
         recent_quote_validity_avg = _mean_decimal(state.quote_validity_window)
         recent_quote_invalid_ratio = (
-            Decimal('1') - recent_quote_validity_avg
+            Decimal("1") - recent_quote_validity_avg
             if recent_quote_validity_avg is not None
             else None
         )
         recent_quote_jump_bps_avg = _mean_decimal(state.quote_jump_bps_window)
         recent_quote_jump_bps_max = _max_decimal(state.quote_jump_bps_window)
-        recent_microprice_bias_bps_avg = _mean_decimal(
-            state.microprice_bias_bps_window
-        )
+        recent_microprice_bias_bps_avg = _mean_decimal(state.microprice_bias_bps_window)
         recent_above_opening_range_high_ratio = _mean_decimal(
             state.above_opening_range_high_window
         )
@@ -390,7 +463,9 @@ class SessionContextTracker:
 
         if quote_quality.valid:
             state.latest_price_vs_session_open_bps = price_vs_session_open_bps
-            state.latest_price_vs_prev_session_close_bps = price_vs_prev_session_close_bps
+            state.latest_price_vs_prev_session_close_bps = (
+                price_vs_prev_session_close_bps
+            )
             state.latest_price_position_in_session_range = position_in_range
             state.latest_recent_15m_return_bps = recent_15m_return_bps
             state.latest_microbar_volume = microbar_volume
@@ -416,57 +491,71 @@ class SessionContextTracker:
         session_open_rank, session_open_rank_universe_size = self._rank_latest_metric(
             current_day=session_day,
             symbol=symbol,
-            accessor='latest_price_vs_session_open_bps',
+            accessor="latest_price_vs_session_open_bps",
         )
-        range_position_rank, range_position_rank_universe_size = self._rank_latest_metric(
-            current_day=session_day,
-            symbol=symbol,
-            accessor='latest_price_position_in_session_range',
+        range_position_rank, range_position_rank_universe_size = (
+            self._rank_latest_metric(
+                current_day=session_day,
+                symbol=symbol,
+                accessor="latest_price_position_in_session_range",
+            )
         )
         vwap_w5m_rank, vwap_w5m_rank_universe_size = self._rank_latest_metric(
             current_day=session_day,
             symbol=symbol,
-            accessor='latest_price_vs_vwap_w5m_bps',
+            accessor="latest_price_vs_vwap_w5m_bps",
         )
-        vwap_w5m_stretch_rank, vwap_w5m_stretch_rank_universe_size = self._rank_latest_metric(
-            current_day=session_day,
-            symbol=symbol,
-            accessor='latest_vwap_w5m_stretch_bps',
+        vwap_w5m_stretch_rank, vwap_w5m_stretch_rank_universe_size = (
+            self._rank_latest_metric(
+                current_day=session_day,
+                symbol=symbol,
+                accessor="latest_vwap_w5m_stretch_bps",
+            )
         )
-        recent_15m_return_rank, recent_15m_return_rank_universe_size = self._rank_latest_metric(
-            current_day=session_day,
-            symbol=symbol,
-            accessor='latest_recent_15m_return_bps',
+        recent_15m_return_rank, recent_15m_return_rank_universe_size = (
+            self._rank_latest_metric(
+                current_day=session_day,
+                symbol=symbol,
+                accessor="latest_recent_15m_return_bps",
+            )
         )
-        microbar_volume_rank, microbar_volume_rank_universe_size = self._rank_latest_metric(
-            current_day=session_day,
-            symbol=symbol,
-            accessor='latest_microbar_volume',
+        microbar_volume_rank, microbar_volume_rank_universe_size = (
+            self._rank_latest_metric(
+                current_day=session_day,
+                symbol=symbol,
+                accessor="latest_microbar_volume",
+            )
         )
-        recent_imbalance_rank, recent_imbalance_rank_universe_size = self._rank_latest_metric(
-            current_day=session_day,
-            symbol=symbol,
-            accessor='latest_recent_imbalance_pressure_avg',
+        recent_imbalance_rank, recent_imbalance_rank_universe_size = (
+            self._rank_latest_metric(
+                current_day=session_day,
+                symbol=symbol,
+                accessor="latest_recent_imbalance_pressure_avg",
+            )
         )
         rsi14_rank, rsi14_rank_universe_size = self._rank_latest_metric(
             current_day=session_day,
             symbol=symbol,
-            accessor='latest_rsi14',
+            accessor="latest_rsi14",
         )
         macd_hist_rank, macd_hist_rank_universe_size = self._rank_latest_metric(
             current_day=session_day,
             symbol=symbol,
-            accessor='latest_macd_hist',
+            accessor="latest_macd_hist",
         )
-        opening_window_return_rank, opening_window_return_rank_universe_size = self._rank_latest_metric(
-            current_day=session_day,
-            symbol=symbol,
-            accessor='latest_opening_window_return_bps',
+        opening_window_return_rank, opening_window_return_rank_universe_size = (
+            self._rank_latest_metric(
+                current_day=session_day,
+                symbol=symbol,
+                accessor="latest_opening_window_return_bps",
+            )
         )
-        prev_session_close_rank, prev_session_close_rank_universe_size = self._rank_latest_metric(
-            current_day=session_day,
-            symbol=symbol,
-            accessor='latest_price_vs_prev_session_close_bps',
+        prev_session_close_rank, prev_session_close_rank_universe_size = (
+            self._rank_latest_metric(
+                current_day=session_day,
+                symbol=symbol,
+                accessor="latest_price_vs_prev_session_close_bps",
+            )
         )
         (
             opening_window_prev_close_return_rank,
@@ -474,43 +563,47 @@ class SessionContextTracker:
         ) = self._rank_latest_metric(
             current_day=session_day,
             symbol=symbol,
-            accessor='latest_opening_window_return_from_prev_close_bps',
+            accessor="latest_opening_window_return_from_prev_close_bps",
         )
         prev_day_open45_return_rank = _percentile_rank(
             self._last_opening_45_return_by_symbol,
             symbol=symbol,
         )
-        prev_day_open45_return_rank_universe_size = len(self._last_opening_45_return_by_symbol)
+        prev_day_open45_return_rank_universe_size = len(
+            self._last_opening_45_return_by_symbol
+        )
         prev_day_open60_return_rank = _percentile_rank(
             self._last_opening_60_return_by_symbol,
             symbol=symbol,
         )
-        prev_day_open60_return_rank_universe_size = len(self._last_opening_60_return_by_symbol)
+        prev_day_open60_return_rank_universe_size = len(
+            self._last_opening_60_return_by_symbol
+        )
         positive_session_open_ratio = self._positive_ratio_latest_metric(
             current_day=session_day,
-            accessor='latest_price_vs_session_open_bps',
+            accessor="latest_price_vs_session_open_bps",
         )
         positive_opening_window_return_ratio = self._positive_ratio_latest_metric(
             current_day=session_day,
-            accessor='latest_opening_window_return_bps',
+            accessor="latest_opening_window_return_bps",
         )
         positive_prev_session_close_ratio = self._positive_ratio_latest_metric(
             current_day=session_day,
-            accessor='latest_price_vs_prev_session_close_bps',
+            accessor="latest_price_vs_prev_session_close_bps",
         )
         positive_opening_window_return_from_prev_close_ratio = (
             self._positive_ratio_latest_metric(
                 current_day=session_day,
-                accessor='latest_opening_window_return_from_prev_close_bps',
+                accessor="latest_opening_window_return_from_prev_close_bps",
             )
         )
         above_vwap_w5m_ratio = self._positive_ratio_latest_metric(
             current_day=session_day,
-            accessor='latest_price_vs_vwap_w5m_bps',
+            accessor="latest_price_vs_vwap_w5m_bps",
         )
         positive_recent_imbalance_ratio = self._positive_ratio_latest_metric(
             current_day=session_day,
-            accessor='latest_recent_imbalance_pressure_avg',
+            accessor="latest_recent_imbalance_pressure_avg",
         )
         positive_prev_day_open45_return_ratio = _ratio_decimal(
             [value > 0 for value in self._last_opening_45_return_by_symbol.values()]
@@ -577,36 +670,34 @@ class SessionContextTracker:
         cross_section_reversal_rank = _average_decimal(
             [
                 (
-                    Decimal('1') - effective_session_drive_rank
+                    Decimal("1") - effective_session_drive_rank
                     if effective_session_drive_rank is not None
                     else None
                 ),
                 (
-                    Decimal('1') - effective_opening_window_return_rank
+                    Decimal("1") - effective_opening_window_return_rank
                     if effective_opening_window_return_rank is not None
                     else None
                 ),
                 (
-                    Decimal('1') - range_position_rank
+                    Decimal("1") - range_position_rank
                     if range_position_rank is not None
                     else None
                 ),
-                (
-                    Decimal('1') - vwap_w5m_rank
-                    if vwap_w5m_rank is not None
-                    else None
-                ),
+                (Decimal("1") - vwap_w5m_rank if vwap_w5m_rank is not None else None),
                 recent_imbalance_rank,
             ]
         )
-        cross_section_reversal_rank_universe_size = cross_section_continuation_rank_universe_size
+        cross_section_reversal_rank_universe_size = (
+            cross_section_continuation_rank_universe_size
+        )
         cross_section_factor_neutral_residual_rank = _average_decimal(
             [
                 effective_opening_window_return_rank,
                 vwap_w5m_rank,
                 recent_imbalance_rank,
                 (
-                    Decimal('1') - effective_session_drive_rank
+                    Decimal("1") - effective_session_drive_rank
                     if effective_session_drive_rank is not None
                     else None
                 ),
@@ -639,7 +730,7 @@ class SessionContextTracker:
                 cross_section_reversal_rank,
                 vwap_w5m_stretch_rank,
                 (
-                    Decimal('1') - recent_imbalance_rank
+                    Decimal("1") - recent_imbalance_rank
                     if recent_imbalance_rank is not None
                     else None
                 ),
@@ -655,95 +746,95 @@ class SessionContextTracker:
 
         payload.update(
             {
-                'session_open_price': state.session_open_price,
-                'prev_session_close_price': state.prev_session_close_price,
-                'session_high_price': state.session_high_price,
-                'session_low_price': state.session_low_price,
-                'opening_range_high': state.opening_range_high,
-                'opening_range_low': state.opening_range_low,
-                'opening_window_close_price': state.opening_window_close_price,
-                'opening_range_width_bps': opening_range_width_bps,
-                'session_range_bps': session_range_bps,
-                'price_vs_session_open_bps': price_vs_session_open_bps,
-                'price_vs_prev_session_close_bps': price_vs_prev_session_close_bps,
-                'opening_window_return_bps': opening_window_return_bps,
-                'opening_window_return_from_prev_close_bps': opening_window_return_from_prev_close_bps,
-                'price_vs_session_high_bps': price_vs_session_high_bps,
-                'price_vs_session_low_bps': price_vs_session_low_bps,
-                'price_vs_opening_range_high_bps': price_vs_opening_range_high_bps,
-                'price_vs_opening_range_low_bps': price_vs_opening_range_low_bps,
-                'price_vs_opening_window_close_bps': price_vs_opening_window_close_bps,
-                'price_position_in_session_range': position_in_range,
-                'recent_spread_bps_avg': recent_spread_bps_avg,
-                'recent_spread_bps_max': recent_spread_bps_max,
-                'recent_imbalance_pressure_avg': recent_imbalance_pressure_avg,
-                'recent_quote_invalid_ratio': recent_quote_invalid_ratio,
-                'recent_quote_jump_bps_avg': recent_quote_jump_bps_avg,
-                'recent_quote_jump_bps_max': recent_quote_jump_bps_max,
-                'recent_microprice_bias_bps_avg': recent_microprice_bias_bps_avg,
-                'recent_above_opening_range_high_ratio': recent_above_opening_range_high_ratio,
-                'recent_above_opening_window_close_ratio': recent_above_opening_window_close_ratio,
-                'recent_above_vwap_w5m_ratio': recent_above_vwap_w5m_ratio,
-                'recent_15m_return_bps': recent_15m_return_bps,
-                'microbar_volume': microbar_volume,
-                'cross_section_session_open_rank': session_open_rank,
-                'cross_section_session_open_rank_universe_size': session_open_rank_universe_size,
-                'cross_section_prev_session_close_rank': prev_session_close_rank,
-                'cross_section_prev_session_close_rank_universe_size': prev_session_close_rank_universe_size,
-                'cross_section_opening_window_return_rank': opening_window_return_rank,
-                'cross_section_opening_window_return_rank_universe_size': opening_window_return_rank_universe_size,
-                'cross_section_opening_window_return_from_prev_close_rank': (
+                "session_open_price": state.session_open_price,
+                "prev_session_close_price": state.prev_session_close_price,
+                "session_high_price": state.session_high_price,
+                "session_low_price": state.session_low_price,
+                "opening_range_high": state.opening_range_high,
+                "opening_range_low": state.opening_range_low,
+                "opening_window_close_price": state.opening_window_close_price,
+                "opening_range_width_bps": opening_range_width_bps,
+                "session_range_bps": session_range_bps,
+                "price_vs_session_open_bps": price_vs_session_open_bps,
+                "price_vs_prev_session_close_bps": price_vs_prev_session_close_bps,
+                "opening_window_return_bps": opening_window_return_bps,
+                "opening_window_return_from_prev_close_bps": opening_window_return_from_prev_close_bps,
+                "price_vs_session_high_bps": price_vs_session_high_bps,
+                "price_vs_session_low_bps": price_vs_session_low_bps,
+                "price_vs_opening_range_high_bps": price_vs_opening_range_high_bps,
+                "price_vs_opening_range_low_bps": price_vs_opening_range_low_bps,
+                "price_vs_opening_window_close_bps": price_vs_opening_window_close_bps,
+                "price_position_in_session_range": position_in_range,
+                "recent_spread_bps_avg": recent_spread_bps_avg,
+                "recent_spread_bps_max": recent_spread_bps_max,
+                "recent_imbalance_pressure_avg": recent_imbalance_pressure_avg,
+                "recent_quote_invalid_ratio": recent_quote_invalid_ratio,
+                "recent_quote_jump_bps_avg": recent_quote_jump_bps_avg,
+                "recent_quote_jump_bps_max": recent_quote_jump_bps_max,
+                "recent_microprice_bias_bps_avg": recent_microprice_bias_bps_avg,
+                "recent_above_opening_range_high_ratio": recent_above_opening_range_high_ratio,
+                "recent_above_opening_window_close_ratio": recent_above_opening_window_close_ratio,
+                "recent_above_vwap_w5m_ratio": recent_above_vwap_w5m_ratio,
+                "recent_15m_return_bps": recent_15m_return_bps,
+                "microbar_volume": microbar_volume,
+                "cross_section_session_open_rank": session_open_rank,
+                "cross_section_session_open_rank_universe_size": session_open_rank_universe_size,
+                "cross_section_prev_session_close_rank": prev_session_close_rank,
+                "cross_section_prev_session_close_rank_universe_size": prev_session_close_rank_universe_size,
+                "cross_section_opening_window_return_rank": opening_window_return_rank,
+                "cross_section_opening_window_return_rank_universe_size": opening_window_return_rank_universe_size,
+                "cross_section_opening_window_return_from_prev_close_rank": (
                     opening_window_prev_close_return_rank
                 ),
-                'cross_section_opening_window_return_from_prev_close_rank_universe_size': (
+                "cross_section_opening_window_return_from_prev_close_rank_universe_size": (
                     opening_window_prev_close_return_rank_universe_size
                 ),
-                'cross_section_prev_day_open45_return_rank': prev_day_open45_return_rank,
-                'cross_section_prev_day_open45_return_rank_universe_size': prev_day_open45_return_rank_universe_size,
-                'cross_section_prev_day_open60_return_rank': prev_day_open60_return_rank,
-                'cross_section_prev_day_open60_return_rank_universe_size': prev_day_open60_return_rank_universe_size,
-                'cross_section_range_position_rank': range_position_rank,
-                'cross_section_range_position_rank_universe_size': range_position_rank_universe_size,
-                'cross_section_vwap_w5m_rank': vwap_w5m_rank,
-                'cross_section_vwap_w5m_rank_universe_size': vwap_w5m_rank_universe_size,
-                'cross_section_vwap_w5m_stretch_rank': vwap_w5m_stretch_rank,
-                'cross_section_vwap_w5m_stretch_rank_universe_size': vwap_w5m_stretch_rank_universe_size,
-                'cross_section_recent_15m_return_rank': recent_15m_return_rank,
-                'cross_section_recent_15m_return_rank_universe_size': recent_15m_return_rank_universe_size,
-                'cross_section_microbar_volume_rank': microbar_volume_rank,
-                'cross_section_microbar_volume_rank_universe_size': microbar_volume_rank_universe_size,
-                'cross_section_recent_imbalance_rank': recent_imbalance_rank,
-                'cross_section_recent_imbalance_rank_universe_size': recent_imbalance_rank_universe_size,
-                'cross_section_rsi14_rank': rsi14_rank,
-                'cross_section_rsi14_rank_universe_size': rsi14_rank_universe_size,
-                'cross_section_macd_hist_rank': macd_hist_rank,
-                'cross_section_macd_hist_rank_universe_size': macd_hist_rank_universe_size,
-                'cross_section_positive_session_open_ratio': positive_session_open_ratio,
-                'cross_section_positive_prev_session_close_ratio': positive_prev_session_close_ratio,
-                'cross_section_positive_opening_window_return_ratio': positive_opening_window_return_ratio,
-                'cross_section_positive_opening_window_return_from_prev_close_ratio': (
+                "cross_section_prev_day_open45_return_rank": prev_day_open45_return_rank,
+                "cross_section_prev_day_open45_return_rank_universe_size": prev_day_open45_return_rank_universe_size,
+                "cross_section_prev_day_open60_return_rank": prev_day_open60_return_rank,
+                "cross_section_prev_day_open60_return_rank_universe_size": prev_day_open60_return_rank_universe_size,
+                "cross_section_range_position_rank": range_position_rank,
+                "cross_section_range_position_rank_universe_size": range_position_rank_universe_size,
+                "cross_section_vwap_w5m_rank": vwap_w5m_rank,
+                "cross_section_vwap_w5m_rank_universe_size": vwap_w5m_rank_universe_size,
+                "cross_section_vwap_w5m_stretch_rank": vwap_w5m_stretch_rank,
+                "cross_section_vwap_w5m_stretch_rank_universe_size": vwap_w5m_stretch_rank_universe_size,
+                "cross_section_recent_15m_return_rank": recent_15m_return_rank,
+                "cross_section_recent_15m_return_rank_universe_size": recent_15m_return_rank_universe_size,
+                "cross_section_microbar_volume_rank": microbar_volume_rank,
+                "cross_section_microbar_volume_rank_universe_size": microbar_volume_rank_universe_size,
+                "cross_section_recent_imbalance_rank": recent_imbalance_rank,
+                "cross_section_recent_imbalance_rank_universe_size": recent_imbalance_rank_universe_size,
+                "cross_section_rsi14_rank": rsi14_rank,
+                "cross_section_rsi14_rank_universe_size": rsi14_rank_universe_size,
+                "cross_section_macd_hist_rank": macd_hist_rank,
+                "cross_section_macd_hist_rank_universe_size": macd_hist_rank_universe_size,
+                "cross_section_positive_session_open_ratio": positive_session_open_ratio,
+                "cross_section_positive_prev_session_close_ratio": positive_prev_session_close_ratio,
+                "cross_section_positive_opening_window_return_ratio": positive_opening_window_return_ratio,
+                "cross_section_positive_opening_window_return_from_prev_close_ratio": (
                     positive_opening_window_return_from_prev_close_ratio
                 ),
-                'cross_section_positive_prev_day_open45_return_ratio': (
+                "cross_section_positive_prev_day_open45_return_ratio": (
                     positive_prev_day_open45_return_ratio
                 ),
-                'cross_section_positive_prev_day_open60_return_ratio': (
+                "cross_section_positive_prev_day_open60_return_ratio": (
                     positive_prev_day_open60_return_ratio
                 ),
-                'cross_section_above_vwap_w5m_ratio': above_vwap_w5m_ratio,
-                'cross_section_positive_recent_imbalance_ratio': positive_recent_imbalance_ratio,
-                'cross_section_continuation_breadth': cross_section_continuation_breadth,
-                'cross_section_continuation_rank': cross_section_continuation_rank,
-                'cross_section_continuation_rank_universe_size': cross_section_continuation_rank_universe_size,
-                'cross_section_reversal_rank': cross_section_reversal_rank,
-                'cross_section_reversal_rank_universe_size': cross_section_reversal_rank_universe_size,
-                'cross_section_factor_neutral_residual_rank': cross_section_factor_neutral_residual_rank,
-                'cross_section_factor_neutral_residual_rank_universe_size': cross_section_factor_neutral_residual_rank_universe_size,
-                'cross_section_pair_relative_return_rank': cross_section_pair_relative_return_rank,
-                'cross_section_pair_relative_return_rank_universe_size': cross_section_pair_relative_return_rank_universe_size,
-                'cross_section_residual_spread_zscore_rank': cross_section_residual_spread_zscore_rank,
-                'cross_section_residual_spread_zscore_rank_universe_size': cross_section_residual_spread_zscore_rank_universe_size,
-                'session_minutes_elapsed': minutes_elapsed,
+                "cross_section_above_vwap_w5m_ratio": above_vwap_w5m_ratio,
+                "cross_section_positive_recent_imbalance_ratio": positive_recent_imbalance_ratio,
+                "cross_section_continuation_breadth": cross_section_continuation_breadth,
+                "cross_section_continuation_rank": cross_section_continuation_rank,
+                "cross_section_continuation_rank_universe_size": cross_section_continuation_rank_universe_size,
+                "cross_section_reversal_rank": cross_section_reversal_rank,
+                "cross_section_reversal_rank_universe_size": cross_section_reversal_rank_universe_size,
+                "cross_section_factor_neutral_residual_rank": cross_section_factor_neutral_residual_rank,
+                "cross_section_factor_neutral_residual_rank_universe_size": cross_section_factor_neutral_residual_rank_universe_size,
+                "cross_section_pair_relative_return_rank": cross_section_pair_relative_return_rank,
+                "cross_section_pair_relative_return_rank_universe_size": cross_section_pair_relative_return_rank_universe_size,
+                "cross_section_residual_spread_zscore_rank": cross_section_residual_spread_zscore_rank,
+                "cross_section_residual_spread_zscore_rank_universe_size": cross_section_residual_spread_zscore_rank_universe_size,
+                "session_minutes_elapsed": minutes_elapsed,
             }
         )
         return payload
@@ -760,9 +851,13 @@ class SessionContextTracker:
             if previous_close > 0:
                 self._last_session_close_by_symbol[candidate_symbol] = previous_close
             if state.opening_45_return_bps is not None:
-                self._last_opening_45_return_by_symbol[candidate_symbol] = state.opening_45_return_bps
+                self._last_opening_45_return_by_symbol[candidate_symbol] = (
+                    state.opening_45_return_bps
+                )
             if state.opening_60_return_bps is not None:
-                self._last_opening_60_return_by_symbol[candidate_symbol] = state.opening_60_return_bps
+                self._last_opening_60_return_by_symbol[candidate_symbol] = (
+                    state.opening_60_return_bps
+                )
             del self._state_by_symbol[candidate_symbol]
 
     def _rank_latest_metric(

--- a/services/torghut/app/trading/strategy_runtime.py
+++ b/services/torghut/app/trading/strategy_runtime.py
@@ -27,6 +27,7 @@ from .research_sleeves import (
     evaluate_momentum_pullback_long,
     evaluate_washout_rebound_long,
 )
+from .session_context import regular_session_minutes_elapsed
 from .strategy_specs import (
     build_compiled_strategy_artifacts,
     strategy_type_supports_spec_v2,
@@ -108,18 +109,22 @@ def _microbar_minutes_elapsed(
     context: "StrategyContext",
     features: FeatureVectorV3,
 ) -> int | None:
+    event_minutes: int | None = None
+    try:
+        event_ts = datetime.fromisoformat(context.event_ts)
+        event_minutes = regular_session_minutes_elapsed(event_ts)
+    except ValueError:
+        event_minutes = None
     raw_minutes = features.values.get("session_minutes_elapsed")
     if raw_minutes is not None:
         try:
-            return max(0, int(raw_minutes))
+            parsed_minutes = max(0, int(raw_minutes))
         except (TypeError, ValueError):
             return None
-    try:
-        event_ts = datetime.fromisoformat(context.event_ts)
-    except ValueError:
-        return None
-    session_open = event_ts.replace(hour=13, minute=30, second=0, microsecond=0)
-    return max(0, int((event_ts - session_open).total_seconds() // 60))
+        if event_minutes is not None and event_minutes > parsed_minutes:
+            return event_minutes
+        return parsed_minutes
+    return event_minutes
 
 
 def _microbar_exit_minute_after_open(params: dict[str, Any]) -> int | None:

--- a/services/torghut/scripts/local_intraday_tsmom_replay.py
+++ b/services/torghut/scripts/local_intraday_tsmom_replay.py
@@ -15,7 +15,7 @@ import time as time_mod
 import uuid
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Iterable, Mapping
@@ -57,15 +57,17 @@ from app.trading.quote_quality import (
     SignalQuoteQualityTracker,
     assess_signal_quote_quality,
 )
-from app.trading.session_context import SessionContextTracker
+from app.trading.session_context import (
+    SessionContextTracker,
+    regular_session_close_utc_for,
+    regular_session_open_utc_for,
+)
 from app.trading.strategy_runtime import StrategyRuntime
 
 logging.getLogger("alembic").setLevel(logging.WARNING)
 
 logging.getLogger("alembic").setLevel(logging.WARNING)
 
-REGULAR_OPEN_UTC = time(hour=13, minute=30)
-REGULAR_CLOSE_UTC = time(hour=20, minute=0)
 DEFAULT_CHUNK_MINUTES = 10
 DEFAULT_START_EQUITY = Decimal("31590.02")
 DEFAULT_CLICKHOUSE_QUERY_TIMEOUT_SECONDS = 30
@@ -562,14 +564,10 @@ def _append_ledger_fill(
                 "spread": _decimal_text_or_none(cost_lineage.spread),
                 "volatility": _decimal_text_or_none(cost_lineage.volatility),
                 "spread_cost_bps": _decimal_text(cost_lineage.spread_cost_bps),
-                "volatility_cost_bps": _decimal_text(
-                    cost_lineage.volatility_cost_bps
-                ),
+                "volatility_cost_bps": _decimal_text(cost_lineage.volatility_cost_bps),
                 "impact_cost_bps": _decimal_text(cost_lineage.impact_cost_bps),
                 "commission_cost": _decimal_text(cost_lineage.commission_cost),
-                "commission_cost_bps": _decimal_text(
-                    cost_lineage.commission_cost_bps
-                ),
+                "commission_cost_bps": _decimal_text(cost_lineage.commission_cost_bps),
                 "total_cost_bps": _decimal_text(cost_lineage.total_cost_bps),
                 "max_participation_rate": _decimal_text(
                     cost_lineage.max_participation_rate
@@ -921,12 +919,8 @@ def _iter_signal_rows(config: ReplayConfig) -> Iterable[SignalEnvelope]:
             )
             current_day += timedelta(days=1)
             continue
-        session_start = datetime.combine(
-            current_day, REGULAR_OPEN_UTC, tzinfo=timezone.utc
-        )
-        session_end = datetime.combine(
-            current_day, REGULAR_CLOSE_UTC, tzinfo=timezone.utc
-        )
+        session_start = regular_session_open_utc_for(current_day)
+        session_end = regular_session_close_utc_for(current_day)
         logger.info(
             "replay_day_fetch_start day=%s session_start=%s session_end=%s",
             current_day.isoformat(),
@@ -1746,11 +1740,7 @@ def _pending_censor_time(
     pending: PendingOrder,
     fallback: datetime,
 ) -> datetime:
-    close_ts = datetime.combine(
-        pending.created_at.date(),
-        REGULAR_CLOSE_UTC,
-        tzinfo=timezone.utc,
-    )
+    close_ts = regular_session_close_utc_for(pending.created_at)
     if close_ts > pending.created_at:
         return close_ts
     return fallback
@@ -2947,11 +2937,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
                     cash = cash_ref[0]
                 _censor_pending_orders(
                     reason="day_boundary",
-                    fallback=datetime.combine(
-                        current_day,
-                        REGULAR_CLOSE_UTC,
-                        tzinfo=timezone.utc,
-                    ),
+                    fallback=regular_session_close_utc_for(current_day),
                 )
                 completed_day_stats = _active_day_stats(current_day)
                 completed_day_equity = _record_capital_snapshot(
@@ -3368,11 +3354,7 @@ def run_replay(config: ReplayConfig) -> dict[str, Any]:
         if current_day is not None:
             _censor_pending_orders(
                 reason="replay_end",
-                fallback=datetime.combine(
-                    current_day,
-                    REGULAR_CLOSE_UTC,
-                    tzinfo=timezone.utc,
-                ),
+                fallback=regular_session_close_utc_for(current_day),
             )
         if current_day is not None:
             final_day_stats = _active_day_stats(current_day)
@@ -3719,7 +3701,7 @@ def _flatten_positions(
         fill_price = last_prices.get(symbol, position.avg_entry_price)
         exit_action = "buy" if position.qty < 0 else "sell"
         exit_qty = abs(position.qty)
-        closed_at = datetime.combine(day, REGULAR_CLOSE_UTC, tzinfo=timezone.utc)
+        closed_at = regular_session_close_utc_for(day)
         synthetic_decision = StrategyDecision(
             strategy_id=position.strategy_id,
             symbol=symbol,

--- a/services/torghut/tests/test_replay_tape.py
+++ b/services/torghut/tests/test_replay_tape.py
@@ -182,6 +182,42 @@ class TestReplayTape(TestCase):
             first_manifest.content_sha256, second_manifest.content_sha256
         )
 
+    def test_materialize_manifest_session_window_follows_new_york_dst(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            winter_manifest = materialize_signal_tape(
+                rows=[],
+                tape_path=Path(tmpdir) / "winter.jsonl",
+                dataset_snapshot_ref="snapshot-a",
+                start_date=date(2026, 1, 5),
+                end_date=date(2026, 1, 5),
+                source_query_digest=build_source_query_digest({"window": "winter"}),
+            )
+            summer_manifest = materialize_signal_tape(
+                rows=[],
+                tape_path=Path(tmpdir) / "summer.jsonl",
+                dataset_snapshot_ref="snapshot-a",
+                start_date=date(2026, 5, 29),
+                end_date=date(2026, 5, 29),
+                source_query_digest=build_source_query_digest({"window": "summer"}),
+            )
+
+        self.assertEqual(
+            winter_manifest.start_ts,
+            datetime(2026, 1, 5, 14, 30, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            winter_manifest.end_ts,
+            datetime(2026, 1, 5, 21, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            summer_manifest.start_ts,
+            datetime(2026, 5, 29, 13, 30, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            summer_manifest.end_ts,
+            datetime(2026, 5, 29, 20, 0, tzinfo=timezone.utc),
+        )
+
     def test_manifest_payload_rejects_wrong_schema_and_coerces_loose_metadata(
         self,
     ) -> None:

--- a/services/torghut/tests/test_session_context.py
+++ b/services/torghut/tests/test_session_context.py
@@ -6,13 +6,17 @@ from typing import cast
 from unittest import TestCase
 
 from app.trading.models import SignalEnvelope
-from app.trading.session_context import SessionContextTracker
+from app.trading.session_context import (
+    SessionContextTracker,
+    regular_session_close_utc_for,
+    regular_session_open_utc_for,
+)
 
 
 def _signal(
     *,
     event_ts: datetime,
-    symbol: str = 'META',
+    symbol: str = "META",
     price: str,
     spread: str,
     bid_sz: str,
@@ -29,537 +33,645 @@ def _signal(
     return SignalEnvelope(
         event_ts=event_ts,
         symbol=symbol,
-        timeframe='1Sec',
+        timeframe="1Sec",
         seq=1,
-        source='ta',
+        source="ta",
         payload={
-            'price': price_value,
-            'spread': spread_value,
-            'imbalance_bid_px': bid_px,
-            'imbalance_ask_px': ask_px,
-            'imbalance_bid_sz': Decimal(bid_sz),
-            'imbalance_ask_sz': Decimal(ask_sz),
-            'vwap_w5m': Decimal(vwap_w5m) if vwap_w5m is not None else None,
-            'rsi14': Decimal(rsi14) if rsi14 is not None else None,
-            'macd_hist': Decimal(macd_hist) if macd_hist is not None else None,
-            'microbar_volume': Decimal(microbar_volume) if microbar_volume is not None else None,
+            "price": price_value,
+            "spread": spread_value,
+            "imbalance_bid_px": bid_px,
+            "imbalance_ask_px": ask_px,
+            "imbalance_bid_sz": Decimal(bid_sz),
+            "imbalance_ask_sz": Decimal(ask_sz),
+            "vwap_w5m": Decimal(vwap_w5m) if vwap_w5m is not None else None,
+            "rsi14": Decimal(rsi14) if rsi14 is not None else None,
+            "macd_hist": Decimal(macd_hist) if macd_hist is not None else None,
+            "microbar_volume": Decimal(microbar_volume)
+            if microbar_volume is not None
+            else None,
         },
     )
 
 
 class TestSessionContextTracker(TestCase):
+    def test_regular_session_boundaries_follow_new_york_dst(self) -> None:
+        summer_day = datetime(2026, 5, 29, 15, 30, tzinfo=timezone.utc)
+        winter_day = datetime(2026, 1, 5, 15, 30, tzinfo=timezone.utc)
+
+        self.assertEqual(
+            regular_session_open_utc_for(summer_day),
+            datetime(2026, 5, 29, 13, 30, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            regular_session_close_utc_for(summer_day),
+            datetime(2026, 5, 29, 20, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            regular_session_open_utc_for(winter_day),
+            datetime(2026, 1, 5, 14, 30, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            regular_session_close_utc_for(winter_day),
+            datetime(2026, 1, 5, 21, 0, tzinfo=timezone.utc),
+        )
+
     def test_tracker_enriches_session_and_opening_range_fields(self) -> None:
         tracker = SessionContextTracker()
 
         open_signal = _signal(
             event_ts=datetime(2026, 3, 24, 13, 30, 5, tzinfo=timezone.utc),
-            price='100.00',
-            spread='0.04',
-            bid_sz='4200',
-            ask_sz='3800',
+            price="100.00",
+            spread="0.04",
+            bid_sz="4200",
+            ask_sz="3800",
         )
         breakout_signal = _signal(
             event_ts=datetime(2026, 3, 24, 14, 5, 0, tzinfo=timezone.utc),
-            price='101.20',
-            spread='0.03',
-            bid_sz='5100',
-            ask_sz='4300',
+            price="101.20",
+            spread="0.03",
+            bid_sz="5100",
+            ask_sz="4300",
         )
 
         open_payload = tracker.enrich_signal_payload(open_signal)
         breakout_payload = tracker.enrich_signal_payload(breakout_signal)
 
-        self.assertEqual(open_payload['session_open_price'], Decimal('100.00'))
-        self.assertEqual(breakout_payload['session_open_price'], Decimal('100.00'))
-        self.assertEqual(breakout_payload['opening_range_high'], Decimal('100.00'))
-        self.assertEqual(breakout_payload['opening_range_low'], Decimal('100.00'))
-        self.assertEqual(breakout_payload['opening_window_close_price'], Decimal('100.00'))
-        self.assertEqual(breakout_payload['opening_window_return_bps'], Decimal('0'))
-        self.assertEqual(breakout_payload['session_high_price'], Decimal('101.20'))
-        self.assertEqual(breakout_payload['session_low_price'], Decimal('100.00'))
-        self.assertEqual(breakout_payload['session_minutes_elapsed'], 35)
-        self.assertGreater(breakout_payload['price_vs_session_open_bps'], Decimal('100'))
-        self.assertGreater(breakout_payload['price_vs_opening_range_high_bps'], Decimal('100'))
-        self.assertGreater(breakout_payload['recent_spread_bps_avg'], Decimal('0'))
-        self.assertGreater(breakout_payload['recent_imbalance_pressure_avg'], Decimal('0'))
+        self.assertEqual(open_payload["session_open_price"], Decimal("100.00"))
+        self.assertEqual(breakout_payload["session_open_price"], Decimal("100.00"))
+        self.assertEqual(breakout_payload["opening_range_high"], Decimal("100.00"))
+        self.assertEqual(breakout_payload["opening_range_low"], Decimal("100.00"))
+        self.assertEqual(
+            breakout_payload["opening_window_close_price"], Decimal("100.00")
+        )
+        self.assertEqual(breakout_payload["opening_window_return_bps"], Decimal("0"))
+        self.assertEqual(breakout_payload["session_high_price"], Decimal("101.20"))
+        self.assertEqual(breakout_payload["session_low_price"], Decimal("100.00"))
+        self.assertEqual(breakout_payload["session_minutes_elapsed"], 35)
+        self.assertGreater(
+            breakout_payload["price_vs_session_open_bps"], Decimal("100")
+        )
+        self.assertGreater(
+            breakout_payload["price_vs_opening_range_high_bps"], Decimal("100")
+        )
+        self.assertGreater(breakout_payload["recent_spread_bps_avg"], Decimal("0"))
+        self.assertGreater(
+            breakout_payload["recent_imbalance_pressure_avg"], Decimal("0")
+        )
 
     def test_tracker_resets_state_on_new_session_day(self) -> None:
         tracker = SessionContextTracker()
         first_day = _signal(
             event_ts=datetime(2026, 3, 24, 19, 45, 0, tzinfo=timezone.utc),
-            price='101.00',
-            spread='0.03',
-            bid_sz='4500',
-            ask_sz='4100',
+            price="101.00",
+            spread="0.03",
+            bid_sz="4500",
+            ask_sz="4100",
         )
         second_day = _signal(
             event_ts=datetime(2026, 3, 25, 13, 30, 0, tzinfo=timezone.utc),
-            price='98.00',
-            spread='0.02',
-            bid_sz='3900',
-            ask_sz='4200',
+            price="98.00",
+            spread="0.02",
+            bid_sz="3900",
+            ask_sz="4200",
         )
 
         tracker.enrich_signal_payload(first_day)
         second_payload = tracker.enrich_signal_payload(second_day)
 
-        self.assertEqual(second_payload['session_open_price'], Decimal('98.00'))
-        self.assertEqual(second_payload['prev_session_close_price'], Decimal('101.00'))
-        self.assertEqual(second_payload['session_high_price'], Decimal('98.00'))
-        self.assertEqual(second_payload['opening_range_high'], Decimal('98.00'))
-        self.assertEqual(second_payload['price_vs_session_open_bps'], Decimal('0'))
+        self.assertEqual(second_payload["session_open_price"], Decimal("98.00"))
+        self.assertEqual(second_payload["prev_session_close_price"], Decimal("101.00"))
+        self.assertEqual(second_payload["session_high_price"], Decimal("98.00"))
+        self.assertEqual(second_payload["opening_range_high"], Decimal("98.00"))
+        self.assertEqual(second_payload["price_vs_session_open_bps"], Decimal("0"))
         self.assertEqual(
-            second_payload['price_vs_prev_session_close_bps'],
-            Decimal('-297.0297029702970297029702970'),
+            second_payload["price_vs_prev_session_close_bps"],
+            Decimal("-297.0297029702970297029702970"),
         )
 
-    def test_tracker_ignores_premarket_tick_for_regular_session_open_anchor(self) -> None:
+    def test_tracker_ignores_premarket_tick_for_regular_session_open_anchor(
+        self,
+    ) -> None:
         tracker = SessionContextTracker()
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 19, 59, 0, tzinfo=timezone.utc),
-                price='101.00',
-                spread='0.03',
-                bid_sz='4500',
-                ask_sz='4100',
+                price="101.00",
+                spread="0.03",
+                bid_sz="4500",
+                ask_sz="4100",
             )
         )
         premarket_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 25, 12, 45, 0, tzinfo=timezone.utc),
-                price='99.00',
-                spread='0.02',
-                bid_sz='3900',
-                ask_sz='4200',
+                price="99.00",
+                spread="0.02",
+                bid_sz="3900",
+                ask_sz="4200",
             )
         )
         open_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 25, 13, 30, 5, tzinfo=timezone.utc),
-                price='100.00',
-                spread='0.03',
-                bid_sz='4200',
-                ask_sz='3800',
+                price="100.00",
+                spread="0.03",
+                bid_sz="4200",
+                ask_sz="3800",
             )
         )
 
-        self.assertNotIn('session_open_price', premarket_payload)
+        self.assertNotIn("session_open_price", premarket_payload)
         self.assertEqual(
-            premarket_payload['prev_session_close_price'],
-            Decimal('101.00'),
+            premarket_payload["prev_session_close_price"],
+            Decimal("101.00"),
         )
-        self.assertEqual(open_payload['session_open_price'], Decimal('100.00'))
-        self.assertEqual(open_payload['opening_range_high'], Decimal('100.00'))
-        self.assertEqual(open_payload['opening_window_close_price'], Decimal('100.00'))
+        self.assertEqual(open_payload["session_open_price"], Decimal("100.00"))
+        self.assertEqual(open_payload["opening_range_high"], Decimal("100.00"))
+        self.assertEqual(open_payload["opening_window_close_price"], Decimal("100.00"))
 
-    def test_invalid_regular_quote_initializes_guardrails_and_reanchors_on_first_valid_quote(self) -> None:
+    def test_tracker_uses_standard_time_regular_open_for_session_minutes(self) -> None:
+        tracker = SessionContextTracker()
+        open_payload = tracker.enrich_signal_payload(
+            _signal(
+                event_ts=datetime(2026, 1, 5, 14, 30, 5, tzinfo=timezone.utc),
+                price="100.00",
+                spread="0.03",
+                bid_sz="4200",
+                ask_sz="3800",
+            )
+        )
+        exit_payload = tracker.enrich_signal_payload(
+            _signal(
+                event_ts=datetime(2026, 1, 5, 16, 30, 0, tzinfo=timezone.utc),
+                price="99.50",
+                spread="0.03",
+                bid_sz="4100",
+                ask_sz="3900",
+            )
+        )
+
+        self.assertEqual(open_payload["session_minutes_elapsed"], 0)
+        self.assertEqual(exit_payload["session_minutes_elapsed"], 120)
+
+    def test_invalid_regular_quote_initializes_guardrails_and_reanchors_on_first_valid_quote(
+        self,
+    ) -> None:
         tracker = SessionContextTracker()
 
         invalid_open_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 25, 13, 30, 5, tzinfo=timezone.utc),
-                price='100.00',
-                spread='5.00',
-                bid_sz='4200',
-                ask_sz='3800',
+                price="100.00",
+                spread="5.00",
+                bid_sz="4200",
+                ask_sz="3800",
             )
         )
         valid_open_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 25, 13, 31, 0, tzinfo=timezone.utc),
-                price='100.10',
-                spread='0.03',
-                bid_sz='4300',
-                ask_sz='3700',
+                price="100.10",
+                spread="0.03",
+                bid_sz="4300",
+                ask_sz="3700",
             )
         )
 
-        self.assertEqual(invalid_open_payload['session_open_price'], Decimal('100.00'))
-        self.assertEqual(invalid_open_payload['recent_quote_invalid_ratio'], Decimal('1'))
-        self.assertEqual(valid_open_payload['session_open_price'], Decimal('100.10'))
-        self.assertEqual(valid_open_payload['opening_range_high'], Decimal('100.10'))
-        self.assertEqual(valid_open_payload['session_high_price'], Decimal('100.10'))
-        self.assertEqual(valid_open_payload['recent_quote_invalid_ratio'], Decimal('0.5'))
+        self.assertEqual(invalid_open_payload["session_open_price"], Decimal("100.00"))
+        self.assertEqual(
+            invalid_open_payload["recent_quote_invalid_ratio"], Decimal("1")
+        )
+        self.assertEqual(valid_open_payload["session_open_price"], Decimal("100.10"))
+        self.assertEqual(valid_open_payload["opening_range_high"], Decimal("100.10"))
+        self.assertEqual(valid_open_payload["session_high_price"], Decimal("100.10"))
+        self.assertEqual(
+            valid_open_payload["recent_quote_invalid_ratio"], Decimal("0.5")
+        )
 
     def test_invalid_quote_does_not_poison_session_high_or_opening_range(self) -> None:
         tracker = SessionContextTracker()
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 13, 30, 5, tzinfo=timezone.utc),
-                price='100.00',
-                spread='0.03',
-                bid_sz='4200',
-                ask_sz='3800',
+                price="100.00",
+                spread="0.03",
+                bid_sz="4200",
+                ask_sz="3800",
             )
         )
         invalid_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 13, 35, 0, tzinfo=timezone.utc),
-                price='103.50',
-                spread='5.00',
-                bid_sz='6100',
-                ask_sz='3500',
+                price="103.50",
+                spread="5.00",
+                bid_sz="6100",
+                ask_sz="3500",
             )
         )
         breakout_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 5, 0, tzinfo=timezone.utc),
-                price='101.20',
-                spread='0.03',
-                bid_sz='5100',
-                ask_sz='4300',
+                price="101.20",
+                spread="0.03",
+                bid_sz="5100",
+                ask_sz="4300",
             )
         )
 
-        self.assertEqual(invalid_payload['session_open_price'], Decimal('100.00'))
-        self.assertEqual(invalid_payload['session_high_price'], Decimal('100.00'))
-        self.assertEqual(invalid_payload['opening_range_high'], Decimal('100.00'))
-        self.assertEqual(breakout_payload['session_high_price'], Decimal('101.20'))
-        self.assertEqual(breakout_payload['opening_range_high'], Decimal('100.00'))
+        self.assertEqual(invalid_payload["session_open_price"], Decimal("100.00"))
+        self.assertEqual(invalid_payload["session_high_price"], Decimal("100.00"))
+        self.assertEqual(invalid_payload["opening_range_high"], Decimal("100.00"))
+        self.assertEqual(breakout_payload["session_high_price"], Decimal("101.20"))
+        self.assertEqual(breakout_payload["opening_range_high"], Decimal("100.00"))
         self.assertGreater(
-            breakout_payload['recent_quote_invalid_ratio'],
-            Decimal('0'),
+            breakout_payload["recent_quote_invalid_ratio"],
+            Decimal("0"),
         )
 
-    def test_tracker_locks_opening_window_close_and_return_after_first_half_hour(self) -> None:
+    def test_tracker_locks_opening_window_close_and_return_after_first_half_hour(
+        self,
+    ) -> None:
         tracker = SessionContextTracker()
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 13, 30, 5, tzinfo=timezone.utc),
-                price='100.00',
-                spread='0.03',
-                bid_sz='4200',
-                ask_sz='3800',
+                price="100.00",
+                spread="0.03",
+                bid_sz="4200",
+                ask_sz="3800",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 13, 55, 0, tzinfo=timezone.utc),
-                price='101.00',
-                spread='0.03',
-                bid_sz='4600',
-                ask_sz='3900',
+                price="101.00",
+                spread="0.03",
+                bid_sz="4600",
+                ask_sz="3900",
             )
         )
         late_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 20, 0, tzinfo=timezone.utc),
-                price='102.50',
-                spread='0.03',
-                bid_sz='5100',
-                ask_sz='4200',
+                price="102.50",
+                spread="0.03",
+                bid_sz="5100",
+                ask_sz="4200",
             )
         )
 
-        self.assertEqual(late_payload['opening_window_close_price'], Decimal('101.00'))
-        self.assertEqual(late_payload['opening_window_return_bps'], Decimal('100'))
-        self.assertEqual(late_payload['price_vs_opening_window_close_bps'], Decimal('148.5148514851485148514851485'))
+        self.assertEqual(late_payload["opening_window_close_price"], Decimal("101.00"))
+        self.assertEqual(late_payload["opening_window_return_bps"], Decimal("100"))
+        self.assertEqual(
+            late_payload["price_vs_opening_window_close_bps"],
+            Decimal("148.5148514851485148514851485"),
+        )
 
     def test_tracker_emits_previous_close_anchored_opening_metrics(self) -> None:
         tracker = SessionContextTracker()
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 19, 59, 0, tzinfo=timezone.utc),
-                price='101.00',
-                spread='0.03',
-                bid_sz='4500',
-                ask_sz='4100',
+                price="101.00",
+                spread="0.03",
+                bid_sz="4500",
+                ask_sz="4100",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 25, 13, 30, 5, tzinfo=timezone.utc),
-                price='99.00',
-                spread='0.03',
-                bid_sz='4200',
-                ask_sz='3800',
+                price="99.00",
+                spread="0.03",
+                bid_sz="4200",
+                ask_sz="3800",
             )
         )
         opening_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 25, 13, 55, 0, tzinfo=timezone.utc),
-                price='100.50',
-                spread='0.03',
-                bid_sz='4700',
-                ask_sz='3900',
+                price="100.50",
+                spread="0.03",
+                bid_sz="4700",
+                ask_sz="3900",
             )
         )
 
-        self.assertEqual(opening_payload['prev_session_close_price'], Decimal('101.00'))
+        self.assertEqual(opening_payload["prev_session_close_price"], Decimal("101.00"))
         self.assertEqual(
-            opening_payload['opening_window_return_bps'],
-            Decimal('151.5151515151515151515151515'),
+            opening_payload["opening_window_return_bps"],
+            Decimal("151.5151515151515151515151515"),
         )
         self.assertEqual(
-            opening_payload['opening_window_return_from_prev_close_bps'],
-            Decimal('-49.50495049504950495049504950'),
+            opening_payload["opening_window_return_from_prev_close_bps"],
+            Decimal("-49.50495049504950495049504950"),
         )
         self.assertEqual(
-            opening_payload['price_vs_prev_session_close_bps'],
-            Decimal('-49.50495049504950495049504950'),
+            opening_payload["price_vs_prev_session_close_bps"],
+            Decimal("-49.50495049504950495049504950"),
         )
 
     def test_tracker_prefers_nested_midpoint_over_vwap_fallback(self) -> None:
         tracker = SessionContextTracker()
         signal = SignalEnvelope(
             event_ts=datetime(2026, 3, 24, 13, 45, 0, tzinfo=timezone.utc),
-            symbol='META',
-            timeframe='1Sec',
+            symbol="META",
+            timeframe="1Sec",
             seq=2,
-            source='ta',
+            source="ta",
             payload={
-                'vwap': {'session': Decimal('100.0'), 'w5m': Decimal('100.2')},
-                'imbalance': {
-                    'bid_px': Decimal('101.0'),
-                    'ask_px': Decimal('103.0'),
-                    'spread': Decimal('0.2'),
-                    'bid_sz': Decimal('5200'),
-                    'ask_sz': Decimal('4300'),
+                "vwap": {"session": Decimal("100.0"), "w5m": Decimal("100.2")},
+                "imbalance": {
+                    "bid_px": Decimal("101.0"),
+                    "ask_px": Decimal("103.0"),
+                    "spread": Decimal("0.2"),
+                    "bid_sz": Decimal("5200"),
+                    "ask_sz": Decimal("4300"),
                 },
             },
         )
 
         payload = tracker.enrich_signal_payload(signal)
-        self.assertEqual(payload['session_open_price'], Decimal('102.0'))
-        self.assertGreater(payload['recent_spread_bps_avg'], Decimal('0'))
-        self.assertGreater(payload['recent_imbalance_pressure_avg'], Decimal('0'))
+        self.assertEqual(payload["session_open_price"], Decimal("102.0"))
+        self.assertGreater(payload["recent_spread_bps_avg"], Decimal("0"))
+        self.assertGreater(payload["recent_imbalance_pressure_avg"], Decimal("0"))
 
     def test_tracker_emits_cross_section_continuation_and_reversal_ranks(self) -> None:
         tracker = SessionContextTracker()
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 13, 30, 5, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='100.00',
-                spread='0.03',
-                bid_sz='5200',
-                ask_sz='4100',
-                vwap_w5m='100.00',
-                microbar_volume='1000',
+                symbol="AAPL",
+                price="100.00",
+                spread="0.03",
+                bid_sz="5200",
+                ask_sz="4100",
+                vwap_w5m="100.00",
+                microbar_volume="1000",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 13, 30, 6, tzinfo=timezone.utc),
-                symbol='META',
-                price='100.00',
-                spread='0.03',
-                bid_sz='4200',
-                ask_sz='4300',
-                vwap_w5m='100.00',
-                microbar_volume='1200',
+                symbol="META",
+                price="100.00",
+                spread="0.03",
+                bid_sz="4200",
+                ask_sz="4300",
+                vwap_w5m="100.00",
+                microbar_volume="1200",
             )
         )
 
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 13, 55, 0, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='101.10',
-                spread='0.03',
-                bid_sz='5500',
-                ask_sz='4000',
-                vwap_w5m='100.80',
-                rsi14='66',
-                macd_hist='0.040',
-                microbar_volume='1800',
+                symbol="AAPL",
+                price="101.10",
+                spread="0.03",
+                bid_sz="5500",
+                ask_sz="4000",
+                vwap_w5m="100.80",
+                rsi14="66",
+                macd_hist="0.040",
+                microbar_volume="1800",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 13, 55, 5, tzinfo=timezone.utc),
-                symbol='META',
-                price='99.10',
-                spread='0.03',
-                bid_sz='4300',
-                ask_sz='4400',
-                vwap_w5m='99.40',
-                rsi14='38',
-                macd_hist='-0.020',
-                microbar_volume='1100',
+                symbol="META",
+                price="99.10",
+                spread="0.03",
+                bid_sz="4300",
+                ask_sz="4400",
+                vwap_w5m="99.40",
+                rsi14="38",
+                macd_hist="-0.020",
+                microbar_volume="1100",
             )
         )
 
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 5, 0, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='102.40',
-                spread='0.03',
-                bid_sz='5600',
-                ask_sz='3900',
-                vwap_w5m='101.90',
-                rsi14='71',
-                macd_hist='0.055',
-                microbar_volume='2100',
+                symbol="AAPL",
+                price="102.40",
+                spread="0.03",
+                bid_sz="5600",
+                ask_sz="3900",
+                vwap_w5m="101.90",
+                rsi14="71",
+                macd_hist="0.055",
+                microbar_volume="2100",
             )
         )
         loser_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 5, 5, tzinfo=timezone.utc),
-                symbol='META',
-                price='98.70',
-                spread='0.03',
-                bid_sz='5400',
-                ask_sz='3600',
-                vwap_w5m='99.30',
-                rsi14='35',
-                macd_hist='-0.030',
-                microbar_volume='900',
+                symbol="META",
+                price="98.70",
+                spread="0.03",
+                bid_sz="5400",
+                ask_sz="3600",
+                vwap_w5m="99.30",
+                rsi14="35",
+                macd_hist="-0.030",
+                microbar_volume="900",
             )
         )
         leader_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 5, 10, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='102.55',
-                spread='0.03',
-                bid_sz='5700',
-                ask_sz='3800',
-                vwap_w5m='102.00',
-                rsi14='73',
-                macd_hist='0.060',
-                microbar_volume='2400',
+                symbol="AAPL",
+                price="102.55",
+                spread="0.03",
+                bid_sz="5700",
+                ask_sz="3800",
+                vwap_w5m="102.00",
+                rsi14="73",
+                macd_hist="0.060",
+                microbar_volume="2400",
             )
         )
 
-        self.assertEqual(loser_payload['cross_section_session_open_rank'], Decimal('0'))
-        self.assertEqual(loser_payload['cross_section_opening_window_return_rank'], Decimal('0'))
-        self.assertEqual(leader_payload['cross_section_session_open_rank'], Decimal('1'))
-        self.assertEqual(leader_payload['cross_section_opening_window_return_rank'], Decimal('1'))
-        self.assertEqual(leader_payload['cross_section_positive_session_open_ratio'], Decimal('0.5'))
-        self.assertEqual(leader_payload['cross_section_positive_opening_window_return_ratio'], Decimal('0.5'))
-        self.assertEqual(leader_payload['cross_section_above_vwap_w5m_ratio'], Decimal('0.5'))
-        self.assertEqual(leader_payload['cross_section_positive_recent_imbalance_ratio'], Decimal('1'))
-        self.assertEqual(leader_payload['cross_section_continuation_breadth'], Decimal('0.625'))
-        self.assertEqual(loser_payload['cross_section_rsi14_rank'], Decimal('0'))
-        self.assertEqual(loser_payload['cross_section_macd_hist_rank'], Decimal('0'))
-        self.assertEqual(loser_payload['cross_section_recent_15m_return_rank'], Decimal('0'))
-        self.assertEqual(loser_payload['cross_section_microbar_volume_rank'], Decimal('0'))
-        self.assertLess(cast(Decimal, loser_payload['recent_15m_return_bps']), Decimal('0'))
-        self.assertEqual(leader_payload['cross_section_rsi14_rank'], Decimal('1'))
-        self.assertEqual(leader_payload['cross_section_macd_hist_rank'], Decimal('1'))
-        self.assertEqual(leader_payload['cross_section_recent_15m_return_rank'], Decimal('1'))
-        self.assertEqual(leader_payload['cross_section_microbar_volume_rank'], Decimal('1'))
-        self.assertEqual(leader_payload['cross_section_microbar_volume_rank_universe_size'], 2)
-        self.assertEqual(leader_payload['cross_section_continuation_rank_universe_size'], 2)
+        self.assertEqual(loser_payload["cross_section_session_open_rank"], Decimal("0"))
         self.assertEqual(
-            leader_payload['cross_section_factor_neutral_residual_rank_universe_size'],
-            2,
+            loser_payload["cross_section_opening_window_return_rank"], Decimal("0")
         )
         self.assertEqual(
-            leader_payload['cross_section_pair_relative_return_rank_universe_size'],
-            2,
+            leader_payload["cross_section_session_open_rank"], Decimal("1")
         )
         self.assertEqual(
-            leader_payload['cross_section_residual_spread_zscore_rank_universe_size'],
-            2,
+            leader_payload["cross_section_opening_window_return_rank"], Decimal("1")
         )
-        self.assertGreater(cast(Decimal, leader_payload['recent_15m_return_bps']), Decimal('200'))
-        self.assertGreater(
-            cast(Decimal, leader_payload['cross_section_pair_relative_return_rank']),
-            cast(Decimal, loser_payload['cross_section_pair_relative_return_rank']),
+        self.assertEqual(
+            leader_payload["cross_section_positive_session_open_ratio"], Decimal("0.5")
         )
-        self.assertGreater(
-            cast(Decimal, leader_payload['cross_section_vwap_w5m_stretch_rank']),
-            cast(Decimal, loser_payload['cross_section_vwap_w5m_stretch_rank']),
+        self.assertEqual(
+            leader_payload["cross_section_positive_opening_window_return_ratio"],
+            Decimal("0.5"),
+        )
+        self.assertEqual(
+            leader_payload["cross_section_above_vwap_w5m_ratio"], Decimal("0.5")
+        )
+        self.assertEqual(
+            leader_payload["cross_section_positive_recent_imbalance_ratio"],
+            Decimal("1"),
+        )
+        self.assertEqual(
+            leader_payload["cross_section_continuation_breadth"], Decimal("0.625")
+        )
+        self.assertEqual(loser_payload["cross_section_rsi14_rank"], Decimal("0"))
+        self.assertEqual(loser_payload["cross_section_macd_hist_rank"], Decimal("0"))
+        self.assertEqual(
+            loser_payload["cross_section_recent_15m_return_rank"], Decimal("0")
+        )
+        self.assertEqual(
+            loser_payload["cross_section_microbar_volume_rank"], Decimal("0")
         )
         self.assertLess(
-            cast(Decimal, loser_payload['cross_section_continuation_rank']),
-            cast(Decimal, leader_payload['cross_section_continuation_rank']),
+            cast(Decimal, loser_payload["recent_15m_return_bps"]), Decimal("0")
+        )
+        self.assertEqual(leader_payload["cross_section_rsi14_rank"], Decimal("1"))
+        self.assertEqual(leader_payload["cross_section_macd_hist_rank"], Decimal("1"))
+        self.assertEqual(
+            leader_payload["cross_section_recent_15m_return_rank"], Decimal("1")
+        )
+        self.assertEqual(
+            leader_payload["cross_section_microbar_volume_rank"], Decimal("1")
+        )
+        self.assertEqual(
+            leader_payload["cross_section_microbar_volume_rank_universe_size"], 2
+        )
+        self.assertEqual(
+            leader_payload["cross_section_continuation_rank_universe_size"], 2
+        )
+        self.assertEqual(
+            leader_payload["cross_section_factor_neutral_residual_rank_universe_size"],
+            2,
+        )
+        self.assertEqual(
+            leader_payload["cross_section_pair_relative_return_rank_universe_size"],
+            2,
+        )
+        self.assertEqual(
+            leader_payload["cross_section_residual_spread_zscore_rank_universe_size"],
+            2,
         )
         self.assertGreater(
-            cast(Decimal, loser_payload['cross_section_reversal_rank']),
-            cast(Decimal, leader_payload['cross_section_reversal_rank']),
+            cast(Decimal, leader_payload["recent_15m_return_bps"]), Decimal("200")
+        )
+        self.assertGreater(
+            cast(Decimal, leader_payload["cross_section_pair_relative_return_rank"]),
+            cast(Decimal, loser_payload["cross_section_pair_relative_return_rank"]),
+        )
+        self.assertGreater(
+            cast(Decimal, leader_payload["cross_section_vwap_w5m_stretch_rank"]),
+            cast(Decimal, loser_payload["cross_section_vwap_w5m_stretch_rank"]),
+        )
+        self.assertLess(
+            cast(Decimal, loser_payload["cross_section_continuation_rank"]),
+            cast(Decimal, leader_payload["cross_section_continuation_rank"]),
+        )
+        self.assertGreater(
+            cast(Decimal, loser_payload["cross_section_reversal_rank"]),
+            cast(Decimal, leader_payload["cross_section_reversal_rank"]),
         )
 
-    def test_tracker_excludes_invalid_quotes_from_executable_rank_universe(self) -> None:
+    def test_tracker_excludes_invalid_quotes_from_executable_rank_universe(
+        self,
+    ) -> None:
         tracker = SessionContextTracker()
         event_ts = datetime(2026, 3, 24, 14, 0, 0, tzinfo=timezone.utc)
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=event_ts,
-                symbol='NVDA',
-                price='100.00',
-                spread='0.02',
-                bid_sz='4200',
-                ask_sz='3800',
-                microbar_volume='100',
+                symbol="NVDA",
+                price="100.00",
+                spread="0.02",
+                bid_sz="4200",
+                ask_sz="3800",
+                microbar_volume="100",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=event_ts,
-                symbol='AAPL',
-                price='100.00',
-                spread='0.02',
-                bid_sz='4200',
-                ask_sz='3800',
-                microbar_volume='200',
+                symbol="AAPL",
+                price="100.00",
+                spread="0.02",
+                bid_sz="4200",
+                ask_sz="3800",
+                microbar_volume="200",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 5, 0, tzinfo=timezone.utc),
-                symbol='NVDA',
-                price='100.00',
-                spread='2.00',
-                bid_sz='4200',
-                ask_sz='3800',
-                microbar_volume='10000',
+                symbol="NVDA",
+                price="100.00",
+                spread="2.00",
+                bid_sz="4200",
+                ask_sz="3800",
+                microbar_volume="10000",
             )
         )
 
         executable_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 5, 1, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='100.01',
-                spread='0.02',
-                bid_sz='4200',
-                ask_sz='3800',
-                microbar_volume='300',
+                symbol="AAPL",
+                price="100.01",
+                spread="0.02",
+                bid_sz="4200",
+                ask_sz="3800",
+                microbar_volume="300",
             )
         )
 
-        self.assertEqual(executable_payload['cross_section_microbar_volume_rank'], Decimal('1'))
-        self.assertEqual(executable_payload['cross_section_microbar_volume_rank_universe_size'], 2)
+        self.assertEqual(
+            executable_payload["cross_section_microbar_volume_rank"], Decimal("1")
+        )
+        self.assertEqual(
+            executable_payload["cross_section_microbar_volume_rank_universe_size"], 2
+        )
 
     def test_tracker_emits_quote_instability_and_microprice_bias_features(self) -> None:
         tracker = SessionContextTracker()
         first_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 18, 8, 24, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='210.00',
-                spread='0.04',
-                bid_sz='6200',
-                ask_sz='4100',
-                vwap_w5m='209.95',
+                symbol="AAPL",
+                price="210.00",
+                spread="0.04",
+                bid_sz="6200",
+                ask_sz="4100",
+                vwap_w5m="209.95",
             )
         )
         unstable_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 18, 8, 25, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='210.00',
-                spread='2.10',
-                bid_sz='6400',
-                ask_sz='3900',
-                vwap_w5m='209.96',
+                symbol="AAPL",
+                price="210.00",
+                spread="2.10",
+                bid_sz="6400",
+                ask_sz="3900",
+                vwap_w5m="209.96",
             )
         )
 
-        self.assertEqual(first_payload['recent_quote_invalid_ratio'], Decimal('0'))
-        self.assertEqual(unstable_payload['recent_quote_invalid_ratio'], Decimal('0.5'))
-        self.assertIsNone(unstable_payload['recent_quote_jump_bps_max'])
+        self.assertEqual(first_payload["recent_quote_invalid_ratio"], Decimal("0"))
+        self.assertEqual(unstable_payload["recent_quote_invalid_ratio"], Decimal("0.5"))
+        self.assertIsNone(unstable_payload["recent_quote_jump_bps_max"])
         self.assertEqual(
-            unstable_payload['recent_spread_bps_avg'],
-            first_payload['recent_spread_bps_avg'],
+            unstable_payload["recent_spread_bps_avg"],
+            first_payload["recent_spread_bps_avg"],
         )
         self.assertGreater(
-            cast(Decimal, unstable_payload['recent_microprice_bias_bps_avg']),
-            Decimal('0'),
+            cast(Decimal, unstable_payload["recent_microprice_bias_bps_avg"]),
+            Decimal("0"),
         )
 
     def test_tracker_emits_recent_hold_quality_ratios_from_valid_quotes(self) -> None:
@@ -567,247 +679,259 @@ class TestSessionContextTracker(TestCase):
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 13, 30, 5, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='100.00',
-                spread='0.03',
-                bid_sz='5200',
-                ask_sz='4100',
-                vwap_w5m='100.00',
+                symbol="AAPL",
+                price="100.00",
+                spread="0.03",
+                bid_sz="5200",
+                ask_sz="4100",
+                vwap_w5m="100.00",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 5, 0, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='101.20',
-                spread='0.03',
-                bid_sz='5600',
-                ask_sz='3900',
-                vwap_w5m='100.90',
+                symbol="AAPL",
+                price="101.20",
+                spread="0.03",
+                bid_sz="5600",
+                ask_sz="3900",
+                vwap_w5m="100.90",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 5, 5, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='100.85',
-                spread='0.03',
-                bid_sz='5400',
-                ask_sz='4000',
-                vwap_w5m='100.90',
+                symbol="AAPL",
+                price="100.85",
+                spread="0.03",
+                bid_sz="5400",
+                ask_sz="4000",
+                vwap_w5m="100.90",
             )
         )
         invalid_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 5, 10, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='101.40',
-                spread='5.00',
-                bid_sz='6100',
-                ask_sz='3500',
-                vwap_w5m='101.00',
+                symbol="AAPL",
+                price="101.40",
+                spread="5.00",
+                bid_sz="6100",
+                ask_sz="3500",
+                vwap_w5m="101.00",
             )
         )
         final_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 5, 15, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='101.35',
-                spread='0.03',
-                bid_sz='5700',
-                ask_sz='3800',
-                vwap_w5m='101.05',
+                symbol="AAPL",
+                price="101.35",
+                spread="0.03",
+                bid_sz="5700",
+                ask_sz="3800",
+                vwap_w5m="101.05",
             )
         )
 
         self.assertEqual(
-            final_payload['recent_above_opening_range_high_ratio'],
-            Decimal('1'),
+            final_payload["recent_above_opening_range_high_ratio"],
+            Decimal("1"),
         )
         self.assertEqual(
-            final_payload['recent_above_opening_window_close_ratio'],
-            Decimal('1'),
+            final_payload["recent_above_opening_window_close_ratio"],
+            Decimal("1"),
         )
         self.assertEqual(
-            final_payload['recent_above_vwap_w5m_ratio'],
-            Decimal('0.75'),
+            final_payload["recent_above_vwap_w5m_ratio"],
+            Decimal("0.75"),
         )
         self.assertEqual(
-            invalid_payload['recent_above_opening_range_high_ratio'],
-            Decimal('1'),
+            invalid_payload["recent_above_opening_range_high_ratio"],
+            Decimal("1"),
         )
 
-    def test_tracker_prefers_prev_close_in_cross_section_continuation_rank(self) -> None:
+    def test_tracker_prefers_prev_close_in_cross_section_continuation_rank(
+        self,
+    ) -> None:
         tracker = SessionContextTracker()
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 19, 59, 0, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='105.00',
-                spread='0.03',
-                bid_sz='5200',
-                ask_sz='4100',
-                vwap_w5m='104.80',
+                symbol="AAPL",
+                price="105.00",
+                spread="0.03",
+                bid_sz="5200",
+                ask_sz="4100",
+                vwap_w5m="104.80",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 19, 59, 1, tzinfo=timezone.utc),
-                symbol='META',
-                price='95.00',
-                spread='0.03',
-                bid_sz='5000',
-                ask_sz='4200',
-                vwap_w5m='95.10',
+                symbol="META",
+                price="95.00",
+                spread="0.03",
+                bid_sz="5000",
+                ask_sz="4200",
+                vwap_w5m="95.10",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 25, 13, 30, 5, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='99.00',
-                spread='0.03',
-                bid_sz='5100',
-                ask_sz='4300',
-                vwap_w5m='99.00',
+                symbol="AAPL",
+                price="99.00",
+                spread="0.03",
+                bid_sz="5100",
+                ask_sz="4300",
+                vwap_w5m="99.00",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 25, 13, 30, 6, tzinfo=timezone.utc),
-                symbol='META',
-                price='99.00',
-                spread='0.03',
-                bid_sz='5300',
-                ask_sz='4000',
-                vwap_w5m='99.00',
+                symbol="META",
+                price="99.00",
+                spread="0.03",
+                bid_sz="5300",
+                ask_sz="4000",
+                vwap_w5m="99.00",
             )
         )
         aapl_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 25, 13, 55, 0, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='100.50',
-                spread='0.03',
-                bid_sz='5200',
-                ask_sz='4100',
-                vwap_w5m='100.30',
+                symbol="AAPL",
+                price="100.50",
+                spread="0.03",
+                bid_sz="5200",
+                ask_sz="4100",
+                vwap_w5m="100.30",
             )
         )
         meta_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 25, 13, 55, 1, tzinfo=timezone.utc),
-                symbol='META',
-                price='100.50',
-                spread='0.03',
-                bid_sz='5400',
-                ask_sz='3900',
-                vwap_w5m='100.30',
+                symbol="META",
+                price="100.50",
+                spread="0.03",
+                bid_sz="5400",
+                ask_sz="3900",
+                vwap_w5m="100.30",
             )
         )
 
         self.assertLess(
-            cast(Decimal, aapl_payload['cross_section_prev_session_close_rank']),
-            cast(Decimal, meta_payload['cross_section_prev_session_close_rank']),
+            cast(Decimal, aapl_payload["cross_section_prev_session_close_rank"]),
+            cast(Decimal, meta_payload["cross_section_prev_session_close_rank"]),
         )
         self.assertLess(
-            cast(Decimal, aapl_payload['cross_section_continuation_rank']),
-            cast(Decimal, meta_payload['cross_section_continuation_rank']),
+            cast(Decimal, aapl_payload["cross_section_continuation_rank"]),
+            cast(Decimal, meta_payload["cross_section_continuation_rank"]),
         )
 
-    def test_tracker_carries_prev_day_open45_cross_section_ranks_into_next_open(self) -> None:
+    def test_tracker_carries_prev_day_open45_cross_section_ranks_into_next_open(
+        self,
+    ) -> None:
         tracker = SessionContextTracker()
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 13, 30, 0, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='100.00',
-                spread='0.03',
-                bid_sz='5000',
-                ask_sz='4000',
+                symbol="AAPL",
+                price="100.00",
+                spread="0.03",
+                bid_sz="5000",
+                ask_sz="4000",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 13, 30, 1, tzinfo=timezone.utc),
-                symbol='META',
-                price='100.00',
-                spread='0.03',
-                bid_sz='5000',
-                ask_sz='4000',
+                symbol="META",
+                price="100.00",
+                spread="0.03",
+                bid_sz="5000",
+                ask_sz="4000",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 15, 0, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='102.00',
-                spread='0.03',
-                bid_sz='5200',
-                ask_sz='3900',
+                symbol="AAPL",
+                price="102.00",
+                spread="0.03",
+                bid_sz="5200",
+                ask_sz="3900",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 15, 1, tzinfo=timezone.utc),
-                symbol='META',
-                price='98.00',
-                spread='0.03',
-                bid_sz='4800',
-                ask_sz='4300',
+                symbol="META",
+                price="98.00",
+                spread="0.03",
+                bid_sz="4800",
+                ask_sz="4300",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 30, 0, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='103.00',
-                spread='0.03',
-                bid_sz='5200',
-                ask_sz='3900',
+                symbol="AAPL",
+                price="103.00",
+                spread="0.03",
+                bid_sz="5200",
+                ask_sz="3900",
             )
         )
         tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 24, 14, 30, 1, tzinfo=timezone.utc),
-                symbol='META',
-                price='97.00',
-                spread='0.03',
-                bid_sz='4800',
-                ask_sz='4300',
+                symbol="META",
+                price="97.00",
+                spread="0.03",
+                bid_sz="4800",
+                ask_sz="4300",
             )
         )
 
         aapl_open_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 25, 13, 30, 0, tzinfo=timezone.utc),
-                symbol='AAPL',
-                price='101.00',
-                spread='0.03',
-                bid_sz='5100',
-                ask_sz='4100',
+                symbol="AAPL",
+                price="101.00",
+                spread="0.03",
+                bid_sz="5100",
+                ask_sz="4100",
             )
         )
         meta_open_payload = tracker.enrich_signal_payload(
             _signal(
                 event_ts=datetime(2026, 3, 25, 13, 30, 1, tzinfo=timezone.utc),
-                symbol='META',
-                price='99.00',
-                spread='0.03',
-                bid_sz='4900',
-                ask_sz='4200',
+                symbol="META",
+                price="99.00",
+                spread="0.03",
+                bid_sz="4900",
+                ask_sz="4200",
             )
         )
 
-        self.assertEqual(aapl_open_payload['cross_section_prev_day_open45_return_rank'], Decimal('1'))
-        self.assertEqual(meta_open_payload['cross_section_prev_day_open45_return_rank'], Decimal('0'))
         self.assertEqual(
-            aapl_open_payload['cross_section_positive_prev_day_open45_return_ratio'],
-            Decimal('0.5'),
+            aapl_open_payload["cross_section_prev_day_open45_return_rank"], Decimal("1")
         )
-        self.assertEqual(aapl_open_payload['cross_section_prev_day_open60_return_rank'], Decimal('1'))
-        self.assertEqual(meta_open_payload['cross_section_prev_day_open60_return_rank'], Decimal('0'))
         self.assertEqual(
-            aapl_open_payload['cross_section_positive_prev_day_open60_return_ratio'],
-            Decimal('0.5'),
+            meta_open_payload["cross_section_prev_day_open45_return_rank"], Decimal("0")
+        )
+        self.assertEqual(
+            aapl_open_payload["cross_section_positive_prev_day_open45_return_ratio"],
+            Decimal("0.5"),
+        )
+        self.assertEqual(
+            aapl_open_payload["cross_section_prev_day_open60_return_rank"], Decimal("1")
+        )
+        self.assertEqual(
+            meta_open_payload["cross_section_prev_day_open60_return_rank"], Decimal("0")
+        )
+        self.assertEqual(
+            aapl_open_payload["cross_section_positive_prev_day_open60_return_ratio"],
+            Decimal("0.5"),
         )

--- a/services/torghut/tests/test_strategy_runtime.py
+++ b/services/torghut/tests/test_strategy_runtime.py
@@ -5487,7 +5487,7 @@ class TestStrategyRuntimeMicrobarCoverage(TestCase):
         context = self._context()
         self.assertEqual(
             _microbar_minutes_elapsed(
-                context=context,
+                context=self._context(event_ts="2026-03-24T14:31:00+00:00"),
                 features=_test_feature_vector({"session_minutes_elapsed": "61"}),
             ),
             61,
@@ -5504,6 +5504,20 @@ class TestStrategyRuntimeMicrobarCoverage(TestCase):
                 features=_test_feature_vector({}),
             ),
             65,
+        )
+        self.assertEqual(
+            _microbar_minutes_elapsed(
+                context=self._context(event_ts="2026-05-29T15:30:00+00:00"),
+                features=_test_feature_vector({"session_minutes_elapsed": 60}),
+            ),
+            120,
+        )
+        self.assertEqual(
+            _microbar_minutes_elapsed(
+                context=self._context(event_ts="2026-01-05T15:30:00+00:00"),
+                features=_test_feature_vector({}),
+            ),
+            60,
         )
         self.assertIsNone(
             _microbar_minutes_elapsed(
@@ -5602,7 +5616,9 @@ class TestStrategyRuntimeMicrobarCoverage(TestCase):
         self.assertEqual(missing_minutes.trace.first_failed_gate, "schedule")
 
         mismatched_minute = _evaluate_microbar_cross_sectional(
-            context=self._context(params=base_params),
+            context=self._context(
+                params=base_params, event_ts="2026-03-24T14:29:00+00:00"
+            ),
             features=_test_feature_vector({"session_minutes_elapsed": 59}),
             entry_action="buy",
             exit_action="sell",

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -4428,6 +4428,12 @@ class TestTradingPipeline(TestCase):
             ),
             datetime(2026, 3, 27, 13, 30, tzinfo=timezone.utc),
         )
+        self.assertEqual(
+            SimpleTradingPipeline._paper_route_probe_session_open(
+                datetime(2026, 1, 5, 15, 31, tzinfo=timezone.utc)
+            ),
+            datetime(2026, 1, 5, 14, 30, tzinfo=timezone.utc),
+        )
 
     def test_simple_pipeline_does_not_close_paper_route_probe_before_exit_minute(
         self,
@@ -4530,7 +4536,9 @@ class TestTradingPipeline(TestCase):
         self.assertEqual(alpaca_client.submitted, [])
         with self.session_local() as session:
             decisions = (
-                session.execute(select(TradeDecision).order_by(TradeDecision.created_at))
+                session.execute(
+                    select(TradeDecision).order_by(TradeDecision.created_at)
+                )
                 .scalars()
                 .all()
             )


### PR DESCRIPTION
## Summary

- Resolve Torghut regular-session open and close from `America/New_York` instead of fixed UTC constants.
- Apply the shared session boundary helper to session-context feature enrichment, H-PAIRS runtime minute fallback, paper-route probe retries/exits, position tagging, replay tape manifests, and local exact replay windows.
- Add regression coverage for DST and standard-time session boundaries so exit-minute logic does not become a fresh entry and leave H-PAIRS exposure open.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_session_context.py tests/test_replay_tape.py tests/test_strategy_runtime.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -k 'paper_route_probe_exit_session_open or resolve_execution_context_positions_tags_matching_strategy_fill or attach_current_session_strategy_position_tags' -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/session_context.py app/trading/strategy_runtime.py app/trading/scheduler/simple_pipeline.py app/trading/scheduler/pipeline.py app/trading/discovery/replay_tape.py scripts/local_intraday_tsmom_replay.py tests/test_session_context.py tests/test_strategy_runtime.py tests/test_trading_pipeline.py tests/test_replay_tape.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/session_context.py app/trading/strategy_runtime.py app/trading/scheduler/simple_pipeline.py app/trading/scheduler/pipeline.py app/trading/discovery/replay_tape.py scripts/local_intraday_tsmom_replay.py tests/test_session_context.py tests/test_strategy_runtime.py tests/test_trading_pipeline.py tests/test_replay_tape.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
