### PR TITLE
fix(torghut): isolate profit-proof exposure from route probes

### DIFF
--- a/services/torghut/app/trading/scheduler/simple_pipeline.py
+++ b/services/torghut/app/trading/scheduler/simple_pipeline.py
@@ -33,6 +33,7 @@ from ..runtime_decision_authority import (
     ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
     STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
     normalize_source_decision_mode,
+    source_decision_mode_is_profit_proof_eligible,
 )
 from ..session_context import regular_session_open_utc_for
 from ..simple_risk import (
@@ -76,6 +77,8 @@ _PAPER_ROUTE_PROBE_QTY_STEP = Decimal("0.0001")
 _REGULAR_SESSION_MINUTES = 390
 _PAPER_ROUTE_TARGET_PLAN_CACHE_SECONDS = 60
 _PAPER_ROUTE_TARGET_PLAN_STALE_SUCCESS_SECONDS = 600
+_PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK = timedelta(days=7)
+_PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON = Decimal("0.00000001")
 
 
 def _safe_int(value: object) -> int:
@@ -1642,6 +1645,7 @@ class SimpleTradingPipeline(TradingPipeline):
             strategies=strategies,
             allowed_symbols=allowed_symbols,
             positions=positions,
+            session=session,
         )
         for decision in decisions:
             self.state.metrics.decisions_total += 1
@@ -2383,6 +2387,7 @@ class SimpleTradingPipeline(TradingPipeline):
         strategies: Sequence[Strategy],
         allowed_symbols: set[str],
         positions: Sequence[Mapping[str, Any]] | None = None,
+        session: Session | None = None,
     ) -> list[StrategyDecision]:
         if settings.trading_mode != "paper":
             return []
@@ -2430,6 +2435,17 @@ class SimpleTradingPipeline(TradingPipeline):
                 if self._paper_route_target_symbol_has_open_position(
                     positions,
                     symbol,
+                ):
+                    continue
+                if (
+                    session is not None
+                    and self._paper_route_target_symbol_has_open_profit_proof_exposure(
+                        session=session,
+                        strategy=strategy,
+                        symbol=symbol,
+                        account_label=self.account_label,
+                        window_start=window_start,
+                    )
                 ):
                     continue
                 key = (str(strategy.id), symbol, window_start.isoformat(), action)
@@ -2487,6 +2503,79 @@ class SimpleTradingPipeline(TradingPipeline):
                     )
                 )
         return decisions
+
+    @staticmethod
+    def _paper_route_target_symbol_has_open_profit_proof_exposure(
+        *,
+        session: Session,
+        strategy: Strategy,
+        symbol: str,
+        account_label: str,
+        window_start: datetime,
+    ) -> bool:
+        strategy_id = getattr(strategy, "id", None)
+        normalized_symbol = symbol.strip().upper()
+        if strategy_id is None or not normalized_symbol:
+            return False
+
+        guard_start = window_start - _PAPER_ROUTE_TARGET_PROFIT_PROOF_EXPOSURE_LOOKBACK
+        try:
+            rows = session.execute(
+                select(
+                    Execution.side,
+                    Execution.filled_qty,
+                    TradeDecision.decision_json,
+                )
+                .join(TradeDecision, Execution.trade_decision_id == TradeDecision.id)
+                .where(
+                    Execution.alpaca_account_label == account_label,
+                    TradeDecision.alpaca_account_label == account_label,
+                    TradeDecision.strategy_id == strategy_id,
+                    Execution.symbol == normalized_symbol,
+                    TradeDecision.symbol == normalized_symbol,
+                    Execution.filled_qty > 0,
+                    Execution.status.in_(("filled", "partially_filled")),
+                    Execution.created_at >= guard_start,
+                )
+            ).all()
+        except Exception:
+            logger.exception(
+                "Failed to inspect paper-route target source proof exposure "
+                "strategy_id=%s symbol=%s account_label=%s",
+                strategy_id,
+                normalized_symbol,
+                account_label,
+            )
+            return True
+
+        signed_qty = Decimal("0")
+        for side, filled_qty, raw_decision_json in rows:
+            if not isinstance(raw_decision_json, Mapping):
+                continue
+            decision_json = cast(Mapping[str, Any], raw_decision_json)
+            raw_params = decision_json.get("params")
+            if not isinstance(raw_params, Mapping):
+                continue
+            params = cast(Mapping[str, Any], raw_params)
+            lineage = _paper_route_probe_lineage_from_params(params)
+            profit_proof_eligible = _target_bool(lineage.get("profit_proof_eligible"))
+            if profit_proof_eligible is False:
+                continue
+            if (
+                profit_proof_eligible is not True
+                and not source_decision_mode_is_profit_proof_eligible(
+                    lineage.get("source_decision_mode")
+                )
+            ):
+                continue
+            qty = _optional_decimal(filled_qty)
+            if qty is None or qty <= 0:
+                continue
+            if str(side or "").strip().lower() == "sell":
+                signed_qty -= qty
+            else:
+                signed_qty += qty
+        return abs(signed_qty) > _PAPER_ROUTE_TARGET_OPEN_EXPOSURE_EPSILON
 
     @staticmethod
     def _paper_route_target_symbol_has_open_position(
@@ -3108,12 +3197,9 @@ class SimpleTradingPipeline(TradingPipeline):
         )
         paper_route_probe_applied = False
         if proof_floor_block_reason is not None:
