### PR TITLE
fix(torghut): collect live order-feed lifecycle evidence

### DIFF
--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -88,7 +88,7 @@ spec:
             - name: TRADING_SIMPLE_SUBMIT_ENABLED
               value: "false"
             - name: TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED
-              value: "false"
+              value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_ENABLED
               value: "true"
             - name: TRADING_SIMPLE_PAPER_ROUTE_PROBE_MAX_NOTIONAL
@@ -170,6 +170,29 @@ spec:
               value: "5000"
             - name: TRADING_RECONCILE_MS
               value: "15000"
+            - name: TRADING_ORDER_FEED_ENABLED
+              value: "true"
+            - name: TRADING_ORDER_FEED_BOOTSTRAP_SERVERS
+              value: kafka-kafka-bootstrap.kafka:9092
+            - name: TRADING_ORDER_FEED_SECURITY_PROTOCOL
+              value: SASL_PLAINTEXT
+            - name: TRADING_ORDER_FEED_SASL_MECHANISM
+              value: SCRAM-SHA-512
+            - name: TRADING_ORDER_FEED_SASL_USERNAME
+              value: torghut-ws
+            - name: TRADING_ORDER_FEED_SASL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: torghut-ws
+                  key: password
+            - name: TRADING_ORDER_FEED_TOPIC
+              value: ""
+            - name: TRADING_ORDER_FEED_GROUP_ID
+              value: torghut-order-feed-live-default
+            - name: TRADING_ORDER_FEED_ASSIGNMENT_MODE
+              value: manual
+            - name: TRADING_ORDER_FEED_AUTO_OFFSET_RESET
+              value: latest
             - name: TRADING_ORDER_FEED_TOPIC_V2
               value: torghut.trade-updates.v2
             - name: TRADING_EXECUTION_PREFER_LIMIT

--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -6076,6 +6076,13 @@ def _build_simple_lane_status_payload() -> dict[str, object]:
         "order_feed_telemetry_enabled": (
             settings.trading_simple_order_feed_telemetry_enabled
         ),
+        "order_feed_ingestion_enabled": settings.trading_order_feed_enabled,
+        "order_feed_bootstrap_configured": bool(
+            settings.trading_order_feed_bootstrap_server_list
+        ),
+        "order_feed_topic_count": len(settings.trading_order_feed_topics),
+        "order_feed_assignment_mode": settings.trading_order_feed_assignment_mode,
+        "order_feed_auto_offset_reset": settings.trading_order_feed_auto_offset_reset,
         "order_feed_lifecycle_required": (
             settings.trading_pipeline_mode == "simple"
             and settings.trading_mode in {"paper", "live"}

--- a/services/torghut/app/trading/proof_floor.py
+++ b/services/torghut/app/trading/proof_floor.py
@@ -520,6 +520,13 @@ def build_profitability_proof_floor_receipt(
     order_feed_telemetry_enabled = _truthy(
         simple_status.get("order_feed_telemetry_enabled")
     )
+    order_feed_ingestion_enabled = _truthy(
+        simple_status.get("order_feed_ingestion_enabled")
+    )
+    order_feed_bootstrap_configured = _truthy(
+        simple_status.get("order_feed_bootstrap_configured")
+    )
+    order_feed_topic_count = _int(simple_status.get("order_feed_topic_count"))
     if order_feed_lifecycle_required and not order_feed_telemetry_enabled:
         order_feed_state = "fail"
         order_feed_reason = "order_feed_lifecycle_disabled"
@@ -528,6 +535,39 @@ def build_profitability_proof_floor_receipt(
             code="enable_order_feed_lifecycle",
             dimension="order_feed_lifecycle",
             action="enable_simple_order_feed_ingestion_before_proof_floor_authority",
+            reason=order_feed_reason,
+            priority=72,
+        )
+    elif order_feed_lifecycle_required and not order_feed_ingestion_enabled:
+        order_feed_state = "fail"
+        order_feed_reason = "order_feed_ingestion_disabled"
+        _add_repair(
+            repairs,
+            code="enable_order_feed_lifecycle",
+            dimension="order_feed_lifecycle",
+            action="enable_simple_order_feed_ingestion_before_proof_floor_authority",
+            reason=order_feed_reason,
+            priority=72,
+        )
+    elif order_feed_lifecycle_required and not order_feed_bootstrap_configured:
+        order_feed_state = "fail"
+        order_feed_reason = "order_feed_bootstrap_missing"
+        _add_repair(
+            repairs,
+            code="enable_order_feed_lifecycle",
+            dimension="order_feed_lifecycle",
+            action="configure_order_feed_bootstrap_before_proof_floor_authority",
+            reason=order_feed_reason,
+            priority=72,
+        )
+    elif order_feed_lifecycle_required and order_feed_topic_count <= 0:
+        order_feed_state = "fail"
+        order_feed_reason = "order_feed_topic_missing"
+        _add_repair(
+            repairs,
+            code="enable_order_feed_lifecycle",
+            dimension="order_feed_lifecycle",
+            action="configure_order_feed_topic_before_proof_floor_authority",
             reason=order_feed_reason,
             priority=72,
         )
@@ -550,6 +590,15 @@ def build_profitability_proof_floor_receipt(
             "simple_lane_enabled": _truthy(simple_status.get("enabled")),
             "lifecycle_required": order_feed_lifecycle_required,
             "order_feed_telemetry_enabled": order_feed_telemetry_enabled,
+            "order_feed_ingestion_enabled": order_feed_ingestion_enabled,
+            "order_feed_bootstrap_configured": order_feed_bootstrap_configured,
+            "order_feed_topic_count": order_feed_topic_count,
+            "order_feed_assignment_mode": simple_status.get(
+                "order_feed_assignment_mode"
+            ),
+            "order_feed_auto_offset_reset": simple_status.get(
+                "order_feed_auto_offset_reset"
+            ),
             "order_feed_lifecycle_status": simple_status.get(
                 "order_feed_lifecycle_status"
             ),

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -1823,6 +1823,19 @@ class SimpleTradingPipeline(TradingPipeline):
                     "order_feed_telemetry_enabled": (
                         settings.trading_simple_order_feed_telemetry_enabled
                     ),
+                    "order_feed_ingestion_enabled": (
+                        settings.trading_order_feed_enabled
+                    ),
+                    "order_feed_bootstrap_configured": bool(
+                        settings.trading_order_feed_bootstrap_server_list
+                    ),
+                    "order_feed_topic_count": len(settings.trading_order_feed_topics),
+                    "order_feed_assignment_mode": (
+                        settings.trading_order_feed_assignment_mode
+                    ),
+                    "order_feed_auto_offset_reset": (
+                        settings.trading_order_feed_auto_offset_reset
+                    ),
                     "order_feed_lifecycle_required": (
                         settings.trading_pipeline_mode == "simple"
                         and settings.trading_mode in {"paper", "live"}

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -429,11 +429,15 @@ class TestLiveConfigManifestContract(TestCase):
                 self.assertEqual(params.get("max_gross_exposure_pct_equity"), "4.0")
                 self.assertEqual(params.get("max_pair_legs"), "2")
                 self.assertEqual(params.get("top_n"), "1")
-                self.assertEqual(params.get("min_cross_section_continuation_rank"), "0.55")
+                self.assertEqual(
+                    params.get("min_cross_section_continuation_rank"), "0.55"
+                )
                 self.assertEqual(params.get("entry_minute_after_open"), "60")
                 self.assertEqual(params.get("exit_minute_after_open"), "120")
                 self.assertEqual(params.get("long_stop_loss_bps"), "10")
-                self.assertEqual(params.get("long_trailing_stop_activation_profit_bps"), "8")
+                self.assertEqual(
+                    params.get("long_trailing_stop_activation_profit_bps"), "8"
+                )
                 self.assertEqual(params.get("long_trailing_stop_drawdown_bps"), "4")
                 self.assertEqual(params.get("max_hold_seconds"), "7200")
                 self.assertEqual(params.get("max_session_negative_exit_bps"), "10")
@@ -583,6 +587,7 @@ class TestLiveConfigManifestContract(TestCase):
         sim_env = _load_knative_env(
             "argocd/applications/torghut/knative-service-sim.yaml"
         )
+        live_env = _load_torghut_knative_env()
 
         self.assertTrue(_manifest_bool(sim_env, "TRADING_ENABLED"))
         self.assertEqual(sim_env.get("TRADING_MODE"), "paper")
@@ -741,6 +746,28 @@ class TestLiveConfigManifestContract(TestCase):
             "no_signals_in_window",
             _csv_values(sim_env.get("TRADING_SIGNAL_STALENESS_ALERT_CRITICAL_REASONS")),
         )
+
+        self.assertEqual(live_env.get("TRADING_MODE"), "live")
+        self.assertFalse(_manifest_bool(live_env, "TRADING_SIMPLE_SUBMIT_ENABLED"))
+        self.assertTrue(
+            _manifest_bool(live_env, "TRADING_SIMPLE_ORDER_FEED_TELEMETRY_ENABLED"),
+            "live proof floor requires lifecycle telemetry even while submit stays disabled",
+        )
+        self.assertTrue(_manifest_bool(live_env, "TRADING_ORDER_FEED_ENABLED"))
+        self.assertEqual(
+            live_env.get("TRADING_ORDER_FEED_TOPIC"),
+            "",
+            "live telemetry should consume account-labelled v2 envelopes only",
+        )
+        self.assertEqual(
+            live_env.get("TRADING_ORDER_FEED_TOPIC_V2"), "torghut.trade-updates.v2"
+        )
+        self.assertEqual(
+            live_env.get("TRADING_ORDER_FEED_GROUP_ID"),
+            "torghut-order-feed-live-default",
+        )
+        self.assertEqual(live_env.get("TRADING_ORDER_FEED_ASSIGNMENT_MODE"), "manual")
+        self.assertEqual(live_env.get("TRADING_ORDER_FEED_AUTO_OFFSET_RESET"), "latest")
 
     def test_autonomy_config_does_not_treat_normal_no_signal_as_critical(self) -> None:
         manifest = _load_yaml_mapping(

--- a/services/torghut/tests/test_profitability_proof_floor.py
+++ b/services/torghut/tests/test_profitability_proof_floor.py
@@ -72,6 +72,11 @@ def _simple_lane_status() -> dict[str, object]:
         "enabled": True,
         "submit_enabled": True,
         "order_feed_telemetry_enabled": True,
+        "order_feed_ingestion_enabled": True,
+        "order_feed_bootstrap_configured": True,
+        "order_feed_topic_count": 1,
+        "order_feed_assignment_mode": "manual",
+        "order_feed_auto_offset_reset": "latest",
         "order_feed_lifecycle_required": True,
         "order_feed_lifecycle_status": "enabled",
         "route_symbol_filter_enabled": True,
@@ -354,6 +359,126 @@ def test_required_order_feed_lifecycle_blocks_simple_proof_floor() -> None:
     assert order_feed_dimension["state"] == "fail"
     assert order_feed_dimension["capital_effect"] == "paper_hold"
     assert receipt["repair_ladder"][0]["code"] == "enable_order_feed_lifecycle"
+
+
+def test_required_order_feed_ingestion_config_blocks_simple_proof_floor() -> None:
+    receipt = build_profitability_proof_floor_receipt(
+        account_label="TORGHUT_SIM",
+        torghut_revision="torghut-sim-00345",
+        trading_mode="paper",
+        market_session_open=True,
+        live_submission_gate={
+            "allowed": True,
+            "reason": "non_live_mode",
+            "blocked_reasons": [],
+            "capital_stage": "paper",
+        },
+        hypothesis_payload=_healthy_hypothesis_payload(),
+        empirical_jobs_status=_healthy_empirical_jobs(),
+        quant_evidence=_healthy_quant_evidence(),
+        market_context_status=_healthy_market_context(),
+        tca_summary=_fresh_tca_summary(),
+        simple_lane_status={
+            **_simple_lane_status(),
+            "order_feed_ingestion_enabled": False,
+            "order_feed_bootstrap_configured": False,
+            "order_feed_topic_count": 0,
+        },
+        now=NOW,
+    )
+
+    assert receipt["route_state"] == "repair_only"
+    assert receipt["capital_state"] == "zero_notional"
+    assert receipt["blocking_reasons"] == ["order_feed_ingestion_disabled"]
+    order_feed_dimension = next(
+        item
+        for item in receipt["proof_dimensions"]
+        if item["dimension"] == "order_feed_lifecycle"
+    )
+    assert order_feed_dimension["state"] == "fail"
+    assert order_feed_dimension["reason"] == "order_feed_ingestion_disabled"
+    assert order_feed_dimension["source_ref"]["order_feed_telemetry_enabled"] is True
+    assert order_feed_dimension["source_ref"]["order_feed_ingestion_enabled"] is False
+    assert order_feed_dimension["source_ref"]["order_feed_topic_count"] == 0
+    assert receipt["repair_ladder"][0]["code"] == "enable_order_feed_lifecycle"
+
+
+def test_required_order_feed_bootstrap_config_blocks_simple_proof_floor() -> None:
+    receipt = build_profitability_proof_floor_receipt(
+        account_label="TORGHUT_SIM",
+        torghut_revision="torghut-sim-00345",
+        trading_mode="paper",
+        market_session_open=True,
+        live_submission_gate={
+            "allowed": True,
+            "reason": "non_live_mode",
+            "blocked_reasons": [],
+            "capital_stage": "paper",
+        },
+        hypothesis_payload=_healthy_hypothesis_payload(),
+        empirical_jobs_status=_healthy_empirical_jobs(),
+        quant_evidence=_healthy_quant_evidence(),
+        market_context_status=_healthy_market_context(),
+        tca_summary=_fresh_tca_summary(),
+        simple_lane_status={
+            **_simple_lane_status(),
+            "order_feed_bootstrap_configured": False,
+        },
+        now=NOW,
+    )
+
+    assert receipt["route_state"] == "repair_only"
+    assert receipt["capital_state"] == "zero_notional"
+    assert receipt["blocking_reasons"] == ["order_feed_bootstrap_missing"]
+    order_feed_dimension = next(
+        item
+        for item in receipt["proof_dimensions"]
+        if item["dimension"] == "order_feed_lifecycle"
+    )
+    assert order_feed_dimension["state"] == "fail"
+    assert order_feed_dimension["reason"] == "order_feed_bootstrap_missing"
+    assert receipt["repair_ladder"][0]["action"] == (
+        "configure_order_feed_bootstrap_before_proof_floor_authority"
+    )
+
+
+def test_required_order_feed_topic_config_blocks_simple_proof_floor() -> None:
+    receipt = build_profitability_proof_floor_receipt(
+        account_label="TORGHUT_SIM",
+        torghut_revision="torghut-sim-00345",
+        trading_mode="paper",
+        market_session_open=True,
+        live_submission_gate={
+            "allowed": True,
+            "reason": "non_live_mode",
+            "blocked_reasons": [],
+            "capital_stage": "paper",
+        },
+        hypothesis_payload=_healthy_hypothesis_payload(),
+        empirical_jobs_status=_healthy_empirical_jobs(),
+        quant_evidence=_healthy_quant_evidence(),
+        market_context_status=_healthy_market_context(),
+        tca_summary=_fresh_tca_summary(),
+        simple_lane_status={
+            **_simple_lane_status(),
+            "order_feed_topic_count": 0,
+        },
+        now=NOW,
+    )
+
+    assert receipt["route_state"] == "repair_only"
+    assert receipt["capital_state"] == "zero_notional"
+    assert receipt["blocking_reasons"] == ["order_feed_topic_missing"]
+    order_feed_dimension = next(
+        item
+        for item in receipt["proof_dimensions"]
+        if item["dimension"] == "order_feed_lifecycle"
+    )
+    assert order_feed_dimension["state"] == "fail"
+    assert order_feed_dimension["reason"] == "order_feed_topic_missing"
+    assert receipt["repair_ladder"][0]["action"] == (
+        "configure_order_feed_topic_before_proof_floor_authority"
+    )
 
 
 def test_optional_degraded_quant_evidence_is_informational() -> None:
@@ -870,8 +995,7 @@ def test_execution_tca_route_universe_uses_adverse_signed_shortfall() -> None:
     assert symbol_routes["routeable_symbol_count"] == 1
     assert symbol_routes["routeable_symbols"][0]["symbol"] == "AAPL"
     assert (
-        symbol_routes["routeable_symbols"][0]["avg_abs_slippage_bps"]
-        == "28.05213012"
+        symbol_routes["routeable_symbols"][0]["avg_abs_slippage_bps"] == "28.05213012"
     )
     assert (
         symbol_routes["routeable_symbols"][0]["avg_realized_shortfall_bps"]

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -791,6 +791,12 @@ class TestTradingPipeline(TestCase):
                 "trading_simple_max_notional_per_order",
                 "trading_simple_max_notional_per_symbol",
                 "trading_simple_order_feed_telemetry_enabled",
+                "trading_order_feed_enabled",
+                "trading_order_feed_bootstrap_servers",
+                "trading_order_feed_topic",
+                "trading_order_feed_topic_v2",
+                "trading_order_feed_assignment_mode",
+                "trading_order_feed_auto_offset_reset",
                 "trading_simple_paper_route_probe_enabled",
                 "trading_simple_paper_route_probe_max_notional",
                 "trading_simple_paper_route_probe_retry_attempt_limit",
@@ -2541,6 +2547,12 @@ class TestTradingPipeline(TestCase):
         config.settings.trading_live_enabled = False
         config.settings.trading_pipeline_mode = "simple"
         config.settings.trading_simple_order_feed_telemetry_enabled = True
+        config.settings.trading_order_feed_enabled = True
+        config.settings.trading_order_feed_bootstrap_servers = "kafka:9092"
+        config.settings.trading_order_feed_topic = "torghut.trade-updates.v1"
+        config.settings.trading_order_feed_topic_v2 = None
+        config.settings.trading_order_feed_assignment_mode = "manual"
+        config.settings.trading_order_feed_auto_offset_reset = "latest"
         config.settings.trading_market_context_url = "http://market-context.test/api"
         config.settings.trading_market_context_timeout_seconds = 1
         config.settings.trading_market_context_max_staleness_seconds = 300


### PR DESCRIPTION
## Summary

- Enables live Torghut order-feed telemetry ingestion while keeping live submit disabled, so future broker lifecycle events can be collected for proof without adding capital authority.
- Adds live Kafka order-feed configuration using manual assignment, the account-labelled v2 topic, and `latest` offset reset to avoid broad historical backfill.
- Hardens proof-floor lifecycle gating so telemetry alone is not enough; ingestion, bootstrap configuration, and at least one order-feed topic must also be present.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_profitability_proof_floor.py tests/test_live_config_manifest_contract.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_profitability_proof_floor.py tests/test_live_config_manifest_contract.py tests/test_trading_pipeline.py -k 'order_feed or sim_manifest_runs_paper_live_signal_profile or proof_floor' -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/proof_floor.py app/trading/scheduler/simple_pipeline.py app/main.py tests/test_profitability_proof_floor.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/proof_floor.py app/trading/scheduler/simple_pipeline.py app/main.py tests/test_profitability_proof_floor.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None. Live submit remains disabled; this only enables lifecycle telemetry ingestion for future proof collection.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
