### PR TITLE
fix(torghut): resolve tigerbeetle replica DNS

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_client.py
+++ b/services/torghut/app/trading/tigerbeetle_client.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import ipaddress
+import socket
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 from app.config import Settings
 from app.trading.tigerbeetle_ledger_model import (
@@ -49,16 +51,75 @@ def parse_replica_addresses(raw: str) -> list[str]:
     return [item.strip() for item in raw.split(",") if item.strip()]
 
 
+def _is_ip_literal(value: str) -> bool:
+    try:
+        ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _split_host_port(address: str) -> tuple[str, str | None]:
+    if address.count(":") != 1:
+        return address, None
+
+    host, port = address.rsplit(":", 1)
+    if not host or not port:
+        return address, None
+    return host, port
+
+
+def _resolve_replica_address(address: str) -> list[str]:
+    host, port = _split_host_port(address)
+    if address.isdigit() or _is_ip_literal(host):
+        return [address]
+
+    try:
+        infos = socket.getaddrinfo(
+            host,
+            port,
+            family=socket.AF_INET,
+            type=socket.SOCK_STREAM,
+        )
+    except socket.gaierror as exc:
+        raise ValueError(
+            f"could not resolve TigerBeetle replica address {address!r}"
+        ) from exc
+
+    resolved: list[str] = []
+    for info in infos:
+        sockaddr = cast(tuple[str, int], info[4])
+        resolved_address = f"{sockaddr[0]}:{port}" if port is not None else sockaddr[0]
+        if resolved_address not in resolved:
+            resolved.append(resolved_address)
+
+    if not resolved:
+        raise ValueError(f"could not resolve TigerBeetle replica address {address!r}")
+    return resolved
+
+
+def resolve_replica_addresses(replica_addresses: Sequence[str]) -> list[str]:
+    resolved: list[str] = []
+    for address in replica_addresses:
+        for resolved_address in _resolve_replica_address(address):
+            if resolved_address not in resolved:
+                resolved.append(resolved_address)
+    return resolved
+
+
 class RealTigerBeetleClient:
     """Small wrapper around the official synchronous TigerBeetle client."""
 
     def __init__(self, *, cluster_id: int, replica_addresses: Sequence[str]) -> None:
         import tigerbeetle as tb
 
+        # The official client validates endpoint syntax before dialing and
+        # accepts IP endpoints, not Kubernetes DNS service names.
+        official_addresses = resolve_replica_addresses(replica_addresses)
         self._tb: Any = tb
         self._client: Any = tb.ClientSync(
             cluster_id=cluster_id,
-            replica_addresses=",".join(replica_addresses),
+            replica_addresses=",".join(official_addresses),
         )
 
     def close(self) -> None:

--- a/services/torghut/tests/test_tigerbeetle_client.py
+++ b/services/torghut/tests/test_tigerbeetle_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import socket
 import sys
 from types import SimpleNamespace
 from unittest import TestCase
@@ -12,6 +13,7 @@ from app.trading.tigerbeetle_client import (
     check_tigerbeetle_health,
     create_tigerbeetle_client,
     parse_replica_addresses,
+    resolve_replica_addresses,
 )
 from app.trading.tigerbeetle_ledger_model import (
     LEDGER_USD_MICRO,
@@ -31,6 +33,60 @@ class TestTigerBeetleClient(TestCase):
             parse_replica_addresses(" 127.0.0.1:3000,127.0.0.2:3000 ,, "),
             ["127.0.0.1:3000", "127.0.0.2:3000"],
         )
+
+    def test_resolve_replica_addresses_resolves_kubernetes_dns(self) -> None:
+        def fake_getaddrinfo(
+            host: str,
+            port: str | None,
+            *,
+            family: socket.AddressFamily,
+            type: socket.SocketKind,
+        ) -> list[
+            tuple[socket.AddressFamily, socket.SocketKind, int, str, tuple[str, int]]
+        ]:
+            self.assertEqual(family, socket.AF_INET)
+            self.assertEqual(type, socket.SOCK_STREAM)
+            self.assertEqual(host, "torghut-tigerbeetle.torghut.svc.cluster.local")
+            self.assertEqual(port, "3000")
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.99.251.1", 3000)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.99.251.1", 3000)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.99.251.2", 3000)),
+            ]
+
+        with patch(
+            "app.trading.tigerbeetle_client.socket.getaddrinfo",
+            side_effect=fake_getaddrinfo,
+        ):
+            self.assertEqual(
+                resolve_replica_addresses(
+                    [
+                        "torghut-tigerbeetle.torghut.svc.cluster.local:3000",
+                        "127.0.0.1:3000",
+                    ]
+                ),
+                ["10.99.251.1:3000", "10.99.251.2:3000", "127.0.0.1:3000"],
+            )
+
+    def test_resolve_replica_addresses_leaves_ip_and_port_literals(self) -> None:
+        with patch("app.trading.tigerbeetle_client.socket.getaddrinfo") as getaddrinfo:
+            self.assertEqual(
+                resolve_replica_addresses(["3000", "127.0.0.1:3000"]),
+                ["3000", "127.0.0.1:3000"],
+            )
+
+        getaddrinfo.assert_not_called()
+
+    def test_resolve_replica_addresses_reports_dns_failure(self) -> None:
+        with patch(
+            "app.trading.tigerbeetle_client.socket.getaddrinfo",
+            side_effect=socket.gaierror("no such host"),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "could not resolve TigerBeetle replica address 'missing-tb:3000'",
+            ):
+                resolve_replica_addresses(["missing-tb:3000"])
 
     def test_health_is_ok_when_disabled(self) -> None:
         settings = Settings(TORGHUT_TIGERBEETLE_ENABLED=False)
