### PR TITLE
fix(torghut): block contaminated paper window imports

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -3578,6 +3578,31 @@ def build_paper_route_target_plan_payload(
         and _safe_int(latest_closed_targets.get("target_count")) > 0
         else next_targets
     )
+    source_target_audits = [
+        _target_audit(
+            session,
+            raw_target=target,
+            probe=probe,
+            generated_at=resolved_generated_at,
+            lookback_hours=DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+        )
+        for target in targets
+    ]
+    runtime_window_import_target_audits = [
+        _target_audit(
+            session,
+            raw_target=target,
+            probe=probe,
+            generated_at=resolved_generated_at,
+            lookback_hours=DEFAULT_PAPER_ROUTE_EVIDENCE_LOOKBACK_HOURS,
+        )
+        for target in _as_mapping_items(runtime_window_import_plan.get("targets"))
+    ]
+    runtime_window_import_audit = _runtime_window_import_audit(
+        next_targets=runtime_window_import_plan,
+        target_audits=source_target_audits,
+        next_target_audits=runtime_window_import_target_audits,
+    )
     return {
         "schema_version": PAPER_ROUTE_TARGET_PLAN_PAYLOAD_SCHEMA_VERSION,
         "generated_at": _isoformat(resolved_generated_at),
@@ -3614,6 +3639,7 @@ def build_paper_route_target_plan_payload(
         },
         "paper_route_probe": probe,
         "runtime_window_import_plan": runtime_window_import_plan,
+        "runtime_window_import_audit": runtime_window_import_audit,
         "source_runtime_window_import_plan": source_targets,
         "latest_closed_paper_route_runtime_window_targets": latest_closed_targets,
         "next_paper_route_runtime_window_targets": next_targets,
@@ -3633,6 +3659,12 @@ def build_paper_route_target_plan_payload(
             ),
             "source_runtime_window_target_count": _safe_int(
                 source_targets.get("target_count")
+            ),
+            "runtime_window_import_audit_state": _safe_text(
+                runtime_window_import_audit.get("state")
+            ),
+            "runtime_window_import_audit_blockers": _unique_text_items(
+                runtime_window_import_audit.get("blockers")
             ),
             "skipped_target_count": _safe_int(next_targets.get("skipped_target_count")),
             "promotion_authority": {

--- a/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
+++ b/services/torghut/scripts/renew_latest_empirical_promotion_jobs.py
@@ -119,6 +119,13 @@ RUNTIME_WINDOW_TARGET_PLAN_DEFERRED_REASONS = frozenset(
         "runtime_window_target_plan_window_settlement_pending",
     )
 )
+RUNTIME_WINDOW_TARGET_PLAN_IMPORT_BLOCKED_STATES = frozenset(
+    (
+        "import_due_account_contamination_detected",
+        "import_due_account_state_not_clean",
+        "import_due_source_activity_missing",
+    )
+)
 OFFLINE_REPLAY_TRIAGE_CANDIDATE_LIMIT = 5
 
 
@@ -504,6 +511,7 @@ def _read_runtime_window_target_plan(ref: str) -> dict[str, Any]:
 def _runtime_window_target_plan_from_payload(
     payload: Mapping[str, Any],
 ) -> dict[str, Any]:
+    _raise_if_runtime_window_target_plan_import_blocked(payload)
     direct_plan = _as_dict(payload.get("runtime_window_import_plan"))
     if direct_plan:
         return direct_plan
@@ -526,6 +534,26 @@ def _runtime_window_target_plan_from_payload(
     if paper_route_plan:
         return paper_route_plan
     return _as_dict(payload)
+
+
+def _raise_if_runtime_window_target_plan_import_blocked(
+    payload: Mapping[str, Any],
+) -> None:
+    audit = _as_dict(payload.get("runtime_window_import_audit"))
+    if not audit:
+        return
+    state = str(audit.get("state") or "").strip()
+    if state not in RUNTIME_WINDOW_TARGET_PLAN_IMPORT_BLOCKED_STATES:
+        return
+    blockers = [
+        str(item).strip()
+        for item in _as_sequence(audit.get("blockers"))
+        if str(item).strip()
+    ]
+    blocker_text = ",".join(blockers) if blockers else "unknown"
+    raise RuntimeError(
+        f"runtime_window_target_plan_import_blocked:{state}:{blocker_text}"
+    )
 
 
 def _runtime_window_target_plan_has_targets(plan: Mapping[str, Any]) -> bool:

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -3555,47 +3555,56 @@ class TestPaperRouteEvidenceAudit(TestCase):
             )
             session.commit()
 
+            live_submission_gate = {
+                "allowed": False,
+                "reason": "paper_route_probe_only",
+                "blocked_reasons": [],
+                "runtime_ledger_paper_probation_import_plan": {
+                    "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                    "target_count": "1",
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-CONTAMINATION",
+                            "candidate_id": "candidate-contamination",
+                            "observed_stage": "paper",
+                            "strategy_family": "microbar_pairs",
+                            "strategy_name": "contamination-proof-strategy",
+                            "strategy_id": "contamination_proof_strategy@research",
+                            "account_label": "TORGHUT_SIM",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                            "source_manifest_ref": "config/trading/hypotheses/h-contamination.json",
+                            "window_start": window_start.isoformat(),
+                            "window_end": window_end.isoformat(),
+                            "paper_probation_authorized": True,
+                        }
+                    ],
+                },
+            }
+            route_reacquisition_book = {
+                "schema_version": "torghut.route-reacquisition-book.v1",
+                "state": "repair_only",
+                "summary": {
+                    "paper_route_probe_eligible_symbols": ["AAPL"],
+                    "paper_route_probe_active_symbols": ["AAPL"],
+                },
+                "paper_route_probe": {
+                    "configured_enabled": True,
+                    "active": True,
+                    "effective_max_notional": 25,
+                    "next_session_max_notional": 25,
+                },
+            }
+
             payload = build_paper_route_evidence_audit(
                 session,
-                live_submission_gate={
-                    "allowed": False,
-                    "reason": "paper_route_probe_only",
-                    "blocked_reasons": [],
-                    "runtime_ledger_paper_probation_import_plan": {
-                        "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
-                        "target_count": "1",
-                        "targets": [
-                            {
-                                "hypothesis_id": "H-CONTAMINATION",
-                                "candidate_id": "candidate-contamination",
-                                "observed_stage": "paper",
-                                "strategy_family": "microbar_pairs",
-                                "strategy_name": "contamination-proof-strategy",
-                                "strategy_id": "contamination_proof_strategy@research",
-                                "account_label": "TORGHUT_SIM",
-                                "source_kind": "paper_route_probe_runtime_observed",
-                                "source_manifest_ref": "config/trading/hypotheses/h-contamination.json",
-                                "window_start": window_start.isoformat(),
-                                "window_end": window_end.isoformat(),
-                                "paper_probation_authorized": True,
-                            }
-                        ],
-                    },
-                },
-                route_reacquisition_book={
-                    "schema_version": "torghut.route-reacquisition-book.v1",
-                    "state": "repair_only",
-                    "summary": {
-                        "paper_route_probe_eligible_symbols": ["AAPL"],
-                        "paper_route_probe_active_symbols": ["AAPL"],
-                    },
-                    "paper_route_probe": {
-                        "configured_enabled": True,
-                        "active": True,
-                        "effective_max_notional": 25,
-                        "next_session_max_notional": 25,
-                    },
-                },
+                live_submission_gate=live_submission_gate,
+                route_reacquisition_book=route_reacquisition_book,
+                generated_at=now,
+            )
+            target_plan_payload = build_paper_route_target_plan_payload(
+                session,
+                live_submission_gate=live_submission_gate,
+                route_reacquisition_book=route_reacquisition_book,
                 generated_at=now,
             )
 
