### PR TITLE
fix(jangar): avoid registry pulls for cached app image

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -50,7 +50,7 @@ spec:
       containers:
         - name: app
           image: registry.ide-newton.ts.net/lab/jangar:640cb586@sha256:78913053b4bd222d01d2351eb19136edfda3fa4cb8253541b4ac0736f092ac26
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: NODE_ENV
               value: production


### PR DESCRIPTION
## Summary

- Changes the Jangar app container image pull policy from `Always` to `IfNotPresent`.
- Keeps Jangar able to restart from the node-cached image during private registry GC/outage windows.
- Matches the existing bootstrap and Docker sidecar pull policy behavior.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/jangar --enable-helm >/dev/null`
- `git diff --check`
- Live failure prompting this patch: registry is returning `502 Bad Gateway` for `registry.ide-newton.ts.net/v2/lab/jangar/manifests/*`, and Jangar app container stayed in `ImagePullBackOff` with `imagePullPolicy: Always`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
