### PR TITLE
feat(torghut): add microstructure fast replay diagnostics

### DIFF
--- a/services/torghut/app/trading/discovery/fast_replay.py
+++ b/services/torghut/app/trading/discovery/fast_replay.py
@@ -16,7 +16,7 @@ from app.trading.discovery.replay_tape import ReplayTapeManifest
 from app.trading.models import SignalEnvelope
 
 FAST_REPLAY_PREVIEW_SCHEMA_VERSION = "torghut.fast-replay-preview.v1"
-FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v1"
+FAST_REPLAY_PREVIEW_ROW_SCHEMA_VERSION = "torghut.fast-replay-preview-row.v2"
 
 
 @dataclass(frozen=True)
@@ -35,6 +35,11 @@ class FastReplayPreviewRow:
     median_spread_bps: Decimal
     activity_score: Decimal
     coverage_score: Decimal
+    ofi_pressure_score: Decimal
+    microprice_bias_bps: Decimal
+    spread_tail_bps: Decimal
+    return_tail_abs_bps: Decimal
+    impact_liquidity_penalty_bps: Decimal
 
     def to_payload(self) -> dict[str, Any]:
         return {
@@ -53,6 +58,13 @@ class FastReplayPreviewRow:
             "median_spread_bps": str(self.median_spread_bps),
             "activity_score": str(self.activity_score),
             "coverage_score": str(self.coverage_score),
+            "ofi_pressure_score": str(self.ofi_pressure_score),
+            "microprice_bias_bps": str(self.microprice_bias_bps),
+            "spread_tail_bps": str(self.spread_tail_bps),
+            "return_tail_abs_bps": str(self.return_tail_abs_bps),
+            "impact_liquidity_penalty_bps": str(
+                self.impact_liquidity_penalty_bps
+            ),
         }
 
 
@@ -99,6 +111,11 @@ class _SymbolTapeStats:
     trading_day_count: int
     returns_bps: NDArray[np.float64]
     median_spread_bps: float
+    spread_tail_bps: float
+    ofi_pressure_score: float
+    microprice_bias_bps: float
+    median_volume: float
+    return_tail_abs_bps: float
 
 
 def build_fast_replay_preview(
@@ -158,6 +175,11 @@ def build_fast_replay_preview(
             median_spread_bps=row.median_spread_bps,
             activity_score=row.activity_score,
             coverage_score=row.coverage_score,
+            ofi_pressure_score=row.ofi_pressure_score,
+            microprice_bias_bps=row.microprice_bias_bps,
+            spread_tail_bps=row.spread_tail_bps,
+            return_tail_abs_bps=row.return_tail_abs_bps,
+            impact_liquidity_penalty_bps=row.impact_liquidity_penalty_bps,
         )
         for index, row in enumerate(ranked_rows, start=1)
     )
@@ -201,6 +223,18 @@ def _build_symbol_stats(
             for row in ordered
             if (spread := _extract_spread_bps(row)) is not None
         ]
+        ofi_values = [
+            ofi for row in ordered if (ofi := _extract_ofi_pressure(row)) is not None
+        ]
+        microprice_bias_values = [
+            bias
+            for row in ordered
+            if (bias := _extract_microprice_bias_bps(row)) is not None
+        ]
+        volume_values = [
+            volume for row in ordered if (volume := _extract_volume(row)) is not None
+        ]
+        abs_returns = np.abs(returns) if returns.size else np.asarray([], dtype=np.float64)
         stats[symbol] = _SymbolTapeStats(
             symbol=symbol,
             row_count=len(ordered),
@@ -209,6 +243,19 @@ def _build_symbol_stats(
             ),
             returns_bps=returns,
             median_spread_bps=float(np.median(spread_values)) if spread_values else 0.0,
+            spread_tail_bps=float(np.percentile(spread_values, 95))
+            if spread_values
+            else 0.0,
+            ofi_pressure_score=float(np.mean(ofi_values)) if ofi_values else 0.0,
+            microprice_bias_bps=(
+                float(np.mean(microprice_bias_values))
+                if microprice_bias_values
+                else 0.0
+            ),
+            median_volume=float(np.median(volume_values)) if volume_values else 0.0,
+            return_tail_abs_bps=(
+                float(np.percentile(abs_returns, 95)) if abs_returns.size else 0.0
+            ),
         )
     return stats
 
