### PR TITLE
fix(torghut): repair source-linked H-PAIRS evidence plumbing

### DIFF
--- a/services/torghut/app/trading/features.py
+++ b/services/torghut/app/trading/features.py
@@ -71,6 +71,10 @@ FEATURE_VECTOR_V3_VALUE_FIELDS = (
     'recent_above_vwap_w5m_ratio',
     'recent_15m_return_bps',
     'microbar_volume',
+    'clusterlob_directional_ofi',
+    'clusterlob_opportunistic_ofi',
+    'clusterlob_market_making_ofi',
+    'clusterlob_event_cluster_stability_score',
     'cross_section_session_open_rank',
     'cross_section_session_open_rank_universe_size',
     'cross_section_prev_session_close_rank',
@@ -93,6 +97,8 @@ FEATURE_VECTOR_V3_VALUE_FIELDS = (
     'cross_section_recent_15m_return_rank_universe_size',
     'cross_section_microbar_volume_rank',
     'cross_section_microbar_volume_rank_universe_size',
+    'cross_section_clusterlob_directional_ofi_rank',
+    'cross_section_clusterlob_directional_ofi_rank_universe_size',
     'cross_section_recent_imbalance_rank',
     'cross_section_recent_imbalance_rank_universe_size',
     'cross_section_rsi14_rank',
@@ -442,6 +448,12 @@ def map_feature_values_v3(signal: SignalEnvelope) -> dict[str, Any]:
         ),
         'recent_15m_return_bps': optional_decimal(payload.get('recent_15m_return_bps')),
         'microbar_volume': optional_decimal(payload.get('microbar_volume')),
+        'clusterlob_directional_ofi': optional_decimal(payload.get('clusterlob_directional_ofi')),
+        'clusterlob_opportunistic_ofi': optional_decimal(payload.get('clusterlob_opportunistic_ofi')),
+        'clusterlob_market_making_ofi': optional_decimal(payload.get('clusterlob_market_making_ofi')),
+        'clusterlob_event_cluster_stability_score': optional_decimal(
+            payload.get('clusterlob_event_cluster_stability_score')
+        ),
         'cross_section_session_open_rank': optional_decimal(payload.get('cross_section_session_open_rank')),
         'cross_section_session_open_rank_universe_size': optional_decimal(
             payload.get('cross_section_session_open_rank_universe_size')
@@ -499,6 +511,12 @@ def map_feature_values_v3(signal: SignalEnvelope) -> dict[str, Any]:
         ),
         'cross_section_microbar_volume_rank_universe_size': optional_decimal(
             payload.get('cross_section_microbar_volume_rank_universe_size')
+        ),
+        'cross_section_clusterlob_directional_ofi_rank': optional_decimal(
+            payload.get('cross_section_clusterlob_directional_ofi_rank')
+        ),
+        'cross_section_clusterlob_directional_ofi_rank_universe_size': optional_decimal(
+            payload.get('cross_section_clusterlob_directional_ofi_rank_universe_size')
         ),
         'cross_section_recent_imbalance_rank': optional_decimal(payload.get('cross_section_recent_imbalance_rank')),
         'cross_section_recent_imbalance_rank_universe_size': optional_decimal(

--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -941,6 +941,7 @@ def link_order_events_to_execution(session: Session, execution: Execution) -> in
             changed = True
         if not changed:
             continue
+        _ensure_source_window_for_event(session, event)
         session.add(event)
         _refresh_source_window_linkage_counts(session, event)
         latest_event = event
@@ -997,17 +998,35 @@ def backfill_order_feed_source_windows(
         "events_linked": 0,
     }
     for event in events:
-        source_window = _find_existing_source_window_for_event(session, event)
+        source_window, created = _ensure_source_window_for_event(session, event)
         if source_window is None:
-            source_window = _create_historical_source_window_for_event(session, event)
+            continue
+        if created:
             counters["source_windows_created"] += 1
         else:
             counters["source_windows_reused"] += 1
-        event.source_window_id = source_window.id
         session.add(event)
         _refresh_source_window_linkage_counts(session, event)
         counters["events_linked"] += 1
     return counters
+
+
+def _ensure_source_window_for_event(
+    session: Session,
+    event: ExecutionOrderEvent,
+) -> tuple[OrderFeedSourceWindow | None, bool]:
+    if event.source_window_id is not None:
+        source_window = session.get(OrderFeedSourceWindow, event.source_window_id)
+        return source_window, False
+    if event.source_partition is None or event.source_offset is None:
+        return None, False
+    source_window = _find_existing_source_window_for_event(session, event)
+    created = False
+    if source_window is None:
+        source_window = _create_historical_source_window_for_event(session, event)
+        created = True
+    event.source_window_id = source_window.id
+    return source_window, created
 
 
 def _resolve_execution(

--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -218,6 +218,10 @@ def build_runtime_ledger_buckets(
             )
         return buckets
 
+    grouped_positions: dict[
+        tuple[str | None, ...],
+        dict[tuple[str | None, str | None, str | None], _PositionState],
+    ] = {}
     for bucket_start, bucket_end in normalized_ranges:
         bucket_rows = [
             row
@@ -236,6 +240,7 @@ def build_runtime_ledger_buckets(
                     rows=grouped_rows[key],
                     group_by=group_by,
                     group_key=key,
+                    carried_positions=grouped_positions.setdefault(key, {}),
                     require_order_lifecycle=require_order_lifecycle,
                 )
             )
@@ -425,7 +430,9 @@ def _order_lifecycle_blockers(
     if unfilled_order_count > 0:
         blockers.append("unfilled_order_present")
 
-    if not usable_fills or any(row.execution_policy_hash is None for row in usable_fills):
+    if not usable_fills or any(
+        row.execution_policy_hash is None for row in usable_fills
+    ):
         blockers.append("execution_policy_hash_missing")
     if not usable_fills or any(row.cost_model_hash is None for row in usable_fills):
         blockers.append("cost_model_hash_missing")

--- a/services/torghut/app/trading/session_context.py
+++ b/services/torghut/app/trading/session_context.py
@@ -257,6 +257,7 @@ class _SymbolSessionState:
     latest_price_position_in_session_range: Decimal | None = None
     latest_recent_15m_return_bps: Decimal | None = None
     latest_microbar_volume: Decimal | None = None
+    latest_clusterlob_directional_ofi: Decimal | None = None
     latest_price_vs_vwap_w5m_bps: Decimal | None = None
     latest_opening_window_return_bps: Decimal | None = None
     latest_opening_window_return_from_prev_close_bps: Decimal | None = None
@@ -351,6 +352,18 @@ class SessionContextTracker:
         microbar_volume = optional_decimal(payload_value(payload, "microbar_volume"))
         if microbar_volume is None:
             microbar_volume = optional_decimal(payload_value(payload, "volume"))
+        clusterlob_directional_ofi = optional_decimal(
+            payload_value(payload, "clusterlob_directional_ofi")
+        )
+        clusterlob_opportunistic_ofi = optional_decimal(
+            payload_value(payload, "clusterlob_opportunistic_ofi")
+        )
+        clusterlob_market_making_ofi = optional_decimal(
+            payload_value(payload, "clusterlob_market_making_ofi")
+        )
+        clusterlob_event_cluster_stability_score = optional_decimal(
+            payload_value(payload, "clusterlob_event_cluster_stability_score")
+        )
         vwap_w5m = optional_decimal(
             payload_value(payload, "vwap_w5m", block="vwap", nested_key="w5m")
         )
@@ -469,6 +482,7 @@ class SessionContextTracker:
             state.latest_price_position_in_session_range = position_in_range
             state.latest_recent_15m_return_bps = recent_15m_return_bps
             state.latest_microbar_volume = microbar_volume
+            state.latest_clusterlob_directional_ofi = clusterlob_directional_ofi
             state.latest_price_vs_vwap_w5m_bps = price_vs_vwap_w5m_bps
             state.latest_opening_window_return_bps = opening_window_return_bps
             state.latest_opening_window_return_from_prev_close_bps = (
@@ -525,6 +539,14 @@ class SessionContextTracker:
                 symbol=symbol,
                 accessor="latest_microbar_volume",
             )
+        )
+        (
+            clusterlob_directional_ofi_rank,
+            clusterlob_directional_ofi_rank_universe_size,
+        ) = self._rank_latest_metric(
+            current_day=session_day,
+            symbol=symbol,
+            accessor="latest_clusterlob_directional_ofi",
         )
         recent_imbalance_rank, recent_imbalance_rank_universe_size = (
             self._rank_latest_metric(
@@ -716,6 +738,7 @@ class SessionContextTracker:
                 effective_session_drive_rank,
                 effective_opening_window_return_rank,
                 recent_15m_return_rank,
+                clusterlob_directional_ofi_rank,
             ]
         )
         cross_section_pair_relative_return_rank_universe_size = _rank_universe_size(
@@ -723,6 +746,7 @@ class SessionContextTracker:
                 effective_session_drive_rank_universe_size,
                 effective_opening_window_return_rank_universe_size,
                 recent_15m_return_rank_universe_size,
+                clusterlob_directional_ofi_rank_universe_size,
             ]
         )
         cross_section_residual_spread_zscore_rank = _average_decimal(
@@ -777,6 +801,12 @@ class SessionContextTracker:
                 "recent_above_vwap_w5m_ratio": recent_above_vwap_w5m_ratio,
                 "recent_15m_return_bps": recent_15m_return_bps,
                 "microbar_volume": microbar_volume,
+                "clusterlob_directional_ofi": clusterlob_directional_ofi,
+                "clusterlob_opportunistic_ofi": clusterlob_opportunistic_ofi,
+                "clusterlob_market_making_ofi": clusterlob_market_making_ofi,
+                "clusterlob_event_cluster_stability_score": (
+                    clusterlob_event_cluster_stability_score
+                ),
                 "cross_section_session_open_rank": session_open_rank,
                 "cross_section_session_open_rank_universe_size": session_open_rank_universe_size,
                 "cross_section_prev_session_close_rank": prev_session_close_rank,
@@ -803,6 +833,12 @@ class SessionContextTracker:
                 "cross_section_recent_15m_return_rank_universe_size": recent_15m_return_rank_universe_size,
                 "cross_section_microbar_volume_rank": microbar_volume_rank,
                 "cross_section_microbar_volume_rank_universe_size": microbar_volume_rank_universe_size,
+                "cross_section_clusterlob_directional_ofi_rank": (
+                    clusterlob_directional_ofi_rank
+                ),
+                "cross_section_clusterlob_directional_ofi_rank_universe_size": (
+                    clusterlob_directional_ofi_rank_universe_size
+                ),
                 "cross_section_recent_imbalance_rank": recent_imbalance_rank,
                 "cross_section_recent_imbalance_rank_universe_size": recent_imbalance_rank_universe_size,
                 "cross_section_rsi14_rank": rsi14_rank,

--- a/services/torghut/config/trading/families/microbar_cross_sectional_pairs_v1.yaml
+++ b/services/torghut/config/trading/families/microbar_cross_sectional_pairs_v1.yaml
@@ -12,6 +12,8 @@ required_features:
   - cross_section_prev_session_close_rank
   - cross_section_opening_window_return_from_prev_close_rank
   - cross_section_positive_opening_window_return_from_prev_close_ratio
+  - clusterlob_directional_ofi
+  - cross_section_clusterlob_directional_ofi_rank
 allowed_normalizations:
   - market_neutral_gross_scaled
 entry_motifs:
@@ -28,6 +30,7 @@ risk_controls:
   - market_neutral_pairing
   - gross_notional_cap
   - transaction_cost_stress
+  - clusterlob_event_stream_prefilter
 activity_model:
   min_active_day_ratio: '1.0'
   min_daily_notional: '300000'

--- a/services/torghut/config/trading/profitability-frontier-consistent-microbar-cross-sectional-pairs.yaml
+++ b/services/torghut/config/trading/profitability-frontier-consistent-microbar-cross-sectional-pairs.yaml
@@ -46,10 +46,17 @@ parameters:
     - 'open_window_continuation'
     - 'factor_neutral_residual_continuation'
   rank_feature:
+    - 'cross_section_clusterlob_directional_ofi_rank'
     - 'cross_section_vwap_w5m_rank'
     - 'cross_section_session_open_rank'
     - 'cross_section_factor_neutral_residual_rank'
     - 'cross_section_pair_relative_return_rank'
+  gate_feature:
+    - ''
+    - 'clusterlob_event_cluster_stability_score'
+  gate_min:
+    - '0'
+    - '0.60'
   selection_mode:
     - 'continuation'
   top_n:

--- a/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
+++ b/services/torghut/config/trading/research-programs/portfolio-profit-autoresearch-500-v1.yaml
@@ -1001,6 +1001,18 @@ families:
     consistency_repair_iterations: 1
     consistency_repair_candidates: 2
     parameter_mutations:
+      rank_feature:
+        mode: explicit_values
+        values:
+          - 'cross_section_clusterlob_directional_ofi_rank'
+          - 'cross_section_pair_relative_return_rank'
+          - 'cross_section_vwap_w5m_rank'
+      gate_feature:
+        mode: explicit_values
+        values: ['', 'clusterlob_event_cluster_stability_score']
+      gate_min:
+        mode: explicit_values
+        values: ['0', '0.60']
       min_cross_section_continuation_rank:
         mode: numeric_step
         deltas: ['-0.05', '0', '0.05']

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -4063,7 +4063,7 @@ def _query_timestamps(
                 f"""
                 select
                     oe.id,
-                    coalesce(oe.trade_decision_id, e.trade_decision_id),
+                    coalesce(oe.trade_decision_id, e.trade_decision_id, d_by_client.id),
                     e.id,
                     coalesce(oe.event_ts, oe.created_at),
                     oe.symbol,
@@ -4115,8 +4115,22 @@ def _query_timestamps(
                     join executions matched on matched.id = exact_match.ids[1]
                     where exact_match.match_count = 1
                 ) e on true
+                left join lateral (
+                    select matched.*
+                    from (
+                        select
+                            array_agg(d_match.id order by d_match.created_at, d_match.id) as ids,
+                            count(*) as match_count
+                        from trade_decisions d_match
+                        where d_match.alpaca_account_label = oe.alpaca_account_label
+                          and nullif(oe.client_order_id, '') is not null
+                          and d_match.decision_hash = oe.client_order_id
+                    ) exact_decision_match
+                    join trade_decisions matched on matched.id = exact_decision_match.ids[1]
+                    where exact_decision_match.match_count = 1
+                ) d_by_client on true
                 join trade_decisions d
-                  on d.id = coalesce(oe.trade_decision_id, e.trade_decision_id)
+                  on d.id = coalesce(oe.trade_decision_id, e.trade_decision_id, d_by_client.id)
                 join strategies s on s.id = d.strategy_id
                 where s.name = any(%s)
                   and d.alpaca_account_label = %s
@@ -4182,7 +4196,7 @@ def _query_timestamps(
                     f"""
                     select
                         oe.id,
-                        coalesce(oe.trade_decision_id, e.trade_decision_id),
+                        coalesce(oe.trade_decision_id, e.trade_decision_id, d_by_client.id),
                         e.id,
                         coalesce(oe.event_ts, oe.created_at),
                         oe.symbol,
@@ -4234,12 +4248,26 @@ def _query_timestamps(
                         join executions matched on matched.id = exact_match.ids[1]
                         where exact_match.match_count = 1
                     ) e on true
+                    left join lateral (
+                        select matched.*
+                        from (
+                            select
+                                array_agg(d_match.id order by d_match.created_at, d_match.id) as ids,
+                                count(*) as match_count
+                            from trade_decisions d_match
+                            where d_match.alpaca_account_label = oe.alpaca_account_label
+                              and nullif(oe.client_order_id, '') is not null
+                              and d_match.decision_hash = oe.client_order_id
+                        ) exact_decision_match
+                        join trade_decisions matched on matched.id = exact_decision_match.ids[1]
+                        where exact_decision_match.match_count = 1
+                    ) d_by_client on true
                     where oe.alpaca_account_label = %s
                       and coalesce(oe.event_ts, oe.created_at) >= %s
                       and coalesce(oe.event_ts, oe.created_at) < %s
                       and (
                             e.id is null
-                            or coalesce(oe.trade_decision_id, e.trade_decision_id) is null
+                            or coalesce(oe.trade_decision_id, e.trade_decision_id, d_by_client.id) is null
                           )
                       and (
                             lower(coalesce(oe.event_type, oe.status, '')) in (

--- a/services/torghut/tests/test_feature_contract_v3.py
+++ b/services/torghut/tests/test_feature_contract_v3.py
@@ -207,6 +207,11 @@ class TestFeatureContractV3(TestCase):
                 'recent_microprice_bias_bps_avg': '0.85',
                 'recent_15m_return_bps': '54',
                 'microbar_volume': '18200',
+                'clusterlob_directional_ofi': '0.18',
+                'clusterlob_opportunistic_ofi': '0.04',
+                'clusterlob_market_making_ofi': '-0.02',
+                'clusterlob_event_cluster_stability_score': '0.74',
+                'cross_section_clusterlob_directional_ofi_rank': '0.82',
                 'cross_section_prev_session_close_rank': '0.91',
                 'cross_section_positive_session_open_ratio': '0.58',
                 'cross_section_positive_prev_session_close_ratio': '0.75',
@@ -248,6 +253,12 @@ class TestFeatureContractV3(TestCase):
         )
         self.assertEqual(fv.values['price_vs_opening_window_close_bps'], Decimal('29.73'))
         self.assertEqual(fv.values['recent_spread_bps_avg'], Decimal('0.75'))
+        self.assertEqual(fv.values['clusterlob_directional_ofi'], Decimal('0.18'))
+        self.assertEqual(fv.values['clusterlob_event_cluster_stability_score'], Decimal('0.74'))
+        self.assertEqual(
+            fv.values['cross_section_clusterlob_directional_ofi_rank'],
+            Decimal('0.82'),
+        )
         self.assertEqual(fv.values['recent_quote_invalid_ratio'], Decimal('0.04'))
         self.assertEqual(fv.values['recent_quote_jump_bps_max'], Decimal('18.2'))
         self.assertEqual(fv.values['recent_microprice_bias_bps_avg'], Decimal('0.85'))

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -4402,9 +4402,11 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIn("left join lateral", unlinked_query)
         self.assertIn("exact_match.match_count = 1", unlinked_query)
         self.assertIn(
-            "or coalesce(oe.trade_decision_id, e.trade_decision_id) is null",
+            "or coalesce(oe.trade_decision_id, e.trade_decision_id, d_by_client.id) is null",
             unlinked_query,
         )
+        self.assertIn("exact_decision_match.match_count = 1", unlinked_query)
+        self.assertIn("d_match.decision_hash = oe.client_order_id", unlinked_query)
         self.assertIn("upper(oe.symbol) = any(%s)", unlinked_query)
         self.assertEqual(unlinked_params[-1], ["AAPL"])
         self.assertEqual(diagnostics["order_feed_unlinked_fill_lifecycle_count"], 1)
@@ -4574,11 +4576,15 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIn("left join lateral", order_event_query)
         self.assertIn("exact_match.match_count = 1", order_event_query)
         self.assertIn(
-            "coalesce(oe.trade_decision_id, e.trade_decision_id)",
+            "coalesce(oe.trade_decision_id, e.trade_decision_id, d_by_client.id)",
             order_event_query,
         )
+        self.assertIn("exact_decision_match.match_count = 1", order_event_query)
+        self.assertIn("d_match.decision_hash = oe.client_order_id", order_event_query)
         self.assertIn("left join lateral", unlinked_query)
         self.assertIn("exact_match.match_count = 1", unlinked_query)
+        self.assertIn("exact_decision_match.match_count = 1", unlinked_query)
+        self.assertIn("d_match.decision_hash = oe.client_order_id", unlinked_query)
         self.assertEqual(diagnostics["order_feed_unlinked_fill_lifecycle_count"], 0)
         self.assertEqual(
             diagnostics["order_feed_unlinked_strategy_fill_lifecycle_count"], 0
@@ -4734,9 +4740,11 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertIn("left join lateral", unlinked_query)
         self.assertIn("exact_match.match_count = 1", unlinked_query)
         self.assertIn(
-            "or coalesce(oe.trade_decision_id, e.trade_decision_id) is null",
+            "or coalesce(oe.trade_decision_id, e.trade_decision_id, d_by_client.id) is null",
             unlinked_query,
         )
+        self.assertIn("exact_decision_match.match_count = 1", unlinked_query)
+        self.assertIn("d_match.decision_hash = oe.client_order_id", unlinked_query)
         self.assertIn("upper(oe.symbol) = any(%s)", unlinked_query)
         self.assertEqual(unlinked_params[-1], ["AAPL"])
         self.assertIn("upper(d.symbol) = any(%s)", tca_query)

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -1065,6 +1065,52 @@ class TestOrderFeed(TestCase):
         self.assertEqual(source_window.unlinked_execution_count, 1)
         self.assertEqual(source_window.unlinked_decision_count, 1)
 
+    def test_linking_legacy_offset_event_creates_source_window_lineage(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = self._seed_execution(session)
+            execution_id = execution.id
+            trade_decision_id = execution.trade_decision_id
+            linkable_event = ExecutionOrderEvent(
+                event_fingerprint="legacy-fill-linkable-missing-source-window",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=188,
+                alpaca_account_label="paper",
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id=execution.alpaca_order_id,
+                client_order_id=execution.client_order_id,
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("191.25"),
+                raw_event={"event": "fill"},
+            )
+            session.add(linkable_event)
+            session.commit()
+
+            linked = link_order_events_to_execution(session, execution)
+            session.commit()
+            session.refresh(linkable_event)
+            source_window = session.execute(select(OrderFeedSourceWindow)).scalar_one()
+
+        self.assertEqual(linked, 1)
+        self.assertEqual(linkable_event.execution_id, execution_id)
+        self.assertEqual(linkable_event.trade_decision_id, trade_decision_id)
+        self.assertEqual(linkable_event.source_window_id, source_window.id)
+        self.assertEqual(
+            source_window.source_revision,
+            HISTORICAL_ORDER_EVENT_SOURCE_WINDOW_REVISION,
+        )
+        self.assertEqual(source_window.status, "inserted")
+        self.assertEqual(source_window.start_offset, 188)
+        self.assertEqual(source_window.end_offset, 188)
+        self.assertEqual(source_window.inserted_count, 1)
+        self.assertEqual(source_window.unlinked_execution_count, 0)
+        self.assertEqual(source_window.unlinked_decision_count, 0)
+
     def test_historical_source_window_helpers_handle_missing_and_aware_offsets(
         self,
     ) -> None:

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -303,6 +303,50 @@ def test_positions_carry_across_bucket_boundaries() -> None:
     )
 
 
+def test_grouped_positions_carry_across_bucket_boundaries() -> None:
+    buckets = build_runtime_ledger_buckets(
+        [
+            RuntimeLedgerFill(
+                executed_at=_ts(1),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="buy",
+                filled_qty=Decimal("10"),
+                avg_fill_price=Decimal("100"),
+                cost_amount=Decimal("1"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+            RuntimeLedgerFill(
+                executed_at=_ts(35),
+                account_label="paper",
+                strategy_id="strategy-1",
+                symbol="NVDA",
+                side="sell",
+                filled_qty=Decimal("10"),
+                avg_fill_price=Decimal("110"),
+                cost_amount=Decimal("2"),
+                cost_basis="broker_reported_commission_and_fees",
+            ),
+        ],
+        bucket_ranges=[(_ts(), _ts(30)), (_ts(30), _ts(60))],
+        group_by=("strategy_id", "symbol"),
+    )
+
+    assert len(buckets) == 2
+    assert buckets[0].closed_trade_count == 0
+    assert "unclosed_position" in buckets[0].blockers
+    assert buckets[1].blockers == []
+    assert buckets[1].closed_trade_count == 1
+    assert buckets[1].open_position_count == 0
+    assert buckets[1].filled_notional == Decimal("2100")
+    assert buckets[1].net_strategy_pnl_after_costs == Decimal("97")
+    _assert_decimal_close(
+        buckets[1].post_cost_expectancy_bps,
+        (Decimal("97") / Decimal("2100")) * Decimal("10000"),
+    )
+
+
 def test_tca_shortfall_rows_do_not_count_as_strategy_pnl() -> None:
     bucket = _bucket(
         [

--- a/services/torghut/tests/test_session_context.py
+++ b/services/torghut/tests/test_session_context.py
@@ -25,6 +25,8 @@ def _signal(
     rsi14: str | None = None,
     macd_hist: str | None = None,
     microbar_volume: str | None = None,
+    clusterlob_directional_ofi: str | None = None,
+    clusterlob_event_cluster_stability_score: str | None = None,
 ) -> SignalEnvelope:
     price_value = Decimal(price)
     spread_value = Decimal(spread)
@@ -48,6 +50,14 @@ def _signal(
             "macd_hist": Decimal(macd_hist) if macd_hist is not None else None,
             "microbar_volume": Decimal(microbar_volume)
             if microbar_volume is not None
+            else None,
+            "clusterlob_directional_ofi": Decimal(clusterlob_directional_ofi)
+            if clusterlob_directional_ofi is not None
+            else None,
+            "clusterlob_event_cluster_stability_score": Decimal(
+                clusterlob_event_cluster_stability_score
+            )
+            if clusterlob_event_cluster_stability_score is not None
             else None,
         },
     )
@@ -435,6 +445,8 @@ class TestSessionContextTracker(TestCase):
                 rsi14="66",
                 macd_hist="0.040",
                 microbar_volume="1800",
+                clusterlob_directional_ofi="0.12",
+                clusterlob_event_cluster_stability_score="0.71",
             )
         )
         tracker.enrich_signal_payload(
@@ -449,6 +461,8 @@ class TestSessionContextTracker(TestCase):
                 rsi14="38",
                 macd_hist="-0.020",
                 microbar_volume="1100",
+                clusterlob_directional_ofi="-0.04",
+                clusterlob_event_cluster_stability_score="0.65",
             )
         )
 
@@ -464,6 +478,8 @@ class TestSessionContextTracker(TestCase):
                 rsi14="71",
                 macd_hist="0.055",
                 microbar_volume="2100",
+                clusterlob_directional_ofi="0.18",
+                clusterlob_event_cluster_stability_score="0.78",
             )
         )
         loser_payload = tracker.enrich_signal_payload(
@@ -478,6 +494,8 @@ class TestSessionContextTracker(TestCase):
                 rsi14="35",
                 macd_hist="-0.030",
                 microbar_volume="900",
+                clusterlob_directional_ofi="-0.08",
+                clusterlob_event_cluster_stability_score="0.69",
             )
         )
         leader_payload = tracker.enrich_signal_payload(
@@ -492,6 +510,8 @@ class TestSessionContextTracker(TestCase):
                 rsi14="73",
                 macd_hist="0.060",
                 microbar_volume="2400",
+                clusterlob_directional_ofi="0.21",
+                clusterlob_event_cluster_stability_score="0.81",
             )
         )
 
@@ -530,6 +550,10 @@ class TestSessionContextTracker(TestCase):
         self.assertEqual(
             loser_payload["cross_section_microbar_volume_rank"], Decimal("0")
         )
+        self.assertEqual(
+            loser_payload["cross_section_clusterlob_directional_ofi_rank"],
+            Decimal("0"),
+        )
         self.assertLess(
             cast(Decimal, loser_payload["recent_15m_return_bps"]), Decimal("0")
         )
@@ -540,6 +564,20 @@ class TestSessionContextTracker(TestCase):
         )
         self.assertEqual(
             leader_payload["cross_section_microbar_volume_rank"], Decimal("1")
+        )
+        self.assertEqual(
+            leader_payload["cross_section_clusterlob_directional_ofi_rank"],
+            Decimal("1"),
+        )
+        self.assertEqual(
+            leader_payload[
+                "cross_section_clusterlob_directional_ofi_rank_universe_size"
+            ],
+            2,
+        )
+        self.assertEqual(
+            leader_payload["clusterlob_event_cluster_stability_score"],
+            Decimal("0.81"),
         )
         self.assertEqual(
             leader_payload["cross_section_microbar_volume_rank_universe_size"], 2

--- a/services/torghut/tests/test_strategy_runtime.py
+++ b/services/torghut/tests/test_strategy_runtime.py
@@ -5872,6 +5872,36 @@ class TestStrategyRuntimeMicrobarCoverage(TestCase):
             executable_universe_buy.trace.gates[0].context["universe_size"], 5
         )
 
+        clusterlob_rank_buy = _evaluate_microbar_cross_sectional(
+            context=self._context(
+                params={
+                    "entry_minute_after_open": "60",
+                    "signal_motif": "clusterlob_directional_ofi_continuation",
+                    "rank_feature": "cross_section_clusterlob_directional_ofi_rank",
+                    "gate_feature": "clusterlob_event_cluster_stability_score",
+                    "gate_min": "0.60",
+                    "selection_mode": "continuation",
+                    "top_n": "2",
+                    "universe_size": "6",
+                }
+            ),
+            features=_test_feature_vector(
+                {
+                    "session_minutes_elapsed": 60,
+                    "cross_section_clusterlob_directional_ofi_rank": Decimal("0.90"),
+                    "clusterlob_event_cluster_stability_score": Decimal("0.72"),
+                }
+            ),
+            entry_action="buy",
+            exit_action="sell",
+        )
+        self.assertIsNotNone(clusterlob_rank_buy.intent)
+        assert clusterlob_rank_buy.intent is not None
+        self.assertIn(
+            "rank_feature:cross_section_clusterlob_directional_ofi_rank",
+            clusterlob_rank_buy.intent.rationale,
+        )
+
         reversal_buy = _evaluate_microbar_cross_sectional(
             context=self._context(
                 params={


### PR DESCRIPTION
## Summary

- Repairs source-linked H-PAIRS evidence plumbing by creating historical order-feed source windows when legacy offset-bearing events are linked to executions.
- Adds importer fallback from exact `client_order_id` / decision-hash lifecycle events to unique trade decisions, keeping ambiguous rows blocked.
- Carries grouped runtime-ledger open positions across bucket boundaries so target-window closures can retain source-backed state.
- Adds ClusterLOB-style OFI/rank feature fields to the H-PAIRS research frontier as discovery inputs, not promotion authority.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_feature_contract_v3.py tests/test_session_context.py tests/test_strategy_runtime.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/features.py app/trading/order_feed.py app/trading/runtime_ledger.py app/trading/session_context.py scripts/import_hypothesis_runtime_windows.py tests/test_feature_contract_v3.py tests/test_import_hypothesis_runtime_windows.py tests/test_order_feed.py tests/test_runtime_ledger.py tests/test_session_context.py tests/test_strategy_runtime.py`
- `git diff --check origin/main...HEAD`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
