### PR TITLE
fix(torghut): resolve paper route runtime harness names

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -33,6 +33,12 @@ from .runtime_cost_authority import cost_basis_counts_have_non_promotion_grade_c
 from .runtime_decision_authority import ROUTE_ACQUISITION_SOURCE_DECISION_MODE
 from .runtime_ledger import POST_COST_PNL_BASIS
 from .runtime_ledger_proof_policy import runtime_ledger_proof_policy_from_env
+from .runtime_strategy_resolution import (
+    derived_strategy_name_from_strategy_id,
+    explicit_runtime_strategy_name_or_family_harness,
+    runtime_strategy_name_from_strategy_id,
+    strategy_names_from_strategy_id,
+)
 
 
 PAPER_ROUTE_EVIDENCE_SCHEMA_VERSION = "torghut.paper-route-evidence.v1"
@@ -225,11 +231,7 @@ def _safe_text(value: object) -> str | None:
 
 
 def _strategy_name_from_strategy_id(strategy_id: object) -> str | None:
-    text = _safe_text(strategy_id)
-    if text is None:
-        return None
-    base = text.split("@", 1)[0].strip()
-    return base.replace("_", "-") if base else None
+    return runtime_strategy_name_from_strategy_id(strategy_id)
 
 
 def _looks_like_uuid_text(value: object) -> bool:
@@ -271,13 +273,18 @@ def _canonical_runtime_strategy_name(
     matched_strategy: Mapping[str, object] | None = None,
 ) -> str | None:
     matched_name = _safe_text((matched_strategy or {}).get("strategy_name"))
-    derived_name = _strategy_name_from_strategy_id(strategy_id)
+    explicit_or_family_name = explicit_runtime_strategy_name_or_family_harness(
+        runtime_strategy_name=runtime_strategy_name,
+        strategy_name=strategy_name,
+        strategy_id=strategy_id,
+    )
     preferred = _strategy_lookup_names(
         matched_name,
+        explicit_or_family_name,
+        strategy_names_from_strategy_id(strategy_id),
+        _strategy_lookup_names(strategy_lookup_names),
         runtime_strategy_name,
         strategy_name,
-        derived_name,
-        _strategy_lookup_names(strategy_lookup_names),
     )
     for name in preferred:
         if not _looks_like_uuid_text(name):
