### PR TITLE
fix(torghut): align tigerbeetle health timeout

### DIFF
--- a/argocd/applications/torghut/knative-service-sim.yaml
+++ b/argocd/applications/torghut/knative-service-sim.yaml
@@ -75,7 +75,7 @@ spec:
             - name: TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES
               value: torghut-tigerbeetle.torghut.svc.cluster.local:3000
             - name: TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS
-              value: "2"
+              value: "5"
             - name: TORGHUT_TIGERBEETLE_JOURNAL_ENABLED
               value: "true"
             - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED

--- a/argocd/applications/torghut/knative-service.yaml
+++ b/argocd/applications/torghut/knative-service.yaml
@@ -58,7 +58,7 @@ spec:
             - name: TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES
               value: torghut-tigerbeetle.torghut.svc.cluster.local:3000
             - name: TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS
-              value: "2"
+              value: "5"
             - name: TORGHUT_TIGERBEETLE_JOURNAL_ENABLED
               value: "true"
             - name: TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -902,7 +902,7 @@ class TestLiveConfigManifestContract(TestCase):
             "TORGHUT_TIGERBEETLE_REQUIRED": "false",
             "TORGHUT_TIGERBEETLE_CLUSTER_ID": "2001",
             "TORGHUT_TIGERBEETLE_REPLICA_ADDRESSES": "torghut-tigerbeetle.torghut.svc.cluster.local:3000",
-            "TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS": "2",
+            "TORGHUT_TIGERBEETLE_HEALTH_TIMEOUT_SECONDS": "5",
             "TORGHUT_TIGERBEETLE_JOURNAL_ENABLED": "true",
             "TORGHUT_TIGERBEETLE_RECONCILE_REQUIRED": "false",
         }


### PR DESCRIPTION
## Summary

- Align live Torghut and Torghut sim TigerBeetle protocol health timeouts with the passing 5s smoke-hook timeout.
- Prevent `/trading/status` from reporting TigerBeetle protocol timeout during normal client connect latency after rollout.
- Lock the production env contract in `test_live_config_manifest_contract.py`.

## Related Issues

None

## Testing

- `uv run --frozen --extra dev pytest tests/test_live_config_manifest_contract.py -q`
- `bun run lint:argocd`
- `git diff --check`
- `kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f argocd/applications/torghut/knative-service.yaml -f argocd/applications/torghut/knative-service-sim.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
