### PR TITLE
fix(torghut): replace overlapping runtime ledger imports

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 from typing import Any, Mapping, Sequence, cast
 from zoneinfo import ZoneInfo
 
-from sqlalchemy import delete, select
+from sqlalchemy import and_, delete, or_, select
 from sqlalchemy.orm import Session
 
 from ..models import (
@@ -1213,6 +1213,78 @@ def _runtime_ledger_bucket_payloads(payload: Mapping[str, Any]) -> list[dict[str
     return [single_payload] if single_payload else []
 
 
+def _runtime_ledger_bucket_replacement_scopes(
+    *,
+    buckets: Sequence[ObservedRuntimeBucket],
+    runtime_payload: Mapping[str, Any],
+) -> list[tuple[datetime, datetime, str | None, str | None]]:
+    scopes: list[tuple[datetime, datetime, str | None, str | None]] = []
+    seen: set[tuple[datetime, datetime, str | None, str | None]] = set()
+    for bucket in buckets:
+        for ledger_payload in _runtime_ledger_bucket_payloads(bucket.payload_json):
+            bucket_started_at = (
+                _parse_observation_datetime(ledger_payload.get("bucket_started_at"))
+                or bucket.window_started_at
+            )
+            bucket_ended_at = (
+                _parse_observation_datetime(ledger_payload.get("bucket_ended_at"))
+                or bucket.window_ended_at
+            )
+            account_label = _text(ledger_payload.get("account_label")) or _text(
+                runtime_payload.get("account_label")
+            )
+            runtime_strategy_name = _text(ledger_payload.get("strategy_id")) or _text(
+                runtime_payload.get("strategy_name")
+            )
+            scope = (
+                bucket_started_at,
+                bucket_ended_at,
+                account_label,
+                runtime_strategy_name,
+            )
+            if scope not in seen:
+                seen.add(scope)
+                scopes.append(scope)
+    return scopes
+
+
+def _delete_replaced_runtime_ledger_buckets(
+    *,
+    session: Session,
+    run_id: str,
+    candidate_id: str | None,
+    hypothesis_id: str,
+    observed_stage: str,
+    replacement_scopes: Sequence[tuple[datetime, datetime, str | None, str | None]],
+) -> int:
+    if not replacement_scopes:
+        return 0
+    overlap_predicates = [
+        and_(
+            StrategyRuntimeLedgerBucket.bucket_started_at < bucket_ended_at,
+            StrategyRuntimeLedgerBucket.bucket_ended_at > bucket_started_at,
+            StrategyRuntimeLedgerBucket.account_label == account_label,
+            StrategyRuntimeLedgerBucket.runtime_strategy_name == runtime_strategy_name,
+        )
+        for (
+            bucket_started_at,
+            bucket_ended_at,
+            account_label,
+            runtime_strategy_name,
+        ) in replacement_scopes
+    ]
+    result = session.execute(
+        delete(StrategyRuntimeLedgerBucket).where(
+            StrategyRuntimeLedgerBucket.run_id != run_id,
+            StrategyRuntimeLedgerBucket.candidate_id == candidate_id,
+            StrategyRuntimeLedgerBucket.hypothesis_id == hypothesis_id,
+            StrategyRuntimeLedgerBucket.observed_stage == observed_stage,
+            or_(*overlap_predicates),
+        )
+    )
+    return int(getattr(result, "rowcount", 0) or 0)
+
+
 def _runtime_ledger_post_cost_from_observed_buckets(
     buckets: Sequence[ObservedRuntimeBucket],
 ) -> tuple[Decimal | None, Decimal, Decimal, int]:
@@ -1583,6 +1655,17 @@ def persist_observed_runtime_windows(
         for bucket in raw_buckets
         if bucket.decision_count > 0 or bucket.trade_count > 0 or bucket.order_count > 0
     ]
+    replaced_runtime_ledger_bucket_count = _delete_replaced_runtime_ledger_buckets(
+        session=session,
+        run_id=run_id,
+        candidate_id=candidate_id,
+        hypothesis_id=hypothesis_id,
+        observed_stage=observed_stage,
+        replacement_scopes=_runtime_ledger_bucket_replacement_scopes(
+            buckets=sorted_buckets,
+            runtime_payload=runtime_payload,
+        ),
+    )
     raw_window_count = len(raw_buckets)
     skipped_zero_activity_window_count = raw_window_count - len(sorted_buckets)
     runtime_ledger_daily_summary = _runtime_ledger_daily_summary_from_observed_buckets(
@@ -1958,6 +2041,7 @@ def persist_observed_runtime_windows(
         "evidence_grade_runtime_ledger_bucket_count": len(
             evidence_grade_runtime_ledger_rows
         ),
+        "replaced_runtime_ledger_bucket_count": replaced_runtime_ledger_bucket_count,
         "runtime_ledger_fill_count": sum(
             max(0, int(row.fill_count or 0)) for row in runtime_ledger_rows
         ),
@@ -2022,6 +2106,9 @@ def persist_observed_runtime_windows(
             "evidence_grade_runtime_ledger_bucket_ids": [
                 str(row.id) for row in evidence_grade_runtime_ledger_rows
             ],
+            "replaced_runtime_ledger_bucket_count": (
+                replaced_runtime_ledger_bucket_count
+            ),
         }
     )
     return {
@@ -2054,6 +2141,7 @@ def persist_observed_runtime_windows(
         "evidence_blocking_reasons": evidence_blocking_reasons,
         "proof_status": proof_status,
         "proof_blockers": proof_blockers,
+        "replaced_runtime_ledger_bucket_count": replaced_runtime_ledger_bucket_count,
         "runtime_materialization_target": runtime_materialization_target,
         "runtime_observation": runtime_payload,
         "delay_adjusted_depth_stress": delay_depth_stress_summary,

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -804,6 +804,88 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(decisions[0].allowed, False)
         self.assertEqual(decisions[0].state, "shadow")
 
+    def test_persist_observed_runtime_windows_replaces_overlapping_ledger_buckets(
+        self,
+    ) -> None:
+        def buckets_for(net_pnl: str):
+            return build_observed_runtime_buckets(
+                bucket_ranges=[
+                    (
+                        datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                        datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                        6,
+                    )
+                ],
+                decision_times=[datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc)],
+                execution_times=[datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc)],
+                tca_rows=[
+                    {
+                        "computed_at": datetime(
+                            2026, 3, 6, 14, 36, tzinfo=timezone.utc
+                        ),
+                        "abs_slippage_bps": Decimal("1"),
+                        "post_cost_expectancy_bps": Decimal("40"),
+                        "runtime_ledger_bucket": _runtime_ledger_bucket(
+                            bucket_started_at="2026-03-06T14:35:00+00:00",
+                            bucket_ended_at="2026-03-06T14:36:00+00:00",
+                            account_label="TORGHUT_SIM",
+                            strategy_id="microbar-cross-sectional-pairs-v1",
+                            net_strategy_pnl_after_costs=net_pnl,
+                        ),
+                        **_runtime_pnl_basis(),
+                    }
+                ],
+                continuity_ok=True,
+                drift_ok=True,
+                dependency_quorum_decision="allow",
+            )
+
+        with self.session_local() as session:
+            old_summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-live-dedupe-old",
+                candidate_id="cand-dedupe",
+                hypothesis_id="H-PAIRS-01",
+                observed_stage="paper",
+                strategy_family="microbar_cross_sectional_pairs",
+                source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+                buckets=buckets_for("0.80"),
+                runtime_observation_payload={
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                },
+            )
+            new_summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-live-dedupe-new",
+                candidate_id="cand-dedupe",
+                hypothesis_id="H-PAIRS-01",
+                observed_stage="paper",
+                strategy_family="microbar_cross_sectional_pairs",
+                source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+                buckets=buckets_for("1.25"),
+                runtime_observation_payload={
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                },
+            )
+            session.commit()
+            ledger_rows = (
+                session.execute(
+                    select(StrategyRuntimeLedgerBucket).order_by(
+                        StrategyRuntimeLedgerBucket.created_at
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        self.assertEqual(old_summary["replaced_runtime_ledger_bucket_count"], 0)
+        self.assertEqual(new_summary["replaced_runtime_ledger_bucket_count"], 1)
+        self.assertEqual(len(ledger_rows), 1)
+        self.assertEqual(ledger_rows[0].run_id, "import-live-dedupe-new")
+        self.assertEqual(ledger_rows[0].net_strategy_pnl_after_costs, Decimal("1.25"))
+
     def test_persist_observed_runtime_windows_uses_notional_weighted_ledger_summary(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Replaces prior overlapping `StrategyRuntimeLedgerBucket` rows for the same candidate, stage, account, strategy, and bucket window before inserting a renewed runtime-window import.
- Surfaces the replacement count in the import summary and runtime materialization target so proof packets can audit when stale duplicate ledger rows were removed.
- Adds a regression test proving a second import for the same runtime-ledger window replaces the old proof row instead of double-counting PnL/notional.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_runtime_window_import.py::TestRuntimeWindowImport::test_persist_observed_runtime_windows_replaces_overlapping_ledger_buckets -q`
- `uv run --frozen pytest tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen pytest tests/test_completion_trace.py -q`
- `uv run --frozen pytest tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_completion_trace.py -q`
- `uv run --frozen ruff check app/trading/runtime_window_import.py tests/test_runtime_window_import.py tests/test_import_hypothesis_runtime_windows.py tests/test_completion_trace.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
