### PR TITLE
fix(torghut): materialize exact order feed lifecycle

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -3814,7 +3814,33 @@ def _query_timestamps(
                     e.execution_audit_json,
                     e.raw_order
                 from execution_order_events oe
-                left join executions e on e.id = oe.execution_id
+                left join lateral (
+                    select matched.*
+                    from (
+                        select
+                            array_agg(e_match.id order by e_match.created_at, e_match.id) as ids,
+                            count(*) as match_count
+                        from executions e_match
+                        where coalesce(e_match.alpaca_account_label, oe.alpaca_account_label)
+                              = oe.alpaca_account_label
+                          and (
+                                (
+                                    oe.execution_id is not null
+                                    and e_match.id = oe.execution_id
+                                )
+                                or (
+                                    nullif(oe.alpaca_order_id, '') is not null
+                                    and e_match.alpaca_order_id = oe.alpaca_order_id
+                                )
+                                or (
+                                    nullif(oe.client_order_id, '') is not null
+                                    and e_match.client_order_id = oe.client_order_id
+                                )
+                              )
+                    ) exact_match
+                    join executions matched on matched.id = exact_match.ids[1]
+                    where exact_match.match_count = 1
+                ) e on true
                 join trade_decisions d
                   on d.id = coalesce(oe.trade_decision_id, e.trade_decision_id)
                 join strategies s on s.id = d.strategy_id
@@ -3882,8 +3908,8 @@ def _query_timestamps(
                     f"""
                     select
                         oe.id,
-                        oe.trade_decision_id,
-                        oe.execution_id,
+                        coalesce(oe.trade_decision_id, e.trade_decision_id),
+                        e.id,
                         coalesce(oe.event_ts, oe.created_at),
                         oe.symbol,
                         oe.alpaca_account_label,
@@ -3894,7 +3920,7 @@ def _query_timestamps(
                         oe.client_order_id,
                         oe.event_type,
                         oe.status,
-                        null,
+                        e.side,
                         oe.qty,
                         oe.filled_qty,
                         oe.avg_fill_price,
@@ -3904,13 +3930,43 @@ def _query_timestamps(
                         oe.source_offset,
                         oe.source_window_id,
                         oe.raw_event,
-                        null,
-                        null
+                        e.execution_audit_json,
+                        e.raw_order
                     from execution_order_events oe
+                    left join lateral (
+                        select matched.*
+                        from (
+                            select
+                                array_agg(e_match.id order by e_match.created_at, e_match.id) as ids,
+                                count(*) as match_count
+                            from executions e_match
+                            where coalesce(e_match.alpaca_account_label, oe.alpaca_account_label)
+                                  = oe.alpaca_account_label
+                              and (
+                                    (
+                                        oe.execution_id is not null
+                                        and e_match.id = oe.execution_id
+                                    )
+                                    or (
+                                        nullif(oe.alpaca_order_id, '') is not null
+                                        and e_match.alpaca_order_id = oe.alpaca_order_id
+                                    )
+                                    or (
+                                        nullif(oe.client_order_id, '') is not null
+                                        and e_match.client_order_id = oe.client_order_id
+                                    )
+                                  )
+                        ) exact_match
+                        join executions matched on matched.id = exact_match.ids[1]
+                        where exact_match.match_count = 1
+                    ) e on true
                     where oe.alpaca_account_label = %s
                       and coalesce(oe.event_ts, oe.created_at) >= %s
                       and coalesce(oe.event_ts, oe.created_at) < %s
-                      and (oe.execution_id is null or oe.trade_decision_id is null)
+                      and (
+                            e.id is null
+                            or coalesce(oe.trade_decision_id, e.trade_decision_id) is null
+                          )
                       and (
                             lower(coalesce(oe.event_type, oe.status, '')) in (
                                 'fill', 'filled', 'partial_fill', 'partially_filled'

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -4200,8 +4200,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(len(cursor.executed), 5)
         unlinked_query, unlinked_params = cursor.executed[3]
         self.assertIn("from execution_order_events oe", unlinked_query)
+        self.assertIn("left join lateral", unlinked_query)
+        self.assertIn("exact_match.match_count = 1", unlinked_query)
         self.assertIn(
-            "and (oe.execution_id is null or oe.trade_decision_id is null)",
+            "or coalesce(oe.trade_decision_id, e.trade_decision_id) is null",
             unlinked_query,
         )
         self.assertIn("upper(oe.symbol) = any(%s)", unlinked_query)
@@ -4291,6 +4293,101 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertEqual(diagnostics["order_feed_unattributed_fill_lifecycle_count"], 0)
         self.assertIn(
+            "order_feed_unlinked_fill_lifecycle_present",
+            _source_activity_diagnostics_blockers(diagnostics),
+        )
+
+    def test_query_timestamps_materializes_exact_order_identity_lifecycle(
+        self,
+    ) -> None:
+        cursor = _FakeCursor()
+        cursor._results = [
+            [
+                (
+                    "decision-id-1",
+                    datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "AAPL",
+                    "TORGHUT_SIM",
+                    "microbar-cross-sectional-pairs-v1",
+                    "decision-sha",
+                    {},
+                )
+            ],
+            [_FakeCursor()._results[1][0]],
+            [
+                (
+                    "source-event-id-1",
+                    "decision-id-1",
+                    "execution-id-1",
+                    datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    "AAPL",
+                    "TORGHUT_SIM",
+                    "microbar-cross-sectional-pairs-v1",
+                    "decision-sha",
+                    {},
+                    "alpaca-order-1",
+                    "client-order-1",
+                    "fill",
+                    "filled",
+                    "buy",
+                    Decimal("1"),
+                    Decimal("1"),
+                    Decimal("100"),
+                    "source-event-fingerprint-1",
+                    "torghut.trade-updates.v1",
+                    0,
+                    35803,
+                    "source-window-1",
+                    {},
+                    {
+                        "cost_amount": "0.01",
+                        "cost_basis": "broker_reported_commission_and_fees",
+                    },
+                    {
+                        "execution_policy_hash": "policy-sha",
+                        "cost_model_hash": "cost-sha",
+                        "lineage_hash": "lineage-sha",
+                    },
+                )
+            ],
+            [],
+            [],
+        ]
+        connection = _FakeConnection(cursor)
+        diagnostics: dict[str, object] = {}
+
+        with patch(
+            "scripts.import_hypothesis_runtime_windows.psycopg.connect",
+            return_value=connection,
+        ):
+            _query_timestamps(
+                dsn="postgresql://example",
+                strategy_names=["microbar-cross-sectional-pairs-v1"],
+                account_label="TORGHUT_SIM",
+                window_start=datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                window_end=datetime(2026, 3, 6, 15, 0, tzinfo=timezone.utc),
+                symbols=["AAPL"],
+                source_activity_diagnostics=diagnostics,
+            )
+
+        order_event_query, _ = cursor.executed[2]
+        unlinked_query, _ = cursor.executed[3]
+        self.assertIn("left join lateral", order_event_query)
+        self.assertIn("exact_match.match_count = 1", order_event_query)
+        self.assertIn(
+            "coalesce(oe.trade_decision_id, e.trade_decision_id)",
+            order_event_query,
+        )
+        self.assertIn("left join lateral", unlinked_query)
+        self.assertIn("exact_match.match_count = 1", unlinked_query)
+        self.assertEqual(diagnostics["order_feed_unlinked_fill_lifecycle_count"], 0)
+        self.assertEqual(
+            diagnostics["order_feed_unlinked_strategy_fill_lifecycle_count"], 0
+        )
+        self.assertEqual(
+            diagnostics["fill_order_lifecycle_rows_after_lineage_filter"], 1
+        )
+        self.assertNotIn(
             "order_feed_unlinked_fill_lifecycle_present",
             _source_activity_diagnostics_blockers(diagnostics),
         )
@@ -4435,8 +4532,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         )
         self.assertEqual(order_event_params[-2:], (["AAPL"], ["AAPL"]))
         self.assertIn("from execution_order_events oe", unlinked_query)
+        self.assertIn("left join lateral", unlinked_query)
+        self.assertIn("exact_match.match_count = 1", unlinked_query)
         self.assertIn(
-            "and (oe.execution_id is null or oe.trade_decision_id is null)",
+            "or coalesce(oe.trade_decision_id, e.trade_decision_id) is null",
             unlinked_query,
         )
         self.assertIn("upper(oe.symbol) = any(%s)", unlinked_query)


### PR DESCRIPTION
## Summary

- Materializes order-feed lifecycle rows through an exact one-execution match by account plus execution/order/client-order identity.
- Keeps ambiguous or unmatched lifecycle rows fail-closed as unlinked fill evidence instead of treating them as authority.
- Updates H-PAIRS runtime-window import tests for exact lifecycle materialization and unlinked fill diagnostics.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py -q`
- `cd services/torghut && uv run --frozen ruff format --check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`
- Read-only SIM DB check: 86 of 152 TORGHUT_SIM fill lifecycle events currently have exactly one execution plus trade-decision match, with 0 ambiguous matches.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
