### PR TITLE
chore(symphony): promote image b6729e5b

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-29T22:45:08Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-31T07:07:00Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c39dcf4b"
-    digest: sha256:cd29281bc803aea0fe494b40bd5c95cbff41a5580d2fe4d7f9df20d89f4ac2cf
+    newTag: "b6729e5b"
+    digest: sha256:29d8b1b330ac5d0ad7a3efba5bfbd0e26a30e1ae1c0ac582ed8bcd6e5c39f8c6

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-29T22:45:08Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-31T07:07:00Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c39dcf4b"
-    digest: sha256:cd29281bc803aea0fe494b40bd5c95cbff41a5580d2fe4d7f9df20d89f4ac2cf
+    newTag: "b6729e5b"
+    digest: sha256:29d8b1b330ac5d0ad7a3efba5bfbd0e26a30e1ae1c0ac582ed8bcd6e5c39f8c6

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-29T22:45:08Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-31T07:07:00Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "c39dcf4b"
-    digest: sha256:cd29281bc803aea0fe494b40bd5c95cbff41a5580d2fe4d7f9df20d89f4ac2cf
+    newTag: "b6729e5b"
+    digest: sha256:29d8b1b330ac5d0ad7a3efba5bfbd0e26a30e1ae1c0ac582ed8bcd6e5c39f8c6


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `b6729e5bc11f7940025b839f962e11283a89f9c0`
- Image tag: `b6729e5b`
- Image digest: `sha256:29d8b1b330ac5d0ad7a3efba5bfbd0e26a30e1ae1c0ac582ed8bcd6e5c39f8c6`