### PR TITLE
fix(torghut): prefer strategy signal source mode params

### DIFF
--- a/services/torghut/scripts/import_hypothesis_runtime_windows.py
+++ b/services/torghut/scripts/import_hypothesis_runtime_windows.py
@@ -416,6 +416,7 @@ def _source_decision_priority_payloads(
                 payloads.append(nested)
         params = _as_mapping(decision_json.get("params"))
         if params:
+            payloads.append(params)
             for key in (
                 "strategy_signal_paper",
                 "paper_route_target_plan",

--- a/services/torghut/tests/test_import_hypothesis_runtime_windows.py
+++ b/services/torghut/tests/test_import_hypothesis_runtime_windows.py
@@ -946,6 +946,44 @@ class TestImportHypothesisRuntimeWindows(TestCase):
             )
         )
 
+    def test_source_decision_helpers_prefer_params_signal_over_nested_probe(
+        self,
+    ) -> None:
+        row = {
+            "decision_json": {
+                "params": {
+                    "strategy_runtime": {"mode": "scheduler_v3"},
+                    "paper_route_probe": {
+                        "source_decision_mode": "route_acquisition_probe",
+                        "profit_proof_eligible": False,
+                    },
+                    "source_decision_mode": "strategy_signal_paper",
+                    "profit_proof_eligible": True,
+                    "source_candidate_ids": ["c88421d619759b2cfaa6f4d0"],
+                    "source_hypothesis_ids": ["H-PAIRS-01"],
+                    "strategy_signal_paper": {
+                        "source_decision_mode": "strategy_signal_paper",
+                        "profit_proof_eligible": True,
+                    },
+                }
+            }
+        }
+
+        self.assertEqual(_source_decision_mode(row), "strategy_signal_paper")
+        self.assertEqual(
+            _source_decision_mode_counts([row]),
+            {"strategy_signal_paper": 1},
+        )
+        self.assertTrue(_source_decision_rows_profit_proof_eligible([row]))
+        self.assertTrue(
+            _source_row_matches_lineage(
+                row,
+                candidate_id="c88421d619759b2cfaa6f4d0",
+                hypothesis_id="H-PAIRS-01",
+                require_source_lineage=True,
+            )
+        )
+
     def test_runtime_ledger_tca_rows_from_durable_buckets_queries_matching_proof(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Prioritize `decision_json.params.source_decision_mode` when importing runtime-window source rows.
- Prevent strategy-signal paper rows from being misclassified by nearby nested probe or scheduler metadata.
- Add a regression covering H-PAIRS-style params payloads with nested route-acquisition and scheduler fields.

## Related Issues

None

## Testing

- `cd services/torghut && uv run --frozen pytest tests/test_import_hypothesis_runtime_windows.py -q`
- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
