### PR TITLE
fix(torghut): repair order-feed proof linkage

### DIFF
--- a/services/torghut/app/trading/order_feed.py
+++ b/services/torghut/app/trading/order_feed.py
@@ -984,6 +984,68 @@ def link_order_events_to_execution(session: Session, execution: Execution) -> in
     return linked
 
 
+def repair_order_feed_execution_links(
+    session: Session,
+    *,
+    account_label: str | None = None,
+    limit: int = 1000,
+) -> dict[str, int]:
+    """Attach unlinked order-feed lifecycle rows to matching executions.
+
+    This is a bounded repair for already-consumed broker events. It preserves
+    fail-closed proof semantics: if no matching execution exists, the event stays
+    unlinked and remains a runtime-ledger/source-authority blocker.
+    """
+
+    bounded_limit = max(1, min(int(limit), 5000))
+    stmt = (
+        select(ExecutionOrderEvent)
+        .where(
+            (
+                (ExecutionOrderEvent.execution_id.is_(None))
+                | (ExecutionOrderEvent.trade_decision_id.is_(None))
+            ),
+            (
+                (ExecutionOrderEvent.alpaca_order_id.is_not(None))
+                | (ExecutionOrderEvent.client_order_id.is_not(None))
+            ),
+        )
+        .order_by(
+            ExecutionOrderEvent.event_ts.asc().nullsfirst(),
+            ExecutionOrderEvent.feed_seq.asc().nullsfirst(),
+            ExecutionOrderEvent.created_at.asc(),
+        )
+        .limit(bounded_limit)
+    )
+    if account_label:
+        stmt = stmt.where(ExecutionOrderEvent.alpaca_account_label == account_label)
+
+    events = session.execute(stmt).scalars().all()
+    processed_execution_ids: set[object] = set()
+    counters = {
+        "selected": len(events),
+        "executions_matched": 0,
+        "executions_linked": 0,
+        "events_linked": 0,
+        "events_without_execution": 0,
+    }
+    for event in events:
+        execution = _execution_for_order_event(session, event)
+        if execution is None:
+            counters["events_without_execution"] += 1
+            continue
+        if execution.id in processed_execution_ids:
+            continue
+        processed_execution_ids.add(execution.id)
+        counters["executions_matched"] += 1
+        linked = link_order_events_to_execution(session, execution)
+        if linked <= 0:
+            continue
+        counters["executions_linked"] += 1
+        counters["events_linked"] += linked
+    return counters
+
+
 def backfill_order_feed_source_windows(
     session: Session,
     *,
@@ -1035,6 +1097,39 @@ def backfill_order_feed_source_windows(
         _refresh_source_window_linkage_counts(session, event)
         counters["events_linked"] += 1
     return counters
+
+
+def _execution_for_order_event(
+    session: Session,
+    event: ExecutionOrderEvent,
+) -> Execution | None:
+    clauses: list[ColumnElement[bool]] = []
+    if event.alpaca_order_id:
+        clauses.append(
+            (Execution.alpaca_order_id == event.alpaca_order_id)
+            & (Execution.alpaca_account_label == event.alpaca_account_label)
+        )
+    if event.client_order_id:
+        clauses.append(
+            (Execution.client_order_id == event.client_order_id)
+            & (Execution.alpaca_account_label == event.alpaca_account_label)
+        )
+    if not clauses:
+        return None
+    return (
+        session.execute(
+            select(Execution)
+            .where(or_(*clauses))
+            .order_by(
+                Execution.order_feed_last_event_ts.desc().nullslast(),
+                Execution.last_update_at.desc().nullslast(),
+                Execution.created_at.desc(),
+            )
+            .limit(1)
+        )
+        .scalars()
+        .first()
+    )
 
 
 def _ensure_source_window_for_event(
@@ -1506,5 +1601,6 @@ __all__ = [
     "apply_order_event_to_execution",
     "backfill_order_feed_source_windows",
     "link_order_events_to_execution",
+    "repair_order_feed_execution_links",
     "latest_order_event_for_execution",
 ]

--- a/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/scripts/assemble_runtime_ledger_proof_packet.py
@@ -1637,6 +1637,15 @@ def build_runtime_ledger_proof_packet(
         if net_pnl is not None and trading_days > 0
         else None
     )
+    median_daily_net_pnl = _decimal(
+        runtime_summary.get("runtime_ledger_median_daily_net_pnl_after_costs")
+    )
+    p10_daily_net_pnl = _decimal(
+        runtime_summary.get("runtime_ledger_p10_daily_net_pnl_after_costs")
+    )
+    worst_day_net_pnl = _decimal(
+        runtime_summary.get("runtime_ledger_worst_day_net_pnl_after_costs")
+    )
     drawdown_pct, drawdown_source = _first_decimal(
         runtime_summary,
         (
@@ -1644,6 +1653,13 @@ def build_runtime_ledger_proof_packet(
             "runtime_ledger_drawdown_pct_equity",
             "max_drawdown_pct_equity",
             "drawdown_pct_equity",
+        ),
+    )
+    max_intraday_drawdown, max_intraday_drawdown_source = _first_decimal(
+        runtime_summary,
+        (
+            "runtime_ledger_max_intraday_drawdown",
+            "max_intraday_drawdown",
         ),
     )
     best_day_share, best_day_share_source = _first_decimal(
@@ -1661,6 +1677,14 @@ def build_runtime_ledger_proof_packet(
             "runtime_ledger_symbol_concentration_share",
             "symbol_concentration_share",
         ),
+    )
+    avg_daily_filled_notional = _decimal(
+        runtime_summary.get("runtime_ledger_avg_daily_filled_notional")
+    )
+    target_implied_avg_daily_filled_notional = (
+        min_runtime_ledger_daily_net_pnl * Decimal("10000") / expectancy_bps
+        if expectancy_bps is not None and expectancy_bps > 0
+        else None
     )
     _check(
         checks,
@@ -1737,6 +1761,110 @@ def build_runtime_ledger_proof_packet(
         status=None if runtime_import_due else deferred_until_runtime_import_due,
     )
     _extend_unique(blockers, pnl_blockers)
+    daily_distribution_blockers: list[str] = []
+    if runtime_import_due and final_authority_mode:
+        if median_daily_net_pnl is None:
+            daily_distribution_blockers.append(
+                "runtime_ledger_median_daily_net_pnl_after_costs_missing"
+            )
+        elif (
+            median_daily_net_pnl
+            < DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_min_median_daily_net_pnl_after_costs
+        ):
+            daily_distribution_blockers.append(
+                "runtime_ledger_median_daily_net_pnl_after_costs_below_floor"
+            )
+        if p10_daily_net_pnl is None:
+            daily_distribution_blockers.append(
+                "runtime_ledger_p10_daily_net_pnl_after_costs_missing"
+            )
+        elif (
+            p10_daily_net_pnl
+            < DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_min_p10_daily_net_pnl_after_costs
+        ):
+            daily_distribution_blockers.append(
+                "runtime_ledger_p10_daily_net_pnl_after_costs_below_floor"
+            )
+        if worst_day_net_pnl is None:
+            daily_distribution_blockers.append(
+                "runtime_ledger_worst_day_net_pnl_after_costs_missing"
+            )
+        elif (
+            worst_day_net_pnl
+            < DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_min_worst_day_net_pnl_after_costs
+        ):
+            daily_distribution_blockers.append(
+                "runtime_ledger_worst_day_net_pnl_after_costs_below_floor"
+            )
+    _check(
+        checks,
+        "runtime_ledger_daily_distribution_authority",
+        passed=not daily_distribution_blockers,
+        observed={
+            "runtime_import_due": runtime_import_due,
+            "final_authority": final_authority_mode,
+            "median_daily_net_pnl_after_costs": _decimal_text(median_daily_net_pnl),
+            "p10_daily_net_pnl_after_costs": _decimal_text(p10_daily_net_pnl),
+            "worst_day_net_pnl_after_costs": _decimal_text(worst_day_net_pnl),
+        },
+        expected={
+            "min_median_daily_net_pnl_after_costs": _decimal_text(
+                DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_min_median_daily_net_pnl_after_costs
+            ),
+            "min_p10_daily_net_pnl_after_costs": _decimal_text(
+                DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_min_p10_daily_net_pnl_after_costs
+            ),
+            "min_worst_day_net_pnl_after_costs": _decimal_text(
+                DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_min_worst_day_net_pnl_after_costs
+            ),
+        },
+        blockers=daily_distribution_blockers,
+        status=None if runtime_import_due else deferred_until_runtime_import_due,
+    )
+    _extend_unique(blockers, daily_distribution_blockers)
+    scale_blockers: list[str] = []
+    if runtime_import_due and final_authority_mode:
+        if avg_daily_filled_notional is None:
+            scale_blockers.append("runtime_ledger_avg_daily_filled_notional_missing")
+        elif (
+            target_implied_avg_daily_filled_notional is not None
+            and avg_daily_filled_notional < target_implied_avg_daily_filled_notional
+        ):
+            scale_blockers.append(
+                "runtime_ledger_avg_daily_filled_notional_below_target_implied_floor"
+            )
+    _check(
+        checks,
+        "runtime_ledger_target_implied_scale",
+        passed=not scale_blockers,
+        observed={
+            "runtime_import_due": runtime_import_due,
+            "final_authority": final_authority_mode,
+            "post_cost_expectancy_bps": _decimal_text(expectancy_bps),
+            "avg_daily_filled_notional": _decimal_text(avg_daily_filled_notional),
+            "target_implied_avg_daily_filled_notional": _decimal_text(
+                target_implied_avg_daily_filled_notional
+            ),
+            "target_implied_avg_daily_filled_notional_basis": (
+                "min_runtime_ledger_daily_net_pnl_after_costs / "
+                "observed_post_cost_expectancy_bps"
+                if target_implied_avg_daily_filled_notional is not None
+                else None
+            ),
+        },
+        expected={
+            "min_runtime_ledger_daily_net_pnl_after_costs": _decimal_text(
+                min_runtime_ledger_daily_net_pnl
+            ),
+            "formula": (
+                "required_daily_notional = min_daily_net_pnl_after_costs "
+                "/ (observed_post_cost_expectancy_bps / 10000)"
+            ),
+        },
+        blockers=scale_blockers,
+        status=None if runtime_import_due else deferred_until_runtime_import_due,
+    )
+    _extend_unique(blockers, scale_blockers)
     risk_blockers: list[str] = []
     if runtime_import_due and drawdown_pct is None:
         risk_blockers.append("runtime_ledger_drawdown_pct_equity_missing")
@@ -1746,6 +1874,16 @@ def build_runtime_ledger_proof_packet(
         and drawdown_pct > max_runtime_ledger_drawdown_pct_equity
     ):
         risk_blockers.append("runtime_ledger_drawdown_pct_equity_above_limit")
+    if runtime_import_due and final_authority_mode and max_intraday_drawdown is None:
+        risk_blockers.append("runtime_ledger_max_intraday_drawdown_missing")
+    elif (
+        runtime_import_due
+        and final_authority_mode
+        and max_intraday_drawdown is not None
+        and max_intraday_drawdown
+        > DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_max_intraday_drawdown
+    ):
+        risk_blockers.append("runtime_ledger_max_intraday_drawdown_above_limit")
     if runtime_import_due and best_day_share is None:
         risk_blockers.append("runtime_ledger_best_day_share_missing")
     elif (
@@ -1770,6 +1908,8 @@ def build_runtime_ledger_proof_packet(
             "runtime_import_due": runtime_import_due,
             "drawdown_pct_equity": _decimal_text(drawdown_pct),
             "drawdown_pct_equity_source": drawdown_source,
+            "max_intraday_drawdown": _decimal_text(max_intraday_drawdown),
+            "max_intraday_drawdown_source": max_intraday_drawdown_source,
             "best_day_share": _decimal_text(best_day_share),
             "best_day_share_source": best_day_share_source,
             "symbol_concentration_share": _decimal_text(symbol_concentration_share),
@@ -1778,6 +1918,9 @@ def build_runtime_ledger_proof_packet(
         expected={
             "max_drawdown_pct_equity": _decimal_text(
                 max_runtime_ledger_drawdown_pct_equity
+            ),
+            "max_intraday_drawdown": _decimal_text(
+                DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_max_intraday_drawdown
             ),
             "max_best_day_share": _decimal_text(max_runtime_ledger_best_day_share),
             "max_symbol_concentration_share": _decimal_text(
@@ -1893,14 +2036,29 @@ def build_runtime_ledger_proof_packet(
                 min_runtime_ledger_daily_net_pnl
             ),
             "min_runtime_ledger_trading_days": min_runtime_ledger_trading_days,
+            "min_runtime_ledger_median_daily_net_pnl_after_costs": _decimal_text(
+                DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_min_median_daily_net_pnl_after_costs
+            ),
+            "min_runtime_ledger_p10_daily_net_pnl_after_costs": _decimal_text(
+                DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_min_p10_daily_net_pnl_after_costs
+            ),
+            "min_runtime_ledger_worst_day_net_pnl_after_costs": _decimal_text(
+                DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_min_worst_day_net_pnl_after_costs
+            ),
             "max_runtime_ledger_drawdown_pct_equity": _decimal_text(
                 max_runtime_ledger_drawdown_pct_equity
+            ),
+            "max_runtime_ledger_intraday_drawdown": _decimal_text(
+                DEFAULT_RUNTIME_LEDGER_PROOF_POLICY.authority_max_intraday_drawdown
             ),
             "max_runtime_ledger_best_day_share": _decimal_text(
                 max_runtime_ledger_best_day_share
             ),
             "max_runtime_ledger_symbol_concentration_share": _decimal_text(
                 max_runtime_ledger_symbol_concentration_share
+            ),
+            "target_implied_avg_daily_filled_notional": _decimal_text(
+                target_implied_avg_daily_filled_notional
             ),
         },
         "candidate": _first_identity(

--- a/services/torghut/scripts/repair_order_feed_source_windows.py
+++ b/services/torghut/scripts/repair_order_feed_source_windows.py
@@ -12,7 +12,10 @@ from typing import Any
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from app.trading.order_feed import backfill_order_feed_source_windows
+from app.trading.order_feed import (
+    backfill_order_feed_source_windows,
+    repair_order_feed_execution_links,
+)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -45,6 +48,21 @@ def _payload(
         ),
         "source_windows_reused": sum(batch["source_windows_reused"] for batch in batches),
         "events_linked": sum(batch["events_linked"] for batch in batches),
+        "execution_link_candidates": sum(
+            batch["execution_link_candidates"] for batch in batches
+        ),
+        "execution_link_executions_matched": sum(
+            batch["execution_link_executions_matched"] for batch in batches
+        ),
+        "execution_link_executions_linked": sum(
+            batch["execution_link_executions_linked"] for batch in batches
+        ),
+        "execution_link_events_linked": sum(
+            batch["execution_link_events_linked"] for batch in batches
+        ),
+        "execution_link_events_without_execution": sum(
+            batch["execution_link_events_without_execution"] for batch in batches
+        ),
     }
     return {
         "status": "ok",
@@ -91,18 +109,40 @@ def main() -> int:
     batches: list[dict[str, int]] = []
     with session_factory() as session:
         for _ in range(max_batches):
-            batch = backfill_order_feed_source_windows(
+            source_window_batch = backfill_order_feed_source_windows(
                 session,
                 account_label=args.account_label,
                 limit=batch_size,
             )
+            execution_link_batch = repair_order_feed_execution_links(
+                session,
+                account_label=args.account_label,
+                limit=batch_size,
+            )
+            batch = {
+                **source_window_batch,
+                "execution_link_candidates": execution_link_batch["selected"],
+                "execution_link_executions_matched": execution_link_batch[
+                    "executions_matched"
+                ],
+                "execution_link_executions_linked": execution_link_batch[
+                    "executions_linked"
+                ],
+                "execution_link_events_linked": execution_link_batch["events_linked"],
+                "execution_link_events_without_execution": execution_link_batch[
+                    "events_without_execution"
+                ],
+            }
             batches.append(batch)
             if args.apply:
                 session.commit()
             else:
                 session.rollback()
                 break
-            if int(batch.get("selected") or 0) < batch_size:
+            if (
+                int(source_window_batch.get("selected") or 0) < batch_size
+                and int(execution_link_batch.get("selected") or 0) < batch_size
+            ):
                 break
 
     payload = _payload(args=args, started_at=started_at, batches=batches)

--- a/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
+++ b/services/torghut/tests/test_assemble_runtime_ledger_proof_packet.py
@@ -243,6 +243,12 @@ def _completion(
     net_pnl: str = "10000",
     trading_days: int = 20,
     expectancy_bps: str = "13",
+    filled_notional: str = "10000000",
+    avg_daily_filled_notional: str | None = "500000",
+    median_daily_net_pnl: str | None = "500",
+    p10_daily_net_pnl: str | None = "500",
+    worst_day_net_pnl: str | None = "500",
+    max_intraday_drawdown: str | None = "500",
     drawdown_pct: str | None = "0.02",
     best_day_share: str | None = "0.20",
     symbol_concentration_share: str | None = "0.35",
@@ -253,11 +259,31 @@ def _completion(
         "runtime_ledger_bucket_count": 1,
         "runtime_ledger_fill_count": 4,
         "runtime_ledger_closed_trade_count": 2,
-        "runtime_ledger_filled_notional": "50000",
+        "runtime_ledger_filled_notional": filled_notional,
         "runtime_ledger_net_strategy_pnl_after_costs": net_pnl,
         "runtime_ledger_post_cost_expectancy_bps": expectancy_bps,
         "runtime_ledger_observed_trading_day_count": trading_days,
     }
+    if avg_daily_filled_notional is not None:
+        runtime_ledger_summary["runtime_ledger_avg_daily_filled_notional"] = (
+            avg_daily_filled_notional
+        )
+    if median_daily_net_pnl is not None:
+        runtime_ledger_summary["runtime_ledger_median_daily_net_pnl_after_costs"] = (
+            median_daily_net_pnl
+        )
+    if p10_daily_net_pnl is not None:
+        runtime_ledger_summary["runtime_ledger_p10_daily_net_pnl_after_costs"] = (
+            p10_daily_net_pnl
+        )
+    if worst_day_net_pnl is not None:
+        runtime_ledger_summary["runtime_ledger_worst_day_net_pnl_after_costs"] = (
+            worst_day_net_pnl
+        )
+    if max_intraday_drawdown is not None:
+        runtime_ledger_summary["runtime_ledger_max_intraday_drawdown"] = (
+            max_intraday_drawdown
+        )
     if drawdown_pct is not None:
         runtime_ledger_summary["runtime_ledger_max_drawdown_pct_equity"] = drawdown_pct
     if best_day_share is not None:
@@ -409,12 +435,112 @@ class TestRuntimeLedgerProofPacket(TestCase):
             "0.02",
         )
         self.assertEqual(
+            result["checks"]["runtime_ledger_daily_distribution_authority"][
+                "observed"
+            ]["median_daily_net_pnl_after_costs"],
+            "500",
+        )
+        self.assertEqual(
+            result["checks"]["runtime_ledger_target_implied_scale"]["observed"][
+                "target_implied_avg_daily_filled_notional"
+            ],
+            "384615.3846153846153846153846",
+        )
+        self.assertEqual(
             result["target"]["max_runtime_ledger_drawdown_pct_equity"],
             "0.03",
+        )
+        self.assertEqual(
+            result["target"]["min_runtime_ledger_median_daily_net_pnl_after_costs"],
+            "250",
+        )
+        self.assertEqual(result["target"]["max_runtime_ledger_intraday_drawdown"], "1500")
+        self.assertEqual(
+            result["target"]["target_implied_avg_daily_filled_notional"],
+            "384615.3846153846153846153846",
         )
         self.assertEqual(result["proof_mode"], "authority")
         self.assertTrue(result["final_authority_ok"])
         self.assertFalse(result["evidence_collection_only"])
+
+    def test_authority_packet_requires_daily_distribution_and_scale(self) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(
+                avg_daily_filled_notional="200000",
+                median_daily_net_pnl="200",
+                p10_daily_net_pnl="-300",
+                worst_day_net_pnl="-800",
+                max_intraday_drawdown="1600",
+            ),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertFalse(result["final_authority_ok"])
+        daily_blockers = result["checks"]["runtime_ledger_daily_distribution_authority"][
+            "blockers"
+        ]
+        self.assertIn(
+            "runtime_ledger_median_daily_net_pnl_after_costs_below_floor",
+            daily_blockers,
+        )
+        self.assertIn(
+            "runtime_ledger_p10_daily_net_pnl_after_costs_below_floor",
+            daily_blockers,
+        )
+        self.assertIn(
+            "runtime_ledger_worst_day_net_pnl_after_costs_below_floor",
+            daily_blockers,
+        )
+        self.assertIn(
+            "runtime_ledger_avg_daily_filled_notional_below_target_implied_floor",
+            result["checks"]["runtime_ledger_target_implied_scale"]["blockers"],
+        )
+        self.assertIn(
+            "runtime_ledger_max_intraday_drawdown_above_limit",
+            result["checks"]["runtime_ledger_risk_quality"]["blockers"],
+        )
+        self.assertEqual(result["verdict"], "blocked")
+
+    def test_authority_packet_requires_daily_distribution_fields(self) -> None:
+        result = packet.build_runtime_ledger_proof_packet(
+            _status(),
+            paper_route_evidence=_paper_route_evidence(),
+            runtime_window_import=_runtime_import(),
+            completion_status=_completion(
+                avg_daily_filled_notional=None,
+                median_daily_net_pnl=None,
+                p10_daily_net_pnl=None,
+                worst_day_net_pnl=None,
+                max_intraday_drawdown=None,
+            ),
+            generated_at="2026-05-26T21:05:00+00:00",
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertIn(
+            "runtime_ledger_median_daily_net_pnl_after_costs_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "runtime_ledger_p10_daily_net_pnl_after_costs_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "runtime_ledger_worst_day_net_pnl_after_costs_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "runtime_ledger_avg_daily_filled_notional_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
+        self.assertIn(
+            "runtime_ledger_max_intraday_drawdown_missing",
+            result["promotion_authority"]["blocking_reasons"],
+        )
 
     def test_smoke_packet_cannot_grant_promotion_authority(self) -> None:
         result = packet.build_runtime_ledger_proof_packet(
@@ -1166,6 +1292,7 @@ class TestRuntimeLedgerProofPacket(TestCase):
             result["checks"]["runtime_ledger_risk_quality"]["expected"],
             {
                 "max_drawdown_pct_equity": "0.03",
+                "max_intraday_drawdown": "1500",
                 "max_best_day_share": "0.25",
                 "max_symbol_concentration_share": "0.35",
             },

--- a/services/torghut/tests/test_order_feed.py
+++ b/services/torghut/tests/test_order_feed.py
@@ -38,6 +38,7 @@ from app.trading.order_feed import (
     merge_execution_raw_order_update,
     normalize_order_feed_record,
     persist_order_event,
+    repair_order_feed_execution_links,
 )
 
 
@@ -1232,6 +1233,81 @@ class TestOrderFeed(TestCase):
         self.assertEqual(source_window.start_offset, 188)
         self.assertEqual(source_window.end_offset, 188)
         self.assertEqual(source_window.inserted_count, 1)
+        self.assertEqual(source_window.unlinked_execution_count, 0)
+        self.assertEqual(source_window.unlinked_decision_count, 0)
+
+    def test_repair_order_feed_execution_links_links_matching_lifecycle_rows(
+        self,
+    ) -> None:
+        with Session(self.engine) as session:
+            execution = self._seed_execution(session)
+            execution_id = execution.id
+            trade_decision_id = execution.trade_decision_id
+            linkable_event = ExecutionOrderEvent(
+                event_fingerprint="repair-linkable-fill",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=288,
+                alpaca_account_label="paper",
+                event_ts=datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+                symbol="AAPL",
+                alpaca_order_id=execution.alpaca_order_id,
+                client_order_id=execution.client_order_id,
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("191.25"),
+                raw_event={"event": "fill"},
+            )
+            unmatched_event = ExecutionOrderEvent(
+                event_fingerprint="repair-unmatched-fill",
+                source_topic="torghut.trade-updates.v1",
+                source_partition=0,
+                source_offset=289,
+                alpaca_account_label="paper",
+                event_ts=datetime(2026, 2, 1, 10, 1, tzinfo=timezone.utc),
+                symbol="MSFT",
+                alpaca_order_id="missing-order",
+                client_order_id="missing-client",
+                event_type="fill",
+                status="filled",
+                filled_qty=Decimal("1"),
+                avg_fill_price=Decimal("320.00"),
+                raw_event={"event": "fill"},
+            )
+            session.add_all([linkable_event, unmatched_event])
+            session.commit()
+
+            result = repair_order_feed_execution_links(
+                session,
+                account_label="paper",
+                limit=10,
+            )
+            session.commit()
+            session.refresh(linkable_event)
+            session.refresh(unmatched_event)
+            session.refresh(execution)
+            source_window = session.execute(select(OrderFeedSourceWindow)).scalar_one()
+            tca_metric = session.execute(select(ExecutionTCAMetric)).scalar_one()
+
+        self.assertEqual(
+            result,
+            {
+                "selected": 2,
+                "executions_matched": 1,
+                "executions_linked": 1,
+                "events_linked": 1,
+                "events_without_execution": 1,
+            },
+        )
+        self.assertEqual(linkable_event.execution_id, execution_id)
+        self.assertEqual(linkable_event.trade_decision_id, trade_decision_id)
+        self.assertEqual(linkable_event.source_window_id, source_window.id)
+        self.assertIsNone(unmatched_event.execution_id)
+        self.assertIsNone(unmatched_event.trade_decision_id)
+        self.assertEqual(execution.status, "filled")
+        self.assertEqual(execution.filled_qty, Decimal("1.00000000"))
+        self.assertEqual(tca_metric.execution_id, execution_id)
         self.assertEqual(source_window.unlinked_execution_count, 0)
         self.assertEqual(source_window.unlinked_decision_count, 0)
 

--- a/services/torghut/tests/test_repair_order_feed_source_windows_script.py
+++ b/services/torghut/tests/test_repair_order_feed_source_windows_script.py
@@ -73,6 +73,17 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
                     "events_linked": 5,
                 },
             ) as backfill,
+            patch.object(
+                script,
+                "repair_order_feed_execution_links",
+                return_value={
+                    "selected": 4,
+                    "executions_matched": 3,
+                    "executions_linked": 2,
+                    "events_linked": 3,
+                    "events_without_execution": 1,
+                },
+            ) as repair_links,
             patch("sys.stdout", stdout),
         ):
             exit_code = script.main()
@@ -87,6 +98,11 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(payload["source_windows_created"], 3)
         self.assertEqual(payload["source_windows_reused"], 2)
         self.assertEqual(payload["events_linked"], 5)
+        self.assertEqual(payload["execution_link_candidates"], 4)
+        self.assertEqual(payload["execution_link_executions_matched"], 3)
+        self.assertEqual(payload["execution_link_executions_linked"], 2)
+        self.assertEqual(payload["execution_link_events_linked"], 3)
+        self.assertEqual(payload["execution_link_events_without_execution"], 1)
         self.assertEqual(fake_session.commits, 0)
         self.assertEqual(fake_session.rollbacks, 1)
         create_engine.assert_called_once_with(
@@ -95,6 +111,11 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
             future=True,
         )
         backfill.assert_called_once_with(
+            fake_session,
+            account_label=None,
+            limit=5000,
+        )
+        repair_links.assert_called_once_with(
             fake_session,
             account_label=None,
             limit=5000,
@@ -146,6 +167,26 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
                     },
                 ],
             ) as backfill,
+            patch.object(
+                script,
+                "repair_order_feed_execution_links",
+                side_effect=[
+                    {
+                        "selected": 2,
+                        "executions_matched": 2,
+                        "executions_linked": 1,
+                        "events_linked": 2,
+                        "events_without_execution": 0,
+                    },
+                    {
+                        "selected": 0,
+                        "executions_matched": 0,
+                        "executions_linked": 0,
+                        "events_linked": 0,
+                        "events_without_execution": 0,
+                    },
+                ],
+            ) as repair_links,
             patch("sys.stdout", stdout),
         ):
             exit_code = script.main()
@@ -158,11 +199,19 @@ class TestRepairOrderFeedSourceWindowsScript(TestCase):
         self.assertEqual(payload["source_windows_created"], 2)
         self.assertEqual(payload["source_windows_reused"], 1)
         self.assertEqual(payload["events_linked"], 3)
+        self.assertEqual(payload["execution_link_candidates"], 2)
+        self.assertEqual(payload["execution_link_executions_matched"], 2)
+        self.assertEqual(payload["execution_link_executions_linked"], 1)
+        self.assertEqual(payload["execution_link_events_linked"], 2)
+        self.assertEqual(payload["execution_link_events_without_execution"], 0)
         self.assertEqual(fake_session.commits, 2)
         self.assertEqual(fake_session.rollbacks, 0)
         self.assertEqual(backfill.call_count, 2)
         self.assertEqual(backfill.call_args.kwargs["account_label"], "TORGHUT_SIM")
         self.assertEqual(backfill.call_args.kwargs["limit"], 2)
+        self.assertEqual(repair_links.call_count, 2)
+        self.assertEqual(repair_links.call_args.kwargs["account_label"], "TORGHUT_SIM")
+        self.assertEqual(repair_links.call_args.kwargs["limit"], 2)
 
     def test_main_requires_configured_dsn_env(self) -> None:
         with (


### PR DESCRIPTION
## Summary

- Repairs already-ingested order-feed lifecycle rows by linking them back to matching executions and trade decisions through the existing order-feed reconciliation path.
- Extends the source-window repair job so it refreshes source-window lineage and execution-link/TCA lineage in the same bounded run.
- Hardens authority proof packets with daily distribution gates, target-implied filled-notional scale, and intraday drawdown checks before promotion authority can pass.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_assemble_runtime_ledger_proof_packet.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_verify_trading_readiness.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_order_feed.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_repair_order_feed_source_windows_script.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'order_feed_fill_lifecycle or source_backed or source_authority' -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/order_feed.py scripts/assemble_runtime_ledger_proof_packet.py scripts/repair_order_feed_source_windows.py tests/test_assemble_runtime_ledger_proof_packet.py tests/test_order_feed.py tests/test_repair_order_feed_source_windows_script.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
