### PR TITLE
fix(torghut): allow prechecked reducing exits past notional cap

### DIFF
--- a/services/torghut/app/trading/execution_policy.py
+++ b/services/torghut/app/trading/execution_policy.py
@@ -202,7 +202,12 @@ class ExecutionPolicy:
 
         price = _resolve_price(decision, market_snapshot)
         position_qty = _position_summary(decision.symbol, positions)
-        short_increasing = _is_short_increasing(decision, positions)
+        prechecked_reducing_position_qty = _prechecked_reducing_position_qty(decision)
+        if prechecked_reducing_position_qty is not None:
+            position_qty = prechecked_reducing_position_qty
+            short_increasing = False
+        else:
+            short_increasing = _is_short_increasing(decision, positions)
         position_reducing = _is_position_reducing(decision, position_qty)
         qty, notional = self._resolve_qty_and_notional(
             decision=decision,
@@ -1276,6 +1281,72 @@ def _is_position_reducing(
     if decision.action == "buy" and position_qty < 0:
         return qty <= abs(position_qty)
     return False
+
+
+def _prechecked_reducing_position_qty(decision: StrategyDecision) -> Decimal | None:
+    if decision.action.strip().lower() != "sell":
+        return None
+    qty = _optional_decimal(decision.qty)
+    if qty is None or qty <= 0:
+        return None
+    for key in ("simple_lane", "simple_lane_precheck"):
+        section = decision.params.get(key)
+        if not isinstance(section, Mapping):
+            continue
+        section_map = cast(Mapping[str, Any], section)
+        resolution = section_map.get("quantity_resolution")
+        if not isinstance(resolution, Mapping):
+            continue
+        resolution_map = cast(Mapping[str, Any], resolution)
+        if not _quantity_resolution_matches_decision(
+            decision=decision,
+            resolution=resolution_map,
+        ):
+            continue
+        position_qty = _optional_decimal(resolution_map.get("position_qty"))
+        if position_qty is None or position_qty <= 0 or qty > position_qty:
+            continue
+        reason = str(resolution_map.get("reason") or "").strip().lower()
+        short_increasing = _coerce_optional_bool(
+            resolution_map.get("short_increasing")
+        )
+        if short_increasing is False and reason.startswith("sell_reducing_"):
+            return position_qty
+    return None
+
+
+def _quantity_resolution_matches_decision(
+    *,
+    decision: StrategyDecision,
+    resolution: Mapping[str, Any],
+) -> bool:
+    symbol = str(resolution.get("symbol") or "").strip().upper()
+    if symbol and symbol != decision.symbol.strip().upper():
+        return False
+    action = str(resolution.get("action") or "").strip().lower()
+    if action and action != decision.action.strip().lower():
+        return False
+    requested_qty = _optional_decimal(resolution.get("requested_qty"))
+    decision_qty = _optional_decimal(decision.qty)
+    if (
+        requested_qty is not None
+        and decision_qty is not None
+        and requested_qty < decision_qty
+    ):
+        return False
+    return True
+
+
+def _coerce_optional_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    return None
 
 
 def _optional_decimal(value: Any) -> Optional[Decimal]:

--- a/services/torghut/tests/test_execution_policy.py
+++ b/services/torghut/tests/test_execution_policy.py
@@ -47,6 +47,24 @@ def _decision(
     )
 
 
+def _with_simple_lane_quantity_resolution(
+    decision: StrategyDecision,
+    **overrides: object,
+) -> StrategyDecision:
+    resolution: dict[str, object] = {
+        "action": "sell",
+        "reason": "sell_reducing_long_fractional_allowed",
+        "symbol": "AAPL",
+        "position_qty": "184",
+        "requested_qty": "184.0000",
+        "short_increasing": False,
+    }
+    resolution.update(overrides)
+    params = dict(decision.params)
+    params["simple_lane"] = {"quantity_resolution": resolution}
+    return decision.model_copy(update={"params": params})
+
+
 class TestExecutionPolicy(TestCase):
     def setUp(self) -> None:
         self._advisor_enabled = config.settings.trading_execution_advisor_enabled
@@ -151,6 +169,122 @@ class TestExecutionPolicy(TestCase):
 
         self.assertTrue(outcome.approved)
         self.assertNotIn("max_notional_exceeded", outcome.reasons)
+
+    def test_max_notional_does_not_block_prechecked_reducing_sell_when_snapshot_missing(
+        self,
+    ) -> None:
+        policy = ExecutionPolicy(config=_config(max_notional=Decimal("100")))
+        decision = _decision(
+            action="sell",
+            qty=Decimal("184.0000"),
+            price=Decimal("273.97"),
+        )
+        decision = _with_simple_lane_quantity_resolution(
+            decision,
+            short_increasing="off",
+        )
+
+        outcome = policy.evaluate(
+            decision,
+            strategy=None,
+            positions=[],
+            market_snapshot=None,
+        )
+
+        self.assertTrue(outcome.approved)
+        self.assertNotIn("max_notional_exceeded", outcome.reasons)
+        self.assertNotIn("shorts_not_allowed", outcome.reasons)
+
+    def test_max_notional_still_blocks_unmatched_prechecked_reducing_sell(
+        self,
+    ) -> None:
+        policy = ExecutionPolicy(config=_config(max_notional=Decimal("100")))
+        decision = _decision(
+            action="sell",
+            qty=Decimal("184.0000"),
+            price=Decimal("273.97"),
+        )
+        decision = _with_simple_lane_quantity_resolution(decision, symbol="MSFT")
+
+        outcome = policy.evaluate(
+            decision,
+            strategy=None,
+            positions=[],
+            market_snapshot=None,
+        )
+
+        self.assertFalse(outcome.approved)
+        self.assertIn("max_notional_exceeded", outcome.reasons)
+
+    def test_max_notional_still_blocks_invalid_prechecked_reducing_metadata(
+        self,
+    ) -> None:
+        policy = ExecutionPolicy(config=_config(max_notional=Decimal("100")))
+        base_decision = _decision(
+            action="sell",
+            qty=Decimal("184.0000"),
+            price=Decimal("273.97"),
+        )
+        cases: list[dict[str, object]] = [
+            {"action": "buy"},
+            {"position_qty": "100"},
+            {"requested_qty": "100"},
+            {"short_increasing": "yes"},
+            {"short_increasing": None},
+        ]
+
+        for overrides in cases:
+            with self.subTest(overrides=overrides):
+                outcome = policy.evaluate(
+                    _with_simple_lane_quantity_resolution(base_decision, **overrides),
+                    strategy=None,
+                    positions=[],
+                    market_snapshot=None,
+                )
+
+                self.assertFalse(outcome.approved)
+                self.assertIn("max_notional_exceeded", outcome.reasons)
+
+    def test_max_notional_ignores_non_mapping_prechecked_resolution(
+        self,
+    ) -> None:
+        policy = ExecutionPolicy(config=_config(max_notional=Decimal("100")))
+        decision = _decision(
+            action="sell",
+            qty=Decimal("184.0000"),
+            price=Decimal("273.97"),
+        )
+        params = dict(decision.params)
+        params["simple_lane"] = {"quantity_resolution": "not-a-resolution"}
+
+        outcome = policy.evaluate(
+            decision.model_copy(update={"params": params}),
+            strategy=None,
+            positions=[],
+            market_snapshot=None,
+        )
+
+        self.assertFalse(outcome.approved)
+        self.assertIn("max_notional_exceeded", outcome.reasons)
+
+    def test_prechecked_reducing_sell_ignores_non_positive_qty(
+        self,
+    ) -> None:
+        policy = ExecutionPolicy(config=_config(max_notional=Decimal("100")))
+        decision = _with_simple_lane_quantity_resolution(
+            _decision(action="sell", qty=Decimal("0"), price=Decimal("273.97")),
+            requested_qty="0",
+        )
+
+        outcome = policy.evaluate(
+            decision,
+            strategy=None,
+            positions=[],
+            market_snapshot=None,
+        )
+
+        self.assertFalse(outcome.approved)
+        self.assertIn("qty_non_positive", outcome.reasons)
 
     def test_max_notional_does_not_block_short_cover(self) -> None:
         policy = ExecutionPolicy(config=_config(max_notional=Decimal("100")))


### PR DESCRIPTION
## Summary

- Allows execution policy to honor system-generated simple-lane reducing-sell quantity resolution when the positions snapshot is missing or stale.
- Prevents reducing exits from being rejected by the entry max-notional cap while keeping unmatched/increasing sells blocked.
- Adds regression coverage for the live H-PAIRS-style rejected exit shape.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_execution_policy.py tests/test_simple_risk.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_execution_policy.py --cov=app.trading.execution_policy --cov-report=xml:/tmp/torghut-execution-policy-coverage.xml -q && uv run --frozen python scripts/check_diff_coverage.py --coverage-xml /tmp/torghut-execution-policy-coverage.xml --threshold 90`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -k "position_reducing_probe_exit or short_increasing_sell_classification or retries_previous_position_reducing_probe_exit" -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/execution_policy.py tests/test_execution_policy.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
