### PR TITLE
fix(torghut): use tigerbeetle lookup for client probe

### DIFF
--- a/services/torghut/app/trading/tigerbeetle_client.py
+++ b/services/torghut/app/trading/tigerbeetle_client.py
@@ -14,6 +14,8 @@ from app.trading.tigerbeetle_ledger_model import (
     TigerBeetleTransferSpec,
 )
 
+HEALTH_PROBE_ACCOUNT_ID = 1
+
 
 class TigerBeetleClientProtocol(Protocol):
     def nop(self) -> None: ...
@@ -132,7 +134,10 @@ class RealTigerBeetleClient:
             exit_fn(None, None, None)
 
     def nop(self) -> None:
-        self._client.nop()
+        # The Python client does not expose TigerBeetle's internal NOP request.
+        # A one-id account lookup is read-only but still proves client/server
+        # protocol connectivity through the official public API.
+        self._client.lookup_accounts([HEALTH_PROBE_ACCOUNT_ID])
 
     def _account_event(self, account: object) -> object:
         if not isinstance(account, TigerBeetleAccountSpec):

--- a/services/torghut/scripts/verify_tigerbeetle_ledger.py
+++ b/services/torghut/scripts/verify_tigerbeetle_ledger.py
@@ -62,7 +62,7 @@ def run_smoke(settings: Settings) -> dict[str, Any]:
     )
 
     client.nop()
-    print("nop ok")
+    print("protocol probe ok")
     client.create_accounts(accounts)
     client.create_accounts(accounts)
     looked_up_accounts = client.lookup_accounts([item.account_id for item in accounts])

--- a/services/torghut/tests/test_tigerbeetle_client.py
+++ b/services/torghut/tests/test_tigerbeetle_client.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from app.config import Settings
 from app.trading.tigerbeetle_client import (
     FakeTigerBeetleClient,
+    HEALTH_PROBE_ACCOUNT_ID,
     RealTigerBeetleClient,
     check_tigerbeetle_health,
     create_tigerbeetle_client,
@@ -168,14 +169,12 @@ class TestTigerBeetleClient(TestCase):
                 self.replica_addresses = replica_addresses
                 self.created_accounts: list[object] = []
                 self.created_transfers: list[object] = []
+                self.lookup_account_requests: list[list[int]] = []
                 self.closed = False
                 instances.append(self)
 
             def close(self) -> None:
                 self.closed = True
-
-            def nop(self) -> None:
-                return None
 
             def create_accounts(
                 self, accounts: list[object]
@@ -184,6 +183,7 @@ class TestTigerBeetleClient(TestCase):
                 return [{"status": "created"}]
 
             def lookup_accounts(self, ids: list[int]) -> list[object]:
+                self.lookup_account_requests.append(ids)
                 return [{"id": item} for item in ids]
 
             def create_transfers(
@@ -252,6 +252,7 @@ class TestTigerBeetleClient(TestCase):
         self.assertEqual(sync.replica_addresses, "10.99.251.1:3000")
         self.assertEqual(sync.created_accounts[0].id, 11)
         self.assertEqual(sync.created_transfers[0].id, 22)
+        self.assertEqual(sync.lookup_account_requests[-1], [HEALTH_PROBE_ACCOUNT_ID])
         self.assertTrue(sync.closed)
 
     def test_real_client_close_uses_exit_when_close_missing(self) -> None:

--- a/services/torghut/tests/test_verify_tigerbeetle_ledger.py
+++ b/services/torghut/tests/test_verify_tigerbeetle_ledger.py
@@ -22,7 +22,9 @@ class MissingTransferLookupClient(FakeTigerBeetleClient):
 
 
 class TestVerifyTigerBeetleLedger(TestCase):
-    def test_run_smoke_proves_nop_idempotent_writes_and_lookup(self) -> None:
+    def test_run_smoke_proves_protocol_probe_idempotent_writes_and_lookup(
+        self,
+    ) -> None:
         client = FakeTigerBeetleClient()
         out = io.StringIO()
 
@@ -37,7 +39,7 @@ class TestVerifyTigerBeetleLedger(TestCase):
         self.assertEqual(len(client.accounts), 2)
         self.assertEqual(len(client.transfers), 1)
         output = out.getvalue()
-        self.assertIn("nop ok", output)
+        self.assertIn("protocol probe ok", output)
         self.assertIn("create_accounts idempotent ok", output)
         self.assertIn("create_transfers idempotent ok", output)
         self.assertIn("lookup_transfers ok", output)


### PR DESCRIPTION
## Summary

- Replaced the Torghut TigerBeetle client health probe with a read-only official Python `lookup_accounts([1])` request instead of calling a non-existent `.nop()` method.
- Updated the live smoke script wording to report `protocol probe ok` before idempotent account, transfer, lookup, and reconciliation checks.
- Added regression coverage with a fake official Python client that exposes lookup/create APIs but no `.nop()` method.

## Related Issues

None

## Testing

- `uv run --frozen ruff format app/trading/tigerbeetle_client.py scripts/verify_tigerbeetle_ledger.py tests/test_tigerbeetle_client.py tests/test_verify_tigerbeetle_ledger.py`
- `uv run --frozen ruff check app/trading/tigerbeetle_client.py scripts/verify_tigerbeetle_ledger.py tests/test_tigerbeetle_client.py tests/test_verify_tigerbeetle_ledger.py`
- `uv run --frozen --extra dev pytest tests/test_tigerbeetle_client.py tests/test_verify_tigerbeetle_ledger.py -q`
- `uv sync --frozen --extra dev`
- `uv run --frozen --extra dev pytest tests/test_tigerbeetle_client.py tests/test_tigerbeetle_status.py tests/test_verify_tigerbeetle_ledger.py tests/test_tigerbeetle_reconcile.py -q`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- Live diagnosis before fix: `kubectl -n torghut exec torghut-00817-deployment-7794c85bd9-cqf2p -c user-container -- /bin/bash -lc 'cd /app && /opt/venv/bin/python scripts/verify_tigerbeetle_ledger.py --mode smoke'` failed with `AttributeError: 'ClientSync' object has no attribute 'nop'`.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
