### PR TITLE
fix(torghut): split order feed lifecycle from execution economics

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -2150,8 +2150,7 @@ def _strategy_relevant_unlinked_fill_lifecycle_rows(
             continue
         if (
             strategy_identifiers
-            and _runtime_lifecycle_identifier_values(normalized)
-            & strategy_identifiers
+            and _runtime_lifecycle_identifier_values(normalized) & strategy_identifiers
         ):
             relevant_rows.append(normalized)
     return relevant_rows
@@ -2178,7 +2177,6 @@ def _order_feed_fill_lifecycle_blockers(
         return []
 
     observed_fill_order_ids: set[str] = set()
-    complete_fill_order_ids: set[str] = set()
     for row in order_lifecycle_rows or []:
         event_type = _runtime_ledger_event_type(
             {str(key): value for key, value in row.items()}
@@ -2189,15 +2187,6 @@ def _order_feed_fill_lifecycle_blockers(
         if order_id is None:
             continue
         observed_fill_order_ids.add(order_id)
-        if (
-            _runtime_lifecycle_ledger_row(
-                row,
-                event_type=event_type,
-                require_complete_fill=True,
-            )
-            is not None
-        ):
-            complete_fill_order_ids.add(order_id)
 
     blockers: list[str] = []
     if _strategy_relevant_unlinked_fill_lifecycle_rows(
@@ -2211,8 +2200,6 @@ def _order_feed_fill_lifecycle_blockers(
     if not observed_fill_order_ids:
         blockers.append(ORDER_FEED_FILL_LIFECYCLE_MISSING_BLOCKER)
     elif expected_order_ids - observed_fill_order_ids:
-        blockers.append(ORDER_FEED_FILL_LIFECYCLE_INCOMPLETE_BLOCKER)
-    elif expected_order_ids - complete_fill_order_ids:
         blockers.append(ORDER_FEED_FILL_LIFECYCLE_INCOMPLETE_BLOCKER)
     return blockers
 
@@ -2356,6 +2343,8 @@ def _build_realized_strategy_pnl_rows(
     event_sourced_lifecycle_rows = 0
     event_sourced_fill_economics_rows = 0
     event_sourced_fill_economics_order_ids: set[str] = set()
+    execution_fill_economics_rows = 0
+    execution_fill_economics_order_ids: set[str] = set()
     expected_execution_fill_order_ids: set[str] = set()
     order_feed_fill_lifecycle_blockers = _order_feed_fill_lifecycle_blockers(
         execution_rows=execution_rows,
@@ -2526,6 +2515,10 @@ def _build_realized_strategy_pnl_rows(
             filled_qty=filled_qty,
             filled_notional=filled_notional,
         )
+        if cost_amount is not None and cost_amount >= 0 and cost_basis is not None:
+            execution_fill_economics_rows += 1
+            if order_id is not None:
+                execution_fill_economics_order_ids.add(order_id)
         if _cost_basis_is_alpaca_fee_schedule(cost_basis):
             common_ledger_fields["cost_model_hash"] = (
                 _alpaca_2026_equity_fee_schedule_hash()
@@ -2616,11 +2609,16 @@ def _build_realized_strategy_pnl_rows(
         "event_fingerprint",
     )
     source_offsets = _source_offset_values(order_lifecycle_rows)
-    order_feed_fill_economics_complete = (
-        bool(expected_execution_fill_order_ids)
-        and expected_execution_fill_order_ids.issubset(
-            event_sourced_fill_economics_order_ids
-        )
+    order_feed_fill_economics_complete = bool(
+        expected_execution_fill_order_ids
+    ) and expected_execution_fill_order_ids.issubset(
+        event_sourced_fill_economics_order_ids
+    )
+    execution_fill_economics_complete = bool(
+        expected_execution_fill_order_ids
+    ) and expected_execution_fill_order_ids.issubset(execution_fill_economics_order_ids)
+    fill_economics_complete = (
+        order_feed_fill_economics_complete or execution_fill_economics_complete
     )
     source_materialization = None
     authority_class = None
@@ -2628,6 +2626,13 @@ def _build_realized_strategy_pnl_rows(
         if event_sourced_fill_economics_rows > 0 and order_feed_fill_economics_complete:
             source_materialization = "execution_order_events"
             authority_class = "runtime_order_feed_execution_source"
+        elif (
+            event_sourced_lifecycle_rows > 0
+            and execution_fill_economics_rows > 0
+            and execution_fill_economics_complete
+        ):
+            source_materialization = "source_execution_lifecycle"
+            authority_class = "source_execution_lifecycle_materialized_runtime_ledger"
         elif event_sourced_lifecycle_rows > 0:
             source_materialization = "source_execution_lifecycle"
             authority_class = "source_execution_lifecycle_materialized_runtime_ledger"
@@ -2703,8 +2708,7 @@ def _build_realized_strategy_pnl_rows(
             row["runtime_ledger_bucket"] = bucket_payload
         source_backed_runtime_ledger = (
             allow_authoritative_runtime_ledger_materialization
-            and event_sourced_fill_economics_rows > 0
-            and order_feed_fill_economics_complete
+            and fill_economics_complete
             and not order_feed_fill_lifecycle_blockers
             and isinstance(bucket_payload, Mapping)
             and not runtime_ledger_promotion_source_authority_blockers(bucket_payload)
@@ -2727,7 +2731,9 @@ def _build_realized_strategy_pnl_rows(
                     "authoritative": True,
                     "authority_reason": "event_sourced_runtime_ledger_profit_proof",
                     "pnl_derivation": "execution_order_events_runtime_ledger",
-                    "source_materialization": "execution_order_events",
+                    "source_materialization": (
+                        source_materialization or "source_execution_lifecycle"
+                    ),
                 }
                 if equity_denominator is not None:
                     runtime_bucket["account_equity"] = str(equity_denominator[0])
@@ -2757,7 +2763,9 @@ def _build_realized_strategy_pnl_rows(
                         "source_execution_lifecycle_materialized_runtime_ledger"
                     ),
                     "pnl_derivation": "execution_order_events_runtime_ledger",
-                    "source_materialization": "execution_order_events",
+                    "source_materialization": (
+                        source_materialization or "source_execution_lifecycle"
+                    ),
                 }
                 if equity_denominator is not None:
                     runtime_bucket["account_equity"] = str(equity_denominator[0])

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -2369,6 +2369,169 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["blockers"], [])
         self.assertEqual(bucket["source_materialization"], "execution_order_events")
 
+    def test_build_realized_strategy_pnl_rows_accepts_execution_economics_with_order_feed_lifecycle(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "execution_id": "execution-buy",
+                    "computed_at": datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 31, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "execution_id": "execution-sell",
+                    "computed_at": datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 32, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            decision_lifecycle_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    "event_type": "decision",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 31, tzinfo=timezone.utc),
+                    "event_type": "decision",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            order_lifecycle_rows=[
+                {
+                    "execution_order_event_id": "event-new-buy",
+                    "trade_decision_id": "decision-buy",
+                    "event_ts": datetime(2026, 3, 6, 14, 30, 1, tzinfo=timezone.utc),
+                    "event_type": "new",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 210,
+                    "source_window_id": "source-window-new-buy",
+                },
+                {
+                    "execution_order_event_id": "event-new-sell",
+                    "trade_decision_id": "decision-sell",
+                    "event_ts": datetime(2026, 3, 6, 14, 31, 1, tzinfo=timezone.utc),
+                    "event_type": "new",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 211,
+                    "source_window_id": "source-window-new-sell",
+                },
+                {
+                    "execution_order_event_id": "event-fill-buy",
+                    "trade_decision_id": "decision-buy",
+                    "execution_id": "execution-buy",
+                    "event_ts": datetime(2026, 3, 6, 14, 31, 1, tzinfo=timezone.utc),
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 212,
+                    "source_window_id": "source-window-fill-buy",
+                },
+                {
+                    "execution_order_event_id": "event-fill-sell",
+                    "trade_decision_id": "decision-sell",
+                    "execution_id": "execution-sell",
+                    "event_ts": datetime(2026, 3, 6, 14, 32, 1, tzinfo=timezone.utc),
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 213,
+                    "source_window_id": "source-window-fill-sell",
+                },
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["realized_net_pnl"], Decimal("0.70"))
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], True)
+        self.assertEqual(rows[0]["authoritative"], True)
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["blockers"], [])
+        self.assertEqual(bucket["source_materialization"], "source_execution_lifecycle")
+        self.assertEqual(
+            bucket["cost_basis_counts"],
+            {"broker_reported_commission_and_fees": 2},
+        )
+
     def test_order_event_lifecycle_uses_execution_raw_order_metadata(self) -> None:
         row = {
             "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
@@ -3475,9 +3638,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             unlinked_order_lifecycle_rows=[
                 {
                     "execution_order_event_id": "unlinked-fill",
-                    "event_ts": datetime(
-                        2026, 3, 6, 14, 41, 2, tzinfo=timezone.utc
-                    ),
+                    "event_ts": datetime(2026, 3, 6, 14, 41, 2, tzinfo=timezone.utc),
                     "symbol": "AAPL",
                     "account_label": "TORGHUT_SIM",
                     "alpaca_order_id": "order-sell",
@@ -3504,9 +3665,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             "execution_reconstruction_not_runtime_ledger_proof",
         )
         bucket = cast(Mapping[str, object], row["runtime_ledger_bucket"])
-        self.assertIn(
-            "order_feed_unlinked_fill_lifecycle_present", bucket["blockers"]
-        )
+        self.assertIn("order_feed_unlinked_fill_lifecycle_present", bucket["blockers"])
         self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
 
         rows = _build_realized_strategy_pnl_rows(
@@ -3515,9 +3674,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             unlinked_order_lifecycle_rows=[
                 {
                     "execution_order_event_id": "external-fill",
-                    "event_ts": datetime(
-                        2026, 3, 6, 14, 41, 2, tzinfo=timezone.utc
-                    ),
+                    "event_ts": datetime(2026, 3, 6, 14, 41, 2, tzinfo=timezone.utc),
                     "symbol": "AAPL",
                     "account_label": "TORGHUT_SIM",
                     "alpaca_order_id": "external-close-order",
@@ -4004,9 +4161,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             diagnostics["order_feed_unlinked_strategy_fill_lifecycle_event_ids"],
             [],
         )
-        self.assertEqual(
-            diagnostics["order_feed_unattributed_fill_lifecycle_count"], 1
-        )
+        self.assertEqual(diagnostics["order_feed_unattributed_fill_lifecycle_count"], 1)
         self.assertEqual(
             diagnostics["order_feed_unattributed_fill_lifecycle_event_ids"],
             ["unlinked-event-id"],
@@ -4077,9 +4232,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             diagnostics["order_feed_unlinked_strategy_fill_lifecycle_event_ids"],
             ["unlinked-event-id"],
         )
-        self.assertEqual(
-            diagnostics["order_feed_unattributed_fill_lifecycle_count"], 0
-        )
+        self.assertEqual(diagnostics["order_feed_unattributed_fill_lifecycle_count"], 0)
         self.assertIn(
             "order_feed_unlinked_fill_lifecycle_present",
             _source_activity_diagnostics_blockers(diagnostics),


### PR DESCRIPTION
## Summary

- Split order-feed fill lifecycle proof from execution economics in runtime-window import.
- Let source-backed runtime-ledger materialization use execution rows for fill price, notional, and explicit costs while order-feed rows prove lifecycle and Kafka/source-window lineage.
- Preserve fail-closed promotion authority: source refs, source windows, execution refs, cost basis, lineage hashes, closed trips, and runtime-ledger blockers are still required.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'order_feed_fill_lifecycle or accepts_execution_economics or counts_order_feed_fill_economics or runtime_ledger_tca_row_separates_explicit_cost_from_slippage' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger_source_authority.py tests/test_runtime_window_import.py -q`
- `cd services/torghut && uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff origin/main...HEAD --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
