### PR TITLE
fix(torghut): require source authority for doc29 ledger proof

### DIFF
--- a/services/torghut/app/trading/completion.py
+++ b/services/torghut/app/trading/completion.py
@@ -23,7 +23,12 @@ from ..models import (
 )
 from .empirical_jobs import EMPIRICAL_JOB_TYPES, build_empirical_jobs_status
 from .hypotheses import HypothesisManifest, load_hypothesis_registry
+from .runtime_cost_authority import (
+    cost_basis_counts_have_non_promotion_grade_costs,
+    is_non_promotion_grade_runtime_cost_basis,
+)
 from .runtime_ledger import EXACT_REPLAY_LEDGER_SCHEMA_VERSION, POST_COST_PNL_BASIS
+from .runtime_ledger_source_authority import runtime_ledger_promotion_source_authority_blockers
 
 
 def _runtime_matrix_path() -> Path:
@@ -614,6 +619,52 @@ def _positive_hash_count(value: Any) -> bool:
     return bool(mapping) and any(_safe_int(count) > 0 for count in mapping.values())
 
 
+def _runtime_ledger_bucket_promotion_payload(
+    bucket: StrategyRuntimeLedgerBucket,
+) -> dict[str, Any]:
+    payload = _as_dict(bucket.payload_json)
+    canonical_fields = {
+        'run_id': bucket.run_id,
+        'candidate_id': bucket.candidate_id,
+        'hypothesis_id': bucket.hypothesis_id,
+        'observed_stage': bucket.observed_stage,
+        'account_label': bucket.account_label,
+        'runtime_strategy_name': bucket.runtime_strategy_name,
+        'strategy_family': bucket.strategy_family,
+        'fill_count': bucket.fill_count,
+        'decision_count': bucket.decision_count,
+        'submitted_order_count': bucket.submitted_order_count,
+        'cancelled_order_count': bucket.cancelled_order_count,
+        'rejected_order_count': bucket.rejected_order_count,
+        'unfilled_order_count': bucket.unfilled_order_count,
+        'closed_trade_count': bucket.closed_trade_count,
+        'open_position_count': bucket.open_position_count,
+        'filled_notional': bucket.filled_notional,
+        'gross_strategy_pnl': bucket.gross_strategy_pnl,
+        'cost_amount': bucket.cost_amount,
+        'net_strategy_pnl_after_costs': bucket.net_strategy_pnl_after_costs,
+        'post_cost_expectancy_bps': bucket.post_cost_expectancy_bps,
+        'ledger_schema_version': bucket.ledger_schema_version,
+        'pnl_basis': bucket.pnl_basis,
+        'execution_policy_hash_counts': bucket.execution_policy_hash_counts,
+        'cost_model_hash_counts': bucket.cost_model_hash_counts,
+        'lineage_hash_counts': bucket.lineage_hash_counts,
+    }
+    return {**payload, **canonical_fields}
+
+
+def _runtime_ledger_bucket_existing_blockers(
+    bucket: StrategyRuntimeLedgerBucket,
+) -> list[str]:
+    payload = _as_dict(bucket.payload_json)
+    blockers = [
+        str(item).strip()
+        for item in [*_as_list(bucket.blockers_json), *_as_list(payload.get('blockers'))]
+        if str(item).strip()
+    ]
+    return list(dict.fromkeys(blockers))
+
+
 def _runtime_ledger_bucket_matches_window(
     bucket: StrategyRuntimeLedgerBucket,
     window: StrategyHypothesisMetricWindow,
@@ -662,20 +713,28 @@ def _runtime_ledger_bucket_window_match_key(
 def _runtime_ledger_bucket_is_promotion_grade(
     bucket: StrategyRuntimeLedgerBucket,
 ) -> bool:
-    blockers = [item for item in _as_list(bucket.blockers_json) if str(item).strip()]
+    payload = _runtime_ledger_bucket_promotion_payload(bucket)
+    blockers = _runtime_ledger_bucket_existing_blockers(bucket)
+    if blockers:
+        return False
+    if runtime_ledger_promotion_source_authority_blockers(payload):
+        return False
+    if is_non_promotion_grade_runtime_cost_basis(payload.get('cost_basis')):
+        return False
+    if cost_basis_counts_have_non_promotion_grade_costs(payload.get('cost_basis_counts')):
+        return False
     return (
-        _as_text(bucket.ledger_schema_version) in _RUNTIME_LEDGER_BUCKET_SCHEMAS
-        and _as_text(bucket.pnl_basis) == POST_COST_PNL_BASIS
-        and not blockers
-        and _safe_int(bucket.fill_count) > 0
-        and _safe_int(bucket.decision_count) > 0
-        and _safe_int(bucket.submitted_order_count) > 0
-        and _safe_int(bucket.closed_trade_count) > 0
-        and _safe_int(bucket.open_position_count) == 0
-        and bucket.filled_notional > 0
-        and _positive_hash_count(bucket.execution_policy_hash_counts)
-        and _positive_hash_count(bucket.cost_model_hash_counts)
-        and _positive_hash_count(bucket.lineage_hash_counts)
+        _as_text(payload.get('ledger_schema_version')) in _RUNTIME_LEDGER_BUCKET_SCHEMAS
+        and _as_text(payload.get('pnl_basis')) == POST_COST_PNL_BASIS
+        and _safe_int(payload.get('fill_count')) > 0
+        and _safe_int(payload.get('decision_count')) > 0
+        and _safe_int(payload.get('submitted_order_count')) > 0
+        and _safe_int(payload.get('closed_trade_count')) > 0
+        and _safe_int(payload.get('open_position_count')) == 0
+        and _safe_float(payload.get('filled_notional')) > 0
+        and _positive_hash_count(payload.get('execution_policy_hash_counts'))
+        and _positive_hash_count(payload.get('cost_model_hash_counts'))
+        and _positive_hash_count(payload.get('lineage_hash_counts'))
     )
 
 

--- a/services/torghut/tests/test_completion_trace.py
+++ b/services/torghut/tests/test_completion_trace.py
@@ -78,6 +78,50 @@ def _promotion_decision(
     )
 
 
+def _runtime_ledger_source_authority_payload(
+    *,
+    cost_basis: str | None = 'alpaca_2026_equity_fee_schedule',
+    cost_basis_counts: dict[str, int] | None = None,
+    extra: dict[str, object] | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        'source': 'runtime-order-feed',
+        'source_window_start': '2026-03-06T14:30:00+00:00',
+        'source_window_end': '2026-03-06T15:00:00+00:00',
+        'source_refs': [
+            'postgres:trade_decisions',
+            'postgres:executions',
+            'postgres:execution_order_events',
+            'postgres:order_feed_source_windows',
+        ],
+        'source_row_counts': {
+            'trade_decisions': 24,
+            'executions': 12,
+            'execution_order_events': 12,
+            'order_feed_source_windows': 12,
+        },
+        'source_window_ids': ['source-window-1'],
+        'trade_decision_ids': ['trade-decision-1'],
+        'execution_ids': ['execution-1'],
+        'execution_order_event_ids': ['execution-order-event-1'],
+        'source_offsets': [
+            {
+                'topic': 'torghut.trade-updates.v2',
+                'partition': 0,
+                'offset': 42,
+            }
+        ],
+        'source_materialization': 'execution_order_events',
+        'authority_class': 'runtime_order_feed_execution_source',
+    }
+    if cost_basis is not None:
+        payload['cost_basis'] = cost_basis
+        payload['cost_basis_counts'] = cost_basis_counts or {cost_basis: 12}
+    if extra:
+        payload.update(extra)
+    return payload
+
+
 def _runtime_ledger_bucket(
     *,
     run_id: str,
@@ -117,7 +161,7 @@ def _runtime_ledger_bucket(
         cost_model_hash_counts={'cost-hash': 12},
         lineage_hash_counts={'lineage-hash': 12},
         blockers_json=[],
-        payload_json=payload_json or {'source': 'test-runtime-ledger'},
+        payload_json=_runtime_ledger_source_authority_payload() if payload_json is None else payload_json,
     )
 
 
@@ -638,10 +682,9 @@ class TestCompletionTrace(TestCase):
                         run_id=run_id,
                         bucket_started_at=live_window_start,
                         bucket_ended_at=live_window_end,
-                        payload_json={
-                            'source': 'test-runtime-ledger',
-                            'runtime_ledger_daily_summary': runtime_daily_summary,
-                        },
+                        payload_json=_runtime_ledger_source_authority_payload(
+                            extra={'runtime_ledger_daily_summary': runtime_daily_summary}
+                        ),
                     )
                 )
             session.commit()
@@ -806,6 +849,73 @@ class TestCompletionTrace(TestCase):
         self.assertEqual(backed_windows, [window])
         self.assertEqual(matched_buckets, [exact])
         self.assertEqual(unbacked_window_refs, [])
+
+    def test_runtime_ledger_window_refs_reject_legacy_aggregate_only_bucket(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+        with self.session_local() as session:
+            window = StrategyHypothesisMetricWindow(
+                run_id='legacy-aggregate-run',
+                candidate_id='cand-1',
+                hypothesis_id='legacy_macd_rsi',
+                observed_stage='live',
+                window_started_at=window_start,
+                window_ended_at=window_end,
+            )
+            source_less = _runtime_ledger_bucket(
+                run_id='legacy-aggregate-run',
+                bucket_started_at=window_start,
+                bucket_ended_at=window_end,
+                payload_json={'source': 'legacy-aggregate-runtime-ledger'},
+            )
+            session.add_all([window, source_less])
+            session.commit()
+
+            backed_windows, matched_buckets, unbacked_window_refs = _runtime_ledger_bucket_refs_for_windows(
+                session,
+                [window],
+            )
+
+        self.assertEqual(backed_windows, [])
+        self.assertEqual(matched_buckets, [])
+        self.assertEqual(unbacked_window_refs, [str(window.id)])
+
+    def test_runtime_ledger_window_refs_reject_non_promotion_cost_basis(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc)
+        with self.session_local() as session:
+            window = StrategyHypothesisMetricWindow(
+                run_id='modeled-cost-run',
+                candidate_id='cand-1',
+                hypothesis_id='legacy_macd_rsi',
+                observed_stage='live',
+                window_started_at=window_start,
+                window_ended_at=window_end,
+            )
+            modeled_cost = _runtime_ledger_bucket(
+                run_id='modeled-cost-run',
+                bucket_started_at=window_start,
+                bucket_ended_at=window_end,
+                payload_json=_runtime_ledger_source_authority_payload(
+                    cost_basis='modeled_paper_cost_budget',
+                    cost_basis_counts={'modeled_paper_cost_budget': 12},
+                ),
+            )
+            session.add_all([window, modeled_cost])
+            session.commit()
+
+            backed_windows, matched_buckets, unbacked_window_refs = _runtime_ledger_bucket_refs_for_windows(
+                session,
+                [window],
+            )
+
+        self.assertEqual(backed_windows, [])
+        self.assertEqual(matched_buckets, [])
+        self.assertEqual(unbacked_window_refs, [str(window.id)])
 
     def test_doc29_live_scale_blocks_non_runtime_ledger_window_pnl(self) -> None:
         trace = build_completion_trace(


### PR DESCRIPTION
## Summary

- Require doc29 live-scale runtime-ledger bucket matching to pass the shared promotion source-authority contract.
- Reject aggregate-only legacy buckets and non-promotion runtime cost bases before they can back live-scale completion windows.
- Update completion trace fixtures and regressions so source-backed exact-boundary buckets still qualify while source-less or modeled-cost buckets do not.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_completion_trace.py -k 'runtime_ledger_window_refs or live_scale' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_window_import.py tests/test_runtime_ledger_source_authority.py tests/test_assemble_runtime_ledger_proof_packet.py -k 'source_authority or materialization or promotion_authority' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_completion_trace.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_completion_trace.py tests/test_runtime_window_import.py tests/test_runtime_ledger_source_authority.py tests/test_assemble_runtime_ledger_proof_packet.py -k 'runtime_ledger_window_refs or live_scale or source_authority or materialization or promotion_authority' -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/completion.py tests/test_completion_trace.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
