### PR TITLE
fix(atlas): bound code search health sampling

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -356,6 +356,8 @@ spec:
               value: "60000"
             - name: ATLAS_CODE_SEARCH_SEMANTIC_CANDIDATE_LIMIT
               value: "100"
+            - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
+              value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
               value: "26707664123"
             - name: JANGAR_SOURCE_CI_CONCLUSION

--- a/services/jangar/src/server/__tests__/atlas-store.test.ts
+++ b/services/jangar/src/server/__tests__/atlas-store.test.ts
@@ -211,6 +211,7 @@ describe('atlas store', () => {
       'ATLAS_CODE_SEARCH_SEMANTIC_TIMEOUT_MS',
       'ATLAS_CODE_SEARCH_QUERY_EMBEDDING_CACHE_TTL_MS',
       'ATLAS_CODE_SEARCH_SEMANTIC_CANDIDATE_LIMIT',
+      'ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT',
     ]) {
       previousEnv[key] = process.env[key]
     }
@@ -433,6 +434,27 @@ describe('atlas store', () => {
     expect(health.sample).toMatchObject({ chunks: 2, embedded: 1, missing: 1, coverage: 0.5 })
     expect(health.model).toBe('test-embedding')
     expect(health.dimension).toBe(3)
+  })
+
+  it('keeps default semantic code-search health sampling bounded', async () => {
+    const { db, calls } = makeFakeDb({
+      selectRows: [{ chunk_id: 'chunk-1', embedded_chunk_id: 'chunk-1' }],
+    })
+    const store = createPostgresAtlasStore({
+      url: 'postgresql://user:pass@localhost:5432/db',
+      createDb: () => db,
+    })
+
+    const health = await store.codeSearchHealth({
+      repository: 'proompteng/lab',
+      ref: 'main',
+      pathPrefix: 'services/jangar',
+    })
+
+    const healthSql = calls.find((call) => call.sql.toLowerCase().includes('left join "atlas"."chunk_embeddings"'))
+    expect(health.sample.limit).toBe(50)
+    expect(healthSql?.params).toContain(50)
+    expect(healthSql?.params).not.toContain(500)
   })
 
   it('ranks exact identifier matches above weaker lexical-only matches', async () => {

--- a/services/jangar/src/server/atlas-code-search.ts
+++ b/services/jangar/src/server/atlas-code-search.ts
@@ -116,7 +116,7 @@ const DEFAULT_CODE_SEARCH_SEMANTIC_CANDIDATE_LIMIT = 100
 const DEFAULT_CODE_SEARCH_SEMANTIC_CANDIDATE_LIMIT_CAP = 500
 const DEFAULT_CODE_SEARCH_SEMANTIC_CANDIDATE_MULTIPLIER = 20
 const MAX_CODE_SEARCH_SEMANTIC_CANDIDATE_LIMIT = 50_000
-const DEFAULT_CODE_SEARCH_HEALTH_SAMPLE_LIMIT = 500
+const DEFAULT_CODE_SEARCH_HEALTH_SAMPLE_LIMIT = 50
 const MAX_CODE_SEARCH_HEALTH_SAMPLE_LIMIT = 5_000
 const DEFAULT_MIN_SEMANTIC_COVERAGE = 0.95
 
@@ -193,7 +193,12 @@ const normalizeCoverageThreshold = (value: number | undefined) => {
 }
 
 const normalizeHealthSampleLimit = (value: number | undefined) => {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
+  const defaultLimit = parsePositiveIntEnv(
+    'ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT',
+    DEFAULT_CODE_SEARCH_HEALTH_SAMPLE_LIMIT,
+    MAX_CODE_SEARCH_HEALTH_SAMPLE_LIMIT,
+  )
+  if (typeof value !== 'number' || !Number.isFinite(value)) return defaultLimit
   return Math.max(1, Math.min(MAX_CODE_SEARCH_HEALTH_SAMPLE_LIMIT, Math.floor(value)))
 }
 


### PR DESCRIPTION
## Summary

- Lowers the default Atlas code-search semantic health sample from 500 chunks to 50.
- Adds `ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT` so production can tune the default without a code change.
- Pins Jangar production to `ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT=50` and adds a regression test for the bounded default.

## Related Issues

None

## Testing

- `bunx vitest run --config vitest.config.ts src/server/__tests__/atlas-store.test.ts`
- `bun run test`
- `bun run lint:oxlint:type` (passed with existing warnings only)
- `bunx oxfmt --check services/jangar/src/server/atlas-code-search.ts services/jangar/src/server/__tests__/atlas-store.test.ts`
- `kubectl kustomize argocd/applications/jangar --enable-helm >/dev/null`
- `git diff --check`
- Live diagnosis: default health sample 500 made `atlas code search semantic coverage` take `22.09s`; explicit `healthSampleLimit:50` returned HTTP 200 with semantic distances and healthy coverage.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
