### PR TITLE
fix(torghut): require source authority for paper route ledger evidence

### DIFF
--- a/services/torghut/app/trading/paper_route_evidence.py
+++ b/services/torghut/app/trading/paper_route_evidence.py
@@ -37,6 +37,9 @@ from .runtime_decision_authority import (
 )
 from .runtime_ledger import POST_COST_PNL_BASIS
 from .runtime_ledger_proof_policy import runtime_ledger_proof_policy_from_env
+from .runtime_ledger_source_authority import (
+    runtime_ledger_promotion_source_authority_blockers,
+)
 from .runtime_strategy_resolution import (
     derived_strategy_name_from_strategy_id,
     explicit_runtime_strategy_name_or_family_harness,
@@ -2430,6 +2433,9 @@ def _runtime_ledger_bucket_evidence_grade(row: StrategyRuntimeLedgerBucket) -> b
         for item in _as_sequence(row.blockers_json)
         if str(item).strip()
     ]
+    source_authority_blockers = runtime_ledger_promotion_source_authority_blockers(
+        _as_mapping(row.payload_json)
+    )
     return (
         row.pnl_basis == POST_COST_PNL_BASIS
         and _safe_int(row.fill_count) > 0
@@ -2444,7 +2450,22 @@ def _runtime_ledger_bucket_evidence_grade(row: StrategyRuntimeLedgerBucket) -> b
             _as_mapping(row.payload_json).get("cost_basis_counts")
         )
         and not blockers
+        and not source_authority_blockers
     )
