### PR TITLE
fix(olden): restore source note contrast

### DIFF
--- a/apps/olden/src/components/wiki/__tests__/content-integrity.test.ts
+++ b/apps/olden/src/components/wiki/__tests__/content-integrity.test.ts
@@ -7,6 +7,7 @@ import { gameModes } from '@/src/data/olden/game-modes'
 import { referenceCategories } from '@/src/data/olden/reference'
 import { roadmapItems } from '@/src/data/olden/roadmap'
 import { sourceIds, wikiSources } from '@/src/data/olden/sources'
+import { sourceNoteClassNames } from '@/src/components/wiki/source-note'
 
 const contentRoot = join(import.meta.dir, '../../../../content/docs')
 
@@ -52,6 +53,23 @@ describe('Olden Era wiki data', () => {
     for (const source of wikiSources) {
       expect(source.url).toMatch(/^https:\/\//)
       expect(source.retrievedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    }
+  })
+})
+
+describe('Olden Era wiki components', () => {
+  it('uses theme-aware source note colors instead of dark-mode-only overrides', () => {
+    expect(sourceNoteClassNames.aside).toContain('border-fd-border')
+    expect(sourceNoteClassNames.aside).toContain('bg-fd-card')
+    expect(sourceNoteClassNames.title).toContain('text-fd-foreground')
+    expect(sourceNoteClassNames.link).toContain('text-fd-foreground')
+    expect(sourceNoteClassNames.meta).toContain('text-fd-muted-foreground')
+
+    for (const className of Object.values(sourceNoteClassNames)) {
+      expect(className).not.toContain('dark:')
+      expect(className).not.toContain('bg-zinc-50')
+      expect(className).not.toContain('text-zinc-900')
+      expect(className).not.toContain('text-zinc-950')
     }
   })
 })

--- a/apps/olden/src/components/wiki/source-note.tsx
+++ b/apps/olden/src/components/wiki/source-note.tsx
@@ -4,19 +4,27 @@ type SourceNoteProps = {
   ids: string[]
 }
 
+export const sourceNoteClassNames = {
+  aside: 'not-prose rounded-lg border border-fd-border bg-fd-card p-4 text-sm text-fd-muted-foreground shadow-sm',
+  title: 'text-sm font-semibold text-fd-foreground',
+  list: 'mt-2 space-y-2',
+  link: 'font-medium text-fd-foreground underline decoration-fd-muted-foreground underline-offset-2 transition hover:text-fd-primary hover:decoration-fd-primary',
+  meta: 'text-fd-muted-foreground',
+} as const
+
 export function SourceNote({ ids }: SourceNoteProps) {
   const sources = wikiSources.filter((source) => ids.includes(source.id))
 
   return (
-    <aside className="not-prose rounded-lg border border-zinc-200 bg-zinc-50 p-4 text-sm dark:border-zinc-800 dark:bg-zinc-950">
-      <h2 className="text-sm font-semibold text-zinc-950 dark:text-zinc-50">Sources</h2>
-      <ul className="mt-2 space-y-2">
+    <aside className={sourceNoteClassNames.aside}>
+      <h2 className={sourceNoteClassNames.title}>Sources</h2>
+      <ul className={sourceNoteClassNames.list}>
         {sources.map((source) => (
           <li key={source.id}>
-            <a className="font-medium text-zinc-900 underline dark:text-zinc-100" href={source.url}>
+            <a className={sourceNoteClassNames.link} href={source.url}>
               {source.title}
             </a>
-            <span className="text-zinc-600 dark:text-zinc-400"> - retrieved {source.retrievedAt}</span>
+            <span className={sourceNoteClassNames.meta}> - retrieved {source.retrievedAt}</span>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary

- Replaces the Olden wiki source-note card colors with Fumadocs theme tokens so it stays readable in dark rendering.
- Exposes the source-note class set for regression coverage.
- Adds a focused content-integrity test that blocks the previous `dark:`/light-card class regression.

## Related Issues

None

## Testing

- `bun run test:olden`
- `bun run lint:olden`
- `bun run --cwd apps/olden lint:oxlint`
- `bun run --cwd apps/olden lint:oxlint:type`
- `bun run build:olden`
- Local rendered check at `http://localhost:3022/docs/getting-started` with dark color scheme; source-note computed colors were `rgb(25, 25, 25)` background, `rgb(235, 235, 235)` title/link, and `rgba(179, 179, 179, 0.8)` metadata.

## Screenshots (if applicable)

Local screenshot captured at `/tmp/olden-source-card-local-after-rebase.png`; the source card is dark with readable source links and retrieval dates.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
