### PR TITLE
fix(olden): set numeric runtime user

### DIFF
--- a/argocd/applications/olden/deployment.yaml
+++ b/argocd/applications/olden/deployment.yaml
@@ -31,6 +31,8 @@ spec:
               drop:
                 - ALL
             runAsNonRoot: true
+            runAsGroup: 1001
+            runAsUser: 1001
           resources:
             limits:
               cpu: "1"


### PR DESCRIPTION
## Summary

- Adds numeric `runAsUser` and `runAsGroup` values for Olden's restricted container security context.
- Matches the `nextjs` runtime user created in the Olden Docker image.
- Prevents `CreateContainerConfigError` during the managed `0.581.1` rollback rollout.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/olden`
- `bun run lint:argocd`
- Live emergency validation: patched `deployment/olden` with the same UID/GID values and verified `deployment/olden` rolled out successfully at `1/1` ready.
- Live URL validation: `https://olden.proompteng.ai/docs/getting-started` returned HTTP 200 after emergency pod removal.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
