### PR TITLE
fix(torghut): carry source-backed runtime positions into proof buckets

### DIFF
--- a/services/torghut/app/trading/runtime_ledger.py
+++ b/services/torghut/app/trading/runtime_ledger.py
@@ -181,6 +181,7 @@ def build_runtime_ledger_buckets(
     bucket_ranges: Sequence[tuple[datetime, datetime]],
     group_by: Sequence[str] = (),
     require_order_lifecycle: bool = False,
+    carry_in_rows: Sequence[RuntimeLedgerFill | Mapping[str, object]] = (),
 ) -> list[RuntimeLedgerBucket]:
     """Aggregate runtime fills into fail-closed post-cost PnL buckets.
 
@@ -192,6 +193,10 @@ def build_runtime_ledger_buckets(
     normalized_rows = [
         _normalize_fill_row(row, row_index=index) for index, row in enumerate(rows)
     ]
+    normalized_carry_in_rows = [
+        _normalize_fill_row(row, row_index=-(index + 1))
+        for index, row in enumerate(carry_in_rows)
+    ]
     normalized_ranges = [(_utc(start), _utc(end)) for start, end in bucket_ranges]
     for start, end in normalized_ranges:
         if end <= start:
@@ -200,6 +205,7 @@ def build_runtime_ledger_buckets(
     buckets: list[RuntimeLedgerBucket] = []
     if not group_by:
         positions: dict[tuple[str | None, str | None, str | None], _PositionState] = {}
+        applied_carry_in_row_indexes: set[int] = set()
         for bucket_start, bucket_end in normalized_ranges:
             bucket_rows = [
                 row
@@ -207,11 +213,17 @@ def build_runtime_ledger_buckets(
                 if row.executed_at is not None
                 and bucket_start <= row.executed_at < bucket_end
             ]
+            bucket_carry_in_rows = _carry_in_rows_before_bucket(
+                normalized_carry_in_rows,
+                bucket_start=bucket_start,
+                applied_row_indexes=applied_carry_in_row_indexes,
+            )
             buckets.append(
                 _build_bucket(
                     bucket_start=bucket_start,
                     bucket_end=bucket_end,
                     rows=bucket_rows,
+                    carry_in_rows=bucket_carry_in_rows,
                     carried_positions=positions,
                     require_order_lifecycle=require_order_lifecycle,
                 )
@@ -222,6 +234,7 @@ def build_runtime_ledger_buckets(
         tuple[str | None, ...],
         dict[tuple[str | None, str | None, str | None], _PositionState],
     ] = {}
+    grouped_applied_carry_in_row_indexes: set[int] = set()
     for bucket_start, bucket_end in normalized_ranges:
         bucket_rows = [
             row
@@ -233,11 +246,21 @@ def build_runtime_ledger_buckets(
         for row in bucket_rows:
             grouped_rows.setdefault(_group_key(row, group_by), []).append(row)
         for key in sorted(grouped_rows):
+            bucket_carry_in_rows = _carry_in_rows_before_bucket(
+                [
+                    row
+                    for row in normalized_carry_in_rows
+                    if _group_key(row, group_by) == key
+                ],
+                bucket_start=bucket_start,
+                applied_row_indexes=grouped_applied_carry_in_row_indexes,
+            )
             buckets.append(
                 _build_bucket(
                     bucket_start=bucket_start,
                     bucket_end=bucket_end,
                     rows=grouped_rows[key],
+                    carry_in_rows=bucket_carry_in_rows,
                     group_by=group_by,
                     group_key=key,
                     carried_positions=grouped_positions.setdefault(key, {}),
@@ -252,6 +275,7 @@ def _build_bucket(
     bucket_start: datetime,
     bucket_end: datetime,
     rows: Sequence[_NormalizedFill],
+    carry_in_rows: Sequence[_NormalizedFill] = (),
     group_by: Sequence[str] = (),
     group_key: tuple[str | None, ...] = (),
     carried_positions: dict[tuple[str | None, str | None, str | None], _PositionState]
@@ -259,10 +283,12 @@ def _build_bucket(
     require_order_lifecycle: bool = False,
 ) -> RuntimeLedgerBucket:
     blockers: list[str] = []
-    for row in rows:
+    for row in [*carry_in_rows, *rows]:
         blockers.extend(row.blockers)
 
-    lifecycle_rows = [row for row in rows if row.event_type in _LIFECYCLE_EVENTS]
+    lifecycle_rows = [
+        row for row in [*carry_in_rows, *rows] if row.event_type in _LIFECYCLE_EVENTS
+    ]
     decision_count = sum(1 for row in rows if row.event_type in _DECISION_EVENTS)
     submitted_order_count = sum(
         1 for row in rows if row.event_type in _SUBMITTED_ORDER_EVENTS
@@ -277,6 +303,8 @@ def _build_bucket(
         1 for row in rows if row.event_type in _UNFILLED_ORDER_EVENTS
     )
     usable_fills = [row for row in rows if row.is_usable_fill]
+    carry_in_usable_fills = [row for row in carry_in_rows if row.is_usable_fill]
+    all_usable_fills = [*carry_in_usable_fills, *usable_fills]
     if not usable_fills:
         blockers.append("runtime_fills_missing")
 
@@ -290,13 +318,34 @@ def _build_bucket(
             execution_policy_hash_counter[row.execution_policy_hash] += 1
         if (lineage_hash := row.lineage_hash or row.replay_data_hash) is not None:
             lineage_hash_counter[lineage_hash] += 1
-    for row in usable_fills:
+    for row in all_usable_fills:
         if row.cost_model_hash is not None:
             cost_model_hash_counter[row.cost_model_hash] += 1
 
     positions: dict[tuple[str | None, str | None, str | None], _PositionState] = (
         carried_positions if carried_positions is not None else {}
     )
+    carry_in_accumulator = _LedgerAccumulator()
+    for fill in sorted(
+        carry_in_usable_fills,
+        key=lambda item: (item.executed_at or bucket_start, item.row_index),
+    ):
+        assert fill.side is not None
+        assert fill.filled_qty is not None
+        assert fill.avg_fill_price is not None
+        assert fill.filled_notional is not None
+        assert fill.cost_amount is not None
+        assert fill.cost_basis is not None
+
+        cost_basis_counter[fill.cost_basis] += 1
+        position_key = (fill.account_label, fill.strategy_id, fill.symbol)
+        state = positions.setdefault(position_key, _PositionState())
+        _apply_fill_to_position(
+            state=state,
+            fill=fill,
+            accumulator=carry_in_accumulator,
+        )
+
     for fill in sorted(
         usable_fills,
         key=lambda item: (item.executed_at or bucket_start, item.row_index),
@@ -326,7 +375,7 @@ def _build_bucket(
         blockers.extend(
             _order_lifecycle_blockers(
                 lifecycle_rows=lifecycle_rows,
-                usable_fills=usable_fills,
+                usable_fills=all_usable_fills,
                 decision_count=decision_count,
                 submitted_order_count=submitted_order_count,
                 rejected_order_count=rejected_order_count,
@@ -381,6 +430,23 @@ def _build_bucket(
         blockers=unique_blockers,
         diagnostic_closed_trade_expectancy_bps=diagnostic_closed_trade_expectancy_bps,
     )
+
+
+def _carry_in_rows_before_bucket(
+    rows: Sequence[_NormalizedFill],
+    *,
+    bucket_start: datetime,
+    applied_row_indexes: set[int],
+) -> list[_NormalizedFill]:
+    bucket_rows = [
+        row
+        for row in rows
+        if row.row_index not in applied_row_indexes
+        and row.executed_at is not None
+        and row.executed_at < bucket_start
+    ]
+    applied_row_indexes.update(row.row_index for row in bucket_rows)
+    return bucket_rows
 
 
 def _order_lifecycle_blockers(

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -78,6 +78,7 @@ EXACT_REPLAY_ARTIFACT_AUTHORITY_BLOCKERS = (
     "runtime_ledger_source_refs_missing",
 )
 RUNTIME_LEDGER_SOURCE_WINDOW_MISSING_BLOCKER = "runtime_ledger_source_window_missing"
+RUNTIME_LEDGER_CARRY_IN_LOOKBACK = timedelta(days=5)
 RUNTIME_LEDGER_SOURCE_REFS_MISSING_BLOCKER = "runtime_ledger_source_refs_missing"
 _RUNTIME_LEDGER_DECISION_EVENTS = frozenset(
     {"decision", "trade_decision", "signal_decision"}
@@ -514,11 +515,17 @@ def _partition_runtime_source_rows_by_decision_mode(
     execution_rows: list[dict[str, object]],
     decision_lifecycle_rows: list[dict[str, object]] | None,
     order_lifecycle_rows: list[dict[str, object]] | None,
+    carry_in_execution_rows: list[dict[str, object]] | None = None,
+    carry_in_decision_lifecycle_rows: list[dict[str, object]] | None = None,
+    carry_in_order_lifecycle_rows: list[dict[str, object]] | None = None,
 ) -> (
     list[
         tuple[
             str,
             list[dict[str, object]],
+            list[dict[str, object]] | None,
+            list[dict[str, object]] | None,
+            list[dict[str, object]] | None,
             list[dict[str, object]] | None,
             list[dict[str, object]] | None,
         ]
@@ -529,6 +536,9 @@ def _partition_runtime_source_rows_by_decision_mode(
         *execution_rows,
         *(decision_lifecycle_rows or []),
         *(order_lifecycle_rows or []),
+        *(carry_in_execution_rows or []),
+        *(carry_in_decision_lifecycle_rows or []),
+        *(carry_in_order_lifecycle_rows or []),
     ]
     if not source_rows:
         return None
@@ -547,6 +557,9 @@ def _partition_runtime_source_rows_by_decision_mode(
         tuple[
             str,
             list[dict[str, object]],
+            list[dict[str, object]] | None,
+            list[dict[str, object]] | None,
+            list[dict[str, object]] | None,
             list[dict[str, object]] | None,
             list[dict[str, object]] | None,
         ]
@@ -579,12 +592,42 @@ def _partition_runtime_source_rows_by_decision_mode(
             )
             == mode_key
         ]
+        partition_carry_in_execution_rows = [
+            row
+            for row in carry_in_execution_rows or []
+            if _source_decision_mode_partition_key(
+                row,
+                modes_by_identifier=modes_by_identifier,
+            )
+            == mode_key
+        ]
+        partition_carry_in_decision_rows = [
+            row
+            for row in carry_in_decision_lifecycle_rows or []
+            if _source_decision_mode_partition_key(
+                row,
+                modes_by_identifier=modes_by_identifier,
+            )
+            == mode_key
+        ]
+        partition_carry_in_order_rows = [
+            row
+            for row in carry_in_order_lifecycle_rows or []
+            if _source_decision_mode_partition_key(
+                row,
+                modes_by_identifier=modes_by_identifier,
+            )
+            == mode_key
+        ]
         partitions.append(
             (
                 mode_key,
                 partition_execution_rows,
                 partition_decision_rows or None,
                 partition_order_rows or None,
+                partition_carry_in_execution_rows or None,
+                partition_carry_in_decision_rows or None,
+                partition_carry_in_order_rows or None,
             )
         )
     return partitions
@@ -2268,6 +2311,24 @@ def _runtime_source_row_in_bucket(
     )
 
 
+def _runtime_source_row_before_bucket(
+    row: Mapping[str, object],
+    *,
+    bucket: RuntimeLedgerBucket,
+) -> bool:
+    row_symbol = _runtime_source_row_symbol(row)
+    if (
+        bucket.symbol is not None
+        and row_symbol is not None
+        and row_symbol != bucket.symbol
+    ):
+        return False
+    event_time = _runtime_ledger_row_time(
+        {str(key): value for key, value in row.items()}
+    )
+    return event_time is not None and event_time < bucket.bucket_started_at
+
+
 def _runtime_source_decision_ids(rows: Sequence[Mapping[str, object]]) -> set[str]:
     identifiers: set[str] = set()
     for row in rows:
@@ -2321,6 +2382,24 @@ def _runtime_decision_rows_for_bucket(
     rows: list[dict[str, object]] = []
     for row in decision_lifecycle_rows or []:
         if not _runtime_source_row_in_bucket(row, bucket=bucket):
+            continue
+        row_ids = _runtime_source_decision_ids([row])
+        if decision_ids and not (row_ids & decision_ids):
+            continue
+        rows.append(dict(row))
+    return rows
+
+
+def _runtime_decision_rows_before_bucket(
+    *,
+    bucket: RuntimeLedgerBucket,
+    decision_lifecycle_rows: list[dict[str, object]] | None,
+    source_rows: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    decision_ids = _runtime_source_decision_ids(source_rows)
+    rows: list[dict[str, object]] = []
+    for row in decision_lifecycle_rows or []:
+        if not _runtime_source_row_before_bucket(row, bucket=bucket):
             continue
         row_ids = _runtime_source_decision_ids([row])
         if decision_ids and not (row_ids & decision_ids):
@@ -2436,18 +2515,27 @@ def _runtime_source_context_for_bucket(
     decision_lifecycle_rows: list[dict[str, object]] | None,
     order_lifecycle_rows: list[dict[str, object]] | None,
     unlinked_order_lifecycle_rows: list[dict[str, object]] | None,
+    carry_in_execution_rows: list[dict[str, object]] | None = None,
+    carry_in_decision_lifecycle_rows: list[dict[str, object]] | None = None,
+    carry_in_order_lifecycle_rows: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
-    bucket_order_rows = _runtime_order_rows_for_bucket(
+    target_order_rows = _runtime_order_rows_for_bucket(
         bucket=bucket,
         execution_rows=execution_rows,
         order_lifecycle_rows=order_lifecycle_rows,
     )
+    bucket_carry_in_order_rows = [
+        dict(row)
+        for row in carry_in_order_lifecycle_rows or []
+        if _runtime_source_row_before_bucket(row, bucket=bucket)
+    ]
+    bucket_order_rows = [*bucket_carry_in_order_rows, *target_order_rows]
     bucket_order_ids = {
         order_id
         for row in bucket_order_rows
         if (order_id := _runtime_order_id(row)) is not None
     }
-    bucket_execution_rows = [
+    target_execution_rows = [
         dict(row)
         for row in execution_rows
         if _execution_row_has_fill(row)
@@ -2459,17 +2547,40 @@ def _runtime_source_context_for_bucket(
             )
         )
     ]
-    bucket_decision_rows = _runtime_decision_rows_for_bucket(
+    bucket_carry_in_execution_rows = [
+        dict(row)
+        for row in carry_in_execution_rows or []
+        if _execution_row_has_fill(row)
+        and _runtime_source_row_before_bucket(row, bucket=bucket)
+    ]
+    bucket_execution_rows = [*bucket_carry_in_execution_rows, *target_execution_rows]
+    target_decision_rows = _runtime_decision_rows_for_bucket(
         bucket=bucket,
         decision_lifecycle_rows=decision_lifecycle_rows,
         source_rows=[*bucket_execution_rows, *bucket_order_rows],
     )
+    carry_in_decision_rows = _runtime_decision_rows_before_bucket(
+        bucket=bucket,
+        decision_lifecycle_rows=carry_in_decision_lifecycle_rows,
+        source_rows=[*bucket_execution_rows, *bucket_order_rows],
+    )
+    bucket_decision_rows = [*carry_in_decision_rows, *target_decision_rows]
     bucket_unlinked_order_rows = _runtime_unlinked_order_rows_for_bucket(
         bucket=bucket,
         unlinked_order_lifecycle_rows=unlinked_order_lifecycle_rows,
         bucket_order_ids=bucket_order_ids,
     )
     source_rows = [*bucket_execution_rows, *bucket_decision_rows, *bucket_order_rows]
+    source_row_times = [
+        event_time
+        for row in source_rows
+        if (
+            event_time := _runtime_ledger_row_time(
+                {str(key): value for key, value in row.items()}
+            )
+        )
+        is not None
+    ]
     source_window_ids = _source_identifier_values(
         bucket_order_rows,
         "source_window_id",
@@ -2491,12 +2602,16 @@ def _runtime_source_context_for_bucket(
         )
         if source_row_counts.get(table, 0) > 0
     ]
-    expected_execution_fill_order_ids = {
-        order_id
-        for row in [*bucket_execution_rows, *bucket_order_rows]
-        if _runtime_source_row_in_bucket(row, bucket=bucket)
-        and (order_id := _runtime_order_id(row)) is not None
-    }
+    expected_execution_fill_order_ids = set()
+    for row in bucket_execution_rows:
+        if (
+            _execution_row_has_fill(row)
+            and (order_id := _runtime_order_id(row)) is not None
+        ):
+            expected_execution_fill_order_ids.add(order_id)
+    for row in bucket_order_rows:
+        if (order_id := _runtime_order_id(row)) is not None:
+            expected_execution_fill_order_ids.add(order_id)
     event_sourced_fill_order_ids = _event_sourced_fill_economics_order_ids(
         bucket_order_rows
     )
@@ -2531,6 +2646,14 @@ def _runtime_source_context_for_bucket(
         "unlinked_order_rows": bucket_unlinked_order_rows,
         "source_rows": source_rows,
         "source_window_ids": source_window_ids,
+        "source_window_start": (
+            min(source_row_times) if source_row_times else bucket.bucket_started_at
+        ),
+        "source_window_end": (
+            max(source_row_times) + timedelta(microseconds=1)
+            if source_row_times
+            else bucket.bucket_ended_at
+        ),
         "source_row_counts": source_row_counts,
         "source_refs": source_refs,
         "trade_decision_ids": _source_identifier_values(
@@ -2661,12 +2784,153 @@ def _source_activity_diagnostics_blockers(
     return blockers
 
 
+def _runtime_execution_ledger_fill_from_row(
+    row: Mapping[str, object],
+    *,
+    order_lifecycle_rows: Sequence[Mapping[str, object]] | None,
+) -> tuple[RuntimeLedgerFill | None, list[datetime]]:
+    computed_at = row.get("computed_at")
+    execution_event_at = row.get("execution_event_at")
+    execution_created_at = row.get("execution_created_at")
+    fill_event_at = (
+        execution_created_at
+        if isinstance(execution_created_at, datetime)
+        else computed_at
+    )
+    if isinstance(execution_event_at, datetime):
+        fill_event_at = execution_event_at
+    ledger_computed_at = (
+        fill_event_at if isinstance(fill_event_at, datetime) else computed_at
+    )
+    price = _first_decimal(
+        row,
+        "avg_fill_price",
+        "filled_avg_price",
+        "filled_average_price",
+        "average_fill_price",
+        "fill_price",
+        "filled_price",
+    )
+    side = _first_text(row, "side", "order_side") or ""
+    signed_qty = _execution_signed_qty(
+        side=side,
+        qty=_first_decimal(
+            row,
+            "filled_qty",
+            "filled_quantity",
+            "qty",
+            "quantity",
+        ),
+    )
+    symbol = str(row.get("symbol") or "").strip().upper()
+    if not symbol or not isinstance(ledger_computed_at, datetime):
+        return None, []
+    decision_id = _first_text(row, "decision_id", "trade_decision_id", "decision_hash")
+    order_id = _first_text(
+        row,
+        "order_id",
+        "alpaca_order_id",
+        "client_order_id",
+        "execution_correlation_id",
+    )
+    execution_policy_hash = _first_text(
+        row,
+        "execution_policy_hash",
+        "execution_policy_sha256",
+        "policy_hash",
+    ) or _first_payload_digest(
+        row,
+        "execution_policy",
+        "execution_policy_context",
+        "execution_advisor",
+        "_execution_advice_provenance",
+    )
+    cost_model_hash = _first_text(
+        row, "cost_model_hash", "fee_model_hash", "cost_model_sha256"
+    ) or _first_payload_digest(
+        row,
+        "cost_model",
+        "cost_model_config",
+        "transaction_cost_model",
+        "fee_model",
+        "fees_model",
+        "model",
+    )
+    lineage_hash = _first_text(
+        row,
+        "lineage_hash",
+        "candidate_lineage_hash",
+        "replay_lineage_hash",
+        "candidate_evaluation_key",
+    ) or _first_lineage_digest(row)
+    replay_data_hash = _first_text(
+        row,
+        "replay_data_hash",
+        "replay_tape_content_sha256",
+        "dataset_snapshot_hash",
+        "source_query_digest",
+    )
+    if price is None or price <= 0 or signed_qty == 0:
+        return None, []
+    if order_id is not None and order_id in _event_sourced_fill_economics_order_ids(
+        order_lifecycle_rows or []
+    ):
+        return None, []
+    event_times = [ledger_computed_at]
+    if isinstance(fill_event_at, datetime):
+        event_times.append(fill_event_at)
+    filled_qty = abs(signed_qty)
+    filled_notional = filled_qty * price
+    cost_amount = _runtime_execution_cost_amount(
+        row,
+        filled_notional=filled_notional,
+        side=side,
+        filled_qty=filled_qty,
+    )
+    cost_basis = _runtime_execution_cost_basis(
+        row,
+        cost_amount=cost_amount,
+        side=side,
+        filled_qty=filled_qty,
+        filled_notional=filled_notional,
+    )
+    if _cost_basis_is_alpaca_fee_schedule(cost_basis):
+        cost_model_hash = _alpaca_2026_equity_fee_schedule_hash()
+    return (
+        RuntimeLedgerFill(
+            executed_at=fill_event_at
+            if isinstance(fill_event_at, datetime)
+            else ledger_computed_at,
+            event_type="fill",
+            decision_id=decision_id,
+            order_id=order_id,
+            execution_policy_hash=execution_policy_hash,
+            cost_model_hash=cost_model_hash,
+            lineage_hash=lineage_hash,
+            replay_data_hash=replay_data_hash,
+            side=side,
+            filled_qty=filled_qty,
+            avg_fill_price=price,
+            filled_notional=filled_notional,
+            cost_amount=cost_amount,
+            cost_basis=cost_basis,
+            account_label=str(row.get("account_label") or "") or None,
+            strategy_id=str(row.get("strategy_id") or "") or None,
+            symbol=symbol,
+        ),
+        event_times,
+    )
+
+
 def _build_realized_strategy_pnl_rows(
     execution_rows: list[dict[str, object]],
     *,
     decision_lifecycle_rows: list[dict[str, object]] | None = None,
     order_lifecycle_rows: list[dict[str, object]] | None = None,
     unlinked_order_lifecycle_rows: list[dict[str, object]] | None = None,
+    carry_in_execution_rows: list[dict[str, object]] | None = None,
+    carry_in_decision_lifecycle_rows: list[dict[str, object]] | None = None,
+    carry_in_order_lifecycle_rows: list[dict[str, object]] | None = None,
     allow_authoritative_runtime_ledger_materialization: bool = False,
     split_mixed_source_decision_modes: bool = True,
 ) -> list[dict[str, object]]:
@@ -2675,6 +2939,9 @@ def _build_realized_strategy_pnl_rows(
             execution_rows=execution_rows,
             decision_lifecycle_rows=decision_lifecycle_rows,
             order_lifecycle_rows=order_lifecycle_rows,
+            carry_in_execution_rows=carry_in_execution_rows,
+            carry_in_decision_lifecycle_rows=carry_in_decision_lifecycle_rows,
+            carry_in_order_lifecycle_rows=carry_in_order_lifecycle_rows,
         )
         if partitions is not None:
             partition_rows: list[dict[str, object]] = []
@@ -2683,12 +2950,18 @@ def _build_realized_strategy_pnl_rows(
                 partition_execution_rows,
                 partition_decision_rows,
                 partition_order_rows,
+                partition_carry_in_execution_rows,
+                partition_carry_in_decision_rows,
+                partition_carry_in_order_rows,
             ) in partitions:
                 for row in _build_realized_strategy_pnl_rows(
                     partition_execution_rows,
                     decision_lifecycle_rows=partition_decision_rows,
                     order_lifecycle_rows=partition_order_rows,
                     unlinked_order_lifecycle_rows=unlinked_order_lifecycle_rows,
+                    carry_in_execution_rows=partition_carry_in_execution_rows,
+                    carry_in_decision_lifecycle_rows=partition_carry_in_decision_rows,
+                    carry_in_order_lifecycle_rows=partition_carry_in_order_rows,
                     allow_authoritative_runtime_ledger_materialization=(
                         allow_authoritative_runtime_ledger_materialization
                     ),
@@ -2705,6 +2978,7 @@ def _build_realized_strategy_pnl_rows(
             return partition_rows
 
     ledger_rows: list[RuntimeLedgerFill | dict[str, object]] = []
+    carry_in_ledger_rows: list[RuntimeLedgerFill | dict[str, object]] = []
     event_times: list[datetime] = []
     for row in decision_lifecycle_rows or []:
         lifecycle_row = _runtime_lifecycle_ledger_row(row, event_type="decision")
@@ -2745,153 +3019,41 @@ def _build_realized_strategy_pnl_rows(
         if isinstance(event_time, datetime):
             event_times.append(event_time)
     for row in execution_rows:
-        computed_at = row.get("computed_at")
-        execution_event_at = row.get("execution_event_at")
-        execution_created_at = row.get("execution_created_at")
-        fill_event_at = (
-            execution_created_at
-            if isinstance(execution_created_at, datetime)
-            else computed_at
-        )
-        if isinstance(execution_event_at, datetime):
-            fill_event_at = execution_event_at
-        ledger_computed_at = (
-            fill_event_at if isinstance(fill_event_at, datetime) else computed_at
-        )
-        price = _first_decimal(
+        ledger_fill, ledger_event_times = _runtime_execution_ledger_fill_from_row(
             row,
-            "avg_fill_price",
-            "filled_avg_price",
-            "filled_average_price",
-            "average_fill_price",
-            "fill_price",
-            "filled_price",
+            order_lifecycle_rows=order_lifecycle_rows,
         )
-        side = _first_text(row, "side", "order_side") or ""
-        signed_qty = _execution_signed_qty(
-            side=side,
-            qty=_first_decimal(
-                row,
-                "filled_qty",
-                "filled_quantity",
-                "qty",
-                "quantity",
-            ),
-        )
-        symbol = str(row.get("symbol") or "").strip().upper()
-        if not symbol or not isinstance(ledger_computed_at, datetime):
+        if ledger_fill is None:
             continue
-        decision_id = _first_text(
-            row, "decision_id", "trade_decision_id", "decision_hash"
+        ledger_rows.append(ledger_fill)
+        event_times.extend(ledger_event_times)
+
+    for row in carry_in_decision_lifecycle_rows or []:
+        lifecycle_row = _runtime_lifecycle_ledger_row(row, event_type="decision")
+        if lifecycle_row is not None:
+            carry_in_ledger_rows.append(lifecycle_row)
+    for row in carry_in_order_lifecycle_rows or []:
+        event_type = _runtime_ledger_event_type(
+            {str(key): value for key, value in row.items()}
         )
-        order_id = _first_text(
+        lifecycle_row = _runtime_lifecycle_ledger_row(
             row,
-            "order_id",
-            "alpaca_order_id",
-            "client_order_id",
-            "execution_correlation_id",
+            event_type=event_type,
+            require_complete_fill=event_type in _RUNTIME_LEDGER_FILL_EVENTS,
         )
-        common_ledger_fields = {
-            "executed_at": ledger_computed_at,
-            "account_label": str(row.get("account_label") or "") or None,
-            "strategy_id": str(row.get("strategy_id") or "") or None,
-            "symbol": symbol,
-            "decision_id": decision_id,
-            "order_id": order_id,
-            "execution_policy_hash": _first_text(
-                row,
-                "execution_policy_hash",
-                "execution_policy_sha256",
-                "policy_hash",
-            )
-            or _first_payload_digest(
-                row,
-                "execution_policy",
-                "execution_policy_context",
-                "execution_advisor",
-                "_execution_advice_provenance",
-            ),
-            "cost_model_hash": _first_text(
-                row, "cost_model_hash", "fee_model_hash", "cost_model_sha256"
-            )
-            or _first_payload_digest(
-                row,
-                "cost_model",
-                "cost_model_config",
-                "transaction_cost_model",
-                "fee_model",
-                "fees_model",
-                "model",
-            ),
-            "lineage_hash": _first_text(
-                row,
-                "lineage_hash",
-                "candidate_lineage_hash",
-                "replay_lineage_hash",
-                "candidate_evaluation_key",
-            )
-            or _first_lineage_digest(row),
-            "replay_data_hash": _first_text(
-                row,
-                "replay_data_hash",
-                "replay_tape_content_sha256",
-                "dataset_snapshot_hash",
-                "source_query_digest",
-            ),
-        }
-        if price is None or price <= 0 or signed_qty == 0:
-            continue
-        if order_id is not None and order_id in _event_sourced_fill_economics_order_ids(
-            order_lifecycle_rows or []
-        ):
-            continue
-        event_times.append(ledger_computed_at)
-        if isinstance(fill_event_at, datetime):
-            event_times.append(fill_event_at)
-        filled_qty = abs(signed_qty)
-        filled_notional = filled_qty * price
-        cost_amount = _runtime_execution_cost_amount(
+        if lifecycle_row is not None:
+            carry_in_ledger_rows.append(lifecycle_row)
+    combined_order_lifecycle_rows = [
+        *(carry_in_order_lifecycle_rows or []),
+        *(order_lifecycle_rows or []),
+    ]
+    for row in carry_in_execution_rows or []:
+        ledger_fill, _ledger_event_times = _runtime_execution_ledger_fill_from_row(
             row,
-            filled_notional=filled_notional,
-            side=side,
-            filled_qty=filled_qty,
+            order_lifecycle_rows=combined_order_lifecycle_rows,
         )
-        cost_basis = _runtime_execution_cost_basis(
-            row,
-            cost_amount=cost_amount,
-            side=side,
-            filled_qty=filled_qty,
-            filled_notional=filled_notional,
-        )
-        if _cost_basis_is_alpaca_fee_schedule(cost_basis):
-            common_ledger_fields["cost_model_hash"] = (
-                _alpaca_2026_equity_fee_schedule_hash()
-            )
-        ledger_rows.append(
-            RuntimeLedgerFill(
-                executed_at=(
-                    fill_event_at
-                    if isinstance(fill_event_at, datetime)
-                    else ledger_computed_at
-                ),
-                event_type="fill",
-                decision_id=decision_id,
-                order_id=order_id,
-                execution_policy_hash=common_ledger_fields["execution_policy_hash"],
-                cost_model_hash=common_ledger_fields["cost_model_hash"],
-                lineage_hash=common_ledger_fields["lineage_hash"],
-                replay_data_hash=common_ledger_fields["replay_data_hash"],
-                side=side,
-                filled_qty=filled_qty,
-                avg_fill_price=price,
-                filled_notional=filled_notional,
-                cost_amount=cost_amount,
-                cost_basis=cost_basis,
-                account_label=str(row.get("account_label") or "") or None,
-                strategy_id=str(row.get("strategy_id") or "") or None,
-                symbol=symbol,
-            )
-        )
+        if ledger_fill is not None:
+            carry_in_ledger_rows.append(ledger_fill)
     if not event_times:
         return []
     unique_times = sorted(set(event_times))
@@ -2902,6 +3064,7 @@ def _build_realized_strategy_pnl_rows(
         bucket_ranges=bucket_ranges,
         group_by=("symbol",),
         require_order_lifecycle=True,
+        carry_in_rows=carry_in_ledger_rows,
     ):
         if bucket.closed_trade_count <= 0 and not bucket.blockers:
             continue
@@ -2916,6 +3079,9 @@ def _build_realized_strategy_pnl_rows(
             decision_lifecycle_rows=decision_lifecycle_rows,
             order_lifecycle_rows=order_lifecycle_rows,
             unlinked_order_lifecycle_rows=unlinked_order_lifecycle_rows,
+            carry_in_execution_rows=carry_in_execution_rows,
+            carry_in_decision_lifecycle_rows=carry_in_decision_lifecycle_rows,
+            carry_in_order_lifecycle_rows=carry_in_order_lifecycle_rows,
         )
         source_account_labels = cast(list[str], source_context["source_account_labels"])
         source_decision_mode_counts = cast(
@@ -2932,6 +3098,8 @@ def _build_realized_strategy_pnl_rows(
             list[str], source_context["execution_order_event_ids"]
         )
         source_window_ids = cast(list[str], source_context["source_window_ids"])
+        source_window_start = cast(datetime, source_context["source_window_start"])
+        source_window_end = cast(datetime, source_context["source_window_end"])
         source_offsets = cast(
             list[Mapping[str, object]], source_context["source_offsets"]
         )
@@ -2989,8 +3157,8 @@ def _build_realized_strategy_pnl_rows(
         if isinstance(bucket_payload, Mapping):
             bucket_payload = _with_runtime_ledger_source_authority_context(
                 bucket_payload,
-                source_window_start=bucket.bucket_started_at,
-                source_window_end=bucket.bucket_ended_at,
+                source_window_start=source_window_start,
+                source_window_end=source_window_end,
                 source_refs=source_refs,
                 source_row_counts=source_row_counts,
                 trade_decision_ids=trade_decision_ids,
@@ -3848,6 +4016,10 @@ def _query_timestamps(
     decision_lifecycle_rows: list[dict[str, object]] = []
     order_lifecycle_rows: list[dict[str, object]] = []
     unlinked_order_lifecycle_rows: list[dict[str, object]] = []
+    carry_in_execution_rows: list[dict[str, object]] = []
+    carry_in_decision_lifecycle_rows: list[dict[str, object]] = []
+    carry_in_order_lifecycle_rows: list[dict[str, object]] = []
+    carry_in_window_start = window_start - RUNTIME_LEDGER_CARRY_IN_LOOKBACK
     symbol_filter = _metadata_symbol_list(symbols or ())
     if source_activity_diagnostics is not None:
         source_activity_diagnostics.update(
@@ -3857,6 +4029,8 @@ def _query_timestamps(
                 "source_account_label": source_account_label,
                 "window_start": window_start.isoformat(),
                 "window_end": window_end.isoformat(),
+                "carry_in_window_start": carry_in_window_start.isoformat(),
+                "carry_in_window_end": window_start.isoformat(),
                 "source_activity_symbol_filter": symbol_filter,
                 "candidate_id": candidate_id,
                 "hypothesis_id": hypothesis_id,
@@ -4191,6 +4365,303 @@ def _query_timestamps(
                 candidate_id=candidate_id,
                 hypothesis_id=hypothesis_id,
             )
+            if allow_authoritative_runtime_ledger_materialization:
+                cur.execute(
+                    f"""
+                    select
+                        d.id,
+                        d.created_at,
+                        d.symbol,
+                        d.alpaca_account_label,
+                        s.name,
+                        d.decision_hash,
+                        d.decision_json
+                    from trade_decisions d
+                    join strategies s on s.id = d.strategy_id
+                    where s.name = any(%s)
+                      and d.alpaca_account_label = %s
+                      and d.status = any(%s)
+                      and d.created_at >= %s
+                      and d.created_at < %s
+                      {decision_symbol_clause}
+                    order by d.created_at
+                    """,
+                    (
+                        strategy_names,
+                        account_label,
+                        list(EXECUTION_ELIGIBLE_DECISION_STATUSES),
+                        carry_in_window_start,
+                        window_start,
+                        *decision_symbol_params,
+                    ),
+                )
+                carry_in_decision_lifecycle_rows = [
+                    _decision_lifecycle_query_row(row)
+                    for row in cur.fetchall()
+                    if _decision_lifecycle_query_row_has_time(row)
+                ]
+                if source_activity_diagnostics is not None:
+                    source_activity_diagnostics[
+                        "carry_in_decision_rows_before_lineage_filter"
+                    ] = len(carry_in_decision_lifecycle_rows)
+                carry_in_decision_lifecycle_rows = [
+                    row
+                    for row in carry_in_decision_lifecycle_rows
+                    if _source_row_matches_lineage(
+                        row,
+                        candidate_id=candidate_id,
+                        hypothesis_id=hypothesis_id,
+                        require_source_lineage=require_source_lineage,
+                    )
+                ]
+                if source_activity_diagnostics is not None:
+                    source_activity_diagnostics[
+                        "carry_in_decision_rows_after_lineage_filter"
+                    ] = len(carry_in_decision_lifecycle_rows)
+                carry_in_decision_lifecycle_rows = _attach_source_lineage_context(
+                    carry_in_decision_lifecycle_rows,
+                    candidate_id=candidate_id,
+                    hypothesis_id=hypothesis_id,
+                )
+                cur.execute(
+                    f"""
+                    select
+                        e.id,
+                        d.id,
+                        d.created_at,
+                        coalesce(
+                            e.order_feed_last_event_ts,
+                            e.last_update_at,
+                            e.updated_at,
+                            e.created_at
+                        ) as execution_event_at,
+                        e.created_at,
+                        e.symbol,
+                        e.side,
+                        e.filled_qty,
+                        e.avg_fill_price,
+                        t.shortfall_notional,
+                        e.execution_audit_json,
+                        e.raw_order,
+                        e.alpaca_account_label,
+                        s.name,
+                        d.decision_hash,
+                        d.decision_json,
+                        e.alpaca_order_id,
+                        e.client_order_id,
+                        e.status
+                    from executions e
+                    join trade_decisions d on d.id = e.trade_decision_id
+                    join strategies s on s.id = d.strategy_id
+                    left join execution_tca_metrics t on t.execution_id = e.id
+                    where s.name = any(%s)
+                      and d.alpaca_account_label = %s
+                      and e.alpaca_account_label = %s
+                      and coalesce(
+                            e.order_feed_last_event_ts,
+                            e.last_update_at,
+                            e.updated_at,
+                            e.created_at
+                          ) >= %s
+                      and coalesce(
+                            e.order_feed_last_event_ts,
+                            e.last_update_at,
+                            e.updated_at,
+                            e.created_at
+                          ) < %s
+                      {execution_symbol_clause}
+                    order by coalesce(
+                        e.order_feed_last_event_ts,
+                        e.last_update_at,
+                        e.updated_at,
+                        e.created_at
+                    )
+                    """,
+                    (
+                        strategy_names,
+                        account_label,
+                        account_label,
+                        carry_in_window_start,
+                        window_start,
+                        *execution_symbol_params,
+                    ),
+                )
+                carry_in_execution_rows = [
+                    _execution_query_row(row)
+                    for row in cur.fetchall()
+                    if _execution_query_row_has_time(row)
+                ]
+                if source_activity_diagnostics is not None:
+                    source_activity_diagnostics[
+                        "carry_in_execution_rows_before_lineage_filter"
+                    ] = len(carry_in_execution_rows)
+                    source_activity_diagnostics[
+                        "carry_in_fill_execution_rows_before_lineage_filter"
+                    ] = sum(
+                        1
+                        for row in carry_in_execution_rows
+                        if _execution_row_has_fill(row)
+                    )
+                carry_in_execution_rows = [
+                    row
+                    for row in carry_in_execution_rows
+                    if _source_row_matches_lineage(
+                        row,
+                        candidate_id=candidate_id,
+                        hypothesis_id=hypothesis_id,
+                        require_source_lineage=require_source_lineage,
+                    )
+                ]
+                if source_activity_diagnostics is not None:
+                    source_activity_diagnostics[
+                        "carry_in_execution_rows_after_lineage_filter"
+                    ] = len(carry_in_execution_rows)
+                    source_activity_diagnostics[
+                        "carry_in_fill_execution_rows_after_lineage_filter"
+                    ] = sum(
+                        1
+                        for row in carry_in_execution_rows
+                        if _execution_row_has_fill(row)
+                    )
+                carry_in_execution_rows = _attach_source_lineage_context(
+                    carry_in_execution_rows,
+                    candidate_id=candidate_id,
+                    hypothesis_id=hypothesis_id,
+                )
+                cur.execute(
+                    f"""
+                    select
+                        oe.id,
+                        coalesce(oe.trade_decision_id, e.trade_decision_id, d_by_client.id),
+                        e.id,
+                        coalesce(oe.event_ts, oe.created_at),
+                        oe.symbol,
+                        oe.alpaca_account_label,
+                        s.name,
+                        d.decision_hash,
+                        d.decision_json,
+                        oe.alpaca_order_id,
+                        oe.client_order_id,
+                        oe.event_type,
+                        oe.status,
+                        e.side,
+                        oe.qty,
+                        oe.filled_qty,
+                        oe.avg_fill_price,
+                        oe.event_fingerprint,
+                        oe.source_topic,
+                        oe.source_partition,
+                        oe.source_offset,
+                        oe.source_window_id,
+                        oe.raw_event,
+                        e.execution_audit_json,
+                        e.raw_order
+                    from execution_order_events oe
+                    left join lateral (
+                        select matched.*
+                        from (
+                            select
+                                array_agg(e_match.id order by e_match.created_at, e_match.id) as ids,
+                                count(*) as match_count
+                            from executions e_match
+                            where coalesce(e_match.alpaca_account_label, oe.alpaca_account_label)
+                                  = oe.alpaca_account_label
+                              and (
+                                    (
+                                        oe.execution_id is not null
+                                        and e_match.id = oe.execution_id
+                                    )
+                                    or (
+                                        nullif(oe.alpaca_order_id, '') is not null
+                                        and e_match.alpaca_order_id = oe.alpaca_order_id
+                                    )
+                                    or (
+                                        nullif(oe.client_order_id, '') is not null
+                                        and e_match.client_order_id = oe.client_order_id
+                                    )
+                                  )
+                        ) exact_match
+                        join executions matched on matched.id = exact_match.ids[1]
+                        where exact_match.match_count = 1
+                    ) e on true
+                    left join lateral (
+                        select matched.*
+                        from (
+                            select
+                                array_agg(d_match.id order by d_match.created_at, d_match.id) as ids,
+                                count(*) as match_count
+                            from trade_decisions d_match
+                            where d_match.alpaca_account_label = oe.alpaca_account_label
+                              and nullif(oe.client_order_id, '') is not null
+                              and d_match.decision_hash = oe.client_order_id
+                        ) exact_decision_match
+                        join trade_decisions matched on matched.id = exact_decision_match.ids[1]
+                        where exact_decision_match.match_count = 1
+                    ) d_by_client on true
+                    join trade_decisions d
+                      on d.id = coalesce(oe.trade_decision_id, e.trade_decision_id, d_by_client.id)
+                    join strategies s on s.id = d.strategy_id
+                    where s.name = any(%s)
+                      and d.alpaca_account_label = %s
+                      and oe.alpaca_account_label = %s
+                      and coalesce(oe.event_ts, oe.created_at) >= %s
+                      and coalesce(oe.event_ts, oe.created_at) < %s
+                      {order_event_symbol_clause}
+                    order by coalesce(oe.event_ts, oe.created_at), oe.created_at
+                    """,
+                    (
+                        strategy_names,
+                        account_label,
+                        account_label,
+                        carry_in_window_start,
+                        window_start,
+                        *order_event_symbol_params,
+                    ),
+                )
+                carry_in_order_lifecycle_rows = [
+                    _order_lifecycle_query_row(row)
+                    for row in cur.fetchall()
+                    if _order_lifecycle_query_row_has_time(row)
+                ]
+                if source_activity_diagnostics is not None:
+                    source_activity_diagnostics[
+                        "carry_in_order_lifecycle_rows_before_lineage_filter"
+                    ] = len(carry_in_order_lifecycle_rows)
+                    source_activity_diagnostics[
+                        "carry_in_fill_order_lifecycle_rows_before_lineage_filter"
+                    ] = sum(
+                        1
+                        for row in carry_in_order_lifecycle_rows
+                        if _runtime_ledger_event_type(row)
+                        in _RUNTIME_LEDGER_FILL_EVENTS
+                    )
+                carry_in_order_lifecycle_rows = [
+                    row
+                    for row in carry_in_order_lifecycle_rows
+                    if _source_row_matches_lineage(
+                        row,
+                        candidate_id=candidate_id,
+                        hypothesis_id=hypothesis_id,
+                        require_source_lineage=require_source_lineage,
+                    )
+                ]
+                if source_activity_diagnostics is not None:
+                    source_activity_diagnostics[
+                        "carry_in_order_lifecycle_rows_after_lineage_filter"
+                    ] = len(carry_in_order_lifecycle_rows)
+                    source_activity_diagnostics[
+                        "carry_in_fill_order_lifecycle_rows_after_lineage_filter"
+                    ] = sum(
+                        1
+                        for row in carry_in_order_lifecycle_rows
+                        if _runtime_ledger_event_type(row)
+                        in _RUNTIME_LEDGER_FILL_EVENTS
+                    )
+                carry_in_order_lifecycle_rows = _attach_source_lineage_context(
+                    carry_in_order_lifecycle_rows,
+                    candidate_id=candidate_id,
+                    hypothesis_id=hypothesis_id,
+                )
             if symbol_filter:
                 cur.execute(
                     f"""
