### PR TITLE
fix(tigresse): deploy v0.1.5 operator

### DIFF
--- a/argocd/applications/tigresse/charts/tigresse/Chart.yaml
+++ b/argocd/applications/tigresse/charts/tigresse/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tigresse
 description: Production TigerBeetle Kubernetes operator
 type: application
-version: 0.1.4
-appVersion: v0.1.4
+version: 0.1.5
+appVersion: v0.1.5
 home: https://github.com/proompteng/tigresse
 sources:
   - https://github.com/proompteng/tigresse

--- a/argocd/applications/tigresse/charts/tigresse/values.yaml
+++ b/argocd/applications/tigresse/charts/tigresse/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/proompteng/tigresse
-  tag: "v0.1.4"
+  tag: "v0.1.5"
   digest: ""
   pullPolicy: IfNotPresent
 
@@ -23,7 +23,7 @@ podSecurityContext:
   runAsUser: 65532
   runAsGroup: 65532
   seccompProfile:
-    type: RuntimeDefault
+    type: Unconfined
 
 securityContext:
   allowPrivilegeEscalation: false

--- a/argocd/applications/tigresse/values.yaml
+++ b/argocd/applications/tigresse/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: registry.ide-newton.ts.net/lab/tigresse
-  tag: v0.1.4
-  digest: sha256:0bcc6bb0929389789d76b95afbf7df97e48f175857d67d77ad1e22a0d55aa16e
+  tag: v0.1.5
+  digest: sha256:b73cc34f3f82b21a28eeea6b480a634bdbe93ac91d1a5710d082d33a211521eb
   pullPolicy: IfNotPresent
 
 podSecurityContext:
@@ -9,4 +9,4 @@ podSecurityContext:
   runAsUser: 65532
   runAsGroup: 65532
   seccompProfile:
-    type: RuntimeDefault
+    type: Unconfined

--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -53,9 +53,9 @@ spec:
                 enabled: "true"
                 managedNamespaceMetadata:
                   labels:
-                    pod-security.kubernetes.io/enforce: restricted
-                    pod-security.kubernetes.io/audit: restricted
-                    pod-security.kubernetes.io/warn: restricted
+                    pod-security.kubernetes.io/enforce: privileged
+                    pod-security.kubernetes.io/audit: privileged
+                    pod-security.kubernetes.io/warn: privileged
               - name: metrics-server
                 path: manifests/overlays/release-ha-1.21+
                 repoURL: https://github.com/kubernetes-sigs/metrics-server.git


### PR DESCRIPTION
## Summary

- Update the vendored Tigresse chart to v0.1.5.
- Pin the lab Tigresse deployment to the internal multi-arch v0.1.5 digest.
- Mark `tigresse-system` privileged because Tigresse manager protocol health uses the TigerBeetle Go client, which requires `io_uring`.

## Related Issues

None

## Testing

- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/tigresse:v0.1.5`
- `diff -ru /Users/gregkonush/github.com/tigresse/charts/tigresse argocd/applications/tigresse/charts/tigresse`
- `helm lint argocd/applications/tigresse/charts/tigresse -f argocd/applications/tigresse/values.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/tigresse >/tmp/tigresse-lab-render-v015.yaml`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
