### PR TITLE
fix(registry): keep image registry available

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -173,8 +173,37 @@ jobs:
     needs: [version, build-proompteng, build-app, build-synthesis, build-docs, build-olden]
     if: failure()
     steps:
-      - name: Delete release if any build failed
-        run: gh release delete ${{ needs.version.outputs.new_tag }} --cleanup-tag --yes
-        continue-on-error: true
+      - name: Delete release and tag if any build failed
+        uses: actions/github-script@v8
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.version.outputs.new_tag }}
+        with:
+          script: |
+            const tag = process.env.RELEASE_TAG;
+            if (!tag) {
+              core.info('No release tag was produced; nothing to clean up.');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+
+            try {
+              const release = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+              await github.rest.repos.deleteRelease({ owner, repo, release_id: release.data.id });
+              core.info(`Deleted release ${tag}.`);
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+              core.info(`Release ${tag} was already absent.`);
+            }
+
+            try {
+              await github.rest.git.deleteRef({ owner, repo, ref: `tags/${tag}` });
+              core.info(`Deleted tag ${tag}.`);
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+              core.info(`Tag ${tag} was already absent.`);
+            }

--- a/argocd/applications/registry/deployment.yaml
+++ b/argocd/applications/registry/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: registry
   namespace: registry
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: registry

--- a/argocd/applications/registry/registry-gc-cronjob.yaml
+++ b/argocd/applications/registry/registry-gc-cronjob.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   schedule: "0 3 * * 0"
   timeZone: America/Los_Angeles
+  suspend: true
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 1800
   successfulJobsHistoryLimit: 1
@@ -44,7 +45,7 @@ spec:
                   chmod +x /usr/local/bin/kubectl
 
                   desired_replicas="$(kubectl -n registry get deployment/registry -o jsonpath='{.spec.replicas}' || echo '1')"
-                  if [ -z "${desired_replicas}" ]; then
+                  if [ -z "${desired_replicas}" ] || [ "${desired_replicas}" = "0" ]; then
                     desired_replicas="1"
                   fi
 


### PR DESCRIPTION
## Summary

- Keeps the registry deployment reconciled at one replica so Argo can recover drift from an accidental scale-down.
- Suspends the disruptive automatic registry GC CronJob and guards its restore logic so a zero-replica snapshot restores to one replica if it is re-enabled.
- Replaces failed-release cleanup's missing `gh` dependency with `actions/github-script` so failed image builds delete the GitHub release and tag reliably.

## Related Issues

None.

## Testing

- `kubectl kustomize argocd/applications/registry`
- `bun run lint:argocd`
- `actionlint -ignore 'label "arc-arm64" is unknown' .github/workflows/docker-build-push.yaml`
- `git diff --check`
- Emergency live recovery: deleted the stuck registry GC jobs, scaled `deployment/registry` to one replica, and verified `https://registry.ide-newton.ts.net/v2/` plus `lab/olden:0.581.1` manifest requests returned HTTP 200.

## Screenshots (if applicable)

N/A.

## Breaking Changes

Automatic registry garbage collection is suspended. Manual registry storage maintenance is required until a non-disruptive GC process is implemented.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
