### PR TITLE
fix(olden): keep source notes compact on mobile

### DIFF
--- a/apps/olden/src/components/wiki/__tests__/content-integrity.test.ts
+++ b/apps/olden/src/components/wiki/__tests__/content-integrity.test.ts
@@ -10,7 +10,12 @@ import { referenceCategories } from '@/src/data/olden/reference'
 import { roadmapItems } from '@/src/data/olden/roadmap'
 import { sourceIds, wikiSources } from '@/src/data/olden/sources'
 import { videoTranscriptAudits } from '@/src/data/olden/video-guides'
-import { sourceNoteClassNames, sourceNoteStyles } from '@/src/components/wiki/source-note'
+import {
+  sourceNoteClassNames,
+  sourceNoteItemStyles,
+  sourceNoteListStyles,
+  sourceNoteStyles,
+} from '@/src/components/wiki/source-note'
 
 const contentRoot = join(import.meta.dir, '../../../../content/docs')
 const publicRoot = join(import.meta.dir, '../../../../public')
@@ -97,11 +102,19 @@ describe('Olden Era wiki components', () => {
   it('keeps source notes compact and readable on the dark docs surface', () => {
     expect(sourceNoteClassNames.aside).toContain('px-3')
     expect(sourceNoteClassNames.aside).toContain('py-2')
+    expect(sourceNoteClassNames.aside).toContain('overflow-x-auto')
+    expect(sourceNoteClassNames.aside).toContain('whitespace-nowrap')
+    expect(sourceNoteClassNames.list).toContain('whitespace-nowrap')
+    expect(sourceNoteClassNames.item).toContain('whitespace-nowrap')
     expect(sourceNoteClassNames.label).toContain('text-zinc-200')
     expect(sourceNoteClassNames.link).toContain('text-zinc-100')
     expect(sourceNoteClassNames.meta).toContain('text-zinc-500')
     expect(sourceNoteStyles.backgroundColor).toBe('#09090b')
     expect(sourceNoteStyles.borderColor).toBe('#27272a')
+    expect(sourceNoteListStyles.display).toBe('inline')
+    expect(sourceNoteListStyles.whiteSpace).toBe('nowrap')
+    expect(sourceNoteItemStyles.display).toBe('inline')
+    expect(sourceNoteItemStyles.whiteSpace).toBe('nowrap')
 
     for (const className of Object.values(sourceNoteClassNames)) {
       expect(className).not.toContain('dark:')

--- a/apps/olden/src/components/wiki/source-note.tsx
+++ b/apps/olden/src/components/wiki/source-note.tsx
@@ -7,10 +7,11 @@ type SourceNoteProps = {
 }
 
 export const sourceNoteClassNames = {
-  aside: 'not-prose my-6 rounded-md border px-3 py-2 text-xs leading-6 text-zinc-400 shadow-sm',
+  aside:
+    'not-prose my-6 overflow-x-auto rounded-md border px-3 py-2 text-xs leading-6 whitespace-nowrap text-zinc-400 shadow-sm',
   label: 'mr-2 font-medium text-zinc-200',
-  list: 'm-0 inline list-none p-0',
-  item: 'inline',
+  list: 'm-0 inline list-none p-0 whitespace-nowrap',
+  item: 'inline whitespace-nowrap',
   link: 'font-medium text-zinc-100 underline decoration-zinc-500 underline-offset-2 transition hover:text-white hover:decoration-zinc-200',
   meta: 'text-zinc-500',
   separator: 'mx-2 text-zinc-700',
@@ -21,15 +22,28 @@ export const sourceNoteStyles = {
   borderColor: '#27272a',
 } satisfies CSSProperties
 
+export const sourceNoteListStyles = {
+  display: 'inline',
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+  whiteSpace: 'nowrap',
+} satisfies CSSProperties
+
+export const sourceNoteItemStyles = {
+  display: 'inline',
+  whiteSpace: 'nowrap',
+} satisfies CSSProperties
+
 export function SourceNote({ ids }: SourceNoteProps) {
   const sources = wikiSources.filter((source) => ids.includes(source.id))
 
   return (
     <aside className={sourceNoteClassNames.aside} style={sourceNoteStyles} aria-label="Sources">
       <span className={sourceNoteClassNames.label}>Sources:</span>
-      <ul className={sourceNoteClassNames.list}>
+      <ul className={sourceNoteClassNames.list} style={sourceNoteListStyles}>
         {sources.map((source, index) => (
-          <li key={source.id} className={sourceNoteClassNames.item}>
+          <li key={source.id} className={sourceNoteClassNames.item} style={sourceNoteItemStyles}>
             <a className={sourceNoteClassNames.link} href={source.url}>
               {source.title}
             </a>


### PR DESCRIPTION
## Summary

- Keeps Olden source notes on a single horizontally scrollable line so pages with many sources do not create tall mobile blocks.
- Adds explicit inline display styles for the source list/items because prose styles can override Tailwind display utilities inside MDX content.
- Extends the source-note regression test to cover nowrap and inline display requirements.

## Related Issues

None.

## Testing

- `bun run test:olden`
- `bun run lint:olden`
- `bun run --cwd apps/olden lint:oxlint`
- `bun run --cwd apps/olden lint:oxlint:type`
- `bun run build:olden`
- Local Playwright check on `http://127.0.0.1:3024/docs/meta/video-transcript-audit` verified the mobile dark source note is 42px tall, horizontally scrollable, and still uses the dark source-note colors.

## Screenshots (if applicable)

Generated local verification screenshot: `/tmp/olden-local-transcript-nowrap.png`.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
