### PR TITLE
fix(torghut): mark pre-session account checks pending

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -1590,12 +1590,18 @@ def _next_paper_route_runtime_window_targets(
         }
     )
     account_pre_session_items = [
-        _as_mapping(target.get("paper_route_account_pre_session_state"))
+        item
         for target in planned_targets
+        if (item := _as_mapping(target.get("paper_route_account_pre_session_state")))
     ]
     account_pre_session_items.extend(
-        _as_mapping(skipped_target.get("paper_route_account_pre_session_state"))
+        item
         for skipped_target in skipped_targets
+        if (
+            item := _as_mapping(
+                skipped_target.get("paper_route_account_pre_session_state")
+            )
+        )
     )
     account_pre_session_required_count = sum(
         1 for item in account_pre_session_items if bool(item.get("required"))
@@ -1607,12 +1613,44 @@ def _next_paper_route_runtime_window_targets(
             for blocker in _unique_text_items(item.get("blockers"))
         }
     )
+    account_pre_session_not_yet_required_count = sum(
+        1
+        for item in account_pre_session_items
+        if item.get("state") == "not_required_until_pre_session"
+    )
     account_pre_session_clean_count = sum(
         1
         for item in account_pre_session_items
-        if item.get("state") in {"clean", "not_required_until_pre_session"}
+        if item.get("state") == "clean"
         and not _unique_text_items(item.get("blockers"))
     )
+    account_pre_session_blocked_count = sum(
+        1
+        for item in account_pre_session_items
+        if item.get("state") == "blocked"
+        or bool(_unique_text_items(item.get("blockers")))
+    )
+    account_pre_session_pending_count = sum(
+        1
+        for item in account_pre_session_items
+        if item.get("state") == "not_required_until_pre_session"
+        and not _unique_text_items(item.get("blockers"))
+    )
+    account_pre_session_required_after_values = sorted(
+        str(item.get("required_after"))
+        for item in account_pre_session_items
+        if item.get("required_after") is not None
+    )
+    if not account_pre_session_items:
+        account_pre_session_summary_state = "no_targets"
+    elif account_pre_session_blocked_count:
+        account_pre_session_summary_state = "blocked"
+    elif account_pre_session_pending_count:
+        account_pre_session_summary_state = "pending_until_pre_session"
+    elif account_pre_session_clean_count == len(account_pre_session_items):
+        account_pre_session_summary_state = "clean"
+    else:
+        account_pre_session_summary_state = "unknown"
     return {
         "schema_version": NEXT_PAPER_ROUTE_RUNTIME_WINDOW_TARGETS_SCHEMA_VERSION,
         "source": "paper_route_evidence_audit",
@@ -1646,11 +1684,19 @@ def _next_paper_route_runtime_window_targets(
         },
         "account_pre_session_readiness": {
             "schema_version": "torghut.paper-route-account-pre-session-readiness-summary.v1",
+            "state": account_pre_session_summary_state,
             "target_count": len(account_pre_session_items),
             "required_target_count": account_pre_session_required_count,
+            "not_yet_required_target_count": (
+                account_pre_session_not_yet_required_count
+            ),
+            "pending_target_count": account_pre_session_pending_count,
             "clean_target_count": account_pre_session_clean_count,
-            "blocked_target_count": (
-                len(account_pre_session_items) - account_pre_session_clean_count
+            "blocked_target_count": account_pre_session_blocked_count,
+            "next_required_after": (
+                account_pre_session_required_after_values[0]
+                if account_pre_session_required_after_values
+                else None
             ),
             "blockers": account_pre_session_blockers,
         },

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -255,8 +255,13 @@ class TestPaperRouteEvidenceAudit(TestCase):
             "paper_route_account_pre_session_non_target_positions_present", blockers
         )
         readiness = plan["account_pre_session_readiness"]
+        self.assertEqual(readiness["state"], "blocked")
+        self.assertEqual(readiness["target_count"], 1)
         self.assertEqual(readiness["required_target_count"], 1)
+        self.assertEqual(readiness["not_yet_required_target_count"], 0)
+        self.assertEqual(readiness["pending_target_count"], 0)
         self.assertEqual(readiness["clean_target_count"], 0)
+        self.assertEqual(readiness["blocked_target_count"], 1)
         self.assertIn("paper_route_account_pre_session_not_flat", readiness["blockers"])
 
     def test_pre_session_missing_account_snapshot_skips_target(self) -> None:
@@ -754,6 +759,19 @@ class TestPaperRouteEvidenceAudit(TestCase):
             plan["session_readiness"]["settlement_ready_at"],
             "2026-05-26T21:00:00+00:00",
         )
+        account_pre_session = plan["account_pre_session_readiness"]
+        self.assertEqual(account_pre_session["state"], "pending_until_pre_session")
+        self.assertEqual(account_pre_session["target_count"], 1)
+        self.assertEqual(account_pre_session["required_target_count"], 0)
+        self.assertEqual(account_pre_session["not_yet_required_target_count"], 1)
+        self.assertEqual(account_pre_session["pending_target_count"], 1)
+        self.assertEqual(account_pre_session["clean_target_count"], 0)
+        self.assertEqual(account_pre_session["blocked_target_count"], 0)
+        self.assertEqual(
+            account_pre_session["next_required_after"],
+            "2026-05-26T13:15:00+00:00",
+        )
+        self.assertEqual(account_pre_session["blockers"], [])
         self.assertEqual(
             plan["session_readiness"]["import_blockers"],
             ["paper_route_session_window_not_open"],


### PR DESCRIPTION
## Summary

- Separate pending pre-session account checks from actually clean checks in Torghut paper-route target readiness.
- Stop counting `not_required_until_pre_session` targets as clean before the account-flatten window starts.
- Add explicit readiness counts and next required timestamp so H-PAIRS evidence collection status is harder to misread.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -k 'pre_session or next_paper_route_runtime_window_targets' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_verify_trading_readiness.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
