### PR TITLE
fix(atlas): harden source code semantic search

### DIFF
--- a/argocd/applications/bumba/atlas-chunk-embedding-backfill-job.yaml
+++ b/argocd/applications/bumba/atlas-chunk-embedding-backfill-job.yaml
@@ -1,0 +1,71 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: atlas-chunk-embedding-backfill-services-jangar-20260531
+  namespace: jangar
+  labels:
+    app.kubernetes.io/name: bumba
+    app.kubernetes.io/part-of: lab
+    atlas.proompteng.ai/backfill: chunk-embeddings
+spec:
+  activeDeadlineSeconds: 86400
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bumba
+        app.kubernetes.io/part-of: lab
+        atlas.proompteng.ai/backfill: chunk-embeddings
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      restartPolicy: Never
+      containers:
+        - name: backfill
+          image: registry.ide-newton.ts.net/lab/bumba
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+          args:
+            - |
+              set -euo pipefail
+              rm -rf /tmp/lab
+              git clone --depth 1 --branch main https://github.com/proompteng/lab.git /tmp/lab
+              cd /tmp/lab
+              bun run packages/scripts/src/atlas/backfill-chunk-embeddings.ts \
+                --apply \
+                --repository proompteng/lab \
+                --ref main \
+                --path-prefix services/jangar \
+                --limit 2500 \
+                --batch-size 1 \
+                --continue-on-error \
+                --max-errors 100 \
+                --sleep-ms 250 \
+                --json
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: jangar-db-app
+                  key: uri
+            - name: PGSSLMODE
+              value: require
+            - name: OPENAI_EMBEDDING_API_BASE_URL
+              value: http://saigak.saigak.svc.cluster.local:11434/v1
+            - name: OPENAI_EMBEDDING_MODEL
+              value: qwen3-embedding-saigak:8b
+            - name: OPENAI_EMBEDDING_DIMENSION
+              value: "4096"
+            - name: OPENAI_EMBEDDING_TIMEOUT_MS
+              value: "180000"
+            - name: OPENAI_EMBEDDING_MAX_INPUT_CHARS
+              value: "60000"
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 2Gi

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: jangar
 resources:
   - pvc-rwo.yaml
   - deployment.yaml
+  - atlas-chunk-embedding-backfill-job.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
     newTag: sha-b6729e5

--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -347,7 +347,7 @@ spec:
             - name: OPENAI_API_BASE_URL
               value: http://saigak.saigak.svc.cluster.local:11434/v1
             - name: OPENAI_EMBEDDING_API_BASE_URL
-              value: http://saigak.saigak.svc.cluster.local:11435/v1
+              value: http://saigak.saigak.svc.cluster.local:11434/v1
             - name: OPENAI_EMBEDDING_MODEL
               value: qwen3-embedding-saigak:8b
             - name: OPENAI_EMBEDDING_DIMENSION