-            if (
-                settings.trading_mode == "paper"
-                and (
-                    self._paper_route_probe_exit_metadata(decision) is not None
-                    or _paper_route_probe_entry_metadata(decision.params) is not None
-                )
+            if settings.trading_mode == "paper" and (
+                self._paper_route_probe_exit_metadata(decision) is not None
+                or _paper_route_probe_entry_metadata(decision.params) is not None
             ):
                 paper_route_probe_applied = True
             if not paper_route_probe_applied:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -6060,6 +6060,115 @@ class TestTradingPipeline(TestCase):
 
         self.assertEqual([decision.symbol for decision in decisions], ["AMZN"])
 
+    def test_paper_route_target_profit_proof_exposure_helper_fails_closed(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid4(),
+            name="paper-route-candidate-v1",
+            description="paper route candidate",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        mock_session = Mock(spec=Session)
+        mock_session.execute.side_effect = RuntimeError("database offline")
+
+        self.assertTrue(
+            SimpleTradingPipeline._paper_route_target_symbol_has_open_profit_proof_exposure(
+                session=cast(Session, mock_session),
+                strategy=strategy,
+                symbol="AAPL",
+                account_label="paper",
+                window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+            )
+        )
+
+    def test_paper_route_target_profit_proof_exposure_helper_ignores_noise(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            id=uuid4(),
+            name="paper-route-candidate-v1",
+            description="paper route candidate",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        result = Mock()
+        result.all.return_value = [
+            ("buy", Decimal("1"), ["not-a-decision-mapping"]),
+            ("buy", Decimal("1"), {"params": "not-a-param-mapping"}),
+            (
+                "buy",
+                Decimal("1"),
+                {
+                    "params": {
+                        "source_decision_mode": ROUTE_ACQUISITION_SOURCE_DECISION_MODE
+                    }
+                },
+            ),
+            ("buy", None, {"params": {"profit_proof_eligible": True}}),
+            (
+                "sell",
+                Decimal("2"),
+                {
+                    "params": {
+                        "source_decision_mode": STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+                    }
+                },
+            ),
+        ]
+        mock_session = Mock(spec=Session)
+        mock_session.execute.return_value = result
+
+        self.assertTrue(
+            SimpleTradingPipeline._paper_route_target_symbol_has_open_profit_proof_exposure(
+                session=cast(Session, mock_session),
+                strategy=strategy,
+                symbol="aapl",
+                account_label="paper",
+                window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+            )
+        )
+
+    def test_paper_route_target_profit_proof_exposure_helper_returns_false_without_key(
+        self,
+    ) -> None:
+        strategy = Strategy(
+            name="paper-route-candidate-v1",
+            description="paper route candidate",
+            enabled=True,
+            base_timeframe="1Min",
+            universe_type="static",
+            universe_symbols=["AAPL"],
+            max_notional_per_trade=Decimal("1000"),
+        )
+        mock_session = Mock(spec=Session)
+
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_target_symbol_has_open_profit_proof_exposure(
+                session=cast(Session, mock_session),
+                strategy=strategy,
+                symbol="AAPL",
+                account_label="paper",
+                window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+            )
+        )
+        self.assertFalse(
+            SimpleTradingPipeline._paper_route_target_symbol_has_open_profit_proof_exposure(
+                session=cast(Session, mock_session),
+                strategy=strategy,
+                symbol=" ",
+                account_label="paper",
+                window_start=datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc),
+            )
+        )
+
     def test_process_paper_route_target_source_decisions_records_submit_failure(
         self,
     ) -> None:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -57,6 +57,10 @@ from app.trading.models import SignalEnvelope, StrategyDecision
 from app.trading.prices import MarketSnapshot, PriceFetcher
 from app.trading.ingest import SignalBatch
 from app.trading.reconcile import Reconciler
+from app.trading.runtime_decision_authority import (
+    ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
+    STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE,
+)
 from app.trading.risk import RiskEngine
 from app.trading.scheduler.pipeline import TradingPipeline
 from app.trading.scheduler.simple_pipeline import (
@@ -5938,6 +5942,124 @@ class TestTradingPipeline(TestCase):
 
         self.assertEqual([decision.symbol for decision in decisions], ["AAPL"])
 
+    def test_paper_route_target_source_decisions_skip_db_profit_proof_exposure(
+        self,
+    ) -> None:
+        from app import config
+
+        now = datetime(2026, 5, 26, 14, 0, tzinfo=timezone.utc)
+        window_start = datetime(2026, 5, 26, 13, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 26, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="paper-route-candidate-v1",
+                description="paper route candidate",
+                enabled=True,
+                base_timeframe="1Min",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN"],
+                max_notional_per_trade=Decimal("1000"),
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+
+            for symbol, source_decision_mode, profit_proof_eligible in (
+                ("AAPL", STRATEGY_SIGNAL_PAPER_SOURCE_DECISION_MODE, True),
+                ("AMZN", ROUTE_ACQUISITION_SOURCE_DECISION_MODE, False),
+            ):
+                decision_hash = f"source-mode-{symbol.lower()}-{uuid4()}"
+                decision_row = TradeDecision(
+                    strategy_id=strategy.id,
+                    alpaca_account_label="paper",
+                    symbol=symbol,
+                    timeframe="1Min",
+                    decision_json=StrategyDecision(
+                        strategy_id=str(strategy.id),
+                        symbol=symbol,
+                        event_ts=window_start + timedelta(minutes=5),
+                        timeframe="1Min",
+                        action="buy",
+                        qty=Decimal("10"),
+                        rationale="source-mode-fixture",
+                        params={
+                            "source_decision_mode": source_decision_mode,
+                            "profit_proof_eligible": profit_proof_eligible,
+                        },
+                    ).model_dump(mode="json"),
+                    rationale="source-mode-fixture",
+                    status="submitted",
+                    decision_hash=decision_hash,
+                    created_at=window_start + timedelta(minutes=5),
+                )
+                session.add(decision_row)
+                session.commit()
+                session.refresh(decision_row)
+                session.add(
+                    Execution(
+                        trade_decision_id=decision_row.id,
+                        alpaca_account_label="paper",
+                        alpaca_order_id=f"{symbol.lower()}-{uuid4()}",
+                        client_order_id=decision_hash,
+                        symbol=symbol,
+                        side="buy",
+                        order_type="market",
+                        time_in_force="day",
+                        submitted_qty=Decimal("10"),
+                        filled_qty=Decimal("10"),
+                        avg_fill_price=Decimal("100"),
+                        status="filled",
+                        created_at=window_start + timedelta(minutes=6),
+                    )
+                )
+            session.commit()
+
+            target = {
+                "strategy_name": "paper-route-candidate-v1",
+                "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                "paper_route_probe_next_session_max_notional": "25",
+                "paper_route_probe_window_start": window_start.isoformat(),
+                "paper_route_probe_window_end": window_end.isoformat(),
+            }
+            pipeline = SimpleTradingPipeline(
+                alpaca_client=FakeAlpacaClient(),
+                order_firewall=OrderFirewall(FakeAlpacaClient()),
+                ingestor=FakeIngestor([]),
+                decision_engine=DecisionEngine(),
+                risk_engine=RiskEngine(),
+                executor=OrderExecutor(),
+                execution_adapter=FakeAlpacaClient(),
+                reconciler=Reconciler(),
+                universe_resolver=UniverseResolver(),
+                state=TradingState(),
+                account_label="paper",
+                session_factory=self.session_local,
+            )
+            pipeline._is_market_session_open = lambda _now=None: True  # type: ignore[method-assign]
+
+            with (
+                patch.object(
+                    SimpleTradingPipeline,
+                    "_external_paper_route_target_probe_symbols_cached",
+                    return_value=({"AAPL", "AMZN"}, None, [target]),
+                ),
+                patch(
+                    "app.trading.scheduler.simple_pipeline.trading_now",
+                    return_value=now,
+                ),
+            ):
+                decisions = pipeline._paper_route_target_source_decisions(
+                    session=session,
+                    strategies=[strategy],
+                    allowed_symbols={"AAPL", "AMZN"},
+                    positions=[],
+                )
+
+        self.assertEqual([decision.symbol for decision in decisions], ["AMZN"])
+
     def test_process_paper_route_target_source_decisions_records_submit_failure(
         self,
     ) -> None:
@@ -6003,6 +6125,7 @@ class TestTradingPipeline(TestCase):
             strategies=[strategy],
             allowed_symbols={"AAPL"},
             positions=positions,
+            session=session,
         )
         self.assertEqual(state.metrics.decisions_total, 1)
         self.assertEqual(state.metrics.orders_rejected_total, 1)


### PR DESCRIPTION
## Summary

- Prevent paper-route target source decisions from opening route-acquisition probe exposure on a symbol that already has DB-backed profit-proof strategy-signal exposure for the same account and strategy.
- Add a fail-closed source-mode exposure guard that only counts profit-proof source decision modes or explicit `profit_proof_eligible=true` fills.
- Add regression coverage proving strategy-signal paper exposure blocks AAPL route acquisition while non-profit route-acquisition exposure does not block AMZN.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen ruff check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/scheduler/simple_pipeline.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -k "paper_route_target_source_decisions" -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_pipeline.py -q`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
