### PR TITLE
chore(symphony): promote image cae13b67

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-31T07:07:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-31T08:27:57Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "b6729e5b"
-    digest: sha256:29d8b1b330ac5d0ad7a3efba5bfbd0e26a30e1ae1c0ac582ed8bcd6e5c39f8c6
+    newTag: "cae13b67"
+    digest: sha256:bf2cba0ab474779f22ee86a7b34b1092910c8ebc03beca372f0bd59b8e2b4a4e

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-31T07:07:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-31T08:27:57Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -25,5 +25,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "b6729e5b"
-    digest: sha256:29d8b1b330ac5d0ad7a3efba5bfbd0e26a30e1ae1c0ac582ed8bcd6e5c39f8c6
+    newTag: "cae13b67"
+    digest: sha256:bf2cba0ab474779f22ee86a7b34b1092910c8ebc03beca372f0bd59b8e2b4a4e

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-05-31T07:07:00Z"
+        kubectl.kubernetes.io/restartedAt: "2026-05-31T08:27:57Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -18,5 +18,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "b6729e5b"
-    digest: sha256:29d8b1b330ac5d0ad7a3efba5bfbd0e26a30e1ae1c0ac582ed8bcd6e5c39f8c6
+    newTag: "cae13b67"
+    digest: sha256:bf2cba0ab474779f22ee86a7b34b1092910c8ebc03beca372f0bd59b8e2b4a4e


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `cae13b67afa452a030fd660e94edb3279f9c2e7d`
- Image tag: `cae13b67`
- Image digest: `sha256:bf2cba0ab474779f22ee86a7b34b1092910c8ebc03beca372f0bd59b8e2b4a4e`