### PR TITLE
fix(torghut): enforce source collection authority coverage

### DIFF
--- a/services/torghut/app/trading/runtime_ledger_source_authority.py
+++ b/services/torghut/app/trading/runtime_ledger_source_authority.py
@@ -111,6 +111,42 @@ def _source_refs_present(bucket: Mapping[str, object], *keys: str) -> bool:
     return any(_source_ref_present(bucket.get(key)) for key in keys)
 
 
+def _source_ref_count(bucket: Mapping[str, object], *keys: str) -> int:
+    refs: set[str] = set()
+    for key in keys:
+        value = bucket.get(key)
+        if isinstance(value, Mapping):
+            for ref_key, ref_value in cast(Mapping[object, object], value).items():
+                ref_text = _text(ref_value)
+                if ref_text is None or ref_text in {"True", "False"}:
+                    ref_text = _text(ref_key)
+                if ref_text is not None:
+                    refs.add(ref_text)
+            continue
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            refs.update(_string_list(cast(Sequence[object], value)))
+            continue
+        if (ref := _text(value)) is not None:
+            refs.add(ref)
+    return len(refs)
+
+
+def _source_row_count(bucket: Mapping[str, object], table_name: str) -> int:
+    source_row_counts = bucket.get("source_row_counts")
+    if not isinstance(source_row_counts, Mapping):
+        return 0
+    value = cast(Mapping[object, object], source_row_counts).get(table_name)
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return 0
+    if not parsed.is_finite() or parsed <= 0:
+        return 0
+    return int(parsed)
+
+
 def _source_ref_table_names(value: object) -> set[str]:
     refs = _string_list(value)
     table_names: set[str] = set()
@@ -128,15 +164,7 @@ def _source_ref_table_names(value: object) -> set[str]:
 def _source_row_counts_have_positive_rows(
     bucket: Mapping[str, object], table_name: str
 ) -> bool:
-    source_row_counts = bucket.get("source_row_counts")
-    if not isinstance(source_row_counts, Mapping):
-        return False
-    value = cast(Mapping[object, object], source_row_counts).get(table_name)
-    try:
-        parsed = Decimal(str(value))
-    except (InvalidOperation, ValueError):
-        return False
-    return parsed.is_finite() and parsed > 0
+    return _source_row_count(bucket, table_name) > 0
 
 
 def _promotion_grade_source_refs_present(bucket: Mapping[str, object]) -> bool:
@@ -149,6 +177,10 @@ def _promotion_grade_source_refs_present(bucket: Mapping[str, object]) -> bool:
 
 
 def _source_offsets_present(bucket: Mapping[str, object]) -> bool:
+    return _source_offset_count(bucket) > 0
+
+
+def _source_offset_count(bucket: Mapping[str, object]) -> int:
     def has_source_offset_triplet(value: Mapping[object, object]) -> bool:
         return (
             _text(value.get("topic")) is not None
@@ -158,15 +190,24 @@ def _source_offsets_present(bucket: Mapping[str, object]) -> bool:
 
     source_offsets = bucket.get("source_offsets")
     if isinstance(source_offsets, Mapping):
-        return has_source_offset_triplet(cast(Mapping[object, object], source_offsets))
+        return int(has_source_offset_triplet(cast(Mapping[object, object], source_offsets)))
     if isinstance(source_offsets, Sequence) and not isinstance(
         source_offsets, (str, bytes, bytearray)
     ):
+        offsets: set[tuple[str, str, str]] = set()
         for item in cast(Sequence[object], source_offsets):
             if isinstance(item, Mapping):
-                if has_source_offset_triplet(cast(Mapping[object, object], item)):
-                    return True
-    return (
+                typed_item = cast(Mapping[object, object], item)
+                if has_source_offset_triplet(typed_item):
+                    offsets.add(
+                        (
+                            str(typed_item.get("topic")),
+                            str(typed_item.get("partition")),
+                            str(typed_item.get("offset")),
+                        )
+                    )
+        return len(offsets)
+    return int(
         _text(bucket.get("source_topic")) is not None
         and bucket.get("source_partition") is not None
         and bucket.get("source_offset") is not None
@@ -184,15 +225,7 @@ def _promotion_grade_source_materialization_present(
 
 
 def _promotion_grade_authority_class_present(bucket: Mapping[str, object]) -> bool:
-    authority_values = (
-        bucket.get("authority_class"),
-        bucket.get("authority_reason"),
-    )
-    for value in authority_values:
-        text = _text(value)
-        if text in _PROMOTION_GRADE_AUTHORITY_CLASSES:
-            return True
-    return False
+    return _text(bucket.get("authority_class")) in _PROMOTION_GRADE_AUTHORITY_CLASSES
 
 
 def runtime_ledger_source_window_present(bucket: Mapping[str, object]) -> bool:
@@ -253,7 +286,13 @@ def runtime_ledger_promotion_source_authority_blockers(
         "source_window_id",
         "runtime_ledger_source_window_ids",
         "runtime_ledger_source_window_id",
-    ):
+    ) or _source_ref_count(
+        bucket,
+        "source_window_ids",
+        "source_window_id",
+        "runtime_ledger_source_window_ids",
+        "runtime_ledger_source_window_id",
+    ) < _source_row_count(bucket, "order_feed_source_windows"):
         blockers.append(RUNTIME_LEDGER_SOURCE_WINDOW_IDS_MISSING_BLOCKER)
     if not _source_refs_present(
         bucket,
@@ -262,23 +301,42 @@ def runtime_ledger_promotion_source_authority_blockers(
         "trade_decision_id",
         "decision_ids",
         "decision_id",
-    ):
+    ) or _source_ref_count(
+        bucket,
+        "trade_decision_ids",
+        "trade_decision_refs",
+        "trade_decision_id",
+        "decision_ids",
+        "decision_id",
+    ) < _source_row_count(bucket, "trade_decisions"):
         blockers.append(RUNTIME_LEDGER_TRADE_DECISION_REFS_MISSING_BLOCKER)
     if not _source_refs_present(
         bucket,
         "execution_ids",
         "execution_refs",
         "execution_id",
-    ):
+    ) or _source_ref_count(
+        bucket,
+        "execution_ids",
+        "execution_refs",
+        "execution_id",
+    ) < _source_row_count(bucket, "executions"):
         blockers.append(RUNTIME_LEDGER_EXECUTION_REFS_MISSING_BLOCKER)
     if not _source_refs_present(
         bucket,
         "execution_order_event_ids",
         "execution_order_event_refs",
         "execution_order_event_id",
-    ):
+    ) or _source_ref_count(
+        bucket,
+        "execution_order_event_ids",
+        "execution_order_event_refs",
+        "execution_order_event_id",
+    ) < _source_row_count(bucket, "execution_order_events"):
         blockers.append(RUNTIME_LEDGER_EXECUTION_ORDER_EVENT_REFS_MISSING_BLOCKER)
-    if not _source_offsets_present(bucket):
+    if not _source_offsets_present(bucket) or _source_offset_count(
+        bucket
+    ) < _source_row_count(bucket, "execution_order_events"):
         blockers.append(RUNTIME_LEDGER_SOURCE_OFFSETS_MISSING_BLOCKER)
     if not _promotion_grade_source_materialization_present(bucket):
         blockers.append(RUNTIME_LEDGER_SOURCE_MATERIALIZATION_MISSING_BLOCKER)

--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -1597,9 +1597,24 @@ _AUTHORITATIVE_RUNTIME_LEDGER_MATERIALIZATION_SOURCE_KINDS = frozenset(
     {
         "paper_route_probe_runtime_observed",
         "paper_runtime_observed",
+        "runtime_ledger_source_collection_candidate",
         "live_runtime_observed",
     }
 )
+
+
+def _source_collection_target_authorization_blockers(
+    target_metadata: Mapping[str, Any],
+) -> list[str]:
+    blockers: list[str] = []
+    if target_metadata.get("source_collection_authorized") is not True:
+        blockers.append("source_collection_authorization_missing")
+    if (
+        str(target_metadata.get("source_collection_authorization_scope") or "").strip()
+        != "source_window_evidence_collection_only"
+    ):
+        blockers.append("source_collection_authorization_scope_invalid")
+    return blockers
 
 
 def _source_kind_allows_runtime_ledger_materialization(
@@ -1613,6 +1628,8 @@ def _source_kind_allows_runtime_ledger_materialization(
     ):
         return False
     normalized = source_kind.strip().lower().replace("-", "_")
+    if normalized == "runtime_ledger_source_collection_candidate":
+        return not _source_collection_target_authorization_blockers(target_metadata)
     return normalized in _AUTHORITATIVE_RUNTIME_LEDGER_MATERIALIZATION_SOURCE_KINDS
 
 
@@ -1630,6 +1647,11 @@ def _runtime_window_import_proof_hygiene_blockers(
         target_metadata=target_metadata,
     ):
         blockers.append("runtime_window_target_metadata_missing")
+    if (
+        source_kind.strip().lower().replace("-", "_")
+        == "runtime_ledger_source_collection_candidate"
+    ):
+        blockers.extend(_source_collection_target_authorization_blockers(target_metadata))
     if not dependency_quorum_decision.strip():
         blockers.append("dependency_quorum_decision_missing")
     if not continuity_ok.strip():

--- a/services/torghut/tests/test_completion_trace.py
+++ b/services/torghut/tests/test_completion_trace.py
@@ -84,6 +84,20 @@ def _runtime_ledger_source_authority_payload(
     cost_basis_counts: dict[str, int] | None = None,
     extra: dict[str, object] | None = None,
 ) -> dict[str, object]:
+    trade_decision_ids = [f'trade-decision-{index}' for index in range(24)]
+    execution_ids = [f'execution-{index}' for index in range(12)]
+    execution_order_event_ids = [
+        f'execution-order-event-{index}' for index in range(12)
+    ]
+    source_window_ids = [f'source-window-{index}' for index in range(12)]
+    source_offsets = [
+        {
+            'topic': 'torghut.trade-updates.v2',
+            'partition': 0,
+            'offset': 42 + index,
+        }
+        for index in range(12)
+    ]
     payload: dict[str, object] = {
         'source': 'runtime-order-feed',
         'source_window_start': '2026-03-06T14:30:00+00:00',
@@ -100,17 +114,11 @@ def _runtime_ledger_source_authority_payload(
             'execution_order_events': 12,
             'order_feed_source_windows': 12,
         },
-        'source_window_ids': ['source-window-1'],
-        'trade_decision_ids': ['trade-decision-1'],
-        'execution_ids': ['execution-1'],
-        'execution_order_event_ids': ['execution-order-event-1'],
-        'source_offsets': [
-            {
-                'topic': 'torghut.trade-updates.v2',
-                'partition': 0,
-                'offset': 42,
-            }
-        ],
+        'source_window_ids': source_window_ids,
+        'trade_decision_ids': trade_decision_ids,
+        'execution_ids': execution_ids,
+        'execution_order_event_ids': execution_order_event_ids,
+        'source_offsets': source_offsets,
         'source_materialization': 'execution_order_events',
         'authority_class': 'runtime_order_feed_execution_source',
     }

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -252,7 +252,22 @@ class _SourceLedgerCursor:
                                 "topic": "alpaca.trade_updates",
                                 "partition": 0,
                                 "offset": 100,
-                            }
+                            },
+                            {
+                                "topic": "alpaca.trade_updates",
+                                "partition": 0,
+                                "offset": 101,
+                            },
+                            {
+                                "topic": "alpaca.trade_updates",
+                                "partition": 0,
+                                "offset": 102,
+                            },
+                            {
+                                "topic": "alpaca.trade_updates",
+                                "partition": 0,
+                                "offset": 103,
+                            },
                         ],
                         "source_materialization": "execution_order_events",
                         "authority_class": "runtime_order_feed_execution_source",
