### PR TITLE
feat(torghut): expand hpairs replay-guided search

### DIFF
--- a/services/torghut/app/trading/discovery/candidate_specs.py
+++ b/services/torghut/app/trading/discovery/candidate_specs.py
@@ -2511,6 +2511,69 @@ _PORTFOLIO_ORACLE_COVERAGE_EXECUTION_PROFILES: dict[str, tuple[dict[str, Any], .
     ),
 }
 
+_H_PAIRS_REPLAY_LEDGER_BREADTH_EXECUTION_PROFILES: tuple[dict[str, Any], ...] = (
+    {
+        "universe_symbols": list(_PORTFOLIO_COVERAGE_UNIVERSE_PROFILE),
+        "normalization_regime": "market_neutral_gross_scaled",
+        "max_position_pct_equity": "1.0",
+        "max_notional_per_trade": "30000",
+        "params": {
+            "entry_minute_after_open": "45",
+            "exit_minute_after_open": "close",
+            "signal_motif": "replay_ledger_notional_breadth_continuation",
+            "rank_feature": "cross_section_session_open_rank",
+            "selection_mode": "continuation",
+            "top_n": "4",
+            "min_cross_section_continuation_rank": "0.48",
+            "max_pair_legs": "5",
+            "max_entries_per_session": "8",
+            "max_concurrent_positions": "4",
+            "entry_cooldown_seconds": "240",
+            "entry_notional_max_multiplier": "1.0",
+            "long_stop_loss_bps": "4",
+            "long_trailing_stop_activation_profit_bps": "4",
+            "long_trailing_stop_drawdown_bps": "2",
+            "max_hold_seconds": "3600",
+            "max_session_negative_exit_bps": "3",
+            "max_stop_loss_exits_per_session": "1",
+            "stop_loss_lockout_seconds": "1200",
+            "replay_ledger_guidance_profile": "hpairs_notional_breadth_v1",
+            "replay_ledger_guidance_scope": "bounded_exact_replay_prefilter",
+        },
+    },
+    {
+        "universe_symbols": list(_PORTFOLIO_COVERAGE_UNIVERSE_PROFILE),
+        "normalization_regime": "market_neutral_gross_scaled",
+        "max_position_pct_equity": "0.8",
+        "max_notional_per_trade": "25000",
+        "params": {
+            "entry_minute_after_open": "30",
+            "entry_window_minutes": "40",
+            "exit_minute_after_open": "150",
+            "signal_motif": "replay_ledger_pair_breadth_reversal",
+            "rank_feature": "cross_section_session_open_rank",
+            "selection_mode": "reversal",
+            "top_n": "5",
+            "max_cross_section_continuation_rank": "0.52",
+            "min_cross_section_reversal_rank": "0.56",
+            "max_pair_legs": "5",
+            "max_entries_per_session": "6",
+            "max_concurrent_positions": "4",
+            "entry_cooldown_seconds": "300",
+            "entry_notional_max_multiplier": "0.9",
+            "long_stop_loss_bps": "4",
+            "long_trailing_stop_activation_profit_bps": "4",
+            "long_trailing_stop_drawdown_bps": "2",
+            "max_hold_seconds": "2700",
+            "max_session_negative_exit_bps": "3",
+            "max_stop_loss_exits_per_session": "1",
+            "stop_loss_lockout_seconds": "1200",
+            "replay_ledger_guidance_profile": "hpairs_pair_breadth_reversal_v1",
+            "replay_ledger_guidance_scope": "bounded_exact_replay_prefilter",
+        },
+    },
+)
+
 
 def _stable_hash(payload: Mapping[str, Any]) -> str:
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
@@ -2775,13 +2838,28 @@ def _notional_throughput_feedback_escape_profile(
         max(1, min(2, _profile_rank_count_floor(next_profile)))
     )
     if "max_pair_legs" in params:
-        params["max_pair_legs"] = str(
-            max(1, min(2, _int_profile_param(params, "max_pair_legs", default=2)))
-        )
+        current_pair_legs = _int_profile_param(params, "max_pair_legs", default=2)
+        if "top_n" in params:
+            params["max_pair_legs"] = str(max(3, min(5, current_pair_legs + 2)))
+            params["max_concurrent_positions"] = str(
+                max(
+                    2,
+                    min(
+                        4,
+                        max(
+                            _int_profile_param(
+                                params, "max_concurrent_positions", default=1
+                            ),
+                            current_pair_legs,
+                        ),
+                    ),
+                )
+            )
+        else:
+            params["max_pair_legs"] = str(max(1, min(2, current_pair_legs)))
     if "top_n" in params:
