### PR TITLE
fix(torghut): flatten paper account before open

### DIFF
--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -7,7 +7,8 @@ metadata:
     app.kubernetes.io/name: torghut
     app.kubernetes.io/component: paper-account-flatten
 spec:
-  schedule: "5,20,35,50 19 * * 1-5"
+  schedule: "5,20 9 * * 1-5"
+  timeZone: America/New_York
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 3
@@ -15,7 +16,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
-      activeDeadlineSeconds: 180
+      activeDeadlineSeconds: 300
       template:
         spec:
           restartPolicy: OnFailure
@@ -49,9 +50,19 @@ spec:
                     --paper-base-url https://paper-api.alpaca.markets \
                     --max-gross-market-value 100000 \
                     --max-position-count 25 \
+                    --extended-hours-limit \
+                    --limit-away-bps 200 \
+                    --wait-flat-seconds 120 \
+                    --poll-seconds 10 \
+                    --persist-snapshot \
                     --apply \
                     --json
               env:
+                - name: DB_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: torghut-db-app
+                      key: uri
                 - name: APCA_API_KEY_ID
                   valueFrom:
                     secretKeyRef:

--- a/services/torghut/scripts/flatten_paper_account_positions.py
+++ b/services/torghut/scripts/flatten_paper_account_positions.py
@@ -5,21 +5,27 @@ from __future__ import annotations
 
 import argparse
 import json
+import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from decimal import Decimal, InvalidOperation
-from typing import Any, Protocol
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any, Protocol, cast
 
 from app.alpaca_client import TorghutAlpacaClient
 from app.config import settings
+from app.db import SessionLocal
+from app.snapshots import snapshot_account_and_positions
 from app.trading.firewall import OrderFirewall
 
 DEFAULT_ACCOUNT_LABEL = "TORGHUT_SIM"
 DEFAULT_PAPER_BASE_URL = "https://paper-api.alpaca.markets"
 DEFAULT_MAX_GROSS_MARKET_VALUE = Decimal("100000")
 DEFAULT_MAX_POSITION_COUNT = 25
-TERMINAL_CLEAN_STATUSES = frozenset({"clean", "dry_run", "submitted"})
+DEFAULT_EXTENDED_HOURS_LIMIT_AWAY_BPS = Decimal("200")
+DEFAULT_WAIT_FLAT_SECONDS = 0.0
+DEFAULT_POLL_SECONDS = 5.0
+TERMINAL_CLEAN_STATUSES = frozenset({"clean", "dry_run", "submitted", "flattened"})
 
 
 class PaperFlattenClient(Protocol):
@@ -46,6 +52,7 @@ class FlattenPosition:
     qty: Decimal
     side: str
     market_value: Decimal
+    reference_price: Decimal | None
 
     @property
     def close_side(self) -> str:
@@ -87,6 +94,39 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Submit flatten orders. Without this flag, only report the plan.",
     )
+    parser.add_argument(
+        "--extended-hours-limit",
+        action="store_true",
+        help=(
+            "Use aggressive extended-hours limit orders instead of regular-session "
+            "market orders. Still paper-only and account-label guarded."
+        ),
+    )
+    parser.add_argument(
+        "--limit-away-bps",
+        default=str(DEFAULT_EXTENDED_HOURS_LIMIT_AWAY_BPS),
+        help=(
+            "Basis points away from the position reference price for extended-hours "
+            "limit closes: sells below reference, buys above reference."
+        ),
+    )
+    parser.add_argument(
+        "--wait-flat-seconds",
+        type=float,
+        default=DEFAULT_WAIT_FLAT_SECONDS,
+        help="Poll the account after submitting close orders and fail if positions remain after this many seconds.",
+    )
+    parser.add_argument(
+        "--poll-seconds",
+        type=float,
+        default=DEFAULT_POLL_SECONDS,
+        help="Polling interval used with --wait-flat-seconds.",
+    )
+    parser.add_argument(
+        "--persist-snapshot",
+        action="store_true",
+        help="Persist a fresh PositionSnapshot after the flatten attempt for runtime-window readiness gates.",
+    )
     parser.add_argument("--json", action="store_true")
     return parser.parse_args()
 