+
+
+def _runtime_ledger_bucket_diagnostic_blockers(
+    row: StrategyRuntimeLedgerBucket,
+) -> list[str]:
+    blockers = [
+        str(item).strip()
+        for item in _as_sequence(row.blockers_json)
+        if str(item).strip()
+    ]
+    blockers.extend(
+        runtime_ledger_promotion_source_authority_blockers(_as_mapping(row.payload_json))
+    )
+    return list(dict.fromkeys(blockers))
 
 
 def _runtime_ledger_row_diagnostic_expectancy_bps(
@@ -2546,10 +2567,9 @@ def _runtime_ledger_non_evidence_diagnostic_summary(
         Decimal("0"),
     )
     blocker_counts: Counter[str] = Counter(
-        str(item).strip()
+        blocker
         for row in rows
-        for item in _as_sequence(row.blockers_json)
-        if str(item).strip()
+        for blocker in _runtime_ledger_bucket_diagnostic_blockers(row)
     )
     source_decision_mode_counts: Counter[str] = Counter()
     source_decision_mode_bucket_counts: Counter[str] = Counter()
@@ -2713,10 +2733,9 @@ def _runtime_ledger_summary(
         "db_row_refs": [str(row.id) for row in rows],
         "blockers": sorted(
             {
-                str(item).strip()
+                blocker
                 for row in rows
-                for item in _as_sequence(row.blockers_json)
-                if str(item).strip()
+                for blocker in _runtime_ledger_bucket_diagnostic_blockers(row)
             }
         ),
         "non_evidence_grade_diagnostic": (

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -27,6 +27,7 @@ from app.trading.paper_route_evidence import (
     _next_regular_equities_session_window,
     _normalized_open_positions,
     _paper_route_probe_summary,
+    _runtime_ledger_bucket_evidence_grade,
     _runtime_ledger_non_evidence_diagnostic_summary,
     _runtime_ledger_row_diagnostic_expectancy_bps,
     build_paper_route_evidence_audit,
@@ -43,6 +44,47 @@ class TestPaperRouteEvidenceAudit(TestCase):
             poolclass=StaticPool,
         )
         Base.metadata.create_all(self.engine)
+
+    def _runtime_ledger_source_authority_payload(
+        self,
+        *,
+        window_start: datetime,
+        window_end: datetime,
+        suffix: str = "fixture",
+    ) -> dict[str, object]:
+        return {
+            "source_window_start": window_start.isoformat(),
+            "source_window_end": window_end.isoformat(),
+            "source_refs": [
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+                "postgres:order_feed_source_windows",
+            ],
+            "source_row_counts": {
+                "trade_decisions": 1,
+                "executions": 1,
+                "execution_order_events": 2,
+                "order_feed_source_windows": 1,
+            },
+            "trade_decision_ids": [f"decision-{suffix}"],
+            "execution_ids": [f"execution-{suffix}"],
+            "execution_order_event_ids": [
+                f"event-new-{suffix}",
+                f"event-fill-{suffix}",
+            ],
+            "source_window_ids": [f"source-window-{suffix}"],
+            "source_offsets": [
+                {
+                    "topic": "alpaca.trade_updates",
+                    "partition": 0,
+                    "offset": 100,
+                }
+            ],
+            "source_materialization": "execution_order_events",
+            "authority_class": "runtime_order_feed_execution_source",
+            "source_decision_mode_counts": {"strategy_signal_paper": 1},
+        }
 
     def _add_flat_account_start_snapshot(
         self,
@@ -426,6 +468,61 @@ class TestPaperRouteEvidenceAudit(TestCase):
         )
 
         self.assertIsNone(_runtime_ledger_row_diagnostic_expectancy_bps(row))
+
+    def test_runtime_ledger_evidence_grade_requires_source_authority_payload(
+        self,
+    ) -> None:
+        window_start = datetime(2026, 5, 28, 14, 30, tzinfo=timezone.utc)
+        window_end = datetime(2026, 5, 28, 15, 30, tzinfo=timezone.utc)
+        row = StrategyRuntimeLedgerBucket(
+            run_id="aggregate-only-runtime-ledger-run",
+            candidate_id="candidate-aggregate-only",
+            hypothesis_id="H-AGGREGATE-ONLY",
+            observed_stage="paper",
+            bucket_started_at=window_start,
+            bucket_ended_at=window_end,
+            account_label="TORGHUT_SIM",
+            runtime_strategy_name="aggregate-only-strategy",
+            strategy_family="microbar_pairs",
+            fill_count=2,
+            decision_count=1,
+            submitted_order_count=1,
+            closed_trade_count=1,
+            open_position_count=0,
+            filled_notional=Decimal("1000"),
+            gross_strategy_pnl=Decimal("20"),
+            cost_amount=Decimal("1"),
+            net_strategy_pnl_after_costs=Decimal("19"),
+            post_cost_expectancy_bps=Decimal("190"),
+            ledger_schema_version="torghut.runtime-ledger-bucket.v1",
+            pnl_basis="realized_strategy_pnl_after_explicit_costs",
+            execution_policy_hash_counts={"policy-a": 1},
+            cost_model_hash_counts={"cost-a": 1},
+            lineage_hash_counts={"lineage-a": 1},
+            blockers_json=[],
+            payload_json={},
+        )
+
+        self.assertFalse(_runtime_ledger_bucket_evidence_grade(row))
+        diagnostic = _runtime_ledger_non_evidence_diagnostic_summary([row])
+        blocker_counts = diagnostic["blocker_counts"]
+        self.assertIn("runtime_ledger_source_window_missing", blocker_counts)
+        self.assertIn("runtime_ledger_source_refs_missing", blocker_counts)
+        self.assertIn("runtime_ledger_trade_decision_refs_missing", blocker_counts)
+        self.assertIn("runtime_ledger_execution_refs_missing", blocker_counts)
+        self.assertIn(
+            "runtime_ledger_execution_order_event_refs_missing", blocker_counts
+        )
+        self.assertIn("runtime_ledger_source_offsets_missing", blocker_counts)
+        self.assertIn("runtime_ledger_source_materialization_missing", blocker_counts)
+        self.assertIn("runtime_ledger_authority_class_missing", blocker_counts)
+
+        row.payload_json = self._runtime_ledger_source_authority_payload(
+            window_start=window_start,
+            window_end=window_end,
+            suffix="aggregate-source",
+        )
+        self.assertTrue(_runtime_ledger_bucket_evidence_grade(row))
 
     def test_runtime_ledger_diagnostic_splits_route_probe_from_profit_source(
         self,
@@ -2017,6 +2114,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     cost_model_hash_counts={"cost-a": 1},
                     lineage_hash_counts={"lineage-a": 1},
                     blockers_json=["open_position_count_nonzero"],
+                    payload_json=self._runtime_ledger_source_authority_payload(
+                        window_start=window_start,
+                        window_end=window_end,
+                        suffix="ledger-audit-open",
+                    ),
                 )
             )
             session.commit()
@@ -3282,6 +3384,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         cost_model_hash_counts={"cost-a": 1},
                         lineage_hash_counts={"lineage-a": 1},
                         blockers_json=[],
+                        payload_json=self._runtime_ledger_source_authority_payload(
+                            window_start=window_start,
+                            window_end=window_end,
+                            suffix="active-grade",
+                        ),
                     ),
                     StrategyRuntimeLedgerBucket(
                         run_id="paper-route-run-2",
@@ -3309,6 +3416,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         cost_model_hash_counts={"cost-a": 25},
                         lineage_hash_counts={"lineage-a": 25},
                         blockers_json=["open_position_count_nonzero"],
+                        payload_json=self._runtime_ledger_source_authority_payload(
+                            window_start=window_start,
+                            window_end=window_end,
+                            suffix="active-open",
+                        ),
                     ),
                     StrategyHypothesisMetricWindow(
                         run_id="paper-route-run-2",
@@ -4357,6 +4469,11 @@ class TestPaperRouteEvidenceAudit(TestCase):
                         cost_model_hash_counts={"cost-a": 1},
                         lineage_hash_counts={"lineage-a": 1},
                         blockers_json=[],
+                        payload_json=self._runtime_ledger_source_authority_payload(
+                            window_start=window_start,
+                            window_end=window_end,
+                            suffix="selected-grade",
+                        ),
                     ),
                 ]
             )

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7211,6 +7211,36 @@ class TestTradingApi(TestCase):
                 cost_model_hash_counts={"cost-a": 4},
                 lineage_hash_counts={"lineage-a": 4},
                 blockers_json=[],