-        params["top_n"] = str(
-            max(1, min(2, _int_profile_param(params, "top_n", default=2)))
-        )
+        current_top_n = _int_profile_param(params, "top_n", default=2)
+        params["top_n"] = str(max(3, min(5, current_top_n + 2)))
     current_cooldown = _int_profile_param(params, "entry_cooldown_seconds", default=300)
     params["entry_cooldown_seconds"] = str(max(90, min(300, current_cooldown)))
     current_hold_seconds = _int_profile_param(params, "max_hold_seconds", default=900)
@@ -5495,6 +5573,11 @@ def _execution_profiles_for_target(
     portfolio_profiles = _PORTFOLIO_ORACLE_COVERAGE_EXECUTION_PROFILES.get(
         family_template_id, ()
     )
+    h_pairs_replay_ledger_breadth_profiles = (
+        _H_PAIRS_REPLAY_LEDGER_BREADTH_EXECUTION_PROFILES
+        if family_template_id == "microbar_cross_sectional_pairs_v1"
+        else ()
+    )
     rejected_signal_rescue_profiles = (
         _REJECTED_SIGNAL_FALSE_NEGATIVE_RESCUE_EXECUTION_PROFILES.get(
             family_template_id, ()
@@ -5506,6 +5589,7 @@ def _execution_profiles_for_target(
         *rejected_signal_rescue_profiles,
         *base_profiles,
         *portfolio_profiles,
+        *h_pairs_replay_ledger_breadth_profiles,
     )
     capital_constrained_profiles = _capital_constrained_execution_profiles(
         exploratory_profiles
@@ -5774,6 +5858,25 @@ def compile_candidate_specs(
                     hard_vetoes=hard_vetoes,
                     promotion_contract=promotion_contract,
                 )
+                replay_guidance_profile = _string(
+                    _mapping(strategy_overrides.get("params")).get(
+                        "replay_ledger_guidance_profile"
+                    )
+                )
+                if replay_guidance_profile:
+                    parameter_space.update(
+                        {
+                            "replay_ledger_guided_candidate_expansion": True,
+                            "replay_ledger_guidance_profile": replay_guidance_profile,
+                        }
+                    )
+                    promotion_contract.update(
+                        {
+                            "requires_runtime_ledger_profit_proof": True,
+                            "requires_source_backed_runtime_ledger": True,
+                            "replay_ledger_guided_search_is_not_promotion_proof": True,
+                        }
+                    )
                 base_payload = {
                     "hypothesis_id": card.hypothesis_id,
                     "family_template_id": family_template_id,

--- a/services/torghut/app/trading/discovery/replay_ledger_guided_search.py
+++ b/services/torghut/app/trading/discovery/replay_ledger_guided_search.py
@@ -260,7 +260,52 @@ def _expand_breadth_parameters(
         )
     if changed:
         payload["parameters"] = parameters
+    if _is_microbar_pairs_sweep(payload):
+        changed |= _ensure_microbar_pair_breadth_grid(
+            parameters=parameters,
+            factor=factor,
+            parameter_changes=parameter_changes,
+        )
+        if changed:
+            payload["parameters"] = parameters
     return changed
+
+
+def _is_microbar_pairs_sweep(payload: Mapping[str, Any]) -> bool:
+    return (
+        _string(payload.get("family_template_id"))
+        == "microbar_cross_sectional_pairs_v1"
+    )
+
+
+def _ensure_microbar_pair_breadth_grid(
+    *,
+    parameters: dict[str, Any],
+    factor: int,
+    parameter_changes: list[dict[str, str]],
+) -> bool:
+    if "max_pair_legs" in parameters:
+        return False
+    seed_values = (
+        _positive_decimal_grid_values(parameters.get("top_n"))
+        or _positive_decimal_grid_values(parameters.get("max_entries_per_session"))
+        or (Decimal("2"),)
+    )
+    seed = max(2, _ceil_to_int(max(seed_values)))
+    values = _expanded_positive_int_grid(
+        [str(seed)], factor=factor, maximum=_MAX_ENTRY_COUNT
+    )
+    if not values:
+        return False
+    parameters["max_pair_legs"] = values
+    parameter_changes.append(
+        {
+            "key": "parameters.max_pair_legs",
+            "before": "",
+            "after": ",".join(values),
+        }
+    )
+    return True
 
 
 def _expanded_positive_int_grid(

--- a/services/torghut/scripts/run_strategy_factory_v2.py
+++ b/services/torghut/scripts/run_strategy_factory_v2.py
@@ -7,7 +7,7 @@ import argparse
 import json
 import os
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from decimal import Decimal, ROUND_CEILING
 from pathlib import Path
@@ -26,6 +26,9 @@ from app.trading.discovery.family_templates import (
 )
 from app.trading.discovery.promotion_contract import (
     blocked_research_candidate_promotion_readiness,
+)
+from app.trading.discovery.replay_ledger_guided_search import (
+    apply_replay_ledger_remediation_guidance,
 )
 from scripts.search_consistent_profitability_frontier import (
     run_consistent_profitability_frontier,
@@ -488,6 +491,33 @@ def _compile_sweep_config(
     )
 
 
+def _replay_ledger_remediation_report(
+    experiment_payload: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    for key in (
+        "exact_replay_ledger_remediation",
+        "replay_ledger_remediation",
+        "remediation_report",
+    ):
+        report = _mapping(experiment_payload.get(key))
+        if report:
+            return report
+    return None
+
+
+def _apply_replay_ledger_guidance_to_compiled_sweep(
+    compiled: CompiledExperimentSweep,
+) -> CompiledExperimentSweep:
+    remediation_report = _replay_ledger_remediation_report(compiled.experiment_payload)
+    guided_sweep = apply_replay_ledger_remediation_guidance(
+        sweep_config=compiled.sweep_config,
+        remediation_report=remediation_report,
+    )
+    if not guided_sweep.applied:
+        return compiled
+    return replace(compiled, sweep_config=guided_sweep.sweep_config)
+
+
 def _frontier_args(
     *,
     args: argparse.Namespace,
@@ -778,6 +808,7 @@ def run_strategy_factory_v2_from_specs(
             train_days=max(1, int(args.train_days)),
             holdout_days=max(1, int(args.holdout_days)),
         )
+        compiled = _apply_replay_ledger_guidance_to_compiled_sweep(compiled)
         experiment_root = args.output_dir / compiled.experiment_id
         experiment_root.mkdir(parents=True, exist_ok=True)
         compiled_sweep_path = experiment_root / "compiled-sweep.yaml"
@@ -840,6 +871,11 @@ def run_strategy_factory_v2_from_specs(
             family_template_id=compiled.family_template.family_id,
             runtime_harness=compiled.family_template.runtime_harness,
         )
+        replay_guidance = _mapping(
+            _mapping(compiled.sweep_config.get("metadata")).get(
+                "replay_ledger_guided_search"
+            )
+        )
         results.append(
             {
                 "source_run_id": compiled.source_run_id,
@@ -866,6 +902,9 @@ def run_strategy_factory_v2_from_specs(
                     )
                     if top_candidates
                     else ""
+                ),
+                "replay_ledger_guided_actions": _list_of_strings(
+                    replay_guidance.get("applied_actions")
                 ),
                 "promotion_readiness": promotion_readiness,
                 "persistence_status": dict(persistence_status)

--- a/services/torghut/tests/test_candidate_specs.py
+++ b/services/torghut/tests/test_candidate_specs.py
@@ -2257,12 +2257,66 @@ class TestCandidateSpecs(TestCase):
                     candidate_spec_capital_features(spec)["capital_feasible_flag"], 1.0
                 )
 
+    def test_portfolio_profit_target_adds_h_pairs_replay_ledger_breadth_profiles(
+        self,
+    ) -> None:
+        cards = build_hypothesis_cards(
+            source_run_id="paper-hpairs-ledger-breadth",
+            claims=[
+                {
+                    "claim_id": "claim-hpairs-breadth",
+                    "claim_type": "signal_mechanism",
+                    "claim_text": (
+                        "Cross-sectional pair ranking over intraday order-flow and "
+                        "opening-window signals can improve H-PAIRS notional throughput."
+                    ),
+                    "confidence": "0.86",
+                }
+            ],
+        )
+
+        specs = compile_candidate_specs(
+            hypothesis_cards=cards, target_net_pnl_per_day=Decimal("500")
+        )
+
+        replay_guided_specs = [
+            spec
+            for spec in specs
+            if spec.family_template_id == "microbar_cross_sectional_pairs_v1"
+            and spec.parameter_space.get("replay_ledger_guided_candidate_expansion")
+            and not spec.strategy_overrides["params"].get(
+                "feedback_remediation_profile"
+            )
+        ]
+        self.assertGreaterEqual(len(replay_guided_specs), 2)
+        for spec in replay_guided_specs:
+            params = spec.strategy_overrides["params"]
+            self.assertGreaterEqual(int(params["top_n"]), 4)
+            self.assertGreaterEqual(int(params["max_pair_legs"]), 5)
+            self.assertGreaterEqual(int(params["max_entries_per_session"]), 6)
+            self.assertEqual(
+                params["replay_ledger_guidance_scope"],
+                "bounded_exact_replay_prefilter",
+            )
+            self.assertEqual(
+                spec.promotion_contract["promotion_policy"], "research_only"
+            )
+            self.assertTrue(
+                spec.promotion_contract["requires_runtime_ledger_profit_proof"]
+            )
+            self.assertTrue(
+                spec.promotion_contract[
+                    "replay_ledger_guided_search_is_not_promotion_proof"
+                ]
+            )
+
     def test_feedback_escape_profiles_dedupe_and_fallback_invalid_params(self) -> None:
         profile = {
             "params": {
                 "entry_minute_after_open": "not-a-decimal",
                 "exit_minute_after_open": "invalid",
                 "top_n": "2",
+                "max_pair_legs": "2",
                 "gate_feature": "cross_section_positive_opening_window_return_from_prev_close_ratio",
                 "gate_min": "0.20",
                 "gate_max": "0.80",
@@ -2299,6 +2353,8 @@ class TestCandidateSpecs(TestCase):
             int(notional["params"]["max_entries_per_session"]),
             10,
         )
+        self.assertGreaterEqual(int(notional["params"]["top_n"]), 4)
+        self.assertGreaterEqual(int(notional["params"]["max_pair_legs"]), 4)
         self.assertEqual(notional["params"]["entry_notional_max_multiplier"], "1.0")
         adverse_selection = expanded[4]
         self.assertEqual(

--- a/services/torghut/tests/test_replay_ledger_guided_search.py
+++ b/services/torghut/tests/test_replay_ledger_guided_search.py
@@ -144,3 +144,45 @@ class TestReplayLedgerGuidedSearch(TestCase):
                 }
             ],
         )
+
+    def test_microbar_notional_blocker_adds_pair_breadth_when_missing(self) -> None:
+        result = apply_replay_ledger_remediation_guidance(
+            sweep_config={
+                "schema_version": "torghut.replay-frontier-sweep.v1",
+                "family_template_id": "microbar_cross_sectional_pairs_v1",
+                "parameters": {
+                    "top_n": ["1"],
+                    "max_entries_per_session": ["1"],
+                },
+            },
+            remediation_report={
+                "status": "blocked_pending_search_remediation",
+                "candidate_id": "hpairs-candidate",
+                "promotion_blockers": ["avg_filled_notional_per_day_below_min"],
+                "runtime_ledger_blockers": [],
+                "recommended_search_actions": [
+                    {
+                        "action": "increase_tradeable_pair_breadth",
+                        "required_multiplier": "2.0",
+                    }
+                ],
+            },
+        )
+
+        self.assertTrue(result.applied)
+        self.assertEqual(result.sweep_config["parameters"]["top_n"], ["1", "2"])
+        self.assertEqual(
+            result.sweep_config["parameters"]["max_entries_per_session"],
+            ["1", "2"],
+        )
+        self.assertEqual(result.sweep_config["parameters"]["max_pair_legs"], ["2", "4"])
+        self.assertIn(
+            {
+                "key": "parameters.max_pair_legs",
+                "before": "",
+                "after": "2,4",
+            },
+            result.sweep_config["metadata"]["replay_ledger_guided_search"][
+                "parameter_changes"
+            ],
+        )

--- a/services/torghut/tests/test_run_strategy_factory_v2.py
+++ b/services/torghut/tests/test_run_strategy_factory_v2.py
@@ -875,6 +875,83 @@ class TestRunStrategyFactoryV2(TestCase):
             result["persistence_failures"][0]["candidate_spec_id"], "exp-breakout-1"
         )
 
+    def test_run_strategy_factory_v2_applies_replay_ledger_guidance_before_frontier(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            strategy_configmap = self._write_strategy_configmap(root)
+            family_template_dir = self._write_family_template(root)
+            seed_sweep_dir = self._write_seed_sweep(root)
+            output_dir = root / "artifacts"
+            output_dir.mkdir()
+
+            experiment_row = runner.InMemoryExperimentSpec(
+                run_id="paper-run-1",
+                experiment_id="exp-breakout-guided",
+                payload_json={
+                    "family_template_id": "breakout_reclaim_v2",
+                    "selection_objectives": {"target_net_pnl_per_day": "500"},
+                    "template_overrides": {"params": {"max_entries_per_session": "1"}},
+                    "exact_replay_ledger_remediation": {
+                        "status": "blocked_pending_search_remediation",
+                        "candidate_id": "cand-replay-blocked",
+                        "promotion_blockers": ["avg_filled_notional_per_day_below_min"],
+                        "runtime_ledger_blockers": [],
+                        "recommended_search_actions": [{"required_multiplier": "2.0"}],
+                    },
+                },
+            )
+
+            observed_sweep_configs: list[dict[str, object]] = []
+
+            def fake_frontier(args: Namespace) -> dict[str, object]:
+                observed_sweep_configs.append(
+                    yaml.safe_load(Path(args.sweep_config).read_text(encoding="utf-8"))
+                )
+                return {
+                    "candidate_count": 2,
+                    "dataset_snapshot_receipt": {"snapshot_id": "snap-guided"},
+                    "top": [
+                        {
+                            "candidate_id": "cand-guided",
+                            "full_window": {"net_per_day": "501"},
+                        }
+                    ],
+                }
+
+            with patch(
+                "scripts.run_strategy_factory_v2.run_consistent_profitability_frontier",
+                side_effect=fake_frontier,
+            ):
+                result = runner.run_strategy_factory_v2_from_specs(
+                    Namespace(
+                        **{
+                            **vars(
+                                self._args(
+                                    output_dir=output_dir,
+                                    strategy_configmap=strategy_configmap,
+                                    family_template_dir=family_template_dir,
+                                    seed_sweep_dir=seed_sweep_dir,
+                                )
+                            ),
+                            "persist_results": False,
+                        }
+                    ),
+                    source_specs=[experiment_row],
+                )
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(
+            result["experiments"][0]["replay_ledger_guided_actions"], ["breadth"]
+        )
+        compiled = observed_sweep_configs[0]
+        self.assertEqual(compiled["parameters"]["max_entries_per_session"], ["1", "2"])
+        self.assertEqual(
+            compiled["metadata"]["replay_ledger_guided_search"]["source_candidate_id"],
+            "cand-replay-blocked",
+        )
+
     def test_run_strategy_factory_v2_respects_global_candidate_budget(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Summary

- Adds bounded H-PAIRS replay-ledger breadth profiles for `$500/day` research candidates, with explicit source-backed runtime-ledger proof requirements kept in the promotion contract.
- Stops notional-throughput feedback expansion from clamping microbar pair breadth to two legs while preserving 1x cash/exposure feasibility.
- Applies exact replay-ledger remediation guidance inside strategy factory v2 before frontier replay so blocked candidates can drive the next bounded sweep.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen ruff check app/trading/discovery/candidate_specs.py app/trading/discovery/replay_ledger_guided_search.py scripts/run_strategy_factory_v2.py tests/test_candidate_specs.py tests/test_replay_ledger_guided_search.py tests/test_run_strategy_factory_v2.py`
- `cd services/torghut && git diff --check`
- `cd services/torghut && uv run --frozen pytest tests/test_candidate_specs.py tests/test_replay_ledger_guided_search.py tests/test_run_strategy_factory_v2.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
