### PR TITLE
fix(torghut): repair paper route proof handoff

### DIFF
--- a/services/torghut/app/main.py
+++ b/services/torghut/app/main.py
@@ -4580,24 +4580,31 @@ def trading_paper_route_evidence(
         cast(Mapping[str, Any], live_submission_gate)
     )
     simple_lane_status = _build_simple_lane_status_payload()
-    proof_floor = _build_profitability_proof_floor_payload(
-        state=scheduler.state,
-        torghut_revision=BUILD_VERSION,
-        live_submission_gate=live_submission_gate,
-        hypothesis_payload=hypothesis_payload,
-        empirical_jobs_status=empirical_jobs,
-        quant_evidence=quant_evidence,
-        market_context_status=market_context_status,
-        tca_summary=tca_summary,
+    route_reacquisition_book = _paper_route_probe_book_from_target_plan(
+        live_submission_gate,
         simple_lane_status=simple_lane_status,
+        state=scheduler.state,
     )
+    if route_reacquisition_book is None:
+        proof_floor = _build_profitability_proof_floor_payload(
+            state=scheduler.state,
+            torghut_revision=BUILD_VERSION,
+            live_submission_gate=live_submission_gate,
+            hypothesis_payload=hypothesis_payload,
+            empirical_jobs_status=empirical_jobs,
+            quant_evidence=quant_evidence,
+            market_context_status=market_context_status,
+            tca_summary=tca_summary,
+            simple_lane_status=simple_lane_status,
+        )
+        route_reacquisition_book = cast(
+            Mapping[str, Any],
+            proof_floor.get("route_reacquisition_book") or {},
+        )
     payload = build_paper_route_evidence_audit(
         session,
         live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
-        route_reacquisition_book=cast(
-            Mapping[str, Any],
-            proof_floor.get("route_reacquisition_book") or {},
-        ),
+        route_reacquisition_book=route_reacquisition_book,
     )
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 
@@ -4640,30 +4647,148 @@ def trading_paper_route_target_plan(
     live_submission_gate = _merge_external_paper_route_target_plan(
         cast(Mapping[str, Any], live_submission_gate)
     )
-    proof_floor = _build_profitability_proof_floor_payload(
+    simple_lane_status = _build_simple_lane_status_payload()
+    route_reacquisition_book = _paper_route_probe_book_from_target_plan(
+        live_submission_gate,
+        simple_lane_status=simple_lane_status,
         state=scheduler.state,
-        torghut_revision=BUILD_VERSION,
-        live_submission_gate=live_submission_gate,
-        hypothesis_payload=hypothesis_payload,
-        empirical_jobs_status=empirical_jobs,
-        quant_evidence=quant_evidence,
-        market_context_status=market_context_status,
-        tca_summary=tca_summary,
-        simple_lane_status=_build_simple_lane_status_payload(),
     )
+    if route_reacquisition_book is None:
+        proof_floor = _build_profitability_proof_floor_payload(
+            state=scheduler.state,
+            torghut_revision=BUILD_VERSION,
+            live_submission_gate=live_submission_gate,
+            hypothesis_payload=hypothesis_payload,
+            empirical_jobs_status=empirical_jobs,
+            quant_evidence=quant_evidence,
+            market_context_status=market_context_status,
+            tca_summary=tca_summary,
+            simple_lane_status=simple_lane_status,
+        )
+        route_reacquisition_book = cast(
+            Mapping[str, Any],
+            proof_floor.get("route_reacquisition_book") or {},
+        )
     payload = build_paper_route_target_plan_payload(
         session,
         live_submission_gate=cast(Mapping[str, Any], live_submission_gate),
-        route_reacquisition_book=cast(
-            Mapping[str, Any],
-            proof_floor.get("route_reacquisition_book") or {},
-        ),
+        route_reacquisition_book=route_reacquisition_book,
     )
     return JSONResponse(status_code=200, content=jsonable_encoder(payload))
 
 
 def _mapping_items(value: object) -> list[dict[str, Any]]:
     return _shared_mapping_items(value)
+
+
+def _paper_route_target_plan_probe_symbols(plan: Mapping[str, Any]) -> list[str]:
+    symbols: list[str] = []
+    for target in _paper_route_target_plan_targets(plan):
+        raw_symbols = target.get("paper_route_probe_symbols")
+        if isinstance(raw_symbols, str):
+            values: Sequence[object] = raw_symbols.split(",")
+        elif isinstance(raw_symbols, Sequence) and not isinstance(
+            raw_symbols,
+            (bytes, bytearray),
+        ):
+            values = cast(Sequence[object], raw_symbols)
+        else:
+            values = ()
+        for item in values:
+            symbol = str(item).strip().upper()
+            if symbol and symbol not in symbols:
+                symbols.append(symbol)
+    return symbols
+
+
+def _paper_route_target_plan_probe_notional(
+    plan: Mapping[str, Any],
+    *,
+    simple_lane_status: Mapping[str, Any],
+) -> str | None:
+    candidate_values: list[object] = []
+    for target in _paper_route_target_plan_targets(plan):
+        candidate_values.extend(
+            [
+                target.get("paper_route_probe_next_session_max_notional"),
+                target.get("bounded_evidence_collection_max_notional"),
+                target.get("paper_route_probe_effective_max_notional"),
+            ]
+        )
+    candidate_values.append(simple_lane_status.get("paper_route_probe_max_notional"))
+    positive_values = [
+        amount
+        for value in candidate_values
+        if (amount := _decimal_or_none(value)) is not None and amount > 0
+    ]
+    if not positive_values:
+        return None
+    return _decimal_to_string(max(positive_values))
+
+
+def _paper_route_probe_book_from_target_plan(
+    live_submission_gate: Mapping[str, Any],
+    *,
+    simple_lane_status: Mapping[str, Any],
+    state: object,
+) -> Mapping[str, Any] | None:
+    plan = _paper_route_target_plan_from_payload(live_submission_gate)
+    targets = _paper_route_target_plan_targets(plan)
+    if not targets:
+        return None
+    eligible_symbols = _paper_route_target_plan_probe_symbols(plan)
+    if not eligible_symbols:
+        return None
+    next_session_max_notional = _paper_route_target_plan_probe_notional(
+        plan,
+        simple_lane_status=simple_lane_status,
+    )
+    if next_session_max_notional is None:
+        return None
+
+    configured_enabled = bool(simple_lane_status.get("paper_route_probe_enabled"))
+    if not configured_enabled:
+        return None
+    market_session_open = cast(bool | None, getattr(state, "market_session_open", None))
+    blocking_reasons: list[str] = []
+    if market_session_open is not True:
+        blocking_reasons.append("market_session_closed")
+    active = configured_enabled and market_session_open is True
+    effective_max_notional = next_session_max_notional if active else "0"
+    active_symbols = eligible_symbols if active else []
+    return {
+        "schema_version": "torghut.route-reacquisition-book.v1",
+        "source": "paper_route_target_plan",
+        "state": "repair_only",
+        "account_label": settings.trading_account_label,
+        "trading_mode": settings.trading_mode,
+        "market_session_open": market_session_open,
+        "summary": {
+            "paper_route_probe_eligible_symbols": eligible_symbols,
+            "paper_route_probe_active_symbols": active_symbols,
+        },
+        "paper_route_probe": {
+            "configured_enabled": configured_enabled,
+            "active": active,
+            "effective_max_notional": effective_max_notional,
+            "next_session_max_notional": next_session_max_notional,
+            "eligible_symbol_count": len(eligible_symbols),
+            "eligible_symbols": eligible_symbols,
+            "active_symbols": active_symbols,
+            "blocking_reasons": blocking_reasons,
+            "capital_authority": "none",
+        },
+        "source_refs": {
+            "target_plan_source": live_submission_gate.get(
+                "paper_route_target_plan_source"
+            ),
+            "target_plan_target_count": len(targets),
+        },
+        "rollback_target": {
+            "paper_probe_notional_limit": "0",
+            "live_submit_enabled": False,
+        },
+    }
 
 
 def _paper_route_target_plan_targets(plan: Mapping[str, Any]) -> list[dict[str, Any]]:

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -1227,6 +1227,34 @@ def _execution_query_row_has_time(row: Sequence[object]) -> bool:
 
 
 def _order_lifecycle_query_row(row: Sequence[object]) -> dict[str, object]:
+    if len(row) >= 25:
+        return {
+            "execution_order_event_id": str(row[0]),
+            "trade_decision_id": str(row[1]),
+            "execution_id": str(row[2]) if row[2] is not None else None,
+            "event_ts": row[3],
+            "symbol": row[4],
+            "account_label": row[5],
+            "strategy_id": row[6],
+            "decision_hash": row[7],
+            "decision_json": row[8],
+            "alpaca_order_id": row[9],
+            "client_order_id": row[10],
+            "event_type": row[11],
+            "order_status": row[12],
+            "side": row[13],
+            "qty": row[14],
+            "filled_qty": row[15],
+            "avg_fill_price": row[16],
+            "event_fingerprint": row[17],
+            "source_topic": row[18],
+            "source_partition": row[19],
+            "source_offset": row[20],
+            "source_window_id": str(row[21]) if row[21] is not None else None,
+            "raw_event": row[22],
+            "execution_audit_json": row[23],
+            "raw_order": row[24],
+        }
     if len(row) >= 21:
         return {
             "execution_order_event_id": str(row[0]),
@@ -3773,6 +3801,10 @@ def _query_timestamps(
                     oe.client_order_id,
                     oe.event_type,
                     oe.status,
+                    e.side,
+                    oe.qty,
+                    oe.filled_qty,
+                    oe.avg_fill_price,
                     oe.event_fingerprint,
                     oe.source_topic,
                     oe.source_partition,
@@ -3862,6 +3894,10 @@ def _query_timestamps(
                         oe.client_order_id,
                         oe.event_type,
                         oe.status,
+                        null,
+                        oe.qty,
+                        oe.filled_qty,
+                        oe.avg_fill_price,
                         oe.event_fingerprint,
                         oe.source_topic,
                         oe.source_partition,

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -29,6 +29,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _load_json_artifact,
     _load_report_post_cost_expectancy_bps,
     _nonnegative_int,
+    _order_lifecycle_query_row,
     _parse_args,
     _parse_dt_or_none,
     _parse_target_metadata,
@@ -2686,6 +2687,62 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ledger_row["cost_model_hash"],
             _alpaca_2026_equity_fee_schedule_hash(),
         )
+
+    def test_order_lifecycle_query_row_preserves_fill_economics_columns(
+        self,
+    ) -> None:
+        query_row = (
+            "event-1",
+            "decision-1",
+            "execution-1",
+            datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+            "AAPL",
+            "TORGHUT_SIM",
+            "microbar-cross-sectional-pairs-v1",
+            "decision-hash",
+            {"source_decision_mode": "strategy_signal_paper"},
+            "alpaca-order-1",
+            "client-order-1",
+            "fill",
+            "filled",
+            "sell",
+            Decimal("10"),
+            Decimal("10"),
+            Decimal("100"),
+            "fingerprint-1",
+            "torghut.trade-updates.v1",
+            2,
+            22124,
+            "source-window-1",
+            {"event": "fill"},
+            {
+                "execution_policy_hash": "policy-sha",
+                "lineage_hash": "lineage-sha",
+            },
+            {
+                "runtime_ledger_cost": {
+                    "cost_amount": "0.04",
+                    "cost_basis": "broker_reported_commission_and_fees",
+                }
+            },
+        )
+
+        row = _order_lifecycle_query_row(query_row)
+        ledger_row = _runtime_lifecycle_ledger_row(
+            row,
+            event_type="fill",
+            require_complete_fill=True,
+        )
+
+        self.assertEqual(row["side"], "sell")
+        self.assertEqual(row["filled_qty"], Decimal("10"))
+        self.assertEqual(row["avg_fill_price"], Decimal("100"))
+        self.assertEqual(row["source_window_id"], "source-window-1")
+        self.assertIsNotNone(ledger_row)
+        assert ledger_row is not None
+        self.assertEqual(ledger_row["filled_notional"], Decimal("1000"))
+        self.assertEqual(ledger_row["cost_amount"], Decimal("0.04"))
+        self.assertEqual(ledger_row["source"], "execution_order_event")
 
     def test_build_realized_strategy_pnl_rows_does_not_use_idempotency_key_as_policy_hash(
         self,

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7462,6 +7462,79 @@ class TestTradingApi(TestCase):
             else:
                 app.state.trading_scheduler = original_scheduler
 
+    def test_paper_route_target_plan_skips_full_proof_floor_when_target_plan_ready(
+        self,
+    ) -> None:
+        original_scheduler = getattr(app.state, "trading_scheduler", None)
+        target = {
+            "hypothesis_id": "H-PAIRS-01",
+            "candidate_id": "c88421d619759b2cfaa6f4d0",
+            "observed_stage": "paper",
+            "strategy_family": "microbar_cross_sectional_pairs",
+            "strategy_name": "microbar-cross-sectional-pairs-v1",
+            "account_label": "TORGHUT_SIM",
+            "source_kind": "runtime_ledger_paper_probation_candidates",
+            "source_manifest_ref": "config/trading/hypotheses/h-pairs.json",
+            "dataset_snapshot_ref": "portfolio-profit-autoresearch-500-v1",
+            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+            "paper_route_probe_next_session_max_notional": "75000",
+            "paper_probation_authorized": True,
+            "source_collection_authorized": True,
+            "promotion_allowed": False,
+            "final_promotion_allowed": False,
+            "max_notional": "0",
+        }
+        live_gate = {
+            "allowed": True,
+            "reason": "paper_probe_ready",
+            "blocked_reasons": [],
+            "promotion_eligible_total": 0,
+            "runtime_ledger_paper_probation_import_plan": {
+                "schema_version": "torghut.runtime-ledger-paper-probation-import-plan.v1",
+                "target_count": 1,
+                "skipped_target_count": 0,
+                "promotion_allowed": False,
+                "final_promotion_allowed": False,
+                "targets": [target],
+            },
+        }
+        try:
+            if hasattr(app.state, "trading_scheduler"):
+                del app.state.trading_scheduler
+            with (
+                patch(
+                    "app.main._build_live_submission_gate_payload",
+                    return_value=live_gate,
+                ),
+                patch(
+                    "app.main._build_simple_lane_status_payload",
+                    return_value={
+                        "paper_route_probe_enabled": True,
+                        "paper_route_probe_max_notional": "75000",
+                    },
+                ),
+                patch(
+                    "app.main._build_profitability_proof_floor_payload",
+                    side_effect=AssertionError("full proof floor should not run"),
+                ),
+            ):
+                response = self.client.get("/trading/paper-route-target-plan")
+            self.assertEqual(response.status_code, 200)
+            payload = response.json()
+            self.assertEqual(
+                payload["paper_route_probe"]["eligible_symbols"], ["AAPL", "AMZN"]
+            )
+            self.assertEqual(
+                payload["paper_route_probe"]["next_session_max_notional"], "75000"
+            )
+            self.assertFalse(payload["summary"]["promotion_authority"]["allowed"])
+        finally:
+            if original_scheduler is None:
+                if hasattr(app.state, "trading_scheduler"):
+                    del app.state.trading_scheduler
+            else:
+                app.state.trading_scheduler = original_scheduler
+
     def test_trading_paper_route_evidence_uses_external_plan_when_url_configured(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Add a lightweight paper-route probe book path for target-plan-backed H-PAIRS evidence handoff.
- Keep `/trading/paper-route-evidence` and `/trading/paper-route-target-plan` from building the full profitability proof floor when the target plan already contains probe symbols and bounded notional.
- Preserve order-feed `qty`, `filled_qty`, and `avg_fill_price` columns when importing runtime lifecycle rows so source-backed paper fills can become runtime-ledger economics.
- Preserve fail-closed capital semantics: this only exposes evidence-collection/readiness and materializes real fill economics; it does not grant promotion authority or live-capital approval.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_api.py -k "paper_route_target_plan_skips_full_proof_floor or trading_paper_route_target_plan_returns_lightweight_plan or trading_paper_route_evidence_endpoint_audits_probation_targets" -q`
- `uv run --frozen pytest tests/test_paper_route_evidence.py -k "target_plan_import_plan_uses_latest_closed_window_on_weekend or source_runtime_window_import_plan_keeps_next_session_window" -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k "order_lifecycle_query_row_preserves_fill_economics_columns or order_event_lifecycle_materializes_alpaca_fee_schedule_costs or build_realized_strategy_pnl_rows_partitions_mixed_source_decision_modes" -q`
- `uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen pytest tests/test_trading_api.py tests/test_paper_route_evidence.py -q`
- `uv run --frozen pytest tests/test_trading_api.py tests/test_paper_route_evidence.py tests/test_import_hypothesis_runtime_windows.py -q`
- `uv run --frozen ruff check app/main.py tests/test_trading_api.py`
- `uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `uv run --frozen ruff format --check app/main.py tests/test_trading_api.py`
- `uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