+                payload_json={
+                    "source_window_start": window_start.isoformat(),
+                    "source_window_end": window_end.isoformat(),
+                    "source_refs": [
+                        "postgres:trade_decisions",
+                        "postgres:executions",
+                        "postgres:execution_order_events",
+                        "postgres:order_feed_source_windows",
+                    ],
+                    "source_row_counts": {
+                        "trade_decisions": 5,
+                        "executions": 4,
+                        "execution_order_events": 4,
+                        "order_feed_source_windows": 1,
+                    },
+                    "trade_decision_ids": ["paper-route-decision"],
+                    "execution_ids": ["paper-route-execution"],
+                    "execution_order_event_ids": ["paper-route-order-event"],
+                    "source_window_ids": ["paper-route-source-window"],
+                    "source_offsets": [
+                        {
+                            "topic": "alpaca.trade_updates",
+                            "partition": 0,
+                            "offset": 100,
+                        }
+                    ],
+                    "source_materialization": "execution_order_events",
+                    "authority_class": "runtime_order_feed_execution_source",
+                    "source_decision_mode_counts": {"strategy_signal_paper": 5},
+                },
             )
             metric_window = StrategyHypothesisMetricWindow(
                 run_id="paper-route-run-1",


### PR DESCRIPTION
## Summary

- Require paper-route runtime-ledger evidence-grade buckets to pass the shared promotion-grade source-authority contract.
- Surface missing source-window/source-ref/order-event/decision/execution lineage blockers in runtime-ledger diagnostics instead of counting aggregate-only buckets as proof.
- Add regression coverage proving aggregate-only buckets stay non-evidence-grade until source authority payload fields are present.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_paper_route_evidence.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_evidence_endpoint_audits_probation_targets' -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/paper_route_evidence.py tests/test_paper_route_evidence.py tests/test_trading_api.py`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
