### PR TITLE
fix(tigresse): deploy v0.1.6 operator

### DIFF
--- a/argocd/applications/tigresse/charts/tigresse/Chart.yaml
+++ b/argocd/applications/tigresse/charts/tigresse/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tigresse
 description: Production TigerBeetle Kubernetes operator
 type: application
-version: 0.1.5
-appVersion: v0.1.5
+version: 0.1.6
+appVersion: v0.1.6
 home: https://github.com/proompteng/tigresse
 sources:
   - https://github.com/proompteng/tigresse

--- a/argocd/applications/tigresse/charts/tigresse/values.yaml
+++ b/argocd/applications/tigresse/charts/tigresse/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/proompteng/tigresse
-  tag: "v0.1.5"
+  tag: "v0.1.6"
   digest: ""
   pullPolicy: IfNotPresent
 

--- a/argocd/applications/tigresse/values.yaml
+++ b/argocd/applications/tigresse/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: registry.ide-newton.ts.net/lab/tigresse
-  tag: v0.1.5
-  digest: sha256:b73cc34f3f82b21a28eeea6b480a634bdbe93ac91d1a5710d082d33a211521eb
+  tag: v0.1.6
+  digest: sha256:a357c07d629f9561f04b3452c1d9c41b81b9d816d29de415bd0141e859e92e39
   pullPolicy: IfNotPresent
 
 podSecurityContext:


### PR DESCRIPTION
## Summary

- Deploys Tigresse operator `v0.1.6` through the lab Argo CD application.
- Updates the vendored Tigresse Helm chart metadata and default image tag to `v0.1.6`.
- Pins the lab deployment to the verified internal multi-arch image digest `sha256:a357c07d629f9561f04b3452c1d9c41b81b9d816d29de415bd0141e859e92e39`.

## Related Issues

None

## Testing

- `helm lint argocd/applications/tigresse/charts/tigresse -f argocd/applications/tigresse/values.yaml`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/tigresse >/tmp/tigresse-lab-render-v016.yaml`
- `rg -n "image:|tigresse@sha256|a357c07d|seccompProfile|Unconfined|kind: Namespace" /tmp/tigresse-lab-render-v016.yaml`
- `bun run lint:argocd`
- `git diff --check`
- `docker buildx imagetools inspect registry.ide-newton.ts.net/lab/tigresse:v0.1.6`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
