### PR TITLE
fix(torghut): permit tigerbeetle client io_uring

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -28,6 +28,9 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
+          securityContext:
+            seccompProfile:
+              type: Unconfined
           image: registry.ide-newton.ts.net/lab/torghut@sha256:46fa917cb9542a0ab5f7aa75cfac9f07f296d92fb8a107d3c904ad9b5ef169f6
           ports:
             - name: http1

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -28,6 +28,9 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
+          securityContext:
+            seccompProfile:
+              type: Unconfined
           image: registry.ide-newton.ts.net/lab/torghut@sha256:46fa917cb9542a0ab5f7aa75cfac9f07f296d92fb8a107d3c904ad9b5ef169f6
           ports:
             - name: http1

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -34,6 +34,8 @@ spec:
           image: registry.ide-newton.ts.net/lab/torghut@sha256:46fa917cb9542a0ab5f7aa75cfac9f07f296d92fb8a107d3c904ad9b5ef169f6
           imagePullPolicy: IfNotPresent
           securityContext:
+            seccompProfile:
+              type: Unconfined
             allowPrivilegeEscalation: false
             capabilities:
               drop:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -92,6 +92,22 @@ def _load_knative_env(relative_path: str) -> dict[str, object]:
     return env
 
 
+def _load_knative_template_spec(relative_path: str) -> Mapping[str, object]:
+    manifest = _load_yaml_mapping(relative_path)
+    return cast(
+        Mapping[str, object],
+        manifest.get("spec", {}).get("template", {}).get("spec", {}),
+    )
+
+
+def _load_knative_container(relative_path: str) -> Mapping[str, object]:
+    template_spec = _load_knative_template_spec(relative_path)
+    containers = cast(list[Mapping[str, object]], template_spec.get("containers", []))
+    if not containers:
+        raise AssertionError(f"{relative_path} missing spec.template.spec.containers")
+    return containers[0]
+
+
 def _load_torghut_knative_env() -> dict[str, object]:
     return _load_knative_env("argocd/applications/torghut/knative-service.yaml")
 
@@ -897,6 +913,39 @@ class TestLiveConfigManifestContract(TestCase):
             env = _load_knative_env(relative_path)
             for key, value in expected.items():
                 self.assertEqual(env.get(key), value, f"{relative_path} {key}")
+
+    def test_torghut_tigerbeetle_client_pods_allow_io_uring(self) -> None:
+        for relative_path in (
+            "argocd/applications/torghut/knative-service.yaml",
+            "argocd/applications/torghut/knative-service-sim.yaml",
+        ):
+            container = _load_knative_container(relative_path)
+            security_context = cast(
+                Mapping[str, object],
+                container.get("securityContext", {}),
+            )
+            seccomp_profile = cast(
+                Mapping[str, object],
+                security_context.get("seccompProfile", {}),
+            )
+            self.assertEqual(
+                seccomp_profile.get("type"),
+                "Unconfined",
+                f"{relative_path} official TigerBeetle client requires io_uring",
+            )
+
+        _, smoke_container = _load_job_container(
+            "argocd/applications/torghut/tigerbeetle-smoke-job.yaml"
+        )
+        smoke_security_context = cast(
+            Mapping[str, object],
+            smoke_container.get("securityContext", {}),
+        )
+        smoke_seccomp_profile = cast(
+            Mapping[str, object],
+            smoke_security_context.get("seccompProfile", {}),
+        )
+        self.assertEqual(smoke_seccomp_profile.get("type"), "Unconfined")
 
     def test_torghut_tigerbeetle_smoke_job_runs_protocol_proof(self) -> None:
         spec, container = _load_job_container(


### PR DESCRIPTION
## Summary

- Allows the Torghut and Torghut sim user containers to run the official TigerBeetle client with container-level `seccompProfile: Unconfined`.
- Allows the PostSync TigerBeetle smoke job container to use the same io_uring-compatible seccomp profile while keeping the pod default and dropped capabilities.
- Adds a manifest contract test so TigerBeetle client workloads cannot regress to a seccomp profile that blocks io_uring.

## Related Issues

None

## Testing

- `uv run --frozen ruff format tests/test_live_config_manifest_contract.py && uv run --frozen ruff check tests/test_live_config_manifest_contract.py`
- `uv run --frozen --extra dev pytest tests/test_live_config_manifest_contract.py -k 'tigerbeetle' -q`
- `kubectl apply --dry-run=server -f argocd/applications/torghut/knative-service.yaml -f argocd/applications/torghut/knative-service-sim.yaml`
- `perl -0pe 's/name: torghut-tigerbeetle-smoke/name: torghut-tigerbeetle-smoke-dryrun/' argocd/applications/torghut/tigerbeetle-smoke-job.yaml | kubectl create --dry-run=server -f -`
- `bun run lint:argocd`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