@@ -1009,7 +1024,22 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                                 "topic": "alpaca.trade_updates",
                                 "partition": 0,
                                 "offset": 100,
-                            }
+                            },
+                            {
+                                "topic": "alpaca.trade_updates",
+                                "partition": 0,
+                                "offset": 101,
+                            },
+                            {
+                                "topic": "alpaca.trade_updates",
+                                "partition": 0,
+                                "offset": 102,
+                            },
+                            {
+                                "topic": "alpaca.trade_updates",
+                                "partition": 0,
+                                "offset": 103,
+                            },
                         ],
                         "source_materialization": "execution_order_events",
                         "authority_class": "runtime_order_feed_execution_source",
@@ -1479,6 +1509,47 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                 target_metadata={"evidence_scope": "evidence_collection_only"},
             )
         )
+        self.assertTrue(
+            _source_kind_allows_runtime_ledger_materialization(
+                source_kind="runtime_ledger_source_collection_candidate",
+                target_metadata={
+                    "source_collection_authorized": True,
+                    "source_collection_authorization_scope": (
+                        "source_window_evidence_collection_only"
+                    ),
+                    "runtime_ledger_target_metadata_blockers": [
+                        "runtime_ledger_source_window_evidence_pending"
+                    ],
+                },
+            )
+        )
+        self.assertFalse(
+            _runtime_window_source_kind_is_informational(
+                source_kind="runtime_ledger_source_collection_candidate",
+                target_metadata={
+                    "source_collection_authorized": True,
+                    "source_collection_authorization_scope": (
+                        "source_window_evidence_collection_only"
+                    )
+                },
+            )
+        )
+        self.assertFalse(
+            _source_kind_allows_runtime_ledger_materialization(
+                source_kind="runtime_ledger_source_collection_candidate",
+                target_metadata={
+                    "source_collection_authorization_scope": (
+                        "source_window_evidence_collection_only"
+                    )
+                },
+            )
+        )
+        self.assertFalse(
+            _source_kind_allows_runtime_ledger_materialization(
+                source_kind="runtime_ledger_source_collection_candidate",
+                target_metadata={"source_collection_authorized": True},
+            )
+        )
         self.assertFalse(
             _runtime_window_source_kind_is_informational(
                 source_kind="paper_route_probe_runtime_observed",
@@ -1486,6 +1557,34 @@ class TestImportHypothesisRuntimeWindows(TestCase):
                     "paper_probation_authorization_scope": "evidence_collection_only"
                 },
             )