@@ -891,13 +898,19 @@ def _target_identity(
     strategy_name = _safe_text(target.get("strategy_name"))
     strategy_id = _safe_text(target.get("strategy_id"))
     runtime_strategy_name = (
-        _safe_text(target.get("runtime_strategy_name")) or strategy_name
+        explicit_runtime_strategy_name_or_family_harness(
+            runtime_strategy_name=target.get("runtime_strategy_name"),
+            strategy_name=strategy_name,
+            strategy_id=strategy_id,
+        )
+        or strategy_name
     )
     strategy_lookup_names = _strategy_lookup_names(
         target.get("strategy_lookup_names"),
         runtime_strategy_name,
         strategy_name,
-        _strategy_name_from_strategy_id(strategy_id),
+        strategy_names_from_strategy_id(strategy_id),
+        derived_strategy_name_from_strategy_id(strategy_id),
     )
     return {
         "hypothesis_id": _safe_text(target.get("hypothesis_id")),
@@ -1221,14 +1234,23 @@ def _next_paper_route_runtime_window_targets(
         strategy_family = _safe_text(target.get("strategy_family"))
         strategy_name = _safe_text(target.get("strategy_name"))
         strategy_id = _safe_text(target.get("strategy_id"))
-        runtime_strategy_name = (
+        source_runtime_strategy_name = (
             _safe_text(target.get("runtime_strategy_name")) or strategy_name
+        )
+        runtime_strategy_name = (
+            explicit_runtime_strategy_name_or_family_harness(
+                runtime_strategy_name=target.get("runtime_strategy_name"),
+                strategy_name=strategy_name,
+                strategy_id=strategy_id,
+            )
+            or strategy_name
         )
         strategy_lookup_names = _strategy_lookup_names(
             target.get("strategy_lookup_names"),
             runtime_strategy_name,
             strategy_name,
-            _strategy_name_from_strategy_id(strategy_id),
+            strategy_names_from_strategy_id(strategy_id),
+            derived_strategy_name_from_strategy_id(strategy_id),
         )
         raw_target_probe_symbols = _target_probe_symbols(target, probe)
         strategy_universe_symbols = _strategy_universe_symbols(
@@ -1277,7 +1299,8 @@ def _next_paper_route_runtime_window_targets(
             strategy_lookup_names,
             runtime_strategy_name,
             strategy_name,
-            _strategy_name_from_strategy_id(strategy_id),
+            strategy_names_from_strategy_id(strategy_id),
+            derived_strategy_name_from_strategy_id(strategy_id),
         )
         target_probe_ready = (
             bool(probe.get("configured_enabled"))
@@ -1429,7 +1452,7 @@ def _next_paper_route_runtime_window_targets(
             "strategy_id": strategy_id or "",
             "runtime_strategy_name": canonical_strategy_name or "",
             "source_strategy_name": strategy_name or "",
-            "source_runtime_strategy_name": runtime_strategy_name or "",
+            "source_runtime_strategy_name": source_runtime_strategy_name or "",
             "strategy_lookup_names": strategy_lookup_names,
             "account_label": PAPER_ROUTE_RUNTIME_ACCOUNT_LABEL,
             "source_account_label": source_account_label or "",

--- a/services/torghut/app/trading/runtime_strategy_resolution.py
+++ b/services/torghut/app/trading/runtime_strategy_resolution.py
@@ -1,0 +1,83 @@
+"""Runtime strategy-name resolution from family strategy identifiers."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from .discovery.family_templates import load_family_template
+
+
+def _safe_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def family_template_id_from_strategy_id(strategy_id: object) -> str | None:
+    text = _safe_text(strategy_id)
+    if text is None:
+        return None
+    base = text.split("@", 1)[0].strip()
+    return base or None
+
+
+def derived_strategy_name_from_strategy_id(strategy_id: object) -> str | None:
+    family_template_id = family_template_id_from_strategy_id(strategy_id)
+    if family_template_id is None:
+        return None
+    return family_template_id.replace("_", "-")
+
+
+@lru_cache(maxsize=256)
+def _runtime_harness_strategy_name(family_template_id: str) -> str | None:
+    try:
+        template = load_family_template(family_template_id)
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+    return _safe_text(template.runtime_harness.get("strategy_name"))
+
+
+def runtime_strategy_name_from_strategy_id(strategy_id: object) -> str | None:
+    family_template_id = family_template_id_from_strategy_id(strategy_id)
+    if family_template_id is None:
+        return None
+    return _runtime_harness_strategy_name(
+        family_template_id
+    ) or derived_strategy_name_from_strategy_id(strategy_id)
+
+
+def strategy_names_from_strategy_id(strategy_id: object) -> tuple[str, ...]:
+    names: list[str] = []
+    for name in (
+        runtime_strategy_name_from_strategy_id(strategy_id),
+        derived_strategy_name_from_strategy_id(strategy_id),
+    ):
+        if name is not None and name not in names:
+            names.append(name)
+    return tuple(names)
+
+
+def explicit_runtime_strategy_name_or_family_harness(
+    *,
+    runtime_strategy_name: object,
+    strategy_name: object = None,
+    strategy_id: object,
+) -> str | None:
+    explicit_runtime_name = _safe_text(runtime_strategy_name)
+    explicit_strategy_name = _safe_text(strategy_name)
+    family_runtime_name = runtime_strategy_name_from_strategy_id(strategy_id)
+    derived_name = derived_strategy_name_from_strategy_id(strategy_id)
+    has_family_harness = (
+        family_runtime_name is not None
+        and derived_name is not None
+        and family_runtime_name != derived_name
+    )
+
+    for explicit_name in (explicit_runtime_name, explicit_strategy_name):
+        if explicit_name is None:
+            continue
+        if has_family_harness and explicit_name == derived_name:
+            continue
+        return explicit_name
+    return family_runtime_name

--- a/services/torghut/app/trading/submission_council.py
+++ b/services/torghut/app/trading/submission_council.py
@@ -57,6 +57,11 @@ from .runtime_ledger_source_authority import (
     RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER,
     runtime_ledger_promotion_source_authority_blockers,
 )
+from .runtime_strategy_resolution import (
+    derived_strategy_name_from_strategy_id,
+    explicit_runtime_strategy_name_or_family_harness,
+    strategy_names_from_strategy_id,
+)
 from .tca import build_tca_gate_inputs
 
 _CAPITAL_STAGE_ORDER = (
@@ -1440,14 +1445,6 @@ def _runtime_ledger_source_collection_candidates(
     ]
 
 
-def _strategy_name_from_strategy_id(strategy_id: object) -> str | None:
-    text = _safe_text(strategy_id)
-    if text is None:
-        return None
-    base = text.split("@", 1)[0].strip()
-    return base.replace("_", "-") if base else None
-
-
 def _strategy_lookup_names(*values: object) -> list[str]:
     names: list[str] = []
     for value in values:
@@ -1476,8 +1473,10 @@ def _hypothesis_manifest_ref(hypothesis_id: object) -> str | None:
 def _runtime_ledger_paper_probation_strategy_name(
     candidate: Mapping[str, object],
 ) -> str | None:
-    return _safe_text(candidate.get("runtime_strategy_name")) or (
-        _strategy_name_from_strategy_id(candidate.get("strategy_id"))
+    return explicit_runtime_strategy_name_or_family_harness(
+        runtime_strategy_name=candidate.get("runtime_strategy_name"),
+        strategy_name=candidate.get("strategy_name"),
+        strategy_id=candidate.get("strategy_id"),
     )
 
 
@@ -1509,7 +1508,8 @@ def _runtime_ledger_paper_probation_import_plan(
             candidate.get("strategy_lookup_names"),
             strategy_name,
             candidate_strategy_name,
-            _strategy_name_from_strategy_id(strategy_id),
+            strategy_names_from_strategy_id(strategy_id),
+            derived_strategy_name_from_strategy_id(strategy_id),
         )
         account_label = _safe_text(candidate.get("account")) or "TORGHUT_SIM"
         window_start = _safe_text(candidate.get("bucket_started_at"))

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -1107,6 +1107,104 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
         self.assertFalse(summary_target["profit_proof_eligible"])
 
+    def test_next_paper_route_targets_use_family_runtime_harness_from_strategy_id(
+        self,
+    ) -> None:
+        generated_at = datetime(2026, 5, 29, 12, tzinfo=timezone.utc)
+        with Session(self.engine) as session:
+            session.add(
+                Strategy(
+                    name="intraday-tsmom-profit-v3",
+                    description="runtime harness strategy",
+                    enabled=True,
+                    base_timeframe="1Min",
+                    universe_type="static",
+                    universe_symbols=["NVDA", "AAPL"],
+                    max_notional_per_trade=Decimal("25000"),
+                )
+            )
+            session.commit()
+            payload = build_paper_route_evidence_audit(
+                session,
+                live_submission_gate={
+                    "allowed": False,
+                    "reason": "paper_route_probe_only",
+                    "blocked_reasons": [],
+                    "promotion_eligible_total": 0,
+                    "dependency_quorum_decision": "allow",
+                    "continuity_ok": True,
+                    "continuity_reason": "signal_continuity_nominal",
+                    "drift_ok": True,
+                    "drift_reason": "drift_live_promotion_eligible",
+                    "runtime_ledger_paper_probation_import_plan": {
+                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                        "target_count": 1,
+                        "targets": [
+                            {
+                                "hypothesis_id": "H-TSMOM-LIQ",
+                                "candidate_id": "candidate-tsmom",
+                                "observed_stage": "paper",
+                                "strategy_family": "intraday_tsmom_consistent",
+                                "strategy_name": "intraday-tsmom-v2",
+                                "runtime_strategy_name": "intraday-tsmom-v2",
+                                "strategy_id": "intraday_tsmom_v2@research",
+                                "strategy_lookup_names": ["intraday-tsmom-v2"],
+                                "account_label": "TORGHUT_SIM",
+                                "source_kind": "durable_runtime_ledger_bucket",
+                                "source_manifest_ref": "config/trading/hypotheses/h-tsmom-liq.json",
+                                "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+                                "paper_probation_authorized": True,
+                                "source_collection_authorized": True,
+                                "promotion_allowed": False,
+                                "final_promotion_authorized": False,
+                                "max_notional": "0",
+                            }
+                        ],
+                    },
+                },
+                route_reacquisition_book={
+                    "schema_version": "torghut.route-reacquisition-book.v1",
+                    "state": "repair_only",
+                    "summary": {
+                        "paper_route_probe_eligible_symbols": ["NVDA", "AAPL", "MSFT"],
+                        "paper_route_probe_active_symbols": [],
+                    },
+                    "paper_route_probe": {
+                        "configured_enabled": True,
+                        "active": False,
+                        "next_session_max_notional": "25000",
+                        "eligible_symbol_count": 3,
+                        "eligible_symbols": ["NVDA", "AAPL", "MSFT"],
+                        "blocking_reasons": ["market_session_closed"],
+                    },
+                },
+                generated_at=generated_at,
+            )
+
+        plan = payload["next_paper_route_runtime_window_targets"]
+        self.assertEqual(plan["source_decision_readiness"]["ready_target_count"], 1)
+        target = plan["targets"][0]
+        readiness = target["source_decision_readiness"]
+        self.assertTrue(readiness["ready"])
+        self.assertEqual(readiness["blockers"], [])
+        self.assertEqual(target["strategy_name"], "intraday-tsmom-profit-v3")
+        self.assertEqual(target["runtime_strategy_name"], "intraday-tsmom-profit-v3")
+        self.assertEqual(target["source_strategy_name"], "intraday-tsmom-v2")
+        self.assertEqual(target["source_runtime_strategy_name"], "intraday-tsmom-v2")
+        self.assertEqual(
+            target["strategy_lookup_names"],
+            ["intraday-tsmom-profit-v3", "intraday-tsmom-v2"],
+        )
+        self.assertEqual(
+            readiness["matched_strategy"]["strategy_name"],
+            "intraday-tsmom-profit-v3",
+        )
+        self.assertEqual(readiness["scoped_probe_symbols"], ["NVDA", "AAPL"])
+        self.assertEqual(
+            target["paper_route_probe_out_of_strategy_scope_symbols"],
+            ["MSFT"],
+        )
+
     def test_next_paper_route_targets_use_strategy_universe_when_route_probe_empty(
         self,
     ) -> None:

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -1061,6 +1061,38 @@ class TestSubmissionCouncil(TestCase):
         self.assertIn("strategy_name", skipped_target["missing_fields"])
         self.assertIn("source_manifest_ref", skipped_target["missing_fields"])
 
+    def test_runtime_ledger_paper_probation_import_plan_uses_family_runtime_harness(
+        self,
+    ) -> None:
+        plan = _runtime_ledger_paper_probation_import_plan(
+            [
+                {
+                    "hypothesis_id": "H-TSMOM-LIQ",
+                    "candidate_id": "candidate-tsmom",
+                    "strategy_id": "intraday_tsmom_v2@research",
+                    "runtime_strategy_name": "intraday-tsmom-v2",
+                    "strategy_family": "intraday_tsmom_consistent",
+                    "account": "TORGHUT_SIM",
+                    "bucket_started_at": "2026-05-29T13:30:00+00:00",
+                    "bucket_ended_at": "2026-05-29T20:00:00+00:00",
+                    "reason_codes": ["runtime_ledger_source_collection_pending"],
+                }
+            ]
+        )
+
+        self.assertEqual(plan["target_count"], 1)
+        target = plan["targets"][0]
+        self.assertEqual(target["strategy_id"], "intraday_tsmom_v2@research")
+        self.assertEqual(target["strategy_name"], "intraday-tsmom-profit-v3")
+        self.assertEqual(target["runtime_strategy_name"], "intraday-tsmom-profit-v3")
+        self.assertEqual(
+            target["strategy_lookup_names"],
+            ["intraday-tsmom-profit-v3", "intraday-tsmom-v2"],
+        )
+        self.assertFalse(target["promotion_allowed"])
+        self.assertFalse(target["final_promotion_authorized"])
+        self.assertFalse(target["final_promotion_allowed"])
+
     def test_runtime_ledger_paper_probation_import_plan_dedupes_same_window_targets(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Resolve family `strategy_id` values through checked-in runtime harness templates before falling back to hyphenated legacy names.
- Keep legacy derived aliases in lookup lists so older evidence remains searchable while `intraday_tsmom_v2@research` maps to `intraday-tsmom-profit-v3`.
- Apply the resolver to paper-route target planning and submission-council import targets without changing promotion authority or allowing final promotion.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py::TestSubmissionCouncil::test_runtime_ledger_paper_probation_import_plan_uses_family_runtime_harness tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_next_paper_route_targets_use_family_runtime_harness_from_strategy_id -q`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_strategy_resolution.py app/trading/paper_route_evidence.py app/trading/submission_council.py tests/test_paper_route_evidence.py tests/test_submission_council.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_strategy_resolution.py app/trading/paper_route_evidence.py app/trading/submission_council.py tests/test_paper_route_evidence.py tests/test_submission_council.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
