### PR TITLE
fix(tigresse): deploy v0.1.4 operator

### DIFF
--- a/argocd/applications/tigresse/charts/tigresse/Chart.yaml
+++ b/argocd/applications/tigresse/charts/tigresse/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tigresse
 description: Production TigerBeetle Kubernetes operator
 type: application
-version: 0.1.3
-appVersion: v0.1.3
+version: 0.1.4
+appVersion: v0.1.4
 home: https://github.com/proompteng/tigresse
 sources:
   - https://github.com/proompteng/tigresse

--- a/argocd/applications/tigresse/charts/tigresse/values.yaml
+++ b/argocd/applications/tigresse/charts/tigresse/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/proompteng/tigresse
-  tag: "v0.1.3"
+  tag: "v0.1.4"
   digest: ""
   pullPolicy: IfNotPresent
 

--- a/argocd/applications/tigresse/values.yaml
+++ b/argocd/applications/tigresse/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: registry.ide-newton.ts.net/lab/tigresse
-  tag: v0.1.3
-  digest: sha256:c8b5966fc1226796d8bb122d8adea469f46090c5c136d3f1f9082bfd8e150b0b
+  tag: v0.1.4
+  digest: sha256:0bcc6bb0929389789d76b95afbf7df97e48f175857d67d77ad1e22a0d55aa16e
   pullPolicy: IfNotPresent
 
 podSecurityContext:


### PR DESCRIPTION
## Summary

- Update the vendored Tigresse chart to v0.1.4.
- Pin the lab Tigresse deployment to the internal multi-arch v0.1.4 digest.
- Carry the upstream smoke fixes for official TigerBeetle image startup and PVC immutable drift detection.

## Related Issues

None

## Testing

- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/tigresse:v0.1.4`
- `diff -ru /Users/gregkonush/github.com/tigresse/charts/tigresse argocd/applications/tigresse/charts/tigresse`
- `helm lint argocd/applications/tigresse/charts/tigresse -f argocd/applications/tigresse/values.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/tigresse >/tmp/tigresse-lab-render-v014.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
