### PR TITLE
fix(torghut): precheck paper route probe sizing

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -231,6 +231,7 @@ spec:
             - name: TRADING_ORDER_FEED_AUTO_OFFSET_RESET
               value: earliest
             - name: TRADING_ORDER_FEED_TOPIC_V2
+              value: ""
             - name: TRADING_SIMULATION_ORDER_UPDATES_TOPIC
               value: torghut.sim.trade-updates.v1
             - name: TRADING_SIMULATION_ORDER_UPDATES_BOOTSTRAP_SERVERS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -186,6 +186,7 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TRADING_ORDER_FEED_TOPIC
+              value: ""
             - name: TRADING_ORDER_FEED_GROUP_ID
               value: torghut-order-feed-live-default
             - name: TRADING_ORDER_FEED_ASSIGNMENT_MODE

--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -1699,6 +1699,28 @@ class SimpleTradingPipeline(TradingPipeline):
         decision, snapshot = self._ensure_decision_price(
             decision, signal_price=decision.params.get("price")
         )
+        proof_floor = self._profitability_proof_floor(session=session)
+        proof_floor_block_reason = self._proof_floor_submission_block_reason(
+            proof_floor
+        )
+        if (
+            proof_floor_block_reason is not None
+            and settings.trading_mode == "paper"
+            and self._paper_route_probe_exit_metadata(decision) is None
+            and _paper_route_probe_entry_metadata(decision.params) is None
+        ):
+            probe_context = self._paper_route_probe_context(
+                proof_floor=proof_floor,
+                decision=decision,
+                strategy=strategy,
+            )
+            capped_decision = self._paper_route_probe_capped_decision(
+                decision=decision,
+                proof_floor=proof_floor,
+                context=probe_context or {},
+            )
+            if capped_decision is not None:
+                decision = capped_decision
         max_notional_per_order = _min_optional_decimal(
             _optional_decimal(settings.trading_simple_max_notional_per_order),
             _optional_decimal(settings.trading_max_notional_per_trade),
@@ -1730,22 +1752,25 @@ class SimpleTradingPipeline(TradingPipeline):
             )
             or Decimal("0"),
         )
-        self.executor.sync_decision_state(session, decision_row, preparation.decision)
+        prepared_decision = self._align_prechecked_paper_route_probe_cap(
+            preparation.decision
+        )
+        self.executor.sync_decision_state(session, decision_row, prepared_decision)
         if preparation.diagnostics:
-            params_update = dict(preparation.decision.params)
+            params_update = dict(prepared_decision.params)
             params_update["simple_lane_precheck"] = preparation.diagnostics
             self.executor.update_decision_params(session, decision_row, params_update)
         if not preparation.approved or preparation.reject_reason is not None:
             reason = preparation.reject_reason or "broker_precheck_failed"
             self._record_decision_rejection(
                 session=session,
-                decision=preparation.decision,
+                decision=prepared_decision,
                 decision_row=decision_row,
                 reasons=[reason],
                 log_template="Simple-lane decision rejected strategy_id=%s symbol=%s reason=%s",
             )
             return None
-        return preparation.decision, snapshot
+        return prepared_decision, snapshot
 
     def _passes_risk_verdict(
         self,
@@ -2951,26 +2976,24 @@ class SimpleTradingPipeline(TradingPipeline):
         )
         return decision_row
 
-    def _apply_paper_route_probe_cap(
+    def _paper_route_probe_capped_decision(
         self,
         *,
-        session: Session,
         decision: StrategyDecision,
-        decision_row: TradeDecision,
         proof_floor: Mapping[str, object],
         context: Mapping[str, object],
-    ) -> bool:
+    ) -> StrategyDecision | None:
         cap = _optional_decimal(context.get("max_notional"))
         price = self._paper_route_probe_reference_price(decision)
         if cap is None or cap <= 0 or price is None or price <= 0:
-            return False
+            return None
 
         capped_qty = (cap / price).quantize(
             _PAPER_ROUTE_PROBE_QTY_STEP,
             rounding=ROUND_DOWN,
         )
         if capped_qty <= 0:
-            return False
+            return None
         target_source_authorized = bool(context.get("target_source_authorized"))
         if decision.qty > 0 and not target_source_authorized:
             capped_qty = min(decision.qty, capped_qty)
@@ -2992,19 +3015,36 @@ class SimpleTradingPipeline(TradingPipeline):
             "capital_stage": str(proof_floor.get("capital_state") or "zero_notional"),
             "target_source_notional_sized": target_source_authorized,
         }