+        )
+
+    def test_runtime_window_proof_hygiene_requires_source_collection_authorization(
+        self,
+    ) -> None:
+        self.assertEqual(
+            _runtime_window_import_proof_hygiene_blockers(
+                source_kind="runtime_ledger_source_collection_candidate",
+                target_metadata={
+                    "source_collection_authorization_scope": (
+                        "source_window_evidence_collection_only"
+                    )
+                },
+                dependency_quorum_decision="allow",
+                continuity_ok="ok",
+                drift_ok="ok",
+            ),
+            ["source_collection_authorization_missing"],
+        )
+        self.assertEqual(
+            _runtime_window_import_proof_hygiene_blockers(
+                source_kind="runtime_ledger_source_collection_candidate",
+                target_metadata={"source_collection_authorized": True},
+                dependency_quorum_decision="allow",
+                continuity_ok="ok",
+                drift_ok="ok",
+            ),
+            ["source_collection_authorization_scope_invalid"],
         )
 
     def test_source_activity_missing_summary_includes_proof_hygiene_blockers(

--- a/services/torghut/tests/test_paper_route_evidence.py
+++ b/services/torghut/tests/test_paper_route_evidence.py
@@ -79,7 +79,12 @@ class TestPaperRouteEvidenceAudit(TestCase):
                     "topic": "alpaca.trade_updates",
                     "partition": 0,
                     "offset": 100,
-                }
+                },
+                {
+                    "topic": "alpaca.trade_updates",
+                    "partition": 0,
+                    "offset": 101,
+                },
             ],
             "source_materialization": "execution_order_events",
             "authority_class": "runtime_order_feed_execution_source",

