### PR TITLE
fix(torghut): replace stale ledger buckets by source window

### DIFF
--- a/services/torghut/app/trading/runtime_window_import.py
+++ b/services/torghut/app/trading/runtime_window_import.py
@@ -1223,6 +1223,21 @@ def _runtime_ledger_bucket_replacement_scopes(
 ) -> list[tuple[datetime, datetime, str | None, str | None]]:
     scopes: list[tuple[datetime, datetime, str | None, str | None]] = []
     seen: set[tuple[datetime, datetime, str | None, str | None]] = set()
+
+    def add_scope(
+        *,
+        started_at: datetime,
+        ended_at: datetime,
+        account_label: str | None,
+        runtime_strategy_name: str | None,
+    ) -> None:
+        if ended_at <= started_at:
+            return
+        scope = (started_at, ended_at, account_label, runtime_strategy_name)
+        if scope not in seen:
+            seen.add(scope)
+            scopes.append(scope)
+
     for bucket in buckets:
         for ledger_payload in _runtime_ledger_bucket_payloads(bucket.payload_json):
             bucket_started_at = (
@@ -1239,15 +1254,28 @@ def _runtime_ledger_bucket_replacement_scopes(
             runtime_strategy_name = _text(ledger_payload.get("strategy_id")) or _text(
                 runtime_payload.get("strategy_name")
             )
-            scope = (
-                bucket_started_at,
-                bucket_ended_at,
-                account_label,
-                runtime_strategy_name,
+            add_scope(
+                started_at=bucket_started_at,
+                ended_at=bucket_ended_at,
+                account_label=account_label,
+                runtime_strategy_name=runtime_strategy_name,
             )
-            if scope not in seen:
-                seen.add(scope)
-                scopes.append(scope)
+            source_window_started_at = _parse_observation_datetime(
+                ledger_payload.get("source_window_start")
+            )
+            source_window_ended_at = _parse_observation_datetime(
+                ledger_payload.get("source_window_end")
+            )
+            if (
+                source_window_started_at is not None
+                and source_window_ended_at is not None
+            ):
+                add_scope(
+                    started_at=source_window_started_at,
+                    ended_at=source_window_ended_at,
+                    account_label=account_label,
+                    runtime_strategy_name=runtime_strategy_name,
+                )
     return scopes
 
 

--- a/services/torghut/tests/test_runtime_window_import.py
+++ b/services/torghut/tests/test_runtime_window_import.py
@@ -922,6 +922,119 @@ class TestRuntimeWindowImport(TestCase):
         self.assertEqual(ledger_rows[0].run_id, "import-live-dedupe-new")
         self.assertEqual(ledger_rows[0].net_strategy_pnl_after_costs, Decimal("1.25"))
 
+    def test_persist_observed_runtime_windows_replaces_stale_open_bucket_from_source_window(
+        self,
+    ) -> None:
+        def buckets_for(
+            *,
+            computed_at: datetime,
+            bucket_started_at: str,
+            bucket_ended_at: str,
+            source_window_start: str,
+            source_window_end: str,
+            closed_trade_count: int,
+            open_position_count: int,
+            net_pnl: str,
+        ):
+            return build_observed_runtime_buckets(
+                bucket_ranges=[
+                    (
+                        computed_at - timedelta(minutes=1),
+                        computed_at + timedelta(minutes=1),
+                        6,
+                    )
+                ],
+                decision_times=[computed_at - timedelta(seconds=30)],
+                execution_times=[computed_at],
+                tca_rows=[
+                    {
+                        "computed_at": computed_at,
+                        "abs_slippage_bps": Decimal("1"),
+                        "post_cost_expectancy_bps": Decimal("40"),
+                        "runtime_ledger_bucket": _runtime_ledger_bucket(
+                            bucket_started_at=bucket_started_at,
+                            bucket_ended_at=bucket_ended_at,
+                            source_window_start=source_window_start,
+                            source_window_end=source_window_end,
+                            account_label="TORGHUT_SIM",
+                            strategy_id="microbar-cross-sectional-pairs-v1",
+                            closed_trade_count=closed_trade_count,
+                            open_position_count=open_position_count,
+                            net_strategy_pnl_after_costs=net_pnl,
+                        ),
+                        **_runtime_pnl_basis(),
+                    }
+                ],
+                continuity_ok=True,
+                drift_ok=True,
+                dependency_quorum_decision="allow",
+            )
+
+        with self.session_local() as session:
+            old_summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-source-window-old-open",
+                candidate_id="cand-source-window",
+                hypothesis_id="H-PAIRS-01",
+                observed_stage="paper",
+                strategy_family="microbar_cross_sectional_pairs",
+                source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+                buckets=buckets_for(
+                    computed_at=datetime(2026, 3, 6, 14, 36, tzinfo=timezone.utc),
+                    bucket_started_at="2026-03-06T14:35:00+00:00",
+                    bucket_ended_at="2026-03-06T14:36:00+00:00",
+                    source_window_start="2026-03-06T14:35:00+00:00",
+                    source_window_end="2026-03-06T14:36:00+00:00",
+                    closed_trade_count=0,
+                    open_position_count=1,
+                    net_pnl="0",
+                ),
+                runtime_observation_payload={
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                },
+            )
+            new_summary = persist_observed_runtime_windows(
+                session=session,
+                run_id="import-source-window-new-close",
+                candidate_id="cand-source-window",
+                hypothesis_id="H-PAIRS-01",
+                observed_stage="paper",
+                strategy_family="microbar_cross_sectional_pairs",
+                source_manifest_ref="config/trading/hypotheses/h-pairs-01.json",
+                buckets=buckets_for(
+                    computed_at=datetime(2026, 3, 6, 14, 56, tzinfo=timezone.utc),
+                    bucket_started_at="2026-03-06T14:55:00+00:00",
+                    bucket_ended_at="2026-03-06T14:56:00+00:00",
+                    source_window_start="2026-03-06T14:35:00+00:00",
+                    source_window_end="2026-03-06T14:56:00+00:00",
+                    closed_trade_count=1,
+                    open_position_count=0,
+                    net_pnl="1.25",
+                ),
+                runtime_observation_payload={
+                    "account_label": "TORGHUT_SIM",
+                    "strategy_name": "microbar-cross-sectional-pairs-v1",
+                },
+            )
+            session.commit()
+            ledger_rows = (
+                session.execute(
+                    select(StrategyRuntimeLedgerBucket).order_by(
+                        StrategyRuntimeLedgerBucket.created_at
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        self.assertEqual(old_summary["replaced_runtime_ledger_bucket_count"], 0)
+        self.assertEqual(new_summary["replaced_runtime_ledger_bucket_count"], 1)
+        self.assertEqual(len(ledger_rows), 1)
+        self.assertEqual(ledger_rows[0].run_id, "import-source-window-new-close")
+        self.assertEqual(ledger_rows[0].open_position_count, 0)
+        self.assertEqual(ledger_rows[0].closed_trade_count, 1)
+
     def test_persist_observed_runtime_windows_uses_notional_weighted_ledger_summary(
         self,
     ) -> None:

--- a/services/torghut/tests/test_trading_pipeline.py
+++ b/services/torghut/tests/test_trading_pipeline.py
@@ -56,6 +56,7 @@ from app.trading.llm.schema import (
 from app.trading.models import SignalEnvelope, StrategyDecision
 from app.trading.prices import MarketSnapshot, PriceFetcher
 from app.trading.ingest import SignalBatch
+from app.trading.paper_route_target_plan import paper_route_target_plan_from_payload
 from app.trading.reconcile import Reconciler
 from app.trading.runtime_decision_authority import (
     ROUTE_ACQUISITION_SOURCE_DECISION_MODE,
@@ -7255,6 +7256,137 @@ class TestTradingPipeline(TestCase):
         self.assertTrue(target_plan.get("profit_proof_eligible"))
         self.assertNotIn("paper_route_probe", params)
         self.assertNotIn("paper_route_target_plan_source_decision", params)
+
+    def test_strategy_signal_paper_uses_next_target_plan_over_closed_import_plan(
+        self,
+    ) -> None:
+        from app import config
+
+        closed_window_start = datetime(2026, 5, 29, 13, 30, tzinfo=timezone.utc)
+        closed_window_end = datetime(2026, 5, 29, 20, 0, tzinfo=timezone.utc)
+        next_window_start = datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc)
+        next_window_end = datetime(2026, 6, 1, 20, 0, tzinfo=timezone.utc)
+        config.settings.trading_mode = "paper"
+        config.settings.trading_simple_paper_route_probe_enabled = True
+        config.settings.trading_paper_route_target_plan_url = (
+            "http://torghut.local/trading/paper-route-target-plan"
+        )
+        config.settings.trading_paper_route_target_plan_timeout_seconds = 1.0
+        pipeline = SimpleTradingPipeline(
+            alpaca_client=FakeAlpacaClient(),
+            order_firewall=OrderFirewall(FakeAlpacaClient()),
+            ingestor=FakeIngestor([]),
+            decision_engine=DecisionEngine(),
+            risk_engine=RiskEngine(),
+            executor=OrderExecutor(),
+            execution_adapter=FakeAlpacaClient(),
+            reconciler=Reconciler(),
+            universe_resolver=UniverseResolver(),
+            state=TradingState(),
+            account_label="paper",
+            session_factory=self.session_local,
+        )
+        with self.session_local() as session:
+            strategy = Strategy(
+                name="microbar-cross-sectional-pairs-v1",
+                enabled=True,
+                base_timeframe="1Sec",
+                universe_type="static",
+                universe_symbols=["AAPL", "AMZN"],
+            )
+            session.add(strategy)
+            session.commit()
+            session.refresh(strategy)
+            target_plan_payload = {
+                "schema_version": "torghut.paper-route-target-plan.v1",
+                "runtime_window_import_plan": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "purpose": "latest_closed_session_paper_route_runtime_window_import",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                            "paper_route_probe_window_start": (
+                                closed_window_start.isoformat()
+                            ),
+                            "paper_route_probe_window_end": (
+                                closed_window_end.isoformat()
+                            ),
+                            "candidate_id": "closed-friday-candidate",
+                            "hypothesis_id": "H-PAIRS-01",
+                            "observed_stage": "paper",
+                            "strategy_family": "microbar_cross_sectional_pairs",
+                            "strategy_name": "microbar-cross-sectional-pairs-v1",
+                            "source_kind": "paper_route_probe_runtime_observed",
+                            "paper_probation_authorized": True,
+                        }
+                    ],
+                },
+                "next_paper_route_runtime_window_targets": {
+                    "schema_version": "torghut.next-paper-route-runtime-window-targets.v1",
+                    "purpose": "next_session_paper_route_runtime_window_evidence_collection",
+                    "target_count": 1,
+                    "targets": [
+                        {
+                            "paper_route_probe_symbols": ["AAPL", "AMZN"],
+                            "paper_route_probe_window_start": (
+                                next_window_start.isoformat()
+                            ),
+                            "paper_route_probe_window_end": next_window_end.isoformat(),
+                            "candidate_id": "candidate-pairs-monday",
+                            "hypothesis_id": "H-PAIRS-01",
+                            "observed_stage": "paper",
+                            "strategy_family": "microbar_cross_sectional_pairs",
+                            "strategy_name": "microbar-cross-sectional-pairs-v1",
+                            "strategy_lookup_names": [
+                                str(strategy.id),
+                                "microbar-cross-sectional-pairs-v1",
+                            ],
+                            "source_kind": "paper_route_probe_runtime_observed",
+                            "source_manifest_ref": (
+                                "config/trading/hypotheses/h-pairs-01.json"
+                            ),
+                            "dataset_snapshot_ref": (
+                                "portfolio-profit-autoresearch-500-v1"
+                            ),
+                            "paper_probation_authorized": True,
+                        }
+                    ],
+                },
+            }
+            decision = StrategyDecision(
+                strategy_id=str(strategy.id),
+                symbol="AAPL",
+                event_ts=datetime(2026, 6, 1, 15, 30, tzinfo=timezone.utc),
+                timeframe="1Sec",
+                action="sell",
+                qty=Decimal("1"),
+                params={"price": "100"},
+            )
+            with patch(
+                "app.trading.scheduler.simple_pipeline.fetch_paper_route_target_plan_url",
+                return_value=paper_route_target_plan_from_payload(target_plan_payload),
+            ):
+                row = pipeline._ensure_pending_decision_row(
+                    session=session,
+                    decision=decision,
+                    strategy=strategy,
+                )
+
+            self.assertIsNotNone(row)
+            assert row is not None
+            payload = cast(dict[str, Any], row.decision_json)
+            params = cast(dict[str, Any], payload.get("params"))
+            authority = cast(dict[str, Any], params.get("strategy_signal_paper"))
+
+        self.assertEqual(params.get("source_decision_mode"), "strategy_signal_paper")
+        self.assertTrue(params.get("profit_proof_eligible"))
+        self.assertEqual(authority.get("candidate_id"), "candidate-pairs-monday")
+        self.assertNotEqual(authority.get("candidate_id"), "closed-friday-candidate")
+        self.assertEqual(
+            authority.get("paper_route_probe_window_start"),
+            next_window_start.isoformat(),
+        )
 
     def test_strategy_signal_paper_target_rejects_unqualified_targets(
         self,


### PR DESCRIPTION
## Summary

- Expands runtime-ledger replacement scopes to include source-window bounds when authoritative runtime bucket payloads include them.
- Prevents stale open-position ledger buckets from surviving after a later source-backed close covers the same source window.
- Adds regression coverage for source-window replacement and for Monday paper-route decisions using next-session targets over closed import targets.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_runtime_window_import.py tests/test_trading_pipeline.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `cd services/torghut && uv run --frozen ruff format --check app/trading/runtime_window_import.py tests/test_runtime_window_import.py tests/test_trading_pipeline.py`
- `cd services/torghut && uv run --frozen ruff check app/trading/runtime_window_import.py tests/test_runtime_window_import.py tests/test_trading_pipeline.py`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
