### PR TITLE
fix(olden): compact source note card

### DIFF
--- a/apps/olden/src/components/wiki/source-note.tsx
+++ b/apps/olden/src/components/wiki/source-note.tsx
@@ -5,9 +5,9 @@ type SourceNoteProps = {
 }
 
 export const sourceNoteClassNames = {
-  aside: 'not-prose rounded-lg border border-fd-border bg-fd-card p-4 text-sm text-fd-muted-foreground shadow-sm',
-  title: 'text-sm font-semibold text-fd-foreground',
-  list: 'mt-2 space-y-2',
+  aside: 'not-prose rounded-lg border border-fd-border bg-fd-card p-3 text-sm text-fd-muted-foreground',
+  title: 'mb-2 text-xs font-semibold text-fd-foreground',
+  list: 'space-y-1.5',
   link: 'font-medium text-fd-foreground underline decoration-fd-muted-foreground underline-offset-2 transition hover:text-fd-primary hover:decoration-fd-primary',
   meta: 'text-fd-muted-foreground',
 } as const
@@ -16,8 +16,8 @@ export function SourceNote({ ids }: SourceNoteProps) {
   const sources = wikiSources.filter((source) => ids.includes(source.id))
 
   return (
-    <aside className={sourceNoteClassNames.aside}>
-      <h2 className={sourceNoteClassNames.title}>Sources</h2>
+    <aside className={sourceNoteClassNames.aside} aria-label="Sources">
+      <p className={sourceNoteClassNames.title}>Sources</p>
       <ul className={sourceNoteClassNames.list}>
         {sources.map((source) => (
           <li key={source.id}>


### PR DESCRIPTION
## Summary

- Compacts the Olden source-note block so it no longer appears as an oversized card below short pages.
- Replaces the internal `h2` with an accessible labeled paragraph to avoid prose heading styles stretching the block.
- Keeps source links on Fumadocs theme tokens for readable light and dark mode contrast.

## Related Issues

None

## Testing

- `bun run test:olden`
- `bun run lint:olden`
- `bun run --cwd apps/olden lint:oxlint`
- `bun run --cwd apps/olden lint:oxlint:type`
- `bun run build:olden`
- Rendered `http://localhost:3022/docs/getting-started` in Playwright dark mode and verified the source note computed as `rgb(25, 25, 25)` background with `rgb(235, 235, 235)` title/link text.
- Rendered the same page at `390x844` and verified the source note stayed within the viewport with wrapping source links.

## Screenshots (if applicable)

Rendered locally in Playwright; no image artifact committed.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
