### PR TITLE
fix(torghut): flatten H-PAIRS pair legs before close

### DIFF
--- a/argocd/applications/torghut/strategy-configmap.yaml
+++ b/argocd/applications/torghut/strategy-configmap.yaml
@@ -453,6 +453,7 @@ data:
           max_session_negative_exit_bps: "10"
           max_stop_loss_exits_per_session: "1"
           stop_loss_lockout_seconds: "1800"
+          session_flatten_start_minute_utc: "1170"
           position_isolation_mode: "per_strategy"
       - name: microbar-volume-continuation-long-top2-v11
         strategy_id: microbar_volume_continuation_long_top2@prod

--- a/services/torghut/app/trading/decisions.py
+++ b/services/torghut/app/trading/decisions.py
@@ -1876,10 +1876,9 @@ def _build_runtime_position_exit_overlay(
         for strategy in strategies
         if strategy.enabled
         and strategy.base_timeframe == timeframe
-        and (
-            _treats_sell_as_exit_only(strategy)
-            if position_side == "long"
-            else _treats_buy_as_exit_only(strategy)
+        and _supports_runtime_position_exit_overlay(
+            strategy=strategy,
+            position_side=position_side,
         )
     ]
     if not eligible_strategies:
@@ -2206,6 +2205,44 @@ def _strategy_uses_position_isolation(strategy: Strategy) -> bool:
         "late_day_continuation_long_v1",
         "end_of_day_reversal_long_v1",
     }