@@ -118,6 +158,26 @@ def _position_market_value(position: Mapping[str, Any], qty: Decimal) -> Decimal
     return abs(qty) * abs(price)
 
 
+def _position_reference_price(
+    position: Mapping[str, Any], qty: Decimal, market_value: Decimal
+) -> Decimal | None:
+    for key in (
+        "current_price",
+        "currentPrice",
+        "lastday_price",
+        "lastdayPrice",
+        "avg_entry_price",
+        "avgEntryPrice",
+    ):
+        price = _decimal(position.get(key))
+        if price > 0:
+            return price
+    abs_qty = abs(qty)
+    if abs_qty > 0 and market_value > 0:
+        return market_value / abs_qty
+    return None
+
+
 def _normalize_positions(
     raw_positions: Sequence[Mapping[str, Any]] | None,
 ) -> list[FlattenPosition]:
@@ -132,26 +192,69 @@ def _normalize_positions(
         side = str(raw.get("side") or "").strip().lower()
         if side not in {"long", "short"}:
             side = "short" if qty < 0 else "long"
+        market_value = _position_market_value(raw, qty)
         normalized.append(
             FlattenPosition(
                 symbol=symbol,
                 qty=qty,
                 side=side,
-                market_value=_position_market_value(raw, qty),
+                market_value=market_value,
+                reference_price=_position_reference_price(raw, qty, market_value),
             )
         )
     return sorted(normalized, key=lambda item: item.symbol)
 
 
-def _position_payload(position: FlattenPosition) -> dict[str, str]:
+def _position_payload(position: FlattenPosition) -> dict[str, str | None]:
     return {
         "symbol": position.symbol,
         "qty": str(position.qty),
         "side": position.side,
         "market_value": str(position.market_value),
+        "reference_price": str(position.reference_price)
+        if position.reference_price is not None
+        else None,
         "close_side": position.close_side,
         "close_qty": str(position.close_qty),
     }
+
+
+def _quantize_price(price: Decimal) -> Decimal:
+    quantum = Decimal("0.01") if price >= Decimal("1") else Decimal("0.0001")
+    return price.quantize(quantum, rounding=ROUND_HALF_UP)
+
+
+def _extended_hours_limit_price(
+    position: FlattenPosition, limit_away_bps: Decimal
+) -> Decimal | None:
+    reference = position.reference_price
+    if reference is None or reference <= 0:
+        return None
+    away = max(Decimal("0"), limit_away_bps) / Decimal("10000")
+    if position.close_side == "sell":
+        raw_price = reference * (Decimal("1") - away)
+    else:
+        raw_price = reference * (Decimal("1") + away)
+    if raw_price <= 0:
+        raw_price = Decimal("0.0001")
+    return _quantize_price(raw_price)
+
+
+def _wait_until_flat(
+    *,
+    client: PaperFlattenClient,
+    deadline_seconds: float,
+    poll_seconds: float,
+) -> tuple[str, list[FlattenPosition]]:
+    deadline = time.monotonic() + max(0.0, deadline_seconds)
+    latest_positions = _normalize_positions(client.list_positions())
+    while latest_positions:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return "submitted_not_flat", latest_positions
+        time.sleep(min(max(0.1, poll_seconds), remaining))
+        latest_positions = _normalize_positions(client.list_positions())
+    return "flattened", []
 
 
 def flatten_paper_account_positions(
@@ -163,6 +266,10 @@ def flatten_paper_account_positions(
     apply: bool,
     max_gross_market_value: Decimal,
     max_position_count: int,
+    extended_hours_limit: bool = False,
+    limit_away_bps: Decimal = DEFAULT_EXTENDED_HOURS_LIMIT_AWAY_BPS,
+    wait_flat_seconds: float = DEFAULT_WAIT_FLAT_SECONDS,
+    poll_seconds: float = DEFAULT_POLL_SECONDS,
     generated_at: datetime | None = None,
 ) -> dict[str, Any]:
     generated_at = generated_at or datetime.now(timezone.utc)
@@ -185,10 +292,22 @@ def flatten_paper_account_positions(
         blockers.append("paper_account_flatten_position_count_above_limit")
     if gross_market_value > max_gross_market_value:
         blockers.append("paper_account_flatten_gross_market_value_above_limit")
+    extended_limit_prices: dict[str, Decimal] = {}
+    missing_limit_symbols: list[str] = []
+    if extended_hours_limit:
+        for position in positions:
+            limit_price = _extended_hours_limit_price(position, limit_away_bps)
+            if limit_price is None:
+                missing_limit_symbols.append(position.symbol)
+            else:
+                extended_limit_prices[position.symbol] = limit_price
+        if missing_limit_symbols:
+            blockers.append("paper_account_flatten_extended_hours_limit_price_missing")
 
     status = "clean" if not positions and not blockers else "blocked"
     cancelled_orders: list[dict[str, Any]] = []
     submitted_orders: list[dict[str, Any]] = []
+    final_positions = positions
     if blockers:
         status = "blocked"
     elif not apply:
@@ -196,38 +315,58 @@ def flatten_paper_account_positions(
     elif positions:
         cancelled_orders = client.cancel_all_orders()
         for position in positions:
+            order_type = "limit" if extended_hours_limit else "market"
+            limit_price = extended_limit_prices.get(position.symbol)
+            extra_params: dict[str, Any] = {
+                "client_order_id": (
+                    "torghut-paper-flatten-"
+                    f"{generated_at.strftime('%Y%m%d%H%M%S')}-"
+                    f"{position.symbol.lower()}"
+                )
+            }
+            if extended_hours_limit:
+                extra_params["extended_hours"] = True
             submitted_orders.append(
                 client.submit_order(
                     symbol=position.symbol,
                     side=position.close_side,
                     qty=float(position.close_qty),
-                    order_type="market",
+                    order_type=order_type,
                     time_in_force="day",
-                    extra_params={
-                        "client_order_id": (
-                            "torghut-paper-flatten-"
-                            f"{generated_at.strftime('%Y%m%d%H%M%S')}-"
-                            f"{position.symbol.lower()}"
-                        )
-                    },
+                    limit_price=float(limit_price) if limit_price is not None else None,
+                    extra_params=extra_params,
                 )
             )
-        status = "submitted"
+        if wait_flat_seconds > 0:
+            status, final_positions = _wait_until_flat(
+                client=client,
+                deadline_seconds=wait_flat_seconds,
+                poll_seconds=poll_seconds,
+            )
+        else:
+            status = "submitted"
 
     return {
         "schema_version": "torghut.paper-account-flatten.v1",
         "status": status,
         "apply": apply,
+        "extended_hours_limit": extended_hours_limit,
+        "limit_away_bps": str(limit_away_bps),
+        "wait_flat_seconds": wait_flat_seconds,
+        "poll_seconds": poll_seconds,
         "generated_at": generated_at.isoformat(),
         "account_label": normalized_label,
         "expected_account_label": expected_label,
         "trading_mode": normalized_mode,
         "position_count": len(positions),
+        "final_position_count": len(final_positions),
         "gross_market_value": str(gross_market_value),
         "max_gross_market_value": str(max_gross_market_value),
         "max_position_count": max_position_count,
         "blockers": blockers,
+        "extended_hours_limit_missing_symbols": missing_limit_symbols,
         "positions": [_position_payload(position) for position in positions],
+        "final_positions": [_position_payload(position) for position in final_positions],
         "cancelled_order_count": len(cancelled_orders),
         "cancelled_orders": cancelled_orders,
         "submitted_order_count": len(submitted_orders),
@@ -241,6 +380,10 @@ def main() -> int:
         args.max_gross_market_value,
         default=DEFAULT_MAX_GROSS_MARKET_VALUE,
     )
+    limit_away_bps = _decimal(
+        args.limit_away_bps,
+        default=DEFAULT_EXTENDED_HOURS_LIMIT_AWAY_BPS,
+    )
     client = TorghutAlpacaClient(paper=True, base_url=str(args.paper_base_url or ""))
     firewall = OrderFirewall(client)
     payload = flatten_paper_account_positions(
@@ -251,7 +394,28 @@ def main() -> int:
         apply=bool(args.apply),
         max_gross_market_value=max_gross_market_value,
         max_position_count=max(0, int(args.max_position_count)),
+        extended_hours_limit=bool(args.extended_hours_limit),
+        limit_away_bps=limit_away_bps,
+        wait_flat_seconds=max(0.0, float(args.wait_flat_seconds or 0.0)),
+        poll_seconds=max(0.1, float(args.poll_seconds or DEFAULT_POLL_SECONDS)),
     )
+    if args.persist_snapshot:
+        if (
+            payload["trading_mode"] == "paper"
+            and payload["account_label"] == payload["expected_account_label"]
+        ):
+            with SessionLocal() as session:
+                snapshot = snapshot_account_and_positions(
+                    session,
+                    cast(Any, firewall),
+                    str(args.account_label or ""),
+                )
+            payload["position_snapshot_id"] = str(snapshot.id)
+            payload["position_snapshot_as_of"] = snapshot.as_of.isoformat()
+        else:
+            payload["position_snapshot_skipped"] = (
+                "paper_account_label_or_mode_guard_failed"
+            )
     if args.json:
         print(json.dumps(payload, sort_keys=True))
     else:

--- a/services/torghut/tests/test_flatten_paper_account_positions.py
+++ b/services/torghut/tests/test_flatten_paper_account_positions.py
@@ -6,6 +6,7 @@ from contextlib import redirect_stdout
 from datetime import datetime, timezone
 from decimal import Decimal
 from io import StringIO
+from types import SimpleNamespace
 from typing import Any
 from unittest import TestCase
 from unittest.mock import patch
@@ -48,10 +49,31 @@ class FakeFlattenClient:
             "qty": str(qty),
             "type": order_type,
             "time_in_force": time_in_force,
+            "limit_price": limit_price,
+            "extended_hours": (extra_params or {}).get("extended_hours"),
             "client_order_id": (extra_params or {}).get("client_order_id"),
         }
         self.submitted.append(order)
         return order
+
+
+class SequencedFlattenClient(FakeFlattenClient):
+    def __init__(self, position_snapshots: list[list[dict[str, Any]]]) -> None:
+        super().__init__(position_snapshots[0] if position_snapshots else [])
+        self.position_snapshots = list(position_snapshots)
+
+    def list_positions(self) -> list[dict[str, Any]]:
+        if len(self.position_snapshots) > 1:
+            return self.position_snapshots.pop(0)
+        return self.position_snapshots[0] if self.position_snapshots else []
+
+
+class FakeSessionContext:
+    def __enter__(self) -> object:
+        return object()
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        return None
 
 
 class TestFlattenPaperAccountPositions(TestCase):
@@ -114,6 +136,162 @@ class TestFlattenPaperAccountPositions(TestCase):
             [("AMAT", "sell", "market"), ("TSM", "buy", "market")],
         )
         self.assertEqual(payload["submitted_order_count"], 2)
+
+    def test_extended_hours_limit_orders_use_guarded_reference_prices(self) -> None:
+        client = FakeFlattenClient(
+            [
+                {
+                    "symbol": "AMAT",
+                    "qty": "2",
+                    "side": "long",
+                    "current_price": "100",
+                },
+                {
+                    "symbol": "TSM",
+                    "qty": "3",
+                    "side": "short",
+                    "current_price": "50",
+                },
+            ]
+        )
+
+        payload = flatten_paper_account_positions(
+            client=client,
+            account_label="TORGHUT_SIM",
+            expected_account_label="TORGHUT_SIM",
+            trading_mode="paper",
+            apply=True,
+            max_gross_market_value=Decimal("2500"),
+            max_position_count=10,
+            extended_hours_limit=True,
+            limit_away_bps=Decimal("200"),
+            generated_at=datetime(2026, 5, 29, 13, 5, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(payload["status"], "submitted")
+        self.assertTrue(payload["extended_hours_limit"])
+        self.assertEqual(payload["limit_away_bps"], "200")
+        self.assertEqual(payload["extended_hours_limit_missing_symbols"], [])
+        self.assertEqual(
+            [
+                (
+                    order["symbol"],
+                    order["side"],
+                    order["type"],
+                    order["limit_price"],
+                    order["extended_hours"],
+                )
+                for order in client.submitted
+            ],
+            [
+                ("AMAT", "sell", "limit", 98.0, True),
+                ("TSM", "buy", "limit", 51.0, True),
+            ],
+        )
+
+    def test_extended_hours_limit_blocks_missing_reference_prices(self) -> None:
+        client = FakeFlattenClient([{"symbol": "AMAT", "qty": "2", "side": "long"}])
+
+        payload = flatten_paper_account_positions(
+            client=client,
+            account_label="TORGHUT_SIM",
+            expected_account_label="TORGHUT_SIM",
+            trading_mode="paper",
+            apply=True,
+            max_gross_market_value=Decimal("2500"),
+            max_position_count=10,
+            extended_hours_limit=True,
+            limit_away_bps=Decimal("200"),
+        )
+
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["extended_hours_limit_missing_symbols"], ["AMAT"])
+        self.assertIn(
+            "paper_account_flatten_extended_hours_limit_price_missing",
+            payload["blockers"],
+        )
+        self.assertFalse(client.cancelled)
+        self.assertEqual(client.submitted, [])
+
+    def test_extended_hours_limit_clamps_non_positive_sell_limit(self) -> None:
+        client = FakeFlattenClient(
+            [
+                {
+                    "symbol": "PENNY",
+                    "qty": "1",
+                    "side": "long",
+                    "current_price": "0.000001",
+                }
+            ]
+        )
+
+        payload = flatten_paper_account_positions(
+            client=client,
+            account_label="TORGHUT_SIM",
+            expected_account_label="TORGHUT_SIM",
+            trading_mode="paper",
+            apply=True,
+            max_gross_market_value=Decimal("2500"),
+            max_position_count=10,
+            extended_hours_limit=True,
+            limit_away_bps=Decimal("20000"),
+        )
+
+        self.assertEqual(payload["status"], "submitted")
+        self.assertEqual(client.submitted[0]["type"], "limit")
+        self.assertEqual(client.submitted[0]["limit_price"], 0.0001)
+
+    def test_wait_flat_marks_submitted_not_flat_when_positions_remain(self) -> None:
+        client = FakeFlattenClient(
+            [{"symbol": "AMAT", "qty": "2", "side": "long", "current_price": "100"}]
+        )
+
+        payload = flatten_paper_account_positions(
+            client=client,
+            account_label="TORGHUT_SIM",
+            expected_account_label="TORGHUT_SIM",
+            trading_mode="paper",
+            apply=True,
+            max_gross_market_value=Decimal("2500"),
+            max_position_count=10,
+            wait_flat_seconds=0.01,
+            poll_seconds=0.01,
+        )
+
+        self.assertEqual(payload["status"], "submitted_not_flat")
+        self.assertEqual(payload["position_count"], 1)
+        self.assertEqual(payload["final_position_count"], 1)
+
+    def test_wait_flat_marks_flattened_when_positions_clear(self) -> None:
+        client = SequencedFlattenClient(
+            [
+                [
+                    {
+                        "symbol": "AMAT",
+                        "qty": "2",
+                        "side": "long",
+                        "current_price": "100",
+                    }
+                ],
+                [],
+            ]
+        )
+
+        payload = flatten_paper_account_positions(
+            client=client,
+            account_label="TORGHUT_SIM",
+            expected_account_label="TORGHUT_SIM",
+            trading_mode="paper",
+            apply=True,
+            max_gross_market_value=Decimal("2500"),
+            max_position_count=10,
+            wait_flat_seconds=0.01,
+            poll_seconds=0.01,
+        )
+
+        self.assertEqual(payload["status"], "flattened")
+        self.assertEqual(payload["position_count"], 1)
+        self.assertEqual(payload["final_position_count"], 0)
 
     def test_refuses_live_mode_or_wrong_account(self) -> None:
         client = FakeFlattenClient(
@@ -289,6 +467,14 @@ class TestFlattenPaperAccountPositions(TestCase):
             "1234.56",
             "--max-position-count",
             "3",
+            "--extended-hours-limit",
+            "--limit-away-bps",
+            "150",
+            "--wait-flat-seconds",
+            "45",
+            "--poll-seconds",
+            "3",
+            "--persist-snapshot",
             "--apply",
             "--json",
         ]
@@ -302,6 +488,11 @@ class TestFlattenPaperAccountPositions(TestCase):
         self.assertEqual(args.paper_base_url, "https://paper-api.alpaca.markets")
         self.assertEqual(args.max_gross_market_value, "1234.56")
         self.assertEqual(args.max_position_count, 3)
+        self.assertTrue(args.extended_hours_limit)
+        self.assertEqual(args.limit_away_bps, "150")
+        self.assertEqual(args.wait_flat_seconds, 45)
+        self.assertEqual(args.poll_seconds, 3)
+        self.assertTrue(args.persist_snapshot)
         self.assertTrue(args.apply)
         self.assertTrue(args.json)
 
@@ -332,6 +523,82 @@ class TestFlattenPaperAccountPositions(TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(payload["status"], "clean")
         self.assertEqual(payload["position_count"], 0)
+
+    def test_main_persists_snapshot_for_guarded_paper_account(self) -> None:
+        client = FakeFlattenClient()
+        snapshot = SimpleNamespace(
+            id="snapshot-1",
+            as_of=datetime(2026, 5, 31, 6, 35, tzinfo=timezone.utc),
+        )
+        argv = [
+            "flatten_paper_account_positions.py",
+            "--account-label",
+            "TORGHUT_SIM",
+            "--expected-account-label",
+            "TORGHUT_SIM",
+            "--trading-mode",
+            "paper",
+            "--persist-snapshot",
+            "--json",
+        ]
+
+        with (
+            patch.object(sys, "argv", argv),
+            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(
+                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+            ),
+            patch.object(flatten_script, "SessionLocal", return_value=FakeSessionContext()),
+            patch.object(
+                flatten_script, "snapshot_account_and_positions", return_value=snapshot
+            ) as snapshot_account,
+            redirect_stdout(StringIO()) as output,
+        ):
+            exit_code = flatten_script.main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["position_snapshot_id"], "snapshot-1")
+        self.assertEqual(
+            payload["position_snapshot_as_of"],
+            "2026-05-31T06:35:00+00:00",
+        )
+        snapshot_account.assert_called_once()
+
+    def test_main_skips_snapshot_persistence_when_guard_fails(self) -> None:
+        client = FakeFlattenClient()
+        argv = [
+            "flatten_paper_account_positions.py",
+            "--account-label",
+            "WRONG",
+            "--expected-account-label",
+            "TORGHUT_SIM",
+            "--trading-mode",
+            "paper",
+            "--persist-snapshot",
+            "--json",
+        ]
+
+        with (
+            patch.object(sys, "argv", argv),
+            patch.object(flatten_script, "TorghutAlpacaClient", return_value=client),
+            patch.object(
+                flatten_script, "OrderFirewall", side_effect=lambda wrapped: wrapped
+            ),
+            patch.object(flatten_script, "SessionLocal") as session_local,
+            patch.object(flatten_script, "snapshot_account_and_positions") as snapshot_account,
+            redirect_stdout(StringIO()) as output,
+        ):
+            exit_code = flatten_script.main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(
+            payload["position_snapshot_skipped"],
+            "paper_account_label_or_mode_guard_failed",
+        )
+        session_local.assert_not_called()
+        snapshot_account.assert_not_called()
 
     def test_main_outputs_text_and_returns_blocked_status(self) -> None:
         client = FakeFlattenClient(

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -923,7 +923,8 @@ class TestLiveConfigManifestContract(TestCase):
             "argocd/applications/torghut/paper-account-flatten-cronjob.yaml"
         )
 
-        self.assertEqual(spec.get("schedule"), "5,20,35,50 19 * * 1-5")
+        self.assertEqual(spec.get("schedule"), "5,20 9 * * 1-5")
+        self.assertEqual(spec.get("timeZone"), "America/New_York")
         self.assertEqual(spec.get("concurrencyPolicy"), "Forbid")
         job_spec = cast(
             Mapping[str, object],
@@ -934,7 +935,7 @@ class TestLiveConfigManifestContract(TestCase):
             cast(Mapping[str, object], job_spec.get("template", {})),
         )
         pod_spec = cast(Mapping[str, object], template.get("spec", {}))
-        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 180)
+        self.assertEqual(job_spec.get("activeDeadlineSeconds"), 300)
         self.assertEqual(pod_spec.get("serviceAccountName"), "torghut-runtime")
         self.assertEqual(
             pod_spec.get("nodeSelector"),
@@ -961,6 +962,12 @@ class TestLiveConfigManifestContract(TestCase):
             item.get("name"): item
             for item in cast(list[Mapping[str, object]], container.get("env", []))
         }
+        db_dsn = cast(Mapping[str, object], env["DB_DSN"])
+        value_from = cast(Mapping[str, object], db_dsn.get("valueFrom", {}))
+        self.assertEqual(
+            value_from.get("secretKeyRef"),
+            {"name": "torghut-db-app", "key": "uri"},
+        )
         self.assertEqual(env["TRADING_MODE"].get("value"), "paper")
         self.assertEqual(env["TRADING_ACCOUNT_LABEL"].get("value"), "TORGHUT_SIM")
         self.assertEqual(env["TRADING_KILL_SWITCH_ENABLED"].get("value"), "false")
@@ -974,6 +981,11 @@ class TestLiveConfigManifestContract(TestCase):
         self.assertIn("--max-gross-market-value 100000", args)
         self.assertNotIn("--max-gross-market-value 2500", args)
         self.assertIn("--max-position-count 25", args)
+        self.assertIn("--extended-hours-limit", args)
+        self.assertIn("--limit-away-bps 200", args)
+        self.assertIn("--wait-flat-seconds 120", args)
+        self.assertIn("--poll-seconds 10", args)
+        self.assertIn("--persist-snapshot", args)
         self.assertIn("--apply", args)
         self.assertIn("--json", args)
 


### PR DESCRIPTION
## Summary

- Move the `torghut-paper-account-flatten` GitOps CronJob out of the proof window and into a pre-open New York schedule.
- Add paper-only extended-hours limit flattening with reference-price guardrails, flatness polling, and post-attempt position snapshot persistence.
- Extend unit coverage for extended-hours close pricing, missing reference-price blockers, wait-for-flat failure, and CLI parsing.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_flatten_paper_account_positions.py -q`
- `uv run --frozen pytest tests/test_live_config_manifest_contract.py::TestLiveConfigManifestContract::test_paper_account_flatten_cronjob_can_clean_dirty_paper_proof_account tests/test_flatten_paper_account_positions.py -q`
- `uv run --frozen ruff check scripts/flatten_paper_account_positions.py tests/test_flatten_paper_account_positions.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `kubectl kustomize argocd/applications/torghut >/tmp/torghut-kustomize-render.yaml`
- `bun run lint:argocd`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