--- a/services/torghut/tests/test_runtime_ledger_source_authority.py
+++ b/services/torghut/tests/test_runtime_ledger_source_authority.py
@@ -84,8 +84,8 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
             "source_row_counts": {
                 "trade_decisions": 2,
                 "executions": 2,
-                "execution_order_events": 4,
-                "order_feed_source_windows": 4,
+                "execution_order_events": 2,
+                "order_feed_source_windows": 2,
             },
         }
 
@@ -106,7 +106,8 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
             "execution_order_event_ids": ["event-1", "event-2"],
             "source_window_ids": ["source-window-1", "source-window-2"],
             "source_offsets": [
-                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42},
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 43},
             ],
             "source_materialization": "execution_order_events",
             "authority_class": "runtime_order_feed_execution_source",
@@ -116,6 +117,114 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
             runtime_ledger_promotion_source_authority_blockers(source_backed),
             [],
         )
+
+    def test_promotion_source_authority_rejects_underlinked_row_refs(
+        self,
+    ) -> None:
+        underlinked = {
+            "source_window_start": "2026-05-29T14:30:00+00:00",
+            "source_window_end": "2026-05-29T15:00:00+00:00",
+            "source_refs": [
+                "postgres:trade_decisions",
+                "postgres:executions",
+                "postgres:execution_order_events",
+                "postgres:order_feed_source_windows",
+            ],
+            "source_row_counts": {
+                "trade_decisions": 3,
+                "executions": 3,
+                "execution_order_events": 4,
+                "order_feed_source_windows": 3,
+            },
+            "trade_decision_ids": ["decision-1", "decision-2"],
+            "execution_ids": ["execution-1", "execution-2"],
+            "execution_order_event_ids": ["event-1", "event-2"],
+            "source_window_ids": ["source-window-1", "source-window-2"],
+            "source_offsets": [
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+            ],
+            "source_materialization": "execution_order_events",
+            "authority_class": "runtime_order_feed_execution_source",
+        }
+
+        blockers = runtime_ledger_promotion_source_authority_blockers(underlinked)
+
+        self.assertIn("runtime_ledger_trade_decision_refs_missing", blockers)
+        self.assertIn("runtime_ledger_execution_refs_missing", blockers)
+        self.assertIn("runtime_ledger_execution_order_event_refs_missing", blockers)
+        self.assertIn("runtime_ledger_source_window_ids_missing", blockers)
+        self.assertIn("runtime_ledger_source_offsets_missing", blockers)
+
+    def test_promotion_source_authority_counts_mapping_and_scalar_refs(
+        self,
+    ) -> None:
+        blockers = runtime_ledger_promotion_source_authority_blockers(
+            {
+                "source_window_start": "2026-05-29T14:30:00+00:00",
+                "source_window_end": "2026-05-29T15:00:00+00:00",
+                "source_refs": [
+                    "postgres:trade_decisions",
+                    "postgres:executions",
+                    "postgres:execution_order_events",
+                    "postgres:order_feed_source_windows",
+                ],
+                "source_row_counts": {
+                    "trade_decisions": 1,
+                    "executions": 1,
+                    "execution_order_events": 1,
+                    "order_feed_source_windows": 1,
+                },
+                "trade_decision_id": "decision-1",
+                "execution_id": "execution-1",
+                "execution_order_event_id": "event-1",
+                "source_window_ids": {"source-window-1": True},
+                "source_offsets": [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+                ],
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
+            }
+        )
+
+        self.assertEqual(blockers, [])
+
+    def test_promotion_source_authority_rejects_duplicate_refs_and_offsets(
+        self,
+    ) -> None:
+        blockers = runtime_ledger_promotion_source_authority_blockers(
+            {
+                "source_window_start": "2026-05-29T14:30:00+00:00",
+                "source_window_end": "2026-05-29T15:00:00+00:00",
+                "source_refs": [
+                    "postgres:trade_decisions",
+                    "postgres:executions",
+                    "postgres:execution_order_events",
+                    "postgres:order_feed_source_windows",
+                ],
+                "source_row_counts": {
+                    "trade_decisions": 2,
+                    "executions": 2,
+                    "execution_order_events": 2,
+                    "order_feed_source_windows": 2,
+                },
+                "trade_decision_ids": ["decision-1", "decision-1"],
+                "execution_ids": ["execution-1", "execution-1"],
+                "execution_order_event_ids": ["event-1", "event-1"],
+                "source_window_ids": ["source-window-1", "source-window-1"],
+                "source_offsets": [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42},
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42},
+                ],
+                "source_materialization": "execution_order_events",
+                "authority_class": "runtime_order_feed_execution_source",
+            }
+        )
+
+        self.assertIn("runtime_ledger_trade_decision_refs_missing", blockers)
+        self.assertIn("runtime_ledger_execution_refs_missing", blockers)
+        self.assertIn("runtime_ledger_execution_order_event_refs_missing", blockers)
+        self.assertIn("runtime_ledger_source_window_ids_missing", blockers)
+        self.assertIn("runtime_ledger_source_offsets_missing", blockers)
 
     def test_promotion_source_authority_rejects_unstructured_source_offsets(
         self,
@@ -181,6 +290,39 @@ class TestRuntimeLedgerSourceAuthority(TestCase):
                 ],
                 "source_materialization": "execution_order_events",
                 "pnl_derivation": "execution_order_events_runtime_ledger",
