### PR TITLE
fix(torghut): partition unlinked order proof rows

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -515,6 +515,7 @@ def _partition_runtime_source_rows_by_decision_mode(
     execution_rows: list[dict[str, object]],
     decision_lifecycle_rows: list[dict[str, object]] | None,
     order_lifecycle_rows: list[dict[str, object]] | None,
+    unlinked_order_lifecycle_rows: list[dict[str, object]] | None = None,
     carry_in_execution_rows: list[dict[str, object]] | None = None,
     carry_in_decision_lifecycle_rows: list[dict[str, object]] | None = None,
     carry_in_order_lifecycle_rows: list[dict[str, object]] | None = None,
@@ -528,6 +529,7 @@ def _partition_runtime_source_rows_by_decision_mode(
             list[dict[str, object]] | None,
             list[dict[str, object]] | None,
             list[dict[str, object]] | None,
+            list[dict[str, object]] | None,
         ]
     ]
     | None
@@ -536,6 +538,7 @@ def _partition_runtime_source_rows_by_decision_mode(
         *execution_rows,
         *(decision_lifecycle_rows or []),
         *(order_lifecycle_rows or []),
+        *(unlinked_order_lifecycle_rows or []),
         *(carry_in_execution_rows or []),
         *(carry_in_decision_lifecycle_rows or []),
         *(carry_in_order_lifecycle_rows or []),
@@ -557,6 +560,7 @@ def _partition_runtime_source_rows_by_decision_mode(
         tuple[
             str,
             list[dict[str, object]],
+            list[dict[str, object]] | None,
             list[dict[str, object]] | None,
             list[dict[str, object]] | None,
             list[dict[str, object]] | None,
@@ -592,6 +596,17 @@ def _partition_runtime_source_rows_by_decision_mode(
             )
             == mode_key
         ]
+        partition_unlinked_order_rows = []
+        for row in unlinked_order_lifecycle_rows or []:
+            partition_key = _source_decision_mode_partition_key(
+                row,
+                modes_by_identifier=modes_by_identifier,
+            )
+            if partition_key == mode_key or (
+                partition_key == SOURCE_DECISION_MODE_MISSING_PARTITION
+                and mode_key != SOURCE_DECISION_MODE_MISSING_PARTITION
+            ):
+                partition_unlinked_order_rows.append(row)
         partition_carry_in_execution_rows = [
             row
             for row in carry_in_execution_rows or []
@@ -625,6 +640,7 @@ def _partition_runtime_source_rows_by_decision_mode(
                 partition_execution_rows,
                 partition_decision_rows or None,
                 partition_order_rows or None,
+                partition_unlinked_order_rows or None,
                 partition_carry_in_execution_rows or None,
                 partition_carry_in_decision_rows or None,
                 partition_carry_in_order_rows or None,
@@ -2939,6 +2955,7 @@ def _build_realized_strategy_pnl_rows(
             execution_rows=execution_rows,
             decision_lifecycle_rows=decision_lifecycle_rows,
             order_lifecycle_rows=order_lifecycle_rows,
+            unlinked_order_lifecycle_rows=unlinked_order_lifecycle_rows,
             carry_in_execution_rows=carry_in_execution_rows,
             carry_in_decision_lifecycle_rows=carry_in_decision_lifecycle_rows,
             carry_in_order_lifecycle_rows=carry_in_order_lifecycle_rows,
@@ -2950,6 +2967,7 @@ def _build_realized_strategy_pnl_rows(
                 partition_execution_rows,
                 partition_decision_rows,
                 partition_order_rows,
+                partition_unlinked_order_rows,
                 partition_carry_in_execution_rows,
                 partition_carry_in_decision_rows,
                 partition_carry_in_order_rows,
@@ -2958,7 +2976,7 @@ def _build_realized_strategy_pnl_rows(
                     partition_execution_rows,
                     decision_lifecycle_rows=partition_decision_rows,
                     order_lifecycle_rows=partition_order_rows,
-                    unlinked_order_lifecycle_rows=unlinked_order_lifecycle_rows,
+                    unlinked_order_lifecycle_rows=partition_unlinked_order_rows,
                     carry_in_execution_rows=partition_carry_in_execution_rows,
                     carry_in_decision_lifecycle_rows=partition_carry_in_decision_rows,
                     carry_in_order_lifecycle_rows=partition_carry_in_order_rows,

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -4103,6 +4103,17 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     minute=50,
                 ),
             ],
+            unlinked_order_lifecycle_rows=[
+                order_event_row(
+                    decision_id="route-buy",
+                    execution_id="route-unlinked-exec",
+                    mode="route_acquisition_probe",
+                    event_id="route-unlinked-fill",
+                    event_type="fill",
+                    offset=31,
+                    minute=46,
+                )
+            ],
             allow_authoritative_runtime_ledger_materialization=True,
         )
 
@@ -4130,6 +4141,10 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(
             signal_bucket["source_decision_mode_counts"],
             {"strategy_signal_paper": 8},
+        )
+        self.assertNotIn(
+            "order_feed_unlinked_fill_lifecycle_present",
+            signal_bucket["blockers"],
         )
         self.assertEqual(
             signal_bucket["source_materialization"], "execution_order_events"


### PR DESCRIPTION
## Summary

- Partitions unlinked order-feed lifecycle rows by source-decision mode before runtime-ledger proof bucket assembly.
- Keeps unknown unlinked rows fail-closed by carrying them into concrete source-mode partitions.
- Adds a regression covering route-acquisition unlinked fills so they do not contaminate strategy-signal proof partitions.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'mixed_source_decision_modes or blocks_unlinked_fill_lifecycle' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
