### PR TITLE
fix(torghut): preserve empty env gitops sync

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -231,7 +231,6 @@ spec:
             - name: TRADING_ORDER_FEED_AUTO_OFFSET_RESET
               value: earliest
             - name: TRADING_ORDER_FEED_TOPIC_V2
-              value: ""
             - name: TRADING_SIMULATION_ORDER_UPDATES_TOPIC
               value: torghut.sim.trade-updates.v1
             - name: TRADING_SIMULATION_ORDER_UPDATES_BOOTSTRAP_SERVERS

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -186,7 +186,6 @@ spec:
                   name: torghut-ws
                   key: password
             - name: TRADING_ORDER_FEED_TOPIC
-              value: ""
             - name: TRADING_ORDER_FEED_GROUP_ID
               value: torghut-order-feed-live-default
             - name: TRADING_ORDER_FEED_ASSIGNMENT_MODE

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -80,7 +80,15 @@ def _load_knative_env(relative_path: str) -> dict[str, object]:
             continue
         if "value" in item:
             raw_value = item["value"]
-            env[name] = raw_value if isinstance(raw_value, str) else str(raw_value)
+            env[name] = (
+                raw_value
+                if isinstance(raw_value, str)
+                else ""
+                if raw_value is None
+                else str(raw_value)
+            )
+        elif "valueFrom" not in item:
+            env[name] = ""
     return env
 
 


### PR DESCRIPTION
## Summary

- Normalize name-only Knative env entries as empty strings in the manifest contract test.
- Remove explicit empty-string env values from Torghut live and sim manifests so Kubernetes canonicalization does not leave Argo OutOfSync.
- Preserve the order-feed topic contract: live uses v2 only; sim uses v1 only and keeps v2 empty.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff format tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_sim_manifest_runs_paper_live_signal_profile -q`
- `cd services/torghut && uv run --frozen pytest tests/test_live_config_manifest_contract.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