-        decision.qty = capped_qty
-        decision.params = params
-        self.executor.sync_decision_state(session, decision_row, decision)
-        self.executor.update_decision_params(session, decision_row, params)
-        logger.warning(
-            "Allowing bounded paper route-acquisition probe strategy_id=%s symbol=%s qty=%s notional=%s reasons=%s",
-            decision.strategy_id,
-            decision.symbol,
-            capped_qty,
-            capped_notional,
-            ",".join(cast(list[str], context.get("blocking_reasons") or [])),
-        )
-        return True
+        return decision.model_copy(update={"qty": capped_qty, "params": params})
+
+    def _align_prechecked_paper_route_probe_cap(
+        self,
+        decision: StrategyDecision,
+    ) -> StrategyDecision:
+        metadata = _paper_route_probe_entry_metadata(decision.params)
+        if metadata is None:
+            return decision
+        price = self._paper_route_probe_reference_price(decision)
+        if price is None or price <= 0:
+            return decision
+
+        notional = decision.qty * price
+        params = dict(decision.params)
+        simple_lane = dict(cast(Mapping[str, Any], params.get("simple_lane") or {}))
+        simple_lane["final_qty"] = str(decision.qty)
+        simple_lane["notional"] = str(notional)
+        simple_lane["paper_route_probe_cap_applied"] = True
+        if bool(metadata.get("target_source_authorized")):
+            simple_lane["target_source_notional_sized"] = True
+
+        probe_metadata = dict(metadata)
+        probe_metadata["reference_price"] = str(price)
+        probe_metadata["capped_qty"] = str(decision.qty)
+        probe_metadata["capped_notional"] = str(notional)
+
+        params["simple_lane"] = simple_lane
+        params["paper_route_probe"] = probe_metadata
+        return decision.model_copy(update={"params": params})
 
     @staticmethod
     def _proof_floor_symbol_block_reason(
@@ -3070,27 +3110,12 @@ class SimpleTradingPipeline(TradingPipeline):
         if proof_floor_block_reason is not None:
             if (
                 settings.trading_mode == "paper"
-                and self._paper_route_probe_exit_metadata(decision) is not None
+                and (
+                    self._paper_route_probe_exit_metadata(decision) is not None
+                    or _paper_route_probe_entry_metadata(decision.params) is not None
+                )
             ):
                 paper_route_probe_applied = True
-            else:
-                strategy = self._paper_route_probe_strategy(
-                    session=session,
-                    decision=decision,
-                )
-                probe_context = self._paper_route_probe_context(
-                    proof_floor=proof_floor,
-                    decision=decision,
-                    strategy=strategy,
-                )
-                if probe_context is not None and self._apply_paper_route_probe_cap(
-                    session=session,
-                    decision=decision,
-                    decision_row=decision_row,
-                    proof_floor=proof_floor,
-                    context=probe_context,
-                ):
-                    paper_route_probe_applied = True
             if not paper_route_probe_applied:
                 self._block_decision_submission(
                     session=session,

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -5348,6 +5348,7 @@ class TestTradingPipeline(TestCase):
             self.assertEqual(len(decisions), 1)
             self.assertEqual(len(executions), 1)
             decision = decisions[0]
+            execution = executions[0]
             decision_json = cast(dict[str, Any], decision.decision_json)
             params = cast(dict[str, Any], decision_json.get("params"))
             target_plan = cast(dict[str, Any], params.get("paper_route_target_plan"))
@@ -5356,8 +5357,15 @@ class TestTradingPipeline(TestCase):
                 params.get("paper_route_target_plan_source_decision"),
             )
             paper_route_probe = cast(dict[str, Any], params.get("paper_route_probe"))
+            simple_lane = cast(dict[str, Any], params.get("simple_lane"))
+            simple_lane_precheck = cast(
+                dict[str, Any], params.get("simple_lane_precheck")
+            )
+            execution_policy = cast(dict[str, Any], params.get("execution_policy"))
 
             self.assertEqual(decision.status, "submitted")
+            self.assertEqual(Decimal(str(decision_json["qty"])), Decimal("2.5"))
+            self.assertEqual(execution.submitted_qty, Decimal("2.50000000"))
             created_at = decision.created_at
             if created_at.tzinfo is None:
                 created_at = created_at.replace(tzinfo=timezone.utc)
@@ -5411,8 +5419,18 @@ class TestTradingPipeline(TestCase):
                 "2026-05-26T15:30:00+00:00",
             )
             self.assertEqual(paper_route_probe["capped_qty"], "2.5000")
-            self.assertEqual(paper_route_probe["capped_notional"], "250.000000")
+            self.assertEqual(
+                Decimal(str(paper_route_probe["capped_notional"])), Decimal("250")
+            )
             self.assertTrue(paper_route_probe["target_source_notional_sized"])
+            self.assertEqual(Decimal(str(simple_lane["final_qty"])), Decimal("2.5"))
+            self.assertEqual(Decimal(str(simple_lane["notional"])), Decimal("250"))
+            self.assertTrue(simple_lane["paper_route_probe_cap_applied"])
+            self.assertEqual(simple_lane_precheck["requested_qty"], "2.5000")
+            self.assertEqual(simple_lane_precheck["final_qty"], "2.5000")
+            self.assertEqual(
+                Decimal(str(execution_policy["notional"])), Decimal("250.0")
+            )
 
     def test_simple_pipeline_signal_cycle_still_generates_target_plan_source_decision(
         self,
@@ -7604,19 +7622,15 @@ class TestTradingPipeline(TestCase):
         )
 
         self.assertFalse(
-            pipeline._apply_paper_route_probe_cap(
-                session=cast(Session, None),
+            pipeline._paper_route_probe_capped_decision(
                 decision=missing_price_decision,
-                decision_row=cast(TradeDecision, object()),
                 proof_floor={},
                 context={"max_notional": "25"},
             )
         )
         self.assertFalse(
-            pipeline._apply_paper_route_probe_cap(
-                session=cast(Session, None),
+            pipeline._paper_route_probe_capped_decision(
                 decision=priced_decision,
-                decision_row=cast(TradeDecision, object()),
                 proof_floor={},
                 context={"max_notional": "0.00001"},
             )


### PR DESCRIPTION
## Summary

- Moves bounded paper-route acquisition probe sizing before simple prechecks, execution policy, and risk checks so submitted quantity matches the evaluated quantity.
- Removes the late submission-gate quantity mutation path that let probe orders outgrow the policy-approved seed decision.
- Extends target-plan probe coverage to assert persisted decision quantity, execution quantity, precheck quantity, and policy notional all agree.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -k 'target_plan_source_decision or paper_route_probe_cap_rejects_missing_or_tiny_quantity' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_simple_risk.py tests/test_execution_policy.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
