### PR TITLE
fix(torghut): require fill source lineage for runtime authority

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -2471,6 +2471,38 @@ def _event_sourced_fill_economics_order_ids(
     return order_ids
 
 
+def _source_backed_fill_lifecycle_rows(
+    rows: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    source_backed_rows: list[dict[str, object]] = []
+    for row in rows:
+        normalized = {str(key): value for key, value in row.items()}
+        if _runtime_ledger_event_type(normalized) not in _RUNTIME_LEDGER_FILL_EVENTS:
+            continue
+        if _runtime_order_id(normalized) is None:
+            continue
+        if not _source_identifier_values(
+            [normalized], "execution_order_event_id", "event_fingerprint"
+        ):
+            continue
+        if not _source_identifier_values([normalized], "source_window_id"):
+            continue
+        if not _source_offset_values([normalized]):
+            continue
+        source_backed_rows.append(dict(normalized))
+    return source_backed_rows
+
+
+def _source_backed_fill_lifecycle_order_ids(
+    rows: Sequence[Mapping[str, object]],
+) -> set[str]:
+    return {
+        order_id
+        for row in _source_backed_fill_lifecycle_rows(rows)
+        if (order_id := _runtime_order_id(row)) is not None
+    }
+
+
 def _execution_fill_economics_order_ids(
     rows: Sequence[Mapping[str, object]],
 ) -> set[str]:
@@ -2597,14 +2629,17 @@ def _runtime_source_context_for_bucket(
         )
         is not None
     ]
+    source_backed_fill_lifecycle_rows = _source_backed_fill_lifecycle_rows(
+        bucket_order_rows
+    )
     source_window_ids = _source_identifier_values(
-        bucket_order_rows,
+        source_backed_fill_lifecycle_rows,
         "source_window_id",
     )
     source_row_counts = {
         "trade_decisions": len(bucket_decision_rows),
         "executions": len(bucket_execution_rows),
-        "execution_order_events": len(bucket_order_rows),
+        "execution_order_events": len(source_backed_fill_lifecycle_rows),
     }
     if source_window_ids:
         source_row_counts["order_feed_source_windows"] = len(source_window_ids)
@@ -2628,8 +2663,11 @@ def _runtime_source_context_for_bucket(
     for row in bucket_order_rows:
         if (order_id := _runtime_order_id(row)) is not None:
             expected_execution_fill_order_ids.add(order_id)
+    source_backed_fill_lifecycle_order_ids = (
+        _source_backed_fill_lifecycle_order_ids(source_backed_fill_lifecycle_rows)
+    )
     event_sourced_fill_order_ids = _event_sourced_fill_economics_order_ids(
-        bucket_order_rows
+        source_backed_fill_lifecycle_rows
     )
     execution_fill_order_ids = _execution_fill_economics_order_ids(
         bucket_execution_rows
@@ -2640,11 +2678,16 @@ def _runtime_source_context_for_bucket(
     execution_fill_economics_complete = bool(
         expected_execution_fill_order_ids
     ) and expected_execution_fill_order_ids.issubset(execution_fill_order_ids)
+    source_backed_fill_lifecycle_complete = bool(
+        expected_execution_fill_order_ids
+    ) and expected_execution_fill_order_ids.issubset(
+        source_backed_fill_lifecycle_order_ids
+    )
     source_materialization = None
     authority_class = None
-    source_offsets = _source_offset_values(bucket_order_rows)
+    source_offsets = _source_offset_values(source_backed_fill_lifecycle_rows)
     execution_order_event_ids = _source_identifier_values(
-        bucket_order_rows,
+        source_backed_fill_lifecycle_rows,
         "execution_order_event_id",
         "event_fingerprint",
     )
@@ -2652,7 +2695,10 @@ def _runtime_source_context_for_bucket(
         if order_feed_fill_economics_complete:
             source_materialization = "execution_order_events"
             authority_class = "runtime_order_feed_execution_source"
-        elif execution_fill_economics_complete:
+        elif (
+            execution_fill_economics_complete
+            and source_backed_fill_lifecycle_complete
+        ):
             source_materialization = "source_execution_lifecycle"
             authority_class = "source_execution_lifecycle_materialized_runtime_ledger"
     return {

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -56,6 +56,7 @@ from scripts.import_hypothesis_runtime_windows import (
     _source_row_matches_lineage,
     _persistence_session,
     _source_activity_missing_summary,
+    _source_backed_fill_lifecycle_rows,
     _source_decision_mode,
     _source_decision_mode_counts,
     _source_decision_rows_profit_proof_eligible,
@@ -2049,16 +2050,14 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             bucket["source_row_counts"],
             {
                 "executions": 2,
-                "execution_order_events": 4,
-                "order_feed_source_windows": 4,
+                "execution_order_events": 2,
+                "order_feed_source_windows": 2,
                 "trade_decisions": 2,
             },
         )
         self.assertEqual(
             bucket["source_window_ids"],
             [
-                "source-window-new-buy",
-                "source-window-new-sell",
                 "source-window-fill-buy",
                 "source-window-fill-sell",
             ],
@@ -2254,9 +2253,7 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(
             bucket["source_window_ids"],
             [
-                "source-window-new-buy",
                 "source-window-fill-buy",
-                "source-window-new-sell",
                 "source-window-fill-sell",
             ],
         )
@@ -2264,8 +2261,8 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             bucket["source_row_counts"],
             {
                 "executions": 2,
-                "execution_order_events": 4,
-                "order_feed_source_windows": 4,
+                "execution_order_events": 2,
+                "order_feed_source_windows": 2,
                 "trade_decisions": 2,
             },
         )
@@ -2950,6 +2947,222 @@ class TestImportHypothesisRuntimeWindows(TestCase):
         self.assertEqual(bucket["cost_amount"], "0.30")
         self.assertEqual(bucket["blockers"], [])
         self.assertEqual(bucket["source_materialization"], "execution_order_events")
+
+    def test_build_realized_strategy_pnl_rows_does_not_borrow_source_refs_from_non_fill_lifecycle(
+        self,
+    ) -> None:
+        rows = _build_realized_strategy_pnl_rows(
+            [
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 31, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "modeled_paper_cost_budget",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 30, tzinfo=timezone.utc),
+                    "execution_event_at": datetime(
+                        2026, 3, 6, 14, 32, tzinfo=timezone.utc
+                    ),
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "modeled_paper_cost_budget",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            decision_lifecycle_rows=[
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 34, tzinfo=timezone.utc),
+                    "event_type": "decision",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "decision_json": {"account": {"equity": "10000"}},
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "computed_at": datetime(2026, 3, 6, 14, 39, tzinfo=timezone.utc),
+                    "event_type": "decision",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "decision_json": {"account": {"equity": "10000"}},
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            order_lifecycle_rows=[
+                {
+                    "execution_order_event_id": "event-new-buy",
+                    "trade_decision_id": "decision-buy",
+                    "event_ts": datetime(2026, 3, 6, 14, 34, 1, tzinfo=timezone.utc),
+                    "event_type": "new",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 110,
+                    "source_window_id": "source-window-new-buy",
+                },
+                {
+                    "execution_order_event_id": "event-new-sell",
+                    "trade_decision_id": "decision-sell",
+                    "event_ts": datetime(2026, 3, 6, 14, 39, 1, tzinfo=timezone.utc),
+                    "event_type": "new",
+                    "symbol": "AAPL",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 111,
+                    "source_window_id": "source-window-new-sell",
+                },
+                {
+                    "execution_order_event_id": "event-fill-buy",
+                    "trade_decision_id": "decision-buy",
+                    "execution_id": "execution-buy",
+                    "event_ts": datetime(2026, 3, 6, 14, 35, 1, tzinfo=timezone.utc),
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("100"),
+                    "cost_amount": Decimal("0.20"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-buy",
+                    "alpaca_order_id": "order-buy",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+                {
+                    "execution_order_event_id": "event-fill-sell",
+                    "trade_decision_id": "decision-sell",
+                    "execution_id": "execution-sell",
+                    "event_ts": datetime(2026, 3, 6, 14, 40, 1, tzinfo=timezone.utc),
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "side": "sell",
+                    "filled_qty": Decimal("1"),
+                    "avg_fill_price": Decimal("101"),
+                    "cost_amount": Decimal("0.10"),
+                    "cost_basis": "broker_reported_commission_and_fees",
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_id": "microbar-cross-sectional-pairs-v1",
+                    "decision_hash": "decision-sell",
+                    "alpaca_order_id": "order-sell",
+                    "execution_policy_hash": "policy-sha",
+                    "cost_model_hash": "cost-sha",
+                    "lineage_hash": "lineage-sha",
+                },
+            ],
+            allow_authoritative_runtime_ledger_materialization=True,
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["post_cost_promotion_eligible"], False)
+        self.assertEqual(rows[0]["authoritative"], False)
+        bucket = rows[0]["runtime_ledger_bucket"]
+        self.assertIsInstance(bucket, dict)
+        assert isinstance(bucket, dict)
+        self.assertNotIn("source-window-new-buy", bucket.get("source_window_ids", []))
+        self.assertNotIn("source-window-new-sell", bucket.get("source_window_ids", []))
+        self.assertIn("runtime_ledger_source_window_ids_missing", bucket["blockers"])
+        self.assertIn("runtime_ledger_source_offsets_missing", bucket["blockers"])
+        self.assertIn(
+            "runtime_ledger_source_materialization_missing",
+            bucket["blockers"],
+        )
+        self.assertIn("runtime_ledger_authority_class_missing", bucket["blockers"])
+        self.assertFalse(_runtime_ledger_bucket_profit_proof_present(bucket))
+
+    def test_source_backed_fill_lifecycle_rows_require_order_event_and_offset_refs(
+        self,
+    ) -> None:
+        rows = _source_backed_fill_lifecycle_rows(
+            [
+                {
+                    "execution_order_event_id": "missing-order-id-event",
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 110,
+                    "source_window_id": "source-window-missing-order",
+                },
+                {
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "alpaca_order_id": "order-missing-event-ref",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 111,
+                    "source_window_id": "source-window-missing-event-ref",
+                },
+                {
+                    "execution_order_event_id": "missing-source-offset-event",
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "alpaca_order_id": "order-missing-source-offset",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_window_id": "source-window-missing-offset",
+                },
+                {
+                    "execution_order_event_id": "source-backed-fill-event",
+                    "event_type": "filled",
+                    "symbol": "AAPL",
+                    "alpaca_order_id": "order-source-backed",
+                    "source_topic": "alpaca.trade_updates",
+                    "source_partition": 0,
+                    "source_offset": 112,
+                    "source_window_id": "source-window-backed",
+                },
+            ]
+        )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["execution_order_event_id"], "source-backed-fill-event")
 
     def test_build_realized_strategy_pnl_rows_accepts_execution_economics_with_order_feed_lifecycle(
         self,


### PR DESCRIPTION
## Summary

- Require source-authority metadata for runtime-ledger materialization to come from source-backed fill lifecycle rows, not from same-order `new`/submitted lifecycle rows.
- Keep execution-order source refs, source offsets, source-window IDs, and source materialization tied to the fill events that prove the counted economics.
- Add a regression proving non-fill lifecycle rows cannot lend source refs to fill rows that lack source offsets/source-window IDs.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'does_not_borrow_source_refs_from_non_fill_lifecycle' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -k 'does_not_borrow_source_refs_from_non_fill_lifecycle or counts_order_feed_fill_economics or accepts_execution_economics_with_order_feed_lifecycle or authorizes_event_sourced_lifecycle or uses_source_backed_carry_in or does_not_borrow_source_refs_from_other_symbol or requires_order_feed_fill_lifecycle' -q`
- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_runtime_window_import.py -k 'runtime_ledger_bucket_requires_structured_source_offsets or runtime_ledger_bucket_rejects_missing_source_window_or_refs or source_authority' -q`
- `cd services/torghut && uv run --frozen ruff check scripts/import_hypothesis_runtime_windows.py tests/test_import_hypothesis_runtime_windows.py`
- `git diff --check`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