--- a/packages/scripts/src/atlas/backfill-chunk-embeddings.ts
+++ b/packages/scripts/src/atlas/backfill-chunk-embeddings.ts
@@ -8,6 +8,9 @@ type Options = {
   apply: boolean
   limit: number
   batchSize: number
+  continueOnError: boolean
+  maxErrors: number
+  sleepMs: number
   repository?: string
   ref?: string
   pathPrefix?: string
@@ -52,6 +55,9 @@ Options:
       --apply                Write embeddings. Without this, only reports matching chunks.
       --limit <n>            Max chunks to inspect/backfill (default: 100)
       --batch-size <n>       Embedding request batch size (default: 16)
+      --continue-on-error    Mark failed chunks and keep processing remaining batches.
+      --max-errors <n>       Stop after this many failed chunks when continuing (default: 25).
+      --sleep-ms <n>         Sleep between batches (default: 0).
       --repository <name>    Repository filter (e.g. proompteng/lab)
       --ref <ref>            Ref filter (e.g. main)
       --path-prefix <path>   Path prefix filter
@@ -78,11 +84,20 @@ const parsePositiveInt = (name: string, raw: string) => {
   return Math.floor(parsed)
 }
 
+const parseNonNegativeInt = (name: string, raw: string) => {
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed < 0) fatal(`${name} must be a non-negative integer`)
+  return Math.floor(parsed)
+}
+
 const parseArgs = (argv: string[]): Options => {
   const options: Options = {
     apply: false,
     limit: 100,
     batchSize: 16,
+    continueOnError: false,
+    maxErrors: 25,
+    sleepMs: 0,
     json: false,
   }
 
@@ -102,6 +117,33 @@ const parseArgs = (argv: string[]): Options => {
 
     if (arg === '--json') {
       options.json = true
+      continue
+    }
+
+    if (arg === '--continue-on-error') {
+      options.continueOnError = true
+      continue
+    }
+
+    if (arg === '--max-errors') {
+      options.maxErrors = parsePositiveInt('--max-errors', readValue(arg, argv, i))
+      i += 1
+      continue
+    }
+
+    if (arg.startsWith('--max-errors=')) {
+      options.maxErrors = parsePositiveInt('--max-errors', arg.slice('--max-errors='.length))
+      continue
+    }
+
+    if (arg === '--sleep-ms') {
+      options.sleepMs = parseNonNegativeInt('--sleep-ms', readValue(arg, argv, i))
+      i += 1
+      continue
+    }
+
+    if (arg.startsWith('--sleep-ms=')) {
+      options.sleepMs = parseNonNegativeInt('--sleep-ms', arg.slice('--sleep-ms='.length))
       continue
     }
 
@@ -271,6 +313,24 @@ const withDefaultSslMode = (rawUrl: string) => {
 }
 
 const vectorToPgArray = (values: number[]) => `[${values.join(',')}]`
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const formatUnknownError = (error: unknown) => {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  if (error == null) return 'Unknown error'
+  try {
+    return JSON.stringify(error) ?? 'Unknown error'
+  } catch {
+    return 'Unknown error'
+  }
+}
+
+const truncateError = (error: unknown) => {
+  const message = formatUnknownError(error)
+  return message.length > 500 ? `${message.slice(0, 500)}...` : message
+}
 
 const normalizeEmbeddings = (raw: unknown): number[][] | null => {
   if (!Array.isArray(raw)) return null
@@ -457,15 +517,44 @@ const main = async () => {
     }
 
     let embedded = 0
+    let failed = 0
     for (let index = 0; index < rows.length; index += options.batchSize) {
       const batch = rows.slice(index, index + options.batchSize)
-      const embeddings = await requestEmbeddings(
-        batch.map((row) => row.content),
-        config,
-      )
-      await upsertEmbeddings(db, batch, embeddings, config)
-      embedded += batch.length
-      console.error(`embedded ${embedded}/${rows.length} chunks`)
+      const batchIds = batch.map((row) => row.id)
+      await markChunks(db, batchIds, {
+        embeddingStatus: 'pending',
+        embeddingFailureReason: null,
+        embeddingError: null,
+        embeddingModel: config.model,
+        embeddingDimension: config.dimension,
+      })
+
+      try {
+        const embeddings = await requestEmbeddings(
+          batch.map((row) => row.content),
+          config,
+        )
+        await upsertEmbeddings(db, batch, embeddings, config)
+        embedded += batch.length
+        console.error(`embedded ${embedded}/${rows.length} chunks; failed ${failed}`)
+      } catch (error) {
+        failed += batch.length
+        await markChunks(db, batchIds, {
+          embeddingStatus: 'failed',
+          embeddingFailureReason: 'backfill_embedding_failed',
+          embeddingError: truncateError(error),
+          embeddingModel: config.model,
+          embeddingDimension: config.dimension,
+        })
+        console.error(`failed ${failed}/${rows.length} chunks: ${truncateError(error)}`)
+        if (!options.continueOnError || failed >= options.maxErrors) {
+          throw error
+        }
+      }
+
+      if (options.sleepMs > 0 && index + options.batchSize < rows.length) {
+        await sleep(options.sleepMs)
+      }
     }
 
     const payload = {
@@ -473,6 +562,7 @@ const main = async () => {
       dryRun: false,
       candidates: rows.length,
       embedded,
+      failed,
       model: config.model,
       dimension: config.dimension,
     }

--- a/services/jangar/src/server/__tests__/atlas-store.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-store.test.ts
@@ -445,7 +445,7 @@ describe('atlas store', () => {
     expect(matches[0]?.signals.matchedIdentifiers).toEqual(['BUMBA_ATLAS_CHUNK_INDEXING'])
   })
 
-  it('applies latest file version filter in code search queries', async () => {
+  it('applies indexed latest file version filter in code search queries', async () => {
     const now = new Date('2020-01-01T00:00:00.000Z')
     const lexicalRow = {
       chunk_id: 'chunk-1',
@@ -502,18 +502,16 @@ describe('atlas store', () => {
     expect(lexicalSql).toBeTruthy()
 
     const normalized = String(lexicalSql).toLowerCase().replace(/\s+/g, ' ')
-    expect(normalized).toContain('file_versions.id in ( select ranked.id from ( select fv.id')
-    expect(normalized).toContain('row_number() over ( partition by fv.file_key_id, fv.repository_ref')
-    expect(normalized).toContain('order by fv.updated_at desc, fv.created_at desc, fv.id desc')
-    expect(normalized).toContain('from atlas.file_versions as fv')
-    expect(normalized).toContain('inner join atlas.file_keys as file_keys_scope on file_keys_scope.id = fv.file_key_id')
+    expect(normalized).toContain('not exists ( select 1 from atlas.file_versions as newer_file_versions')
+    expect(normalized).toContain('newer_file_versions.file_key_id = file_versions.file_key_id')
+    expect(normalized).toContain('newer_file_versions.repository_ref = file_versions.repository_ref')
+    expect(normalized).toContain('newer_file_versions.language =')
     expect(normalized).toContain(
-      'inner join atlas.repositories as repositories_scope on repositories_scope.id = file_keys_scope.repository_id',
+      '( newer_file_versions.updated_at, newer_file_versions.created_at, newer_file_versions.id ) >',
     )
-    expect(normalized).toContain('where repositories_scope.name =')
-    expect(normalized).toContain('fv.repository_ref =')
-    expect(normalized).toContain('file_keys_scope.path like')
-    expect(normalized).toContain('fv.language =')
-    expect(normalized).toContain('where ranked.latest_rank = 1 )')
+    expect(normalized).toContain('"repositories"."name" =')
+    expect(normalized).toContain('"file_versions"."repository_ref" =')
+    expect(normalized).toContain('"file_keys"."path" like')
+    expect(normalized).toContain('"file_versions"."language" =')
   })
 })

--- a/services/jangar/src/server/atlas-code-search.ts
+++ b/services/jangar/src/server/atlas-code-search.ts
@@ -112,6 +112,8 @@ const DEFAULT_SEARCH_LIMIT = 10
 const MAX_SEARCH_LIMIT = 200
 const DEFAULT_CODE_SEARCH_SEMANTIC_TIMEOUT_MS = 12_000
 const DEFAULT_CODE_SEARCH_QUERY_EMBEDDING_CACHE_TTL_MS = 60_000
+const DEFAULT_CODE_SEARCH_SEMANTIC_CANDIDATE_LIMIT = 5_000
+const MAX_CODE_SEARCH_SEMANTIC_CANDIDATE_LIMIT = 50_000
 const DEFAULT_CODE_SEARCH_HEALTH_SAMPLE_LIMIT = 500
 const MAX_CODE_SEARCH_HEALTH_SAMPLE_LIMIT = 5_000
 const DEFAULT_MIN_SEMANTIC_COVERAGE = 0.95
@@ -193,6 +195,15 @@ const normalizeHealthSampleLimit = (value: number | undefined) => {
   return Math.max(1, Math.min(MAX_CODE_SEARCH_HEALTH_SAMPLE_LIMIT, Math.floor(value)))
 }
 
+const resolveSemanticCandidateLimit = (resultLimit: number) => {
+  const fallback = Math.max(DEFAULT_CODE_SEARCH_SEMANTIC_CANDIDATE_LIMIT, resultLimit * 100)
+  return parsePositiveIntEnv(
+    'ATLAS_CODE_SEARCH_SEMANTIC_CANDIDATE_LIMIT',
+    fallback,
+    MAX_CODE_SEARCH_SEMANTIC_CANDIDATE_LIMIT,
+  )
+}
+
 const withTimeout = async <T>(input: Promise<T>, timeoutMs: number, message: string): Promise<T> => {
   let timeout: ReturnType<typeof setTimeout> | undefined
   try {
@@ -239,45 +250,32 @@ const applyCodeSearchFilters = <T extends { where: (...args: unknown[]) => T }>(
   return next
 }
 
-const latestFileVersionIdsExpr = (filters: CodeSearchFilters) => {
-  const conditions: Array<ReturnType<typeof sql>> = []
-  if (filters.repository) {
-    conditions.push(sql`repositories_scope.name = ${filters.repository}`)
-  }
-  if (filters.ref) {
-    conditions.push(sql`fv.repository_ref = ${filters.ref}`)
-  }
-  if (filters.pathPrefix) {
-    conditions.push(sql`file_keys_scope.path LIKE ${`${filters.pathPrefix}%`}`)
-  }
-  if (filters.language) {
-    conditions.push(sql`fv.language = ${filters.language}`)
-  }
-
-  const whereClause = conditions.length ? sql`WHERE ${sql.join(conditions, sql` AND `)}` : sql``
-
-  return sql<string>`
-    SELECT ranked.id
-    FROM (
-      SELECT
-        fv.id,
-        ROW_NUMBER() OVER (
-          PARTITION BY fv.file_key_id, fv.repository_ref
-          ORDER BY fv.updated_at DESC, fv.created_at DESC, fv.id DESC
-        ) AS latest_rank
-      FROM atlas.file_versions AS fv
-      INNER JOIN atlas.file_keys AS file_keys_scope ON file_keys_scope.id = fv.file_key_id
-      INNER JOIN atlas.repositories AS repositories_scope ON repositories_scope.id = file_keys_scope.repository_id
-      ${whereClause}
-    ) AS ranked
-    WHERE ranked.latest_rank = 1
+const latestFileVersionPredicate = (filters: CodeSearchFilters) => {
+  const languageClause = filters.language ? sql`AND newer_file_versions.language = ${filters.language}` : sql``
+  return sql<boolean>`
+    NOT EXISTS (
+      SELECT 1
+      FROM atlas.file_versions AS newer_file_versions
+      WHERE newer_file_versions.file_key_id = file_versions.file_key_id
+        AND newer_file_versions.repository_ref = file_versions.repository_ref
+        ${languageClause}
+        AND (
+          newer_file_versions.updated_at,
+          newer_file_versions.created_at,
+          newer_file_versions.id
+        ) > (
+          file_versions.updated_at,
+          file_versions.created_at,
+          file_versions.id
+        )
+    )
   `
 }
 
 const applyLatestFileVersionFilter = <T extends { where: (...args: unknown[]) => T }>(
   query: T,
   filters: CodeSearchFilters,
-) => query.where(sql<boolean>`file_versions.id IN (${latestFileVersionIdsExpr(filters)})`)
+) => query.where(latestFileVersionPredicate(filters))
 
 const toIso = (value: Date | string) => (value instanceof Date ? value.toISOString() : String(value))
 
@@ -373,6 +371,25 @@ const codeSearchSelectColumns = [
   'repositories.created_at as repository_created_at',
   'repositories.updated_at as repository_updated_at',
 ] as const
+
+const codeSearchRawSelectColumns = codeSearchSelectColumns.join(',\n')
+
+const semanticCandidateWhereClause = (filters: CodeSearchFilters) => {
+  const conditions: Array<ReturnType<typeof sql>> = [latestFileVersionPredicate(filters)]
+  if (filters.repository) {
+    conditions.push(sql`repositories.name = ${filters.repository}`)
+  }
+  if (filters.ref) {
+    conditions.push(sql`file_versions.repository_ref = ${filters.ref}`)
+  }
+  if (filters.pathPrefix) {
+    conditions.push(sql`file_keys.path LIKE ${`${filters.pathPrefix}%`}`)
+  }
+  if (filters.language) {
+    conditions.push(sql`file_versions.language = ${filters.language}`)
+  }
+  return sql`WHERE ${sql.join(conditions, sql` AND `)}`
+}
 
 export const createAtlasCodeSearchHandlers = ({
   db,
@@ -523,23 +540,35 @@ export const createAtlasCodeSearchHandlers = ({
                 const vectorString = vectorToPgArray(embedding)
                 const semanticDistanceExpr = sql<number>`chunk_embeddings.embedding <=> ${vectorString}::vector`
 
-                let semanticQuery = db
-                  .selectFrom('atlas.chunk_embeddings as chunk_embeddings')
-                  .innerJoin('atlas.file_chunks as file_chunks', 'file_chunks.id', 'chunk_embeddings.chunk_id')
-                  .innerJoin('atlas.file_versions as file_versions', 'file_versions.id', 'file_chunks.file_version_id')
-                  .innerJoin('atlas.file_keys as file_keys', 'file_keys.id', 'file_versions.file_key_id')
-                  .innerJoin('atlas.repositories as repositories', 'repositories.id', 'file_keys.repository_id')
-                  .select([...codeSearchSelectColumns, semanticDistanceExpr.as('semantic_distance')])
-                  .where('chunk_embeddings.model', '=', embeddingConfig.model)
-                  .where('chunk_embeddings.dimension', '=', embeddingConfig.dimension)
+                const semanticCandidateLimit = resolveSemanticCandidateLimit(resolvedLimit)
+                const whereClause = semanticCandidateWhereClause(filters)
+                const { rows } = await sql<AtlasCodeSearchRow>`
+                  WITH candidate_chunks AS MATERIALIZED (
+                    SELECT ${sql.raw(codeSearchRawSelectColumns)}
+                    FROM atlas.file_chunks AS file_chunks
+                    INNER JOIN atlas.file_versions AS file_versions
+                      ON file_versions.id = file_chunks.file_version_id
+                    INNER JOIN atlas.file_keys AS file_keys
+                      ON file_keys.id = file_versions.file_key_id
+                    INNER JOIN atlas.repositories AS repositories
+                      ON repositories.id = file_keys.repository_id
+                    ${whereClause}
+                    ORDER BY file_chunks.created_at DESC
+                    LIMIT ${semanticCandidateLimit}
+                  )
+                  SELECT
+                    candidate_chunks.*,
+                    ${semanticDistanceExpr} AS semantic_distance
+                  FROM candidate_chunks
+                  INNER JOIN atlas.chunk_embeddings AS chunk_embeddings
+                    ON chunk_embeddings.chunk_id = candidate_chunks.chunk_id
+                   AND chunk_embeddings.model = ${embeddingConfig.model}
+                   AND chunk_embeddings.dimension = ${embeddingConfig.dimension}
+                  ORDER BY semantic_distance
+                  LIMIT ${semanticLimit};
+                `.execute(db)
 
-                semanticQuery = applyCodeSearchFilters(semanticQuery, filters)
-                semanticQuery = applyLatestFileVersionFilter(semanticQuery, filters)
-
-                return (await semanticQuery
-                  .orderBy(semanticDistanceExpr)
-                  .limit(semanticLimit)
-                  .execute()) as AtlasCodeSearchRow[]
+                return rows as AtlasCodeSearchRow[]
               })(),
               semanticTimeoutMs,
               `semantic code search timed out after ${semanticTimeoutMs}ms`,

--- a/services/jangar/src/server/kysely-migrations.ts
+++ b/services/jangar/src/server/kysely-migrations.ts
@@ -19,6 +19,7 @@ import * as torghutQuantMetricsLatestAccountWindowIndexMigration from '~/server/
 import * as torghutQuantPipelineHealthAccountWindowAsofIndexMigration from '~/server/migrations/20260505_torghut_quant_pipeline_health_account_window_asof_index'
 import * as torghutQuantPipelineHealthWindowIndexMigration from '~/server/migrations/20260505_torghut_quant_pipeline_health_window_index'
 import * as torghutQuantPipelineHealthAccountWindowCreatedAtIndexMigration from '~/server/migrations/20260508_torghut_quant_pipeline_health_account_window_created_at_index'
+import * as atlasCodeSearchPerformanceIndexesMigration from '~/server/migrations/20260531_atlas_code_search_performance_indexes'
 
 type MigrationMap = Record<string, Migration>
 
@@ -52,6 +53,7 @@ const migrations: MigrationMap = {
   '20260505_torghut_quant_pipeline_health_window_index': torghutQuantPipelineHealthWindowIndexMigration,
   '20260508_torghut_quant_pipeline_health_account_window_created_at_index':
     torghutQuantPipelineHealthAccountWindowCreatedAtIndexMigration,
+  '20260531_atlas_code_search_performance_indexes': atlasCodeSearchPerformanceIndexesMigration,
 }
 
 export const getRegisteredMigrationNames = () => Object.keys(migrations).sort()

--- a/services/jangar/src/server/migrations/20260531_atlas_code_search_performance_indexes.ts
+++ b/services/jangar/src/server/migrations/20260531_atlas_code_search_performance_indexes.ts
@@ -1,0 +1,38 @@
+import { type Kysely, sql } from 'kysely'
+
+import type { Database } from '../db'
+
+export const up = async (db: Kysely<Database>) => {
+  await sql`
+    CREATE INDEX IF NOT EXISTS atlas_file_versions_latest_idx
+    ON atlas.file_versions (file_key_id, repository_ref, updated_at DESC, created_at DESC, id DESC);
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS atlas_file_chunks_created_at_idx
+    ON atlas.file_chunks (created_at DESC);
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS atlas_file_chunks_file_version_created_idx
+    ON atlas.file_chunks (file_version_id, created_at DESC);
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS atlas_file_keys_repository_path_idx
+    ON atlas.file_keys (repository_id, path text_pattern_ops);
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS atlas_chunk_embeddings_model_dimension_chunk_idx
+    ON atlas.chunk_embeddings (model, dimension, chunk_id);
+  `.execute(db)
+}
+
+export const down = async (db: Kysely<Database>) => {
+  await sql`DROP INDEX IF EXISTS atlas.atlas_chunk_embeddings_model_dimension_chunk_idx;`.execute(db)
+  await sql`DROP INDEX IF EXISTS atlas.atlas_file_keys_repository_path_idx;`.execute(db)
+  await sql`DROP INDEX IF EXISTS atlas.atlas_file_chunks_file_version_created_idx;`.execute(db)
+  await sql`DROP INDEX IF EXISTS atlas.atlas_file_chunks_created_at_idx;`.execute(db)
+  await sql`DROP INDEX IF EXISTS atlas.atlas_file_versions_latest_idx;`.execute(db)
+}


### PR DESCRIPTION
## Summary

- Adds indexed latest-version predicates and bounded semantic candidate retrieval for Atlas source-code search.
- Adds Atlas code-search performance indexes for latest file-version checks, chunk recency, path filtering, and embedding joins.
- Hardens the chunk embedding backfill CLI with pending/failed metadata and continue-on-error behavior.
- Adds a GitOps Bumba Job to backfill `proompteng/lab` `main` `services/jangar` chunk embeddings in-cluster.
- Points deployed Jangar query embeddings at the same Saigak `/v1` endpoint used by Bumba.

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/atlas-store.test.ts src/server/__tests__/kysely-migrations.test.ts src/server/__tests__/mcp.test.ts`
- `bun run test` in `services/jangar`
- `bun run lint:oxlint` in `services/jangar` (existing warnings only)
- `bun run lint:oxlint:type` in `services/jangar` (existing warnings only)
- `bun run packages/scripts/src/atlas/backfill-chunk-embeddings.ts --help`
- `bunx tsc --noEmit --skipLibCheck --module ESNext --moduleResolution Bundler --target ES2022 --types bun-types packages/scripts/src/atlas/backfill-chunk-embeddings.ts`
- `bun run lint:oxlint:type` in `packages/scripts` (existing warnings only)
- `kubectl kustomize argocd/applications/bumba`
- `kubectl kustomize argocd/applications/jangar --enable-helm`
- `bunx oxfmt --check services/jangar/src/server/atlas-code-search.ts services/jangar/src/server/kysely-migrations.ts services/jangar/src/server/__tests__/atlas-store.test.ts services/jangar/src/server/migrations/20260531_atlas_code_search_performance_indexes.ts packages/scripts/src/atlas/backfill-chunk-embeddings.ts argocd/applications/bumba/atlas-chunk-embedding-backfill-job.yaml argocd/applications/bumba/kustomization.yaml argocd/applications/jangar/deployment.yaml`
- `git diff --check`

## Breaking Changes

None. This adds an unordered Jangar migration that creates indexes and a one-shot Bumba Job named `atlas-chunk-embedding-backfill-services-jangar-20260531`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
