### PR TITLE
revert(torghut): rollback failed promotion a721e0be81b73c9e112b8f6526f54f3b769dac56

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -28,9 +28,6 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          securityContext:
-            seccompProfile:
-              type: Unconfined
           image: registry.ide-newton.ts.net/lab/torghut@sha256:46fa917cb9542a0ab5f7aa75cfac9f07f296d92fb8a107d3c904ad9b5ef169f6
           ports:
             - name: http1

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -28,9 +28,6 @@ spec:
       containers:
         - name: user-container
           imagePullPolicy: IfNotPresent
-          securityContext:
-            seccompProfile:
-              type: Unconfined
           image: registry.ide-newton.ts.net/lab/torghut@sha256:46fa917cb9542a0ab5f7aa75cfac9f07f296d92fb8a107d3c904ad9b5ef169f6
           ports:
             - name: http1

--- a/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
+++ b/argocd/applications/torghut/tigerbeetle-smoke-job.yaml
@@ -34,8 +34,6 @@ spec:
           image: registry.ide-newton.ts.net/lab/torghut@sha256:46fa917cb9542a0ab5f7aa75cfac9f07f296d92fb8a107d3c904ad9b5ef169f6
           imagePullPolicy: IfNotPresent
           securityContext:
-            seccompProfile:
-              type: Unconfined
             allowPrivilegeEscalation: false
             capabilities:
               drop:


### PR DESCRIPTION
## Summary
Automatic rollback created because `torghut-post-deploy-verify` failed on `main`.

- Failed commit: `a721e0be81b73c9e112b8f6526f54f3b769dac56`
- Workflow run: `https://github.com/proompteng/lab/actions/runs/26712776679`
- Rollback source: `HEAD^` manifests from the failed run checkout