### PR TITLE
fix(tigresse): set numeric operator runtime user

### DIFF
--- a/argocd/applications/tigresse/README.md
+++ b/argocd/applications/tigresse/README.md
@@ -1,7 +1,7 @@
 # Tigresse
 
 This Argo CD application deploys the standalone Tigresse TigerBeetle operator from `proompteng/tigresse`
-release `v0.1.2`.
+release `v0.1.3`.
 
 The Helm chart is vendored from the release source so Argo CD can render without GHCR Helm registry
 credentials. The operator image is served from the cluster-local registry and pinned by OCI index digest in

--- a/argocd/applications/tigresse/charts/tigresse/Chart.yaml
+++ b/argocd/applications/tigresse/charts/tigresse/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tigresse
 description: Production TigerBeetle Kubernetes operator
 type: application
-version: 0.1.2
-appVersion: v0.1.2
+version: 0.1.3
+appVersion: v0.1.3
 home: https://github.com/proompteng/tigresse
 sources:
   - https://github.com/proompteng/tigresse

--- a/argocd/applications/tigresse/charts/tigresse/values.yaml
+++ b/argocd/applications/tigresse/charts/tigresse/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/proompteng/tigresse
-  tag: "v0.1.2"
+  tag: "v0.1.3"
   digest: ""
   pullPolicy: IfNotPresent
 
@@ -20,6 +20,8 @@ podLabels: {}
 
 podSecurityContext:
   runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
   seccompProfile:
     type: RuntimeDefault
 

--- a/argocd/applications/tigresse/kustomization.yaml
+++ b/argocd/applications/tigresse/kustomization.yaml
@@ -7,7 +7,7 @@ helmGlobals:
 
 helmCharts:
   - name: tigresse
-    version: 0.1.2
+    version: 0.1.3
     releaseName: tigresse
     namespace: tigresse-system
     includeCRDs: true

--- a/argocd/applications/tigresse/values.yaml
+++ b/argocd/applications/tigresse/values.yaml
@@ -1,9 +1,12 @@
 image:
   repository: registry.ide-newton.ts.net/lab/tigresse
-  tag: v0.1.2
-  digest: sha256:e601cc8202a704bbb6134542b95bae2c9015b4bd6d733f92a885f23fafd253d5
+  tag: v0.1.3
+  digest: sha256:c8b5966fc1226796d8bb122d8adea469f46090c5c136d3f1f9082bfd8e150b0b
   pullPolicy: IfNotPresent
 
 podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
   seccompProfile:
     type: RuntimeDefault


### PR DESCRIPTION
## Summary

- Updates the vendored Tigresse chart to `v0.1.3`.
- Pins the lab operator image to `registry.ide-newton.ts.net/lab/tigresse@sha256:c8b5966fc1226796d8bb122d8adea469f46090c5c136d3f1f9082bfd8e150b0b`.
- Sets numeric `runAsUser` and `runAsGroup` values so Kubernetes can verify the distroless nonroot user.

## Related Issues

None

## Testing

- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/tigresse:v0.1.3`
- `diff -ru /Users/gregkonush/github.com/tigresse/charts/tigresse argocd/applications/tigresse/charts/tigresse`
- `helm lint argocd/applications/tigresse/charts/tigresse -f argocd/applications/tigresse/values.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/tigresse > /tmp/tigresse-lab-render.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
