### PR TITLE
revert(torghut): rollback failed promotion a73747a9bcd49b52a9f27c9982de565a3aa9b11b

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -63,20 +63,6 @@ spec:
                   key: password
             - name: DB_DSN
               value: postgresql://$(TORGHUT_SIM_DB_USER):$(TORGHUT_SIM_DB_PASSWORD)@$(TORGHUT_SIM_DB_HOST):$(TORGHUT_SIM_DB_PORT)/torghut_sim_default
-            - name: TORGHUT_TIGERBEETLE_ENABLED
-              value: "true"
-            - name: TORGHUT_TIGERBEETLE_REQUIRED
-              value: "false"
-            - name: TORGHUT_TIGERBEETLE_CLUSTER_ID
-              value: "2001"
-            - name: TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES
-              value: torghut-tigerbeetle.torghut.svc.cluster.local:3000
-            - name: TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS
-              value: "2"
-            - name: TORGHUT_TIGERBEETLE_JOURNAL_ENABLED
-              value: "true"
-            - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
-              value: "false"
             - name: APCA_API_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -46,20 +46,6 @@ spec:
                 secretKeyRef:
                   name: torghut-db-app
                   key: uri
-            - name: TORGHUT_TIGERBEETLE_ENABLED
-              value: "true"
-            - name: TORGHUT_TIGERBEETLE_REQUIRED
-              value: "false"
-            - name: TORGHUT_TIGERBEETLE_CLUSTER_ID
-              value: "2001"
-            - name: TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES
-              value: torghut-tigerbeetle.torghut.svc.cluster.local:3000
-            - name: TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS
-              value: "2"
-            - name: TORGHUT_TIGERBEETLE_JOURNAL_ENABLED
-              value: "true"
-            - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED
-              value: "false"
             - name: APCA_API_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/torghut/kustomization.yaml
+++ b/argocd/applications/torghut/kustomization.yaml
@@ -10,8 +10,6 @@ resources:
   - autonomy-configmap.yaml
   - autonomy-gate-policy-configmap.yaml
   - db-migrations-job.yaml
-  - tigerbeetle-cluster.yaml
-  - tigerbeetle-smoke-job.yaml
   - knative-service.yaml
   - knative-service-sim.yaml
   - tailscale-service.yaml


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `a73747a9bcd49b52a9f27c9982de565a3aa9b11b`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/26711073114`
- Rollback source: `HEAD^` manifests from the failed run checkout