### PR TITLE
chore(jangar): promote image b6729e5b

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-29T23:45:32Z
+    deploy.knative.dev/rollout: 2026-05-31T07:13:26Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 9480b5121279f71890ce50ff65498ad9d0c802ae
+              value: b6729e5bc11f7940025b839f962e11283a89f9c0
             - name: JANGAR_GITOPS_REVISION
-              value: 9480b5121279f71890ce50ff65498ad9d0c802ae
+              value: b6729e5bc11f7940025b839f962e11283a89f9c0
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -355,15 +355,15 @@ spec:
             - name: OPENAI_EMBEDDING_TIMEOUT_MS
               value: "60000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26667916499"
+              value: "26706163835"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:8aa3b4001ba3c932b7cdbcb49523e7a87126183955f21956a96f7ba81c52199d
+              value: sha256:8f4d83856d36e749279845444539bff2582a684079615957997e7b19874ac5f7
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 9480b5121279f71890ce50ff65498ad9d0c802ae
+              value: b6729e5bc11f7940025b839f962e11283a89f9c0
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:8aa3b4001ba3c932b7cdbcb49523e7a87126183955f21956a96f7ba81c52199d
+              value: sha256:8f4d83856d36e749279845444539bff2582a684079615957997e7b19874ac5f7
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: 9480b512
-    digest: sha256:8aa3b4001ba3c932b7cdbcb49523e7a87126183955f21956a96f7ba81c52199d
+    newTag: b6729e5b
+    digest: sha256:8f4d83856d36e749279845444539bff2582a684079615957997e7b19874ac5f7


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `b6729e5bc11f7940025b839f962e11283a89f9c0`
- Image tag: `b6729e5b`
- Image digest: `sha256:8f4d83856d36e749279845444539bff2582a684079615957997e7b19874ac5f7`
- Source CI run: `26706163835`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates