### PR TITLE
chore(jangar): promote image 530cd7ef

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: jangar
     app.kubernetes.io/part-of: lab
   annotations:
-    deploy.knative.dev/rollout: 2026-05-31T08:30:36Z
+    deploy.knative.dev/rollout: 2026-05-31T11:15:31Z
 spec:
   replicas: 1
   strategy:
@@ -57,9 +57,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: cae13b67afa452a030fd660e94edb3279f9c2e7d
+              value: 530cd7ef5cc456738da9c27513162137cccdd1dc
             - name: JANGAR_GITOPS_REVISION
-              value: cae13b67afa452a030fd660e94edb3279f9c2e7d
+              value: 530cd7ef5cc456738da9c27513162137cccdd1dc
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -359,15 +359,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_HEALTH_SAMPLE_LIMIT
               value: "50"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "26707664123"
+              value: "26711027350"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:7d523b3160e48afed66ad7bbc044ac3b3a4082d9872a437951432476e3317a01
+              value: sha256:ef1eb428bd43c9872ca2b24ffb82baecf0eb784051fbf01e9ddbb79b3ec6b8dd
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: cae13b67afa452a030fd660e94edb3279f9c2e7d
+              value: 530cd7ef5cc456738da9c27513162137cccdd1dc
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:7d523b3160e48afed66ad7bbc044ac3b3a4082d9872a437951432476e3317a01
+              value: sha256:ef1eb428bd43c9872ca2b24ffb82baecf0eb784051fbf01e9ddbb79b3ec6b8dd
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: cae13b67
-    digest: sha256:7d523b3160e48afed66ad7bbc044ac3b3a4082d9872a437951432476e3317a01
+    newTag: 530cd7ef
+    digest: sha256:ef1eb428bd43c9872ca2b24ffb82baecf0eb784051fbf01e9ddbb79b3ec6b8dd


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `530cd7ef5cc456738da9c27513162137cccdd1dc`
- Image tag: `530cd7ef`
- Image digest: `sha256:ef1eb428bd43c9872ca2b24ffb82baecf0eb784051fbf01e9ddbb79b3ec6b8dd`
- Source CI run: `26711027350`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates