### PR TITLE
revert(jangar): restore cached image during registry outage

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-31T10:00:40Z
+    deploy.knative.dev/rollout: 2026-05-31T08:30:36Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: f2752a9a58b9863e1d89e223f2095adb97694e13
+              value: cae13b67afa452a030fd660e94edb3279f9c2e7d
             - name: JANGAR_GITOPS_REVISION
-              value: f2752a9a58b9863e1d89e223f2095adb97694e13
+              value: cae13b67afa452a030fd660e94edb3279f9c2e7d
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -357,15 +357,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_SEMANTIC_CANDIDATE_LIMIT
               value: "100"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26709537594"
+              value: "26707664123"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:39ad99129cb1c433d32fda2ca5d34114457818ffb79001f2b982116007c2688b
+              value: sha256:7d523b3160e48afed66ad7bbc044ac3b3a4082d9872a437951432476e3317a01
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: f2752a9a58b9863e1d89e223f2095adb97694e13
+              value: cae13b67afa452a030fd660e94edb3279f9c2e7d
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:39ad99129cb1c433d32fda2ca5d34114457818ffb79001f2b982116007c2688b
+              value: sha256:7d523b3160e48afed66ad7bbc044ac3b3a4082d9872a437951432476e3317a01
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: f2752a9a
-    digest: sha256:39ad99129cb1c433d32fda2ca5d34114457818ffb79001f2b982116007c2688b
+    newTag: cae13b67
+    digest: sha256:7d523b3160e48afed66ad7bbc044ac3b3a4082d9872a437951432476e3317a01


### PR DESCRIPTION
## Summary

- Reverts the Jangar image promotion from `f2752a9a` back to the previously healthy `cae13b67` image.
- Keeps the production source-search candidate cap env from the prior revision.
- Restores service while the private registry is returning 502 during registry GC.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/jangar --enable-helm >/dev/null`
- `git diff --check`
- Live rollout failure observed before rollback: new pod `jangar-8549666d78-n76fd` is `Init:ImagePullBackOff` because registry `HEAD /v2/lab/jangar/manifests/sha256:39ad...` returns `502 Bad Gateway`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