+            }
+        )
+
+        self.assertIn("runtime_ledger_authority_class_missing", blockers)
+
+    def test_promotion_source_authority_rejects_authority_reason_only(
+        self,
+    ) -> None:
+        blockers = runtime_ledger_promotion_source_authority_blockers(
+            {
+                "source_window_start": "2026-05-29T14:30:00+00:00",
+                "source_window_end": "2026-05-29T15:00:00+00:00",
+                "source_refs": [
+                    "postgres:trade_decisions",
+                    "postgres:executions",
+                    "postgres:execution_order_events",
+                    "postgres:order_feed_source_windows",
+                ],
+                "source_row_counts": {
+                    "trade_decisions": 1,
+                    "executions": 1,
+                    "execution_order_events": 1,
+                    "order_feed_source_windows": 1,
+                },
+                "trade_decision_id": "decision-1",
+                "execution_id": "execution-1",
+                "execution_order_event_id": "event-1",
+                "source_window_id": "source-window-1",
+                "source_offsets": [
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 42}
+                ],
+                "source_materialization": "execution_order_events",
+                "authority_reason": "event_sourced_runtime_ledger_profit_proof",
             }
         )
 

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -96,7 +96,8 @@ def _runtime_ledger_bucket(**overrides: object) -> dict[str, object]:
         "execution_order_event_ids": ["event-fill-buy", "event-fill-sell"],
         "source_window_ids": ["source-window-buy", "source-window-sell"],
         "source_offsets": [
-            {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100}
+            {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100},
+            {"topic": "alpaca.trade_updates", "partition": 0, "offset": 101},
         ],
         "source_materialization": "execution_order_events",
         "authority_class": "runtime_order_feed_execution_source",

--- a/services/torghut/tests/test_submission_council.py
+++ b/services/torghut/tests/test_submission_council.py
@@ -239,10 +239,23 @@ class TestSubmissionCouncil(TestCase):
             },
             "trade_decision_ids": ["decision-buy", "decision-sell"],
             "execution_ids": ["execution-buy", "execution-sell"],
-            "execution_order_event_ids": ["event-fill-buy", "event-fill-sell"],
-            "source_window_ids": ["source-window-buy", "source-window-sell"],
+            "execution_order_event_ids": [
+                "event-new-buy",
+                "event-fill-buy",
+                "event-new-sell",
+                "event-fill-sell",
+            ],
+            "source_window_ids": [
+                "source-window-new-buy",
+                "source-window-fill-buy",
+                "source-window-new-sell",
+                "source-window-fill-sell",
+            ],
             "source_offsets": [
-                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100}
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100},
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 101},
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 102},
+                {"topic": "alpaca.trade_updates", "partition": 0, "offset": 103},
             ],
             "source_materialization": "execution_order_events",
             "authority_class": "runtime_order_feed_execution_source",
@@ -632,7 +645,8 @@ class TestSubmissionCouncil(TestCase):
                     "pairs-source-window-sell",
                 ],
                 "source_offsets": [
-                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100}
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100},
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 101},
                 ],
                 "source_materialization": "execution_order_events",
                 "authority_class": "runtime_order_feed_execution_source",
@@ -992,7 +1006,8 @@ class TestSubmissionCouncil(TestCase):
                 "execution_order_event_ids": ["event-fill-buy", "event-fill-sell"],
                 "source_window_ids": ["source-window-buy", "source-window-sell"],
                 "source_offsets": [
-                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100}
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 100},
+                    {"topic": "alpaca.trade_updates", "partition": 0, "offset": 101},
                 ],
                 "source_materialization": "execution_order_events",
                 "authority_class": "runtime_order_feed_execution_source",

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7226,16 +7226,47 @@ class TestTradingApi(TestCase):
                         "execution_order_events": 4,
                         "order_feed_source_windows": 1,
                     },
-                    "trade_decision_ids": ["paper-route-decision"],
-                    "execution_ids": ["paper-route-execution"],
-                    "execution_order_event_ids": ["paper-route-order-event"],
+                    "trade_decision_ids": [
+                        "paper-route-decision-1",
+                        "paper-route-decision-2",
+                        "paper-route-decision-3",
+                        "paper-route-decision-4",
+                        "paper-route-decision-5",
+                    ],
+                    "execution_ids": [
+                        "paper-route-execution-1",
+                        "paper-route-execution-2",
+                        "paper-route-execution-3",
+                        "paper-route-execution-4",
+                    ],
+                    "execution_order_event_ids": [
+                        "paper-route-order-event-1",
+                        "paper-route-order-event-2",
+                        "paper-route-order-event-3",
+                        "paper-route-order-event-4",
+                    ],
                     "source_window_ids": ["paper-route-source-window"],
                     "source_offsets": [
                         {
                             "topic": "alpaca.trade_updates",
                             "partition": 0,
                             "offset": 100,
-                        }
+                        },
+                        {
+                            "topic": "alpaca.trade_updates",
+                            "partition": 0,
+                            "offset": 101,
+                        },
+                        {
+                            "topic": "alpaca.trade_updates",
+                            "partition": 0,
+                            "offset": 102,
+                        },
+                        {
+                            "topic": "alpaca.trade_updates",
+                            "partition": 0,
+                            "offset": 103,
+                        },
                     ],
                     "source_materialization": "execution_order_events",
                     "authority_class": "runtime_order_feed_execution_source",


### PR DESCRIPTION
## Summary

- Allows `runtime_ledger_source_collection_candidate` imports to enter the strict source-backed runtime-ledger materialization path instead of staying evidence-only when real source-backed fills exist.
- Tightens promotion-grade source authority so row-level IDs and structured source offsets must cover the counted source rows, not just be present.
- Adds regressions for source-collection source-kind materialization and underlinked runtime-ledger authority payloads.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_runtime_ledger_source_authority.py tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv run --frozen pytest tests/test_submission_council.py -k 'source_collection or paper_probation_import_plan' -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_ledger_source_authority.py scripts/import_hypothesis_runtime_windows.py tests/test_runtime_ledger_source_authority.py tests/test_import_hypothesis_runtime_windows.py`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