@@ -4457,6 +4928,21 @@ def _query_timestamps(
         target_account_label=materialized_account_label,
         source_account_label=source_account_label,
     )
+    carry_in_decision_lifecycle_rows = _retarget_source_rows_for_materialization(
+        carry_in_decision_lifecycle_rows,
+        target_account_label=materialized_account_label,
+        source_account_label=source_account_label,
+    )
+    carry_in_execution_rows = _retarget_source_rows_for_materialization(
+        carry_in_execution_rows,
+        target_account_label=materialized_account_label,
+        source_account_label=source_account_label,
+    )
+    carry_in_order_lifecycle_rows = _retarget_source_rows_for_materialization(
+        carry_in_order_lifecycle_rows,
+        target_account_label=materialized_account_label,
+        source_account_label=source_account_label,
+    )
     tca_rows = _retarget_runtime_ledger_tca_rows(
         tca_rows,
         target_account_label=materialized_account_label,
@@ -4468,6 +4954,9 @@ def _query_timestamps(
             decision_lifecycle_rows=decision_lifecycle_rows,
             order_lifecycle_rows=order_lifecycle_rows,
             unlinked_order_lifecycle_rows=unlinked_order_lifecycle_rows,
+            carry_in_execution_rows=carry_in_execution_rows,
+            carry_in_decision_lifecycle_rows=carry_in_decision_lifecycle_rows,
+            carry_in_order_lifecycle_rows=carry_in_order_lifecycle_rows,
             allow_authoritative_runtime_ledger_materialization=(
                 allow_authoritative_runtime_ledger_materialization
             ),

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -41,6 +41,8 @@ from scripts.import_hypothesis_runtime_windows import (
     _runtime_lifecycle_ledger_row,
     _runtime_ledger_profit_proof_present,
     _runtime_observation_authority_payload,
+    _runtime_decision_rows_before_bucket,
+    _runtime_execution_ledger_fill_from_row,
     _runtime_ledger_target_metadata_blockers,
     _runtime_ledger_tca_row_from_bucket,
     _runtime_ledger_tca_materialization_metadata,
@@ -2062,6 +2064,386 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             ],
         )
         self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
+
+    def test_build_realized_strategy_pnl_rows_uses_source_backed_carry_in(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "execution_id": "execution-sell",
+                    "trade_decision_id": "decision-sell-id",
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sell",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                },
+            ],
+            decision_lifecycle_rows=[
+                {
+                    "trade_decision_id": "decision-sell-id",
+                    "computed_at": datetime(2026, 3, 6, 14, 39, tzinfo=timezone.utc),
+                    "event_type": "decision",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "decision_json": {"account": {"equity": "10000"}},
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            order_lifecycle_rows=[
+                {
+                    "execution_order_event_id": "event-new-sell",
+                    "trade_decision_id": "decision-sell-id",
+                    "event_ts": datetime(2026, 3, 6, 14, 39, 1, tzinfo=timezone.utc),
+                    "event_type": "new",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sell",
+                    "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 201,
+                    "source_window_id": "source-window-new-sell",
+                },
+                {
+                    "execution_order_event_id": "event-fill-sell",
+                    "trade_decision_id": "decision-sell-id",
+                    "execution_id": "execution-sell",
+                    "event_ts": datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sell",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 202,
+                    "source_window_id": "source-window-fill-sell",
+                },
+            ],
+            carry_in_execution_rows=[
+                {
+                    "execution_id": "execution-buy",
+                    "trade_decision_id": "decision-buy-id",
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-buy",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                },
+            ],
+            carry_in_decision_lifecycle_rows=[
+                {
+                    "trade_decision_id": "decision-buy-id",
+                    "computed_at": datetime(2026, 3, 6, 14, 34, tzinfo=timezone.utc),
+                    "event_type": "decision",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "decision_json": {"account": {"equity": "10000"}},
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            carry_in_order_lifecycle_rows=[
+                {
+                    "execution_order_event_id": "event-new-buy",
+                    "trade_decision_id": "decision-buy-id",
+                    "event_ts": datetime(2026, 3, 6, 14, 34, 1, tzinfo=timezone.utc),
+                    "event_type": "new",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-buy",
+                    "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 199,
+                    "source_window_id": "source-window-new-buy",
+                },
+                {
+                    "execution_order_event_id": "event-fill-buy",
+                    "trade_decision_id": "decision-buy-id",
+                    "execution_id": "execution-buy",
+                    "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-buy",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 200,
+                    "source_window_id": "source-window-fill-buy",
+                },
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0]["post_cost_promotion_eligible"])
+        self.assertTrue(rows[0]["authoritative"])
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["blockers"], [])
+        self.assertEqual(bucket["filled_notional"], "201")
+        self.assertEqual(bucket["cost_amount"], "0.30")
+        self.assertEqual(bucket["net_strategy_pnl_after_costs"], "0.70")
+        self.assertEqual(bucket["open_position_count"], 0)
+        self.assertEqual(bucket["closed_trade_count"], 1)
+        self.assertEqual(bucket["source_window_start"], "2026-03-06T14:34:00+00:00")
+        self.assertEqual(
+            bucket["source_window_ids"],
+            [
+                "source-window-new-buy",
+                "source-window-fill-buy",
+                "source-window-new-sell",
+                "source-window-fill-sell",
+            ],
+        )
+        self.assertEqual(
+            bucket["source_row_counts"],
+            {
+                "executions": 2,
+                "execution_order_events": 4,
+                "order_feed_source_windows": 4,
+                "trade_decisions": 2,
+            },
+        )
+        self.assertTrue(_runtime_ledger_bucket_profit_proof_present(bucket))
+
+    def test_runtime_carry_in_source_filters_reject_wrong_symbol_and_decision(
+        self,
+    ) -> None:
+        bucket = RuntimeLedgerBucket(
+            bucket_started_at=datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+            bucket_ended_at=datetime(2026, 3, 6, 14, 45, tzinfo=timezone.utc),
+            account_label="TORGHUT_SIM",
+            strategy_id="microbar-cross-sectional-pairs-v1",
+            symbol="AAPL",
+            fill_count=0,
+            decision_count=0,
+            submitted_order_count=0,
+            cancelled_order_count=0,
+            rejected_order_count=0,
+            unfilled_order_count=0,
+            closed_trade_count=0,
+            open_position_count=0,
+            filled_notional=Decimal("0"),
+            gross_strategy_pnl=Decimal("0"),
+            cost_amount=Decimal("0"),
+            net_strategy_pnl_after_costs=Decimal("0"),
+            post_cost_expectancy_bps=None,
+            cost_basis_counts={},
+            execution_policy_hash_counts={},
+            cost_model_hash_counts={},
+            lineage_hash_counts={},
+            blockers=[],
+        )
+
+        rows = _runtime_decision_rows_before_bucket(
+            bucket=bucket,
+            decision_lifecycle_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 39, tzinfo=timezone.utc),
+                    "symbol": "MSFT",
+                    "decision_hash": "wanted",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 46, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "decision_hash": "wanted",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 39, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "decision_hash": "other",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 39, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "decision_hash": "wanted",
+                },
+            ],
+            source_rows=[{"decision_hash": "wanted"}],
+        )
+
+        self.assertEqual(
+            rows,
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 39, tzinfo=timezone.utc),
+                    "symbol": "AAPL",
+                    "decision_hash": "wanted",
+                }
+            ],
+        )
+
+    def test_runtime_execution_ledger_fill_helper_validates_and_hashes_cost_model(
+        self,
+    ) -> None:
+        invalid_fill, invalid_times = _runtime_execution_ledger_fill_from_row(
+            {
+                "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                "symbol": "AAPL",
+                "side": "buy",
+                "filled_qty": Decimal("1"),
+                "avg_fill_price": Decimal("0"),
+            },
+            order_lifecycle_rows=None,
+        )
+
+        self.assertIsNone(invalid_fill)
+        self.assertEqual(invalid_times, [])
+
+        fill, event_times = _runtime_execution_ledger_fill_from_row(
+            {
+                "execution_id": "execution-sell",
+                "trade_decision_id": "decision-sell-id",
+                "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                "execution_event_at": datetime(
+                    2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc
+                ),
+                "symbol": "AAPL",
+                "side": "sell",
+                "filled_qty": Decimal("1"),
+                "avg_fill_price": Decimal("101"),
+                "cost_amount": Decimal("0.02"),
+                "cost_basis": "alpaca_2026_equity_fee_schedule",
+                "account_label": "TORGHUT_SIM",
+                "strategy_id": "microbar-cross-sectional-pairs-v1",
+            },
+            order_lifecycle_rows=None,
+        )
+
+        self.assertIsNotNone(fill)
+        assert fill is not None
+        self.assertEqual(fill.cost_model_hash, _alpaca_2026_equity_fee_schedule_hash())
+        self.assertEqual(
+            event_times,
+            [
+                datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
+                datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
+            ],
+        )
+
+    def test_build_realized_strategy_pnl_rows_uses_carry_in_execution_economics(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "execution_id": "execution-sell",
+                    "trade_decision_id": "decision-sell-id",
+                    "computed_at": datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "execution_policy_hash": "policy-sell",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            carry_in_execution_rows=[
+                {
+                    "execution_id": "execution-buy",
+                    "trade_decision_id": "decision-buy-id",
+                    "computed_at": datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "execution_policy_hash": "policy-buy",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            split_mixed_source_decision_modes=False,
+        )
+
+        self.assertEqual(len(rows), 1)
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["closed_trade_count"], 1)
+        self.assertEqual(bucket["filled_notional"], "201")
+        self.assertEqual(bucket["net_strategy_pnl_after_costs"], "0.70")
 
     def test_build_realized_strategy_pnl_rows_does_not_borrow_source_refs_from_other_symbol(
         self,
@@ -4641,6 +5023,254 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             diagnostics["order_feed_fill_lifecycle_blockers"],
             ["order_feed_fill_lifecycle_missing"],
         )
+
+    def test_query_timestamps_materializes_source_backed_carry_in(
+        self,
+    ) -> None:
+        def decision_row(
+            decision_id: str,
+            created_at: datetime,
+            decision_hash: str,
+        ) -> tuple[object, ...]:
+            return (
+                decision_id,
+                created_at,
+                "AAPL",
+                "TORGHUT_SIM",
+                "microbar-cross-sectional-pairs-v1",
+                decision_hash,
+                {},
+            )
+
+        def execution_row(
+            execution_id: str,
+            decision_id: str,
+            decision_created_at: datetime,
+            event_at: datetime,
+            side: str,
+            qty: str,
+            price: str,
+            order_id: str,
+            decision_hash: str,
+        ) -> tuple[object, ...]:
+            return (
+                execution_id,
+                decision_id,
+                decision_created_at,
+                event_at,
+                event_at,
+                "AAPL",
+                side,
+                Decimal(qty),
+                Decimal(price),
+                Decimal("0.01"),
+                {
+                    "cost_amount": "0.01",
+                    "cost_basis": "broker_reported_commission_and_fees",
+                },
+                {},
+                "TORGHUT_SIM",
+                "microbar-cross-sectional-pairs-v1",
+                decision_hash,
+                {},
+                order_id,
+                f"client-{order_id}",
+                "filled",
+            )
+
+        def order_event_row(
+            event_id: str,
+            decision_id: str,
+            execution_id: str,
+            event_at: datetime,
+            event_type: str,
+            side: str,
+            qty: str,
+            price: str,
+            order_id: str,
+            decision_hash: str,
+            source_offset: int,
+        ) -> tuple[object, ...]:
+            return (
+                event_id,
+                decision_id,
+                execution_id,
+                event_at,
+                "AAPL",
+                "TORGHUT_SIM",
+                "microbar-cross-sectional-pairs-v1",
+                decision_hash,
+                {},
+                order_id,
+                f"client-{order_id}",
+                event_type,
+                "filled" if event_type == "filled" else "new",
+                side,
+                Decimal(qty),
+                Decimal(qty) if event_type == "filled" else Decimal("0"),
+                Decimal(price),
+                f"fingerprint-{event_id}",
+                "alpaca.trade_updates",
+                0,
+                source_offset,
+                f"source-window-{event_id}",
+                {},
+                {
+                    "cost_amount": "0.01",
+                    "cost_basis": "broker_reported_commission_and_fees",
+                },
+                {},
+            )
+
+        cursor = _FakeCursor()
+        cursor._results = [
+            [
+                decision_row(
+                    "decision-sell-id",
+                    datetime(2026, 3, 6, 14, 39, tzinfo=timezone.utc),
+                    "decision-sell",
+                )
+            ],
+            [
+                execution_row(
+                    "execution-sell",
+                    "decision-sell-id",
+                    datetime(2026, 3, 6, 14, 39, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "sell",
+                    "1",
+                    "101",
+                    "order-sell",
+                    "decision-sell",
+                )
+            ],
+            [
+                order_event_row(
+                    "event-fill-sell",
+                    "decision-sell-id",
+                    "execution-sell",
+                    datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                    "filled",
+                    "sell",
+                    "1",
+                    "101",
+                    "order-sell",
+                    "decision-sell",
+                    202,
+                )
+            ],
+            [
+                decision_row(
+                    "decision-buy-id",
+                    datetime(2026, 3, 6, 14, 34, tzinfo=timezone.utc),
+                    "decision-buy",
+                )
+            ],
+            [
+                execution_row(
+                    "execution-buy",
+                    "decision-buy-id",
+                    datetime(2026, 3, 6, 14, 34, tzinfo=timezone.utc),
+                    datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "buy",
+                    "1",
+                    "100",
+                    "order-buy",
+                    "decision-buy",
+                )
+            ],
+            [
+                order_event_row(
+                    "event-fill-buy",
+                    "decision-buy-id",
+                    "execution-buy",
+                    datetime(2026, 3, 6, 14, 35, tzinfo=timezone.utc),
+                    "filled",
+                    "buy",
+                    "1",
+                    "100",
+                    "order-buy",
+                    "decision-buy",
+                    200,
+                )
+            ],
+            [],
+            [],
+        ]
+        connection = _FakeConnection(cursor)
+        diagnostics: dict[str, object] = {}
+
+        with patch(
+            "scripts.import_hypothesis_runtime_windows.psycopg.connect",
+            return_value=connection,
+        ):
+            _, _, tca_rows = _query_timestamps(
+                dsn="postgresql://example",
+                strategy_names=["microbar-cross-sectional-pairs-v1"],
+                account_label="TORGHUT_SIM",
+                window_start=datetime(2026, 3, 6, 14, 40, tzinfo=timezone.utc),
+                window_end=datetime(2026, 3, 6, 14, 45, tzinfo=timezone.utc),
+                symbols=["AAPL"],
+                allow_authoritative_runtime_ledger_materialization=True,
+                source_activity_diagnostics=diagnostics,
+            )
+
+        self.assertEqual(len(cursor.executed), 8)
+        carry_decision_query, carry_decision_params = cursor.executed[3]
+        carry_execution_query, carry_execution_params = cursor.executed[4]
+        carry_order_query, carry_order_params = cursor.executed[5]
+        self.assertIn("d.created_at >= %s", carry_decision_query)
+        self.assertIn("d.created_at < %s", carry_decision_query)
+        self.assertIn("from executions e", carry_execution_query)
+        self.assertIn("from execution_order_events oe", carry_order_query)
+        self.assertEqual(
+            carry_decision_params[3],
+            datetime(2026, 3, 1, 14, 40, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            carry_execution_params[3],
+            datetime(2026, 3, 1, 14, 40, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            carry_order_params[3],
+            datetime(2026, 3, 1, 14, 40, tzinfo=timezone.utc),
+        )
+        self.assertEqual(diagnostics["carry_in_decision_rows_before_lineage_filter"], 1)
+        self.assertEqual(diagnostics["carry_in_decision_rows_after_lineage_filter"], 1)
+        self.assertEqual(
+            diagnostics["carry_in_execution_rows_before_lineage_filter"], 1
+        )
+        self.assertEqual(diagnostics["carry_in_execution_rows_after_lineage_filter"], 1)
+        self.assertEqual(
+            diagnostics["carry_in_fill_execution_rows_before_lineage_filter"], 1
+        )
+        self.assertEqual(
+            diagnostics["carry_in_fill_execution_rows_after_lineage_filter"], 1
+        )
+        self.assertEqual(
+            diagnostics["carry_in_order_lifecycle_rows_before_lineage_filter"], 1
+        )
+        self.assertEqual(
+            diagnostics["carry_in_order_lifecycle_rows_after_lineage_filter"], 1
+        )
+        self.assertEqual(
+            diagnostics["carry_in_fill_order_lifecycle_rows_before_lineage_filter"], 1
+        )
+        self.assertEqual(
+            diagnostics["carry_in_fill_order_lifecycle_rows_after_lineage_filter"], 1
+        )
+        runtime_rows = [
+            row
+            for row in tca_rows
+            if row.get("post_cost_expectancy_basis") == POST_COST_BASIS_RUNTIME_LEDGER
+        ]
+        self.assertEqual(len(runtime_rows), 1)
+        bucket = runtime_rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertEqual(bucket["closed_trade_count"], 1)
+        self.assertEqual(bucket["open_position_count"], 0)
+        self.assertEqual(bucket["source_window_start"], "2026-03-06T14:34:00+00:00")
 
     def test_source_activity_diagnostic_blockers_classify_materialization_gap(
         self,

--- a/services/torghut/tests/test_runtime_ledger.py
+++ b/services/torghut/tests/test_runtime_ledger.py
@@ -347,6 +347,162 @@ def test_grouped_positions_carry_across_bucket_boundaries() -> None:
     )
 
 
+def test_source_backed_carry_in_closes_position_opened_before_bucket() -> None:
+    common = {
+        "account_label": "paper",
+        "strategy_id": "strategy-1",
+        "symbol": "NVDA",
+        "cost_model_hash": "cost-sha",
+        "lineage_hash": "lineage-sha",
+    }
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                **common,
+                "event_type": "decision",
+                "executed_at": _ts(35),
+                "decision_id": "decision-sell",
+            },
+            {
+                **common,
+                "event_type": "order_submitted",
+                "executed_at": _ts(36),
+                "decision_id": "decision-sell",
+                "order_id": "order-sell",
+                "execution_policy_hash": "policy-sell",
+            },
+            {
+                **common,
+                "event_type": "fill",
+                "executed_at": _ts(37),
+                "decision_id": "decision-sell",
+                "order_id": "order-sell",
+                "execution_policy_hash": "policy-sell",
+                "side": "sell",
+                "filled_qty": "10",
+                "avg_fill_price": "110",
+                "cost_amount": "2",
+                "cost_basis": "broker_reported_commission_and_fees",
+            },
+        ],
+        carry_in_rows=[
+            {
+                **common,
+                "event_type": "decision",
+                "executed_at": _ts(1),
+                "decision_id": "decision-buy",
+            },
+            {
+                **common,
+                "event_type": "order_submitted",
+                "executed_at": _ts(2),
+                "decision_id": "decision-buy",
+                "order_id": "order-buy",
+                "execution_policy_hash": "policy-buy",
+            },
+            {
+                **common,
+                "event_type": "fill",
+                "executed_at": _ts(3),
+                "decision_id": "decision-buy",
+                "order_id": "order-buy",
+                "execution_policy_hash": "policy-buy",
+                "side": "buy",
+                "filled_qty": "10",
+                "avg_fill_price": "100",
+                "cost_amount": "1",
+                "cost_basis": "broker_reported_commission_and_fees",
+            },
+        ],
+        bucket_ranges=[(_ts(30), _ts(60))],
+        group_by=("symbol",),
+        require_order_lifecycle=True,
+    )[0]
+
+    assert bucket.blockers == []
+    assert bucket.closed_trade_count == 1
+    assert bucket.open_position_count == 0
+    assert bucket.filled_notional == Decimal("2100")
+    assert bucket.cost_amount == Decimal("3")
+    assert bucket.net_strategy_pnl_after_costs == Decimal("97")
+    assert bucket.cost_basis_counts == {"broker_reported_commission_and_fees": 2}
+    assert bucket.cost_model_hash_counts == {"cost-sha": 2}
+    assert bucket.execution_policy_hash_counts == {
+        "policy-buy": 2,
+        "policy-sell": 2,
+    }
+    _assert_decimal_close(
+        bucket.post_cost_expectancy_bps,
+        (Decimal("97") / Decimal("2100")) * Decimal("10000"),
+    )
+
+
+def test_sell_without_carry_in_stays_fail_closed() -> None:
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                "event_type": "fill",
+                "executed_at": _ts(37),
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "sell",
+                "filled_qty": "10",
+                "avg_fill_price": "110",
+                "cost_amount": "2",
+                "cost_basis": "broker_reported_commission_and_fees",
+            },
+        ],
+        bucket_ranges=[(_ts(30), _ts(60))],
+    )[0]
+
+    assert bucket.closed_trade_count == 0
+    assert bucket.open_position_count == 1
+    assert "closed_round_trip_missing" in bucket.blockers
+    assert "unclosed_position" in bucket.blockers
+    assert bucket.post_cost_expectancy_bps is None
+
+
+def test_carry_in_non_promotion_cost_basis_blocks_bucket() -> None:
+    bucket = build_runtime_ledger_buckets(
+        [
+            {
+                "event_type": "fill",
+                "executed_at": _ts(37),
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "sell",
+                "filled_qty": "10",
+                "avg_fill_price": "110",
+                "cost_amount": "2",
+                "cost_basis": "broker_reported_commission_and_fees",
+            },
+        ],
+        carry_in_rows=[
+            {
+                "event_type": "fill",
+                "executed_at": _ts(3),
+                "account_label": "paper",
+                "strategy_id": "strategy-1",
+                "symbol": "NVDA",
+                "side": "buy",
+                "filled_qty": "10",
+                "avg_fill_price": "100",
+                "cost_amount": "1",
+                "cost_basis": "paper_cost_model_estimate",
+            },
+        ],
+        bucket_ranges=[(_ts(30), _ts(60))],
+    )[0]
+
+    assert bucket.closed_trade_count == 0
+    assert bucket.open_position_count == 1
+    assert "runtime_ledger_cost_basis_non_promotion_grade" in bucket.blockers
+    assert "unclosed_position" in bucket.blockers
+    assert bucket.post_cost_expectancy_bps is None
+
+
 def test_tca_shortfall_rows_do_not_count_as_strategy_pnl() -> None:
     bucket = _bucket(
         [


### PR DESCRIPTION
## Summary

- Adds bounded source-backed carry-in rows to runtime-ledger bucket construction so a target window can close positions opened before the window without false `unclosed_position` / `closed_round_trip_missing` blockers.
- Extends runtime-window import materialization to query a five-day source carry-in window only when authoritative runtime-ledger materialization is enabled, preserving default query behavior.
- Includes source-window/source-offset/order/execution/decision lineage from carry-in lifecycle rows in authority context without loosening promotion gates.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_ledger.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_ledger.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py tests/test_runtime_window_import.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_verify_trading_readiness.py tests/test_runtime_ledger.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
