### PR TITLE
chore(torghut): promote image 9d15e16b

### DIFF
--- a/argocd/applications/torghut-options/catalog/deployment.yaml
+++ b/argocd/applications/torghut-options/catalog/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-catalog
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.581.1-2-g852321b97
+              value: v0.582.0-9-g9d15e16b6
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 852321b97e45dc057914d42498f763f14ba3d188
+              value: 9d15e16b692d66fbd215380325c146f4fc714446
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut-options/enricher/deployment.yaml
+++ b/argocd/applications/torghut-options/enricher/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: torghut-options-enricher
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
           imagePullPolicy: IfNotPresent
           command:
             - uvicorn
@@ -71,9 +71,9 @@ spec:
                   name: torghut-options-alpaca
                   key: APCA_API_BASE_URL
             - name: TORGHUT_OPTIONS_VERSION
-              value: v0.581.1-2-g852321b97
+              value: v0.582.0-9-g9d15e16b6
             - name: TORGHUT_OPTIONS_COMMIT
-              value: 852321b97e45dc057914d42498f763f14ba3d188
+              value: 9d15e16b692d66fbd215380325c146f4fc714446
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/torghut/analysis-template-activity.yaml
+++ b/argocd/applications/torghut/analysis-template-activity.yaml
@@ -41,7 +41,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
+++ b/argocd/applications/torghut/analysis-template-artifact-bundle.yaml
@@ -23,7 +23,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-runtime-ready.yaml
+++ b/argocd/applications/torghut/analysis-template-runtime-ready.yaml
@@ -33,7 +33,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
                     imagePullPolicy: IfNotPresent
                     command:
                       - /bin/bash

--- a/argocd/applications/torghut/analysis-template-teardown-clean.yaml
+++ b/argocd/applications/torghut/analysis-template-teardown-clean.yaml
@@ -31,7 +31,7 @@ spec:
                   kubernetes.io/arch: arm64
                 containers:
                   - name: analysis
-                    image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+                    image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
                     imagePullPolicy: IfNotPresent
                     env:
                       - name: DB_DSN

--- a/argocd/applications/torghut/db-migrations-job.yaml
+++ b/argocd/applications/torghut/db-migrations-job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: migrate
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
           command:
             - /bin/sh
             - -ec

--- a/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
+++ b/argocd/applications/torghut/empirical-jobs-backfill-job.yaml
@@ -15,7 +15,7 @@ spec:
         kubernetes.io/arch: arm64
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
+++ b/argocd/applications/torghut/empirical-promotion-renewal-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: renew
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
               imagePullPolicy: IfNotPresent
               resources:
                 requests:
@@ -119,7 +119,7 @@ spec:
                 - name: SIM_DB_DSN
                   value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
                 - name: TORGHUT_IMAGE_DIGEST
-                  value: sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+                  value: sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
                 - name: TORGHUT_EMPIRICAL_CEPH_BUCKET
                   valueFrom:
                     configMapKeyRef:

--- a/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
+++ b/argocd/applications/torghut/empirical-promotion-workflowtemplate.yaml
@@ -23,7 +23,7 @@ spec:
           - name: manifestB64
           - name: outputRoot
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
+++ b/argocd/applications/torghut/execution-tca-refresh-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: refresh-execution-tca
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
               imagePullPolicy: IfNotPresent
               env:
                 - name: DB_DSN

--- a/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
+++ b/argocd/applications/torghut/historical-simulation-workflowtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         - name: allowMissingState
         - name: outputRoot
     container:
-      image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+      image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
       imagePullPolicy: Always
       env:
         - name: DB_DSN

--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-31T09:40:41Z"
+        client.knative.dev/updateTimestamp: "2026-05-31T11:07:50Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
           ports:
             - name: http1
               containerPort: 8181
@@ -512,11 +512,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.581.1-2-g852321b97
+              value: v0.582.0-9-g9d15e16b6
             - name: TORGHUT_COMMIT
-              value: 852321b97e45dc057914d42498f763f14ba3d188
+              value: 9d15e16b692d66fbd215380325c146f4fc714446
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+              value: sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
           envFrom:
             - configMapRef:
                 name: torghut-autonomy-config

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        client.knative.dev/updateTimestamp: "2026-05-31T09:40:41Z"
+        client.knative.dev/updateTimestamp: "2026-05-31T11:07:50Z"
         autoscaling.knative.dev/minScale: "1"
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/target: "80"
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
           ports:
             - name: http1
               containerPort: 8181
@@ -354,11 +354,11 @@ spec:
             - name: TA_CLICKHOUSE_CONN_TIMEOUT_SECONDS
               value: "10"
             - name: TORGHUT_VERSION
-              value: v0.581.1-2-g852321b97
+              value: v0.582.0-9-g9d15e16b6
             - name: TORGHUT_COMMIT
-              value: 852321b97e45dc057914d42498f763f14ba3d188
+              value: 9d15e16b692d66fbd215380325c146f4fc714446
             - name: TORGHUT_IMAGE_DIGEST
-              value: sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+              value: sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
           livenessProbe:
             httpGet:
               path: /healthz

--- a/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
+++ b/argocd/applications/torghut/order-feed-source-window-repair-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: repair-source-windows
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
+++ b/argocd/applications/torghut/paper-account-flatten-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             kubernetes.io/arch: arm64
           containers:
             - name: flatten-paper-account
-              image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+              image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
+++ b/argocd/applications/torghut/whitepaper-autoresearch-workflowtemplate.yaml
@@ -144,7 +144,7 @@ spec:
           - name: selectionOnly
           - name: persistResults
       container:
-        image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+        image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
         imagePullPolicy: IfNotPresent
         command:
           - /bin/bash

--- a/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
+++ b/argocd/applications/torghut/whitepaper-semantic-backfill-job.yaml
@@ -28,7 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backfill
-          image: registry.ide-newton.ts.net/lab/torghut@sha256:477471dba8261202da6e6de62782285e6a515ce32592e27ff586e124545ca9f5
+          image: registry.ide-newton.ts.net/lab/torghut@sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Promote Torghut image into GitOps manifests.

- Source commit: `9d15e16b692d66fbd215380325c146f4fc714446`
- Image tag: `9d15e16b`
- Image digest: `sha256:8653bb9356dab575a8b88eae36e988e81ce6aef301ad3af2d520992ec4b292f4`