+
+
+def _supports_runtime_position_exit_overlay(
+    *,
+    strategy: Strategy,
+    position_side: Literal["long", "short"],
+) -> bool:
+    if (
+        _treats_sell_as_exit_only(strategy)
+        if position_side == "long"
+        else _treats_buy_as_exit_only(strategy)
+    ):
+        return True
+    runtime_type = _strategy_catalog_runtime_type(strategy)
+    if runtime_type != "microbar_cross_sectional_pairs_v1":
+        return False
+    strategy_list = [strategy]
+    has_session_flatten = (
+        _resolve_max_nonnegative_strategy_param(
+            strategies=strategy_list,
+            key="session_flatten_start_minute_utc",
+        )
+        is not None
+    )
+    has_position_exit = any(
+        _resolve_max_nonnegative_strategy_param(strategies=strategy_list, key=key)
+        is not None
+        for key in (
+            "max_hold_seconds",
+            "long_stop_loss_bps",
+            "short_stop_loss_bps",
+            "long_trailing_stop_activation_profit_bps",
+            "long_trailing_stop_drawdown_bps",
+        )
+    )
+    return _strategy_uses_position_isolation(strategy) and (
+        has_session_flatten or has_position_exit
+    )
 
 
 def _position_state_scope_key(

--- a/services/torghut/tests/test_decisions.py
+++ b/services/torghut/tests/test_decisions.py
@@ -4070,6 +4070,156 @@ class TestDecisionEngine(TestCase):
         assert isinstance(session_exit, dict)
         self.assertEqual(session_exit.get("type"), "session_flatten_minute_utc")
 
+    def test_scheduler_runtime_position_exit_overlay_flattens_pair_long_leg(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="microbar-cross-sectional-pairs-v1",
+                    strategy_id="microbar_cross_sectional_pairs_v1@research",
+                    strategy_type="microbar_cross_sectional_pairs_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="microbar_cross_sectional_pairs_v1",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_position_pct_equity=Decimal("0.06"),
+                    max_notional_per_trade=Decimal("75000"),
+                    params={
+                        "session_flatten_start_minute_utc": "1170",
+                        "position_isolation_mode": "per_strategy",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+            max_position_pct_equity=Decimal("0.06"),
+            max_notional_per_trade=Decimal("75000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 19, 30, 0, tzinfo=timezone.utc),
+            symbol="AMZN",
+            timeframe="1Sec",
+            seq=13,
+            payload={
+                "price": 190.10,
+                "spread": 0.03,
+                "ema12": 190.12,
+                "ema26": 190.08,
+                "macd": 0.001,
+                "macd_signal": 0.001,
+                "rsi14": 50.0,
+                "vol_realized_w60s": 0.00012,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "AMZN",
+                        "strategy_id": str(strategy.id),
+                        "qty": "2.5",
+                        "side": "long",
+                        "market_value": "475.25",
+                        "avg_entry_price": "189.80",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "sell")
+        self.assertEqual(decisions[0].rationale, "session_flatten_exit")
+        session_exit = decisions[0].params.get("position_exit")
+        assert isinstance(session_exit, dict)
+        self.assertEqual(session_exit.get("type"), "session_flatten_minute_utc")
+
+    def test_scheduler_runtime_position_exit_overlay_flattens_pair_short_leg(
+        self,
+    ) -> None:
+        engine = DecisionEngine(price_fetcher=None)
+        strategy = Strategy(
+            id=uuid.uuid4(),
+            name="microbar-cross-sectional-pairs-v1",
+            description=_compose_strategy_description(
+                StrategyConfig(
+                    name="microbar-cross-sectional-pairs-v1",
+                    strategy_id="microbar_cross_sectional_pairs_v1@research",
+                    strategy_type="microbar_cross_sectional_pairs_v1",
+                    version="1.0.0",
+                    base_timeframe="1Sec",
+                    universe_type="microbar_cross_sectional_pairs_v1",
+                    universe_symbols=["AAPL", "AMZN"],
+                    max_position_pct_equity=Decimal("0.06"),
+                    max_notional_per_trade=Decimal("75000"),
+                    params={
+                        "session_flatten_start_minute_utc": "1170",
+                        "position_isolation_mode": "per_strategy",
+                    },
+                )
+            ),
+            enabled=True,
+            base_timeframe="1Sec",
+            universe_type="microbar_cross_sectional_pairs_v1",
+            universe_symbols=["AAPL", "AMZN"],
+            max_position_pct_equity=Decimal("0.06"),
+            max_notional_per_trade=Decimal("75000"),
+        )
+        signal = SignalEnvelope(
+            event_ts=datetime(2026, 3, 27, 19, 30, 0, tzinfo=timezone.utc),
+            symbol="AAPL",
+            timeframe="1Sec",
+            seq=13,
+            payload={
+                "price": 225.10,
+                "spread": 0.02,
+                "ema12": 225.12,
+                "ema26": 225.08,
+                "macd": 0.001,
+                "macd_signal": 0.001,
+                "rsi14": 50.0,
+                "vol_realized_w60s": 0.00012,
+            },
+        )
+
+        with (
+            patch.object(settings, "trading_strategy_runtime_mode", "scheduler_v3"),
+            patch.object(settings, "trading_strategy_scheduler_enabled", True),
+            patch.object(settings, "trading_fractional_equities_enabled", True),
+        ):
+            decisions = engine.evaluate(
+                signal,
+                [strategy],
+                positions=[
+                    {
+                        "symbol": "AAPL",
+                        "strategy_id": str(strategy.id),
+                        "qty": "-3",
+                        "side": "short",
+                        "market_value": "-675.30",
+                        "avg_entry_price": "224.50",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].action, "buy")
+        self.assertEqual(decisions[0].rationale, "session_flatten_exit")
+        session_exit = decisions[0].params.get("position_exit")
+        assert isinstance(session_exit, dict)
+        self.assertEqual(session_exit.get("type"), "session_flatten_minute_utc")
+
     def test_scheduler_runtime_position_exit_overlay_session_flatten_bypasses_min_hold(
         self,
     ) -> None:

--- a/services/torghut/tests/test_live_config_manifest_contract.py
+++ b/services/torghut/tests/test_live_config_manifest_contract.py
@@ -481,6 +481,7 @@ class TestLiveConfigManifestContract(TestCase):
                 )
                 self.assertEqual(params.get("entry_minute_after_open"), "60")
                 self.assertEqual(params.get("exit_minute_after_open"), "120")
+                self.assertEqual(params.get("session_flatten_start_minute_utc"), "1170")
                 self.assertEqual(params.get("long_stop_loss_bps"), "10")
                 self.assertEqual(
                     params.get("long_trailing_stop_activation_profit_bps"), "8"


### PR DESCRIPTION
## Summary

- Enables runtime position-exit overlay support for `microbar_cross_sectional_pairs_v1` when the strategy uses per-strategy isolation and explicit session/position exit params.
- Adds a session flatten minute to the active H-PAIRS pair strategy config so pair legs are closed before the market close window.
- Adds regression coverage for long-leg and short-leg pair flattening plus a manifest contract assertion for the live H-PAIRS config.

## Related Issues

None

## Testing

- `cd services/torghut && uv sync --frozen --extra dev`
- `cd services/torghut && uv run --frozen pytest tests/test_decisions.py tests/test_live_config_manifest_contract.py tests/test_strategy_runtime.py -q`
- `cd services/torghut && uv run --frozen ruff check app/trading/decisions.py tests/test_decisions.py tests/test_live_config_manifest_contract.py`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.alpha.json`
- `cd services/torghut && uv run --frozen pyright --project pyrightconfig.scripts.json`
- `mise exec helm@3 -- kustomize build --enable-helm argocd/applications/torghut`
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
