### PR TITLE
fix(torghut): prefer next paper-route target plan

### DIFF
--- a/services/torghut/app/trading/paper_route_target_plan.py
+++ b/services/torghut/app/trading/paper_route_target_plan.py
@@ -39,17 +39,12 @@ def paper_route_target_plan_from_payload(payload: Mapping[str, Any]) -> dict[str
     next_paper_route_plan = _to_str_map(
         payload.get("next_paper_route_runtime_window_targets")
     )
-    paper_route_payload = (
-        payload.get("schema_version") == "torghut.paper-route-evidence.v1"
-    )
-    paper_route_plans = [next_paper_route_plan] if paper_route_payload else []
     candidate_plans = [
-        runtime_window_plan,
-        *paper_route_plans,
+        next_paper_route_plan,
         source_runtime_window_plan,
+        runtime_window_plan,
         _to_str_map(live_gate.get("runtime_ledger_paper_probation_import_plan")),
         _to_str_map(payload.get("runtime_ledger_paper_probation_import_plan")),
-        *([] if paper_route_payload else [next_paper_route_plan]),
         dict(payload) if paper_route_target_plan_targets(payload) else {},
     ]
     for plan in candidate_plans:

--- a/services/torghut/tests/test_trading_api.py
+++ b/services/torghut/tests/test_trading_api.py
@@ -7755,6 +7755,48 @@ class TestTradingApi(TestCase):
 
         self.assertEqual(plan["targets"][0]["candidate_id"], "c88421d619759b2cfaa6f4d0")
 
+    def test_paper_route_target_plan_payload_prefers_next_window_over_closed_import(
+        self,
+    ) -> None:
+        plan = _paper_route_target_plan_from_payload(
+            {
+                "schema_version": "torghut.paper-route-target-plan.v1",
+                "runtime_window_import_plan": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 1,
+                    "purpose": "latest_closed_session_paper_route_runtime_window_import",
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "closed-window-target",
+                            "window_start": "2026-05-29T13:30:00+00:00",
+                            "window_end": "2026-05-29T20:00:00+00:00",
+                            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                        }
+                    ],
+                },
+                "next_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "target_count": 1,
+                    "purpose": "next_paper_route_runtime_window_import",
+                    "targets": [
+                        {
+                            "hypothesis_id": "H-PAIRS-01",
+                            "candidate_id": "next-window-target",
+                            "window_start": "2026-06-01T13:30:00+00:00",
+                            "window_end": "2026-06-01T20:00:00+00:00",
+                            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                        }
+                    ],
+                },
+            }
+        )
+
+        self.assertEqual(plan["targets"][0]["candidate_id"], "next-window-target")
+        self.assertEqual(
+            plan["targets"][0]["window_start"], "2026-06-01T13:30:00+00:00"
+        )
+
     def test_paper_route_target_plan_from_payload_falls_back_to_source_plan(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Prefer `next_paper_route_runtime_window_targets` when parsing external paper-route target-plan payloads for source decisions.
- Keep the closed-session `runtime_window_import_plan` available as fallback so import/renewal flows can still consume it when needed.
- Add regression coverage for payloads that contain both a closed import plan and a future next-session plan.

## Related Issues

None

## Testing

- `uv run --frozen pytest tests/test_trading_api.py -k 'paper_route_target_plan_from_payload or paper_route_target_plan_payload_prefers_next_window_over_closed_import' -q`
- `uv run --frozen pytest tests/test_trading_pipeline.py -k 'external_paper_route_target_plan or target_plan_source_decision' -q`
- `uv run --frozen ruff check app/trading/paper_route_target_plan.py tests/test_trading_api.py`
- `uv run --frozen pyright --project pyrightconfig.json`
- `uv run --frozen pyright --project pyrightconfig.alpha.json`
- `uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