@@ -3625,6 +3634,15 @@ class TestPaperRouteEvidenceAudit(TestCase):
                 "client_order_id_count"
             ],
             1,
+        )
+        target_plan_import_audit = target_plan_payload["runtime_window_import_audit"]
+        self.assertEqual(
+            target_plan_import_audit["state"],
+            "import_due_account_contamination_detected",
+        )
+        self.assertIn(
+            "unlinked_order_events_present",
+            target_plan_payload["summary"]["runtime_window_import_audit_blockers"],
         )
 
     def test_account_window_start_positions_block_runtime_window_import(

--- a/services/torghut/tests/test_run_empirical_promotion_jobs.py
+++ b/services/torghut/tests/test_run_empirical_promotion_jobs.py
@@ -788,6 +788,43 @@ class TestRunEmpiricalPromotionJobs(TestCase):
         self.assertEqual(top_level_plan["targets"][0]["hypothesis_id"], "H-PAIRS-01")
         self.assertEqual(fallback_plan["targets"][0]["hypothesis_id"], "H-FALLBACK-01")
 
+    def test_runtime_window_target_plan_payload_blocks_contaminated_import_audit(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError,
+            (
+                "runtime_window_target_plan_import_blocked:"
+                "import_due_account_contamination_detected:.*"
+                "unlinked_order_events_present"
+            ),
+        ):
+            renewal._runtime_window_target_plan_from_payload(
+                {
+                    "schema_version": "torghut.paper-route-target-plan.v1",
+                    "runtime_window_import_plan": {
+                        "schema_version": (
+                            "torghut.next-paper-route-runtime-window-targets.v1"
+                        ),
+                        "targets": [
+                            {
+                                "candidate_id": "cand-contaminated",
+                                "hypothesis_id": "H-CONTAMINATED",
+                                "window_start": "2026-05-29T13:30:00+00:00",
+                                "window_end": "2026-05-29T20:00:00+00:00",
+                            }
+                        ],
+                    },
+                    "runtime_window_import_audit": {
+                        "state": "import_due_account_contamination_detected",
+                        "blockers": [
+                            "paper_route_account_contamination_detected",
+                            "unlinked_order_events_present",
+                        ],
+                    },
+                }
+            )
+
     def test_runtime_window_target_plan_payload_prefers_next_paper_route_plan(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds the runtime-window import audit to the lightweight `/trading/paper-route-target-plan` payload, not only the full evidence payload.
- Fails closed in the renewal script when the target-plan audit reports a contaminated account/window, dirty account state, or missing source activity.
- Adds regressions for contaminated paper windows so unlinked external order-feed events cannot be imported into misleading H-PAIRS proof rows.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_paper_route_evidence.py::TestPaperRouteEvidenceAudit::test_account_contamination_blocks_runtime_window_import -q`
- `uv run --frozen pytest tests/test_run_empirical_promotion_jobs.py::TestRunEmpiricalPromotionJobs::test_runtime_window_target_plan_payload_blocks_contaminated_import_audit -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py -q`
- `uv run --frozen ruff check app/trading/paper_route_evidence.py scripts/renew_latest_empirical_promotion_jobs.py tests/test_paper_route_evidence.py tests/test_run_empirical_promotion_jobs.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
