### PR TITLE
fix(torghut): split route probes from ledger diagnostics

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -30,7 +30,11 @@ from ..models import (
     TradeDecision,
 )
 from .runtime_cost_authority import cost_basis_counts_have_non_promotion_grade_costs
-from .runtime_decision_authority import ROUTE_ACQUISITION_SOURCE_DECISION_MODE
+from .runtime_decision_authority import (
+    ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+    normalize_source_decision_mode,
+    source_decision_mode_is_profit_proof_eligible,
+)
 from .runtime_ledger import POST_COST_PNL_BASIS
 from .runtime_ledger_proof_policy import runtime_ledger_proof_policy_from_env
 from .runtime_strategy_resolution import (
@@ -2415,6 +2419,71 @@ def _runtime_ledger_row_diagnostic_expectancy_bps(
     )
 
 
+def _runtime_ledger_row_source_decision_mode_counts(
+    row: StrategyRuntimeLedgerBucket,
+) -> Counter[str]:
+    payload = _as_mapping(row.payload_json)
+    counts: Counter[str] = Counter()
+    raw_counts = _as_mapping(payload.get("source_decision_mode_counts"))
+    for raw_mode, raw_count in raw_counts.items():
+        mode = normalize_source_decision_mode(raw_mode) or "missing"
+        count = _safe_int(raw_count)
+        if count > 0:
+            counts[mode] += count
+    if counts:
+        return counts
+
+    mode = normalize_source_decision_mode(payload.get("source_decision_mode"))
+    if mode is not None:
+        counts[mode] += max(
+            1,
+            _safe_int(row.decision_count),
+            _safe_int(row.fill_count),
+        )
+    else:
+        counts["missing"] += max(1, _safe_int(row.decision_count))
+    return counts
+
+
+def _runtime_ledger_row_source_decision_modes_are_profit_proof_eligible(
+    row: StrategyRuntimeLedgerBucket,
+) -> bool:
+    counts = _runtime_ledger_row_source_decision_mode_counts(row)
+    return bool(counts) and all(
+        source_decision_mode_is_profit_proof_eligible(mode) for mode in counts
+    )
+
+
+def _runtime_ledger_diagnostic_totals(
+    rows: Sequence[StrategyRuntimeLedgerBucket],
+) -> dict[str, object]:
+    filled_notional = sum(
+        (_safe_decimal(row.filled_notional) for row in rows), Decimal("0")
+    )
+    net_pnl = sum(
+        (_safe_decimal(row.net_strategy_pnl_after_costs) for row in rows),
+        Decimal("0"),
+    )
+    return {
+        "bucket_count": len(rows),
+        "fill_count": sum(max(0, _safe_int(row.fill_count)) for row in rows),
+        "decision_count": sum(max(0, _safe_int(row.decision_count)) for row in rows),
+        "closed_trade_count": sum(
+            max(0, _safe_int(row.closed_trade_count)) for row in rows
+        ),
+        "open_position_count": sum(
+            max(0, _safe_int(row.open_position_count)) for row in rows
+        ),
+        "filled_notional": _decimal_text(filled_notional),
+        "net_strategy_pnl_after_costs": _decimal_text(net_pnl),
+        "diagnostic_closed_trade_expectancy_bps": _decimal_text(
+            (net_pnl / filled_notional * Decimal("10000"))
+            if filled_notional > 0
+            else Decimal("0")
+        ),
+    }
+
+
 def _runtime_ledger_non_evidence_diagnostic_summary(
     rows: Sequence[StrategyRuntimeLedgerBucket],
 ) -> dict[str, object]:
@@ -2435,6 +2504,26 @@ def _runtime_ledger_non_evidence_diagnostic_summary(
         for row in rows
         for item in _as_sequence(row.blockers_json)
         if str(item).strip()
+    )
+    source_decision_mode_counts: Counter[str] = Counter()
+    source_decision_mode_bucket_counts: Counter[str] = Counter()
+    for row in rows:
+        row_mode_counts = _runtime_ledger_row_source_decision_mode_counts(row)
+        source_decision_mode_counts.update(row_mode_counts)
+        source_decision_mode_bucket_counts.update(row_mode_counts.keys())
+    profit_proof_diagnostic_rows = [
+        row
+        for row in diagnostic_rows
+        if _runtime_ledger_row_source_decision_modes_are_profit_proof_eligible(row)
+    ]
+    profit_proof_diagnostic_row_ids = {id(row) for row in profit_proof_diagnostic_rows}
+    non_profit_proof_diagnostic_rows = [
+        row for row in diagnostic_rows if id(row) not in profit_proof_diagnostic_row_ids
+    ]
+    non_profit_proof_source_decision_modes = sorted(
+        mode
+        for mode in source_decision_mode_counts
+        if not source_decision_mode_is_profit_proof_eligible(mode)
     )
     return {
         "scope": (
@@ -2461,6 +2550,18 @@ def _runtime_ledger_non_evidence_diagnostic_summary(
             else Decimal("0")
         ),
         "blocker_counts": dict(sorted(blocker_counts.items())),
+        "source_decision_mode_counts": dict(sorted(source_decision_mode_counts.items())),
+        "source_decision_mode_bucket_counts": dict(
+            sorted(source_decision_mode_bucket_counts.items())
+        ),
+        "profit_proof_eligible_diagnostic": _runtime_ledger_diagnostic_totals(
+            profit_proof_diagnostic_rows
+        ),
+        "non_profit_proof_diagnostic": {
+            **_runtime_ledger_diagnostic_totals(non_profit_proof_diagnostic_rows),
+            "source_decision_modes": non_profit_proof_source_decision_modes,
+            "reason": "source_decision_mode_not_profit_proof_eligible",
+        },
         "latest_bucket_ended_at": _isoformat(rows[0].bucket_ended_at if rows else None),
         "db_row_refs": [str(row.id) for row in rows],
     }

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -27,6 +27,7 @@ from app.trading.paper_route_evidence import (
     _next_regular_equities_session_window,
     _normalized_open_positions,
     _paper_route_probe_summary,
+    _runtime_ledger_non_evidence_diagnostic_summary,
     _runtime_ledger_row_diagnostic_expectancy_bps,
     build_paper_route_evidence_audit,
     build_paper_route_target_plan_payload,
@@ -420,6 +421,93 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
 
         self.assertIsNone(_runtime_ledger_row_diagnostic_expectancy_bps(row))
+
+    def test_runtime_ledger_diagnostic_splits_route_probe_from_profit_source(
+        self,
+    ) -> None:
+        strategy_row = StrategyRuntimeLedgerBucket(
+            run_id="diagnostic-runtime-ledger-run",
+            candidate_id="candidate-diagnostic",
+            hypothesis_id="H-DIAGNOSTIC",
+            observed_stage="paper",
+            bucket_started_at=datetime(2026, 5, 28, 14, 30, tzinfo=timezone.utc),
+            bucket_ended_at=datetime(2026, 5, 28, 15, 30, tzinfo=timezone.utc),
+            account_label="TORGHUT_SIM",
+            runtime_strategy_name="diagnostic-strategy",
+            strategy_family="microbar_pairs",
+            fill_count=2,
+            decision_count=1,
+            submitted_order_count=1,
+            closed_trade_count=1,
+            open_position_count=1,
+            filled_notional=Decimal("1000"),
+            gross_strategy_pnl=Decimal("20"),
+            cost_amount=Decimal("1"),
+            net_strategy_pnl_after_costs=Decimal("19"),
+            post_cost_expectancy_bps=None,
+            ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+            pnl_basis="realized_strategy_pnl_after_explicit_costs",
+            execution_policy_hash_counts={"policy-a": 1},
+            cost_model_hash_counts={"cost-a": 1},
+            lineage_hash_counts={"lineage-a": 1},
+            blockers_json=["unclosed_position"],
+            payload_json={"source_decision_mode_counts": {"strategy_signal_paper": 1}},
+        )
+        route_probe_row = StrategyRuntimeLedgerBucket(
+            run_id="diagnostic-runtime-ledger-run",
+            candidate_id="candidate-diagnostic",
+            hypothesis_id="H-DIAGNOSTIC",
+            observed_stage="paper",
+            bucket_started_at=datetime(2026, 5, 28, 14, 30, tzinfo=timezone.utc),
+            bucket_ended_at=datetime(2026, 5, 28, 15, 30, tzinfo=timezone.utc),
+            account_label="TORGHUT_SIM",
+            runtime_strategy_name="diagnostic-strategy",
+            strategy_family="microbar_pairs",
+            fill_count=10,
+            decision_count=10,
+            submitted_order_count=10,
+            closed_trade_count=10,
+            open_position_count=1,
+            filled_notional=Decimal("1000000"),
+            gross_strategy_pnl=Decimal("100001"),
+            cost_amount=Decimal("1"),
+            net_strategy_pnl_after_costs=Decimal("100000"),
+            post_cost_expectancy_bps=None,
+            ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+            pnl_basis="realized_strategy_pnl_after_explicit_costs",
+            execution_policy_hash_counts={"policy-a": 1},
+            cost_model_hash_counts={"cost-a": 1},
+            lineage_hash_counts={"lineage-a": 1},
+            blockers_json=["unclosed_position"],
+            payload_json={"source_decision_mode_counts": {"route_acquisition_probe": 10}},
+        )
+
+        summary = _runtime_ledger_non_evidence_diagnostic_summary(
+            [strategy_row, route_probe_row]
+        )
+
+        self.assertEqual(
+            summary["source_decision_mode_counts"],
+            {"route_acquisition_probe": 10, "strategy_signal_paper": 1},
+        )
+        self.assertEqual(
+            summary["source_decision_mode_bucket_counts"],
+            {"route_acquisition_probe": 1, "strategy_signal_paper": 1},
+        )
+        self.assertEqual(
+            summary["profit_proof_eligible_diagnostic"][
+                "net_strategy_pnl_after_costs"
+            ],
+            "19",
+        )
+        self.assertEqual(
+            summary["non_profit_proof_diagnostic"]["net_strategy_pnl_after_costs"],
+            "100000",
+        )
+        self.assertEqual(
+            summary["non_profit_proof_diagnostic"]["source_decision_modes"],
+            ["route_acquisition_probe"],
+        )
 
     def test_next_paper_route_window_stays_on_current_session_for_import(
         self,


### PR DESCRIPTION
## Summary

- Split non-evidence runtime-ledger diagnostics by source decision mode so route-acquisition probe PnL is visible separately from strategy-signal paper PnL.
- Add profit-proof-eligible and non-profit-proof diagnostic totals inside the existing diagnostic-only payload.
- Cover the H-PAIRS confusion case where positive route-probe PnL must not make a candidate look closer to promotion authority.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
