### PR TITLE
fix(olden): keep one ready pod during rollout

### DIFF
--- a/argocd/applications/olden/deployment.yaml
+++ b/argocd/applications/olden/deployment.yaml
@@ -7,8 +7,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: olden
@@ -19,9 +19,18 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/arch: arm64
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: olden
           image: registry.ide-newton.ts.net/lab/olden
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
           resources:
             limits:
               cpu: "1"

--- a/argocd/applications/olden/kustomization.yaml
+++ b/argocd/applications/olden/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
   - service.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/olden
-    newTag: 0.582.0
+    newTag: 0.581.1
     newName: registry.ide-newton.ts.net/lab/olden


### PR DESCRIPTION
## Summary

- Rolls Olden GitOps desired image back to `0.581.1` while the private registry is returning `502` for image manifests.
- Changes the Olden deployment rolling strategy to keep the current pod available while a new image pulls.
- Adds restricted-compatible pod/container security context for future Olden pods.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/olden`
- `bun run lint:argocd`
- Emergency validation: created temporary `olden-emergency-05811` pod pinned to the cached `0.581.1` image on `talos-192-168-1-85`; `https://olden.proompteng.ai/docs/getting-started` returned HTTP 200.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
