### PR TITLE
fix(torghut): require source fill economics for runtime proof

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -2189,7 +2189,14 @@ def _order_feed_fill_lifecycle_blockers(
         if order_id is None:
             continue
         observed_fill_order_ids.add(order_id)
-        if _runtime_ledger_row_time(row) is not None:
+        if (
+            _runtime_lifecycle_ledger_row(
+                row,
+                event_type=event_type,
+                require_complete_fill=True,
+            )
+            is not None
+        ):
             complete_fill_order_ids.add(order_id)
 
     blockers: list[str] = []
@@ -2347,6 +2354,9 @@ def _build_realized_strategy_pnl_rows(
     ledger_rows: list[RuntimeLedgerFill | dict[str, object]] = []
     event_times: list[datetime] = []
     event_sourced_lifecycle_rows = 0
+    event_sourced_fill_economics_rows = 0
+    event_sourced_fill_economics_order_ids: set[str] = set()
+    expected_execution_fill_order_ids: set[str] = set()
     order_feed_fill_lifecycle_blockers = _order_feed_fill_lifecycle_blockers(
         execution_rows=execution_rows,
         order_lifecycle_rows=order_lifecycle_rows,
@@ -2366,6 +2376,22 @@ def _build_realized_strategy_pnl_rows(
             {str(key): value for key, value in row.items()}
         )
         if event_type in _RUNTIME_LEDGER_FILL_EVENTS:
+            lifecycle_row = _runtime_lifecycle_ledger_row(
+                row,
+                event_type=event_type,
+                require_complete_fill=True,
+            )
+            if lifecycle_row is not None:
+                ledger_rows.append(lifecycle_row)
+                event_sourced_lifecycle_rows += 1
+                event_sourced_fill_economics_rows += 1
+                order_id = _runtime_order_id(row)
+                if order_id is not None:
+                    event_sourced_fill_economics_order_ids.add(order_id)
+                event_time = lifecycle_row.get("executed_at")
+                if isinstance(event_time, datetime):
+                    event_times.append(event_time)
+                continue
             event_time = _runtime_ledger_row_time(row)
             if isinstance(event_time, datetime):
                 event_times.append(event_time)
@@ -2428,9 +2454,6 @@ def _build_realized_strategy_pnl_rows(
             "client_order_id",
             "execution_correlation_id",
         )
-        event_times.append(ledger_computed_at)
-        if isinstance(fill_event_at, datetime):
-            event_times.append(fill_event_at)
         common_ledger_fields = {
             "executed_at": ledger_computed_at,
             "account_label": str(row.get("account_label") or "") or None,
@@ -2481,6 +2504,13 @@ def _build_realized_strategy_pnl_rows(
         }
         if price is None or price <= 0 or signed_qty == 0:
             continue
+        if order_id is not None:
+            expected_execution_fill_order_ids.add(order_id)
+            if order_id in event_sourced_fill_economics_order_ids:
+                continue
+        event_times.append(ledger_computed_at)
+        if isinstance(fill_event_at, datetime):
+            event_times.append(fill_event_at)
         filled_qty = abs(signed_qty)
         filled_notional = filled_qty * price
         cost_amount = _runtime_execution_cost_amount(
@@ -2586,6 +2616,21 @@ def _build_realized_strategy_pnl_rows(
         "event_fingerprint",
     )
     source_offsets = _source_offset_values(order_lifecycle_rows)
+    order_feed_fill_economics_complete = (
+        bool(expected_execution_fill_order_ids)
+        and expected_execution_fill_order_ids.issubset(
+            event_sourced_fill_economics_order_ids
+        )
+    )
+    source_materialization = None
+    authority_class = None
+    if source_offsets and execution_order_event_ids:
+        if event_sourced_fill_economics_rows > 0 and order_feed_fill_economics_complete:
+            source_materialization = "execution_order_events"
+            authority_class = "runtime_order_feed_execution_source"
+        elif event_sourced_lifecycle_rows > 0:
+            source_materialization = "source_execution_lifecycle"
+            authority_class = "source_execution_lifecycle_materialized_runtime_ledger"
     realized_rows: list[dict[str, object]] = []
     for bucket in build_runtime_ledger_buckets(
         ledger_rows,
@@ -2652,21 +2697,14 @@ def _build_realized_strategy_pnl_rows(
                 execution_order_event_ids=execution_order_event_ids,
                 source_window_ids=source_window_ids,
                 source_offsets=source_offsets,
-                source_materialization=(
-                    "execution_order_events"
-                    if source_offsets and execution_order_event_ids
-                    else None
-                ),
-                authority_class=(
-                    "runtime_order_feed_execution_source"
-                    if source_offsets and execution_order_event_ids
-                    else None
-                ),
+                source_materialization=source_materialization,
+                authority_class=authority_class,
             )
             row["runtime_ledger_bucket"] = bucket_payload
         source_backed_runtime_ledger = (
             allow_authoritative_runtime_ledger_materialization
-            and event_sourced_lifecycle_rows > 0
+            and event_sourced_fill_economics_rows > 0
+            and order_feed_fill_economics_complete
             and not order_feed_fill_lifecycle_blockers
             and isinstance(bucket_payload, Mapping)
             and not runtime_ledger_promotion_source_authority_blockers(bucket_payload)

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -1924,6 +1924,8 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "side": "buy",
                     "filled_qty": Decimal("1"),
                     "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
                     "decision_hash": "decision-buy",
@@ -1946,6 +1948,8 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "side": "sell",
                     "filled_qty": Decimal("1"),
                     "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
                     "account_label": "TORGHUT_SIM",
                     "strategy_id": "microbar-cross-sectional-pairs-v1",
                     "decision_hash": "decision-sell",
@@ -2183,7 +2187,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["pnl_basis"], POST_COST_BASIS_EXECUTION_RECONSTRUCTION)
         self.assertEqual(bucket["authoritative"], False)
 
-    def test_build_realized_strategy_pnl_rows_does_not_count_order_feed_fill_economics(
+    def test_build_realized_strategy_pnl_rows_counts_order_feed_fill_economics(
         self,
     ) -> None:
         rows = _build_realized_strategy_pnl_rows(
@@ -2347,22 +2351,22 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             rows[0]["computed_at"],
             datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
         )
-        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0"))
-        self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
-        self.assertEqual(rows[0]["authoritative"], False)
+        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.70"))
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], True)
+        self.assertEqual(rows[0]["authoritative"], True)
+        self.assertEqual(
+            rows[0]["authority_reason"],
+            "event_sourced_runtime_ledger_profit_proof",
+        )
         bucket = rows[0]["runtime_ledger_bucket"]
         self.assertIsInstance(bucket, dict)
         assert isinstance(bucket, dict)
-        self.assertEqual(bucket["fill_count"], 0)
-        self.assertEqual(bucket["cost_basis_counts"], {})
-        self.assertIn(
-            "runtime_ledger_cost_basis_non_promotion_grade",
-            bucket["blockers"],
+        self.assertEqual(bucket["fill_count"], 2)
+        self.assertEqual(
+            bucket["cost_basis_counts"], {"broker_reported_commission_and_fees": 2}
         )
-        self.assertNotIn(
-            "broker_reported_commission_and_fees",
-            bucket["cost_basis_counts"],
-        )
+        self.assertEqual(bucket["cost_amount"], "0.30")
+        self.assertEqual(bucket["blockers"], [])
         self.assertEqual(bucket["source_materialization"], "execution_order_events")
 
     def test_order_event_lifecycle_uses_execution_raw_order_metadata(self) -> None:
@@ -3128,7 +3132,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             offset: int,
             minute: int,
         ) -> dict[str, object]:
-            return {
+            row: dict[str, object] = {
                 "execution_order_event_id": event_id,
                 "trade_decision_id": decision_id,
                 "execution_id": execution_id,
@@ -3148,6 +3152,24 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 "lineage_hash": "lineage-sha",
                 "source_decision_mode": mode,
             }
+            if event_type in {"fill", "filled", "partial_fill"}:
+                row.update(
+                    {
+                        "side": "sell" if "sell" in decision_id else "buy",
+                        "filled_qty": Decimal("1"),
+                        "avg_fill_price": Decimal(
+                            {
+                                "route-buy": "100",
+                                "route-sell": "101",
+                                "signal-buy": "110",
+                                "signal-sell": "112",
+                            }[decision_id]
+                        ),
+                        "cost_amount": Decimal("0.10"),
+                        "cost_basis": "broker_reported_commission_and_fees",
+                    }
+                )
+            return row
 
         rows = _build_realized_strategy_pnl_rows(
             [
@@ -3617,10 +3639,18 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "decision_hash": "decision-buy",
                     "alpaca_order_id": "order-buy",
                     "event_type": "fill",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
                     "source_topic": "alpaca-trade-updates",
                     "source_partition": 0,
                     "source_offset": 12,
                     "source_window_id": "source-window-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
                     "source_decision_mode": "route_acquisition_probe",
                 },
                 {
@@ -3654,10 +3684,18 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "decision_hash": "decision-sell",
                     "alpaca_order_id": "order-sell",
                     "event_type": "fill",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
                     "source_topic": "alpaca-trade-updates",
                     "source_partition": 0,
                     "source_offset": 14,
                     "source_window_id": "source-window-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
                     "source_decision_mode": "route_acquisition_probe",
                 },
             ],


### PR DESCRIPTION
## Summary

- Makes runtime-window import consume complete order-feed fill economics instead of ignoring them.
- Prevents source-backed promotion authority unless every reconstructed execution fill is covered by complete source fill economics.
- Replaces the stale regression test that asserted order-feed fill economics should not count.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'build_realized_strategy_pnl_rows' -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_runtime_ledger_source_authority.py tests/test_order_feed.py -q`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `git diff --check`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