@@ -244,6 +291,11 @@ def _score_candidate_spec(
             median_spread_bps=Decimal("0"),
             activity_score=Decimal("0"),
             coverage_score=Decimal("0"),
+            ofi_pressure_score=Decimal("0"),
+            microprice_bias_bps=Decimal("0"),
+            spread_tail_bps=Decimal("0"),
+            return_tail_abs_bps=Decimal("0"),
+            impact_liquidity_penalty_bps=Decimal("0"),
         )
 
     return_vectors = [stat.returns_bps for stat in matched if stat.returns_bps.size]
@@ -256,14 +308,35 @@ def _score_candidate_spec(
     signed_return_bps = float(np.mean(returns)) * direction if returns.size else 0.0
     avg_abs_return_bps = float(np.mean(np.abs(returns))) if returns.size else 0.0
     median_spread_bps = float(np.median([stat.median_spread_bps for stat in matched]))
+    spread_tail_bps = float(np.median([stat.spread_tail_bps for stat in matched]))
+    ofi_pressure_score = _weighted_average(
+        [(stat.ofi_pressure_score, stat.row_count) for stat in matched]
+    )
+    microprice_bias_bps = _weighted_average(
+        [(stat.microprice_bias_bps, stat.row_count) for stat in matched]
+    )
+    return_tail_abs_bps = float(
+        np.median([stat.return_tail_abs_bps for stat in matched])
+    )
+    median_volume = float(np.median([stat.median_volume for stat in matched]))
     activity_score = float(np.log1p(matched_row_count))
     coverage_score = matched_symbol_count / max(1, requested_symbol_count)
+    impact_liquidity_penalty_bps = _impact_liquidity_penalty_bps(
+        median_spread_bps=median_spread_bps,
+        spread_tail_bps=spread_tail_bps,
+        median_volume=median_volume,
+    )
     preview_score = (
         signed_return_bps
         + avg_abs_return_bps * 0.15
+        + direction * ofi_pressure_score * 8.0
+        + direction * microprice_bias_bps * 0.35
         + activity_score
         + coverage_score * 25.0
         - median_spread_bps * 0.05
+        - spread_tail_bps * 0.03
+        - return_tail_abs_bps * 0.02
+        - impact_liquidity_penalty_bps * 0.20
     )
     return FastReplayPreviewRow(
         candidate_spec_id=spec.candidate_spec_id,
@@ -280,6 +353,13 @@ def _score_candidate_spec(
         median_spread_bps=_decimal_from_float(median_spread_bps),
         activity_score=_decimal_from_float(activity_score),
         coverage_score=_decimal_from_float(coverage_score),
+        ofi_pressure_score=_decimal_from_float(ofi_pressure_score),
+        microprice_bias_bps=_decimal_from_float(microprice_bias_bps),
+        spread_tail_bps=_decimal_from_float(spread_tail_bps),
+        return_tail_abs_bps=_decimal_from_float(return_tail_abs_bps),
+        impact_liquidity_penalty_bps=_decimal_from_float(
+            impact_liquidity_penalty_bps
+        ),
     )
 
 
@@ -343,6 +423,137 @@ def _extract_spread_bps(signal: SignalEnvelope) -> float | None:
     price = _extract_price(signal)
     if spread is not None and price is not None and price > 0.0:
         return max(0.0, spread / price * 10_000.0)
+    return None
+
+
+def _extract_ofi_pressure(signal: SignalEnvelope) -> float | None:
+    payload = signal.payload
+    for key in (
+        "ofi_pressure_score",
+        "order_flow_imbalance",
+        "ofi",
+        "signed_order_flow_imbalance",
+        "queue_imbalance",
+        "book_imbalance",
+        "depth_imbalance",
+    ):
+        value = _float_or_none(payload.get(key))
+        if value is None:
+            continue
+        if -1.0 <= value <= 1.0:
+            return value
+        return float(np.tanh(value / 100.0))
+    return _extract_quote_depth_imbalance(signal)
+
+
+def _extract_quote_depth_imbalance(signal: SignalEnvelope) -> float | None:
+    payload = signal.payload
+    bid_size = _first_float(
+        payload,
+        (
+            "bid_size",
+            "bid_qty",
+            "best_bid_size",
+            "best_bid_qty",
+            "bid_depth",
+            "bid_volume",
+        ),
+    )
+    ask_size = _first_float(
+        payload,
+        (
+            "ask_size",
+            "ask_qty",
+            "best_ask_size",
+            "best_ask_qty",
+            "ask_depth",
+            "ask_volume",
+        ),
+    )
+    if (
+        bid_size is None
+        or ask_size is None
+        or bid_size < 0.0
+        or ask_size < 0.0
+        or bid_size + ask_size <= 0.0
+    ):
+        return None
+    return float(np.clip((bid_size - ask_size) / (bid_size + ask_size), -1.0, 1.0))
+
+
+def _extract_microprice_bias_bps(signal: SignalEnvelope) -> float | None:
+    payload = signal.payload
+    bid = _first_float(payload, ("bid", "best_bid", "bid_price", "best_bid_price"))
+    ask = _first_float(payload, ("ask", "best_ask", "ask_price", "best_ask_price"))
+    explicit_microprice = _first_float(payload, ("microprice", "micro_price"))
+    price = _extract_price(signal)
+    if explicit_microprice is not None and price is not None and price > 0.0:
+        return (explicit_microprice - price) / price * 10_000.0
+
+    bid_size = _first_float(
+        payload, ("bid_size", "bid_qty", "best_bid_size", "best_bid_qty")
+    )
+    ask_size = _first_float(
+        payload, ("ask_size", "ask_qty", "best_ask_size", "best_ask_qty")
+    )
+    if (
+        bid is None
+        or ask is None
+        or bid <= 0.0
+        or ask <= 0.0
+        or ask < bid
+        or bid_size is None
+        or ask_size is None
+        or bid_size < 0.0
+        or ask_size < 0.0
+        or bid_size + ask_size <= 0.0
+    ):
+        return None
+    mid = (bid + ask) / 2.0
+    microprice = (ask * bid_size + bid * ask_size) / (bid_size + ask_size)
+    return (microprice - mid) / mid * 10_000.0
+
+
+def _extract_volume(signal: SignalEnvelope) -> float | None:
+    payload = signal.payload
+    return _first_float(
+        payload,
+        (
+            "microbar_volume",
+            "bar_volume",
+            "trade_volume",
+            "volume",
+            "qty",
+            "size",
+        ),
+        positive=True,
+    )
+
+
+def _impact_liquidity_penalty_bps(
+    *, median_spread_bps: float, spread_tail_bps: float, median_volume: float
+) -> float:
+    volume_penalty = 25.0 / max(1.0, np.log1p(max(0.0, median_volume)))
+    return max(0.0, median_spread_bps * 0.5 + spread_tail_bps * 0.5 + volume_penalty)
+
+
+def _weighted_average(values: Sequence[tuple[float, int]]) -> float:
+    total_weight = sum(max(0, weight) for _, weight in values)
+    if total_weight <= 0:
+        return 0.0
+    return sum(value * max(0, weight) for value, weight in values) / total_weight
+
+
+def _first_float(
+    payload: Mapping[str, Any], keys: Sequence[str], *, positive: bool = False
+) -> float | None:
+    for key in keys:
+        value = _float_or_none(payload.get(key))
+        if value is None:
+            continue
+        if positive and value <= 0.0:
+            continue
+        return value
     return None
 
 

--- a/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/scripts/run_whitepaper_autoresearch_profit_target.py
@@ -6341,6 +6341,21 @@ def _apply_fast_replay_preview_narrowing(
             updated["fast_replay_preview_matched_row_count"] = preview_row[
                 "matched_row_count"
             ]
+            updated["fast_replay_preview_ofi_pressure_score"] = preview_row[
+                "ofi_pressure_score"
+            ]
+            updated["fast_replay_preview_microprice_bias_bps"] = preview_row[
+                "microprice_bias_bps"
+            ]
+            updated["fast_replay_preview_spread_tail_bps"] = preview_row[
+                "spread_tail_bps"
+            ]
+            updated["fast_replay_preview_return_tail_abs_bps"] = preview_row[
+                "return_tail_abs_bps"
+            ]
+            updated["fast_replay_preview_impact_liquidity_penalty_bps"] = preview_row[
+                "impact_liquidity_penalty_bps"
+            ]
         if candidate_spec_id in original_selected_ids:
             updated["pre_fast_replay_preview_selected_for_replay"] = bool(
                 row.get("selected_for_replay")

--- a/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
+++ b/services/torghut/tests/test_run_whitepaper_autoresearch_profit_target.py
@@ -34,6 +34,8 @@ from app.models import (
 )
 from app.trading.discovery import fast_replay
 from app.trading.discovery.replay_tape import (
+    REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
+    ReplayTapeManifest,
     build_source_query_digest,
     materialize_signal_tape,
 )
@@ -4504,6 +4506,14 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
             "exact_replay_required", selection["replay_tape_preview"]["blockers"]
         )
         self.assertTrue(preview_scores_exists)
+        nvda_row = next(
+            row
+            for row in selection["rows"]
+            if row["candidate_spec_id"] == "spec-nvda-continuation"
+        )
+        self.assertIn("fast_replay_preview_ofi_pressure_score", nvda_row)
+        self.assertIn("fast_replay_preview_microprice_bias_bps", nvda_row)
+        self.assertIn("fast_replay_preview_impact_liquidity_penalty_bps", nvda_row)
         aapl_row = next(
             row
             for row in selection["rows"]
@@ -4512,6 +4522,106 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
         self.assertTrue(aapl_row["pre_fast_replay_preview_selected_for_replay"])
         self.assertFalse(aapl_row["selected_for_replay"])
         self.assertEqual(aapl_row["selection_reason"], "fast_replay_preview_filtered")
+
+    def test_fast_replay_preview_scores_microstructure_diagnostics_preview_only(
+        self,
+    ) -> None:
+        base_spec = self._candidate_spec(
+            "spec-nvda-microstructure-preview",
+            selection_mode="continuation",
+        )
+        spec = replace(
+            base_spec,
+            strategy_overrides={
+                **base_spec.strategy_overrides,
+                "universe_symbols": ["NVDA"],
+            },
+        )
+        rows = [
+            SignalEnvelope(
+                event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                symbol="NVDA",
+                timeframe="1Sec",
+                seq=1,
+                source="ta",
+                payload={
+                    "bid": Decimal("100.00"),
+                    "ask": Decimal("100.02"),
+                    "bid_size": Decimal("220"),
+                    "ask_size": Decimal("80"),
+                    "microbar_volume": Decimal("15000"),
+                },
+            ),
+            SignalEnvelope(
+                event_ts=datetime(2026, 2, 23, 15, 31, tzinfo=timezone.utc),
+                symbol="NVDA",
+                timeframe="1Sec",
+                seq=2,
+                source="ta",
+                payload={
+                    "bid": Decimal("100.08"),
+                    "ask": Decimal("100.12"),
+                    "bid_size": Decimal("260"),
+                    "ask_size": Decimal("90"),
+                    "microbar_volume": Decimal("17000"),
+                },
+            ),
+            SignalEnvelope(
+                event_ts=datetime(2026, 2, 24, 15, 30, tzinfo=timezone.utc),
+                symbol="NVDA",
+                timeframe="1Sec",
+                seq=3,
+                source="ta",
+                payload={
+                    "bid": Decimal("100.19"),
+                    "ask": Decimal("100.25"),
+                    "order_flow_imbalance": Decimal("0.45"),
+                    "microbar_volume": Decimal("11000"),
+                },
+            ),
+        ]
+        manifest = ReplayTapeManifest(
+            schema_version=REPLAY_TAPE_MANIFEST_SCHEMA_VERSION,
+            dataset_snapshot_ref="microstructure-preview",
+            symbols=("NVDA",),
+            row_symbols=("NVDA",),
+            start_date=date(2026, 2, 23),
+            end_date=date(2026, 2, 24),
+            start_ts=datetime(2026, 2, 23, 14, 30, tzinfo=timezone.utc),
+            end_ts=datetime(2026, 2, 24, 21, 0, tzinfo=timezone.utc),
+            min_event_ts=rows[0].event_ts,
+            max_event_ts=rows[-1].event_ts,
+            trading_day_count=2,
+            row_count=len(rows),
+            source_query_digest="microstructure-preview-query",
+            content_sha256="microstructure-preview-sha",
+            artifact_refs={},
+            source_table_versions={},
+            created_at=datetime(2026, 2, 25, tzinfo=timezone.utc),
+        )
+
+        preview = fast_replay.build_fast_replay_preview(
+            specs=(spec,),
+            rows=rows,
+            replay_tape_manifest=manifest,
+            top_k=1,
+            min_rows_per_candidate=2,
+        )
+        row_payload = preview.rows[0].to_payload()
+        manifest_payload = preview.to_manifest_payload()
+
+        self.assertEqual(
+            row_payload["schema_version"], "torghut.fast-replay-preview-row.v2"
+        )
+        self.assertEqual(manifest_payload["status"], "preview_only")
+        self.assertFalse(manifest_payload["promotion_proof"])
+        self.assertIn("exact_replay_required", manifest_payload["blockers"])
+        self.assertGreater(Decimal(row_payload["ofi_pressure_score"]), Decimal("0"))
+        self.assertGreater(Decimal(row_payload["microprice_bias_bps"]), Decimal("0"))
+        self.assertGreater(Decimal(row_payload["spread_tail_bps"]), Decimal("0"))
+        self.assertGreater(
+            Decimal(row_payload["impact_liquidity_penalty_bps"]), Decimal("0")
+        )
 
     def test_materialize_replay_tape_writes_run_artifacts_and_updates_args(
         self,
@@ -4807,6 +4917,57 @@ class TestRunWhitepaperAutoresearchProfitTarget(TestCase):
                 )
             ),
             5.0,
+        )
+        self.assertAlmostEqual(
+            fast_replay._extract_quote_depth_imbalance(
+                SignalEnvelope(
+                    event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                    symbol="NVDA",
+                    payload={
+                        "bid_size": Decimal("200"),
+                        "ask_size": Decimal("100"),
+                    },
+                )
+            )
+            or 0.0,
+            1.0 / 3.0,
+        )
+        self.assertAlmostEqual(
+            fast_replay._extract_ofi_pressure(
+                SignalEnvelope(
+                    event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                    symbol="NVDA",
+                    payload={"order_flow_imbalance": Decimal("50")},
+                )
+            )
+            or 0.0,
+            0.46211715726000974,
+        )
+        self.assertGreater(
+            fast_replay._extract_microprice_bias_bps(
+                SignalEnvelope(
+                    event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                    symbol="NVDA",
+                    payload={
+                        "bid": Decimal("100"),
+                        "ask": Decimal("101"),
+                        "bid_size": Decimal("200"),
+                        "ask_size": Decimal("100"),
+                    },
+                )
+            )
+            or 0.0,
+            0.0,
+        )
+        self.assertEqual(
+            fast_replay._extract_volume(
+                SignalEnvelope(
+                    event_ts=datetime(2026, 2, 23, 15, 30, tzinfo=timezone.utc),
+                    symbol="NVDA",
+                    payload={"microbar_volume": Decimal("12345")},
+                )
+            ),
+            12345.0,
         )
         self.assertIsNone(
             fast_replay._extract_spread_bps(


### PR DESCRIPTION
## Summary

- Adds preview-only fast replay microstructure diagnostics for OFI/depth pressure, microprice bias, spread tails, return tails, and impact/liquidity penalty.
- Persists those diagnostics into replay-tape preview score rows and candidate-selection rows so exact replay can spend budget on better-ranked specs.
- Keeps the preview artifact explicitly non-authoritative: promotion proof remains false and exact replay/runtime-ledger blockers remain unchanged.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -k 'fast_replay_preview or replay_tape_preview' -q`
- `uv run --frozen ruff check app/trading/discovery/fast_replay.py scripts/run_whitepaper_autoresearch_profit_target.py tests/test_run_whitepaper_autoresearch_profit_target.py`
- `uv sync --frozen --extra dev`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`
- `uv run --frozen pytest tests/test_run_whitepaper_autoresearch_profit_target.py -q`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