@@ -144,10 +200,26 @@ class TestTigerBeetleClient(TestCase):
             Account=_Event,
             Transfer=_Event,
         )
-        with patch.dict(sys.modules, {"tigerbeetle": fake_module}):
+        with (
+            patch.dict(sys.modules, {"tigerbeetle": fake_module}),
+            patch(
+                "app.trading.tigerbeetle_client.socket.getaddrinfo",
+                return_value=[
+                    (
+                        socket.AF_INET,
+                        socket.SOCK_STREAM,
+                        6,
+                        "",
+                        ("10.99.251.1", 3000),
+                    )
+                ],
+            ),
+        ):
             client = RealTigerBeetleClient(
                 cluster_id=2001,
-                replica_addresses=["tb-0:3000", "tb-1:3000"],
+                replica_addresses=[
+                    "torghut-tigerbeetle.torghut.svc.cluster.local:3000"
+                ],
             )
             account = TigerBeetleAccountSpec(
                 account_id=11,
@@ -177,7 +249,7 @@ class TestTigerBeetleClient(TestCase):
 
         sync = instances[0]
         self.assertEqual(sync.cluster_id, 2001)
-        self.assertEqual(sync.replica_addresses, "tb-0:3000,tb-1:3000")
+        self.assertEqual(sync.replica_addresses, "10.99.251.1:3000")
         self.assertEqual(sync.created_accounts[0].id, 11)
         self.assertEqual(sync.created_transfers[0].id, 22)
         self.assertTrue(sync.closed)


### PR DESCRIPTION
## Summary

- Resolve TigerBeetle replica DNS names to IPv4 endpoints before constructing the official Python client.
- Preserve IP literals and port shorthand unchanged, de-dupe resolved DNS A records, and surface DNS failures with explicit context.
- Cover the live Kubernetes service-DNS shape that caused the Argo smoke hook to fail with `InitError: 3`.

## Related Issues

None

## Testing

- `uv run --frozen --extra dev pytest tests/test_tigerbeetle_client.py -q`
- `uv run --frozen ruff format app/trading/tigerbeetle_client.py tests/test_tigerbeetle_client.py`
- `uv run --frozen ruff check app/trading/tigerbeetle_client.py tests/test_tigerbeetle_client.py`
- `uv run --frozen --extra dev pytest tests/test_tigerbeetle_client.py tests/test_tigerbeetle_status.py tests/test_verify_tigerbeetle_ledger.py tests/test_live_config_manifest_contract.py -k 'tigerbeetle or release_workflow' -q`
- `uv run --frozen --extra dev pytest tests/test_tigerbeetle_client.py tests/test_tigerbeetle_journal.py tests/test_tigerbeetle_reconcile.py tests/test_tigerbeetle_ledger_model.py tests/test_tigerbeetle_ids.py tests/test_tigerbeetle_status.py tests/test_verify_tigerbeetle_ledger.py tests/test_order_feed.py -k tigerbeetle -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
